### PR TITLE
cic(#1123): quote the sender's words, not the quote they answered

### DIFF
--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -108,6 +108,101 @@ describe("replyQuote", () => {
   });
 });
 
+// #1123 — replying to a reply used to nest: the quoted body already carried a
+// quote plus its `<< ` tail, so every hop dragged the whole history forward and
+// the line actually being answered ended up buried mid-string.
+describe("replyQuote — a previous quote is dropped (#1123)", () => {
+  it("quotes only what the sender wrote, not the quote they were answering", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "<alice> answer<< ",
+    );
+  });
+
+  // The cut is at the LAST tail, not the first: a body persisted before this
+  // fix carries several hops, and stopping at the first `<< ` would keep every
+  // one of them but the oldest.
+  it("cuts at the last tail, not the first", () => {
+    expect(
+      replyQuote(msg({ sender: "carol", body: "<alice> <bob> original<< answer<< reply" })),
+    ).toBe("<carol> reply<< ");
+  });
+
+  // #1126 gave actions their own quote head (`* nick …`), so the client emits
+  // two shapes and both nest. One bug, both doors.
+  it("drops a previous action-shaped quote too", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "* bob waves<< sure" }))).toBe(
+      "<alice> sure<< ",
+    );
+  });
+
+  it("drops a previous quote inside an action being quoted", () => {
+    expect(
+      replyQuote(
+        msg({ kind: "action", sender: "alice", body: "\x01ACTION <bob> orig<< nods\x01" }),
+      ),
+    ).toBe("* alice nods<< ");
+  });
+
+  // Every legal nick special (RFC 2812 `special` plus the tail-only dash),
+  // mirroring `Grappa.IRC.Identifier`'s nick regex. A charset invented here
+  // instead of derived would silently refuse to strip these.
+  it("recognises a head with every legal nick special", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<_a[b]\\c{d}|e^f`g-1> quoted<< mine" }))).toBe(
+      "<alice> mine<< ",
+    );
+  });
+
+  // 30 chars is the cap the server's nick regex enforces; a head at the cap is
+  // a real nick and must still be recognised.
+  it("recognises a head at the 30-char nick cap", () => {
+    const nick = `n${"x".repeat(29)}`;
+    expect(nick).toHaveLength(30);
+    expect(replyQuote(msg({ sender: "alice", body: `<${nick}> quoted<< mine` }))).toBe(
+      "<alice> mine<< ",
+    );
+  });
+
+  // A body that is nothing BUT a previous quote leaves the sender with no words
+  // of their own; `<alice> <bob> orig<<<< ` is not a reply to anything.
+  it("refuses a body that is only a previous quote", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< " }))).toBeNull();
+  });
+
+  // The wire (or a client) may eat the tail's trailing space, so the tail also
+  // counts when it sits flush against the end of the body.
+  it("refuses a body that is only a previous quote with the tail space eaten", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<" }))).toBeNull();
+  });
+});
+
+describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
+  // `<<` is ordinary text: a bare substring search would eat a real message,
+  // which is worse than the nesting it fixes.
+  it("leaves a shift expression alone", () => {
+    expect(replyQuote(msg({ body: "shift << 2 gives four" }))).toBe(
+      "<vjt> shift << 2 gives four<< ",
+    );
+  });
+
+  it("leaves a heredoc alone", () => {
+    expect(replyQuote(msg({ body: "cat <<EOF > f" }))).toBe("<vjt> cat <<EOF > f<< ");
+  });
+
+  it("leaves a leading angle bracket that is not a nick head alone", () => {
+    expect(replyQuote(msg({ body: "<3 you << me" }))).toBe("<vjt> <3 you << me<< ");
+    expect(replyQuote(msg({ body: "<two words> a << b" }))).toBe("<vjt> <two words> a << b<< ");
+  });
+
+  // The head must be at position 0. `appendToCompose` drops the quote AFTER an
+  // existing draft, so a mid-string quote means the leading text is the
+  // sender's own words — cutting there would delete what they wrote.
+  it("leaves a quote that is not at the start of the body alone", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "bozza <bob> ciao<< risposta" }))).toBe(
+      "<alice> bozza <bob> ciao<< risposta<< ",
+    );
+  });
+});
+
 describe("appendToCompose", () => {
   it("appends to the draft and leaves the caret at the very end", async () => {
     const ta = mountCompose();

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -163,15 +163,21 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   });
 
   // A body that is nothing BUT a previous quote leaves the sender with no words
-  // of their own; `<alice> <bob> orig<<<< ` is not a reply to anything.
+  // of their own; `<alice> <bob> orig<<<< ` is not a reply to anything. Both
+  // spellings are asserted, but they are ONE input: the body is trimmed before
+  // the cut, so the tail sits flush against the end either way — which is also
+  // how a wire that eats trailing whitespace delivers it.
   it("refuses a body that is only a previous quote", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< " }))).toBeNull();
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<" }))).toBeNull();
   });
 
-  // The wire (or a client) may eat the tail's trailing space, so the tail also
-  // counts when it sits flush against the end of the body.
-  it("refuses a body that is only a previous quote with the tail space eaten", () => {
-    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<" }))).toBeNull();
+  // The cut consumes exactly one space of the tail, so anything the sender
+  // typed after a wider gap would arrive with the gap still on it.
+  it("does not carry the gap after the tail into the new quote", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<   spaced" }))).toBe(
+      "<alice> spaced<< ",
+    );
   });
 });
 

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -14,6 +14,30 @@ import { mircPlainText } from "./mircFormat";
 // space included, so the answer is typed straight after the caret.
 export const REPLY_QUOTE_TAIL = "<< ";
 
+// #1123 — the nick charset, mirrored from the server's
+// `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
+// letter-or-special, the tail adds digits and `-`, 30 chars total). Derived
+// rather than invented: a narrower guess would refuse to strip a real
+// `<foo[1]> ` head, and a wider one starts eating ordinary prose.
+const NICK = "[A-Za-z\\[\\]\\\\`_^{|}][\\w\\[\\]\\\\`_^{|}-]{0,29}";
+
+// A previous reply-quote sitting at the head of a body. Anchored at position 0
+// and shaped like what THIS module emits — `<nick> ` for speech, `* nick ` for
+// an action (#1126) — because a bare `<<` search would eat ordinary text
+// (`shift << 2`, `cat <<EOF`), which is worse than the nesting it fixes.
+//
+// `[\s\S]*` is greedy on purpose: the cut lands on the LAST tail, so a body
+// persisted before this fix sheds every hop it accumulated, not just the
+// oldest. The tail also counts flush against the end of the body — a sender
+// whose whole message was a quote wrote nothing of their own.
+const PREVIOUS_QUOTE = new RegExp(`^(?:<${NICK}>|\\* ${NICK}) [\\s\\S]*<<(?: |$)`);
+
+// What the sender actually wrote: their body minus the quote they were
+// answering. Returns the body untouched when it is not quote-shaped.
+function withoutPreviousQuote(body: string): string {
+  return body.replace(PREVIOUS_QUOTE, "").trim();
+}
+
 // The quote for a message, or null when there is nothing to reply to.
 //
 // Only CONTENT kinds quote (`isContentKind` — privmsg/notice/action, the same
@@ -32,7 +56,12 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
   // operator is quoting what they SEE, and a control byte round-tripped through
   // compose would be re-sent as formatting they never chose.
-  const body = mircPlainText(raw).trim();
+  // #1123 — the body being quoted may itself be a reply, carrying its own
+  // quote plus the `<< ` tail. Left in, every hop drags the whole history
+  // forward and the line actually being answered ends up buried mid-string.
+  // Dropping it can empty the body: a sender whose message was nothing but a
+  // quote said nothing to reply to, which the check below already refuses.
+  const body = withoutPreviousQuote(mircPlainText(raw).trim());
   if (body === "") return null;
   // #1126 — an action is NOT speech. Quoting `* vjt waves` as `<vjt> waves`
   // puts a sentence in someone's mouth that they never said, so the quote keeps

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35642,3 +35642,50 @@ this: it triggers on pushes to `master` while the repository's default branch is
 `main`, and no run of it appears in the repository's history. That is a
 plausible reason the fatal stayed invisible, not a measured one — nobody has
 re-pointed the trigger and watched it go red.
+---
+
+## 2026-08-09 — #1123: a quote is what the sender wrote, and the shape is the only safe knife
+
+`replyQuote` built its quote out of the whole body. When the body was itself a
+reply it already carried a quote and the `<< ` tail, so each hop wrapped the
+previous one: three replies deep the line actually being answered sat buried
+mid-string, and on a narrow client the visible part of the message was all
+quote and no content.
+
+**The cut is on shape, never on the delimiter.** The obvious fix — find `<<`,
+cut there — is the one thing that must not be done. `<<` is ordinary text:
+`shift << 2`, C++ stream operators, `cat <<EOF`. Eating a real message on a
+substring hit is a worse defect than the nesting it removes, because the
+nesting is ugly while the substring cut is lossy. The match is therefore
+anchored at position 0 and shaped like what this module itself emits: a
+nick-shaped head, a space, text, and the `<< ` tail. Both heads count —
+`<nick> ` for speech and `* nick ` for an action, since #1126 gave actions
+their own quote form and both nest identically.
+
+**The nick charset is mirrored, not invented.** It comes from the server's
+`Grappa.IRC.Identifier` nick regex (RFC 2812 §2.3.1 — letter-or-special first,
+digits and `-` in the tail, 30 chars). A guess narrower than the wire would
+silently refuse to strip a real `<foo[1]> ` head; a guess wider than the wire
+starts matching prose. The mirror is a second copy of a server constant and
+carries the usual drift risk, but the alternative — a bespoke client charset —
+is drift with no reference point at all.
+
+**Two deliberate under-strips.** The cut lands on the LAST tail, so a body
+persisted before this fix sheds every hop it accumulated rather than all but
+the oldest. But the head must be at position 0, and `appendToCompose` drops
+the quote AFTER whatever draft is already in the box: a quote further in means
+the text before it is the sender's own words, and cutting there would delete
+what they wrote. Likewise a server notice quotes as `<irc.example.org> …`, and
+a hostname is not nick-shaped, so a reply to a reply to a server notice still
+nests. Both are misses, not corruptions — the safe direction.
+
+**What is NOT claimed: this is not false-positive free, and cannot be.** The
+guard recognises the shape the client emits, so a body that genuinely has that
+shape is indistinguishable from one the client built. A hand-typed
+`<html> tag stuff << x`, or a bullet line `* fix the << operator`, will be cut.
+The `* ` head is the weaker of the two — a markdown bullet is a common way to
+start a chat line, where a leading `<nick>` is not — and it is accepted only
+because the conjunction with a nick-shaped token and a later `<< ` makes the
+collision rare, and because the damage is confined to the quote being drafted:
+the sender's message, the compose box's existing draft, and the wire are all
+untouched.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35642,6 +35642,7 @@ this: it triggers on pushes to `master` while the repository's default branch is
 `main`, and no run of it appears in the repository's history. That is a
 plausible reason the fatal stayed invisible, not a measured one — nobody has
 re-pointed the trigger and watched it go red.
+
 ---
 
 ## 2026-08-09 — #1123: a quote is what the sender wrote, and the shape is the only safe knife


### PR DESCRIPTION
Fixes the nesting described in #1123.

## The defect

`replyQuote` built the quote from the whole message body. When the body was
itself a reply it already carried a quote plus the `<< ` tail, so every hop
wrapped the previous one and the line actually being answered ended up buried
mid-string — on a narrow client, all quote and no content.

## The fix

Drop a leading previous quote before building the new one.

The match is **anchored at position 0** and shaped like what this module itself
emits — `<nick> ` for speech, `* nick ` for an action (#1126 gave actions their
own quote head; both nest identically). The nick charset is **mirrored from the
server's `Grappa.IRC.Identifier` nick regex** (RFC 2812 §2.3.1: letter-or-special
first, digits and `-` in the tail, 30 chars) rather than invented here — a
narrower guess silently refuses to strip a real `<foo[1]> ` head, a wider one
starts matching prose.

