### PR TITLE
union: #407 + #499 + #949 + #1127, gated once

### DIFF
--- a/cicchetto/e2e/tests/issue407-modal-backdrop-full-bottom-edge.spec.ts
+++ b/cicchetto/e2e/tests/issue407-modal-backdrop-full-bottom-edge.spec.ts
@@ -1,0 +1,88 @@
+// #407 — the one shape the extraction left without a witness.
+//
+// `.modal-backdrop` carries the scrim's paint and centring and DELIBERATELY no
+// geometry: on its own it is `position: fixed` with `left/right/top: 0` and no
+// bottom and no height — a zero-height box. Every scrim must also wear exactly
+// one geometry variant. `.modal-backdrop-viewport` adds the #143 keyboard-aware
+// height; `.modal-backdrop-full` adds the one declaration that makes the scrim
+// span the layout viewport: `bottom: 0`.
+//
+// `modalChrome.test.ts` pins all of that, but jsdom applies no stylesheet — it
+// proves what the cascade is ASKED to do, never what a browser paints. Two of
+// the three shapes already have a real-browser witness: issue219 clicks
+// `.names-modal-close` and waits for the modal to hide, and issue232 clicks
+// `.mode-modal-backdrop` at (6, 6). The `-full` geometry had none, and the two
+// modals that use it (confirm, delete-account) both dismiss on scrim click with
+// no spec clicking either.
+//
+// WHY THE BOTTOM AND NOT THE CORNER issue232 USES. A click at (6, 6) lands on
+// any box anchored at `top: 0`, so it passes whether or not the scrim has a
+// height at all — it cannot tell `.modal-backdrop-full` from the bare base.
+// `bottom: 0` is the single declaration the variant contributes, so the click
+// has to go where only that declaration can carry it: the bottom edge.
+//
+// RED / GREEN: drop `bottom: 0` from `.modal-backdrop-full`, or ship the scrim
+// wearing the base with no geometry variant, and the scrim collapses to zero
+// height — the box assertion names it, and the click falls through to the
+// window chrome behind while the modal stays open. Restore either and it
+// passes. The bottom-left corner is clear of occluders by construction: the
+// only rules at or above the scrim's z-index are `.error-banners` (z 1000) and
+// `.diag-float` (z 99999), and both are anchored to the TOP.
+//
+// The confirm modal is opened through the destructive close × (#195) and then
+// DISMISSED, which is the safe branch — it never PARTs. The spec asserts the
+// channel is still there afterwards, so a regression that turned dismissal into
+// confirmation could not hide behind a green scrim test. Registered vjt seed;
+// desktop chromium (untagged — an iPhone run would measure the VISUAL viewport,
+// which is the other variant's business).
+
+import {
+  confirmModal,
+  loginAs,
+  selectChannel,
+  sidebarCloseButton,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(60_000);
+
+test("#407 the -full scrim spans to the viewport bottom, and a click there dismisses", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // #195 — the destructive close × opens the leave-channel confirm.
+  await sidebarCloseButton(page, NETWORK_SLUG, CHANNEL).click();
+  const confirm = confirmModal(page);
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+
+  const scrim = page.locator(".confirm-modal-backdrop");
+  await expect(scrim).toHaveClass(/\bmodal-backdrop\b/);
+  await expect(scrim).toHaveClass(/\bmodal-backdrop-full\b/);
+
+  const viewport = page.viewportSize();
+  if (viewport === null) throw new Error("no viewport size — headless config changed");
+  const box = await scrim.boundingBox();
+  if (box === null) throw new Error("the scrim has no box: it is not rendered");
+
+  // Named first, so a collapsed scrim reports as a geometry failure rather than
+  // as an out-of-bounds click position further down.
+  expect(Math.round(box.y), "the scrim must start at the viewport top").toBe(0);
+  expect(Math.round(box.y + box.height), "the scrim must reach the viewport bottom").toBe(
+    viewport.height,
+  );
+
+  // The hit test the box assertion cannot stand in for: the scrim must actually
+  // RECEIVE a pointer event down there, not merely measure as if it would.
+  await scrim.click({ position: { x: 6, y: box.height - 6 } });
+  await expect(confirm).toHaveCount(0, { timeout: 5_000 });
+
+  // Dismissed, not confirmed — the channel is still in the sidebar.
+  await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(1);
+});

--- a/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
@@ -24,12 +24,19 @@
 //
 // Verification strategy. Walk document.styleSheets, find the
 // `.shell-mobile` rule (lives under the `@media (max-width: 768px)`
-// branch — CSSMediaRule), assert it declares both
-// `padding-top: env(safe-area-inset-top)` and
-// `padding-bottom: env(safe-area-inset-bottom)`. Webkit-iphone-15
+// branch — CSSMediaRule), assert it declares
+// `padding-top: env(safe-area-inset-top)`. Webkit-iphone-15
 // emulation matches viewport but doesn't inject real env() values —
 // computed paddingTop resolves to 0px regardless — so this is a
 // SOURCE-shape assertion, not a metric assertion.
+//
+// #1127 (2026-08-09) flipped the BOTTOM edge: the home-indicator inset
+// lifted the shell off the bottom and exposed the transparent area behind
+// it (a black band under the tab strip), so `.shell-mobile` now declares
+// `padding-bottom: 0` and the shell reaches the physical bottom. The edge
+// is still asserted here, with the opposite expectation — and the
+// declaration must still be PRESENT, since base `.shell` would otherwise
+// cascade the inset back in at equal specificity.
 //
 // Also assert `.topic-bar` rule NO LONGER contains `env(` /
 // `safe-area-inset-top` (the previous fix is reverted at the bar
@@ -99,7 +106,7 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
 
   // .shell-mobile rule lives inside @media (max-width: 768px) — must
   // recurse through CSSMediaRule.cssRules to find it. The rule MUST
-  // declare both top + bottom inset.
+  // declare the top inset, and MUST declare a flush bottom edge (#1127).
   const shell = await findRulePadding(page, ".shell-mobile");
   expect(shell).not.toBeNull();
   // The longhands MAY be authored or expanded; tolerate either.
@@ -107,8 +114,10 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
   const shellBottom = shell?.paddingBottom ?? "";
   expect(shellTop).toContain("env(");
   expect(shellTop).toContain("safe-area-inset-top");
-  expect(shellBottom).toContain("env(");
-  expect(shellBottom).toContain("safe-area-inset-bottom");
+  // Zero, and declared: an empty string here means the longhand is gone
+  // and base `.shell`'s inset cascades in. CSSOM may serialize the
+  // authored `0` as `0px`, so accept either spelling.
+  expect(shellBottom).toMatch(/^0(px)?$/);
 
   // .topic-bar MUST NOT carry the inset anymore — pin the UX-3 BIS
   // revert so a future operator can't re-introduce the double-clear

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -21,10 +21,21 @@
 // (a) html.is-ios class lands on iPhone UA (boot-time detection)
 // (b) --vh CSS var writes from visualViewport.height
 // (c) --viewport-height legacy CSS var writes from same source
-// (d) D1 `:has(:focus){padding-bottom:0}` rule applies when input
-//     has focus
 // (e) Smart-pin: window.scrollTo(0,0) clamps any drift
 // (f) Admin → Debug tab renders the diag panel + DiagFloat toggle
