### PR TITLE
SpawnOrchestrator: check the Registry before the capacity gate (#1147)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36099,3 +36099,12 @@ side effect on the fast path (right return value, wrong telemetry) kills only
 the `refute_received`; deleting the emission in `Admission` kills only the
 negative control's `assert_received`. Three mutants, three distinct assertions,
 no overlap.
+
+**One canary goes quiet on the no-op path, deliberately.**
+`check_capacity/1` raises `ArgumentError` when a caller's `flow` and
+`requesting_subject` tag disagree — a loud caller-bug detector. Skipping the
+gate means a mismatched call whose session happens to be live no longer raises.
+The mismatch is a static property of the call site, so the canary still fires
+the first time that site actually spawns; recovering it on the no-op path would
+mean exporting a validate-only verb from `Admission` purely to keep a detector
+warm, which is more surface than the detector is worth.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36039,6 +36039,7 @@ red, shape property green. `String.trim/1` narrowed to `== ""`: exactly the two
 whitespace-only unit tests red, both properties green — so the whitespace
 sub-class is pinned by the named-input tests alone, which is the reason they
 exist rather than leaving the class to the fuzzer.
+
 ## 2026-08-09 — #1147: a gate that guards spawning should not judge a connect that spawns nothing
 
 `SpawnOrchestrator.spawn/4` is the one verb every spawn-initiating surface goes

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36039,3 +36039,63 @@ red, shape property green. `String.trim/1` narrowed to `== ""`: exactly the two
 whitespace-only unit tests red, both properties green — so the whitespace
 sub-class is pinned by the named-input tests alone, which is the reason they
 exist rather than leaving the class to the fuzzer.
+## 2026-08-09 — #1147: a gate that guards spawning should not judge a connect that spawns nothing
+
+`SpawnOrchestrator.spawn/4` is the one verb every spawn-initiating surface goes
+through — Bootstrap's boot-time re-establish, `PATCH /networks/:slug`, the
+operator and visitor spawn paths. Its documented contract has always included
+an idempotent keep: if a session for this `(subject, network_id)` is already
+live, hold it and report `:already_started`. That property held for
+`Session.start_session/3`, which returns `{:error, {:already_started, pid}}`
+from the Registry's uniqueness. It did not hold end-to-end, because the
+orchestrator asked `Admission.check_capacity/1` first and only learned about
+the live session from the spawn's return value — which a capacity error made
+unreachable.
+
+So a network sitting at its cap refused a subject who was **already on it**.
+The cap counts live sessions on the network, and the subject's own session is
+one of them: the connect that should have been a silent no-op was rejected by
+the very count it had contributed to. Nothing was going to be spawned either
+way; the only thing the gate decided was whether to lie about it.
+
+**The gate is not a free read.** It is an ETS circuit check, a Registry count
+and a DB query, and on failure it *records* the refusal with
+`Telemetry.capacity_reject/4`. That last part is the half worth naming: a
+rejection counter was being incremented for requests that never made an
+admission attempt. An operator reading that series would see pressure that does
+not exist, and the noise scales with whatever polls or retries the connect.
+
+**The fix is ordering, not policy.** Look the session up in the
+`SessionRegistry` first and consult admission only when a spawn would really
+follow. No new state: the Registry already knows who is live, and deriving the
+answer from it beats any parallel structure that would need housekeeping.
+
+**Why a racy lookup is still correct.** The fast path is an optimisation over
+an authority that stays where it was. If the session dies between the lookup
+and the spawn, the normal path runs and admission gets its say. If one appears
+in that window, `start_session/3` still returns `{:error, {:already_started,
+pid}}` and the existing branch maps it to the same outcome. Two paths now reach
+`:already_started` and they agree by construction, so the Contract section's
+claim — the session GenServer and the Registry are the real synchronisation
+primitives — is unchanged. A lookup that only ever avoids work it cannot be
+wrong about does not need a lock.
+
+**What stays on the fast path.** `Backoff.reset/2`. A PATCH-while-already-up is
+still an operator action, and M-life-5 says an operator action clears stale
+failure history; moving the reset behind the gate would have been a second,
+undiscussed behaviour change riding in on a bug fix. `reconnect/5` is
+untouched and reaches admission every time: `stop_session/3` polls the Registry
+slot clear before the spawn, so the fast path reads an empty slot — the bounce
+really is about to spawn, which is the definitional contrast with the keep verb.
+
+**The test is a pair, and the second half is the one that gets forgotten.** At
+cap, an already-live subject keeps its session **and** records no reject; a
+subject with no live session still earns the capacity error **and** is still
+recorded. A test reading only the return value would pass while leaving the
+telemetry lying, and a guard that cannot fail is not a guard — hence the
+negative control. Both halves were checked by mutation: deleting the fast path
+kills only the first test's return-value assertion; running the gate for its
+side effect on the fast path (right return value, wrong telemetry) kills only
+the `refute_received`; deleting the emission in `Admission` kills only the
+negative control's `assert_received`. Three mutants, three distinct assertions,
+no overlap.

--- a/lib/grappa/spawn_orchestrator.ex
+++ b/lib/grappa/spawn_orchestrator.ex
@@ -95,6 +95,26 @@ defmodule Grappa.SpawnOrchestrator do
 
   Each `spawn/4` invocation:
 
+    0. Looks the subject's session up in the `SessionRegistry`
+       (`Grappa.Session.whereis/2`). If one is already live, the connect
+       would spawn nothing, so it resets `Backoff` and returns
+       `{:ok, :already_started, pid}` WITHOUT consulting admission.
+       **Why before the gate** (#1147): capacity is not free — an ETS
+       circuit read, a Registry count and a DB query — and a rejection
+       is *recorded* (`Telemetry.capacity_reject/4`). Running it first
+       let a network at its cap refuse a subject who was ALREADY on it,
+       and logged a rejection for a request that was never going to
+       admit anything. The idempotent-keep semantics the callers rely on
+       (Bootstrap restart, PATCH-while-already-up) only held for the
+       spawn call itself, not end-to-end through `spawn/4`.
+
+       The lookup does NOT need to be race-free to be correct, and does
+       not weaken the synchronization story above: the spawn call
+       remains the authority. If the session dies between lookup and
+       spawn the normal path runs; if one appears, `start_session/3`
+       still returns `{:error, {:already_started, pid}}` and step 4 maps
+       it to the same outcome. Two paths reach `:already_started` — the
+       fast one and the raced one — and they agree by construction.
     1. Calls `Grappa.Admission.check_capacity/1` with the caller's
        `capacity_input` (carries `flow:` discriminator —
        `:bootstrap_user`, `:bootstrap_visitor`, or
@@ -148,6 +168,11 @@ defmodule Grappa.SpawnOrchestrator do
       free when `spawn/4` runs ⇒ it returns `{:ok, :spawned, _}`, NEVER
       `:already_started`. That is the definitional contrast with the
       keep verb.
+
+  That contrast survives `spawn/4`'s already-live fast path (step 0),
+  which reads the very Registry slot `stop_session/3` has just polled
+  clear — so the bounce reaches admission every time, as it must: it
+  really is about to spawn.
 
   Teardown is `stop_session/3` (idempotent — no live session ⇒ `:ok`),
   so `reconnect/5` composes cleanly whether or not a session is live.
@@ -204,11 +229,13 @@ defmodule Grappa.SpawnOrchestrator do
 
     * `{:ok, :spawned, pid}` — admission cleared, fresh
       `Session.Server` started under `SessionSupervisor`.
-    * `{:ok, :already_started, pid}` — admission cleared, but a
-      `Session.Server` for the same `(subject, network_id)` was
-      already registered (Bootstrap restart idempotency,
-      NetworksController PATCH-while-already-up). The pid is the
-      live process; caller should treat as no-op.
+    * `{:ok, :already_started, pid}` — a `Session.Server` for the same
+      `(subject, network_id)` was already registered (Bootstrap restart
+      idempotency, NetworksController PATCH-while-already-up), so
+      nothing was spawned. The pid is the live process; caller should
+      treat as no-op. Admission is NOT consulted on this outcome when
+      the fast path saw the session (step 0) — a connect that spawns
+      nothing consumes no capacity and records no rejection.
     * `{:ok, :ignored}` — admission cleared, but `Session.Server.init/1`
       returned `:ignore` because the operator-owned DB row for the
       subject is gone (`Visitors.delete/1`, `Credentials.unbind_credential/2`).
@@ -233,6 +260,11 @@ defmodule Grappa.SpawnOrchestrator do
   passed verbatim to `Admission.check_capacity/1` — caller fills in
   the `flow:` discriminant and `client_id` per its own surface.
 
+  A session already live for this exact `(subject, network_id)`
+  short-circuits to `{:ok, :already_started, pid}` before admission is
+  consulted (#1147): the connect is a no-op, so it neither spends
+  capacity nor records a rejection.
+
   See the moduledoc for the contract of each step + the
   unified `spawn_outcome/0` shape.
   """
@@ -240,6 +272,17 @@ defmodule Grappa.SpawnOrchestrator do
           spawn_outcome()
   def spawn(subject, network_id, plan, capacity_input)
       when is_integer(network_id) and is_map(plan) and is_map(capacity_input) do
+    case Session.whereis(subject, network_id) do
+      pid when is_pid(pid) ->
+        :ok = Backoff.reset(subject, network_id)
+        {:ok, :already_started, pid}
+
+      nil ->
+        admit_then_spawn(subject, network_id, plan, capacity_input)
+    end
+  end
+
+  defp admit_then_spawn(subject, network_id, plan, capacity_input) do
     case Admission.check_capacity(capacity_input) do
       :ok ->
         :ok = Backoff.reset(subject, network_id)

--- a/test/grappa/spawn_orchestrator_test.exs
+++ b/test/grappa/spawn_orchestrator_test.exs
@@ -155,6 +155,28 @@ defmodule Grappa.SpawnOrchestratorTest do
   # the cast to be processed before reading ETS via `failure_count/2`.
   defp sync_backoff, do: :sys.get_state(Backoff)
 
+  # `:telemetry.execute/3` runs handlers in the CALLING process, and the
+  # orchestrator is called inline here — so the message is in this
+  # mailbox by the time `spawn/4` returns. That makes the zero-timeout
+  # `assert_received` / `refute_received` pair exact: no polling window
+  # to widen, and an absence assertion that cannot pass by being early.
+  defp attach_capacity_reject do
+    id = "spawn-orch-capacity-reject-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        id,
+        [:grappa, :admission, :capacity, :reject],
+        fn name, measurements, metadata, pid ->
+          send(pid, {:telemetry, name, measurements, metadata})
+        end,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(id) end)
+  end
+
   describe "spawn/4 happy path" do
     test "admission ok + fresh session — returns {:ok, :spawned, pid}" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
@@ -259,6 +281,80 @@ defmodule Grappa.SpawnOrchestratorTest do
                SpawnOrchestrator.spawn({:user, vjt_b.id}, network.id, plan_b, cap_in)
 
       assert Session.whereis({:user, vjt_b.id}, network.id) == nil
+    end
+  end
+
+  # #1147 — the capacity gate used to run BEFORE the already-live check,
+  # so a connect that would spawn nothing could still be refused for
+  # capacity (and recorded as a rejection that never corresponded to an
+  # admission attempt). The pair below pins both halves: the no-op keeps
+  # the session AND stays out of the reject counter, while a connect that
+  # really would spawn still hits the gate and is still recorded.
+  describe "spawn/4 idempotent connect against a network at its cap (#1147)" do
+    test "already-live subject keeps its session and records no capacity reject" do
+      vjt = user_fixture(name: "idemcap-#{System.unique_integer([:positive])}")
+      {_, port} = start_server()
+      slug = "idemcap-#{System.unique_integer([:positive])}"
+      {network, plan} = setup_credential(vjt, slug, port, %{max_concurrent_user_sessions: 1})
+      :ok = clear_registry_for(network.id)
+      on_exit(fn -> clear_registry_for(network.id) end)
+
+      subject = {:user, vjt.id}
+      cap_in = capacity_input(network.id, :bootstrap_user)
+
+      assert {:ok, :spawned, pid} = SpawnOrchestrator.spawn(subject, network.id, plan, cap_in)
+
+      # The network is now AT its cap of one — and this subject's OWN
+      # session is the one filling it. Attach only now, so the handler
+      # can only witness the second call.
+      attach_capacity_reject()
+
+      assert {:ok, :already_started, ^pid} =
+               SpawnOrchestrator.spawn(subject, network.id, plan, cap_in)
+
+      refute_received {:telemetry, [:grappa, :admission, :capacity, :reject], _, _}
+      assert Session.whereis(subject, network.id) == pid
+    end
+
+    test "subject with no live session still gets the capacity error, and it IS recorded" do
+      vjt_a = user_fixture(name: "capgate-a-#{System.unique_integer([:positive])}")
+      vjt_b = user_fixture(name: "capgate-b-#{System.unique_integer([:positive])}")
+      {_, port} = start_server()
+      slug = "capgate-#{System.unique_integer([:positive])}"
+
+      {network, plan_a} = setup_credential(vjt_a, slug, port, %{max_concurrent_user_sessions: 1})
+
+      {:ok, cred_b} =
+        Credentials.bind_credential(vjt_b, network, %{
+          nick: "vjtb",
+          auth_method: :none,
+          autojoin_channels: []
+        })
+
+      {:ok, plan_b} = SessionPlan.resolve(cred_b)
+
+      :ok = clear_registry_for(network.id)
+      on_exit(fn -> clear_registry_for(network.id) end)
+
+      network_id = network.id
+      cap_in = capacity_input(network_id, :bootstrap_user)
+
+      assert {:ok, :spawned, _} =
+               SpawnOrchestrator.spawn({:user, vjt_a.id}, network_id, plan_a, cap_in)
+
+      attach_capacity_reject()
+
+      assert {:error, :user_cap_exceeded} =
+               SpawnOrchestrator.spawn({:user, vjt_b.id}, network_id, plan_b, cap_in)
+
+      assert_received {:telemetry, [:grappa, :admission, :capacity, :reject], %{},
+                       %{
+                         flow: :bootstrap_user,
+                         error: :user_cap_exceeded,
+                         network_id: ^network_id
+                       }}
+
+      assert Session.whereis({:user, vjt_b.id}, network_id) == nil
     end
   end
 


### PR DESCRIPTION
`SpawnOrchestrator.spawn/4` asked `Admission.check_capacity/1` first and only
learned about an already-live session from the spawn's return value. A capacity
error made that branch unreachable, so a subject **already connected** to a
network sitting at its cap was refused — by a count its own session had
contributed to, for a request that was going to spawn nothing.

The gate is not a free read: an ETS circuit check, a Registry count, a DB query,
and on failure a `Telemetry.capacity_reject/4`. That last part is the half worth
naming — a rejection counter incremented for requests that never made an
admission attempt.

## The change

Look the session up in the `SessionRegistry` first; consult admission only when
a spawn would really follow. No new state — the Registry already knows who is
live.

The lookup does not need to be race-free. The spawn call stays the authority: a
session that dies between lookup and spawn takes the normal path, and one that
appears still comes back as `{:error, {:already_started, pid}}` and maps to the
same outcome. The Contract's synchronisation story is unchanged.

`Backoff.reset/2` stays on the fast path — a PATCH-while-already-up is still an
operator action, and moving the reset behind the gate would be a second,
undiscussed behaviour change riding in on a bug fix. `reconnect/5` is untouched
and reaches admission every time: `stop_session/3` polls the slot clear first,
so the fast path reads an empty Registry.

The cure is in the orchestrator, not a controller — Bootstrap, `PATCH
/networks/:slug`, the operator and visitor spawn paths all inherited the defect.

## Tests

Two, and the second is the guard on the guard:

- at cap, an already-live subject keeps its session **and** records no
  `capacity_reject`;
- at cap, a subject with **no** live session still earns the capacity error
  **and** it is still recorded.

A test reading only the return value would pass while leaving the telemetry
lying. Telemetry handlers run in the calling process, so the assertions are
zero-timeout `assert_received` / `refute_received` — no polling window to widen.

Mutation matrix, each mutant killing exactly one assertion:

| mutant | killed |
|---|---|
| fast path deleted | test 1 return-value assert |
| gate called for its side effect on the fast path | test 1 `refute_received` |
| `Telemetry.capacity_reject` emission removed in `Admission` | test 2 `assert_received` |

## What this narrows

`check_capacity/1` raises on a `flow` / `requesting_subject` mismatch — a
caller-bug canary that the no-op path no longer reaches. The mismatch is static
per call site, so the raise still fires the first time that site really spawns;
recorded in DESIGN_NOTES rather than papered over.

## Gates

`scripts/check.sh` green: 8 doctests, 56 properties, 5615 tests, 0 failures;
Dialyzer `Total errors: 0`; Credo strict, Sobelow, doctor, wire-type drift gate,
383/383 bats. Working tree clean before and after.

Reported by Sonic, who identified both the mechanism and the fix.