### PR TITLE
cic(#1124): dismiss the soft keyboard when the media viewer opens

### DIFF
--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -24,7 +24,7 @@ import { maybeEscapePwaClick } from "./lib/platform";
 // spec 2026-06-10; the spec bans lightbox-on-arrival, not click-to-view).
 //
 // Driven entirely by `mediaViewerState()` (lib/mediaViewer.ts);
-// ScrollbackPane's renderRun calls `openMediaViewer` for links that
+// `MircText`'s link handler calls `openMediaViewer` for links that
 // `classifyMediaLink` accepts. Mounted at Shell root in both branches
 // (PrivacyModal pattern).
 //

--- a/cicchetto/src/__tests__/mediaViewer.test.ts
+++ b/cicchetto/src/__tests__/mediaViewer.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { closeMediaViewer, openMediaViewer } from "../lib/mediaViewer";
+
+// Media-viewer store (#1124). `openMediaViewer` is the single open door —
+// `MircText`'s media-link click handler is its only caller — so the
+// keyboard-dismissing blur is pinned on the VERB here, not at a call site.
+// Sibling shape: audioPlayer.test.ts.
+//
+// What jsdom cannot prove: there is no soft keyboard and no visualViewport
+// resize here, so this asserts the CAUSE (focus leaves the text field) and
+// not the EFFECT (the viewport grows back, the image gets the full height).
+// The effect is device-verify only.
+
+const IMAGE_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz";
+
+afterEach(() => {
+  closeMediaViewer();
+  document.body.replaceChildren();
+});
+
+describe("mediaViewer store", () => {
+  it("openMediaViewer blurs the focused compose field, so iOS dismisses the keyboard", () => {
+    const compose = document.createElement("textarea");
+    document.body.append(compose);
+    compose.focus();
+    expect(document.activeElement).toBe(compose);
+
+    openMediaViewer(IMAGE_URL, "image");
+
+    expect(document.activeElement).not.toBe(compose);
+  });
+});

--- a/cicchetto/src/lib/mediaViewer.ts
+++ b/cicchetto/src/lib/mediaViewer.ts
@@ -1,13 +1,14 @@
 // Media-viewer modal state — media-link cluster (2026-06-11).
 //
 // Module-scope signal store (same pattern as `archive.ts`'s
-// `archiveModalNetwork`): the open trigger lives deep inside
-// ScrollbackPane's module-scope renderRun, far from any component that
-// could thread a callback down — a lib store is the established cic
-// shape for that. `MediaViewerModal.tsx` (mounted at Shell root in
-// both branches) renders the state; `lib/mediaLink.ts` decides which
-// links call `openMediaViewer` (and supplies the page-origin-rooted
-// href).
+// `archiveModalNetwork`): the open trigger lives deep inside a
+// module-scope link renderer, far from any component that could thread
+// a callback down — a lib store is the established cic shape for that.
+// `MediaViewerModal.tsx` (mounted at Shell root in both branches)
+// renders the state; `MircText.tsx`'s link handler is the ONLY caller
+// of `openMediaViewer` (it was ScrollbackPane's `renderRun` until #125
+// extracted `MircBody`), and `lib/mediaLink.ts` decides which links it
+// calls for (and supplies the page-origin-rooted href).
 //
 // identityScopedStore (review fix, same reason as archive.ts:36-39):
 // token rotation/logout must close an open viewer — otherwise the
@@ -28,6 +29,26 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   return {
     mediaViewerState,
     openMediaViewer(href: string, kind: MediaKind): void {
+      // #1124 — dismiss the mobile soft keyboard before the viewer opens.
+      // `.media-viewer-modal` is capped at `var(--viewport-height)`, which
+      // tracks the VISUAL viewport (viewportHeight.ts), so with the keyboard
+      // up the media renders in roughly half the height it could use. Nothing
+      // dismisses it on its own: `keepKeyboard.ts` preventDefaults the
+      // mousedown focus-shift on a `.scrollback-link` tap precisely so the
+      // keyboard survives it. That suppresses the IMPLICIT shift only — it
+      // does not stand in the way of this deliberate blur.
+      //
+      // On the verb, not the call site: this is the single open door, so
+      // there is no per-caller wiring to forget (the same "one owner"
+      // argument keepKeyboard.ts makes for itself).
+      //
+      // Accepted trade-off (vjt, #1124): on close the keyboard does NOT come
+      // back. Do NOT "fix" that by re-focusing the compose — a programmatic
+      // focus re-raises the keyboard through the same visual-viewport resize
+      // path the overlay freeze exists to survive (#196 / #219-general /
+      // #1121). The draft itself is per-window compose state, untouched.
+      const focused = document.activeElement;
+      if (focused instanceof HTMLElement) focused.blur();
       setMediaViewerState({ href, kind });
     },
     closeMediaViewer(): void {


### PR DESCRIPTION
Refs #1124.

## What

`openMediaViewer` (`cicchetto/src/lib/mediaViewer.ts`) blurs the active element
before it flips the viewer state, so tapping an image link with the compose box
focused no longer opens the viewer under a raised keyboard.

## Why here

`.media-viewer-modal` is capped at `max-height: calc(var(--viewport-height) -
2rem)`, and `--viewport-height` tracks the **visual** viewport
(`lib/viewportHeight.ts`, the single writer, rewritten on every `vv.resize`).
With the keyboard up that is roughly half the screen, so the media renders in
half the height it could use.

Nothing dismissed the keyboard on its own, and that is deliberate:
`lib/keepKeyboard.ts` `preventDefault`s the `mousedown` focus-shift on a
`.scrollback-link` tap (media links carry that class) precisely so the keyboard
survives taps on controls. It suppresses the **implicit** focus shift; it does
not stand in the way of a **deliberate** `blur()`. Hence the explicit call.

The blur lives on the verb, not the call site, because the verb is the single
open door — see the correction below.

## One door — with a correction to the issue

The issue says *"both the scrollback's `renderRun` link handler and `MircText`
route through it"*. On `origin/main` that is **stale, in our favour**: there is
exactly **one** production caller, `MircText.tsx:244`. `ScrollbackPane`'s
`renderRun` stopped being a caller in #125, when `MircBody` was extracted into
`MircText` — `ScrollbackPane` has not mentioned `renderRun` since. Verified with
`git grep -n openMediaViewer HEAD -- cicchetto/src cicchetto/e2e` (only
`MircText`, plus comments). No third door exists: `mediaViewerState` is written
only by `openMediaViewer` / `closeMediaViewer` / the identity-rotation reset.

Two comments still named the dead `renderRun`; the first commit here fixes them.

**Deliberately not touched:** `playAudio` (`lib/audioPlayer.ts`) is a sibling
door for `kind: "audio"`, but it opens a *docked* mini-player, not a viewer
capped at the viewport height — it has no keyboard problem to solve, so it keeps
its behaviour.

## Accepted trade-off

On close the keyboard does **not** come back. The compose draft is per-window
state and is untouched, but a reader mid-sentence has to tap the field again.
@vjt accepted this explicitly. It is deliberately **not** "fixed" by re-focusing
the compose on close: a programmatic focus re-raises the keyboard through the
same visual-viewport resize path that motivated the overlay freeze (#196 /
#219-general, and #1121).

## Test, and what it cannot prove

`cicchetto/src/__tests__/mediaViewer.test.ts` — one test, on the store verb.
It asserts the pre-state (the textarea holds focus), calls the verb, and asserts
focus left it.

jsdom has **no soft keyboard and no visual viewport**, so the test pins the
CAUSE (focus leaves the field) and not the EFFECT (the viewport grows back and
the media gets the full height). **The effect is device-verify only — a real
iPhone is the only witness.** No e2e was added: Playwright/WebKit has no soft
keyboard either, so a spec there would assert the same cause with far more
machinery.

### Mutation evidence (disjoint kills, full 4913-test suite each)

| Mutant | Result |
|---|---|
| baseline | `266 files, 4913 passed`, rc 0 |
| **M1** — delete `focused.blur()` | `1 failed / 4912 passed`; the single failure is `mediaViewer.test.ts > openMediaViewer blurs the focused compose field…`. The new test is the **sole** witness of the fix. |
| **M2** — delete `setMediaViewerState({ href, kind })` | `20 failed / 4893 passed` (`MediaViewerModal` + `ScrollbackPane`), and `mediaViewer.test.ts` **passes**. The new test does not merely re-assert the pre-existing open. |

## Gates

- `scripts/bun.sh run test` — 266 files, 4913 passed, rc 0
- `scripts/bun.sh run check` — biome + `tsc --noEmit` (src and e2e), rc 0, re-run
  after deleting `*.tsbuildinfo` so the new file is not a warm-cache false pass
- No lane taken: cic-only change, no server compile, no e2e