### PR TITLE
#1066: SVC_AKILL_CLONES turns off clone detection, not the autokill

### DIFF
--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -87,16 +87,34 @@ services:
       # services' validate_email() rejects the .test TLD; use the real
       # services network domain (azzurra.chat) for the envelope-from.
       SVC_RETURN: "noreply@azzurra.chat"
-      # GH #349 — DISABLE services' clone-autokill (conf.c CLONES →
-      # CONF_AKILL_CLONES; default 5, expiry 600s). grappa is a BOUNCER:
-      # bahamut-test + azzurra + azzurra-reg sessions ALL link to this one
-      # hub from grappa's single container IP, so services see them as
-      # clones and autokill the IP on the 5th connection — a false positive
-      # that turns the FULL suite red from a hard cliff (Autokilled →
-      # session :failed → resetSubject 500 → live-IRC specs time out).
-      # main sits at 4 concurrent (margin-of-1); azzurra-reg is the +1 that
-      # tips it. 0 = akill off (detection/globops still run). This testnet
-      # is single-tenant + hermetic — there are no real clones to police.
+      # GH #349 — keep services from autokilling grappa's container IP.
+      # grappa is a BOUNCER: bahamut-test + azzurra + azzurra-reg sessions
+      # ALL link to this one hub from grappa's single container IP, so
+      # services count them as clones and akill the IP on the 5th — a
+      # false positive that turns the FULL suite red from a hard cliff
+      # (Autokilled → session :failed → resetSubject 500 → live-IRC specs
+      # time out). Measured on this stack: 6 connections from one IP with
+      # the akill armed get `465 You have been Autokilled`.
+      #
+      # GH #1066 — what this value REALLY does. The submodule template
+      # (infra/services/conf.tmpl) writes it to the `CLONES` directive,
+      # NOT to `CLONEKILL`. They are different knobs in azzurra/services:
+      # `CLONES` is a BOOLEAN (conf.c:786 fatals unless 0 or 1) feeding
+      # CONF_SET_CLONE, the master switch that gates check_clones()
+      # outright (users.c:1316); `CLONEKILL` is the NUMERIC threshold
+      # (conf.c:940 — 0, or 5..50) feeding CONF_AKILL_CLONES. So "0" here
+      # turns clone DETECTION off entirely — no scan, no oper globops, and
+      # hence no autokill. CONF_AKILL_CLONES is never written at all and
+      # keeps its built-in 5, moot while detection is off. The effect we
+      # need holds, more bluntly than intended; "autokill off, detection
+      # and globops on" is what CLONEKILL:0 would give and is unreachable
+      # from here until the submodule is fixed.
+      #
+      # Only 0 and 1 are accepted. Every value in the 5..50 range the
+      # submodule's entrypoint.sh documents as valid FATALS services at
+      # startup (`FATAL ERROR: Value 5 for CLONES is not valid`) and takes
+      # the whole stack with it — test/scripts/e2e_clone_directive_test.bats
+      # guards this pairing.
       SVC_AKILL_CLONES: "0"
     networks:
       svc-net: null

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35555,6 +35555,7 @@ non-empty range plus `is-selecting` present plus `text`/`default` resolved means
 WebKit installed everything and painted nothing — lead 1 — and the fix belongs
 in the ordering or the keyboard, not in the class or the CSS. It needs no new
 code.
+
 ## 2026-08-09 — #1066: a variable named after the knob it does not turn
 
 **The defect.** `cicchetto/e2e/compose.yaml` sets `SVC_AKILL_CLONES: "0"` under

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35555,3 +35555,89 @@ non-empty range plus `is-selecting` present plus `text`/`default` resolved means
 WebKit installed everything and painted nothing — lead 1 — and the fix belongs
 in the ordering or the keyboard, not in the class or the CSS. It needs no new
 code.
