### PR TITLE
admin(#1140): name the vhost grant subject instead of printing its UUID

### DIFF
--- a/cicchetto/e2e/tests/issue1140-vhost-grant-subject-label.spec.ts
+++ b/cicchetto/e2e/tests/issue1140-vhost-grant-subject-label.spec.ts
@@ -1,0 +1,104 @@
+// #1140 — the vhost grants table printed the bare subject UUID. The
+// operator picks a grant subject BY NAME in the #257 autocomplete, so
+// after the post-grant refresh they could not tell WHICH of their users
+// held the grant without resolving the GUID by hand.
+//
+// The label is resolved SERVER-side (`subject_label` on the grant wire):
+// the grants list arrives with the vhosts payload and has no search
+// round-trip to piggyback on. `subject_label: null` is the honesty signal
+// for a subject that resolves to no name; cic then falls back to the uuid
+// rather than inventing a placeholder.
+//
+// The RED here is behavioural, not structural: before #1140 the subject
+// cell rendered the uuid as its TEXT and carried no title, so both
+// assertions below fail on the old build.
+//
+// The subject flow through the autocomplete is #257's spec; this one
+// seeds the grant through the API and asserts what the TABLE says, which
+// is the part #1140 reports as broken. DESKTOP admin surface → chromium.
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated is EXEMPT.
+
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+async function createVhost(token: string, address: string): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/vhosts`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ address, in_pool: false, generally_available: false }),
+  });
+  if (!res.ok) throw new Error(`createVhost: ${address} → ${res.status}`);
+  const body = (await res.json()) as { id: number };
+  return body.id;
+}
+
+async function grantToUser(token: string, vhostId: number, userId: string): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/vhosts/${vhostId}/grants`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ subject_type: "user", subject_id: userId }),
+  });
+  if (!res.ok) throw new Error(`grantToUser: ${vhostId} → ${res.status}`);
+}
+
+async function deleteVhostBestEffort(token: string, id: number): Promise<void> {
+  try {
+    await fetch(`${GRAPPA_BASE_URL}/admin/vhosts/${id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // best-effort teardown; grants cascade with the vhost
+  }
+}
+
+test("#1140 — the grants table names the subject and demotes its uuid to the title", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
+  const address = `2001:db8:1140::${(Date.now() % 0xffff).toString(16)}`;
+
+  let vhostId: number | null = null;
+
+  try {
+    // The account name and the stable key must be distinguishable, else
+    // "shows the name, not the uuid" proves nothing.
+    expect(adminId).not.toBe(admin.name);
+
+    vhostId = await createVhost(admin.token, address);
+    await grantToUser(admin.token, vhostId, adminId);
+
+    await page.addInitScript(
+      ([token, subjectJson]) => {
+        localStorage.setItem("grappa-token", token);
+        localStorage.setItem("grappa-subject", subjectJson);
+        localStorage.setItem("cic.installChoice", "browser");
+      },
+      [admin.token, admin.subjectJson] as const,
+    );
+    await page.goto("/");
+    await expectShellReady(page);
+
+    await openAdminConsole(page);
+    await page.getByTestId("admin-tab-vhosts").click();
+    await expect(page.getByTestId("admin-vhosts-table")).toBeVisible({ timeout: 10_000 });
+
+    const grantsTable = page.getByTestId(`admin-vhost-grants-table-${vhostId}`);
+    await expect(grantsTable).toBeVisible({ timeout: 10_000 });
+
+    // The subject cell reads as a human: the account name, resolved by the
+    // server, with the uuid nowhere in the visible text.
+    const subjectCell = grantsTable.locator("[data-testid^='admin-vhost-grant-subject-']").first();
+    await expect(subjectCell).toHaveText(admin.name);
+    await expect(subjectCell).not.toContainText(adminId);
+
+    // …and the stable key is still one hover away — it did not leave the
+    // wire, it left the reading order.
+    await expect(subjectCell).toHaveAttribute("title", adminId);
+  } finally {
+    if (vhostId !== null) await deleteVhostBestEffort(admin.token, vhostId);
+  }
+});

--- a/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
+++ b/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
@@ -113,13 +113,18 @@ test("#257 — picking a visitor from the grant autocomplete stores its stable i
     // Submit the grant.
     await page.getByTestId(`admin-vhost-grant-submit-${vhostId}`).click();
 
-    // The persisted grant row shows the visitor's STABLE id (UUID), never
-    // the typed nick — the whole point of #257.
+    // The persisted grant carries the visitor's STABLE id (UUID), never
+    // the typed nick — the whole point of #257. Since #1140 that id is the
+    // subject cell's `title` rather than its text (the text names the
+    // subject); the storage claim is unchanged, only where it surfaces.
+    // Asserting on the rendered uuid was this spec's oracle, and #1140
+    // moved it — so the oracle moved with it, it was not dropped.
     const grantsTable = page.getByTestId(`admin-vhost-grants-table-${vhostId}`);
     await expect(grantsTable).toBeVisible({ timeout: 10_000 });
     await expect(grantsTable).toContainText("visitor");
-    await expect(grantsTable).toContainText(visitor.id);
-    await expect(grantsTable).not.toContainText(visitor.nick);
+
+    const subjectCell = grantsTable.locator("[data-testid^='admin-vhost-grant-subject-']").first();
+    await expect(subjectCell).toHaveAttribute("title", visitor.id);
   } finally {
     if (vhostId !== null) await deleteVhostBestEffort(admin.token, vhostId);
     await reapVisitors(admin.token, visitorId);

--- a/cicchetto/src/AdminVhostsTab.tsx
+++ b/cicchetto/src/AdminVhostsTab.tsx
@@ -517,7 +517,7 @@ const GrantsDisclosure: Component<{
           <thead>
             <tr>
               <th>subject type</th>
-              <th class="adm-table-grow">subject id</th>
+              <th class="adm-table-grow">subject</th>
               <th>actions</th>
             </tr>
           </thead>
@@ -526,7 +526,16 @@ const GrantsDisclosure: Component<{
               {(g) => (
                 <tr data-testid={`admin-vhost-grant-row-${g.id}`}>
                   <td>{g.subject_type}</td>
-                  <td>{g.subject_id}</td>
+                  {/* #1140 — the operator picks the subject BY NAME in the
+                      autocomplete above; the table answers in the same
+                      language. `subject_label: null` is the server's
+                      honesty signal (row gone / no nick yet) — fall back
+                      to the uuid rather than invent a placeholder. The
+                      uuid stays reachable as the title: it is the stable
+                      key, the label is display. */}
+                  <td title={g.subject_id} data-testid={`admin-vhost-grant-subject-${g.id}`}>
+                    {g.subject_label ?? g.subject_id}
+                  </td>
                   <td>
                     <InlineConfirmButton
                       idleLabel="Revoke"

--- a/cicchetto/src/__tests__/AdminVhostsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminVhostsTab.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AdminVhost, AdminVhostsResponse } from "../lib/api";
+import type { AdminVhost, AdminVhostGrant, AdminVhostsResponse } from "../lib/api";
 
 vi.mock("../lib/auth", () => ({
   token: () => "test-bearer",
@@ -41,10 +41,21 @@ const vhost = (over: Partial<AdminVhost> & { id: number }): AdminVhost => ({
   ...over,
 });
 
-const response = (vhosts: AdminVhost[]): AdminVhostsResponse => ({
+const response = (vhosts: AdminVhost[], grants: AdminVhostGrant[] = []): AdminVhostsResponse => ({
   vhosts,
-  grants: [],
+  grants,
   host_candidates: [],
+});
+
+const GRANT_UUID = "0f2a7c1e-3b4d-4e5f-8a9b-0c1d2e3f4a5b";
+
+const grant = (over: Partial<AdminVhostGrant>): AdminVhostGrant => ({
+  id: 1,
+  vhost_id: 1,
+  subject_type: "user",
+  subject_id: GRANT_UUID,
+  subject_label: null,
+  ...over,
 });
 
 beforeEach(() => {
@@ -147,5 +158,58 @@ describe("AdminVhostsTab — in_pool auto-sets + disables generally_available (#
     fireEvent.click(inPool);
     expect(ga).toBeChecked();
     expect(ga).toBeEnabled();
+  });
+});
+
+// #1140 — the grants table printed the bare subject UUID while the
+// add-grant autocomplete searched BY NAME, so after the post-grant refresh
+// the operator could not tell which of their users held the grant. The
+// server now resolves the name (`subject_label`); the uuid stays the
+// stable key and is demoted to the cell's `title`.
+describe("grants table subject cell (#1140)", () => {
+  it("renders the resolved subject label instead of the uuid", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminListVhosts).mockResolvedValue(
+      response(
+        [vhost({ id: 1 })],
+        [grant({ id: 11, vhost_id: 1, subject_type: "user", subject_label: "vjt" })],
+      ),
+    );
+
+    render(() => <AdminVhostsTab />);
+
+    const cell = await screen.findByTestId("admin-vhost-grant-subject-11");
+    expect(cell).toHaveTextContent("vjt");
+    expect(cell).not.toHaveTextContent(GRANT_UUID);
+  });
+
+  it("keeps the uuid reachable as the cell title — it stays the stable key", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminListVhosts).mockResolvedValue(
+      response(
+        [vhost({ id: 1 })],
+        [grant({ id: 12, vhost_id: 1, subject_type: "visitor", subject_label: "guest" })],
+      ),
+    );
+
+    render(() => <AdminVhostsTab />);
+
+    const cell = await screen.findByTestId("admin-vhost-grant-subject-12");
+    expect(cell).toHaveAttribute("title", GRANT_UUID);
+  });
+
+  it("falls back to the uuid when the server could not resolve a name", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminListVhosts).mockResolvedValue(
+      response([vhost({ id: 1 })], [grant({ id: 13, vhost_id: 1, subject_label: null })]),
+    );
+
+    render(() => <AdminVhostsTab />);
+
+    // `subject_label: null` is the server's honesty signal (the subject row
+    // is gone / holds no nick). Show the key we DO have rather than an
+    // invented placeholder.
+    const cell = await screen.findByTestId("admin-vhost-grant-subject-13");
+    expect(cell).toHaveTextContent(GRANT_UUID);
   });
 });

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1317,7 +1317,13 @@ export const S_ThemesWireT = {
 
 // Grappa.Vhosts.AdminWire.grant_json/0
 export const S_VhostsAdminWireGrantJson = {
-  o: { id: "i", vhost_id: "i", subject_type: { e: ["user", "visitor"] }, subject_id: "s" },
+  o: {
+    id: "i",
+    vhost_id: "i",
+    subject_type: { e: ["user", "visitor"] },
+    subject_id: "s",
+    subject_label: { u: ["s", "z"] },
+  },
 } as const;
 
 // Grappa.Vhosts.AdminWire.vhost_json/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1347,6 +1347,7 @@ export type VhostsAdminWireGrantJson = {
   vhost_id: number;
   subject_type: "user" | "visitor";
   subject_id: string;
+  subject_label: string | null;
 };
 
 // === Grappa.Visitors.AdminWire ===

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35914,3 +35914,73 @@ barrier removes the trigger, not the behaviour. The measurement is filed as its
 own issue against `ScrollbackPane`'s freeze rather than folded into this fix:
 an unexplained number that someone silently rounds off is how the next bug gets
 its hiding place.
+---
+
+## 2026-08-09 — #1140: the grants table printed the key, and the label was already someone's job
+
+The vhost grants table rendered its subject as a bare UUID while the
+add-grant form searches BY NAME (#257). An operator picked "azzurra -
+guest", the post-grant refresh answered with
+`0f2a7c1e-3b4d-4e5f-8a9b-0c1d2e3f4a5b`, and with two grants on one vhost
+the table stopped being readable at all. The label has to be resolved
+server-side: the grants list arrives inside the vhosts payload and has no
+search round-trip to piggyback on.
+
+**The first design was wrong, and grep is what said so.** The autocomplete
+source returns one row PER CREDENTIAL, so a multi-network visitor yields N
+`{network, nick}` rows and a grant — which stores only `visitor_id` —
+cannot recover which row was clicked. That argues for putting the whole
+list on the wire. But the class was already solved twice:
+`Accounts.get_users_by_ids/1` and
+`Credentials.representative_nicks_by_visitor_ids/1` exist precisely so
+"admin endpoints resolve N ids to display labels without N+1", and
+`SessionsController.index/2` already composes them into
+`subject_label: String.t() | nil`. Shipping a list here would have given
+the admin panel two conventions for one concept — the exact
+"Claude copies whichever pattern is closer" drift CLAUDE.md warns about.
+So the list was dropped for the established `subject_label`.
+
+**What that costs, stated rather than hidden.** A visitor is multi-network
+and the label is the REPRESENTATIVE (lowest-`network_id`) nick, so a
+visitor with different nicks on two networks is shown under one of them.
+That is acceptable only because nothing keys on the label: `subject_id`
+stays on the wire as the stable key, and cic demotes it to the cell
+`title`. The label is display, permanently.
+
+**Where the composition lives is forced, not chosen.** `Grappa.Networks`
+deps `Grappa.Vhosts`, so resolving labels inside `Vhosts` would close the
+Boundary cycle `Vhosts → SubjectSearch → Networks → Vhosts`. The web edge
+is where both subject contexts are already reachable — which is also why
+the sessions controller had grown its own private `resolve_label/3`. That
+private helper is now `GrappaWeb.Admin.SubjectLabels`, shared by both
+listings: a second copy would have been the third pattern.
+
+**No defensive orphan arm.** Both `vhost_grants` FKs are ON DELETE
+CASCADE and `foreign_keys: :on` holds in dev, test and runtime, so a grant
+whose subject row vanished is unreachable and needs no code. The `nil`
+that IS reachable is a visitor holding no credential yet — the shape
+`Credentials.list_visitor_credentials/1` documents as "a fresh row the
+reconcile hasn't touched". cic renders the uuid then, never a fabricated
+placeholder.
+
+**A pre-existing spec had made the bug its oracle.** The #257 e2e proved
+"the STABLE id was stored, not the typed nick" by asserting the grants
+table *renders* the UUID and does NOT render the nick — the display this
+change reverses. The assertion was moved, not deleted: it now asserts the
+subject cell's `title` EQUALS `visitor.id`, which is strictly stronger
+than the old substring check, and the "not the nick" claim survives
+because the spec already asserts `visitor.id !== visitor.nick` up front.
+The listing test on the server side was vacuous in the same family
+(`assert is_list(body["grants"])` — satisfied by a wire of pure UUIDs),
+and `Grappa.Vhosts.AdminWire` had no unit test at all; both now exist.
+
+**One test passed against the pre-state and shouldn't have.** The
+`subject_label: null` assertion was green before the field existed,
+because an absent JSON key reads as `nil`. It asserts
+`Map.has_key?(row, "subject_label")` first now: the claim is "present and
+null", not "absent".
+
+`subject_label` is a new field, so this is additive — no
+`protocol_version` bump, and a client that ignores it is unaffected.
+
+_Deploy: **HOT** — server logic + `--cic`. No migration._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35914,6 +35914,7 @@ barrier removes the trigger, not the behaviour. The measurement is filed as its
 own issue against `ScrollbackPane`'s freeze rather than folded into this fix:
 an unexplained number that someone silently rounds off is how the next bug gets
 its hiding place.
+
 ---
 
 ## 2026-08-09 — #1140: the grants table printed the key, and the label was already someone's job

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -188,6 +188,16 @@ defmodule Grappa.Vhosts do
     end
   end
 
+  @doc """
+  Reads a grant's subject back out of its XOR FK — the ONE place that
+  knows which of `user_id` / `visitor_id` is the populated column. Callers
+  outside the context (the admin listing resolving display labels, #1140)
+  get the `Subject.t()` tuple instead of reaching into the schema.
+  """
+  @spec grant_subject(Grant.t()) :: Subject.t()
+  def grant_subject(%Grant{user_id: uid}) when is_binary(uid), do: {:user, uid}
+  def grant_subject(%Grant{visitor_id: vid}) when is_binary(vid), do: {:visitor, vid}
+
   @doc "Every grant for `subject`."
   @spec list_grants_for_subject(Subject.t()) :: [Grant.t()]
   def list_grants_for_subject({_, _} = subject) do

--- a/lib/grappa/vhosts/admin_wire.ex
+++ b/lib/grappa/vhosts/admin_wire.ex
@@ -6,6 +6,7 @@ defmodule Grappa.Vhosts.AdminWire do
   schema field is a deliberate edit here (CLAUDE.md "no leaky
   abstractions").
   """
+  alias Grappa.{Subject, Vhosts}
   alias Grappa.Vhosts.{Grant, Vhost}
 
   @type vhost_json :: %{
@@ -21,7 +22,8 @@ defmodule Grappa.Vhosts.AdminWire do
           id: integer(),
           vhost_id: integer(),
           subject_type: :user | :visitor,
-          subject_id: String.t()
+          subject_id: String.t(),
+          subject_label: String.t() | nil
         }
 
   @doc "Renders a vhost row to the admin JSON shape."
@@ -46,24 +48,24 @@ defmodule Grappa.Vhosts.AdminWire do
   serializes it to the identical wire bytes, and the closed atom union
   is what lets the generated TS mirror be a literal union instead of a
   bare `string` (#448).
+
+  `labels` is the batched `%{subject => name}` map from
+  `GrappaWeb.Admin.SubjectLabels.resolve/1`; the grant's own subject pair
+  is the lookup key, so a user and a visitor sharing a uuid string can
+  never cross. `subject_label: nil` when the subject resolves to no name —
+  the honesty signal (#1140). `subject_id` STAYS on the wire: it is the
+  stable key, the label is display only.
   """
-  @spec grant_to_admin_json(Grant.t()) :: grant_json()
-  def grant_to_admin_json(%Grant{user_id: uid} = g) when is_binary(uid) do
-    base_grant_json(g, :user, uid)
-  end
+  @spec grant_to_admin_json(Grant.t(), %{Subject.t() => String.t()}) :: grant_json()
+  def grant_to_admin_json(%Grant{} = g, labels) when is_map(labels) do
+    {subject_type, subject_id} = subject = Vhosts.grant_subject(g)
 
-  def grant_to_admin_json(%Grant{visitor_id: vid} = g) when is_binary(vid) do
-    base_grant_json(g, :visitor, vid)
-  end
-
-  @spec base_grant_json(Grant.t(), :user | :visitor, String.t()) :: grant_json()
-  defp base_grant_json(%Grant{} = g, subject_type, subject_id)
-       when subject_type in [:user, :visitor] do
     %{
       id: g.id,
       vhost_id: g.vhost_id,
       subject_type: subject_type,
-      subject_id: subject_id
+      subject_id: subject_id,
+      subject_label: Map.get(labels, subject)
     }
   end
 end

--- a/lib/grappa_web/admin/subject_labels.ex
+++ b/lib/grappa_web/admin/subject_labels.ex
@@ -1,0 +1,83 @@
+defmodule GrappaWeb.Admin.SubjectLabels do
+  @moduledoc """
+  ONE batched `subject → human display name` resolver for the admin
+  listings (#1140).
+
+  ## Why it lives at the web layer
+
+  Resolving a subject label crosses BOTH subject contexts — `Accounts`
+  for a user's account name, `Networks.Credentials` for a visitor's
+  per-network nick. Neither owns the other, and the listing contexts
+  (`Grappa.LiveIntrospection`, `Grappa.Vhosts`) deliberately exclude those
+  deps. The composition therefore belongs where every admin listing
+  already meets: the web edge. Promoted from
+  `GrappaWeb.Admin.SessionsController`'s private `resolve_label/3` when
+  `/admin/vhosts` needed the same join (#1140 — the grants table printed
+  the raw subject UUID).
+
+  ## Cost
+
+  Two queries, one per subject kind, whatever the subject count — the
+  batched `Accounts.get_users_by_ids/1` +
+  `Credentials.representative_nicks_by_visitor_ids/1`. A kind with no
+  subjects issues no query at all. Never a per-row lookup: an admin
+  listing is exactly where an N+1 hides.
+
+  ## Missing is missing
+
+  A subject that resolves to no name is ABSENT from the returned map, so
+  the caller renders `nil` — the honesty signal the admin surface already
+  uses for "the DB row isn't there" (`subject_label: null` on
+  `/admin/sessions`, `live_state: null` on `/admin/visitors`). Reachable:
+  a live pid whose user row was deleted, and a visitor holding no
+  credential yet (`Credentials.list_visitor_credentials/1` documents that
+  shape). We never fabricate a placeholder name — the caller still has
+  the stable `subject_id` to fall back on.
+
+  ## The visitor label is the representative nick
+
+  A visitor is multi-network and carries one nick per credential. The
+  label is the representative (lowest-`network_id`) nick — the same
+  identity anchor `Credentials.representative_visitor_credential/1`
+  returns, and the same one `/admin/sessions` shows. It is a display
+  label, never a key: `subject_id` stays on the wire for that.
+  """
+
+  alias Grappa.{Accounts, Subject}
+  alias Grappa.Accounts.User
+  alias Grappa.Networks.Credentials
+
+  @doc """
+  Resolves `subjects` to their display names, keyed by the subject tuple.
+
+  Duplicate subjects collapse; unresolvable subjects are omitted. Two
+  batched queries at most (one per subject kind present).
+  """
+  @spec resolve([Subject.t()]) :: %{Subject.t() => String.t()}
+  def resolve(subjects) when is_list(subjects) do
+    {user_ids, visitor_ids} = partition_ids(subjects)
+
+    user_labels =
+      user_ids
+      |> Accounts.get_users_by_ids()
+      |> Map.new(fn {id, %User{name: name}} -> {{:user, id}, name} end)
+
+    visitor_ids
+    |> Credentials.representative_nicks_by_visitor_ids()
+    |> Map.new(fn {id, nick} -> {{:visitor, id}, nick} end)
+    |> Map.merge(user_labels)
+  end
+
+  # Split into per-kind id lists so each batched lookup gets only the ids
+  # its column can match. No dedup: a subject holding N grants / N live
+  # sessions repeats here, and passing the dups to an `id IN ^ids` query
+  # is harmless (the DB returns one row per id, and the keyed Map.new
+  # collapses them) — same call as `SessionsController.partition_subject_ids/1`.
+  @spec partition_ids([Subject.t()]) :: {[Ecto.UUID.t()], [Ecto.UUID.t()]}
+  defp partition_ids(subjects) do
+    Enum.reduce(subjects, {[], []}, fn
+      {:user, id}, {users, visitors} -> {[id | users], visitors}
+      {:visitor, id}, {users, visitors} -> {users, [id | visitors]}
+    end)
+  end
+end

--- a/lib/grappa_web/controllers/admin/sessions_controller.ex
+++ b/lib/grappa_web/controllers/admin/sessions_controller.ex
@@ -70,8 +70,7 @@ defmodule GrappaWeb.Admin.SessionsController do
   alias Grappa.{Accounts, LiveIntrospection, Operator, Session}
   alias Grappa.LiveIntrospection.AdminWire
   alias Grappa.Net.PtrCache
-  alias Grappa.Networks.Credentials
-  alias GrappaWeb.Admin.AuthPlug
+  alias GrappaWeb.Admin.{AuthPlug, SubjectLabels}
 
   @doc """
   Enumerate every live `Session.Server` registered in the registry.
@@ -79,11 +78,12 @@ defmodule GrappaWeb.Admin.SessionsController do
   for `:connected`-but-no-pid lives on `/admin/visitors` and
   `/admin/credentials`, not here.
 
-  Pre-joins `subject_label` per row via two batched DB lookups
-  (`Accounts.get_users_by_ids/1` + `Visitors.get_by_ids/1`) — one
-  query per subject_kind regardless of session count. The composition
-  lives here, not in `LiveIntrospection`, because that boundary
-  excludes `Accounts` / `Visitors` deps (pure live-state module).
+  Pre-joins `subject_label` per row via `GrappaWeb.Admin.SubjectLabels`
+  — two batched DB lookups, one query per subject_kind regardless of
+  session count. The composition lives at the web layer, not in
+  `LiveIntrospection`, because that boundary excludes `Accounts` /
+  `Credentials` deps (pure live-state module); #1140 promoted it out of
+  this controller so `/admin/vhosts` grants resolve the same way.
   `subject_label: nil` IS the gemello honesty signal: BEAM has a
   pid but the DB row is gone (orphan pid — operator can spot from
   the table without paging through the registry directly).
@@ -92,11 +92,7 @@ defmodule GrappaWeb.Admin.SessionsController do
   def index(conn, _) do
     entries = LiveIntrospection.list_sessions()
     {user_ids, visitor_ids} = partition_subject_ids(entries)
-    users = Accounts.get_users_by_ids(user_ids)
-    # #211 phase 7 — the visitor nick lives per-network on the credential
-    # now, so resolve the session label from the representative (identity-
-    # anchor) credential nick per visitor, batched (one query, no N+1).
-    visitor_nicks = Credentials.representative_nicks_by_visitor_ids(visitor_ids)
+    labels = SubjectLabels.resolve(Enum.map(entries, & &1.subject))
     # MAX(accounts_sessions.last_seen_at) per subject. Two batched
     # queries (one per subject_kind, same shape as the labels lookup)
     # so the controller's DB cost stays O(1) regardless of session
@@ -120,7 +116,7 @@ defmodule GrappaWeb.Admin.SessionsController do
       Enum.map(entries, fn entry ->
         AdminWire.session_to_admin_json(
           entry,
-          resolve_label(entry, users, visitor_nicks),
+          Map.get(labels, entry.subject),
           resolve_last_seen(entry, user_last_seen, visitor_last_seen),
           resolve_peer_name(entry, peer_names)
         )
@@ -143,17 +139,6 @@ defmodule GrappaWeb.Admin.SessionsController do
         {:visitor, id} -> {users, [id | visitors]}
       end
     end)
-  end
-
-  defp resolve_label(%{subject: {:user, id}}, users, _) do
-    case Map.get(users, id) do
-      %Accounts.User{name: name} -> name
-      nil -> nil
-    end
-  end
-
-  defp resolve_label(%{subject: {:visitor, id}}, _, visitor_nicks) do
-    Map.get(visitor_nicks, id)
   end
 
   defp resolve_last_seen(%{subject: {:user, id}}, user_last_seen, _),

--- a/lib/grappa_web/controllers/admin/vhosts_controller.ex
+++ b/lib/grappa_web/controllers/admin/vhosts_controller.ex
@@ -31,6 +31,7 @@ defmodule GrappaWeb.Admin.VhostsController do
 
   alias Grappa.{Accounts, SubjectSearch, Vhosts, Visitors}
   alias Grappa.Vhosts.AdminWire
+  alias GrappaWeb.Admin.SubjectLabels
   alias GrappaWeb.Validation
 
   # #257 — the autocomplete requests a bounded page; the operator narrows
@@ -45,7 +46,14 @@ defmodule GrappaWeb.Admin.VhostsController do
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _) do
     vhosts = Enum.map(Vhosts.list_vhosts(), &AdminWire.vhost_to_admin_json/1)
-    grants = Enum.map(Vhosts.list_grants(), &AdminWire.grant_to_admin_json/1)
+
+    grant_rows = Vhosts.list_grants()
+    # #1140 — resolve every grant's subject to its display name in two
+    # batched queries (one per subject kind), then render. The operator
+    # picks a subject BY NAME in the add-grant autocomplete; the table has
+    # to speak the same language back.
+    labels = grant_rows |> Enum.map(&Vhosts.grant_subject/1) |> SubjectLabels.resolve()
+    grants = Enum.map(grant_rows, &AdminWire.grant_to_admin_json(&1, labels))
 
     json(conn, %{
       vhosts: vhosts,
@@ -110,7 +118,7 @@ defmodule GrappaWeb.Admin.VhostsController do
          {:ok, grant} <- Vhosts.grant_vhost(vhost, subject) do
       conn
       |> put_status(:created)
-      |> json(AdminWire.grant_to_admin_json(grant))
+      |> json(AdminWire.grant_to_admin_json(grant, SubjectLabels.resolve([subject])))
     end
   end
 

--- a/test/grappa/vhosts/admin_wire_test.exs
+++ b/test/grappa/vhosts/admin_wire_test.exs
@@ -1,0 +1,88 @@
+defmodule Grappa.Vhosts.AdminWireTest do
+  @moduledoc """
+  #228 / #1140 — the operator-facing grant + vhost JSON shapes.
+
+  The grant shape carries the subject as the `(subject_type, subject_id)`
+  XOR pair PLUS `subject_label`, the resolved human name (#1140: the table
+  used to print the bare UUID). `subject_id` stays on the wire — it is the
+  stable key; the label is display. `subject_label: nil` is the honesty
+  signal, the same one `Grappa.LiveIntrospection.AdminWire` uses.
+
+  ## Test isolation
+
+  Pure projection — struct fixtures, no DB.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Vhosts.{AdminWire, Grant, Vhost}
+
+  defp grant(attrs) do
+    struct!(%Grant{id: 1, vhost_id: 7}, attrs)
+  end
+
+  describe "grant_to_admin_json/2" do
+    test "keeps the XOR pair and adds the resolved user label" do
+      g = grant(user_id: "u-1")
+
+      assert AdminWire.grant_to_admin_json(g, %{{:user, "u-1"} => "vjt"}) == %{
+               id: 1,
+               vhost_id: 7,
+               subject_type: :user,
+               subject_id: "u-1",
+               subject_label: "vjt"
+             }
+    end
+
+    test "renders a visitor's resolved nick as the label" do
+      g = grant(visitor_id: "v-2")
+
+      assert %{subject_type: :visitor, subject_id: "v-2", subject_label: "guest"} =
+               AdminWire.grant_to_admin_json(g, %{{:visitor, "v-2"} => "guest"})
+    end
+
+    test "an unresolved subject renders nil — no fabricated placeholder" do
+      g = grant(visitor_id: "v-orphan")
+
+      assert %{subject_id: "v-orphan", subject_label: nil} =
+               AdminWire.grant_to_admin_json(g, %{})
+    end
+
+    test "looks the label up by the subject PAIR, not the bare id" do
+      # Keying on the id alone would let a visitor label bleed onto a user
+      # grant that happens to carry the same uuid string.
+      g = grant(user_id: "shared-id")
+
+      assert %{subject_type: :user, subject_label: nil} =
+               AdminWire.grant_to_admin_json(g, %{{:visitor, "shared-id"} => "notme"})
+    end
+
+    test "#251 — no `pinned` field survives on the grant wire" do
+      json = AdminWire.grant_to_admin_json(grant(user_id: "u-4"), %{})
+      refute Map.has_key?(json, :pinned)
+    end
+  end
+
+  describe "vhost_to_admin_json/1" do
+    test "projects the inventory row fields" do
+      now = ~U[2026-08-09 10:00:00.000000Z]
+
+      v = %Vhost{
+        id: 3,
+        address: "2001:db8::1",
+        in_pool: true,
+        generally_available: false,
+        inserted_at: now,
+        updated_at: now
+      }
+
+      assert AdminWire.vhost_to_admin_json(v) == %{
+               id: 3,
+               address: "2001:db8::1",
+               in_pool: true,
+               generally_available: false,
+               inserted_at: now,
+               updated_at: now
+             }
+    end
+  end
+end

--- a/test/grappa/vhosts_test.exs
+++ b/test/grappa/vhosts_test.exs
@@ -117,6 +117,22 @@ defmodule Grappa.VhostsTest do
     end
   end
 
+  describe "grant_subject/1 — the one XOR reader (#1140)" do
+    test "reads a user grant back as its subject tuple" do
+      user = user_fixture()
+      {:ok, v} = Vhosts.create_vhost(%{address: addr()})
+      {:ok, grant} = Vhosts.grant_vhost(v, {:user, user.id})
+      assert Vhosts.grant_subject(grant) == {:user, user.id}
+    end
+
+    test "reads a visitor grant back as its subject tuple" do
+      visitor = visitor_fixture()
+      {:ok, v} = Vhosts.create_vhost(%{address: addr()})
+      {:ok, grant} = Vhosts.grant_vhost(v, {:visitor, visitor.id})
+      assert Vhosts.grant_subject(grant) == {:visitor, visitor.id}
+    end
+  end
+
   describe "allowed_vhosts/2 — mode 1 union of generally-available + in_pool + granted" do
     test "includes generally-available vhosts" do
       user = user_fixture()

--- a/test/grappa_web/admin/subject_labels_test.exs
+++ b/test/grappa_web/admin/subject_labels_test.exs
@@ -1,0 +1,131 @@
+defmodule GrappaWeb.Admin.SubjectLabelsTest do
+  @moduledoc """
+  #1140 — the ONE batched `subject → display name` resolver every admin
+  listing shares (`/admin/sessions` since M-9, `/admin/vhosts` grants
+  since #1140).
+
+  Two batched context lookups, one per subject kind, regardless of how
+  many subjects are asked for. A subject that resolves to nothing is
+  ABSENT from the map — callers render `nil`, the honesty signal, rather
+  than a fabricated name.
+
+  ## Test isolation
+
+  `async: true` — freshly-created rows through the Repo sandbox.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Networks.Credentials
+  alias GrappaWeb.Admin.SubjectLabels
+
+  describe "resolve/1" do
+    test "labels a user subject with the account name" do
+      user = user_fixture(name: "labeluser1140")
+
+      assert SubjectLabels.resolve([{:user, user.id}]) == %{{:user, user.id} => "labeluser1140"}
+    end
+
+    test "labels a visitor subject with its representative credential nick" do
+      {visitor, network} = visitor_with_network(7220)
+
+      {:ok, _} =
+        Credentials.upsert_visitor_credential(visitor.id, network.id, %{
+          nick: "labelvis1140",
+          auth_method: :none
+        })
+
+      assert SubjectLabels.resolve([{:visitor, visitor.id}]) ==
+               %{{:visitor, visitor.id} => "labelvis1140"}
+    end
+
+    test "labels users and visitors in the same call" do
+      user = user_fixture(name: "mixeduser1140")
+      {visitor, network} = visitor_with_network(7221)
+
+      {:ok, _} =
+        Credentials.upsert_visitor_credential(visitor.id, network.id, %{
+          nick: "mixedvis1140",
+          auth_method: :none
+        })
+
+      labels = SubjectLabels.resolve([{:user, user.id}, {:visitor, visitor.id}])
+
+      assert labels == %{
+               {:user, user.id} => "mixeduser1140",
+               {:visitor, visitor.id} => "mixedvis1140"
+             }
+    end
+
+    test "omits a subject that resolves to nothing" do
+      # A visitor whose network slug resolves to no row gets no credential —
+      # the shape `Credentials.list_visitor_credentials/1` documents as
+      # reachable ("a fresh row the reconcile hasn't touched"). No nick
+      # exists, and we do not invent one.
+      visitor = visitor_fixture(network_slug: "absent-network-1140")
+
+      assert SubjectLabels.resolve([{:visitor, visitor.id}]) == %{}
+    end
+
+    test "an empty subject list short-circuits with no DB round-trip" do
+      assert count_repo_queries(fn -> assert SubjectLabels.resolve([]) == %{} end) == 0
+    end
+
+    test "asks the DB the same number of times whatever the subject count (no N+1)" do
+      users = for n <- 1..5, do: user_fixture(name: "batch1140u#{n}")
+      {visitor, _} = visitor_with_network(7222)
+
+      one = count_repo_queries(fn -> SubjectLabels.resolve([{:user, hd(users).id}]) end)
+
+      many =
+        count_repo_queries(fn ->
+          subjects = [{:visitor, visitor.id} | Enum.map(users, &{:user, &1.id})]
+          assert map_size(SubjectLabels.resolve(subjects)) == 6
+        end)
+
+      # Six subjects must not cost more round-trips than one does per kind:
+      # a per-subject loop would grow with the list.
+      assert many <= one + 1,
+             "one subject cost #{one} queries, six cost #{many} — that grows with N"
+    end
+
+    test "a repeated subject is asked for once and labelled once" do
+      user = user_fixture(name: "dup1140")
+      subjects = List.duplicate({:user, user.id}, 4)
+
+      assert SubjectLabels.resolve(subjects) == %{{:user, user.id} => "dup1140"}
+    end
+  end
+
+  # Counts `[:grappa, :repo, :query]` telemetry events emitted while `fun`
+  # runs (Ecto emits one per statement, synchronously in the caller
+  # process). Same shape as `Grappa.WindowCountsTest`'s N+1 pin.
+  defp count_repo_queries(fun) do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:grappa, :repo, :query],
+      fn _, _, _, _ -> send(test_pid, {ref, :q}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach({__MODULE__, ref})
+    end
+
+    drain_query_count(ref, 0)
+  end
+
+  defp drain_query_count(ref, acc) do
+    receive do
+      {^ref, :q} -> drain_query_count(ref, acc + 1)
+    after
+      0 -> acc
+    end
+  end
+end

--- a/test/grappa_web/controllers/admin/vhosts_controller_test.exs
+++ b/test/grappa_web/controllers/admin/vhosts_controller_test.exs
@@ -56,6 +56,63 @@ defmodule GrappaWeb.Admin.VhostsControllerTest do
       assert is_list(body["grants"])
       assert is_list(body["host_candidates"])
     end
+
+    # #1140 — the listing used to assert only `is_list(body["grants"])`,
+    # which a wire that prints nothing but UUIDs satisfies. Assert the
+    # rendered identity.
+    test "a user grant carries the account name, not just the uuid", %{conn: conn} do
+      session = admin_session()
+      {:ok, v} = Vhosts.create_vhost(%{address: addr()})
+      target = user_fixture(name: "granted1140")
+      {:ok, grant} = Vhosts.grant_vhost(v, {:user, target.id})
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/vhosts")
+      row = Enum.find(json_response(conn, 200)["grants"], &(&1["id"] == grant.id))
+
+      assert row["subject_id"] == target.id
+      assert row["subject_label"] == "granted1140"
+    end
+
+    test "a visitor grant carries the representative credential nick", %{conn: conn} do
+      session = admin_session()
+      {:ok, v} = Vhosts.create_vhost(%{address: addr()})
+      {visitor, network} = visitor_with_network(7140)
+
+      {:ok, _} =
+        Credentials.upsert_visitor_credential(visitor.id, network.id, %{
+          nick: "vgranted1140",
+          auth_method: :none
+        })
+
+      {:ok, grant} = Vhosts.grant_vhost(v, {:visitor, visitor.id})
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/vhosts")
+      row = Enum.find(json_response(conn, 200)["grants"], &(&1["id"] == grant.id))
+
+      assert row["subject_type"] == "visitor"
+      assert row["subject_id"] == visitor.id
+      assert row["subject_label"] == "vgranted1140"
+    end
+
+    # #1140 — a visitor holding no credential has no nick to show. `nil` is
+    # the honesty signal (same rule as `/admin/sessions`' subject_label);
+    # cic falls back to the uuid rather than printing a fabricated name.
+    test "a subject with no resolvable name renders subject_label: null", %{conn: conn} do
+      session = admin_session()
+      {:ok, v} = Vhosts.create_vhost(%{address: addr()})
+      visitor = visitor_fixture(network_slug: "absent-network-1140")
+      {:ok, grant} = Vhosts.grant_vhost(v, {:visitor, visitor.id})
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/vhosts")
+      row = Enum.find(json_response(conn, 200)["grants"], &(&1["id"] == grant.id))
+
+      assert row["subject_id"] == visitor.id
+      # `has_key?` FIRST: a wire that never carries the field also reads
+      # `nil` here, so the bare nil assertion passed against the pre-#1140
+      # shape. The claim is "present and null", not "absent".
+      assert Map.has_key?(row, "subject_label")
+      assert row["subject_label"] == nil
+    end
   end
 
   describe "POST /admin/vhosts" do
@@ -131,6 +188,10 @@ defmodule GrappaWeb.Admin.VhostsControllerTest do
       assert body["subject_id"] == target.id
       # #251 — a grant is availability-only; no pinned field on the wire.
       refute Map.has_key?(body, "pinned")
+
+      # #1140 — every door renders the same grant shape: the 201 body
+      # carries the identity too, not only the index listing.
+      assert body["subject_label"] == target.name
     end
 
     test "404s an unknown subject", %{conn: conn} do


### PR DESCRIPTION
Issue #1140. The vhost grants table rendered its subject as a bare UUID while
the add-grant form searches BY NAME (#257): after the post-grant refresh an
operator could not tell which of their users held the grant, and with more than
one grant the table was unreadable.

The label is resolved server-side — the grants list arrives with the vhosts
payload and has no search round-trip to piggyback on.

## The design, and what it rejected

The issue's suggested shape pointed at the autocomplete's source. That source
returns one row PER CREDENTIAL, so a multi-network visitor yields N
`{network, nick}` rows and a grant, which stores only `visitor_id`, cannot
recover which row was clicked. The first design here was therefore a
`[{network, nick}]` list on the wire.

Grepping before building killed it. The class was already solved twice:
`Accounts.get_users_by_ids/1` and
`Credentials.representative_nicks_by_visitor_ids/1` exist so that "admin
endpoints resolve N ids to display labels without N+1 round-trips", and
`SessionsController.index/2` already composes them into
`subject_label: String.t() | nil` where `nil` is the honesty signal. A list here
would have given the admin panel two conventions for one concept, so this
follows the shipped one.

**Stated, not hidden:** a visitor's label is the REPRESENTATIVE (lowest
`network_id`) nick, so a visitor with different nicks on two networks shows
under one of them. That is only acceptable because nothing keys on the label —
`subject_id` stays on the wire as the stable key and is demoted in cic to the
cell `title`.

**Where it lives is forced, not chosen:** `Grappa.Networks` deps
`Grappa.Vhosts`, so resolving labels inside `Vhosts` would close the Boundary
cycle `Vhosts → SubjectSearch → Networks → Vhosts`. The composition is promoted
out of `SessionsController`'s private `resolve_label/3` into
`GrappaWeb.Admin.SubjectLabels`, now shared by both admin listings rather than
copy-pasted into a second controller.

**No defensive orphan arm:** both `vhost_grants` FKs are ON DELETE CASCADE and
`foreign_keys: :on` holds in dev/test/runtime, so a grant whose subject row
vanished is unreachable. The reachable `nil` is a visitor holding no credential
yet, which the reused verb documents; cic then renders the uuid rather than a
fabricated placeholder.

## Cost

Two queries for the whole grants list regardless of grant count; a subject kind
with no subjects issues none. Pinned by a telemetry-counting test comparing one
subject against six — a per-subject loop grows, this does not.

## Wire

`subject_label` is a NEW field: additive, so **no `protocol_version` bump**, and
a client that ignores it is unaffected. `subject_id` is untouched. The TS mirror
is regenerated, not hand-edited.

## Tests

New: `test/grappa_web/admin/subject_labels_test.exs` (7),
`test/grappa/vhosts/admin_wire_test.exs` (6 — the module had no unit test at
all), `Grappa.Vhosts.grant_subject/1` (2), three controller tests, three cic
tests, and the e2e `issue1140-vhost-grant-subject-label.spec.ts`.

Two pre-existing weaknesses fixed rather than worked around:

* `GET /admin/vhosts` was covered by `assert is_list(body["grants"])` — a wire
  of pure UUIDs satisfies it.
* The #257 e2e proved "the STABLE id was stored, not the nick" by asserting the
  table *renders* the UUID and does NOT render the nick — i.e. it had made this
  bug its oracle. The assertion was MOVED, not dropped: it now asserts the
  subject cell's `title` EQUALS `visitor.id`, strictly stronger than the old
  substring check, and the "not the nick" claim survives because the spec
  already asserts `visitor.id !== visitor.nick` up front.

One new test passed against the pre-state and was strengthened: an absent JSON
key also reads as `nil`, so the `subject_label: null` case now asserts
`Map.has_key?/2` first — the claim is "present and null", not "absent".

## Mutation matrix (each mutant applied, run, and READ)

| mutant | killed |
|---|---|
| M1b wire keys on the bare id, ignoring the subject kind | 1 — "looks the label up by the subject PAIR" |
| M2b wire falls back to the uuid instead of `nil` | 3 — both nil tests + the pair test |
| M3 user label keyed `{:visitor, id}` | 5 |
| M4 the two subject legs swapped | 9 (incl. the sessions listing) |
| M5 vhosts controller passes an empty label map | 2 |
| M6 sessions controller drops the label lookup | 1 — the migrated path is pinned by an existing test |
| M7 `resolve/1` loops per subject (the N+1) | 1 — exactly the query-count pin |
| M8 cic renders the uuid as the cell text | 1 |
| M9 cic drops the `title` | 1 |
| M10 cic renders a placeholder instead of the uuid | 1 |

Two earlier attempts (M1/M2) killed five tests each but *not* the assertions
they were aimed at — both had collapsed into "always nil". They were rebuilt as
M1b/M2b rather than reported as kills.

## Gates

* `scripts/check.sh` → **rc=0** (8 doctests, 56 properties, 5617 tests, 0
  failures; format, credo, sobelow, dialyzer, wireTypes drift, bats)
* `scripts/bun.sh run test` → **rc=0** (268 files, 4973 tests)
* `scripts/bun.sh run check` → **rc=0** (biome + tsc + e2e tsc)
* e2e NOT run locally (no stack lane) — it will run in this PR's CI.

Deploy: HOT — server logic + `--cic`, no migration.