### PR TITLE
scrollback(#948): the SELF window follows our own /nick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,16 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   arm, which gates on the window). A window at our old nick is EITHER
   our self window OR a leftover query with a peer who bore that nick
   before us, and the fold-unique index makes those ONE row — only the
-  scrollback's `sender` separates them, folded to MATCH and never
-  written. #514's `rename_own_nick/4` is the sibling that moves the
+  scrollback's `sender` separates them (folded to MATCH; the fold is
+  never STORED). **On a SELF row `sender` MIGRATES** (raw new nick),
+  unlike a peer's frozen `sender`: all three columns name the same
+  person, an UPDATE that does not preserve the shape its predicate
+  matches is one-shot (`a→b→a` via GhostRecovery would strand the
+  window for good), and `Push.Triggers.own_row?/2` reads `sender` as a
+  LIVE identity test. **General rule: a DISPLAY column migrates when a
+  consumer reads it as the LIVE identity** — why #514 re-keys the
+  own-nick TAG in `channel` (#498), and why a peer's `sender` does not
+  move. #514's `rename_own_nick/4` is the sibling that moves the
   inbound-DM own-nick TAG (not a window key), disjoint by the `dm_with`
   conjunct. cic does NOT mirror the self-window rename: the
   `own_nick_changed` event carries neither the old nick nor whether the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,20 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   be added to this migration set or a rename silently strands its
   old-nick rows. Boundary limit: IRC delivers a NICK only to
   channel-sharing peers, so a query with someone in no shared channel
-  cannot follow.
+  cannot follow. **Our OWN nick keys exactly one window — the SELF
+  window (`/msg <ownnick>`, GH #948) — and it has its own set** on
+  `{:own_nick_renamed, old, new}`: `Scrollback.rename_self_window/4`
+  (rows) → `ReadCursor.rename_dm_peer/4` → `QueryWindows.rename/4` →
+  broadcast, GATED on a non-zero row count (the inverse of the peer
+  arm, which gates on the window). A window at our old nick is EITHER
+  our self window OR a leftover query with a peer who bore that nick
+  before us, and the fold-unique index makes those ONE row — only the
+  scrollback's `sender` separates them, folded to MATCH and never
+  written. #514's `rename_own_nick/4` is the sibling that moves the
+  inbound-DM own-nick TAG (not a window key), disjoint by the `dm_with`
+  conjunct. cic does NOT mirror the self-window rename: the
+  `own_nick_changed` event carries neither the old nick nor whether the
+  migration ran, so a client mirror would originate state.
 - **Read state is server-owned, per (subject, network, channel).**
   Cursor = `last_read_message_id` (FK to `messages.id`). Removing
   server-side cursor is a breaking change. The write cadence (settle

--- a/config/config.exs
+++ b/config/config.exs
@@ -528,6 +528,13 @@ config :logger, :console,
     # check: known_keys ⊆ metadata). `:new_nick` pre-exists above.
     :old_nick,
     :rows_migrated,
+    # #948 — the SELF-window sibling of that line reuses `:old_nick` /
+    # `:new_nick` / `:rows_migrated` and adds `:window`
+    # (`:renamed | :noop`), because the rows can migrate while no window
+    # row moves: the self window may be CLOSED with its history in
+    # Archive. Without it the line would claim work the `:noop` branch
+    # did not do.
+    :window,
     # #800 S7 — `Grappa.IRC.Client`'s per-frame outbound-cost line, at
     # DEBUG (silent in production, which runs at :info). `:sent_bytes` and
     # `:commands_10s` are MEASURED — what this process put on the wire and

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35690,6 +35690,7 @@ because the conjunction with a nick-shaped token and a later `<< ` makes the
 collision rare, and because the damage is confined to the quote being drafted:
 the sender's message, the compose box's existing draft, and the wire are all
 untouched.
+
 ## 2026-08-09 — #948: the one window our own nick keys, and the sender that names it
 
 `/msg <ownnick>` — the self window, the scratchpad some people keep. Both ends

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35715,11 +35715,35 @@ except for `sender`. `rename_self_window/4` therefore folds three columns to
 MATCH, and each conjunct excludes a real shape sharing the other two: `sender`
 excludes the outbound DM to such a peer, `channel` excludes an inbound DM FROM
 one, `dm_with` excludes the `channel = sender, dm_with = NULL` NOTICE that
-`route_non_channel_notice_non_chanserv/3` leaves in an open query. Folding
-`sender` is a MATCH, never a write: it is testimony about who spoke, and the
-migration sets only `channel` (folded, the KEY) and `dm_with` (raw, DISPLAY).
-The predicate is disjoint from `#514`'s by the `dm_with` conjunct (`!=` there,
-`==` here), so no row moves twice.
+`route_non_channel_notice_non_chanserv/3` leaves in an open query. The fold is
+a MATCH and is never STORED. The predicate is disjoint from `#514`'s by the
+`dm_with` conjunct (`!=` there, `==` here), so no row moves twice.
+
+**`sender` moves, and the first version of this was wrong not to move it.**
+The migration was written to set `channel` and `dm_with` only, on the rule that
+`sender` is testimony about who spoke — the rule `rename_dm_peer/4` correctly
+applies to a PEER's lines. Review killed it on a flow that is routine here:
+services enforcement parks us on a Guest nick and `Session.GhostRecovery`
+renames us straight back, and with `sender` left behind the round trip
+`a -> b -> a` ended with the scratchpad stranded at `b` FOR GOOD — worse than
+`origin/main`, which moved nothing and healed. The defect is general: **an
+UPDATE that does not preserve the shape its own predicate matches on is
+one-shot, because it destroys the evidence it identified the row by.** On a
+self row all three columns name the same person, so freezing one does not
+preserve history, it makes the row internally inconsistent — and a second
+consumer was reading that inconsistency: `Push.Triggers.own_row?/2` (#532 C)
+compares `sender` to the LIVE nick as the first arm of `should_notify?/4`, and
+`Push.BadgeCount` folds that predicate back over the unread tail. Stale
+`sender` + migrated `channel` = own notes counting as unread DMs. Writing all
+three cannot collide with a peer row: `channel == dm_with == sender` is
+unreachable for any peer conversation, because you cannot DM a peer bearing
+your own nick.
+
+The rule to carry forward, which also explains the apparent inconsistency with
+`rename_dm_peer/4`: **a DISPLAY column must migrate when a consumer reads it as
+the LIVE identity.** `#514` re-keys the own-nick TAG in `channel` for exactly
+that reason (#498 reads it against the live nick); a peer's `sender` stays put
+because nothing does.
 
 **The gate is inverted relative to #373, and that is the design.** The peer arm
 gates on `QueryWindows.rename/4`: there the window row alone identifies what is
@@ -35733,20 +35757,21 @@ touch nothing, rather than dragging a peer's identity to our new name.
 whose history lives in Archive still has to follow, or the archive entry reads
 as a stranded query bearing our old nick.
 
-**What it declines, and why no predicate can do better.** Once a self row has
-migrated once it is `channel == dm_with == b, sender == a`, which is byte-
-identical to an outbound DM to a peer named `b`. A second rename `b -> c`
-therefore leaves it behind. The same collision closes the other end: a
-pre-CP14-B3 self row carries `dm_with IS NULL` and is byte-identical to the peer
-NOTICE the third conjunct exists to protect. Both are the SAME ambiguity — a
-self row whose `sender` no longer folds to its own window key — and no predicate
-over `(channel, dm_with, sender)` can resolve it. Only a durable self-marker
-written at persist time could, and the backfill for it is available today
-(`fold(channel) == fold(dm_with) == fold(sender)` identifies every un-migrated
-self row exactly). That is a schema change, a read-path change, and a rework of
-archive grouping and `delete_for_dm/3`; it is deliberately not this unit. The
-migration declines rather than corrupting a peer's history: incompleteness,
-never a wrong move.
+The gate cuts the other way too, and that is accepted rather than overlooked: a
+GENUINE self window whose history was purged, or which was opened and never
+written to, also counts zero, so its tab stays at the nick we just vacated.
+With no rows there is nothing to strand and no evidence to decide on, and the
+alternative is the corruption above. An empty orphan tab is the cheaper wrong.
+
+**What it declines.** One shape stays unrecoverable: a pre-CP14-B3 self row
+carries `dm_with IS NULL` (inbound rows predate the column) and is
+byte-identical to the peer NOTICE the third conjunct exists to protect. Only a
+durable self-marker written at persist time could separate them, and its
+backfill predicate is already known — `fold(channel) == fold(dm_with) ==
+fold(sender)` identifies every self row exactly. That is a schema change, a
+read-path change, and a rework of archive grouping and `delete_for_dm/3`; it is
+deliberately not this unit. The migration declines rather than corrupting the
+peer's history: incompleteness, never a wrong move.
 
 **The client half needs a wire signal, so it is not here.** cic's caches are
 keyed by the own nick exactly like any query window (`channelKey(slug, ownNick)`

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35690,3 +35690,80 @@ because the conjunction with a nick-shaped token and a later `<< ` makes the
 collision rare, and because the damage is confined to the quote being drafted:
 the sender's message, the compose box's existing draft, and the wire are all
 untouched.
+## 2026-08-09 — #948: the one window our own nick keys, and the sender that names it
+
+`/msg <ownnick>` — the self window, the scratchpad some people keep. Both ends
+of the exchange are us, so the row lands with `channel == dm_with == sender ==
+own nick`. `#514` shipped `Scrollback.rename_own_nick/4` to move the stale
+own-nick TAG on inbound DM rows after a self-rename, and carved this window out
+by name, saying it was tracked apart. It was not; `#948` is that pointer, and
+this is the migration.
+
+**Why it is not the same defect.** For the rows `#514` owns, our own nick is not
+a window key at all: an inbound DM's window is `dm_with` (the peer), and its
+cursor is keyed there too. `channel` is a tag, read back against the live nick
+by `Push.Triggers.dm?/2`, so a stale one costs a badge. On a SELF row `channel`
+IS the window key — `channel_or_dm_where/3`'s own-nick arm reads `channel ==
+live own nick AND fold(dm_with) == live own nick`. Leave it and the conversation
+does not lose a badge, it disappears: the new self window is empty and the whole
+history resurfaces under `where_dm_peer/2` as a phantom query with a peer
+bearing our old nick.
+
+**The disambiguator `#514` named.** A self row is byte-identical to an outbound
+DM to a peer who bears our old nick — both are `channel == dm_with == old` —
+except for `sender`. `rename_self_window/4` therefore folds three columns to
+MATCH, and each conjunct excludes a real shape sharing the other two: `sender`
+excludes the outbound DM to such a peer, `channel` excludes an inbound DM FROM
+one, `dm_with` excludes the `channel = sender, dm_with = NULL` NOTICE that
+`route_non_channel_notice_non_chanserv/3` leaves in an open query. Folding
+`sender` is a MATCH, never a write: it is testimony about who spoke, and the
+migration sets only `channel` (folded, the KEY) and `dm_with` (raw, DISPLAY).
+The predicate is disjoint from `#514`'s by the `dm_with` conjunct (`!=` there,
+`==` here), so no row moves twice.
+
+**The gate is inverted relative to #373, and that is the design.** The peer arm
+gates on `QueryWindows.rename/4`: there the window row alone identifies what is
+being renamed. Here it cannot. A window standing at our old nick is EITHER our
+self window OR a leftover query with a peer who bore that nick before us, and
+the fold-unique index makes those one row — the identities have already
+collapsed. Only the scrollback carries the `sender` that separates them, so the
+row count gates the window and cursor moves. Zero rows: we vacate the nick and
+touch nothing, rather than dragging a peer's identity to our new name.
+`{:ok, :noop}` from the window rename stays a real state — a closed self window
+whose history lives in Archive still has to follow, or the archive entry reads
+as a stranded query bearing our old nick.
+
+**What it declines, and why no predicate can do better.** Once a self row has
+migrated once it is `channel == dm_with == b, sender == a`, which is byte-
+identical to an outbound DM to a peer named `b`. A second rename `b -> c`
+therefore leaves it behind. The same collision closes the other end: a
+pre-CP14-B3 self row carries `dm_with IS NULL` and is byte-identical to the peer
+NOTICE the third conjunct exists to protect. Both are the SAME ambiguity — a
+self row whose `sender` no longer folds to its own window key — and no predicate
+over `(channel, dm_with, sender)` can resolve it. Only a durable self-marker
+written at persist time could, and the backfill for it is available today
+(`fold(channel) == fold(dm_with) == fold(sender)` identifies every un-migrated
+self row exactly). That is a schema change, a read-path change, and a rework of
+archive grouping and `delete_for_dm/3`; it is deliberately not this unit. The
+migration declines rather than corrupting a peer's history: incompleteness,
+never a wrong move.
+
+**The client half needs a wire signal, so it is not here.** cic's caches are
+keyed by the own nick exactly like any query window (`channelKey(slug, ownNick)`
+for scrollback, `cacheKey` for the cursor, and a plain `channelName` selection),
+and `own_nick_changed` today only calls `mutateNetworkNick`. Mirroring the #373
+client set from that event UNCONDITIONALLY would break the invariant it is meant
+to serve: the server migrates only when self rows exist, cic cannot see that
+predicate, and a cic that renamed its caches on a rename the server declined
+would originate state the server disagrees with. Doing it right means making
+the event carry the old nick and whether the self window actually moved — an
+additive wire field plus codegen plus the protocol doc — which is a second unit.
+Until then the durable state is correct on the next load and the sidebar is
+truthful immediately; a device holding the self window focused across the rename
+keeps an orphan selection until it reloads.
+
+**Found on the way.** `rename_own_nick/4`'s own `fold(channel) == fold(old)`
+conjunct was killed by zero assertions: dropping it left the whole scrollback
+suite green while the mutant re-keys every row whose `dm_with` is some other
+peer, stamping our new nick over unrelated DM history. Pinned with one row — an
+inbound DM received while we were somebody else.

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1434,29 +1434,48 @@ defmodule Grappa.Scrollback do
       it drops out on SQL three-valued logic (`lower(NULL) = 'x'` is NULL,
       which `WHERE` rejects) rather than on an explicit `not is_nil`.
 
-  Folding `sender` here is a MATCH, not a key derivation: `sender` is
-  never written by this migration, because it is testimony about who
-  spoke. `channel` is the KEY column → set FOLDED (`Repo.update_all`
-  bypasses `Message.canonicalize_channel/1`, the #537 trap);
-  `dm_with` is DISPLAY → set to the RAW `new_nick`.
+  Folding `sender` here is a MATCH, not a key derivation — the fold is
+  never STORED. `channel` is the KEY column → set FOLDED (`Repo.update_all`
+  bypasses `Message.canonicalize_channel/1`, the #537 trap); `dm_with` and
+  `sender` are DISPLAY → set to the RAW `new_nick`.
+
+  ## Why `sender` moves, unlike on a peer rename
+
+  `rename_dm_peer/4` deliberately freezes `sender`: a peer's line keeps the
+  name they spoke under, because it is testimony about somebody else. On a
+  SELF row all three columns name the SAME person — us — so freezing one of
+  them does not preserve history, it makes the row internally inconsistent,
+  and two things break on that inconsistency:
+
+    * **the UPDATE would not be closed under its own predicate.** A row
+      migrated to `b` with `sender` left at `a` is byte-identical to an
+      outbound DM to a peer named `b`, so the NEXT rename cannot recognise
+      it and the window strands for good. That round trip is routine, not
+      exotic: services enforcement parks us on a Guest nick and
+      `Session.GhostRecovery` renames us straight back. Writing all three
+      keeps the shape the predicate matches on, and cannot collide with a
+      peer row — `channel == dm_with == sender` is unreachable for any peer
+      conversation, because you cannot DM a peer bearing your own nick.
+    * **`Push.Triggers.own_row?/2` reads `sender` as a LIVE identity test**
+      (#532 C), not as a historical record — it is the first arm of
+      `should_notify?/4`, and `Push.BadgeCount` folds that same predicate
+      back over the unread tail. A stale `sender` drops the row out of
+      own-row suppression while the migrated `channel` puts it INTO the DM
+      branch, so notes we wrote to ourselves start counting as unread DMs.
+
+  The general rule this follows: a DISPLAY column must migrate when a
+  consumer reads it as the LIVE identity. That is exactly why
+  `rename_own_nick/4` re-keys the own-nick TAG in `channel` (#498 reads it
+  against the live nick) and why a peer's `sender` stays put (nothing does).
 
   ## What stays ambiguous
 
-  Two row shapes cannot be recovered, and both are the SAME ambiguity read
-  from two sides — the shape a self row takes once its `sender` no longer
-  folds to the window key:
-
-    * a self row already migrated ONCE (now `channel == dm_with == b,
-      sender == a`) is byte-identical to an outbound DM to a peer named
-      `b`, so a SECOND rename `b -> c` leaves it behind. No predicate over
-      `(channel, dm_with, sender)` can separate them; only a durable
-      self-marker written at persist time could, which is a schema change
-      and a different unit of work.
-    * a pre-CP14-B3 self row (`dm_with IS NULL`) is byte-identical to the
-      peer NOTICE the third conjunct exists to protect.
-
-  In both cases the migration declines rather than corrupting a peer's
-  history — incompleteness, never a wrong move.
+  One shape cannot be recovered: a pre-CP14-B3 self row carries
+  `dm_with IS NULL` (inbound rows predate the column) and is byte-identical
+  to the peer NOTICE the third conjunct exists to protect. The migration
+  declines rather than corrupting the peer's history — incompleteness,
+  never a wrong move. Separating them would need a durable self-marker
+  written at persist time, which is a schema change and a different unit.
 
   Returns `{:ok, count}` of migrated rows; `{:ok, 0}` on a case-only
   change (`fold(old) == fold(new)`) or an empty match.
@@ -1485,7 +1504,7 @@ defmodule Grappa.Scrollback do
             Identifier.nick_fold(m.dm_with) == ^folded_old and
             Identifier.nick_fold(m.sender) == ^folded_old
         )
-        |> Repo.update_all(set: [channel: folded_new, dm_with: new_nick])
+        |> Repo.update_all(set: [channel: folded_new, dm_with: new_nick, sender: new_nick])
 
       {:ok, count}
     end

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1368,7 +1368,11 @@ defmodule Grappa.Scrollback do
       own`), whose row shape is indistinguishable from an outbound DM to
       a peer bearing our old nick without also folding `sender`. That is
       a window-key migration (the peer-rename set: window row + cursor),
-      a different defect from this stale tag, and it is tracked apart.
+      a different defect from this stale tag — #948 tracked it and
+      `rename_self_window/4` below now does it, folding `sender` to MATCH
+      exactly as predicted here. The two predicates are DISJOINT by the
+      `dm_with` conjunct: this one takes `fold(dm_with) != fold(old)`, that
+      one `== fold(old)`, so no row is migrated twice.
   """
   @spec rename_own_nick(subject(), integer(), String.t(), String.t()) ::
           {:ok, non_neg_integer()}
@@ -1390,6 +1394,98 @@ defmodule Grappa.Scrollback do
             Identifier.nick_fold(m.dm_with) != ^folded_old
         )
         |> Repo.update_all(set: [channel: folded_new])
+
+      {:ok, count}
+    end
+  end
+
+  @doc """
+  #948 — migrates the subject's OWN SELF window (`/msg <ownnick>`, the
+  scratchpad where both ends of the exchange are us) from `old_nick` to
+  `new_nick` after a SELF nick change.
+
+  Sibling of `rename_own_nick/4` and NOT a duplicate of it: that one moves
+  a stale TAG on rows belonging to a PEER's window, this one moves a
+  WINDOW KEY. `channel_or_dm_where/3`'s own-nick arm reads the self window
+  as `channel == <live own nick> AND fold(dm_with) == <live own nick>`, so
+  leaving these rows behind does not merely cost a badge — the whole
+  conversation disappears from the window and resurfaces as a phantom
+  QUERY with a peer bearing our old nick.
+
+  ## The predicate: three conjuncts, three distinct corruptions
+
+  A self row is `fold(channel) == fold(dm_with) == fold(sender) ==
+  fold(old)` — we sent it, we received it, we are the window. Each
+  conjunct excludes a REAL row shape that shares the other two, and each
+  is pinned by its own test:
+
+    * `fold(sender) == old` — an OUTBOUND DM to a peer who bears our old
+      nick carries `channel == dm_with == peer`; only `sender` (us, under
+      whatever nick we had then) separates them. Without it we file the
+      real peer's history under our new nick. This is exactly the fold
+      `rename_own_nick/4`'s carve-out named as the missing ingredient.
+    * `fold(channel) == old` — an INBOUND DM *from* a peer who bore our
+      old nick before we took it carries `dm_with == sender == old`, with
+      `channel` recording whoever WE were at receipt.
+    * `fold(dm_with) == old` — a non-CTCP NOTICE from a peer we already
+      have a query open with persists at `channel = sender, dm_with =
+      NULL` (`EventRouter.route_non_channel_notice_non_chanserv/3`). From
+      a peer bearing our old nick that is `channel == sender == old`, and
+      it drops out on SQL three-valued logic (`lower(NULL) = 'x'` is NULL,
+      which `WHERE` rejects) rather than on an explicit `not is_nil`.
+
+  Folding `sender` here is a MATCH, not a key derivation: `sender` is
+  never written by this migration, because it is testimony about who
+  spoke. `channel` is the KEY column → set FOLDED (`Repo.update_all`
+  bypasses `Message.canonicalize_channel/1`, the #537 trap);
+  `dm_with` is DISPLAY → set to the RAW `new_nick`.
+
+  ## What stays ambiguous
+
+  Two row shapes cannot be recovered, and both are the SAME ambiguity read
+  from two sides — the shape a self row takes once its `sender` no longer
+  folds to the window key:
+
+    * a self row already migrated ONCE (now `channel == dm_with == b,
+      sender == a`) is byte-identical to an outbound DM to a peer named
+      `b`, so a SECOND rename `b -> c` leaves it behind. No predicate over
+      `(channel, dm_with, sender)` can separate them; only a durable
+      self-marker written at persist time could, which is a schema change
+      and a different unit of work.
+    * a pre-CP14-B3 self row (`dm_with IS NULL`) is byte-identical to the
+      peer NOTICE the third conjunct exists to protect.
+
+  In both cases the migration declines rather than corrupting a peer's
+  history — incompleteness, never a wrong move.
+
+  Returns `{:ok, count}` of migrated rows; `{:ok, 0}` on a case-only
+  change (`fold(old) == fold(new)`) or an empty match.
+
+  Sole production caller: `Grappa.Session.Server.apply_effects/2` on the
+  `{:own_nick_renamed, old, new}` effect, which gates the window-row +
+  read-cursor moves on a non-zero count here.
+  """
+  @spec rename_self_window(subject(), integer(), String.t(), String.t()) ::
+          {:ok, non_neg_integer()}
+  def rename_self_window(subject, network_id, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(old_nick) and is_binary(new_nick) do
+    folded_old = Identifier.canonical_target(old_nick)
+    folded_new = Identifier.canonical_target(new_nick)
+
+    if folded_old == folded_new do
+      {:ok, 0}
+    else
+      {count, _} =
+        Message
+        |> subject_where(subject)
+        |> where([m], m.network_id == ^network_id)
+        |> where(
+          [m],
+          Identifier.nick_fold(m.channel) == ^folded_old and
+            Identifier.nick_fold(m.dm_with) == ^folded_old and
+            Identifier.nick_fold(m.sender) == ^folded_old
+        )
+        |> Repo.update_all(set: [channel: folded_new, dm_with: new_nick])
 
       {:ok, count}
     end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5830,6 +5830,14 @@ defmodule Grappa.Session.Server do
   # zero count means "no self conversation here" and we touch neither the
   # window nor the cursor — following the rename would otherwise file the
   # peer's identity under our new nick.
+  #
+  # The gate cuts the other way too, and that is accepted rather than
+  # overlooked: a GENUINE self window whose history was purged (or which was
+  # opened and never written to) also counts zero, so its tab stays at the
+  # nick we just vacated. With no rows there is no history to strand and no
+  # evidence to decide on, and the alternative — moving every window at our
+  # old nick — is the corruption above. An empty orphan tab is the cheaper
+  # of the two wrongs.
   @spec migrate_self_window(t(), String.t(), String.t()) :: :ok
   defp migrate_self_window(state, old_nick, new_nick) do
     {:ok, migrated} =
@@ -5840,23 +5848,26 @@ defmodule Grappa.Session.Server do
       # (no cursor row → `WindowCounts` counts from 0), the #373 lesson.
       :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
 
-      case QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick) do
-        {:ok, :renamed} ->
-          # LAST, and only when a window actually moved: the event is the
-          # truthful "rename fully applied" barrier (#373 rename-order fix).
-          :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
+      {:ok, window} = QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick)
 
-        {:ok, :noop} ->
-          # Rows but no window: the self window was closed and its history
-          # lives in Archive. It still had to follow, or the archive entry
-          # reads as a stranded query with our old nick.
-          :ok
+      # Broadcast LAST, and only when a window actually moved: the event is
+      # the truthful "rename fully applied" barrier (#373 rename-order fix).
+      # `:noop` is a real state — the self window can be CLOSED while its
+      # history lives in Archive. The rows still had to follow, or the
+      # archive entry reads as a stranded query bearing our old nick; but
+      # no window moved, so announcing one would be a lie.
+      if window == :renamed do
+        :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
       end
 
+      # `window:` rides the line because the two outcomes are different
+      # events for an operator reading this back, and a bare "followed"
+      # would describe work the `:noop` branch did not do.
       Logger.info("self window followed our own NICK",
         old_nick: old_nick,
         new_nick: new_nick,
-        rows_migrated: migrated
+        rows_migrated: migrated,
+        window: window
       )
     end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5778,14 +5778,18 @@ defmodule Grappa.Session.Server do
   end
 
   # #514: WE renamed. Deliberately NOT the peer arm above with the arguments
-  # swapped — our own nick is not a window key, so nothing moves: an inbound
-  # DM's window is `dm_with` (the peer) and its read cursor is keyed there
-  # too, both untouched by our rename. What goes stale is the own-nick TAG
-  # each inbound row carries in `channel`, which `Push.Triggers.dm?/2`
-  # compares to the LIVE nick (#498) when `Push.BadgeCount` folds the notify
-  # predicate back over history. One store, one UPDATE, and no
-  # `query_windows_list` broadcast — there is no window whose identity
-  # changed, so a barrier event would announce something that did not happen.
+  # swapped — for the rows #514 owns, our own nick is not a window key, so
+  # nothing moves: an inbound DM's window is `dm_with` (the peer) and its
+  # read cursor is keyed there too, both untouched by our rename. What goes
+  # stale is the own-nick TAG each inbound row carries in `channel`, which
+  # `Push.Triggers.dm?/2` compares to the LIVE nick (#498) when
+  # `Push.BadgeCount` folds the notify predicate back over history. One
+  # store, one UPDATE, no barrier.
+  #
+  # #948 then found the ONE window our own nick does key: the SELF window
+  # (`/msg <ownnick>`). `migrate_self_window/3` below handles it, and it is
+  # a genuine window-key migration with the full peer-rename set behind it
+  # — hence the barrier broadcast the tag re-key must not fire.
   #
   # `state` here is the POST-route state, so `state.nick` already reads the
   # NEW nick. The arm never consults it — both nicks travel in the effect —
@@ -5807,7 +5811,56 @@ defmodule Grappa.Session.Server do
       )
     end
 
+    migrate_self_window(state, old_nick, new_nick)
+
     apply_effects(rest, state)
+  end
+
+  # #948 — the SELF window (`/msg <ownnick>`) is the one window keyed on OUR
+  # nick, so our rename moves it exactly like #373 moves a peer's: rows,
+  # cursor, window row, then the barrier broadcast LAST.
+  #
+  # The scrollback count is the GATE, and it runs FIRST — the inversion of
+  # the #373 arm, which gates on `QueryWindows.rename/4` instead. There, the
+  # window row alone identifies the thing being renamed. Here it cannot: a
+  # window standing at our old nick is EITHER our self window or a leftover
+  # query with a peer who bore that nick before we took it, and the two are
+  # one row under the fold-unique index. Only the scrollback rows carry the
+  # `sender` that tells them apart (`Scrollback.rename_self_window/4`), so a
+  # zero count means "no self conversation here" and we touch neither the
+  # window nor the cursor — following the rename would otherwise file the
+  # peer's identity under our new nick.
+  @spec migrate_self_window(t(), String.t(), String.t()) :: :ok
+  defp migrate_self_window(state, old_nick, new_nick) do
+    {:ok, migrated} =
+      Scrollback.rename_self_window(state.subject, state.network_id, old_nick, new_nick)
+
+    if migrated > 0 do
+      # Else the migrated history reads fully unread under the new key
+      # (no cursor row → `WindowCounts` counts from 0), the #373 lesson.
+      :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
+
+      case QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick) do
+        {:ok, :renamed} ->
+          # LAST, and only when a window actually moved: the event is the
+          # truthful "rename fully applied" barrier (#373 rename-order fix).
+          :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
+
+        {:ok, :noop} ->
+          # Rows but no window: the self window was closed and its history
+          # lives in Archive. It still had to follow, or the archive entry
+          # reads as a stranded query with our old nick.
+          :ok
+      end
+
+      Logger.info("self window followed our own NICK",
+        old_nick: old_nick,
+        new_nick: new_nick,
+        rows_migrated: migrated
+      )
+    end
+
+    :ok
   end
 
   # #349 — commit-on-+r for USER sessions, scoped to the REGISTER case. A

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -2990,6 +2990,151 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
+  describe "rename_self_window/4 (#948 — the SELF window follows a self nick change)" do
+    # `/msg <ownnick>` — the scratchpad window where both ends are us, so
+    # the row lands with `channel == dm_with == sender == own nick`. Unlike
+    # the #514 tag, `channel` here IS the window key
+    # (`channel_or_dm_where/3`'s own-nick arm matches `channel == live own
+    # nick AND fold(dm_with) == live own nick`), so a self-rename strands
+    # the whole conversation at the old nick and the live self window reads
+    # empty. #514 carved this out and said it was tracked apart; it wasn't.
+    test "a self-DM row migrates old -> new", %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "oldme", dm_with: "oldme"}))
+
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "oldme", "NewMe")
+
+      migrated = Repo.get!(Message, row.id)
+      # `channel` is the window KEY → FOLDED (`Repo.update_all` bypasses the
+      # changeset fold, #537). `dm_with` is DISPLAY → the RAW new nick.
+      # `sender` is testimony about who spoke and is NOT touched.
+      assert migrated.channel == "newme"
+      assert migrated.dm_with == "NewMe"
+      assert migrated.sender == "oldme"
+    end
+
+    # Guard 1 of 3, the `sender` conjunct. I was `alice`, I DM'd `carol`,
+    # carol vanished, I took the nick `carol`, and now I rename
+    # `carol -> dave`. `channel == dm_with == carol` on that row exactly as
+    # on a self row; only `sender` (me-as-alice, not carol) tells them
+    # apart. Drop the sender conjunct and the REAL carol's history is filed
+    # under dave.
+    test "does NOT touch an outbound DM to a peer that bears the old nick",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "carol", sender: "alice", dm_with: "carol"}))
+
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "carol", "dave")
+
+      assert Repo.get!(Message, row.id).channel == "carol"
+    end
+
+    # Guard 2 of 3, the `channel` conjunct. An INBOUND DM from a peer who
+    # bore our old nick before we took it: `dm_with == sender == carol` but
+    # `channel` is whoever WE were at receipt. Drop the channel conjunct and
+    # the peer's inbound half migrates into our self window.
+    test "does NOT touch an inbound DM from a peer that bears the old nick",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "alice", sender: "carol", dm_with: "carol"}))
+
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "carol", "dave")
+
+      row = Repo.get!(Message, row.id)
+      assert row.channel == "alice"
+      assert row.dm_with == "carol"
+    end
+
+    # Guard 3 of 3, the `dm_with` conjunct. A non-CTCP NOTICE from a peer we
+    # already have a query open with persists at `channel = sender,
+    # dm_with = NULL` (`EventRouter.route_non_channel_notice_non_chanserv/3`
+    # → `open_query_or_server/2`). From a peer who bore our old nick that is
+    # `channel == sender == old, dm_with IS NULL` — and `fold(NULL) != x` is
+    # NULL, so the conjunct rejects it on SQL three-valued logic. Drop it and
+    # we both steal the peer's notice AND invent a `dm_with` on it.
+    #
+    # Same shape, and therefore the same verdict, for a pre-CP14-B3 SELF row
+    # (inbound rows predate the `dm_with` column, so legacy self rows carry
+    # NULL too): indistinguishable from this notice, so it does not migrate.
+    # That loss is the price of not corrupting this row.
+    test "does NOT touch an orphan NOTICE row (dm_with IS NULL) from a peer bearing the old nick",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(
+          sample(user, net, 200, %{
+            channel: "carol",
+            sender: "carol",
+            kind: :notice,
+            body: "away from keyboard",
+            dm_with: nil
+          })
+        )
+
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "carol", "dave")
+
+      row = Repo.get!(Message, row.id)
+      assert row.channel == "carol"
+      assert row.dm_with == nil
+    end
+
+    test "ASCII-folded match: a row stored at 'oldme' migrates when matched via 'OldMe' (#525)",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "OLDME", dm_with: "OldMe"}))
+
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "OldMe", "newme")
+
+      assert Repo.get!(Message, row.id).channel == "newme"
+    end
+
+    test "case-only fold (old == new) is a noop, returns {:ok, 0}", %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "Foo", sender: "Foo", dm_with: "Foo"}))
+
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "Foo", "FOO")
+
+      assert Repo.get!(Message, row.id).dm_with == "Foo"
+    end
+
+    test "isolated by subject and network", %{user: user, network: net} do
+      {:ok, other_net} = Networks.find_or_create_network(%{slug: "other-#{uniq()}"})
+      {:ok, alice} = Accounts.create_user(%{name: "alice-#{uniq()}", password: "correct horse battery"})
+
+      {:ok, other_net_row} =
+        Scrollback.persist_event(sample(user, other_net, 100, %{channel: "oldme", sender: "oldme", dm_with: "oldme"}))
+
+      {:ok, alice_row} =
+        Scrollback.persist_event(sample(alice, net, 100, %{channel: "oldme", sender: "oldme", dm_with: "oldme"}))
+
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "oldme", "newme")
+
+      assert Repo.get!(Message, other_net_row.id).channel == "oldme"
+      assert Repo.get!(Message, alice_row.id).channel == "oldme"
+    end
+
+    test "idempotent — returns {:ok, 0} on empty matches", %{user: user, network: net} do
+      assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "ghost", "phantom")
+    end
+
+    # The point of the whole migration, read through the production path:
+    # the self window is keyed on the LIVE own nick, so post-rename the
+    # history must answer under the new nick and nothing must answer under
+    # the old one.
+    test "the self window reads under the new nick and is empty under the old",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "oldme", dm_with: "oldme"}))
+
+      assert [%{id: id}] = read_dm(user, net, "oldme", "oldme")
+      assert id == row.id
+
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "oldme", "newme")
+
+      assert [%{id: ^id}] = read_dm(user, net, "newme", "newme")
+      assert read_dm(user, net, "oldme", "newme") == []
+    end
+  end
+
   describe "delete_for_channel/3 (UX-1)" do
     test "drops all rows for (subject, network, channel) — channel-shaped", %{
       user: user,

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -3022,11 +3022,30 @@ defmodule Grappa.ScrollbackTest do
 
       migrated = Repo.get!(Message, row.id)
       # `channel` is the window KEY → FOLDED (`Repo.update_all` bypasses the
-      # changeset fold, #537). `dm_with` is DISPLAY → the RAW new nick.
-      # `sender` is testimony about who spoke and is NOT touched.
+      # changeset fold, #537). `dm_with` and `sender` are DISPLAY → the RAW
+      # new nick. All three name the same person — us — and the row has to
+      # stay internally consistent or it stops being recognisable as a self
+      # row (see the round-trip test below).
       assert migrated.channel == "newme"
       assert migrated.dm_with == "NewMe"
-      assert migrated.sender == "oldme"
+      assert migrated.sender == "NewMe"
+    end
+
+    # WHY `sender` moves, and the flow that proves it must. A migration whose
+    # UPDATE does not preserve the shape its predicate matches on is one-shot:
+    # it destroys the evidence it identified the row by. The round trip is not
+    # hypothetical — services enforcement parks us on a Guest nick and
+    # `GhostRecovery` renames us straight back.
+    test "a second rename follows too — the UPDATE preserves the shape the predicate matches",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "vjt", sender: "vjt", dm_with: "vjt"}))
+
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "vjt", "Guest12345")
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "Guest12345", "vjt")
+
+      assert [%{id: id}] = read_dm(user, net, "vjt", "vjt")
+      assert id == row.id
     end
 
     # Guard 1 of 3, the `sender` conjunct. I was `alice`, I DM'd `carol`,

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -2903,6 +2903,22 @@ defmodule Grappa.ScrollbackTest do
       assert Repo.get!(Message, orphan.id).channel == "oldme"
     end
 