+## 2026-08-09 — #1066: a variable named after the knob it does not turn
+
+**The defect.** `cicchetto/e2e/compose.yaml` sets `SVC_AKILL_CLONES: "0"` under
+a comment ending "0 = akill off (detection/globops still run)". Detection and
+globops do not still run. The azzurra-testnet template
+(`infra/services/conf.tmpl`) writes that value to the `CLONES` directive, and
+in `azzurra/services` `CLONES` and `CLONEKILL` are two different knobs:
+
+| directive | variable | validator |
+|---|---|---|
+| `CLONES` | `CONF_SET_CLONE` | `conf.c:786` — boolean; fatal unless 0 or 1 |
+| `CLONEKILL` | `CONF_AKILL_CLONES` | `conf.c:940` — 0, or 5..50 |
+
+`CONF_SET_CLONE` gates `check_clones()` outright (`users.c:1316`), so `0` there
+turns clone detection off entirely — no scan, no oper globops, and therefore no
+autokill. `CONF_AKILL_CLONES`, the variable the template is named after, is
+never written at all and keeps its built-in 5, moot while detection is off. All
+line numbers read at `azzurra/services` `2d464b2e`, the `master` the testnet
+Dockerfile builds from.
+
+**Measured, not argued.** The container built from that template fatals on the
+standalone testnet's own default:
+
+```
+[F00019 L00791 T005 S005] FATAL ERROR: Value 5 for CLONES is not valid
+```
+
+`L00791` is the `fatal_error(FACILITY_CONF, __LINE__, …)` in the `CLONES` arm —
+the running binary naming the same source line as the reading above. Sweeping
+the value: 0 and 1 proceed to the hub connect; 2, 5, 20 and 50 all fatal. The
+submodule's `entrypoint.sh` documents "Valid values: 0 (off) or 5..50", which
+is precisely the range that cannot work.
+
+**Three arms on the live stack**, same six connections from one pinned source
+IP, same opered observer on `+g`:
+
+| services.conf | 6 clones from one IP | globops |
+|---|---|---|
+| `CLONES:0` (today) | all six live | none |
+| `CLONEKILL:5` | `465 You have been Autokilled` | `WARNING: 5 clones autokilled from …` |
+| `CLONEKILL:0` | all six live | `Clones: 5 from …` |
+
+The first row's silence only means something because of the other two: the same
+burst does produce a signal when detection is on. The second row is also what
+makes #349's fear concrete rather than theoretical — the autokill is real on
+this testnet, and it is a services akill, not only bahamut's own throttling.
+The third row is the behaviour the comment claimed to have.
+
+**One arm had to be thrown away.** The `CLONEKILL:0` run was first attempted on
+a source IP docker had recycled from the `CLONEKILL:5` run, whose akill was
+still live for its full 600s: every connection was refused at the door with the
+same akill ID and timestamp as the previous arm. Nothing about clone detection
+could be read from it. Re-run from a pinned, unakilled IP.
+
+**What is cured here, and what is not.** The outcome #349 wanted still holds —
+grappa's bouncer IP is not autokilled — so this is a comment fix, not a
+behaviour change. The submodule half is a one-line change
+(`CLONES:${SVC_AKILL_CLONES}` → `CLONEKILL:${SVC_AKILL_CLONES}`) that is
+proposed, not pushed: it is another repository, and the pointer is not bumped
+here.
+
+**The guard follows the fix instead of freezing today.**
+`test/scripts/e2e_clone_directive_test.bats` reads the directive out of the
+template rather than naming it, then checks the compose value against that
+directive's validator. Setting 5 today goes red instead of taking the stack
+down as an opaque cascade; the day the submodule writes `CLONEKILL`, the
+accepted set becomes the numeric one with no edit here — verified by mutating
+the template and re-running. An unrecognised third directive fails loudly,
+because a variable quietly moved onto a knob whose validator nobody read is how
+this happened in the first place.
+
+**Impact on #349's coverage: none lost, because none existed.** No spec
+exercises clone detection, globops, or a services AKILL — the only AKILL-adjacent
+spec, `issue554-operator-kill-terminal.spec.ts`, drives an operator KILL from an
+opered peer. What is lost is a latent safety net, not an assertion. The
+forward-looking note is the opposite one: the registration-wizard specs have
+only ever run with clone detection fully off, so if the submodule is fixed the
+suite runs for the first time with services scanning every connecting user and
+globopsing once grappa's fifth session lands. Harmless by the third row above,
+but never yet observed.
+
+**Not claimed.** That the submodule's `testnet` smoke workflow would have caught
+this: it triggers on pushes to `master` while the repository's default branch is
+`main`, and no run of it appears in the repository's history. That is a
+plausible reason the fatal stayed invisible, not a measured one — nobody has
+re-pointed the trigger and watched it go red.