A bare `<<` substring search was rejected outright, per the issue: `shift << 2`
and `cat <<EOF` are ordinary text, and eating a real message is a worse defect
than the nesting it removes.

The cut lands on the **last** tail, so a body persisted before this fix sheds
every hop it accumulated, not just the oldest.

## Deliberate under-strips

- **Mid-string quote is left alone.** `appendToCompose` drops the quote AFTER
  whatever draft is already in the box, so text before the head is the sender's
  own words; cutting there would delete what they wrote.
- **Server notices still nest.** A notice quotes as `<irc.example.org> …` and a
  hostname is not nick-shaped.

Both are misses, not corruptions — the safe direction.

## What this does NOT claim

A shape guard cannot be false-positive free. A body that genuinely has the shape
the client emits is indistinguishable from one the client built: a hand-typed
`<html> tag stuff << x`, or a bullet line `* fix the << operator`, will be cut.
The `* ` head is the weaker of the two (a markdown bullet is a common way to
start a chat line; a leading `<nick>` is not) and is accepted only because the
conjunction with a nick-shaped token AND a later `<< ` makes the collision rare,
and because the damage is confined to the quote being drafted — the sender's
message, the existing draft, and the wire are untouched.

## Evidence

- TDD: 8 red before the fix, then green.
- Mutation matrix: **11 mutants, 11 killed**; every one of the 12 new tests kills
  at least one. Notably `M8` (cut at the last bare `<<`, what the issue forbids)
  is killed by 4 negative tests, and `M2`/`M3`/`M4`/`M5`/`M6`/`M7`/`M9`/`M10`
  each fall to exactly one assertion.
- `bun run check` rc=0 (biome + tsc + e2e tsc).
- `bun run test` rc=0 — **4982 passed / 268 files**, up from a measured baseline
  of 4970 / 268. The +12 was predicted by name before the run and reconciled
  exactly.

Scope is quote-building only; the sent message and the wire format are
unaffected.