### PR TITLE
cic(#1121): reconcile the overlay close in the epoch each answer belongs to

### DIFF
--- a/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
+++ b/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
@@ -1,0 +1,148 @@
+// #1121 — closing a covering overlay over a reader who was AT the tail must not
+// strand them above it in silence.
+//
+// The mirror image of issue196-preview-scroll-live-arrival, which drives the
+// SCROLLED-UP reader: there the contract is "do not move me", here it is "do not
+// go deaf". Both run the same harness and the same gesture; only the reader's
+// starting position differs, and that difference is the whole bug.
+//
+// While the overlay is up the pane is frozen (#196 / #219-general) and lines
+// landing underneath do not move it — that part is deliberate and is what the
+// #196 spec pins. The damage was at the CLOSE edge, in `applyOverlayRestore`: it
+// reconciled the follow intent from `scrollHeight` measured on the close edge
+// against the scrollTop captured on the OPEN one, so the growth under the
+// overlay read as distance the reader had put between themselves and the tail.
+// A reader who had not moved lost tail-follow, and — because the restore writes
+// nothing when the pane is already where it was held — no scroll event fired,
+// `atBottomNow` stayed stale-true, and both rescue affordances were suppressed
+// with it: no floating scroll-to-bottom button, and `readingAtTailKey` kept
+// telling the badge derivation to hide this window's unread count. The reporter
+// waited a minute and only their own send released it.
+//
+// Two observables, one per broken signal:
+//   * the floating scroll-to-bottom button is VISIBLE right after the close
+//     (the geometry was republished for the close edge);
+//   * a line arriving AFTER the close is scrolled to (the follow intent
+//     survived the freeze).
+//
+// The button assertion runs FIRST and on its own: the follow-up line tail-snaps
+// the pane, which legitimately unmounts the button again.
+//
+// Desktop project only (untagged → chromium), like its #196 twin: desktop Chrome
+// reproduces desktop scroll physics (feedback_playwright_webkit_not_ios_scroll).
+
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "arr1121-peer";
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX (not exported) — the
+// reader counts as AT the tail when distance-to-bottom is within it.
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+test.describe("#1121 — closing an overlay over a tail reader must not strand them", () => {
+  // This spec leaves the pane parked above the tail for part of its run, so its
+  // scroll-settle can advance the shared #bofh cursor to a mid-page position and
+  // leave the trailing peer lines unread. A downstream spec assuming a fully-read
+  // #bofh would then inherit an unread marker → cold-mount marker-jump → scroll
+  // flake. Restore after EACH run, not afterAll: under `--repeat-each` afterAll
+  // fires once after every repeat, far too late, and sibling specs interleave
+  // between our repeats. Cascade hygiene: feedback_cascade_poisoner_pattern.
+  test.afterEach(async () => {
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("closing the media viewer over a tail reader restores the button and keeps following (desktop)", async ({
+    page,
+  }) => {
+    test.slow();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    // Upload an image → a clickable media link lands at the tail, where our
+    // reader already is. No scroll-up here: being AT the tail IS the precondition.
+    const { slug } = await uploadViaPicker(
+      page,
+      { name: "arr1121.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+      { postTimeout: 10_000 },
+    );
+    const { link } = await mediaScrollbackRow(page, "📸", slug);
+    await expect(link).toHaveClass(/scrollback-media-link/);
+
+    const sc = page.getByTestId("scrollback");
+    const scrollButton = page.locator('[data-testid="scroll-to-bottom"]');
+
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      await peer.join(CHANNEL);
+
+      // Pin the reader AT the tail and let onScroll MEASURE it. Both halves
+      // matter: the position is the precondition, and the measurement is what
+      // arms `atBottomNow`/`tailGeometryMeasured` so the stale-true read the bug
+      // depends on can exist at all.
+      const before = await sc.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+        return {
+          top: el.scrollTop,
+          distanceToBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+        };
+      });
+      await page.waitForTimeout(300);
+      expect(before.distanceToBottom).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+      // At the tail, so the button must be down — else the post-close assertion
+      // would be measuring a button that was already there.
+      await expect(scrollButton).toBeHidden({ timeout: 5_000 });
+
+      // Open the preview via a REAL click on the image at the tail.
+      await link.click();
+      const viewer = page.getByRole("dialog", { name: "Media viewer" });
+      await expect(viewer).toBeVisible({ timeout: 5_000 });
+
+      // Three lines land underneath the open overlay — the reporter's exact
+      // gesture. They must NOT move the frozen pane (that is #196's contract,
+      // re-asserted here as the precondition for ours), but they DO grow the
+      // extent, which is what the close edge used to misread. `toBeAttached`,
+      // not `toBeVisible`: they land off-screen below the held viewport.
+      for (let i = 0; i < 3; i++) {
+        const marker = `arr1121-under-${i}`;
+        peer.privmsg(CHANNEL, marker);
+        await expect(page.getByText(marker)).toBeAttached({ timeout: 15_000 });
+      }
+      await page.waitForTimeout(400);
+      const during = await sc.evaluate((el) => el.scrollTop);
+      expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
+
+      // Close it. The reader is now genuinely parked above a tail that moved.
+      await viewer.getByRole("button", { name: "Close media viewer" }).click();
+      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await page.waitForTimeout(400);
+
+      // OBSERVABLE 1 — the geometry was republished, so the pane admits there is
+      // content below and offers the way down. Pre-fix `atBottomNow` was
+      // stale-true and this button never mounted: "non c'e' nessun bottone di
+      // scroll".
+      const afterClose = await sc.evaluate((el) => ({
+        distanceToBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+      }));
+      expect(afterClose.distanceToBottom).toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+      await expect(scrollButton).toBeVisible({ timeout: 5_000 });
+
+      // OBSERVABLE 2 — the follow intent survived, so the next line is tailed
+      // onto rather than dropped below the fold. Pre-fix the intent had been
+      // reconciled off and the pane stayed deaf until the reader's own send.
+      peer.privmsg(CHANNEL, "arr1121-after-close");
+      await expect(page.getByText("arr1121-after-close")).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await peer.disconnect("#1121 tail-reader close done");
+    }
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1072,6 +1072,17 @@ const ScrollbackPane: Component<Props> = (props) => {
   // Both the freeze gate and the restore require this === key(); a switched-to
   // window activates normally. `null` when no overlay snapshot is held.
   let overlaySnapshotKey: string | null = null;
+  // #1121 — the distance-to-tail measured at the same instant as
+  // `overlayScrollSnapshot`, and the reason it must be captured rather than
+  // recomputed. The restore reconciles the follow INTENT, which is a fact about
+  // the OPEN edge ("was the reader following when the freeze began?"), but it
+  // runs on the CLOSE edge, where `scrollHeight` has already absorbed whatever
+  // arrived underneath. Recomputing the distance there mixes an open-edge
+  // scrollTop with a close-edge extent and reads back the GROWTH — so a reader
+  // pinned to the tail looked like a reader who had scrolled up by exactly the
+  // messages they missed, and lost tail-follow for it. Captured with the px,
+  // spent on the intent; the geometry signal is measured fresh instead.
+  let overlaySnapshotDistance: number | null = null;
   // #608 (deep-review §6.1) — the overloaded `atBottom` split into its two
   // independent concerns, the PRIMARY reshape of the single-scroll-authority
   // work:
@@ -1984,10 +1995,14 @@ const ScrollbackPane: Component<Props> = (props) => {
         if (open) {
           overlayScrollSnapshot = listRef.scrollTop;
           overlaySnapshotKey = key();
+          // #1121 — same instant, same epoch as the px above. See its
+          // declaration for why the restore cannot recompute this later.
+          overlaySnapshotDistance = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight;
         }
         const target = overlayScrollSnapshot;
         const snapKey = overlaySnapshotKey;
-        if (target === null || snapKey === null) return;
+        const snapDistance = overlaySnapshotDistance;
+        if (target === null || snapKey === null || snapDistance === null) return;
         // Re-assert across rAF×2 (matching scrollToActivation's frame budget so
         // it lands after the overlay's layout commits) via the applier's W1
         // restore entrypoint — the single owner of this write, key-guarded there.
@@ -2001,7 +2016,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         // close→reopen nulling a just-re-armed snapshot) is now structurally
         // impossible, as is the field-bug "frozen forever under a leaked count".
         requestAnimationFrame(() =>
-          requestAnimationFrame(() => applyOverlayRestore(target, snapKey)),
+          requestAnimationFrame(() => applyOverlayRestore(target, snapKey, snapDistance)),
         );
       },
       { defer: true },
@@ -2981,7 +2996,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // mid-overlay channel switch owns its own activation; never stamp the leaving
   // channel's px onto it) and skips a no-op write. `target` is the px captured on
   // the open edge; `snapKey` the channel it was captured on.
-  const applyOverlayRestore = (target: number, snapKey: string): void => {
+  const applyOverlayRestore = (target: number, snapKey: string, snapDistance: number): void => {
     if (!listRef || snapKey !== key()) return;
     // #608 (regression fix) — reconcile the follow INTENT with the reader's
     // trusted position. The snapshot is the authoritative position across the
@@ -2997,7 +3012,31 @@ const ScrollbackPane: Component<Props> = (props) => {
     // the live `overlayCount()`). Runs even when the position is already held
     // (`scrollTop === target`), so a scrolled-up reader whose px never moved still
     // gets the stale intent corrected.
-    setFollowMode(
+    //
+    // #1121 — the intent is reconciled against `snapDistance`, the distance
+    // measured WITH the snapshot, not one recomputed here. Both readings answer
+    // "where is the reader relative to the tail", but only the captured one
+    // answers it for the epoch the intent belongs to: recomputed on the close
+    // edge it also counts every line that arrived under the overlay, which reads
+    // as a scroll-up the reader never performed. #608's mid-list case is
+    // unchanged — a snapshot taken mid-list carries a large distance either way.
+    setFollowMode(snapDistance <= SCROLL_BOTTOM_THRESHOLD_PX);
+    // #1121 — and the GEOMETRY is republished for the close edge, where it
+    // belongs. It is the SAME expression the intent used to be computed from —
+    // current extent against the restored position — because that expression was
+    // never wrong, only misaddressed: it answers "is the pane at the tail now",
+    // which is `atBottomNow`'s question, not `followMode`'s. Measured against
+    // `target` rather than the live `scrollTop`: both exits below leave the pane
+    // there, so this is the position the reader is about to be looking from.
+    //
+    // This is the only place the pane can learn that the tail moved away from it
+    // while it was held: nothing scrolled, so no `scroll` event fires and
+    // `onScroll` never re-measures. Both consumers of a stale-true `atBottomNow`
+    // then lie in the same direction — the floating scroll-to-bottom button
+    // stays unmounted, and `readingAtTailKey` keeps telling `selection.ts` to
+    // suppress this window's unread badge. Published BEFORE the no-op early
+    // return, because the held-position case IS the one that goes stale.
+    setAtBottomNow(
       listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
     );
     if (listRef.scrollTop === target) return;

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -5379,6 +5379,140 @@ describe("ScrollbackPane", () => {
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
+
+    // #1121 — the close edge must answer TWO questions, and they live in TWO
+    // DIFFERENT epochs:
+    //
+    //   * the follow INTENT — "was the reader following when the freeze began?"
+    //     — is a fact about the OPEN edge;
+    //   * the GEOMETRY (`atBottomNow`) — "is the pane at the tail right now?" —
+    //     is a fact about the CLOSE edge.
+    //
+    // `applyOverlayRestore` computed ONE number for both and spent it on the
+    // intent alone: `scrollHeight` read NOW minus `target` captured on the OPEN
+    // edge. Content arriving under the overlay grows `scrollHeight` by Δ, so for
+    // a reader who was sitting exactly AT the tail that number reads Δ — "the
+    // reader is Δ above the tail" — and `followMode` was reconciled OFF for
+    // someone who never moved. The geometry was not republished at all: the pane
+    // never moved while frozen, so `scrollTop === target`, the restore's no-op
+    // early-return fires, no `scroll` event is emitted, and `atBottomNow` stays
+    // stale-TRUE.
+    //
+    // Two signals, three field symptoms (the reporter's, testnet, 3 runs): the
+    // dead intent hides every message arriving after the close, and the stale
+    // geometry hides BOTH rescue affordances — the floating button is
+    // `<Show when={!atBottomNow()}>`, and `readingAtTailKey` (published from the
+    // same `atBottomNow`) is what `selection.ts` uses to SUPPRESS the unread
+    // badge. The button and the badge are ONE signal with two consumers by
+    // design (see `readingAtTail`), which is why two mutants — not three — cover
+    // this block.
+    //
+    // Same site as the #608 reconciliation above and it must not undo it: a
+    // mid-list snapshot still reconciles the intent OFF. The distinction is the
+    // EPOCH the distance is measured in, not the presence of the reconciliation.
+    describe("#1121 — closing an overlay over a tail reader must not strand them", () => {
+      // The field scenario: a reader MEASURED at the tail, an overlay opened
+      // over them, three lines arriving underneath (rows land AND the extent
+      // grows while the freeze holds scrollTop), then the close.
+      //
+      // The scroll event before the overlay is load-bearing, not decoration: it
+      // is what sets `tailGeometryMeasured`. Without it `readingAtTailKey`
+      // withholds its answer and publishes `null` regardless, so the badge
+      // assertion below would pass on the unfixed code — a vacuous test.
+      const strandATailReader = async (): Promise<HTMLDivElement> => {
+        seedRows();
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const list = screen.getByTestId("scrollback") as HTMLDivElement;
+        await flushRaf();
+
+        Object.defineProperty(list, "scrollHeight", { value: 2000, configurable: true });
+        Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+        Object.defineProperty(list, "scrollTop", {
+          value: 1500,
+          writable: true,
+          configurable: true,
+        });
+        // distance = 2000 - 1500 - 500 = 0 → at the tail, and MEASURED.
+        list.dispatchEvent(new Event("scroll"));
+        await flushRaf();
+
+        pushOverlay(null);
+        await flushRaf();
+
+        // Three lines land underneath. 400px of growth — the reporter's three
+        // chat lines are already well past the 50px threshold.
+        Object.defineProperty(list, "scrollHeight", { value: 2400, configurable: true });
+        setScrollback({
+          "freenode #grappa": Array.from({ length: 23 }, (_, i) => ({
+            id: i + 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: i + 1,
+            kind: "privmsg" as const,
+            sender: "alice",
+            body: `row ${i + 1}`,
+            meta: {},
+          })),
+        });
+        await flushRaf();
+
+        popOverlay(null);
+        await flushRaf();
+        return list;
+      };
+
+      it("keeps the follow intent alive, so a message arriving after the close is tailed", async () => {
+        const list = await strandATailReader();
+        scrollIntoViewSpy.mockClear();
+
+        // A fourth line arrives with no overlay in the way. A reader who was
+        // following must be tailed onto it. Pre-fix `followMode` was reconciled
+        // false by the mixed-epoch read, so the length-effect never armed
+        // tail-follow and the line stayed below the fold indefinitely — the
+        // reporter's "continuo a non vedere un cazzo".
+        Object.defineProperty(list, "scrollHeight", { value: 2500, configurable: true });
+        setScrollback({
+          "freenode #grappa": Array.from({ length: 24 }, (_, i) => ({
+            id: i + 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: i + 1,
+            kind: "privmsg" as const,
+            sender: "alice",
+            body: `row ${i + 1}`,
+            meta: {},
+          })),
+        });
+        // The tail-follow settle poll is frame-budgeted (SETTLE_MAX_FRAMES = 30)
+        // and jsdom never lays out, so `isSettled` can never hold: the write
+        // arrives on the fail-safe frame. Drain past the budget.
+        for (let i = 0; i < 20; i++) await flushRaf();
+
+        expect(scrollIntoViewSpy).toHaveBeenCalled();
+      });
+
+      it("republishes the geometry, so the floating scroll-to-bottom button appears", async () => {
+        await strandATailReader();
+
+        // The pane is parked 400px above the tail. Pre-fix the restore wrote
+        // nothing (position already held), no scroll event fired, `atBottomNow`
+        // stayed stale-true and the button stayed unmounted — the reporter's
+        // "non c'e' nessun bottone di scroll".
+        expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull();
+      });
+
+      it("stops claiming the reader is at the tail, so the unread badge is not suppressed", async () => {
+        await strandATailReader();
+
+        // Same stale `atBottomNow`, second consumer: the pane publishes
+        // `readingAtTailKey`, and `selection.ts` suppresses this window's unread
+        // count while it names it. Parked above the tail, the honest answer is
+        // `null` — every unknown collapses to "show the badge".
+        expect(readingAtTailKey()).toBeNull();
+      });
+    });
   });
 
   // affordances. Rendered as flex siblings BEFORE `.scrollback` they

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,3 +35213,90 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+
+## 2026-08-09 — #1121: the overlay close asks two questions, and they live in two epochs
+
+A reader sitting at the tail of a live channel opened the media viewer, waited
+while three lines landed underneath, and closed it — and the pane went deaf.
+The new lines were invisible, every later line was invisible too, there was no
+floating scroll-to-bottom button and no unread badge, and only their own send
+released it. Reproduced three times on the testnet, then in jsdom.
+
+**The freeze was not the bug.** While a covering overlay is up the pane holds
+its position and every scroll writer bails (#196, widened to the shared
+refcount by #219-general). That is deliberate and it worked. The damage was one
+function at the close edge, `applyOverlayRestore`, and it was doing two things
+wrong at once with a single expression:
+
+```ts
+setFollowMode(
+  listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
+);
+if (listRef.scrollTop === target) return;
+```
+
+`target` is the scrollTop captured on the OPEN edge; `scrollHeight` is read on
+the CLOSE edge. Content arriving under the overlay grows the extent by Δ, so the
+expression returns Δ for a reader who never moved — it cannot tell *"the reader
+scrolled up"* from *"the content grew while they were held"*, and it reconciles
+`followMode` off for the second. That is why the pane stayed deaf long after the
+overlay was gone: the intent was dead, not just the frame.
+
+The same expression was never published to the geometry. The freeze had held the
+pane exactly at `target`, so the restore writes nothing, takes the early return,
+and emits no `scroll` event — and `onScroll` is the only thing that re-measures.
+`atBottomNow` went on asserting a tail the pane had drifted away from. It has two
+consumers and both repeated the lie: the floating button is
+`<Show when={!atBottomNow()}>`, and `readingAtTailKey` — published from the same
+predicate precisely so `selection.ts` can suppress the badge of the window being
+read — kept naming this window. The pane was parked above the tail while every
+part of the UI agreed the reader was caught up.
+
+**The shape of the fix.** The close edge asks two questions and they belong to
+different epochs:
+
+* the follow INTENT — *"was the reader following when the freeze began?"* — is a
+  fact about the OPEN edge. Capture the distance-to-tail alongside the px and
+  reconcile against that. Growth under the overlay then cannot masquerade as a
+  scroll-up.
+* the GEOMETRY — *"is the pane at the tail now?"* — is a fact about the CLOSE
+  edge, and the old expression answered it correctly all along. It was never
+  wrong, only **misaddressed**. Publish it to `atBottomNow`, measured against
+  `target` (both exits leave the pane there), and publish it BEFORE the no-op
+  early return, because the held-position case is exactly the one that goes
+  stale.
+
+**#608 keeps what it bought.** Deleting the reconciliation would have re-opened
+the media-viewer close snap it was written for. A mid-list snapshot carries a
+large distance in either epoch, so a reader who really had scrolled up still
+gets the intent reconciled off. That case gains something too: its `atBottomNow`
+was stale-true for the same reason, hiding the button from a reader who
+genuinely needed it.
+
+**One site, two signals, three symptoms.** The three complaints in the report
+are not three defects and not one: they are two independent signals. The dead
+intent hides the messages; the stale geometry hides both affordances, because
+the button and the badge are one signal with two consumers by design. Two
+mutants prove it — reverting the intent to the mixed-epoch read kills only the
+follow assertion, removing the geometry publish kills only the button and the
+badge. A third mutant moving the publish after the early return kills the same
+pair, which is the honest result: it proves the PLACEMENT is load-bearing, not
+that there is a third signal.
+
+**Not the media viewer's bug.** Twenty surfaces push the shared overlay
+refcount, and all of them route through this one freeze and this one restore.
+The viewer is simply the one a reader keeps open for twenty seconds while a
+channel talks underneath. The fix is at the shared site, so it is class-wide by
+construction — no per-surface census to maintain.
+
+**Left open, deliberately.** The reporter's own proposal — stop freezing under
+a fully-covering surface and just keep following — is a different and larger
+call: the freeze exists because a fullscreen modal shrinks the mobile
+visualViewport and the resulting resize used to drop the reader's position, and
+#219 widened it to surfaces where the pane stays partly visible. Splitting the
+policy by coverage is possible and is not decided here. Nor is the second fork
+this fix surfaces: a reader restored with `followMode` true but parked above the
+tail is offered a button rather than snapped forward. That is the conservative
+direction — it is the reader's position that is being preserved — but "a
+follower's anchor is the tail, not a pixel" is a defensible reading of the same
+invariant, and it would remove the button from this scenario entirely.


### PR DESCRIPTION
Ref #1121.

## What was broken

A reader sitting at the tail opens the media viewer, three lines land underneath, they close it — and the pane goes deaf. No new messages, no floating scroll-to-bottom button, no unread badge, and it stays that way until their own send. Reproduced three times on the testnet; reproduced here in jsdom.

The freeze under the overlay is **not** the bug (#196 / #219-general, deliberate, working). The damage is one function at the close edge, `applyOverlayRestore`, doing two things wrong with one expression:

```ts
setFollowMode(
  listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
);
if (listRef.scrollTop === target) return;
```

* **Mixed epochs.** `target` is the scrollTop captured on the OPEN edge; `scrollHeight` is read on the CLOSE edge. Growth under the overlay therefore reads as distance the reader put between themselves and the tail. A reader who never moved is reconciled to `followMode = false` — and stays there, which is why the pane ignores messages long after the overlay is gone.
* **Geometry never republished.** The freeze held the pane exactly at `target`, so the restore writes nothing, takes the early return, and emits no `scroll` event — and `onScroll` is the only thing that re-measures. `atBottomNow` goes on asserting a tail the pane has drifted away from. Both of its consumers repeat the lie: the floating button is `<Show when={!atBottomNow()}>`, and `readingAtTailKey` — published from the same predicate — is exactly what tells `selection.ts` to suppress this window's unread badge.

## The fix

The close edge asks two questions and they belong to two epochs.

* The follow **intent** ("was the reader following when the freeze began?") is an open-edge fact: capture the distance-to-tail alongside the px, reconcile against that.
* The **geometry** ("is the pane at the tail now?") is a close-edge fact, and the old expression answered it correctly all along — it was only *misaddressed*. Publish it to `atBottomNow`, measured against `target` (both exits leave the pane there), **before** the no-op early return, because the held-position case is the one that goes stale.

#608's reconciliation is preserved, not deleted: a mid-list snapshot carries a large distance in either epoch, so a reader who really had scrolled up is still not yanked to the bottom on close. That case gains something too — its `atBottomNow` was stale-true for the same reason, hiding the button from a reader who needed it.

## One site, two signals, three symptoms

The three reported symptoms are neither three defects nor one. They are **two independent signals**: the dead intent hides the messages; the stale geometry hides *both* affordances, because the button and the badge are one signal with two consumers by design.

Three mutants, two disjoint kill sets — measured, not predicted:

| mutant | kill set |
|---|---|
| revert the intent to the mixed-epoch read | *follow intent* only (1 failed, 2 passed) |
| remove the geometry publish | *button* + *badge* only (2 failed, 1 passed) |
| move the geometry publish after the early return | *button* + *badge* (same pair) |

The third is the honest result rather than a third axis: it proves the **placement** is load-bearing — the assertions exercise the no-op-write path, which is the field path — not that a third signal exists.

## Not the media viewer's bug

Twenty surfaces push the shared overlay refcount and all route through this one freeze and this one restore. The viewer is just the one a reader keeps open for twenty seconds while a channel talks underneath. The fix is at the shared site, so it is class-wide by construction. No other mixed-epoch distance exists in the pane: every other site reads all three terms off the live element in one instant.

## Deliberately not changed

* The freeze itself. A covered pane still holds its position; only the edge reconciliation is epoch-correct now.
* The reporter's proposal to stop freezing under fully-covering surfaces — a larger policy call, recorded in DESIGN_NOTES, not settled here.
* A restored follower parked above the tail is offered a button rather than snapped forward. Conservative direction; the opposite reading ("a follower's anchor is the tail, not a pixel") is defensible and also recorded.

## Gates

* `bun run test` — **4915/4915 passed**, 265 files, rc=0, clean tree before and after.
* `bun run check` (biome + `tsc` over `src/` and `e2e/`) — rc=0. 61 warnings are pre-existing and unchanged (959 → 960 files).
* The e2e spec `issue1121-overlay-close-tail-reader.spec.ts` is **typechecked but NEVER EXECUTED** — it has had no lane. It is modelled line-for-line on its `issue196-preview-scroll-live-arrival` twin, but a spec that has not run is a claim, not evidence. Treat it as unverified until it gets one.

## What the jsdom guard does not prove

It stubs every geometry it reads; jsdom never lays out, so `isSettled` can never hold there and the tail-follow write arrives on the fail-safe frame. `pushOverlay(null)` stands in for the real viewer, so the visualViewport shrink that #196 exists to survive is never exercised. The button assertion proves the element **mounts**, not that it is visible or hit-testable. The badge assertion proves the pane publishes `null`, not that `selection.ts` then renders a count. That gap is what the e2e is for.