--- a/test/scripts/e2e_clone_directive_test.bats
+++ b/test/scripts/e2e_clone_directive_test.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+#
+# #1066 — SVC_AKILL_CLONES must carry a value the directive it actually
+# reaches will accept.
+#
+# cicchetto/e2e/compose.yaml sets SVC_AKILL_CLONES; the azzurra-testnet
+# submodule's services/conf.tmpl decides which services.conf directive
+# that value lands in. Today it lands in `CLONES`, which is a BOOLEAN
+# (conf.c:786 — strtol, then fatal unless the result is 0 or 1), not in
+# `CLONEKILL`, the numeric clone-akill threshold the variable is named
+# after (conf.c:940 — 0, or 5..50). The submodule's own entrypoint.sh
+# documents "Valid values: 0 (off) or 5..50", which is the OTHER
+# directive's range: measured on this stack, 5, 20 and 50 all die with
+#
+#     FATAL ERROR: Value 5 for CLONES is not valid
+#
+# before services finishes parsing its config, and the whole integration
+# stack goes with it as an opaque cascade.
+#
+# So this pairing — the value here, the directive over there — is the
+# thing worth guarding, and neither half can guard it alone. Reading the
+# directive out of the template rather than hardcoding it means the
+# guard keeps working, without an edit, if the submodule is ever fixed
+# to write CLONEKILL: the accepted set simply becomes the numeric one.
+#
+# An unrecognised directive is a FAILURE, not a pass: a third name means
+# somebody moved the variable to a knob whose validator nobody here has
+# read, which is exactly how #1066 happened in the first place.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    TMPL="$REPO_ROOT/cicchetto/e2e/infra/services/conf.tmpl"
+    COMPOSE="$REPO_ROOT/cicchetto/e2e/compose.yaml"
+
+    # A fresh worktree has the submodule empty. Init it the same way
+    # scripts/testnet.sh and scripts/bats.sh already do (#592): the clone
+    # comes from the superproject's local module store over file://, which
+    # the CVE-2022-39253 mitigation blocks without the flag. Offline,
+    # idempotent, a no-op once present. CI checks it out ahead of us.
+    if [ ! -f "$TMPL" ]; then
+        git -C "$REPO_ROOT" -c protocol.file.allow=always \
+            submodule update --init cicchetto/e2e/infra >&2 || true
+    fi
+    [ -f "$TMPL" ]
+    [ -f "$COMPOSE" ]
+}
+
+# Every services.conf directive the template feeds ${SVC_AKILL_CLONES} to.
+tmpl_directives() {
+    sed -n 's/^\([A-Z_]\{1,\}\):\${SVC_AKILL_CLONES}[[:space:]]*$/\1/p' "$TMPL"
+}
+
+# Every value cicchetto/e2e/compose.yaml sets for SVC_AKILL_CLONES.
+compose_values() {
+    sed -n 's/^[[:space:]]*SVC_AKILL_CLONES:[[:space:]]*"\{0,1\}\([0-9]\{1,\}\)"\{0,1\}[[:space:]]*$/\1/p' \
+        "$COMPOSE"
+}
+
+@test "the testnet template feeds SVC_AKILL_CLONES into exactly one directive" {
+    run tmpl_directives
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]
+}
+
+@test "the e2e compose sets SVC_AKILL_CLONES exactly once" {
+    run compose_values
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]
+}
+
+@test "the value the e2e sets is one the directive it reaches accepts" {
+    local directive value
+    directive="$(tmpl_directives)"
+    value="$(compose_values)"
+
+    case "$directive" in
+        # conf.c:786 — CONF_SET_CLONE, the clone-detection master switch.
+        CLONES)
+            [ "$value" = "0" ] || [ "$value" = "1" ]
+            ;;
+        # conf.c:940 — CONF_AKILL_CLONES, the autokill threshold.
+        CLONEKILL)
+            [ "$value" = "0" ] || { [ "$value" -ge 5 ] && [ "$value" -le 50 ]; }
+            ;;
+        *)
+            printf 'SVC_AKILL_CLONES now feeds the %s directive; read its\n' "$directive" >&2
+            printf 'validator in azzurra/services src/conf.c and teach this guard.\n' >&2
+            return 1
+            ;;
+    esac
+}


### PR DESCRIPTION
Refs #1066.

`cicchetto/e2e/compose.yaml` sets `SVC_AKILL_CLONES: "0"` under a comment
that ends *"0 = akill off (detection/globops still run)"*. Detection and
globops do not still run. This PR fixes the grappa-side half — the
comment, and a guard so the next value cannot silently take the stack
down. The submodule half is **proposed below, not pushed**: the pointer
is not bumped here.

## The two directives

Read at `azzurra/services` `2d464b2e` (the `master` the testnet
Dockerfile builds from):

| directive | variable | validator |
|---|---|---|
| `CLONES` | `CONF_SET_CLONE` | `conf.c:786` — boolean, fatal unless 0 or 1 |
| `CLONEKILL` | `CONF_AKILL_CLONES` | `conf.c:940` — 0, or 5..50 |