+    # #948 addendum. The `channel` conjunct above was killed by ZERO tests:
+    # dropping it left the whole of this file green while the mutant re-keys
+    # EVERY row whose `dm_with` is a peer other than our old nick — i.e. it
+    # stamps our new nick over unrelated DM history. Measured with the #948
+    # mutation harness, then pinned here. The row below is the cheapest
+    # witness: an inbound DM received while we were somebody else entirely.
+    test "does NOT touch a DM tagged at a nick that is not the old one",
+         %{user: user, network: net} do
+      {:ok, elsewhere} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "alice", sender: "bob", dm_with: "bob"}))
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "newme")
+
+      assert Repo.get!(Message, elsewhere.id).channel == "alice"
+    end
+
     test "leaves channel rows alone", %{user: user, network: net} do
       {:ok, chan} =
         Scrollback.persist_event(sample(user, net, 100, %{channel: "#sniffo", sender: "alice", dm_with: nil}))

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -3048,6 +3048,30 @@ defmodule Grappa.ScrollbackTest do
       assert id == row.id
     end
 
+    # The OTHER consumer that made `sender` move, pinned against the real
+    # predicate rather than argued. `Push.Triggers.own_row?/2` (#532 C) reads
+    # `sender` as a LIVE identity test and is the first arm of
+    # `should_notify?/4`, which `Push.BadgeCount` folds back over the unread
+    # tail. Migrate `channel` without `sender` and the row leaves own-row
+    # suppression while ENTERING the DM branch — notes we wrote to ourselves
+    # would count as unread DMs.
+    test "a migrated self row still suppresses as our OWN row (#532 C)",
+         %{user: user, network: net} do
+      {:ok, row} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "oldme", dm_with: "oldme"}))
+
+      assert {:ok, 1} = Scrollback.rename_self_window({:user, user.id}, net.id, "oldme", "newme")
+
+      migrated = Repo.get!(Message, row.id)
+
+      refute Grappa.Push.Triggers.should_notify?(
+               migrated,
+               "newme",
+               Grappa.UserSettings.default_notification_prefs(),
+               []
+             )
+    end
+
     # Guard 1 of 3, the `sender` conjunct. I was `alice`, I DM'd `carol`,
     # carol vanished, I took the nick `carol`, and now I rename
     # `carol -> dave`. `channel == dm_with == carol` on that row exactly as

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -3051,14 +3051,14 @@ defmodule Grappa.ScrollbackTest do
     # the peer's inbound half migrates into our self window.
     test "does NOT touch an inbound DM from a peer that bears the old nick",
          %{user: user, network: net} do
