### PR TITLE
#1106: pin the selection window open, and name the diagnostic that cannot decide

### DIFF
--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { closeMessageMenu, openMessageMenu, SELECTING_CLASS } from "../lib/messageMenu";
+import MessageContextMenu from "../MessageContextMenu";
+
+// #1106 — the ORDERING half of "Select… installs no visible selection while the
+// compose keyboard is open".
+//
+// `selectMessageText` installs the range, puts `is-selecting` on <html>, and
+// only THEN registers the `selectionchange` listener that strips the class once
+// the selection is gone. `ContextMenu.handleItemClick` runs `item.action()` and
+// then `props.onClose()`, so the whole menu — portal, backdrop, buttons —
+// unmounts immediately after. `selectionchange` is dispatched ASYNCHRONOUSLY
+// (the spec queues a task), so the event the install itself provokes is
+// delivered AFTER that teardown, straight into the freshly-registered listener.
+// If the teardown emptied the selection, the class would be gone within a
+// macrotask and `html.is-ios.is-selecting .scrollback { -webkit-touch-callout:
+// default }` would never apply — the re-enable #1067 added is what gives the
+// selection its draggable endpoints.
+//
+// The test asserts the window stays OPEN across that teardown. It deliberately
+// uses jsdom's real Selection rather than the stub the rest of
+// `messageMenu.test.ts` uses: a stub cannot deliver the asynchronous event, so
+// it cannot see this ordering at all.
+//
+// SCOPE — this closes the DOM-contract question only. jsdom is not an engine:
+// it does not paint, does not focus a button on click, and its
+// Selection/text-control interaction is already known to diverge from a real
+// one. Nothing here says what WebKit does on device; #1106's leads 1 and 3 are
+// untouched by it.
+
+function scrollbackRow(text: string): HTMLElement {
+  const pane = document.createElement("div");
+  pane.className = "scrollback";
+  const row = document.createElement("div");
+  row.className = "scrollback-line";
+  row.textContent = text;
+  pane.appendChild(row);
+  document.body.appendChild(pane);
+  return row;
+}
+
+function msg(): ScrollbackMessage {
+  return {
+    id: 7,
+    network: "azzurra",
+    channel: "#grappa",
+    server_time: 1_700_000_000_000,
+    kind: "privmsg",
+    sender: "vjt",
+    body: "ciao",
+    meta: {},
+  };
+}
+
+// A macrotask: long enough for the queued `selectionchange` to be delivered.
+const settle = (): Promise<void> => new Promise((res) => setTimeout(res, 0));
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+  closeMessageMenu();
+  window.getSelection()?.removeAllRanges();
+});
+
+describe("Select… with the compose keyboard up", () => {
+  it("keeps the callout window open across the menu's own teardown", async () => {
+    const row = scrollbackRow("12:34 <vjt> ciao");
+    // The keyboard being up IS a focused text control — the precondition that
+    // separates the reported failure from the working case.
+    const compose = document.createElement("textarea");
+    document.body.appendChild(compose);
+    compose.focus();
+
+    render(() => <MessageContextMenu />);
+    openMessageMenu({
+      msg: msg(),
+      row,
+      networkSlug: "azzurra",
+      channelName: "#grappa",
+      at: { x: 10, y: 20 },
+    });
+
+    const delivered: string[] = [];
+    document.addEventListener("selectionchange", () => {
+      delivered.push(window.getSelection()?.toString() ?? "");
+    });
+
+    fireEvent.click(screen.getByText("Select…"));
+    expect(document.querySelectorAll(".context-menu")).toHaveLength(0);
+
+    await settle();
+
+    // Non-vacuity: the guard must have been REACHED. Were the environment to
+    // stop dispatching `selectionchange`, the class would survive for want of
+    // anything to strip it and this test would be green for the wrong reason.
+    expect(delivered.length).toBeGreaterThan(0);
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(true);
+    // And it survived because the guard found a LIVE selection, not because
+    // nothing ever looked.
+    expect(delivered.at(-1)).toBe("12:34 <vjt> ciao");
+  });
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35408,3 +35408,63 @@ hand-injected `padding-bottom` would be overriding the very declaration under
 test, so the simulation would be circular. The on-device look, and whether the
 bottom row of tabs still takes taps reliably inside the home-indicator strip,
 remain owed to a real notched iPhone.
+
+## 2026-08-09 — #1106: the selection window does not close on its own, and the diagnostic the issue proposes cannot separate its leads
+
+**What was asked, and what was refused.** #1106 is an iOS report: long-press a
+message row with the compose keyboard up, choose `Select…`, and no selection
+appears. Nobody working on it here has an iPhone or a WebKit engine, so
+everything about what WebKit *paints* stays unclaimed. Only the lead that is a
+question of ORDERING rather than of rendering was measurable, and only that one
+was measured.
+
+**The hazard shape, which is real.** `selectMessageText` installs the range,
+adds `is-selecting` to `<html>`, and only THEN registers the `selectionchange`
+listener that strips the class once the selection is gone.
+`ContextMenu.handleItemClick` runs `item.action()` and then `props.onClose()`,
+so the portal, backdrop and buttons unmount immediately after. `selectionchange`
+is dispatched ASYNCHRONOUSLY — the spec queues a task — so the event the install
+itself provokes is delivered AFTER that teardown, straight into the listener
+registered a moment earlier. Had the teardown emptied the selection, the class
+would have been stripped within one macrotask and `html.is-ios.is-selecting
+.scrollback { -webkit-touch-callout: default }` would never have applied, which
+is precisely the re-enable #1067 added to make the selection adjustable.
+
+**The measurement.** In jsdom, with a focused `<textarea>` standing in for the
+open keyboard, the class survives: three `selectionchange` events are delivered
+after the click, each carrying the full row text, so the guard is reached,
+finds a live selection and returns early. Removing the menu's own DOM does not
+disturb a range anchored outside it, and nothing else in cic touches the
+selection — the only `removeAllRanges` in the tree is `selectMessageText`'s own,
+and no code refocuses the composer on menu close. Pinned by
+`MessageContextMenu.test.tsx`; proven by a deliberate red (a teardown that
+clears the selection kills that one test and no other, 1 of 4965).
+
+**A stub cannot see an asynchronous event.** `messageMenu.test.ts` stubs
+`window.getSelection`, so its "arms the callout re-enable" test asserts
+synchronously and would pass unchanged if the class were stripped one tick
+later. That is why the new guard uses jsdom's real Selection, and why it
+asserts a `selectionchange` was actually delivered: without that assertion it
+would go green for want of an event rather than for the reason claimed.
+
+**The diagnostic the issue proposes does not discriminate.** #1106 suggests
+capturing `keepKeyboard`'s `kb: scrollback md held=<n>ms → HOLD keep-kbd`
+diag line on the failing device to tell whether the long-press arm is reached,
+"which separates lead 1 from leads 2-3". By `keepKeyboard`'s own documented
+device model, it cannot: that arm fires on `mousedown`, and the module states
+that on real iOS a long-press synthesizes no `mousedown` at all — only taps do,
+so the arm "effectively only ever sees taps" and survives as a cross-platform
+net. The HOLD line is therefore predicted ABSENT on the very gesture under
+test, and observing its absence is consistent with both "arm not reached" and
+"iOS dispatched nothing to reach it". Observing it PRESENT would be
+informative, but only by falsifying that comment.
+
+**What would actually decide it, and it needs the device.** A remote Web
+Inspector console (Mac Safari → Develop → the connected iPhone), immediately
+after tapping `Select…` with the keyboard up, reading three things:
+`getSelection().rangeCount` and `.toString()`; `document.documentElement.className`;
+and `getComputedStyle(row)`'s `webkitUserSelect` / `webkitTouchCallout`. A live
+non-empty range plus `is-selecting` present plus `text`/`default` resolved means
+WebKit installed everything and painted nothing — lead 1 — and the fix belongs
+in the ordering or the keyboard, not in the class or the CSS. It needs no new
+code.


### PR DESCRIPTION
Investigation of #1106 (iOS: `Select…` installs no visible selection
while the compose keyboard is open). **No fix — the one lead that could
be settled without a device turned out negative, and the negative is
worth pinning.**

## What is claimed

Lead 2 of the issue — "the `is-selecting` window may close immediately"
— is a question of ordering, not of rendering, so it is measurable here.
It is false, in the DOM contract:

- `selectionchange` is dispatched asynchronously, so the event
  `selectMessageText`'s own `addRange` provokes is delivered AFTER
  `ContextMenu` has run `props.onClose()` and unmounted the portal,
  straight into the listener registered a moment earlier. That is the
  real hazard shape, and it is worth a guard.
- With a focused `<textarea>` standing in for the open keyboard, three
  such events are delivered after the click, each carrying the full row
  text. The guard is reached, finds a live selection, returns early, and
  `is-selecting` survives.
- Nothing else in cic disturbs it: the only `removeAllRanges` in the
  tree is `selectMessageText`'s own, and no code refocuses the composer
  on menu close.

`MessageContextMenu.test.tsx` pins this. It uses jsdom's real Selection
rather than the stub `messageMenu.test.ts` uses — a stub cannot deliver
an asynchronous event, so the existing "arms the callout re-enable"
test asserts synchronously and would pass unchanged if the class were
stripped one tick later. Delivery is asserted explicitly so the guard
cannot go green for want of an event. Proven by deliberate red: a
teardown that clears the selection kills that one test and no other
(1 failed of 4965).

## What is refused

Nothing about what WebKit paints. There is no iPhone and no WebKit
engine here, so leads 1 and 3 are untouched — not weakened, not
narrowed, simply not addressed. jsdom is not an engine: it does not
paint, does not focus a button on click, and its Selection/text-control
interaction is already visibly divergent (focusing a textarea *after*
installing a range empties the document selection in jsdom, where the
issue's own Chromium table shows 8 rects still painted).

## One correction to the issue

The issue proposes capturing `keepKeyboard`'s
`kb: scrollback md held=<n>ms → HOLD keep-kbd` diag line on the failing
device, "which separates lead 1 from leads 2-3 before any code is
written". By `keepKeyboard`'s own documented device model it cannot:
that arm fires on `mousedown`, and the module states that on real iOS a
long-press synthesizes no `mousedown` at all — only taps do. The HOLD
line is predicted ABSENT on the very gesture under test, so its absence
is consistent with both "arm not reached" and "nothing was dispatched to
reach it". Seeing it PRESENT would be informative, but only by
falsifying that comment.

What would decide it needs the device and no new code: a remote Web
Inspector console, immediately after tapping `Select…` with the keyboard
up, reading `getSelection().rangeCount` / `.toString()`,
`document.documentElement.className`, and `getComputedStyle(row)`'s
`webkitUserSelect` / `webkitTouchCallout`. A live non-empty range plus
`is-selecting` present plus `text`/`default` resolved means WebKit
installed everything and painted nothing — lead 1 — and the fix belongs
in the ordering or the keyboard, not in the class or the CSS.

## Gates

- `bun run test` — 269 files, 4965 tests, all green
- `bun run check` — 0 errors (61 warnings, 5 infos: the pre-existing
  baseline shape)
- Deliberate red on the mutation described above, then reverted