### PR TITLE
union: #1121 + #1124 + #1106, gated once

### DIFF
--- a/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
+++ b/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
@@ -1,0 +1,148 @@
+// #1121 — closing a covering overlay over a reader who was AT the tail must not
+// strand them above it in silence.
+//
+// The mirror image of issue196-preview-scroll-live-arrival, which drives the
+// SCROLLED-UP reader: there the contract is "do not move me", here it is "do not
+// go deaf". Both run the same harness and the same gesture; only the reader's
+// starting position differs, and that difference is the whole bug.
+//
+// While the overlay is up the pane is frozen (#196 / #219-general) and lines
+// landing underneath do not move it — that part is deliberate and is what the
+// #196 spec pins. The damage was at the CLOSE edge, in `applyOverlayRestore`: it
+// reconciled the follow intent from `scrollHeight` measured on the close edge
+// against the scrollTop captured on the OPEN one, so the growth under the
+// overlay read as distance the reader had put between themselves and the tail.
+// A reader who had not moved lost tail-follow, and — because the restore writes
+// nothing when the pane is already where it was held — no scroll event fired,
+// `atBottomNow` stayed stale-true, and both rescue affordances were suppressed
+// with it: no floating scroll-to-bottom button, and `readingAtTailKey` kept
+// telling the badge derivation to hide this window's unread count. The reporter
+// waited a minute and only their own send released it.
+//
+// Two observables, one per broken signal:
+//   * the floating scroll-to-bottom button is VISIBLE right after the close
+//     (the geometry was republished for the close edge);
+//   * a line arriving AFTER the close is scrolled to (the follow intent
+//     survived the freeze).
+//
+// The button assertion runs FIRST and on its own: the follow-up line tail-snaps
+// the pane, which legitimately unmounts the button again.
+//
+// Desktop project only (untagged → chromium), like its #196 twin: desktop Chrome
+// reproduces desktop scroll physics (feedback_playwright_webkit_not_ios_scroll).
+
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "arr1121-peer";
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX (not exported) — the
+// reader counts as AT the tail when distance-to-bottom is within it.
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+test.describe("#1121 — closing an overlay over a tail reader must not strand them", () => {
+  // This spec leaves the pane parked above the tail for part of its run, so its
+  // scroll-settle can advance the shared #bofh cursor to a mid-page position and
+  // leave the trailing peer lines unread. A downstream spec assuming a fully-read
+  // #bofh would then inherit an unread marker → cold-mount marker-jump → scroll
+  // flake. Restore after EACH run, not afterAll: under `--repeat-each` afterAll
+  // fires once after every repeat, far too late, and sibling specs interleave
+  // between our repeats. Cascade hygiene: feedback_cascade_poisoner_pattern.
+  test.afterEach(async () => {
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("closing the media viewer over a tail reader restores the button and keeps following (desktop)", async ({
+    page,
+  }) => {
+    test.slow();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    // Upload an image → a clickable media link lands at the tail, where our
+    // reader already is. No scroll-up here: being AT the tail IS the precondition.
+    const { slug } = await uploadViaPicker(
+      page,
+      { name: "arr1121.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+      { postTimeout: 10_000 },
+    );
+    const { link } = await mediaScrollbackRow(page, "📸", slug);
+    await expect(link).toHaveClass(/scrollback-media-link/);
+
+    const sc = page.getByTestId("scrollback");
+    const scrollButton = page.locator('[data-testid="scroll-to-bottom"]');
+
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      await peer.join(CHANNEL);
+
+      // Pin the reader AT the tail and let onScroll MEASURE it. Both halves
+      // matter: the position is the precondition, and the measurement is what
+      // arms `atBottomNow`/`tailGeometryMeasured` so the stale-true read the bug
+      // depends on can exist at all.
+      const before = await sc.evaluate((el) => {
+        el.scrollTop = el.scrollHeight;
+        return {
+          top: el.scrollTop,
+          distanceToBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+        };
+      });
+      await page.waitForTimeout(300);
+      expect(before.distanceToBottom).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+      // At the tail, so the button must be down — else the post-close assertion
+      // would be measuring a button that was already there.
+      await expect(scrollButton).toBeHidden({ timeout: 5_000 });
+
+      // Open the preview via a REAL click on the image at the tail.
+      await link.click();
+      const viewer = page.getByRole("dialog", { name: "Media viewer" });
+      await expect(viewer).toBeVisible({ timeout: 5_000 });
+
+      // Three lines land underneath the open overlay — the reporter's exact
+      // gesture. They must NOT move the frozen pane (that is #196's contract,
+      // re-asserted here as the precondition for ours), but they DO grow the
+      // extent, which is what the close edge used to misread. `toBeAttached`,
+      // not `toBeVisible`: they land off-screen below the held viewport.
+      for (let i = 0; i < 3; i++) {
+        const marker = `arr1121-under-${i}`;
+        peer.privmsg(CHANNEL, marker);
+        await expect(page.getByText(marker)).toBeAttached({ timeout: 15_000 });
+      }
+      await page.waitForTimeout(400);
+      const during = await sc.evaluate((el) => el.scrollTop);
+      expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
+
+      // Close it. The reader is now genuinely parked above a tail that moved.
+      await viewer.getByRole("button", { name: "Close media viewer" }).click();
+      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await page.waitForTimeout(400);
+
+      // OBSERVABLE 1 — the geometry was republished, so the pane admits there is
+      // content below and offers the way down. Pre-fix `atBottomNow` was
+      // stale-true and this button never mounted: "non c'e' nessun bottone di
+      // scroll".
+      const afterClose = await sc.evaluate((el) => ({
+        distanceToBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+      }));
+      expect(afterClose.distanceToBottom).toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+      await expect(scrollButton).toBeVisible({ timeout: 5_000 });
+
+      // OBSERVABLE 2 — the follow intent survived, so the next line is tailed
+      // onto rather than dropped below the fold. Pre-fix the intent had been
+      // reconciled off and the pane stayed deaf until the reader's own send.
+      peer.privmsg(CHANNEL, "arr1121-after-close");
+      await expect(page.getByText("arr1121-after-close")).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await peer.disconnect("#1121 tail-reader close done");
+    }
+  });
+});

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -24,7 +24,7 @@ import { maybeEscapePwaClick } from "./lib/platform";
 // spec 2026-06-10; the spec bans lightbox-on-arrival, not click-to-view).
 //
 // Driven entirely by `mediaViewerState()` (lib/mediaViewer.ts);
-// ScrollbackPane's renderRun calls `openMediaViewer` for links that
+// `MircText`'s link handler calls `openMediaViewer` for links that
 // `classifyMediaLink` accepts. Mounted at Shell root in both branches
 // (PrivacyModal pattern).
 //

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1057,6 +1057,17 @@ const ScrollbackPane: Component<Props> = (props) => {
   // Both the freeze gate and the restore require this === key(); a switched-to
   // window activates normally. `null` when no overlay snapshot is held.
   let overlaySnapshotKey: string | null = null;
+  // #1121 — the distance-to-tail measured at the same instant as
+  // `overlayScrollSnapshot`, and the reason it must be captured rather than
+  // recomputed. The restore reconciles the follow INTENT, which is a fact about
+  // the OPEN edge ("was the reader following when the freeze began?"), but it
+  // runs on the CLOSE edge, where `scrollHeight` has already absorbed whatever
+  // arrived underneath. Recomputing the distance there mixes an open-edge
+  // scrollTop with a close-edge extent and reads back the GROWTH — so a reader
+  // pinned to the tail looked like a reader who had scrolled up by exactly the
+  // messages they missed, and lost tail-follow for it. Captured with the px,
+  // spent on the intent; the geometry signal is measured fresh instead.
+  let overlaySnapshotDistance: number | null = null;
   // #608 (deep-review §6.1) — the overloaded `atBottom` split into its two
   // independent concerns, the PRIMARY reshape of the single-scroll-authority
   // work:
@@ -1969,10 +1980,14 @@ const ScrollbackPane: Component<Props> = (props) => {
         if (open) {
           overlayScrollSnapshot = listRef.scrollTop;
           overlaySnapshotKey = key();
+          // #1121 — same instant, same epoch as the px above. See its
+          // declaration for why the restore cannot recompute this later.
+          overlaySnapshotDistance = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight;
         }
         const target = overlayScrollSnapshot;
         const snapKey = overlaySnapshotKey;
-        if (target === null || snapKey === null) return;
+        const snapDistance = overlaySnapshotDistance;
+        if (target === null || snapKey === null || snapDistance === null) return;
         // Re-assert across rAF×2 (matching scrollToActivation's frame budget so
         // it lands after the overlay's layout commits) via the applier's W1
         // restore entrypoint — the single owner of this write, key-guarded there.
@@ -1986,7 +2001,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         // close→reopen nulling a just-re-armed snapshot) is now structurally
         // impossible, as is the field-bug "frozen forever under a leaked count".
         requestAnimationFrame(() =>
-          requestAnimationFrame(() => applyOverlayRestore(target, snapKey)),
+          requestAnimationFrame(() => applyOverlayRestore(target, snapKey, snapDistance)),
         );
       },
       { defer: true },
@@ -2966,7 +2981,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // mid-overlay channel switch owns its own activation; never stamp the leaving
   // channel's px onto it) and skips a no-op write. `target` is the px captured on
   // the open edge; `snapKey` the channel it was captured on.
-  const applyOverlayRestore = (target: number, snapKey: string): void => {
+  const applyOverlayRestore = (target: number, snapKey: string, snapDistance: number): void => {
     if (!listRef || snapKey !== key()) return;
     // #608 (regression fix) — reconcile the follow INTENT with the reader's
     // trusted position. The snapshot is the authoritative position across the
@@ -2982,7 +2997,31 @@ const ScrollbackPane: Component<Props> = (props) => {
     // the live `overlayCount()`). Runs even when the position is already held
     // (`scrollTop === target`), so a scrolled-up reader whose px never moved still
     // gets the stale intent corrected.
-    setFollowMode(
+    //
+    // #1121 — the intent is reconciled against `snapDistance`, the distance
+    // measured WITH the snapshot, not one recomputed here. Both readings answer
+    // "where is the reader relative to the tail", but only the captured one
+    // answers it for the epoch the intent belongs to: recomputed on the close
+    // edge it also counts every line that arrived under the overlay, which reads
+    // as a scroll-up the reader never performed. #608's mid-list case is
+    // unchanged — a snapshot taken mid-list carries a large distance either way.
+    setFollowMode(snapDistance <= SCROLL_BOTTOM_THRESHOLD_PX);
+    // #1121 — and the GEOMETRY is republished for the close edge, where it
+    // belongs. It is the SAME expression the intent used to be computed from —
+    // current extent against the restored position — because that expression was
+    // never wrong, only misaddressed: it answers "is the pane at the tail now",
+    // which is `atBottomNow`'s question, not `followMode`'s. Measured against
+    // `target` rather than the live `scrollTop`: both exits below leave the pane
+    // there, so this is the position the reader is about to be looking from.
+    //
+    // This is the only place the pane can learn that the tail moved away from it
+    // while it was held: nothing scrolled, so no `scroll` event fires and
+    // `onScroll` never re-measures. Both consumers of a stale-true `atBottomNow`
+    // then lie in the same direction — the floating scroll-to-bottom button
+    // stays unmounted, and `readingAtTailKey` keeps telling `selection.ts` to
+    // suppress this window's unread badge. Published BEFORE the no-op early
+    // return, because the held-position case IS the one that goes stale.
+    setAtBottomNow(
       listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
     );
     if (listRef.scrollTop === target) return;

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { closeMessageMenu, openMessageMenu, SELECTING_CLASS } from "../lib/messageMenu";
+import MessageContextMenu from "../MessageContextMenu";
+
+// #1106 — the ORDERING half of "Select… installs no visible selection while the
+// compose keyboard is open".
+//
+// `selectMessageText` installs the range, puts `is-selecting` on <html>, and
+// only THEN registers the `selectionchange` listener that strips the class once
+// the selection is gone. `ContextMenu.handleItemClick` runs `item.action()` and
+// then `props.onClose()`, so the whole menu — portal, backdrop, buttons —
+// unmounts immediately after. `selectionchange` is dispatched ASYNCHRONOUSLY
+// (the spec queues a task), so the event the install itself provokes is
+// delivered AFTER that teardown, straight into the freshly-registered listener.
+// If the teardown emptied the selection, the class would be gone within a
+// macrotask and `html.is-ios.is-selecting .scrollback { -webkit-touch-callout:
+// default }` would never apply — the re-enable #1067 added is what gives the
+// selection its draggable endpoints.
+//
+// The test asserts the window stays OPEN across that teardown. It deliberately
+// uses jsdom's real Selection rather than the stub the rest of
+// `messageMenu.test.ts` uses: a stub cannot deliver the asynchronous event, so
+// it cannot see this ordering at all.
+//
+// SCOPE — this closes the DOM-contract question only. jsdom is not an engine:
+// it does not paint, does not focus a button on click, and its
+// Selection/text-control interaction is already known to diverge from a real
+// one. Nothing here says what WebKit does on device; #1106's leads 1 and 3 are
+// untouched by it.
+
+function scrollbackRow(text: string): HTMLElement {
+  const pane = document.createElement("div");
+  pane.className = "scrollback";
+  const row = document.createElement("div");
+  row.className = "scrollback-line";
+  row.textContent = text;
+  pane.appendChild(row);
+  document.body.appendChild(pane);
+  return row;
+}
+
+function msg(): ScrollbackMessage {
+  return {
+    id: 7,
+    network: "azzurra",
+    channel: "#grappa",
+    server_time: 1_700_000_000_000,
+    kind: "privmsg",
+    sender: "vjt",
+    body: "ciao",
+    meta: {},
+  };
+}
+
+// A macrotask: long enough for the queued `selectionchange` to be delivered.
+const settle = (): Promise<void> => new Promise((res) => setTimeout(res, 0));
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+  closeMessageMenu();
+  window.getSelection()?.removeAllRanges();
+});
+
+describe("Select… with the compose keyboard up", () => {
+  it("keeps the callout window open across the menu's own teardown", async () => {
+    const row = scrollbackRow("12:34 <vjt> ciao");
+    // The keyboard being up IS a focused text control — the precondition that
+    // separates the reported failure from the working case.
+    const compose = document.createElement("textarea");
+    document.body.appendChild(compose);
+    compose.focus();
+
+    render(() => <MessageContextMenu />);
+    openMessageMenu({
+      msg: msg(),
+      row,
+      networkSlug: "azzurra",
+      channelName: "#grappa",
+      at: { x: 10, y: 20 },
+    });
+
+    const delivered: string[] = [];
+    document.addEventListener("selectionchange", () => {
+      delivered.push(window.getSelection()?.toString() ?? "");
+    });
+
+    fireEvent.click(screen.getByText("Select…"));
+    expect(document.querySelectorAll(".context-menu")).toHaveLength(0);
+
+    await settle();
+
+    // Non-vacuity: the guard must have been REACHED. Were the environment to
+    // stop dispatching `selectionchange`, the class would survive for want of
+    // anything to strip it and this test would be green for the wrong reason.
+    expect(delivered.length).toBeGreaterThan(0);
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(true);
+    // And it survived because the guard found a LIVE selection, not because
+    // nothing ever looked.
+    expect(delivered.at(-1)).toBe("12:34 <vjt> ciao");
+  });
+});

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -5379,6 +5379,140 @@ describe("ScrollbackPane", () => {
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
+
+    // #1121 — the close edge must answer TWO questions, and they live in TWO
+    // DIFFERENT epochs:
+    //
+    //   * the follow INTENT — "was the reader following when the freeze began?"
+    //     — is a fact about the OPEN edge;
+    //   * the GEOMETRY (`atBottomNow`) — "is the pane at the tail right now?" —
+    //     is a fact about the CLOSE edge.
+    //
+    // `applyOverlayRestore` computed ONE number for both and spent it on the
+    // intent alone: `scrollHeight` read NOW minus `target` captured on the OPEN
+    // edge. Content arriving under the overlay grows `scrollHeight` by Δ, so for
+    // a reader who was sitting exactly AT the tail that number reads Δ — "the
+    // reader is Δ above the tail" — and `followMode` was reconciled OFF for
+    // someone who never moved. The geometry was not republished at all: the pane
+    // never moved while frozen, so `scrollTop === target`, the restore's no-op
+    // early-return fires, no `scroll` event is emitted, and `atBottomNow` stays
+    // stale-TRUE.
+    //
+    // Two signals, three field symptoms (the reporter's, testnet, 3 runs): the
+    // dead intent hides every message arriving after the close, and the stale
+    // geometry hides BOTH rescue affordances — the floating button is
+    // `<Show when={!atBottomNow()}>`, and `readingAtTailKey` (published from the
+    // same `atBottomNow`) is what `selection.ts` uses to SUPPRESS the unread
+    // badge. The button and the badge are ONE signal with two consumers by
+    // design (see `readingAtTail`), which is why two mutants — not three — cover
+    // this block.
+    //
+    // Same site as the #608 reconciliation above and it must not undo it: a
+    // mid-list snapshot still reconciles the intent OFF. The distinction is the
+    // EPOCH the distance is measured in, not the presence of the reconciliation.
+    describe("#1121 — closing an overlay over a tail reader must not strand them", () => {
+      // The field scenario: a reader MEASURED at the tail, an overlay opened
+      // over them, three lines arriving underneath (rows land AND the extent
+      // grows while the freeze holds scrollTop), then the close.
+      //
+      // The scroll event before the overlay is load-bearing, not decoration: it
+      // is what sets `tailGeometryMeasured`. Without it `readingAtTailKey`
+      // withholds its answer and publishes `null` regardless, so the badge
+      // assertion below would pass on the unfixed code — a vacuous test.
+      const strandATailReader = async (): Promise<HTMLDivElement> => {
+        seedRows();
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const list = screen.getByTestId("scrollback") as HTMLDivElement;
+        await flushRaf();
+
+        Object.defineProperty(list, "scrollHeight", { value: 2000, configurable: true });
+        Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+        Object.defineProperty(list, "scrollTop", {
+          value: 1500,
+          writable: true,
+          configurable: true,
+        });
+        // distance = 2000 - 1500 - 500 = 0 → at the tail, and MEASURED.
+        list.dispatchEvent(new Event("scroll"));
+        await flushRaf();
+
+        pushOverlay(null);
+        await flushRaf();
+
+        // Three lines land underneath. 400px of growth — the reporter's three
+        // chat lines are already well past the 50px threshold.
+        Object.defineProperty(list, "scrollHeight", { value: 2400, configurable: true });
+        setScrollback({
+          "freenode #grappa": Array.from({ length: 23 }, (_, i) => ({
+            id: i + 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: i + 1,
+            kind: "privmsg" as const,
+            sender: "alice",
+            body: `row ${i + 1}`,
+            meta: {},
+          })),
+        });
+        await flushRaf();
+
+        popOverlay(null);
+        await flushRaf();
+        return list;
+      };
+
+      it("keeps the follow intent alive, so a message arriving after the close is tailed", async () => {
+        const list = await strandATailReader();
+        scrollIntoViewSpy.mockClear();
+
+        // A fourth line arrives with no overlay in the way. A reader who was
+        // following must be tailed onto it. Pre-fix `followMode` was reconciled
+        // false by the mixed-epoch read, so the length-effect never armed
+        // tail-follow and the line stayed below the fold indefinitely — the
+        // reporter's "continuo a non vedere un cazzo".
+        Object.defineProperty(list, "scrollHeight", { value: 2500, configurable: true });
+        setScrollback({
+          "freenode #grappa": Array.from({ length: 24 }, (_, i) => ({
+            id: i + 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: i + 1,
+            kind: "privmsg" as const,
+            sender: "alice",
+            body: `row ${i + 1}`,
+            meta: {},
+          })),
+        });
+        // The tail-follow settle poll is frame-budgeted (SETTLE_MAX_FRAMES = 30)
+        // and jsdom never lays out, so `isSettled` can never hold: the write
+        // arrives on the fail-safe frame. Drain past the budget.
+        for (let i = 0; i < 20; i++) await flushRaf();
+
+        expect(scrollIntoViewSpy).toHaveBeenCalled();
+      });
+
+      it("republishes the geometry, so the floating scroll-to-bottom button appears", async () => {
+        await strandATailReader();
+
+        // The pane is parked 400px above the tail. Pre-fix the restore wrote
+        // nothing (position already held), no scroll event fired, `atBottomNow`
+        // stayed stale-true and the button stayed unmounted — the reporter's
+        // "non c'e' nessun bottone di scroll".
+        expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull();
+      });
+
+      it("stops claiming the reader is at the tail, so the unread badge is not suppressed", async () => {
+        await strandATailReader();
+
+        // Same stale `atBottomNow`, second consumer: the pane publishes
+        // `readingAtTailKey`, and `selection.ts` suppresses this window's unread
+        // count while it names it. Parked above the tail, the honest answer is
+        // `null` — every unknown collapses to "show the badge".
+        expect(readingAtTailKey()).toBeNull();
+      });
+    });
   });
 
   // affordances. Rendered as flex siblings BEFORE `.scrollback` they

--- a/cicchetto/src/__tests__/mediaViewer.test.ts
+++ b/cicchetto/src/__tests__/mediaViewer.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { closeMediaViewer, openMediaViewer } from "../lib/mediaViewer";
+
+// Media-viewer store (#1124). `openMediaViewer` is the single open door —
+// `MircText`'s media-link click handler is its only caller — so the
+// keyboard-dismissing blur is pinned on the VERB here, not at a call site.
+// Sibling shape: audioPlayer.test.ts.
+//
+// What jsdom cannot prove: there is no soft keyboard and no visualViewport
+// resize here, so this asserts the CAUSE (focus leaves the text field) and
+// not the EFFECT (the viewport grows back, the image gets the full height).
+// The effect is device-verify only.
+
+const IMAGE_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz";
+
+afterEach(() => {
+  closeMediaViewer();
+  document.body.replaceChildren();
+});
+
+describe("mediaViewer store", () => {
+  it("openMediaViewer blurs the focused compose field, so iOS dismisses the keyboard", () => {
+    const compose = document.createElement("textarea");
+    document.body.append(compose);
+    compose.focus();
+    expect(document.activeElement).toBe(compose);
+
+    openMediaViewer(IMAGE_URL, "image");
+
+    expect(document.activeElement).not.toBe(compose);
+  });
+});

--- a/cicchetto/src/lib/mediaViewer.ts
+++ b/cicchetto/src/lib/mediaViewer.ts
@@ -1,13 +1,14 @@
 // Media-viewer modal state — media-link cluster (2026-06-11).
 //
 // Module-scope signal store (same pattern as `archive.ts`'s
-// `archiveModalNetwork`): the open trigger lives deep inside
-// ScrollbackPane's module-scope renderRun, far from any component that
-// could thread a callback down — a lib store is the established cic
-// shape for that. `MediaViewerModal.tsx` (mounted at Shell root in
-// both branches) renders the state; `lib/mediaLink.ts` decides which
-// links call `openMediaViewer` (and supplies the page-origin-rooted
-// href).
+// `archiveModalNetwork`): the open trigger lives deep inside a
+// module-scope link renderer, far from any component that could thread
+// a callback down — a lib store is the established cic shape for that.
+// `MediaViewerModal.tsx` (mounted at Shell root in both branches)
+// renders the state; `MircText.tsx`'s link handler is the ONLY caller
+// of `openMediaViewer` (it was ScrollbackPane's `renderRun` until #125
+// extracted `MircBody`), and `lib/mediaLink.ts` decides which links it
+// calls for (and supplies the page-origin-rooted href).
 //
 // identityScopedStore (review fix, same reason as archive.ts:36-39):
 // token rotation/logout must close an open viewer — otherwise the
@@ -28,6 +29,26 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   return {
     mediaViewerState,
     openMediaViewer(href: string, kind: MediaKind): void {
+      // #1124 — dismiss the mobile soft keyboard before the viewer opens.
+      // `.media-viewer-modal` is capped at `var(--viewport-height)`, which
+      // tracks the VISUAL viewport (viewportHeight.ts), so with the keyboard
+      // up the media renders in roughly half the height it could use. Nothing
+      // dismisses it on its own: `keepKeyboard.ts` preventDefaults the
+      // mousedown focus-shift on a `.scrollback-link` tap precisely so the
+      // keyboard survives it. That suppresses the IMPLICIT shift only — it
+      // does not stand in the way of this deliberate blur.
+      //
+      // On the verb, not the call site: this is the single open door, so
+      // there is no per-caller wiring to forget (the same "one owner"
+      // argument keepKeyboard.ts makes for itself).
+      //
+      // Accepted trade-off (vjt, #1124): on close the keyboard does NOT come
+      // back. Do NOT "fix" that by re-focusing the compose — a programmatic
+      // focus re-raises the keyboard through the same visual-viewport resize
+      // path the overlay freeze exists to survive (#196 / #219-general /
+      // #1121). The draft itself is per-window compose state, untouched.
+      const focused = document.activeElement;
+      if (focused instanceof HTMLElement) focused.blur();
       setMediaViewerState({ href, kind });
     },
     closeMediaViewer(): void {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35408,6 +35408,7 @@ hand-injected `padding-bottom` would be overriding the very declaration under
 test, so the simulation would be circular. The on-device look, and whether the
 bottom row of tabs still takes taps reliably inside the home-indicator strip,
 remain owed to a real notched iPhone.
+
 ## 2026-08-09 — #1121: the overlay close asks two questions, and they live in two epochs
 
 A reader sitting at the tail of a live channel opened the media viewer, waited

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35494,3 +35494,63 @@ tail is offered a button rather than snapped forward. That is the conservative
 direction — it is the reader's position that is being preserved — but "a
 follower's anchor is the tail, not a pixel" is a defensible reading of the same
 invariant, and it would remove the button from this scenario entirely.
+
+## 2026-08-09 — #1106: the selection window does not close on its own, and the diagnostic the issue proposes cannot separate its leads
+
+**What was asked, and what was refused.** #1106 is an iOS report: long-press a
+message row with the compose keyboard up, choose `Select…`, and no selection
+appears. Nobody working on it here has an iPhone or a WebKit engine, so
+everything about what WebKit *paints* stays unclaimed. Only the lead that is a
+question of ORDERING rather than of rendering was measurable, and only that one
+was measured.
+
+**The hazard shape, which is real.** `selectMessageText` installs the range,
+adds `is-selecting` to `<html>`, and only THEN registers the `selectionchange`
+listener that strips the class once the selection is gone.
+`ContextMenu.handleItemClick` runs `item.action()` and then `props.onClose()`,
+so the portal, backdrop and buttons unmount immediately after. `selectionchange`
+is dispatched ASYNCHRONOUSLY — the spec queues a task — so the event the install
+itself provokes is delivered AFTER that teardown, straight into the listener
+registered a moment earlier. Had the teardown emptied the selection, the class
+would have been stripped within one macrotask and `html.is-ios.is-selecting
+.scrollback { -webkit-touch-callout: default }` would never have applied, which
+is precisely the re-enable #1067 added to make the selection adjustable.
+
+**The measurement.** In jsdom, with a focused `<textarea>` standing in for the
+open keyboard, the class survives: three `selectionchange` events are delivered
+after the click, each carrying the full row text, so the guard is reached,
+finds a live selection and returns early. Removing the menu's own DOM does not
+disturb a range anchored outside it, and nothing else in cic touches the
+selection — the only `removeAllRanges` in the tree is `selectMessageText`'s own,
+and no code refocuses the composer on menu close. Pinned by
+`MessageContextMenu.test.tsx`; proven by a deliberate red (a teardown that
+clears the selection kills that one test and no other, 1 of 4965).
+
+**A stub cannot see an asynchronous event.** `messageMenu.test.ts` stubs
+`window.getSelection`, so its "arms the callout re-enable" test asserts
+synchronously and would pass unchanged if the class were stripped one tick
+later. That is why the new guard uses jsdom's real Selection, and why it
+asserts a `selectionchange` was actually delivered: without that assertion it
+would go green for want of an event rather than for the reason claimed.
+
+**The diagnostic the issue proposes does not discriminate.** #1106 suggests
+capturing `keepKeyboard`'s `kb: scrollback md held=<n>ms → HOLD keep-kbd`
+diag line on the failing device to tell whether the long-press arm is reached,
+"which separates lead 1 from leads 2-3". By `keepKeyboard`'s own documented
+device model, it cannot: that arm fires on `mousedown`, and the module states
+that on real iOS a long-press synthesizes no `mousedown` at all — only taps do,
+so the arm "effectively only ever sees taps" and survives as a cross-platform
+net. The HOLD line is therefore predicted ABSENT on the very gesture under
+test, and observing its absence is consistent with both "arm not reached" and
+"iOS dispatched nothing to reach it". Observing it PRESENT would be
+informative, but only by falsifying that comment.
+
+**What would actually decide it, and it needs the device.** A remote Web
+Inspector console (Mac Safari → Develop → the connected iPhone), immediately
+after tapping `Select…` with the keyboard up, reading three things:
+`getSelection().rangeCount` and `.toString()`; `document.documentElement.className`;
+and `getComputedStyle(row)`'s `webkitUserSelect` / `webkitTouchCallout`. A live
+non-empty range plus `is-selecting` present plus `text`/`default` resolved means
+WebKit installed everything and painted nothing — lead 1 — and the fix belongs
+in the ordering or the keyboard, not in the class or the CSS. It needs no new
+code.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35408,3 +35408,89 @@ hand-injected `padding-bottom` would be overriding the very declaration under
 test, so the simulation would be circular. The on-device look, and whether the
 bottom row of tabs still takes taps reliably inside the home-indicator strip,
 remain owed to a real notched iPhone.
+## 2026-08-09 — #1121: the overlay close asks two questions, and they live in two epochs
+
+A reader sitting at the tail of a live channel opened the media viewer, waited
+while three lines landed underneath, and closed it — and the pane went deaf.
+The new lines were invisible, every later line was invisible too, there was no
+floating scroll-to-bottom button and no unread badge, and only their own send
+released it. Reproduced three times on the testnet, then in jsdom.
+
+**The freeze was not the bug.** While a covering overlay is up the pane holds
+its position and every scroll writer bails (#196, widened to the shared
+refcount by #219-general). That is deliberate and it worked. The damage was one
+function at the close edge, `applyOverlayRestore`, and it was doing two things
+wrong at once with a single expression:
+
+```ts
+setFollowMode(
+  listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
+);
+if (listRef.scrollTop === target) return;
+```
+
+`target` is the scrollTop captured on the OPEN edge; `scrollHeight` is read on
+the CLOSE edge. Content arriving under the overlay grows the extent by Δ, so the
+expression returns Δ for a reader who never moved — it cannot tell *"the reader
+scrolled up"* from *"the content grew while they were held"*, and it reconciles
+`followMode` off for the second. That is why the pane stayed deaf long after the
+overlay was gone: the intent was dead, not just the frame.
+
+The same expression was never published to the geometry. The freeze had held the
+pane exactly at `target`, so the restore writes nothing, takes the early return,
+and emits no `scroll` event — and `onScroll` is the only thing that re-measures.
+`atBottomNow` went on asserting a tail the pane had drifted away from. It has two
+consumers and both repeated the lie: the floating button is
+`<Show when={!atBottomNow()}>`, and `readingAtTailKey` — published from the same
+predicate precisely so `selection.ts` can suppress the badge of the window being
+read — kept naming this window. The pane was parked above the tail while every
+part of the UI agreed the reader was caught up.
+
+**The shape of the fix.** The close edge asks two questions and they belong to
+different epochs:
+
+* the follow INTENT — *"was the reader following when the freeze began?"* — is a
+  fact about the OPEN edge. Capture the distance-to-tail alongside the px and
+  reconcile against that. Growth under the overlay then cannot masquerade as a
+  scroll-up.
+* the GEOMETRY — *"is the pane at the tail now?"* — is a fact about the CLOSE
+  edge, and the old expression answered it correctly all along. It was never
+  wrong, only **misaddressed**. Publish it to `atBottomNow`, measured against
+  `target` (both exits leave the pane there), and publish it BEFORE the no-op
+  early return, because the held-position case is exactly the one that goes
+  stale.
+
+**#608 keeps what it bought.** Deleting the reconciliation would have re-opened
+the media-viewer close snap it was written for. A mid-list snapshot carries a
+large distance in either epoch, so a reader who really had scrolled up still
+gets the intent reconciled off. That case gains something too: its `atBottomNow`
+was stale-true for the same reason, hiding the button from a reader who
+genuinely needed it.
+
+**One site, two signals, three symptoms.** The three complaints in the report
+are not three defects and not one: they are two independent signals. The dead
+intent hides the messages; the stale geometry hides both affordances, because
+the button and the badge are one signal with two consumers by design. Two
+mutants prove it — reverting the intent to the mixed-epoch read kills only the
+follow assertion, removing the geometry publish kills only the button and the
+badge. A third mutant moving the publish after the early return kills the same
+pair, which is the honest result: it proves the PLACEMENT is load-bearing, not
+that there is a third signal.
+
+**Not the media viewer's bug.** Twenty surfaces push the shared overlay
+refcount, and all of them route through this one freeze and this one restore.
+The viewer is simply the one a reader keeps open for twenty seconds while a
+channel talks underneath. The fix is at the shared site, so it is class-wide by
+construction — no per-surface census to maintain.
+
+**Left open, deliberately.** The reporter's own proposal — stop freezing under
+a fully-covering surface and just keep following — is a different and larger
+call: the freeze exists because a fullscreen modal shrinks the mobile
+visualViewport and the resulting resize used to drop the reader's position, and
+#219 widened it to surfaces where the pane stays partly visible. Splitting the
+policy by coverage is possible and is not decided here. Nor is the second fork
+this fix surfaces: a reader restored with `followMode` true but parked above the
+tail is offered a button rather than snapped forward. That is the conservative
+direction — it is the reader's position that is being preserved — but "a
+follower's anchor is the tail, not a pixel" is a defensible reading of the same
+invariant, and it would remove the button from this scenario entirely.


### PR DESCRIPTION
## Why a union

#1136 (#1121), #1139 (#1124) and #1141 (#1106) are each 5/5 green, and every one of those greens was earned on `ed67d244` or `92182e9f` — none of them attests anything about `main` as it stands now, nor about each other. Measured intersection: **`#1136 ∩ #1141 = docs/DESIGN_NOTES.md`**; #1139 is disjoint from both. Three rebases would have paid the ~30 min `integration` three times over and still never asked the union question.

Cherry-picked onto current `main` (`1dd03779`), ascending PR order.

## Verification

**Per-file `--numstat` of this branch against `main` is identical to the summed `--numstat` of the three PRs.** That is the check that the replay lost nothing — not that the cherry-picks reported success.

## One more separator, the fourth today

`docs/DESIGN_NOTES.md` grows by appending, so an entry replayed onto a tail that moved loses the blank line before its `##`. Expected **87 + 60 = 147** added lines across the two entries here; **146** landed, and `## 2026-08-09 — #1121` was fused to the tail of the #1126 entry that reached `main` between them. Restored in a one-line commit; every `2026-08-09` heading verified unglued.

## Prediction, registered before this run

**681 passed** — 680 on `main`, **+1**: #1136 adds `issue1121-overlay-close-tail-reader.spec.ts`, one `test(` block; #1139 and #1141 add no e2e spec. Static cross-check: `test(` blocks go 674 → 675.

The verdict needs the named ✓ for `issue1121-overlay-close-tail-reader` as well as the count — a total on its own cannot distinguish "the new spec ran" from "something else moved by one".

## What is in here

- **#1121** — the overlay close reconciled in the epoch each answer belongs to, plus the e2e that drives a tail reader through it.
- **#1124** — the soft keyboard dismissed at `openMediaViewer`, the single door. On close the keyboard deliberately does **not** return: re-focusing the composer would fight the same visual-viewport resize path that motivated the overlay freeze.
- **#1106** — **no fix, and that is the result.** The one lead settleable without a device (does the `is-selecting` window close on the menu's own teardown?) is **false**: `selectionchange` is async, arrives after the portal unmounts, the guard finds a live selection and returns early. Pinned with jsdom's real Selection, because the existing stub-based test would have passed unchanged had the class been stripped a tick later — a guard that could not fail. Leads 1 and 3 need a real iPhone and are named as such, with the four-expression console capture that would decide them.

## Supersedes

#1136, #1139, #1141 — closed by content at merge, since the cherry-pick rewrites their SHAs.