+//
+// Arm (d) is GONE (#1127, 2026-08-09). It asserted that focusing a text
+// field collapsed `.shell-mobile`'s computed padding-bottom to 0px via the
+// D1 `:has(:focus)` override. #1127 zeroed the shell's bottom inset
+// outright — the home-indicator inset lifted the shell off the bottom edge
+// and exposed the transparent band behind it — so the override was deleted
+// as dead code and the arm lost its subject. Note the arm was already
+// vacuous in Playwright: headless WebKit resolves `env()` to 0, so the
+// computed padding read 0px with or without the override applying. The
+// D11 rationale it encoded now lives on the `padding-bottom: 0`
+// declaration in default.css, which is where anyone re-adding an inset on
+// that edge will read it. Arm letters are kept stable so the (e)/(f)
+// references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import {
@@ -116,24 +127,6 @@ test.describe("UX-6 D cluster close — iOS PWA keyboard pattern @webkit", () =>
     expect(vpHeightVar).toMatch(/^\d+px$/);
     const value = Number.parseInt(vpHeightVar, 10);
     expect(value).toBeGreaterThan(100);
-  });
-
-  test("(d) D1 :has(:focus) rule collapses padding-bottom when input focused", async ({ page }) => {
-    await loginAs(page, getSeededVjt());
-    // GREEN-CI batch 2 — UX-4 bucket B made `:home` the cold-load
-    // default selection; HomePane has no `.compose-box`. Select the
-    // autojoin channel first so the ComposeBox mounts (same fix shape
-    // as ios-z-cluster-journey.spec.ts:57 lessons-learned).
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    const composeTa = page.locator(".compose-box textarea").first();
-    await expect(composeTa).toBeVisible({ timeout: 10_000 });
-    await composeTa.focus();
-    const paddingBottom = await page.evaluate(() => {
-      const shell = document.querySelector(".shell-mobile") as HTMLElement | null;
-      if (!shell) return "(no shell)";
-      return getComputedStyle(shell).paddingBottom;
-    });
-    expect(paddingBottom).toBe("0px");
   });
 
   test("(e) smart-pin: programmatic window scroll snaps back to 0", async ({ page }) => {

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -109,7 +109,12 @@ test("@webkit UX-Z cluster — Dynamic Island clearance + RailActions archive + 
   });
   expect(shellPadding).not.toBeNull();
   expect(shellPadding?.top ?? "").toContain("safe-area-inset-top");
-  expect(shellPadding?.bottom ?? "").toContain("safe-area-inset-bottom");
+  // #1127 — the BOTTOM edge is flush now: the home-indicator inset lifted
+  // the shell off the bottom and exposed the transparent area behind it.
+  // Still declared (an empty string would mean base `.shell`'s inset
+  // cascades in at equal specificity), just zero; CSSOM may serialize the
+  // authored `0` as `0px`.
+  expect(shellPadding?.bottom ?? "").toMatch(/^0(px)?$/);
 
   // PART seed channel so the UX-2 archive-button arm has an archived
   // entry to render in the modal.

--- a/cicchetto/src/BanlistModal.tsx
+++ b/cicchetto/src/BanlistModal.tsx
@@ -160,7 +160,10 @@ const BanlistModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="banlist-modal-backdrop" onClick={closeBanlistModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport banlist-modal-backdrop"
+          onClick={closeBanlistModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -180,7 +183,7 @@ const BanlistModal: Component = () => {
               </h2>
               <button
                 type="button"
-                class="banlist-modal-close"
+                class="modal-chrome-button banlist-modal-close"
                 aria-label="close ban list"
                 onClick={closeBanlistModal}
               >

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -48,7 +48,7 @@ const ConfirmModal: Component = () => {
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a non-interactive scrim
         <div
-          class="confirm-modal-backdrop"
+          class="modal-backdrop modal-backdrop-full confirm-modal-backdrop"
           onClick={dismissConfirm}
           data-testid="confirm-modal-backdrop"
         >

--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -20,6 +20,21 @@ import { computeMenuPosition } from "./lib/menuPosition";
 // proven in the Playwright e2e (issue487-context-menu-viewport-clamp.spec.ts)
 // since jsdom gives no real viewport dimensions. Opacity-gated until measured
 // so the pre-measure frame never flashes off-screen.
+//
+// #949 — "inside the viewport" was the LAYOUT viewport, whose origin under
+// `viewport-fit=cover` is the physical top of the display. #913 fixed the same
+// arithmetic for the rail menu and named this door as carrying the residue.
+// The bounds now come from `.context-menu-safe-area`: a fixed, unpainted box
+// laid out at `inset: env(safe-area-inset-*)`, measured with
+// `getBoundingClientRect()`. That indirection is the point. #913 established
+// that JS must NOT read the inset back out of a custom property —
+// `getComputedStyle().getPropertyValue()` on an unregistered one can hand back
+// the token stream rather than a length, and the NaN that follows is swallowed
+// by any `|| 0` into a fix that looks applied and does nothing. A rect is a
+// resolved length by construction: the engine still owns `env()`, and JS reads
+// geometry, which is the one thing it can always trust. The box also yields
+// all four insets from one measurement, which is what the X axis (landscape
+// notch) and the bottom edge (home indicator) need.
 
 export type ContextMenuItem = {
   label: string;
@@ -50,6 +65,7 @@ const ContextMenu: Component<Props> = (props) => {
   };
 
   let menuRef: HTMLDivElement | undefined;
+  let safeAreaRef: HTMLDivElement | undefined;
   const [placement, setPlacement] = createSignal({
     top: props.position.y,
     left: props.position.x,
@@ -62,8 +78,9 @@ const ContextMenu: Component<Props> = (props) => {
     // signal), so `onMount` alone would strand the menu at the first coords.
     const clickX = props.position.x;
     const clickY = props.position.y;
-    if (!menuRef) return;
+    if (!menuRef || !safeAreaRef) return;
     const rect = menuRef.getBoundingClientRect();
+    const safe = safeAreaRef.getBoundingClientRect();
     setPlacement(
       computeMenuPosition({
         clickX,
@@ -80,6 +97,10 @@ const ContextMenu: Component<Props> = (props) => {
         // keyboard-up divergence is a device-dogfood item, not an e2e one.
         viewportWidth: window.visualViewport?.width ?? window.innerWidth,
         viewportHeight: window.visualViewport?.height ?? window.innerHeight,
+        // #949 — the safe box, in layout-viewport coordinates. Where there is
+        // no inset (every desktop browser, every engine in the e2e suite) this
+        // is exactly {0, w, h, 0} and the placement is bit-identical to #487's.
+        safeArea: { top: safe.top, right: safe.right, bottom: safe.bottom, left: safe.left },
       }),
     );
     setPlaced(true);
@@ -94,6 +115,10 @@ const ContextMenu: Component<Props> = (props) => {
     // out-of-pane chrome). Rendering at the document root keeps the z-300/301
     // layers above everything, themed or not.
     <Portal>
+      {/* #949 — the safe-area ruler. Unpainted and untouchable; it exists only
+          so `getBoundingClientRect()` can hand the placement math the four
+          insets as resolved lengths. */}
+      <div ref={safeAreaRef} class="context-menu-safe-area" aria-hidden="true" />
       {/* Backdrop: click-outside closes the menu. Rendered as button for a11y. */}
       <button
         type="button"

--- a/cicchetto/src/DeleteAccountModal.tsx
+++ b/cicchetto/src/DeleteAccountModal.tsx
@@ -80,7 +80,7 @@ const DeleteAccountModal: Component<Props> = (props) => {
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape) */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a non-interactive scrim */}
       <div
-        class="delete-account-backdrop"
+        class="modal-backdrop modal-backdrop-full delete-account-backdrop"
         onClick={props.onClose}
         data-testid="delete-account-backdrop"
       >

--- a/cicchetto/src/LinksModal.tsx
+++ b/cicchetto/src/LinksModal.tsx
@@ -226,7 +226,7 @@ const LinksModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="links-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport links-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -244,7 +244,7 @@ const LinksModal: Component = () => {
                 <div class="links-modal-controls">
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="zoom out"
                     onClick={() =>
                       zoomAround(
@@ -260,7 +260,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="reset view"
                     onClick={resetView}
                   >
@@ -268,7 +268,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="zoom in"
                     onClick={() =>
                       zoomAround(
@@ -284,7 +284,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-close"
+                    class="modal-chrome-button links-modal-close"
                     aria-label="close links"
                     onClick={close}
                   >

--- a/cicchetto/src/ModeModal.tsx
+++ b/cicchetto/src/ModeModal.tsx
@@ -213,7 +213,10 @@ const ModeModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="mode-modal-backdrop" onClick={closeModeModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
+          onClick={closeModeModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -233,7 +236,7 @@ const ModeModal: Component = () => {
               </h2>
               <button
                 type="button"
-                class="mode-modal-close"
+                class="modal-chrome-button mode-modal-close"
                 aria-label="close modes"
                 onClick={closeModeModal}
               >

--- a/cicchetto/src/NamesModal.tsx
+++ b/cicchetto/src/NamesModal.tsx
@@ -92,7 +92,7 @@ const NamesModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="names-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport names-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -109,7 +109,7 @@ const NamesModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="names-modal-close"
+                  class="modal-chrome-button names-modal-close"
                   aria-label="close names"
                   onClick={close}
                 >

--- a/cicchetto/src/PrivacyModal.tsx
+++ b/cicchetto/src/PrivacyModal.tsx
@@ -50,7 +50,10 @@ const PrivacyModal: Component = () => {
       {(host) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim, click is convenience-only
-        <div class="image-upload-modal-backdrop" onClick={onCancel}>
+        <div
+          class="modal-backdrop modal-backdrop-full image-upload-modal-backdrop"
+          onClick={onCancel}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"

--- a/cicchetto/src/RecoverModal.tsx
+++ b/cicchetto/src/RecoverModal.tsx
@@ -81,7 +81,7 @@ const RecoverModal: Component = () => {
       {(st) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="recover-modal-backdrop" onClick={close}>
+        <div class="modal-backdrop modal-backdrop-viewport recover-modal-backdrop" onClick={close}>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -101,7 +101,12 @@ const RecoverModal: Component = () => {
                 </span>
                 Recover your identity
               </h2>
-              <button type="button" class="recover-modal-close" aria-label="close" onClick={close}>
+              <button
+                type="button"
+                class="modal-chrome-button recover-modal-close"
+                aria-label="close"
+                onClick={close}
+              >
                 ×
               </button>
             </header>

--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -223,7 +223,10 @@ const RegistrationWizardModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="registration-wizard-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport registration-wizard-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -245,7 +248,7 @@ const RegistrationWizardModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="registration-wizard-close"
+                  class="modal-chrome-button registration-wizard-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ServerReplyModal.tsx
+++ b/cicchetto/src/ServerReplyModal.tsx
@@ -56,7 +56,10 @@ const ServerReplyModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="server-reply-modal-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport server-reply-modal-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -77,7 +80,7 @@ const ServerReplyModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="server-reply-modal-close"
+                  class="modal-chrome-button server-reply-modal-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -83,7 +83,10 @@ const ServiceModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="service-modal-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport service-modal-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -104,7 +107,7 @@ const ServiceModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="service-modal-close"
+                  class="modal-chrome-button service-modal-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ShareSessionModal.tsx
+++ b/cicchetto/src/ShareSessionModal.tsx
@@ -165,7 +165,7 @@ const ShareSessionModal: Component = () => {
     <Show when={shareModalOpen()}>
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape) */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim */}
-      <div class="share-modal-backdrop" onClick={close}>
+      <div class="modal-backdrop modal-backdrop-viewport share-modal-backdrop" onClick={close}>
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
         <div
           role="dialog"
@@ -180,7 +180,7 @@ const ShareSessionModal: Component = () => {
             <h2 id="share-modal-title">{SHARE_SESSION_LABEL}</h2>
             <button
               type="button"
-              class="share-modal-close"
+              class="modal-chrome-button share-modal-close"
               data-testid="share-modal-close"
               aria-label="close"
               onClick={close}

--- a/cicchetto/src/UmodeModal.tsx
+++ b/cicchetto/src/UmodeModal.tsx
@@ -81,7 +81,10 @@ const UmodeModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="mode-modal-backdrop" onClick={closeUmodeModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
+          onClick={closeUmodeModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -96,7 +99,7 @@ const UmodeModal: Component = () => {
               <h2 id="umode-modal-title">User modes: {t.networkSlug}</h2>
               <button
                 type="button"
-                class="mode-modal-close"
+                class="modal-chrome-button mode-modal-close"
                 aria-label="close user modes"
                 onClick={closeUmodeModal}
               >

--- a/cicchetto/src/WhoModal.tsx
+++ b/cicchetto/src/WhoModal.tsx
@@ -222,7 +222,7 @@ const WhoModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="who-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport who-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -239,7 +239,7 @@ const WhoModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="who-modal-close"
+                  class="modal-chrome-button who-modal-close"
                   aria-label="close who"
                   onClick={close}
                 >

--- a/cicchetto/src/__tests__/ContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import ContextMenu from "../ContextMenu";
+
+// #949 — the WIRING half of the safe-area clamp. The arithmetic is pinned as a
+// pure fn (lib/menuPosition.test.ts) and the stylesheet rules at source level
+// (contextMenuSafeArea.test.ts); neither notices if `ContextMenu` stops
+// rendering the ruler or stops feeding its rect to the math, which would leave
+// the fix dead while both other suites stay green.
+//
+// jsdom reports every rect as zero, so the two boxes that matter are stubbed —
+// the same shape RailActions.test.tsx uses for #913's JS half. That makes these
+// behavioural tests of the component's contract (which numbers it reads, and
+// what it does with them), not layout tests: jsdom does not paint, and the felt
+// result on a notched device is still only confirmable by dogfood.
+
+const ITEMS = [
+  { label: "whois", enabled: true, action: vi.fn() },
+  { label: "query", enabled: true, action: vi.fn() },
+];
+
+// A portrait iPhone 15 under `viewport-fit=cover`: the ruler is laid out at
+// `inset: env(safe-area-inset-*)`, so its rect is the safe box in
+// layout-viewport coordinates — 59px of status bar at the top, 34px of home
+// indicator at the bottom of an 852px display.
+const IPHONE_15_SAFE = { top: 59, right: 393, bottom: 818, left: 0 };
+
+function stubRect(selector: string, rect: Partial<DOMRect>): HTMLElement {
+  const el = document.querySelector(selector);
+  if (!(el instanceof HTMLElement)) throw new Error(`${selector} did not render`);
+  el.getBoundingClientRect = (): DOMRect => rect as DOMRect;
+  return el;
+}
+
+// The placement effect tracks `props.position`, so re-rendering at fresh
+// coordinates is what re-runs it against the stubbed rects.
+function renderThenPlace(
+  safe: Partial<DOMRect>,
+  menu: Partial<DOMRect>,
+  at: { x: number; y: number },
+): HTMLElement {
+  const [position, setPosition] = createSignal({ x: 1, y: 1 });
+  render(() => <ContextMenu items={ITEMS} position={position()} onClose={vi.fn()} />);
+  stubRect(".context-menu-safe-area", safe);
+  const menuEl = stubRect(".context-menu", menu);
+  setPosition(at);
+  return menuEl;
+}
+
+describe("ContextMenu safe-area placement (#949)", () => {
+  it("renders the safe-area ruler, hidden from the accessibility tree", () => {
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    const ruler = document.querySelector(".context-menu-safe-area");
+    // Deleting this element is the cheapest way to silently un-fix #949: the
+    // effect bails on a missing ref and the menu keeps its raw press coords.
+    expect(ruler).not.toBeNull();
+    expect(ruler?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("pins an oversized menu below the top inset, not at the physical top", () => {
+    // 900px of menu against jsdom's 768px viewport: oversized either way, so
+    // the only question is WHICH origin it pins to. y=0 is the #913 defect —
+    // under viewport-fit=cover that coordinate is behind the status bar, and
+    // the menu's own overflow scroll cannot recover a box that STARTS there.
+    const menuEl = renderThenPlace(
+      IPHONE_15_SAFE,
+      { top: 0, left: 0, right: 200, bottom: 900, width: 200, height: 900 },
+      { x: 100, y: 400 },
+    );
+    expect(menuEl.style.top).toBe("59px");
+  });
+
+  it("never opens the menu inside the leading inset", () => {
+    // Landscape: the notch and the rounded corner eat a column on the leading
+    // edge, and unlike the status bar iOS does still deliver touches there — so
+    // a press CAN arrive at x=10 and must not be honoured as an origin.
+    const menuEl = renderThenPlace(
+      { top: 0, right: 793, bottom: 372, left: 59 },
+      { top: 0, left: 0, right: 200, bottom: 120, width: 200, height: 120 },
+      { x: 10, y: 100 },
+    );
+    expect(menuEl.style.left).toBe("59px");
+  });
+
+  it("honours the press coordinates when there is no inset to dodge", () => {
+    // The no-notch case — every desktop browser and every engine in the e2e
+    // suite, where env(safe-area-inset-*) resolves to 0. The fix must be a
+    // NO-OP here, or it is a regression of #487 dressed up as a fix.
+    const menuEl = renderThenPlace(
+      { top: 0, right: 1024, bottom: 768, left: 0 },
+      { top: 0, left: 0, right: 200, bottom: 120, width: 200, height: 120 },
+      { x: 100, y: 400 },
+    );
+    expect(menuEl.style.left).toBe("100px");
+    expect(menuEl.style.top).toBe("400px");
+  });
+});

--- a/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #949 — the context menu carried #913's defect at a second door. #913 fixed
+// `.rail-actions-menu`, whose cap measured the space above the launcher from
+// `getBoundingClientRect().top`: under `viewport-fit=cover` that origin is the
+// PHYSICAL top of the display, behind the status bar. `d129bfb0` recorded that
+// the `placeAxis` / context-menu clamp had the same origin bug "on both edges"
+// and wanted its own issue. This is the stylesheet half of it.
+//
+// Two rules carry the fix and they answer different questions:
+//   * `.context-menu-safe-area` is a RULER — a fixed, unpainted box inset by
+//     all four `env(safe-area-inset-*)` values, whose `getBoundingClientRect()`
+//     hands the placement math the safe box as resolved lengths. It exists
+//     because #913 established JS must not read the inset out of a custom
+//     property: `getComputedStyle().getPropertyValue()` on an unregistered one
+//     can return the token stream, and the resulting NaN is swallowed by any
+//     `|| 0` into a no-op that looks like a fix. A rect cannot be a token
+//     stream.
+//   * `.context-menu`'s `max-height` is the SIZE cap, and it stays in CSS
+//     because the placement effect measures the menu's rendered height — a cap
+//     applied inline after that measurement would position a box against a
+//     height it no longer has.
+//
+// SOURCE-LEVEL guards, for the reason #913 and #205 already record: Playwright
+// resolves `env(safe-area-inset-*)` to 0 on every engine in the suite and jsdom
+// resolves neither `env()` nor `calc()`, so no gate we run can observe the
+// on-device geometry. The wiring is pinned in ContextMenu.test.tsx and the
+// arithmetic in lib/menuPosition.test.ts; the FELT result on a notched iPhone
+// is confirmable only by dogfood.
+
+describe("#949 context menu safe-area clamp", () => {
+  it(":root exposes the bottom inset alongside #913's top one", () => {
+    // The height cap subtracts BOTH vertical insets, and the `0px` fallback is
+    // load-bearing on each: without it an engine that does not know the
+    // variable invalidates the whole declaration, dropping the cap entirely —
+    // which is the uncapped #487 overflow, back.
+    expect(ruleBody(":root")).toMatch(/--safe-area-inset-top:\s*env\(safe-area-inset-top,\s*0px\)/);
+    expect(ruleBody(":root")).toMatch(
+      /--safe-area-inset-bottom:\s*env\(safe-area-inset-bottom,\s*0px\)/,
+    );
+  });
+
+  it("the ruler is fixed, so its rect shares the menu's coordinate space", () => {
+    // `position: fixed` is what makes the rect comparable to the press
+    // coordinates and to the menu's own fixed box. An absolutely-positioned
+    // ruler would report its offset parent's frame and quietly mis-place
+    // everything by that parent's origin.
+    expect(ruleBody(".context-menu-safe-area")).toMatch(/position:\s*fixed/);
+  });
+
+  it("the ruler is inset by all four safe-area values, each with a 0px fallback", () => {
+    // Asserted per-edge rather than against the `inset:` shorthand as written:
+    // a longhand rewrite must keep passing, and a DROPPED edge must fail. The
+    // bottom and the two sides are not decoration — the bottom is the home
+    // indicator, and in landscape the sides are the notch and the rounded
+    // corners, which is the other half of `d129bfb0`'s "both edges".
+    const body = ruleBody(".context-menu-safe-area");
+    for (const edge of ["top", "right", "bottom", "left"]) {
+      expect(body).toMatch(new RegExp(`env\\(safe-area-inset-${edge},\\s*0px\\)`));
+    }
+  });
+
+  it("the ruler cannot be touched, so it never eats the backdrop's click-outside", () => {
+    // It is a sibling of `.context-menu-backdrop` inside the same portal and
+    // covers nearly the same area. Without this it would swallow the press
+    // that is supposed to close the menu.
+    expect(ruleBody(".context-menu-safe-area")).toMatch(/pointer-events:\s*none/);
+  });
+
+  it("the ruler is declared once, so the measured box is the one written here", () => {
+    // The rect is read from live layout, so ANY second rule reaching this class
+    // silently redefines what the placement math measures.
+    expect(themeCss.match(/\.context-menu-safe-area/g)?.length).toBe(1);
+  });
+
+  it(".context-menu caps its height against the viewport MINUS both vertical insets", () => {
+    const body = ruleBody(".context-menu");
+    expect(body).toMatch(/max-height:[^;]*var\(--viewport-height,\s*100vh\)/);
+    expect(body).toMatch(/max-height:[^;]*var\(--safe-area-inset-top,\s*0px\)/);
+    expect(body).toMatch(/max-height:[^;]*var\(--safe-area-inset-bottom,\s*0px\)/);
+  });
+
+  it("the cap is clamped at zero, because a negative max-height is no cap at all", () => {
+    // Subtracting two insets from a keyboard-shrunk `--viewport-height` can go
+    // negative. An out-of-range max-height is an ignored declaration, and an
+    // ignored cap is the #487 overflow — the same trap #588/#913 hit.
+    expect(ruleBody(".context-menu")).toMatch(/max-height:\s*max\(\s*0px\s*,/);
+  });
+
+  it("the menu still scrolls whatever the cap leaves over", () => {
+    // The cap only relocates the overflow; `overflow-y: auto` is what makes the
+    // hidden rows reachable. Capping without it reproduces #487's unclickable
+    // tail with extra steps.
+    expect(ruleBody(".context-menu")).toMatch(/overflow-y:\s*auto/);
+  });
+});

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -42,6 +42,27 @@ export function focusRules(): { selectors: string; body: string }[] {
   return out;
 }
 
+/**
+ * Every body of a rule whose selector is EXACTLY `selector`, at any nesting
+ * depth — `ruleBody`'s column-0 anchor cannot see rules inside an `@media` /
+ * `@supports` block. Returns one entry per block on purpose: a selector can
+ * legitimately have more than one (`.shell-mobile` has a second block under
+ * `@supports not (height: 100dvh)`), and an assertion about which value a
+ * property ends up with has to see them all. Comments stripped, same as
+ * `ruleBody`; throws when the selector has no rule at all, so a rename can't
+ * pass vacuously.
+ */
+export function nestedRuleBodies(selector: string): string[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const out: string[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if ((match[1] ?? "").trim() !== selector) continue;
+    out.push(match[2] ?? "");
+  }
+  if (out.length === 0) throw new Error(`CSS rule not found: ${selector}`);
+  return out;
+}
+
 export function ruleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");

--- a/cicchetto/src/__tests__/ipadSafeArea.test.ts
+++ b/cicchetto/src/__tests__/ipadSafeArea.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { ruleBody, themeCss } from "./helpers/themeCss";
+import { nestedRuleBodies, ruleBody, themeCss } from "./helpers/themeCss";
 
 // #205 — cicchetto as an installed PWA on iPadOS rendered its top chrome
 // (settings cog included) UNDER the iOS status bar, clipped and
@@ -90,5 +90,40 @@ describe("#205 iPad standalone-PWA safe area", () => {
     expect(css).toMatch(
       /\.shell-members\s*\{[\s\S]*?padding-bottom:\s*max\(1\.5rem,\s*env\(safe-area-inset-bottom\)\)/,
     );
+  });
+});
+
+// #1127 — the mobile shell's bottom edge. The guards above pin `.shell`
+// (desktop / iPad) and never mention `.shell-mobile`, so flipping the
+// mobile bottom edge used to land green either way. Same caveat as #205:
+// SOURCE-level, because jsdom resolves no `env()` and desktop Chrome
+// reports every inset as 0 — the on-device look still needs a real
+// notched iPhone.
+describe("#1127 mobile shell bottom edge", () => {
+  it(".shell-mobile declares exactly one bottom edge, and it is 0", () => {
+    // One assertion over the whole declaration list, deliberately: it has
+    // to kill three different regressions at once. Restoring the inset
+    // (`env(safe-area-inset-bottom)`) reopens the black band the issue was
+    // filed for. DELETING the declaration is just as wrong and far more
+    // tempting — base `.shell` declares the same property at the same
+    // specificity and the element carries both classes, so an absent
+    // longhand here means the inset cascades straight back in. And a
+    // second declaration appended after the `0` would silently win.
+    const declared = [
+      ...nestedRuleBodies(".shell-mobile")
+        .join("\n")
+        .matchAll(/padding-bottom:\s*([^;]+);/g),
+    ].map((m) => (m[1] ?? "").trim());
+    expect(declared).toEqual(["0"]);
+  });
+
+  it(".shell-mobile keeps the top / left / right insets", () => {
+    // Bottom edge only. The top inset clears the status bar and keeps the
+    // chrome tappable (UX-3 BIS); the sides matter in the sub-768 landscape
+    // edge on small notched devices.
+    const body = nestedRuleBodies(".shell-mobile").join("\n");
+    expect(body).toMatch(/padding-top:\s*env\(safe-area-inset-top\)/);
+    expect(body).toMatch(/padding-left:\s*env\(safe-area-inset-left\)/);
+    expect(body).toMatch(/padding-right:\s*env\(safe-area-inset-right\)/);
   });
 });

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -1,0 +1,383 @@
+/// <reference types="node" />
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { themeCss } from "./helpers/themeCss";
+
+// #407 — the modal × and the modal scrim were each styled by copying a rule:
+// ten byte-identical `*-close` blocks and thirteen `*-backdrop` blocks that
+// resolve to two shapes. #740 already fixed this defect shape once
+// (.login-quiet-button / .scrollback-inline-button) with a base class worn
+// beside the per-instance one; this is the same move on the modal chrome.
+//
+// An extraction is a promise not to change any pixel, so the guard is not
+// "a base rule exists" — it is that the DECLARATIONS every call site resolves
+// to are byte-for-byte what they were before the base existed. The three maps
+// at the foot of this file were transcribed from the stylesheet as it stood at
+// 6e81170 (origin/main, pre-extraction) and must survive it unchanged.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a browser paints — the visible outcome
+// (the × actually closing the modal) is an e2e concern, not this file's.
+
+/** Per-instance classes that the extracted bases must leave pixel-identical. */
+const CLOSE_SITES = [
+  "banlist-modal-close",
+  "links-modal-close",
+  "mode-modal-close",
+  "names-modal-close",
+  "recover-modal-close",
+  "registration-wizard-close",
+  "server-reply-modal-close",
+  "service-modal-close",
+  "share-modal-close",
+  "who-modal-close",
+];
+
+/** Scrims that #143 shrank to the visible region so the iOS keyboard fits. */
+const BACKDROP_VIEWPORT_SITES = [
+  "banlist-modal-backdrop",
+  "links-modal-backdrop",
+  "mode-modal-backdrop",
+  "names-modal-backdrop",
+  "recover-modal-backdrop",
+  "registration-wizard-backdrop",
+  "server-reply-modal-backdrop",
+  "service-modal-backdrop",
+  "share-modal-backdrop",
+  "who-modal-backdrop",
+];
+
+/** Scrims still spanning the layout viewport — the pre-#143 geometry. */
+const BACKDROP_FULL_SITES = [
+  "confirm-modal-backdrop",
+  "delete-account-backdrop",
+  "image-upload-modal-backdrop",
+];
+
+const SITES = [...CLOSE_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
+
+type Rule = { selectors: string[]; body: string };
+
+/**
+ * Every INNERMOST rule that starts at column 0, as `{ selectors, body }` with
+ * comments stripped. The `[^{}]` classes cannot span a brace, so an `@media`
+ * prelude is never captured as a selector; the column-0 test then drops the
+ * rules nested inside one, which resolve under a condition this file does not
+ * model. The "bare class selectors only" assertion below is what makes that
+ * safe: it fails if a site is ever reached from inside a media query.
+ */
+function topLevelRules(): Rule[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules: Rule[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const prelude = match[1] ?? "";
+    const lines = prelude.split("\n").filter((line) => line.trim() !== "");
+    if (lines.length === 0 || !lines.every((line) => /^\S/.test(line))) continue;
+    rules.push({
+      selectors: prelude
+        .split(",")
+        .map((selector) => selector.trim())
+        .filter(Boolean),
+      body: match[2] ?? "",
+    });
+  }
+  return rules;
+}
+
+/** Split on top-level spaces — `max(1rem, env(safe-area-inset-top))` is ONE. */
+function splitBoxValue(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const character of value) {
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    if (character === " " && depth === 0) {
+      if (current) parts.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
+/**
+ * Box shorthands expand to their longhands, so the fold compares what the box
+ * model RESOLVES to rather than which spelling got there.
+ *
+ * Not cosmetic. `.links-modal-close` reached its margin as `margin: -0.6rem 0`
+ * in one rule and `margin-right: -0.5rem` in a second — the same four values
+ * the other nine × rules spell in a single shorthand. And the two backdrop
+ * geometries spell the same edges as `inset: 0` and as `left/right/top: 0`.
+ * Left unexpanded, the pin would call an identical box a difference, and would
+ * miss a real one hidden under a different spelling.
+ */
+function declarations(body: string): [string, string][] {
+  return body
+    .split(";")
+    .map((declaration) => declaration.trim())
+    .filter(Boolean)
+    .flatMap((declaration): [string, string][] => {
+      const colon = declaration.indexOf(":");
+      const property = declaration.slice(0, colon).trim();
+      const value = declaration
+        .slice(colon + 1)
+        .trim()
+        .replace(/\s+/g, " ");
+      const edges =
+        property === "inset"
+          ? ["top", "right", "bottom", "left"]
+          : property === "margin" || property === "padding"
+            ? [`${property}-top`, `${property}-right`, `${property}-bottom`, `${property}-left`]
+            : null;
+      if (edges === null) return [[property, value]];
+      const [top, right = top, bottom = top, left = right] = splitBoxValue(value);
+      return [top, right, bottom, left].map(
+        (edge, index) => [edges[index] as string, edge as string] as [string, string],
+      );
+    });
+}
+
+/**
+ * Fold every rule matching one of `classes` into a single property→value map,
+ * in source order, then the `:hover` pass on top.
+ *
+ * Source order alone is the right fold ONLY because every rule that reaches a
+ * site is a bare single-class selector — all (0,1,0), all (0,2,0) hovered — so
+ * nothing out-specifies anything. That premise is not assumed, it is asserted.
+ */
+function resolve(classes: string[]): {
+  rest: Record<string, string>;
+  hover: Record<string, string>;
+} {
+  const rules = topLevelRules();
+  const bare = new Set(classes.map((name) => `.${name}`));
+  const hovered = new Set(classes.map((name) => `.${name}:hover`));
+  const rest: Record<string, string> = {};
+  for (const rule of rules) {
+    if (!rule.selectors.some((selector) => bare.has(selector))) continue;
+    for (const [property, value] of declarations(rule.body)) rest[property] = value;
+  }
+  const hover = { ...rest };
+  for (const rule of rules) {
+    if (!rule.selectors.some((selector) => hovered.has(selector))) continue;
+    for (const [property, value] of declarations(rule.body)) hover[property] = value;
+  }
+  return { rest, hover };
+}
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.name.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+/**
+ * The class list each call site actually wears, read off the markup rather
+ * than assumed — the extraction moves paint onto a base class the elements
+ * have to be given, and a typo there is silent in CSS.
+ */
+function callSiteClassLists(): Map<string, { files: string[]; classList: string[] }> {
+  const found = new Map<string, { files: string[]; classList: string[] }>();
+  for (const file of tsxFiles("src")) {
+    if (file.includes("__tests__")) continue;
+    for (const match of readFileSync(file, "utf8").matchAll(/class="([^"]+)"/g)) {
+      const classList = (match[1] ?? "").split(/\s+/).filter(Boolean);
+      const owned = classList.filter((name) => SITES.includes(name));
+      if (owned.length === 0) continue;
+      expect(owned, `${file}: one element wearing two site classes`).toHaveLength(1);
+      const key = owned[0] as string;
+      const seen = found.get(key);
+      if (seen) {
+        expect(seen.classList, `${key} worn with two different class lists`).toEqual(classList);
+        seen.files.push(file);
+      } else {
+        found.set(key, { files: [file], classList });
+      }
+    }
+  }
+  return found;
+}
+
+function resolveSite(name: string): {
+  rest: Record<string, string>;
+  hover: Record<string, string>;
+} {
+  const site = callSiteClassLists().get(name);
+  if (site === undefined) throw new Error(`${name} has no call site in the markup`);
+  return resolve(site.classList);
+}
+
+describe("#407 — the modal chrome extraction changes no pixel", () => {
+  it("reaches every call site through bare class selectors only", () => {
+    // The premise `resolve` folds on. A descendant selector, a media query or
+    // a second class would each out- or under-specify the base and make the
+    // source-order fold below a fiction.
+    const offenders = topLevelRules()
+      .flatMap((rule) => rule.selectors)
+      .filter((selector) => SITES.some((name) => selector.includes(`.${name}`)))
+      .filter((selector) => !/^\.[a-z0-9-]+(:hover)?$/.test(selector));
+    expect(offenders).toEqual([]);
+
+    const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+    const reachable = new Set(topLevelRules().flatMap((rule) => rule.selectors));
+    for (const name of SITES) {
+      const mentions = [...stripped.matchAll(new RegExp(`\\.${name}\\b[^,{]*`, "g"))].map((match) =>
+        (match[0] ?? "").trim(),
+      );
+      for (const mention of mentions) {
+        expect(reachable.has(mention), `.${name}: "${mention}" is not a top-level rule`).toBe(true);
+      }
+    }
+  });
+
+  it("has every call site wearing exactly the class list its pin was taken from", () => {
+    const sites = callSiteClassLists();
+    expect([...sites.keys()].sort()).toEqual([...SITES].sort());
+    expect(Object.fromEntries([...sites].map(([name, { files }]) => [name, files.sort()]))).toEqual(
+      CALL_SITES,
+    );
+  });
+
+  it.each(CLOSE_SITES)("%s resolves to the one × shape", (name) => {
+    expect(resolveSite(name)).toEqual(CLOSE);
+  });
+
+  it.each(BACKDROP_VIEWPORT_SITES)("%s resolves to the one keyboard-aware scrim", (name) => {
+    expect(resolveSite(name)).toEqual(BACKDROP_VIEWPORT);
+  });
+
+  it.each(BACKDROP_FULL_SITES)("%s resolves to the one layout-viewport scrim", (name) => {
+    expect(resolveSite(name)).toEqual(BACKDROP_FULL);
+  });
+
+  it("keeps the two scrim geometries distinct rather than flattening them", () => {
+    // The divergence is real and deliberate: #143 shrank the info modals'
+    // backdrop to the VISIBLE region so the iOS keyboard cannot park the modal
+    // under itself. The three below never got that treatment. Silently
+    // upgrading them here would be a pixel change wearing an extraction's
+    // clothes, so each geometry is a named variant and neither is the default.
+    expect(Object.keys(BACKDROP_VIEWPORT.rest)).not.toContain("bottom");
+    expect(Object.keys(BACKDROP_FULL.rest)).not.toContain("height");
+    expect(Object.keys(BACKDROP_FULL.rest)).not.toContain("padding-top");
+  });
+});
+
+/** Which files wear each site class. A modal losing its × would show up here. */
+const CALL_SITES: Record<string, string[]> = {
+  "banlist-modal-backdrop": ["src/BanlistModal.tsx"],
+  "banlist-modal-close": ["src/BanlistModal.tsx"],
+  "confirm-modal-backdrop": ["src/ConfirmModal.tsx"],
+  "delete-account-backdrop": ["src/DeleteAccountModal.tsx"],
+  "image-upload-modal-backdrop": ["src/PrivacyModal.tsx"],
+  "links-modal-backdrop": ["src/LinksModal.tsx"],
+  "links-modal-close": ["src/LinksModal.tsx"],
+  "mode-modal-backdrop": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
+  "mode-modal-close": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
+  "names-modal-backdrop": ["src/NamesModal.tsx"],
+  "names-modal-close": ["src/NamesModal.tsx"],
+  "recover-modal-backdrop": ["src/RecoverModal.tsx"],
+  "recover-modal-close": ["src/RecoverModal.tsx"],
+  "registration-wizard-backdrop": ["src/RegistrationWizardModal.tsx"],
+  "registration-wizard-close": ["src/RegistrationWizardModal.tsx"],
+  "server-reply-modal-backdrop": ["src/ServerReplyModal.tsx"],
+  "server-reply-modal-close": ["src/ServerReplyModal.tsx"],
+  "service-modal-backdrop": ["src/ServiceModal.tsx"],
+  "service-modal-close": ["src/ServiceModal.tsx"],
+  "share-modal-backdrop": ["src/ShareSessionModal.tsx"],
+  "share-modal-close": ["src/ShareSessionModal.tsx"],
+  "who-modal-backdrop": ["src/WhoModal.tsx"],
+  "who-modal-close": ["src/WhoModal.tsx"],
+};
+
+// The three shapes, transcribed from the stylesheet at 6e81170. That all ten
+// × sites already resolved to ONE of them, character for character, is not an
+// assumption in this file — it is what the ten assertions above measured
+// BEFORE any base class existed. Their surviving the extraction unchanged is
+// the whole claim.
+
+const CLOSE = {
+  rest: {
+    display: "inline-flex",
+    "align-items": "center",
+    "justify-content": "center",
+    "min-width": "var(--tap-min)",
+    "min-height": "var(--tap-min)",
+    "margin-top": "-0.6rem",
+    "margin-right": "-0.5rem",
+    "margin-bottom": "-0.6rem",
+    "margin-left": "0",
+    "padding-top": "0",
+    "padding-right": "0",
+    "padding-bottom": "0",
+    "padding-left": "0",
+    background: "transparent",
+    color: "var(--muted)",
+    border: "none",
+    "font-family": "var(--font-mono)",
+    "font-size": "1.5rem",
+    "line-height": "1",
+    cursor: "pointer",
+  },
+  hover: {
+    display: "inline-flex",
+    "align-items": "center",
+    "justify-content": "center",
+    "min-width": "var(--tap-min)",
+    "min-height": "var(--tap-min)",
+    "margin-top": "-0.6rem",
+    "margin-right": "-0.5rem",
+    "margin-bottom": "-0.6rem",
+    "margin-left": "0",
+    "padding-top": "0",
+    "padding-right": "0",
+    "padding-bottom": "0",
+    "padding-left": "0",
+    background: "transparent",
+    color: "var(--fg)",
+    border: "none",
+    "font-family": "var(--font-mono)",
+    "font-size": "1.5rem",
+    "line-height": "1",
+    cursor: "pointer",
+  },
+};
+
+const BACKDROP_VIEWPORT_REST = {
+  position: "fixed",
+  left: "0",
+  right: "0",
+  top: "0",
+  height: "var(--viewport-height, 100dvh)",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
+  "padding-top": "max(1rem, env(safe-area-inset-top))",
+  "padding-right": "1rem",
+  "padding-bottom": "max(1.5rem, env(safe-area-inset-bottom))",
+  "padding-left": "1rem",
+};
+
+const BACKDROP_FULL_REST = {
+  position: "fixed",
+  top: "0",
+  right: "0",
+  bottom: "0",
+  left: "0",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
+};
+
+// A scrim has no hover affordance, and the extraction must not hand it one.
+const BACKDROP_VIEWPORT = { rest: BACKDROP_VIEWPORT_REST, hover: BACKDROP_VIEWPORT_REST };
+const BACKDROP_FULL = { rest: BACKDROP_FULL_REST, hover: BACKDROP_FULL_REST };

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -221,6 +221,39 @@ function resolveSite(name: string): {
   return resolve(site.classList);
 }
 
+/** Every bare class in the sheet whose own rules resolve to exactly `shape`. */
+function classesResolvingTo(shape: Record<string, string>): string[] {
+  const names = new Set(
+    topLevelRules()
+      .flatMap((rule) => rule.selectors)
+      .filter((selector) => /^\.[a-z0-9-]+$/.test(selector))
+      .map((selector) => selector.slice(1)),
+  );
+  return [...names]
+    .filter((name) => {
+      const { rest } = resolve([name]);
+      const keys = Object.keys(rest);
+      return (
+        keys.length === Object.keys(shape).length && keys.every((key) => rest[key] === shape[key])
+      );
+    })
+    .sort();
+}
+
+/** Every element in the markup wearing the scrim base, as [file, classList]. */
+function backdropElements(): [string, string[]][] {
+  const found: [string, string[]][] = [];
+  for (const file of tsxFiles("src")) {
+    if (file.includes("__tests__")) continue;
+    for (const match of readFileSync(file, "utf8").matchAll(/class="([^"]+)"/g)) {
+      const classList = (match[1] ?? "").split(/\s+/).filter(Boolean);
+      if (classList.includes("modal-backdrop")) found.push([file, classList]);
+    }
+  }
+  expect(found.length, "no element wears .modal-backdrop").toBeGreaterThan(0);
+  return found;
+}
+
 describe("#407 — the modal chrome extraction changes no pixel", () => {
   it("reaches every call site through bare class selectors only", () => {
     // The premise `resolve` folds on. A descendant selector, a media query or
@@ -266,6 +299,28 @@ describe("#407 — the modal chrome extraction changes no pixel", () => {
 
   it.each(BACKDROP_FULL_SITES)("%s resolves to the one layout-viewport scrim", (name) => {
     expect(resolveSite(name)).toEqual(BACKDROP_FULL);
+  });
+
+  it("leaves no rule outside the bases carrying a base's whole shape", () => {
+    // The #740 failure mode: the shared rule lands, the clones stay beside it,
+    // and the next control is copied from whichever was nearer. Keyed on the
+    // WHOLE resolved shape rather than a few marker properties — a control
+    // that genuinely differs (`.links-modal-zoom`, two properties apart) is
+    // not a clone and must not be carved out by an exclusion list.
+    expect(classesResolvingTo(CLOSE.rest)).toEqual(["modal-chrome-button"]);
+    expect(classesResolvingTo(BACKDROP_BASE)).toEqual(["modal-backdrop"]);
+  });
+
+  it("gives every scrim exactly one geometry", () => {
+    // `.modal-backdrop` declares no bottom and no height on purpose, so a
+    // scrim that reaches the markup without a geometry variant is an
+    // invisible zero-height box — silent in CSS, and silent in a unit test
+    // that only checks the classes it expects to find.
+    const geometries = ["modal-backdrop-full", "modal-backdrop-viewport"];
+    for (const [file, classList] of backdropElements()) {
+      const worn = classList.filter((name) => geometries.includes(name));
+      expect(worn, `${file}: ${classList.join(" ")}`).toHaveLength(1);
+    }
   });
 
   it("keeps the two scrim geometries distinct rather than flattening them", () => {
@@ -369,6 +424,21 @@ const ZOOM_DELTA = { "margin-right": "0", "font-size": "1.4rem" };
 const ZOOM = {
   rest: { ...CLOSE.rest, ...ZOOM_DELTA },
   hover: { ...CLOSE.hover, ...ZOOM_DELTA },
+};
+
+// What `.modal-backdrop` declares on its own: paint and centring, no geometry.
+// Spelled out rather than derived from the two maps below, so the clone guard
+// keeps working off a transcription of the stylesheet and not off itself.
+const BACKDROP_BASE = {
+  position: "fixed",
+  left: "0",
+  right: "0",
+  top: "0",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
 };
 
 const BACKDROP_VIEWPORT_REST = {

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -12,8 +12,8 @@ import { themeCss } from "./helpers/themeCss";
 //
 // An extraction is a promise not to change any pixel, so the guard is not
 // "a base rule exists" — it is that the DECLARATIONS every call site resolves
-// to are byte-for-byte what they were before the base existed. The three maps
-// at the foot of this file were transcribed from the stylesheet as it stood at
+// to are byte-for-byte what they were before the base existed. The maps at the
+// foot of this file were transcribed from the stylesheet as it stood at
 // 6e81170 (origin/main, pre-extraction) and must survive it unchanged.
 //
 // jsdom applies no stylesheet, so this reads the source. It proves what the
@@ -33,6 +33,14 @@ const CLOSE_SITES = [
   "share-modal-close",
   "who-modal-close",
 ];
+
+/**
+ * Not a ×, but the same chrome shape: the links modal's zoom controls sit in
+ * the same header row and were cut from the same block, two properties apart.
+ * They are in the census because leaving them out would leave one 14-line copy
+ * of the base standing next to the base — the very thing #407 is removing.
+ */
+const CHROME_SITES = ["links-modal-zoom"];
 
 /** Scrims that #143 shrank to the visible region so the iOS keyboard fits. */
 const BACKDROP_VIEWPORT_SITES = [
@@ -55,7 +63,7 @@ const BACKDROP_FULL_SITES = [
   "image-upload-modal-backdrop",
 ];
 
-const SITES = [...CLOSE_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
+const SITES = [...CLOSE_SITES, ...CHROME_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
 
 type Rule = { selectors: string[]; body: string };
 
@@ -195,7 +203,7 @@ function callSiteClassLists(): Map<string, { files: string[]; classList: string[
       const seen = found.get(key);
       if (seen) {
         expect(seen.classList, `${key} worn with two different class lists`).toEqual(classList);
-        seen.files.push(file);
+        if (!seen.files.includes(file)) seen.files.push(file);
       } else {
         found.set(key, { files: [file], classList });
       }
@@ -248,6 +256,10 @@ describe("#407 — the modal chrome extraction changes no pixel", () => {
     expect(resolveSite(name)).toEqual(CLOSE);
   });
 
+  it.each(CHROME_SITES)("%s resolves to the × shape and exactly two deltas", (name) => {
+    expect(resolveSite(name)).toEqual(ZOOM);
+  });
+
   it.each(BACKDROP_VIEWPORT_SITES)("%s resolves to the one keyboard-aware scrim", (name) => {
     expect(resolveSite(name)).toEqual(BACKDROP_VIEWPORT);
   });
@@ -277,6 +289,7 @@ const CALL_SITES: Record<string, string[]> = {
   "image-upload-modal-backdrop": ["src/PrivacyModal.tsx"],
   "links-modal-backdrop": ["src/LinksModal.tsx"],
   "links-modal-close": ["src/LinksModal.tsx"],
+  "links-modal-zoom": ["src/LinksModal.tsx"],
   "mode-modal-backdrop": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
   "mode-modal-close": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
   "names-modal-backdrop": ["src/NamesModal.tsx"],
@@ -346,6 +359,16 @@ const CLOSE = {
     "line-height": "1",
     cursor: "pointer",
   },
+};
+
+// Spelled as the × shape plus its overrides, because that IS the finding: the
+// zoom control differs from the ten × buttons in two properties out of twenty.
+// Written out longhand instead, a later drift in a shared property would read
+// as an intended difference.
+const ZOOM_DELTA = { "margin-right": "0", "font-size": "1.4rem" };
+const ZOOM = {
+  rest: { ...CLOSE.rest, ...ZOOM_DELTA },
+  hover: { ...CLOSE.hover, ...ZOOM_DELTA },
 };
 
 const BACKDROP_VIEWPORT_REST = {

--- a/cicchetto/src/lib/menuPosition.test.ts
+++ b/cicchetto/src/lib/menuPosition.test.ts
@@ -9,41 +9,93 @@ import { computeMenuPosition, placeAxis, spaceAbove } from "./menuPosition";
 // (issue487-context-menu-viewport-clamp.spec.ts); these tests pin the
 // flip/clamp arithmetic.
 //
-// placeAxis is the 1D primitive applied independently to X and Y:
+// placeAxis is the 1D primitive applied independently to X and Y, over a
+// half-open interval [start, end) rather than [0, viewport):
 //   * fits after the click         → keep the click coord (open down/right)
 //   * overflows the far edge        → FLIP before the click (open up/left,
 //                                     pointer stays on the menu edge)
-//   * flip would underflow origin   → CLAMP to the last fully-visible coord
-//   * menu bigger than the viewport → pin to 0 (CSS max-height + scroll)
+//   * flip would underflow `start`  → CLAMP to the last fully-visible coord
+//   * menu bigger than the interval → pin to `start` (CSS max-height + scroll)
+//
+// #949 — the interval used to be hardcoded to [0, viewport). Zero is the
+// LAYOUT viewport origin, which under `viewport-fit=cover` (index.html) is the
+// physical top of the display, behind the status bar; `viewport` is likewise
+// the physical bottom, behind the home indicator. Both pins addressed occluded
+// coordinates. The bounds are now supplied by the caller, which reads them off
+// a fixed `inset: env(safe-area-inset-*)` frame — see ContextMenu.tsx.
 
 describe("placeAxis (1D flip/clamp primitive)", () => {
   it("keeps the click coord when the menu fits after it", () => {
-    expect(placeAxis(100, 120, 1000)).toBe(100);
+    expect(placeAxis(100, 120, 0, 1000)).toBe(100);
   });
 
   it("flips before the click point when the menu overflows the far edge", () => {
-    // click 950, menu 120, viewport 1000 → 1070 > 1000 → flip: 950 - 120
-    expect(placeAxis(950, 120, 1000)).toBe(830);
+    // click 950, menu 120, end 1000 → 1070 > 1000 → flip: 950 - 120
+    expect(placeAxis(950, 120, 0, 1000)).toBe(830);
   });
 
   it("keeps a click that lands exactly at the far edge", () => {
-    // click 880, menu 120, viewport 1000 → 880 + 120 == 1000 → fits, no flip
-    expect(placeAxis(880, 120, 1000)).toBe(880);
+    // click 880, menu 120, end 1000 → 880 + 120 == 1000 → fits, no flip
+    expect(placeAxis(880, 120, 0, 1000)).toBe(880);
   });
 
-  it("clamps to fully-visible when a flip would underflow the origin", () => {
-    // click 100, menu 180, viewport 200 → overflow (280>200) AND menu fits
-    // (180<200); flip 100-180=-80 < 0 → clamp to viewport-size = 20
-    expect(placeAxis(100, 180, 200)).toBe(20);
+  it("clamps to fully-visible when a flip would underflow the interval start", () => {
+    // click 100, menu 180, [0,200) → overflow (280>200) AND menu fits
+    // (180<200); flip 100-180=-80 < 0 → clamp to end-size = 20
+    expect(placeAxis(100, 180, 0, 200)).toBe(20);
   });
 
-  it("pins to the edge when the menu is taller/wider than the viewport", () => {
-    expect(placeAxis(150, 300, 200)).toBe(0);
-    expect(placeAxis(150, 200, 200)).toBe(0); // equal counts as oversized
+  it("pins to the interval start when the menu is bigger than the interval", () => {
+    expect(placeAxis(150, 300, 0, 200)).toBe(0);
+    expect(placeAxis(150, 200, 0, 200)).toBe(0); // equal counts as oversized
+  });
+
+  // #949 — the four cases above with a non-zero `start` / a pulled-in `end`.
+  // Every one of them used to answer with a coordinate inside an inset.
+
+  it("pins to the safe start, not to zero, when the menu is oversized", () => {
+    // The #913 defect at this door: an oversized menu pinned to y=0, which
+    // under viewport-fit=cover is the physical top of the display. On a
+    // notched iPhone the first row rendered behind the status bar and the
+    // menu's own overflow scroll could not bring it back — the box itself
+    // starts inside the occluded strip.
+    expect(placeAxis(150, 900, 59, 818)).toBe(59);
+  });
+
+  it("clamps a flip against the safe start, not against zero", () => {
+    // The [0,200) clamp case above, shifted into a safe [59, 259): click 100,
+    // menu 180 → 280 > 259 → flip to -80, which is below the safe START, so we
+    // clamp. The last FULLY VISIBLE origin is end-size = 79, not 20.
+    expect(placeAxis(100, 180, 59, 259)).toBe(79);
+  });
+
+  it("flips against the safe end, not against the physical bottom", () => {
+    // click 800, menu 120, safe [59, 818): 800+120=920 > 818 → flip to 680.
+    // Against the physical bottom (852) it would have "fitted" at 800 and the
+    // tail would have run under the home indicator.
+    expect(placeAxis(800, 120, 59, 818)).toBe(680);
+  });
+
+  it("never returns a coordinate before the safe start, even for a click inside the inset", () => {
+    // A press can land inside the LEFT inset in landscape (iOS does not
+    // swallow touches there the way it does under the status bar), and the
+    // menu would then open from a column the display corner is eating.
+    expect(placeAxis(10, 120, 59, 818)).toBe(59);
   });
 });
 
 describe("computeMenuPosition (both axes)", () => {
+  // A safe area equal to the full viewport: what every non-notched browser and
+  // every engine in the Playwright suite reports (env(safe-area-inset-*) → 0).
+  // Keeping the pre-#949 expectations under this shape is the point — the fix
+  // must be a NO-OP where there is no inset.
+  const noInset = (width: number, height: number) => ({
+    top: 0,
+    right: width,
+    bottom: height,
+    left: 0,
+  });
+
   it("passes through when the menu fits below-and-right of the click", () => {
     expect(
       computeMenuPosition({
@@ -53,6 +105,7 @@ describe("computeMenuPosition (both axes)", () => {
         menuHeight: 200,
         viewportWidth: 1280,
         viewportHeight: 720,
+        safeArea: noInset(1280, 720),
       }),
     ).toEqual({ left: 100, top: 200 });
   });
@@ -65,6 +118,7 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 1280,
       viewportHeight: 720,
+      safeArea: noInset(1280, 720),
     });
     expect(p.top).toBe(500); // 700 - 200
     expect(p.left).toBe(100); // X fits — unchanged
@@ -78,6 +132,7 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 1280,
       viewportHeight: 720,
+      safeArea: noInset(1280, 720),
     });
     expect(p.left).toBe(1150); // 1270 - 120
     expect(p.top).toBe(100);
@@ -92,6 +147,7 @@ describe("computeMenuPosition (both axes)", () => {
         menuHeight: 200,
         viewportWidth: 1280,
         viewportHeight: 720,
+        safeArea: noInset(1280, 720),
       }),
     ).toEqual({ left: 1156, top: 516 });
   });
@@ -105,8 +161,96 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 390,
       viewportHeight: 180,
+      safeArea: noInset(390, 180),
     });
     expect(p.top).toBe(0);
+  });
+
+  // #949 — a portrait iPhone 15 under viewport-fit=cover: 393×852 layout
+  // viewport, 59px status-bar inset at the top, 34px home-indicator inset at
+  // the bottom. The safe box is therefore [59, 818) on Y and [0, 393) on X.
+  const iphone15Portrait = { top: 59, right: 393, bottom: 818, left: 0 };
+
+  it("keeps an oversized menu clear of the status bar instead of pinning to y=0", () => {
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 400,
+      menuWidth: 200,
+      menuHeight: 900,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(59);
+  });
+
+  it("keeps a bottom-edge flip clear of the home indicator", () => {
+    // Against the physical bottom (852) the menu "fits" at y=800 and its tail
+    // runs into the home-indicator strip. Against the safe bottom (818) it
+    // flips to 800-120=680.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 800,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(680);
+  });
+
+  it("respects the side insets in landscape, where the notch eats a column", () => {
+    // Landscape iPhone: 852×393, notch on the leading edge → 59px left inset,
+    // 59px right inset, 21px bottom. Safe box: X [59, 793), Y [0, 372).
+    const p = computeMenuPosition({
+      clickX: 700,
+      clickY: 100,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 852,
+      viewportHeight: 393,
+      safeArea: { top: 0, right: 793, bottom: 372, left: 59 },
+    });
+    // 700 + 200 = 900 > 793 → flip to 500. Against the physical width (852)
+    // it would have "fitted" at 700 and run under the rounded corner.
+    expect(p.left).toBe(500);
+  });
+
+  // The keyboard-up case is where the VISUAL viewport and the safe-area frame
+  // disagree, and the placement has to take whichever bound is tighter. The
+  // frame is laid out against the LAYOUT viewport, which iOS does NOT shrink
+  // for the on-screen keyboard; `viewportHeight` (visualViewport.height) is
+  // what shrinks. Both are measured from the same origin, so they compose as a
+  // plain min/max — see the note in computeMenuPosition.
+  it("takes the visual viewport's bottom when the keyboard has pulled it above the safe bottom", () => {
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 400,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 393,
+      viewportHeight: 516, // keyboard up: 852 - ~336
+      safeArea: iphone15Portrait, // bottom still 818, the keyboard is not an inset
+    });
+    // 400 + 120 = 520 > 516 → flip to 280. Trusting the 818 safe bottom would
+    // have left the menu under the keyboard — the #487 symptom.
+    expect(p.top).toBe(280);
+  });
+
+  it("keeps the safe TOP even when the visual viewport is the tighter bottom", () => {
+    // Both bounds bite at once: the keyboard caps the bottom at 516 and the
+    // status bar the top at 59, and a 600px menu fits neither.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 300,
+      menuWidth: 200,
+      menuHeight: 600,
+      viewportWidth: 393,
+      viewportHeight: 516,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(59);
   });
 });
 

--- a/cicchetto/src/lib/menuPosition.ts
+++ b/cicchetto/src/lib/menuPosition.ts
@@ -5,15 +5,28 @@
 // (issue487-context-menu-viewport-clamp.spec.ts). jsdom returns 0-sized rects,
 // so a jsdom placement test would be hollow — hence the seam.
 //
-// placeAxis is the 1D primitive, applied independently to X and Y:
+// placeAxis is the 1D primitive, applied independently to X and Y, over the
+// half-open interval [start, end):
 //   * fits after the click          → keep the click coord (menu opens down/right)
 //   * overflows the far edge         → FLIP before the click (menu opens up/left),
 //                                      keeping the pointer on the menu edge like a
 //                                      native context menu
-//   * flip would underflow origin    → CLAMP to the last fully-visible coord (menu
+//   * flip would underflow `start`   → CLAMP to the last fully-visible coord (menu
 //                                      slides off the cursor but stays whole)
-//   * menu bigger than the viewport  → pin to 0 and let the CSS max-height +
+//   * menu bigger than the interval  → pin to `start` and let the CSS max-height +
 //                                      overflow-y:auto scroll the overflow
+//
+// #949 — that interval used to be hardcoded [0, viewport). Under
+// `viewport-fit=cover` (index.html) 0 is the PHYSICAL top of the display, so
+// the oversize pin put the first row behind the status bar, and `viewport` is
+// the physical bottom, so a flip could tuck the tail under the home indicator
+// (in landscape, the same on X against the notch/rounded corners). Both edges
+// carried the #913 defect at a different door. The interval is now the
+// caller's, taken from a fixed `inset: env(safe-area-inset-*)` frame the
+// engine lays out — see ContextMenu.tsx for why that frame, and not a JS read
+// of `env()`, is the seam.
+
+export type SafeArea = { top: number; right: number; bottom: number; left: number };
 
 export type MenuMeasurement = {
   clickX: number;
@@ -22,21 +35,44 @@ export type MenuMeasurement = {
   menuHeight: number;
   viewportWidth: number;
   viewportHeight: number;
+  safeArea: SafeArea;
 };
 
 export type MenuPlacement = { left: number; top: number };
 
-export function placeAxis(click: number, size: number, viewport: number): number {
-  if (size >= viewport) return 0;
-  if (click + size <= viewport) return click;
+export function placeAxis(click: number, size: number, start: number, end: number): number {
+  if (size >= end - start) return start;
+  if (click + size <= end) return Math.max(click, start);
   const flipped = click - size;
-  return flipped >= 0 ? flipped : viewport - size;
+  return flipped >= start ? flipped : end - size;
 }
 
+// The two bounds come from different places and both can bite:
+//   * `safeArea` is a laid-out box, so its edges are LAYOUT-viewport
+//     coordinates — it knows the notch, and does NOT know the keyboard (iOS
+//     never shrinks the layout viewport for it).
+//   * `viewport{Width,Height}` is the VISUAL viewport, which knows the
+//     keyboard and not the notch. #487 chose it deliberately: `innerHeight`
+//     stays full-screen with the keyboard up and would let the menu render
+//     underneath it.
+// They compose as a plain `min` because both are measured from the layout
+// viewport's origin — true while `visualViewport.offsetTop/Left` are 0, which
+// holds for this non-scrolling, non-zoomable app shell. A pinch-zoomed page
+// would need the offsets added in; the pre-#949 code made the same assumption.
 export function computeMenuPosition(m: MenuMeasurement): MenuPlacement {
   return {
-    left: placeAxis(m.clickX, m.menuWidth, m.viewportWidth),
-    top: placeAxis(m.clickY, m.menuHeight, m.viewportHeight),
+    left: placeAxis(
+      m.clickX,
+      m.menuWidth,
+      m.safeArea.left,
+      Math.min(m.viewportWidth, m.safeArea.right),
+    ),
+    top: placeAxis(
+      m.clickY,
+      m.menuHeight,
+      m.safeArea.top,
+      Math.min(m.viewportHeight, m.safeArea.bottom),
+    ),
   };
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3565,17 +3565,112 @@ html.resize-dragging * {
   flex-shrink: 0;
 }
 
-/* Privacy modal — full-viewport backdrop + centred dialog. */
+/* ------------------------------------------------------------------ *
+ * Shared modal chrome (#407)
+ *
+ * The quiet button in a dialog header and the dim scrim behind the
+ * dialog, each declared once. Both were reached by copying a rule — ten
+ * `*-close` blocks and thirteen `*-backdrop` blocks — so a tap-target or
+ * safe-area fix landed on whichever modal someone had open and left the
+ * rest behind.
+ *
+ * Named for the SHAPE, not the role: eleven controls wear it and one of
+ * them is the links modal's zoom, not a ×. Calling the base
+ * `.modal-close` would have made that one keep its own fourteen-line
+ * copy, which is the defect. Same reasoning as #740's
+ * `.login-quiet-button`.
+ *
+ * Worn BESIDE the per-instance class (`class="modal-chrome-button
+ * share-modal-close"`), also the #740 convention: the base carries the
+ * paint, the per-instance name stays a selector contract for tests and
+ * e2e and a home for any real delta. `modalChrome.test.ts` pins what
+ * each site resolves to and holds the clones out.
+ * ------------------------------------------------------------------ */
 
-.image-upload-modal-backdrop {
+.modal-chrome-button {
+  /* #143 — 44px Apple-HIG tap target, matching the #133 card-× precedent
+     (`.whois-card-close` et al). Negative block margins pull the tall hit
+     box back out of the header row so the title stays vertically compact
+     (margins don't shrink the pointer target). The inline-end pull is for
+     the LAST control in the row; one that is not overrides it. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
+  margin: -0.6rem -0.5rem -0.6rem 0;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.modal-chrome-button:hover {
+  color: var(--fg);
+}
+
+/* The scrim's paint and centring — but NOT its geometry. Every
+   `.modal-backdrop` must also wear exactly one of the two variants below;
+   on its own this rule is a zero-height box, which is deliberate. The two
+   geometries are a real divergence, so neither gets to be the default
+   nobody notices they inherited. */
+.modal-backdrop {
   position: fixed;
-  inset: 0;
+  left: 0;
+  right: 0;
+  top: 0;
   background: rgba(0, 0, 0, 0.6);
+  /* #987 — `center`, not `stretch`. On a flex backdrop `stretch` forces the
+     child to the full cross-axis extent, so the modal was viewport-tall
+     whatever it held and its own `max-height: var(--viewport-height)` read
+     like a cap that never bit: the box was already at that height because
+     the backdrop had put it there. Centred, the box sizes to content, the
+     max-height becomes a real ceiling, and the `overflow-y: auto` +
+     `touch-action: pan-y` already on the modal start earning their keep in
+     the tall case (large text, keyboard up) instead of being dead weight in
+     the short one. */
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
 }
+
+/* Spans the LAYOUT viewport — the pre-#143 geometry. With the iOS keyboard
+   up the visible region is shorter than the layout viewport, so a centred
+   modal can end up partly under the keyboard. Named as its own variant
+   rather than quietly upgraded to the one below: that would move pixels,
+   and #407 is an extraction. */
+.modal-backdrop-full {
+  bottom: 0;
+}
+
+/* #143 — spans only the VISIBLE region (the same keyboard-aware var the
+   modal caps its max-height on), so `align-items: center` centres within
+   what the user can see. Across the layout viewport the backdrop filled the
+   full height while the visible region (visualViewport.height) is shorter
+   when the iOS keyboard is up — parking the modal's lower half under the
+   keyboard. No offsetTop anchor is needed: UX-6-D's `installSmartScrollPin`
+   clamps `vv.offsetTop`→0 (offsetTop is WebKit-broken, #297779; the
+   `translateY(offsetTop)` cancel failed across D6/D8 — see DESIGN_NOTES
+   2026-05-21 UX-6-D).
+
+   The padding is #143's safe-area inset, mirroring `.settings-drawer`
+   (~:1702). The backdrop spans the full visible region, so a full-height
+   modal would otherwise tuck its header under the iOS notch / status bar
+   (and the home indicator at the bottom). `max()` keeps the plain 1rem
+   /1.5rem padding on non-notched devices where the env() insets are 0.
+   With `align-items: center` a short modal stays centred; a full-height
+   one shrinks to the padding box and lands between the safe areas. */
+.modal-backdrop-viewport {
+  height: var(--viewport-height, 100dvh);
+  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
+}
+
+/* Privacy modal — full-viewport backdrop + centred dialog. */
 
 .image-upload-modal {
   background: var(--bg);
@@ -4108,24 +4203,6 @@ html.resize-dragging * {
 /* #157 — delete-account confirm modal (type-your-name irreversibility
    gate). Mirrors the archive-modal scaffold; red-bordered to signal the
    destructive context. */
-.delete-account-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  /* #987 — `center`, not `stretch`. On a flex backdrop `stretch` forces the
-     child to the full cross-axis extent, so the modal was viewport-tall
-     whatever it held and its own `max-height: var(--viewport-height)` read
-     like a cap that never bit: the box was already at that height because the
-     backdrop had put it there. Centred, the box sizes to content, the
-     max-height becomes a real ceiling, and the `overflow-y: auto` +
-     `touch-action: pan-y` already on the modal start earning their keep in the
-     tall case (large text, keyboard up) instead of being dead weight in the
-     short one. `.confirm-modal-backdrop` (~:3878) has always had this. */
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
 
 .delete-account-modal {
   background: var(--bg);
@@ -4221,15 +4298,6 @@ html.resize-dragging * {
    channel, disconnect network). Replaces the removed #172 hold-to-close
    gesture. Centered dialog over a dim scrim; structure mirrors
    .delete-account-* (the closest existing confirm modal). */
-.confirm-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
 
 .confirm-modal {
   background: var(--bg);
@@ -7167,38 +7235,6 @@ html.resize-dragging * {
    close button) but pins header + footer and scrolls only the body so
    the "#channel — N people" heading + "End of /NAMES list" count stay
    visible on large channels. */
-.names-modal-backdrop,
-.who-modal-backdrop,
-.links-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  /* #143 — span only the VISIBLE region (same keyboard-aware var the
-     modal caps its max-height on) instead of `inset: 0`, so
-     `align-items: center` centers within what the user can see. With
-     `inset: 0` the backdrop filled the full LAYOUT viewport while the
-     visible region (visualViewport.height) is shorter when the iOS
-     keyboard is up — parking the modal's lower half under the keyboard.
-     No offsetTop anchor is needed: UX-6-D's `installSmartScrollPin`
-     clamps `vv.offsetTop`→0 (offsetTop is WebKit-broken, #297779; the
-     `translateY(offsetTop)` cancel failed across D6/D8 — see
-     DESIGN_NOTES 2026-05-21 UX-6-D). */
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  /* #143 — safe-area insets, mirroring `.settings-drawer` (~:1702). The
-     backdrop spans the full visible region, so a full-height modal would
-     otherwise tuck its header under the iOS notch / status bar at the top
-     (and the home indicator at the bottom). `max()` keeps the plain 1rem
-     /1.5rem padding on non-notched devices where the env() insets are 0.
-     With `align-items: center` a short modal stays centred; a full-height
-     one shrinks to the padding box and lands between the safe areas. */
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .names-modal,
 .who-modal {
@@ -7236,33 +7272,6 @@ html.resize-dragging * {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.names-modal-close,
-.who-modal-close {
-  /* #143 — 44px Apple-HIG tap target, matching the #133 card-× precedent
-     (`.whois-card-close` et al). Negative block margins pull the tall
-     hit box back out of the header row so the title stays vertically
-     compact (margins don't shrink the pointer target). */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.names-modal-close:hover,
-.who-modal-close:hover {
-  color: var(--fg);
 }
 
 .names-modal-body,
@@ -7539,32 +7548,12 @@ html.resize-dragging * {
   flex: 0 0 auto;
 }
 
-.links-modal-zoom,
-.links-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
+/* The zoom pair is not the last control in the header row, so it does not
+   take the base's inline-end pull; its glyphs also sit a notch smaller than
+   the close button. Everything else is `.modal-chrome-button`. */
+.links-modal-zoom {
+  margin-right: 0;
   font-size: 1.4rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.links-modal-close {
-  margin-right: -0.5rem;
-  font-size: 1.5rem;
-}
-
-.links-modal-zoom:hover,
-.links-modal-close:hover {
-  color: var(--fg);
 }
 
 .links-modal-body {
@@ -7803,20 +7792,6 @@ html.resize-dragging * {
  * gradients (vjt: "a bit retro, but not skeuomorphic"). Theme-safe: only
  * existing --tokens, no new colors. */
 
-.mode-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
-
 .mode-modal {
   background: var(--bg);
   color: var(--fg);
@@ -7860,27 +7835,6 @@ html.resize-dragging * {
   text-transform: none;
   letter-spacing: normal;
   font-size: 0.85rem;
-}
-
-.mode-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.mode-modal-close:hover {
-  color: var(--fg);
 }
 
 .mode-modal-body {
@@ -8716,19 +8670,6 @@ html.resize-dragging * {
  * lines, a phosphor accent on the header sigil + a blinking block cursor in
  * the footer — a 2026 nod to classic-IRC MOTD/INFO screens. Theme-safe: all
  * colors come from the existing CSS vars, so it inherits every theme. */
-.server-reply-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .server-reply-modal {
   background: var(--bg);
@@ -8771,27 +8712,6 @@ html.resize-dragging * {
 .server-reply-modal-sigil {
   color: var(--link, var(--fg));
   margin-right: 0.5rem;
-}
-
-.server-reply-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.server-reply-modal-close:hover {
-  color: var(--fg);
 }
 
 .server-reply-modal-body {
@@ -8849,19 +8769,6 @@ html.resize-dragging * {
  * a leading phosphor `>` sigil + a borderless mono input, so the modal reads
  * as a confined terminal console for the service. Theme-safe: all colors come
  * from the existing CSS vars. */
-.service-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .service-modal {
   background: var(--bg);
@@ -8904,27 +8811,6 @@ html.resize-dragging * {
 .service-modal-sigil {
   color: var(--link, var(--fg));
   margin-right: 0.5rem;
-}
-
-.service-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.service-modal-close:hover {
-  color: var(--fg);
 }
 
 .service-modal-body {
@@ -9010,19 +8896,6 @@ html.resize-dragging * {
  * services console (backdrop scrim, pinned header, scrollable body) but
  * step-driven: an intro/email/password/register/code/verify sequence with
  * a Back/Retry/Next footer. Theme-safe — all colors from CSS vars. */
-.registration-wizard-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .registration-wizard {
   background: var(--bg);
@@ -9060,27 +8933,6 @@ html.resize-dragging * {
 
 .registration-wizard-sigil {
   margin-right: 0.5rem;
-}
-
-.registration-wizard-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.registration-wizard-close:hover {
-  color: var(--fg);
 }
 
 .registration-wizard-steps {
@@ -9223,19 +9075,6 @@ html.resize-dragging * {
 
 /* #581 — "recover my identity" progress modal. Server-driven step list +
  * terminal outcome. Mirrors the registration-wizard / service-modal shell. */
-.recover-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .recover-modal {
   background: var(--bg);
@@ -9273,27 +9112,6 @@ html.resize-dragging * {
 
 .recover-modal-sigil {
   margin-right: 0.5rem;
-}
-
-.recover-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.recover-modal-close:hover {
-  color: var(--fg);
 }
 
 .recover-modal-body {
@@ -9883,19 +9701,6 @@ html.resize-dragging * {
    surface that supersedes the #376 inline card: list rows + a mask-builder
    add row + a per-row remove ×. The op-gate is a HINT (`.banlist-modal-deemph`
    dims but never disables — vjt decision #2). */
-.banlist-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .banlist-modal {
   background: var(--bg);
@@ -9939,27 +9744,6 @@ html.resize-dragging * {
   text-transform: none;
   letter-spacing: normal;
   font-size: 0.85rem;
-}
-
-.banlist-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.banlist-modal-close:hover {
-  color: var(--fg);
 }
 
 .banlist-modal-body {
@@ -11994,20 +11778,6 @@ audio.media-viewer-media {
   font-size: 0.85em;
 }
 
-.share-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
-
 .share-modal {
   background: var(--bg);
   color: var(--fg);
@@ -12049,27 +11819,6 @@ audio.media-viewer-media {
   font-weight: normal;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-}
-
-.share-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.share-modal-close:hover {
-  color: var(--fg);
 }
 
 .share-modal-qr-heading {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -236,6 +236,12 @@
      and the cap disappears (the #588 overflow, back). Theme-independent, so it
      lives on base :root. */
   --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  /* #949 — the bottom (home-indicator) inset, same contract, same reason: the
+     `.context-menu` height cap subtracts BOTH vertical insets from a value
+     (`--viewport-height`) that JS writes, so the subtraction has to happen in
+     CSS. Sibling of the top inset above; the `0px` fallback is load-bearing
+     for the same reason. */
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -6393,9 +6399,46 @@ html.resize-dragging * {
      flip/clamp (lib/menuPosition.ts) pins an oversized menu to the top edge;
      this caps it to the viewport height and scrolls the overflow so every
      item stays reachable. --viewport-height mirrors the mobile shell's
-     keyboard-aware height (main.tsx); 100vh is the desktop fallback. */
-  max-height: var(--viewport-height, 100vh);
+     keyboard-aware height (main.tsx); 100vh is the desktop fallback.
+     #949 — the cap has to lose BOTH vertical insets, and it has to do so
+     HERE rather than inline from JS: the placement effect measures the menu's
+     rendered height, so a cap applied after that measurement would place the
+     box against a height it no longer has. CSS caps first, JS then measures a
+     box that is already the right size — the same division of labour as
+     `.rail-actions-menu` (#913), which likewise lets the engine own `env()`.
+     Over-subtracts by the bottom inset while the keyboard is up (the home
+     indicator is behind the keyboard, so --viewport-height has already
+     excluded it): a menu shorter than it could be, never one that overflows.
+     `max(0px, …)` because a negative max-height is an ignored declaration —
+     i.e. no cap at all, which is the #487 overflow handed straight back. */
+  max-height: max(
+    0px,
+    calc(
+      var(--viewport-height, 100vh) -
+      var(--safe-area-inset-top, 0px) -
+      var(--safe-area-inset-bottom, 0px)
+    )
+  );
   overflow-y: auto;
+}
+
+/* #949 — the ruler the placement math measures (ContextMenu.tsx). Fixed, so
+   its rect is in the same layout-viewport coordinate space as the press
+   coordinates and the menu's own `position: fixed` box; inset by all four
+   safe-area values, so that rect IS the safe box. Nothing paints and nothing
+   hit-tests: `pointer-events: none` keeps it off the backdrop's click-outside,
+   and it carries no background, border or content.
+   The `0px` fallbacks are load-bearing, not defensive — an `inset` shorthand
+   with one unknown `env()` is invalid as a whole, which would collapse the
+   ruler to `auto` on every side and hand back a zero-sized rect: a safe box of
+   [0,0] on both axes, i.e. every menu pinned to the corner. With the fallbacks
+   an engine that knows no insets reports the full viewport, which is exactly
+   the pre-#949 behaviour. */
+.context-menu-safe-area {
+  position: fixed;
+  inset: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  pointer-events: none;
 }
 
 .context-menu-item {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6519,11 +6519,41 @@ html.resize-dragging * {
        (global, line 67) means the inset is consumed FROM the height,
        not added to it. */
     padding-top: env(safe-area-inset-top);
-    /* Home-indicator safe-area inset. (#177 removed the custom on-screen
-       keyboard, whose height reservation was folded in here; the native
-       keyboard shrinks the visual viewport on its own, so no extra
-       reservation is needed.) */
-    padding-bottom: env(safe-area-inset-bottom);
+    /* #1127 — the bottom edge is FLUSH: no home-indicator inset, so the
+       whole mobile shell (the `.bottom-bar` tab strip included) reaches
+       the physical bottom and the reclaimed band goes to content.
+
+       What the inset actually produced was NOT wasted padding inside the
+       bar: it lifted the shell off the bottom edge and exposed the
+       transparent area behind it. Measured on a 320x568x2 emulated
+       viewport with the iOS value injected by hand (`padding-bottom: 34px`
+       here, because desktop Chrome always reports `env()` as 0): the bar
+       ended 34px short, and `elementFromPoint` at the very bottom returned
+       `DIV.shell shell-mobile` computing to `rgba(0, 0, 0, 0)` while the
+       bar itself was `rgb(49, 50, 68)`. The accepted trade is that the tabs
+       now sit inside the home-indicator strip, where iOS also reads
+       gestures — do NOT re-add clearance to "fix" that without a ruling.
+
+       `0`, NOT a deleted declaration. Base `.shell` (~:1195) declares
+       `padding-bottom: env(safe-area-inset-bottom)` at the same
+       specificity, and the mobile element carries BOTH classes
+       (`<div class="shell shell-mobile">`), so dropping this line would
+       simply let the base rule cascade the inset back in.
+
+       This also retires the UX-6 D1/D11 keyboard collapse that used to
+       live below as `.shell-mobile:has(textarea:focus, input:focus) {
+       padding-bottom: 0 }`. D11's finding still holds and is the reason a
+       future bottom inset here is dangerous: with the keyboard up iOS
+       reports `env(safe-area-inset-bottom)` relative to the DEVICE, not
+       the shrunken visual viewport, so an inset here double-counts against
+       `--viewport-height` and reopens a ~34px gap above the keyboard (live
+       diag from vjt's iPhone PWA 18.7; D9 removed the override on a
+       speculative research claim and D11 had to restore it). A zero base
+       has nothing left to collapse — but anyone re-introducing an inset on
+       this edge MUST restore that override in the same change. (#177 had
+       folded the removed custom keyboard's height reservation into this
+       same declaration; nothing reserves height here now.) */
+    padding-bottom: 0;
     /* #205 — left/right insets declared EXPLICITLY here. The mobile
        element is `<div class="shell shell-mobile">` (Shell.tsx) — it
        carries BOTH classes — so it inherits base `.shell`'s new
@@ -6541,26 +6571,6 @@ html.resize-dragging * {
        for the camera housing / rounded corners, not a regression. */
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
-  }
-
-  /* UX-6 bucket D11 (2026-05-21) — D1 restored after D9 removal
-     was wrong. Research claim "double-counts with position:fixed
-     html" was speculation; live diag from vjt's iPhone PWA 18.7
-     showed gap between BottomBar and keyboard top remained ~34px
-     (= env(safe-area-inset-bottom) home indicator inset) because
-     iOS doesn't shrink the safe-area inset when keyboard is up —
-     it reports a value relative to the device, not the visible
-     viewport. With `vv.height = visible-excluding-keyboard` AND
-     `padding-bottom: env(safe-area-inset-bottom)` together, we
-     reserved 34px above what was already correctly shrunken.
-     Collapsing the padding when a text input is focused
-     (`:has(textarea:focus, input:focus)`) closes the gap. */
-  .shell-mobile:has(textarea:focus, input:focus) {
-    /* Native keyboard up → collapse the home-indicator inset (it would
-       double-count against the shrunken visual viewport). (#177: the custom
-       keyboard's height reservation was previously folded in here; with it
-       gone, this reverts to the original collapse-to-0 behavior.) */
-    padding-bottom: 0;
   }
 
   /* Legacy fallback for browsers that don't grok `dvh` (Safari < 15.4).
@@ -11462,9 +11472,11 @@ audio.media-viewer-media {
        focused the keyboard is (about to be) up: bump `--nab-lift` to clear
        the bottom bar too. This ALSO makes the reposition observable in a
        real-browser e2e (headless WebKit raises no soft keyboard, so
-       `--viewport-height` alone would not move on focus). Mirrors the
-       existing `.shell-mobile:has(textarea:focus, input:focus)`
-       keyboard-react rule (~:3444).
+       `--viewport-height` alone would not move on focus). This used to
+       mirror a `.shell-mobile:has(textarea:focus, input:focus)`
+       keyboard-react rule that collapsed the shell's bottom inset; #1127
+       zeroed that inset outright, so the lift below is now the ONLY
+       consumer of the focus signal.
 
    Bigger + a proper CIRCLE (#264 req 2 & 3): symmetric box, 50% radius,
    glyph-only body (count → corner badge below). `min-*: 48px` keeps the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35349,3 +35349,61 @@ paints. Existing e2e already hit-tests two of the three shapes in a real browser
 mis-sized scrim would miss. The `-full` geometry has no such witness; the confirm
 and delete-account scrims both dismiss on backdrop click and neither is clicked
 by any spec.
+## 2026-08-09 — #1127: the wasted band was nothing painting, and zero is not the same as absent
+
+**The defect.** On a notched iPhone PWA a black band sat under the mobile
+window-tab strip. It reads like a bar that is too tall; it is not. The mobile
+shell carried `padding-bottom: env(safe-area-inset-bottom)` on its OUTER box,
+which lifted the whole shell — background included — off the physical bottom
+edge. Nothing painted in the strip it vacated. Measured on a `320x568x2`
+emulated viewport with the iOS value injected by hand (`padding-bottom: 34px`,
+because desktop Chrome always resolves `env()` to 0): `.bottom-bar` ended 34px
+short of `innerHeight`, and `elementFromPoint` at the very bottom returned
+`DIV.shell shell-mobile` computing to `rgba(0, 0, 0, 0)` while the bar itself
+was `rgb(49, 50, 68)`. **The defect does not reproduce without a real inset** —
+any claim about it made on a desktop browser is a claim about an injected
+value, not about the device.
+
+**The ruling** (vjt, on IRC): move the whole shell down, reclaim the band. So
+the bottom edge goes flush and the tabs now sit inside the home-indicator
+strip. That is an ACCEPTED trade, not an oversight: iOS also reads gestures
+there, and if a specific tab turns out to be unusable the answer is a
+measurement, not a unilateral re-add of clearance.
+
+**Zero, not absent.** The tempting edit is to delete the declaration. It is
+wrong. Base `.shell` declares `padding-bottom: env(safe-area-inset-bottom)` at
+the SAME specificity (both are single class selectors; an `@media` prelude adds
+none), and the mobile element carries both classes — `<div class="shell
+shell-mobile">`. `.shell-mobile`'s block is later in the stylesheet, so it wins
+only for as long as it declares the property. Remove the longhand and the inset
+cascades straight back in, silently, with the diff reading like a removal.
+This is the same trap #205 already documented from the other side (left/right
+were arriving from the base rule unannounced), which is why that rule owns all
+four edges explicitly.
+
+**A dead override is a liability, so it is deleted with its reason moved.**
+`.shell-mobile:has(textarea:focus, input:focus) { padding-bottom: 0 }` existed
+because with the keyboard up iOS reports the inset relative to the DEVICE, not
+the shrunken visual viewport, so an inset on this edge double-counts against
+`--viewport-height`. That override was removed once on a speculative research
+claim (UX-6 D9) and had to be restored after live diag from a real device
+(D11). With a zero base it collapses nothing, so it is gone — but its finding
+is not a historical note, it is the precondition anyone re-adding a bottom
+inset here would violate, so it now lives on the `padding-bottom: 0`
+declaration itself.
+
+**The guard, and why it is one assertion.** `ipadSafeArea.test.ts` pinned
+`.shell` and never mentioned `.shell-mobile`, so this change would have landed
+green either way. The new guard collects every `padding-bottom` declared by a
+`.shell-mobile` rule and asserts the list is exactly `["0"]`. One assertion,
+three kills: restoring the inset, deleting the longhand (the cascade trap
+above), and appending a second declaration after the zero. Proven by
+deliberate red on each.
+
+**What is NOT claimed.** Nobody has seen this on a device. jsdom resolves no
+`env()`, Playwright's iPhone emulation resolves every inset to 0, and there is
+no way to make `env(safe-area-inset-bottom)` report 34px from CSS — a
+hand-injected `padding-bottom` would be overriding the very declaration under
+test, so the simulation would be circular. The on-device look, and whether the
+bottom row of tabs still takes taps reliably inside the home-indicator strip,
+remain owed to a real notched iPhone.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35349,6 +35349,7 @@ paints. Existing e2e already hit-tests two of the three shapes in a real browser
 mis-sized scrim would miss. The `-full` geometry has no such witness; the confirm
 and delete-account scrims both dismiss on backdrop click and neither is clicked
 by any spec.
+
 ## 2026-08-09 — #1127: the wasted band was nothing painting, and zero is not the same as absent
 
 **The defect.** On a notched iPhone PWA a black band sat under the mobile

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35281,6 +35281,7 @@ boundary case fails on its FIRST assertion, with `Login.login` returning
 actually a refusal, losing the diagnosis. That is a separate defect on the login
 path, not circuit isolation, and it is left for its own issue rather than
 widened into this one.
+
 ## 2026-08-09 — #407: an extraction is a promise, and a promise needs a witness
 
 Twenty-four modal controls each carried a copy of one of three declaration

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,6 +35213,7 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+
 ## 2026-08-09 — #499: the circuit was not bleeding across tests, it was healing inside one
 
 **The filed diagnosis did not survive measurement.** Issue #499 attributed an

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,3 +35213,70 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+## 2026-08-09 — #499: the circuit was not bleeding across tests, it was healing inside one
+
+**The filed diagnosis did not survive measurement.** Issue #499 attributed an
+intermittent `login_test.exs` red to `Grappa.Admission.NetworkCircuit`'s
+singleton ETS table bleeding across tests serially — sqlite recycles rowids, so
+a fresh network inherits an id a previous test already tripped the circuit for.
+It proposed two test-infra routes: reset the ETS table between tests, or hand
+the affected tests non-colliding ids. Neither was implemented, because neither
+addresses what actually happens.
+
+Two facts falsify the premise. First, `login_test.exs` has called
+`AdmissionStateHelpers.reset_network_circuit/0` from a per-test `setup` since
+2026-05-14 (an inline ETS-delete loop before that) — the very mitigation the
+issue proposes as the fix had been in that file for two months before the issue
+was filed. Second, the instrumented failure shows no foreign row at all. The
+`network_circuit_open` case, run under host load with the ETS snapshot printed
+at the cast drain, reported one row — `{1, 3, _, :open, _}`, count exactly at
+threshold, written by that same test — and `NetworkCircuit.check/1` on the very
+next line already returning `:ok`. Nothing bled in. The circuit the test had
+just opened had already closed itself.
+
+**`check/1` is the only clock-dependent reader, and the test-env cooldown is
+shorter than the tests that depend on it.** An `:open` row reads back as `:ok`
+the instant `now >= cooled_at_ms`; no writer is involved, so no reset can
+prevent it. `config/test.exs` sets `network_circuit_cooldown_ms: 50` (±25%
+jitter → 38..62ms) to keep the cooldown-expiry cases cheap to sleep through.
+That is shorter than the work a *consumer* test does between opening the circuit
+and reading it back, so under load the precondition evaporates and the consumer
+asserts against a circuit it never closed. The same shape existed at ten sites
+across six files: every one of them established "circuit is open" through the
+production transition and then read it back through a clock-dependent path
+(`check/1`, or `AdminWire`'s `retry_after_seconds`).
+
+**The cure is a precondition that cannot decay.**
+`AdmissionStateHelpers.open_circuit!/1` drives the real `record_failure/1`
+transition, raises if it did not land, then pins `cooled_at_ms` a minute out.
+The production module is untouched — its runtime shape is deliberate, and the
+defect was never in it. The split is principled rather than an exclusion list:
+tests where open-ness is a PRECONDITION use the helper; the four whose SUBJECT
+is the clock — the `retry_after` upper bound, cooldown expiry, and the
+`:cooldown_expired` telemetry pair — keep driving the real cooldown, because
+pinning it would delete what they test.
+
+**Raising the cooldown was rejected.** It is the same band-aid one size larger:
+the race window widens but stays a race, and it would have slowed the two
+expiry tests by exactly the amount of headroom bought. A flake is cured by
+making the setup deterministic, not by giving it more room to be lucky in.
+
+**The guard is deterministic where the bug was probabilistic.** The new case
+sleeps twice the configured cooldown — clearing the jitter ceiling — and
+asserts the circuit still reads open. Deleting the pin from the helper turns
+exactly that one assertion red, every run, with `right: :ok`: the circuit
+self-healing, named. Measured incidence for the original symptom: 3 reds in 30
+loaded runs before, 0 in 20 after, with the deterministic guard as the proof
+and the load runs as corroboration.
+
+**What this did not fix, and should not be read as fixing.** Under the same
+load `login_test.exs` reds on eleven other cases that never touch the circuit —
+`433` nick negotiation, handshake waits, the mode-2 admission guard. They share
+a substrate (the in-process `IRCServer` fake plus `pool_size: 1` sqlite), not a
+cause. One of them is circuit-adjacent enough to be worth naming: the `#960`
+boundary case fails on its FIRST assertion, with `Login.login` returning
+`{:error, :connect_timeout}` while the session process logs
+`{:connect_failed, :econnrefused}` — the login surfaces a timeout for what was
+actually a refusal, losing the diagnosis. That is a separate defect on the login
+path, not circuit isolation, and it is left for its own issue rather than
+widened into this one.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35281,3 +35281,70 @@ boundary case fails on its FIRST assertion, with `Login.login` returning
 actually a refusal, losing the diagnosis. That is a separate defect on the login
 path, not circuit isolation, and it is left for its own issue rather than
 widened into this one.
+## 2026-08-09 — #407: an extraction is a promise, and a promise needs a witness
+
+Twenty-four modal controls each carried a copy of one of three declaration
+blocks: eleven dialog-header buttons, ten keyboard-aware scrims, three older
+scrims. The cost is visible in the history — #143 (44px tap target, safe-area
+insets) and #987 (`align-items: center`, not `stretch`) each landed on whichever
+modal their author had open, and the rest kept the old numbers.
+
+**The pin landed first, against the stylesheet with no base in it.** Deduping
+CSS is a promise not to move a pixel, and the promise is worth what it can be
+checked against. `modalChrome.test.ts` resolves each call site the way the
+cascade would — every rule reaching it, folded in source order, `:hover` on top
+— and compares it to a map transcribed from the sheet at 6e81170. It passed
+before the extraction existed; the extraction commit does not touch the test
+file, so the same literals are green on both sides. Two premises that would make
+the fold a fiction are asserted rather than assumed: that nothing reaches these
+classes except a bare single-class selector (so specificity is uniform and
+source order decides), and that the class list being resolved is the one the
+markup actually wears.
+
+**Box shorthands must expand to longhands, or the pin lies in both directions.**
+Nine of the ten × rules spelled their margin as one shorthand;
+`.links-modal-close` reached the same four values through `margin: -0.6rem 0`
+plus a `margin-right` longhand in a second rule with the same selector. The two
+scrim geometries spelled the same edges as `inset: 0` and as `left/right/top: 0`.
+Compared as written, identical boxes read as differences and a real difference
+could hide under a spelling.
+
+**Name the base for the SHAPE, not the role — the role name would have kept a
+clone alive.** The issue proposed `.modal-close`. Grepping the sheet made that
+look right; reading it did not. `.links-modal-close` is the second selector of
+`.links-modal-zoom, .links-modal-close`, and the links modal's zoom buttons wear
+the same block two properties apart (`margin-right: 0`, because they are not the
+last control in the row, and `font-size: 1.4rem`). A base called `.modal-close`
+could not honestly take the zoom, so the zoom would have kept its own
+fourteen-declaration copy standing beside the thing meant to end copies.
+`.modal-chrome-button` takes all eleven and the zoom keeps only its two deltas.
+Same reasoning, same convention as #740's `.login-quiet-button`: worn beside the
+per-instance class, which stays a selector contract — which is why not one
+existing e2e selector had to move.
+
+**The scrim gets a base and TWO named geometries, and no default.**
+`.modal-backdrop` carries the paint and the centring and deliberately no
+geometry; `.modal-backdrop-full` spans the layout viewport, `.modal-backdrop-viewport`
+spans only the visible region (the #143 keyboard fix). Ten scrims have that fix
+and three do not, and with the iOS keyboard up that is a difference in behaviour,
+not in spelling. Either choice of default is a bad one: defaulting to `-full`
+hands the next modal the worse behaviour without anyone choosing it, and
+defaulting to `-viewport` moves three modals' pixels under cover of a refactor.
+So the base alone is a zero-height box and every site names its geometry. That
+failure mode — a scrim shipped with no variant, invisible but present — is
+silent in CSS, so it is asserted against the markup.
+
+**The clone guard is keyed on the whole shape, so it needs no exclusion list.**
+It asks which classes in the sheet resolve to exactly a base's declaration set
+and expects the base alone. `.links-modal-zoom` differs in two properties out of
+twenty and falls out of the rule by itself, rather than being carved out by a
+list the next reader would extend instead of question.
+
+**What the file cannot prove.** jsdom applies no stylesheet: this is an
+assertion about what the cascade is asked to do, never about what a browser
+paints. Existing e2e already hit-tests two of the three shapes in a real browser
+— `issue219` clicks `.names-modal-close` and waits for the modal to hide,
+`issue232` clicks `.mode-modal-backdrop` at (6,6), a corner click that a
+mis-sized scrim would miss. The `-full` geometry has no such witness; the confirm
+and delete-account scrims both dismiss on backdrop click and neither is clicked
+by any spec.

--- a/test/grappa/admission/network_circuit_test.exs
+++ b/test/grappa/admission/network_circuit_test.exs
@@ -57,11 +57,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
     end
 
     test "isolated per-network_id" do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(1)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(1)
 
       assert {:error, :open, _} = NetworkCircuit.check(1)
       assert NetworkCircuit.check(2) == :ok
@@ -81,11 +77,8 @@ defmodule Grappa.Admission.NetworkCircuitTest do
     end
 
     test "clears open circuit" do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(1)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(1)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(1)
 
       :ok = NetworkCircuit.record_success(1)
@@ -130,6 +123,25 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       Process.sleep(NetworkCircuit.cooldown_ms() + 30)
 
       assert NetworkCircuit.check(1) == :ok
+    end
+  end
+
+  describe "#499 — AdmissionStateHelpers.open_circuit!/1" do
+    test "the pinned open state outlives the configured cooldown" do
+      # The guard for every consumer test that treats "circuit is open" as a
+      # precondition. `check/1` self-heals on the wall clock, and the test-env
+      # cooldown (~50ms) is shorter than the work a consumer does before
+      # reading the circuit back — that decay, not cross-test ETS bleed, is
+      # what reddened `login_test.exs`'s network_circuit_open case. Sleeping
+      # 2x the configured cooldown clears the ±25% jitter ceiling, so dropping
+      # the pin from the helper turns this RED deterministically.
+      net_id = 3001
+
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
+
+      Process.sleep(NetworkCircuit.cooldown_ms() * 2)
+
+      assert {:error, :open, _} = NetworkCircuit.check(net_id)
     end
   end
 
@@ -181,12 +193,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       attach_circuit_event([:grappa, :admission, :circuit, :open])
       net_id = 1002
 
-      # Open the circuit.
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net_id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
 
       # Drain the first (and only) event.
       assert_receive {:telemetry, [:grappa, :admission, :circuit, :open], %{}, %{network_id: ^net_id}},
@@ -205,11 +212,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       attach_circuit_event([:grappa, :admission, :circuit, :close])
       net_id = 1003
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net_id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
 
       :ok = NetworkCircuit.record_success(net_id)
       _ = :sys.get_state(NetworkCircuit)

--- a/test/grappa/admission_test.exs
+++ b/test/grappa/admission_test.exs
@@ -9,7 +9,7 @@ defmodule Grappa.AdmissionTest do
 
   alias Grappa.{Admission, AdmissionStateHelpers, Repo, SessionRegistry}
   alias Grappa.Admission.Captcha.{Disabled, HCaptcha, Turnstile}
-  alias Grappa.Admission.{Config, NetworkCircuit}
+  alias Grappa.Admission.Config
   alias Grappa.Networks.Network
   alias Grappa.Session.Server, as: SessionServer
 
@@ -25,11 +25,7 @@ defmodule Grappa.AdmissionTest do
   describe "check_capacity/1 — network circuit gate" do
     test "open circuit short-circuits with {:network_circuit_open, retry_after}",
          %{network: net} do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       input = %{
         network_id: net.id,
@@ -509,11 +505,7 @@ defmodule Grappa.AdmissionTest do
     test "emits :capacity, :reject when circuit open", %{network: net} do
       attach_reject_event()
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       input = %{
         network_id: net.id,

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -184,11 +184,8 @@ defmodule Grappa.OperatorTest do
 
       AdmissionStateHelpers.reset_network_circuit()
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(network.id)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(network.id)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(network.id)
 
       assert {:ok, nil} = Operator.reset_circuit(network.id)

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -716,12 +716,7 @@ defmodule Grappa.Visitors.LoginTest do
 
     test "network_circuit_open → {:error, {:network_circuit_open, retry_after}}",
          %{network: net} do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      # Flush GenServer cast queue before checking.
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       # Task 5: Login surfaces the tuple shape so FallbackController can
       # emit Retry-After. Bare atom would lose the cooldown payload.

--- a/test/grappa_web/controllers/admin/circuit_controller_test.exs
+++ b/test/grappa_web/controllers/admin/circuit_controller_test.exs
@@ -59,11 +59,8 @@ defmodule GrappaWeb.Admin.CircuitControllerTest do
       slug = "c-reset-#{System.unique_integer([:positive])}"
       {:ok, net} = Networks.find_or_create_network(%{slug: slug})
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(net.id)
 
       session = admin_session()

--- a/test/grappa_web/controllers/admin/networks_controller_test.exs
+++ b/test/grappa_web/controllers/admin/networks_controller_test.exs
@@ -104,11 +104,7 @@ defmodule GrappaWeb.Admin.NetworksControllerTest do
       slug = "g-dirty-#{System.unique_integer([:positive])}"
       {:ok, net} = Networks.find_or_create_network(%{slug: slug})
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       session = admin_session()
       conn = conn |> put_bearer(session.id) |> get("/admin/networks")

--- a/test/support/admission_state_helpers.ex
+++ b/test/support/admission_state_helpers.ex
@@ -67,6 +67,11 @@ defmodule Grappa.AdmissionStateHelpers do
   @reset_registry_attempts 600
   @reset_registry_poll_ms 25
 
+  # How far ahead `open_circuit!/1` pins `cooled_at_ms`. Any value that
+  # outlives a single test works; a minute matches the forged row the
+  # H7 case in `network_circuit_test.exs` already uses.
+  @pinned_cooldown_ms 60_000
+
   @doc """
   Clear every per-`network_id` row from the `NetworkCircuit` ETS table,
   every per-`(subject, network_id)` row from the `Backoff` ETS table,
@@ -94,10 +99,60 @@ defmodule Grappa.AdmissionStateHelpers do
   @spec reset_network_circuit() :: :ok
   def reset_network_circuit do
     for {network_id, _, _, _, _} <- NetworkCircuit.entries() do
-      :ets.delete(:admission_network_circuit_state, network_id)
+      :ets.delete(NetworkCircuit.table_name(), network_id)
     end
 
     :ok
+  end
+
+  @doc """
+  Drive `NetworkCircuit` to `:open` for `network_id` through the
+  production `record_failure/1` transition, then pin the row's
+  `cooled_at_ms` a minute out so the open state cannot decay while the
+  test is still running. Raises if the transition did not happen.
+
+  ## Why the pin (GH #499)
+
+  `NetworkCircuit.check/1` is the only clock-dependent reader: an
+  `:open` row reads as `:ok` the moment `now >= cooled_at_ms`, without
+  anything having rewritten it. `config/test.exs` sets
+  `network_circuit_cooldown_ms: 50` (±25% jitter → 38..62ms) so the
+  cooldown-expiry tests stay cheap — which is far shorter than the work
+  a *consumer* test does between opening the circuit and reading it
+  back. The circuit then self-heals mid-test and the consumer observes
+  a closed circuit it never closed.
+
+  Measured on `login_test.exs`'s `network_circuit_open` case under
+  host load: the row was `{count: 3, :open}` at the drain and
+  `check/1` on the very next line already returned `:ok` — a
+  self-inflicted expiry, no cross-test bleed involved.
+
+  So: tests where "the circuit is open" is a PRECONDITION use this
+  helper and get a fact that does not decay. Tests whose SUBJECT is the
+  clock — the retry_after bound, cooldown expiry, the
+  `:cooldown_expired` telemetry — must keep driving the real cooldown
+  and deliberately do NOT use it.
+  """
+  @spec open_circuit!(integer()) :: :ok
+  def open_circuit!(network_id) when is_integer(network_id) do
+    for _ <- 1..NetworkCircuit.threshold() do
+      :ok = NetworkCircuit.record_failure(network_id)
+    end
+
+    # record_failure/1 is a cast; drain the mailbox before reading back.
+    _ = :sys.get_state(NetworkCircuit)
+
+    case :ets.lookup(NetworkCircuit.table_name(), network_id) do
+      [{^network_id, count, window_start_ms, :open, _}] ->
+        pinned_cooled_at = System.monotonic_time(:millisecond) + @pinned_cooldown_ms
+        true = :ets.insert(NetworkCircuit.table_name(), {network_id, count, window_start_ms, :open, pinned_cooled_at})
+
+        :ok
+
+      other ->
+        raise "AdmissionStateHelpers.open_circuit!: #{NetworkCircuit.threshold()} failures " <>
+                "on network_id=#{network_id} did not open the circuit; row is #{inspect(other)}"
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Why a union and not four merges

Each of #1128 (#407), #1129 (#499), #1131 (#949) and #1132 (#1127) is green on its own, and none of those greens attests anything about the other three. Their file intersections are real, not hypothetical:

- `#1128 ∩ #1131 ∩ #1132` → `cicchetto/src/themes/default.css`
- `#1128 ∩ #1129 ∩ #1132` → `docs/DESIGN_NOTES.md`

Landing them one at a time would have forced three rebases through that CSS and that decision log, and paid the ~30 min `integration` three times — while still never asking whether the four stand up **together**. This PR is that question, asked once.

Built the #851 way: each PR's own commits cherry-picked onto a fresh branch off current `main` (`ed67d244`), in ascending PR order.

## Verification, not assertion

**Per-file `--numstat` of this branch against `main` is identical to the summed `--numstat` of the four PRs, across all 35 files.** Nothing was lost or doubled in the replay.

## Three separators the replay ate

`docs/DESIGN_NOTES.md` grows by appending, so every entry replayed onto a tail that has moved loses the blank line that keeps its `##` off the previous entry's last paragraph. It happened to all three entries here — #499, #407, #1127 — and the arithmetic is what catches it: **68 + 68 + 59 = 195 expected, 194 landed** before the restores. Each is a one-line commit, and all three headings are verified unglued.

One of them is worth naming, because it is a trap: **#1128 already carried its own restore commit for exactly this, and git replayed it as EMPTY.** That emptiness was not evidence. The commit's anchor — the blank after the #429 paragraph — was already present, but landing #499's entry *between* #429 and #407 moved the boundary #407 actually needed. A patch reported as already-applied says nothing about the line it was written to protect once a third entry lands between the two.

## Prediction, registered before this run

The e2e count must come back **680, unchanged**: 680 on `main`, **+1** (#1128 adds exactly one `test(`), **−1** (#1132 removes exactly one, adds none). Static cross-check: `test(` blocks are 674 on both `main` and this branch.

**And an unchanged count cannot settle it alone** — 680 is also what a run would report if the new spec never executed *and* the deletion never happened. The verdict needs all three:

1. count == 680;
2. the named ✓ for `issue407-modal-backdrop-full-bottom-edge` **present**;
3. the deleted `ux-6-d` arm **absent**.

Two specs that #1132 flipped (`ux-3-empty-toolbar-island`, `ux-z-cluster-journey`) and the spec #1128 added have **never been executed anywhere** — no lane was free for them. This run is their first.

## Supersedes

#1128, #1129, #1131, #1132. The cherry-pick rewrites their SHAs, so GitHub cannot close them itself — they get closed by content, naming this union, as part of the merge.