-      {:ok, row} =
+      {:ok, inbound} =
         Scrollback.persist_event(sample(user, net, 100, %{channel: "alice", sender: "carol", dm_with: "carol"}))
 
       assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "carol", "dave")
 
-      row = Repo.get!(Message, row.id)
-      assert row.channel == "alice"
-      assert row.dm_with == "carol"
+      untouched = Repo.get!(Message, inbound.id)
+      assert untouched.channel == "alice"
+      assert untouched.dm_with == "carol"
     end
 
     # Guard 3 of 3, the `dm_with` conjunct. A non-CTCP NOTICE from a peer we
@@ -3075,7 +3075,7 @@ defmodule Grappa.ScrollbackTest do
     # That loss is the price of not corrupting this row.
     test "does NOT touch an orphan NOTICE row (dm_with IS NULL) from a peer bearing the old nick",
          %{user: user, network: net} do
-      {:ok, row} =
+      {:ok, orphan} =
         Scrollback.persist_event(
           sample(user, net, 200, %{
             channel: "carol",
@@ -3088,9 +3088,9 @@ defmodule Grappa.ScrollbackTest do
 
       assert {:ok, 0} = Scrollback.rename_self_window({:user, user.id}, net.id, "carol", "dave")
 
-      row = Repo.get!(Message, row.id)
-      assert row.channel == "carol"
-      assert row.dm_with == nil
+      untouched = Repo.get!(Message, orphan.id)
+      assert untouched.channel == "carol"
+      assert untouched.dm_with == nil
     end
 
     test "ASCII-folded match: a row stored at 'oldme' migrates when matched via 'OldMe' (#525)",

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -31,7 +31,7 @@ defmodule Grappa.Session.ServerTest do
   import Mox
 
   alias Grappa.IRC.Message
-  alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, Repo, Scrollback, Session, WSPresence}
+  alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
   alias Grappa.Session.{AwayState, Backoff, GhostRecovery, ISupport, RecoverIdentity, Server, WindowState}
   alias Grappa.SessionStateHelpers
@@ -3112,6 +3112,124 @@ defmodule Grappa.Session.ServerTest do
       assert [row] = Scrollback.fetch({:user, user.id}, network.id, "NickTemporaneo", nil, 10, own, false)
       assert row.body == "ciao"
       assert Scrollback.fetch({:user, user.id}, network.id, "Guest87449", nil, 10, own, false) == []
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
+  describe "#948 — the SELF window follows OUR OWN NICK change" do
+    test "a self /nick migrates the self window row, its scrollback and its read cursor" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      # `/msg <ownnick>` — the ircd delivers our own PRIVMSG back to us
+      # because we ARE the target, so the row lands with
+      # `channel == dm_with == sender == own nick`.
+      IRCServer.feed(server, ":#{own}!~g@host PRIVMSG #{own} :nota per me\r\n")
+
+      # #422 auto-open: the self row mints its own query window. Waiting for
+      # that broadcast proves the window exists pre-rename AND drains it off
+      # the topic so it cannot race the rename assertion below.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :query_windows_list,
+                         windows: %{^net_id => [%{target_nick: ^own}]}
+                       }
+                     },
+                     1_000
+
+      assert [row] = Scrollback.fetch(subject, net_id, own, nil, 10, own, false)
+      row_id = row.id
+      {:ok, _} = ReadCursor.set(subject, net_id, own, row_id)
+
+      # WE rename.
+      IRCServer.feed(server, ":#{own}!~g@host NICK :grappa-new\r\n")
+
+      # Same barrier contract as #373: the broadcast is emitted only after
+      # the scrollback + cursor have moved, so receiving it makes the reads
+      # below deterministic rather than a race.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list, windows: windows}
+                     },
+                     1_000
+
+      assert [%{target_nick: "grappa-new"}] = Map.fetch!(windows, net_id)
+      assert [%{target_nick: "grappa-new"}] = QueryWindows.list_for_subject(subject)[net_id]
+
+      # History answers under the new nick, and nothing answers under the
+      # old one — pre-fix it was the exact reverse, with the conversation
+      # resurfacing as a phantom query with a peer bearing our old nick.
+      assert [%{id: ^row_id, body: "nota per me"}] =
+               Scrollback.fetch(subject, net_id, "grappa-new", nil, 10, "grappa-new", false)
+
+      assert Scrollback.fetch(subject, net_id, own, nil, 10, "grappa-new", false) == []
+
+      # The cursor follows too, else the migrated history reads fully unread.
+      assert %{last_read_message_id: ^row_id} = ReadCursor.get(subject, net_id, "grappa-new")
+      assert ReadCursor.get(subject, net_id, own) == nil
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The gate. A self-rename with no self conversation must move NOTHING:
+    # a query window standing at our old nick then belongs to a peer who
+    # bore it before us, and following our rename would file their identity
+    # under our new nick. No self rows, no migration, no barrier broadcast.
+    test "a self /nick with no self conversation leaves a same-named peer window alone" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+
+      # A window standing at the nick we are ABOUT TO VACATE, owned by a peer
+      # who bore it before we took it: we DM'd them back then, so `sender` is
+      # whoever we were, not the window key. Not a self row.
+      {:ok, _} =
+        Scrollback.persist_event(%{
+          user_id: user.id,
+          network_id: net_id,
+          channel: own,
+          server_time: System.system_time(:millisecond),
+          kind: :privmsg,
+          sender: "previous-me",
+          body: "ciao",
+          dm_with: own
+        })
+
+      {:ok, _} = QueryWindows.open(subject, net_id, own, user.name)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      IRCServer.feed(server, ":#{own}!~g@host NICK :grappa-new\r\n")
+
+      # No barrier broadcast, because nothing migrated. Other user-topic
+      # events (`own_nick_changed`) still ride this topic, so the refutation
+      # is scoped to the barrier kind.
+      refute_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list}
+                     },
+                     300
+
+      assert [%{target_nick: ^own}] = QueryWindows.list_for_subject(subject)[net_id]
+
+      assert [%{body: "ciao"}] =
+               Scrollback.fetch(subject, net_id, own, nil, 10, "grappa-new", false)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Refs #948. The carve-out #514 said was "tracked apart" — it wasn't, and this is it.