`infra/services/conf.tmpl` writes `SVC_AKILL_CLONES` to `CLONES`.
`CONF_SET_CLONE` gates `check_clones()` outright (`users.c:1316`), so `0`
turns clone **detection** off entirely — no scan, no oper globops, hence
no autokill. `CONF_AKILL_CLONES` is never written and keeps its built-in
5, moot while detection is off.

## Measured, not argued

The image built from that template, on the standalone testnet's own
default:

```
[F00019 L00791 T005 S005] FATAL ERROR: Value 5 for CLONES is not valid
```

`L00791` is the `fatal_error(…, __LINE__, …)` inside the `CLONES` arm —
the running binary naming the same source line as the table above.
Sweeping the value: `0` and `1` proceed to the hub connect; `2`, `5`,
`20`, `50` all fatal. The submodule's `entrypoint.sh` documents
*"Valid values: 0 (off) or 5..50"* — precisely the range that cannot
work.

Three arms on the live e2e stack, same six connections from one pinned
source IP, same opered observer on `+g`:

| services.conf | 6 clones from one IP | globops |
|---|---|---|
| `CLONES:0` (today) | all six live | none |
| `CLONEKILL:5` | `465 You have been Autokilled` | `WARNING: 5 clones autokilled from …` |
| `CLONEKILL:0` | all six live | `Clones: 5 from …` |

Row 1's silence only means something because of rows 2 and 3: the same
burst does produce a signal when detection is on. Row 2 also makes
#349's fear concrete — the autokill is real here, and it is a services
akill. Row 3 is the behaviour the comment claimed.

## What is in this PR

- **`cicchetto/e2e/compose.yaml`** — the comment now says what the value
  does. Behaviour unchanged: the outcome #349 wanted (grappa's bouncer IP
  not autokilled) still holds, more bluntly than intended.
- **`test/scripts/e2e_clone_directive_test.bats`** — reads the directive
  out of the template rather than naming it, then checks the compose
  value against that directive's validator. Setting `5` today goes red
  instead of taking the stack down as an opaque cascade; when the
  submodule writes `CLONEKILL` the accepted set becomes the numeric one
  with no edit here. A third directive name fails loudly.
- **`docs/DESIGN_NOTES.md`** — the measurements, and the arm that had to
  be binned.

## The submodule patch, for review — not sent

In `vjt/azzurra-testnet`, one line in `services/conf.tmpl`:

```diff
-CLONES:${SVC_AKILL_CLONES}
+CLONEKILL:${SVC_AKILL_CLONES}
```

`entrypoint.sh:31`'s `: "${SVC_AKILL_CLONES:=5}"` then becomes correct as
written, and the existing `conf.tmpl` comment (which already describes
the `CLONEKILL` validator) becomes accurate. Verified by running the
patched template on the live stack: `CLONEKILL:5` starts and autokills at
the fifth clone; `CLONEKILL:0` starts, detects, globopses, kills nobody.
Whether to open that PR is not this PR's call.

Two further observations for that repository, unmeasured:

- If clone *detection* should also be switchable, it wants its own
  variable feeding `CLONES` with an actual boolean.
- `.github/workflows/testnet.yml` — the smoke job that boots the stack —
  triggers on pushes to `master`, while the repository's default branch
  is `main`. No run of it appears in the repository's history. That is a
  plausible reason the fatal stayed invisible; nobody has re-pointed the
  trigger and watched it go red.

## Coverage impact on #349

None lost, because none existed: no spec exercises clone detection,
globops, or a services AKILL. The only AKILL-adjacent spec,
`issue554-operator-kill-terminal.spec.ts`, drives an operator KILL from
an opered peer. What was lost is a latent safety net, not an assertion.

The forward-looking note is the reverse: the registration-wizard specs
have only ever run with detection fully off, so if the submodule is fixed
the suite runs for the first time with services scanning every connecting
user and globopsing once grappa's fifth session lands. Harmless per row 3
above, but never yet observed.

## Gates

- `scripts/bats.sh` — 383/383, `1..383`, zero `not ok`, rc 0.
- `scripts/testnet.sh up` on this tree — rc 0, every container up or
  healthy; `azzurra-services` renders `CLONES:0` and stays up.
- Guard killed by deliberate mutation: value `5` under `CLONES`; value
  `3` under `CLONEKILL`; an unknown directive; the template dropping the
  variable; the compose setting it twice. Green under `CLONEKILL:0` — the
  proposed fix — with no guard edit.

Not run: the full Playwright integration suite. Nothing here reaches
runtime code — a YAML comment, a bats file, a doc.