## The defect

`/msg <ownnick>` — the self window, where both ends of the exchange are us, so
the row lands with `channel == dm_with == sender == own nick`. Unlike the #514
tag, `channel` there IS the window key: `channel_or_dm_where/3`'s own-nick arm
reads the self window as `channel == live own nick AND fold(dm_with) == live own
nick`. So a self-rename did not cost a badge, it emptied the window — and the
whole conversation resurfaced under `where_dm_peer/2` as a phantom query with a
peer bearing our old nick.

## The disambiguation, which is the decision of this unit

A self row is byte-identical to an outbound DM to a peer who bears our old nick
— both are `channel == dm_with == old` — except for `sender`. That is exactly
the missing ingredient #514's carve-out named. `Scrollback.rename_self_window/4`
folds three columns to MATCH, and each conjunct excludes a real shape that
shares the other two:

| conjunct | excludes |
|---|---|
| `fold(sender) == old` | an OUTBOUND DM to a peer bearing the old nick |
| `fold(channel) == old` | an INBOUND DM FROM such a peer |
| `fold(dm_with) == old` | the `channel = sender, dm_with = NULL` NOTICE an open query keeps |

One test per conjunct; each is killed by exactly one, disjointly (measured).
The predicate is disjoint from `rename_own_nick/4`'s by the `dm_with` conjunct
(`!=` there, `==` here), so no row moves twice.

## `sender` migrates, and the first cut was wrong not to

Frozen `sender` — the rule `rename_dm_peer/4` correctly applies to a peer's
lines — made the UPDATE not closed under its own predicate. A migrated row
became indistinguishable from an outbound DM to a peer, so the return leg of
`a -> b -> a` matched nothing and stranded the window for good. That round trip
is routine here: services enforcement parks us on a Guest nick and
`GhostRecovery` renames us straight back. It was worse than `main`, which moves
nothing and heals.

Second consumer, same root: `Push.Triggers.own_row?/2` reads `sender` as a LIVE
identity test (#532 C) and `Push.BadgeCount` folds that predicate back over the
unread tail — stale `sender` + migrated `channel` moved own notes into the DM
branch and counted them as unread DMs.

**The rule now in CLAUDE.md: a DISPLAY column migrates when a consumer reads it
as the LIVE identity.** That is why #514 re-keys the own-nick tag in `channel`,
and why a peer's `sender` still does not move. Writing all three cannot collide
with a peer row: `channel == dm_with == sender` is unreachable for any peer
conversation, because you cannot DM a peer bearing your own nick.

## The gate is inverted relative to #373, deliberately

The peer arm gates on `QueryWindows.rename/4` — there the window row identifies
what is being renamed. Here it cannot: a window at our old nick is EITHER our
self window OR a leftover query with a peer who bore that nick before us, and
the fold-unique index makes those ONE row. Only the scrollback's `sender`
separates them, so the row count gates the window and cursor moves.

The gate cuts both ways and that is accepted, not overlooked: a genuine but
EMPTY self window (history purged, or opened and never written to) also counts
zero and keeps its tab at the vacated nick. With no rows there is nothing to
strand and no evidence to decide on; the alternative is dragging a peer's
identity to our new name.

## What it declines

A pre-CP14-B3 self row carries `dm_with IS NULL` and is byte-identical to the
peer NOTICE the third conjunct protects. Only a durable self-marker written at
persist time could separate them — its backfill predicate is already known
(`fold(channel) == fold(dm_with) == fold(sender)`), but it is a schema change
plus a rework of archive grouping and `delete_for_dm/3`. Not this unit.

## The client half is absent on purpose

cic keys the self window at `channelKey(slug, ownNick)` like any query window,
and `own_nick_changed` only calls `mutateNetworkNick`. Mirroring the #373 client
set from that event unconditionally would have cic rename caches on a migration
the server DECLINED to run — precisely the "cic never originates state" rule.
Doing it right needs the event to carry the old nick and whether the window
moved: an additive wire field, codegen, and the protocol doc. Filed separately.
Until then the durable state is correct and the sidebar is truthful immediately;
a device holding the self window focused across a rename keeps an orphan
selection until it reloads.

## Also in here

`rename_own_nick/4`'s own `fold(channel)` conjunct was killed by zero
assertions — dropping it left the whole scrollback suite green while the mutant
stamps our new nick over unrelated DM history. Pinned with one row.

## Test plan

- [x] `scripts/check.sh` green end to end: format, credo strict, dialyzer,
      sobelow, doctor, `mix test` on the pushed HEAD `6def3bf8` — 8 doctests,
      56 properties, 5612 tests, 0 failures; working tree clean before and
      after.
- [x] Mutation-measured, disjoint kills: dropping each of the three conjuncts
      kills exactly one named test; dropping the `sender` write kills the
      round-trip test; removing the `apply_effects` call kills the session
      migration test; defeating the `migrated > 0` gate kills the
      no-self-conversation test. That last mutant kills three tests, not one:
      the value written, the round-trip closure, and the own-row suppression
      are three distinct consequences of one write.
- [ ] Full `scripts/integration.sh` — NOT run: the e2e lane was not allocated
      to this unit. Server-only change, no cic and no wire change, but this is
      the remaining ship gate.
