### PR TITLE
infra(#425): pin the UTF-8 locale in both substrates' service definitions

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36109,3 +36109,61 @@ The mismatch is a static property of the call site, so the canary still fires
 the first time that site actually spawns; recovering it on the no-op path would
 mean exporting a validate-only verb from `Admission` purely to keep a detector
 warm, which is more surface than the detector is worth.
+---
+
+## 2026-08-09 — #425: the locale is a property of the machine until a service definition says otherwise
+
+**The defect is latent and the framing has to stay that way.** The BEAM decides
+`native_name_encoding` from the locale it inherits at boot; without a UTF-8 one
+it comes up latin1 and Elixir says so on stderr. That setting governs FILENAME
+handling, which is not academic here — uploads carry user-supplied names.
+Production answers `:file.native_name_encoding() #=> :utf8` today, and the
+reason is that the jail's ambient locale happens to be `C.UTF-8`, not that
+anything pins it. This unit removes an unpinned dependency; it does not repair a
+running defect, and a PR that claimed otherwise would be selling an incident
+that never happened.
+
+**`LANG=C.UTF-8` over `ELIXIR_ERL_OPTIONS="+fnu"`.** The issue offers both and
+taking both would be two mechanisms for one property — redundancy that diverges
+the first time someone edits one of them. `LANG=C.UTF-8` was already the
+repo's spelling in two places before this unit: #419's packaged systemd unit,
+and `Dockerfile.release` (twice, builder and runtime). A third spelling for the
+same property would have been the bug of some later afternoon. It is also the
+wider fix: `+fnu` sets the VM's own filename encoding and nothing else, while
+the environment variable reaches the ports the release spawns — `exiftool` and
+`ffmpeg` for `Grappa.Uploads.MetadataStrip` — and is honored by construction
+rather than by whatever the release boot script forwards.
+
+**What each substrate needed.** systemd starts a unit with no locale at all, so
+`Environment=LANG=C.UTF-8` is the whole fix. FreeBSD's rc.d wrapper runs the
+release through `su -m`, which KEEPS the invoking environment: the locale there
+is root's, whatever rc(8) had. The export therefore goes inside `grappa_runas`'
+`su -c` string next to `RELEASE_TMP` and the `PATH` prepend — the same place,
+for the same reason, as the 2026-06-10 PATH gap. **Declared limit:** an
+`LC_ALL`/`LC_CTYPE` inherited from root still outranks `LANG`. This pins the
+default; it does not fight an override, and pinning `LC_ALL` to win that fight
+would take the choice away from an operator who set it deliberately.
+
+**The guard is dynamic in the set and static in the census.** A pin nobody
+guards is a pin the next unit gets written without, so
+`test/infra/service_locale_pin_test.bats` discovers the tracked service
+definitions (`*.service`, `*/rc.d/*`) filtered to those that actually launch
+`bin/grappa` — a fourth substrate is held to the rule without anyone
+remembering this file, and the `bin/grappa` filter keeps non-BEAM units (the
+#665 certbot oneshot) out. The first case then asserts the three current paths
+verbatim, because a discovery that silently returned nothing would make every
+other case pass vacuously.
+
+**Attribution was worth a second shape.** The first version asserted the
+absolute violation set against a sandbox copied from production, so removing
+one shipped pin turned four cases red, including cases about other substrates.
+The sensitivity cases now assert the DELTA against the pristine sandbox and
+each mutation asserts its pre-state first. Measured on all three: dropping a
+pin now kills the tree-wide case plus only the cases whose subject is that
+file.
+
+**Not verified here, and deliberately not.** That the modified unit really
+boots the BEAM in utf8 is provable only on a host, and no worker touches m42 or
+production. What is proven is the content of the definitions, the guard's
+sensitivity, and the spelling's agreement with the two doors that already had
+it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36109,6 +36109,7 @@ The mismatch is a static property of the call site, so the canary still fires
 the first time that site actually spawns; recovering it on the no-op path would
 mean exporting a validate-only verb from `Admission` purely to keep a detector
 warm, which is more surface than the detector is worth.
+
 ---
 
 ## 2026-08-09 — #425: the locale is a property of the machine until a service definition says otherwise

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36162,8 +36162,24 @@ each mutation asserts its pre-state first. Measured on all three: dropping a
 pin now kills the tree-wide case plus only the cases whose subject is that
 file.
 
+**Measured, and it refines the issue's framing.** Probing the pinned toolchain
+(`elixir -e ':file.native_name_encoding()'` under a controlled environment, dev
+container, OTP 28 / glibc) says the trigger is not an ABSENT locale but an
+effective C/POSIX one: LANG unset and LANG empty both answer `:utf8`, while
+`LANG=C` and `LANG=POSIX` answer `:latin1` and print the warning verbatim. So
+what these pins remove is a dependency on the host not setting a C locale —
+narrower than "not setting a locale", and worth saying out loud rather than
+inheriting the issue's wording. Two more results earned their place: `LC_ALL=C`
+beats `LANG=C.UTF-8` (`:latin1`), which is why the declared limit above is a
+measurement and not a hedge; and `ELIXIR_ERL_OPTIONS="+fnu"` does fix `LANG=C`
+for the CLI, so the choice against it is the one-spelling argument, not a claim
+that it does not work.
+
 **Not verified here, and deliberately not.** That the modified unit really
 boots the BEAM in utf8 is provable only on a host, and no worker touches m42 or
-production. What is proven is the content of the definitions, the guard's
-sensitivity, and the spelling's agreement with the two doors that already had
-it.
+production. The probe above is Linux/glibc in a container, not a FreeBSD jail
+under rc(8), where libc's locale handling is its own; and `C.UTF-8`'s presence
+on FreeBSD rests on the issue's own observation that the jail's login
+environment already carries it. What is proven here is the content of the
+definitions, the guard's sensitivity, the mechanism on one substrate, and the
+spelling's agreement with the two doors that already had it.

--- a/infra/freebsd/rc.d/grappa
+++ b/infra/freebsd/rc.d/grappa
@@ -117,14 +117,15 @@ grappa_runas() {
 	# System.find_executable/1 without this prepend. Found live
 	# 2026-06-10: pkgs installed, yet every media upload 422'd
 	# fail-closed with "exiftool not found on PATH".
-	# LANG pins the BEAM's utf8 native name encoding (#425). `su -m` keeps
+	# LANG pins the BEAM's utf8 native name encoding (#425), which governs
+	# FILENAME handling — uploads carry user-supplied names. `su -m` KEEPS
 	# the invoking environment, so without this the encoding is whatever
-	# locale root happened to have when rc(8) ran — and a jail provisioned
-	# without one boots the release in latin1, which Elixir warns about and
-	# which governs FILENAME handling (uploads carry user-supplied names).
-	# Same spelling as infra/linux/systemd, infra/packaging and
-	# Dockerfile.release. An LC_ALL/LC_CTYPE inherited from root still
-	# outranks LANG — this pins the default, it does not fight an override.
+	# locale root happened to have when rc(8) ran; a C/POSIX one boots the
+	# release in latin1 (measured on OTP 28/glibc, along with the warning
+	# Elixir prints). Same spelling as infra/linux/systemd, infra/packaging
+	# and Dockerfile.release. An LC_ALL/LC_CTYPE inherited from root still
+	# outranks LANG (measured) — this pins the default, it does not fight an
+	# override.
 	su -m "${grappa_user}" -c "export RELEASE_TMP='${grappa_runtime_tmp}'; export LANG=C.UTF-8; export PATH=\"/usr/local/bin:/usr/local/sbin:\${PATH}\"; ${envsrc}${command} ${subcmd}"
 }
 

--- a/infra/freebsd/rc.d/grappa
+++ b/infra/freebsd/rc.d/grappa
@@ -117,7 +117,15 @@ grappa_runas() {
 	# System.find_executable/1 without this prepend. Found live
 	# 2026-06-10: pkgs installed, yet every media upload 422'd
 	# fail-closed with "exiftool not found on PATH".
-	su -m "${grappa_user}" -c "export RELEASE_TMP='${grappa_runtime_tmp}'; export PATH=\"/usr/local/bin:/usr/local/sbin:\${PATH}\"; ${envsrc}${command} ${subcmd}"
+	# LANG pins the BEAM's utf8 native name encoding (#425). `su -m` keeps
+	# the invoking environment, so without this the encoding is whatever
+	# locale root happened to have when rc(8) ran — and a jail provisioned
+	# without one boots the release in latin1, which Elixir warns about and
+	# which governs FILENAME handling (uploads carry user-supplied names).
+	# Same spelling as infra/linux/systemd, infra/packaging and
+	# Dockerfile.release. An LC_ALL/LC_CTYPE inherited from root still
+	# outranks LANG — this pins the default, it does not fight an override.
+	su -m "${grappa_user}" -c "export RELEASE_TMP='${grappa_runtime_tmp}'; export LANG=C.UTF-8; export PATH=\"/usr/local/bin:/usr/local/sbin:\${PATH}\"; ${envsrc}${command} ${subcmd}"
 }
 
 grappa_start() {

--- a/infra/linux/systemd/grappa.service
+++ b/infra/linux/systemd/grappa.service
@@ -49,14 +49,17 @@ EnvironmentFile=@ENV_FILE@
 # not because it's known to be needed on this substrate.
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# UTF-8 locale so the BEAM boots with utf8 native name encoding. systemd
-# sets no LANG by default, and without a UTF-8 one Elixir warns "the VM is
-# running with native name encoding of latin1 which may cause Elixir to
-# malfunction" — that setting governs FILENAME handling, and grappa writes
-# user-supplied names to disk (uploads). Same spelling as the packaged unit
+# UTF-8 locale so the BEAM boots with utf8 native name encoding, which
+# governs FILENAME handling — and grappa writes user-supplied names to disk
+# (uploads). systemd sets no LANG by default; measured on OTP 28/glibc, an
+# ABSENT LANG still yields utf8, but an effective C/POSIX locale yields
+# latin1 and Elixir warns "the VM is running with native name encoding of
+# latin1". So this pins the encoding to the service instead of to whatever
+# locale the host hands it. Same spelling as the packaged unit
 # (infra/packaging/grappa.service) and Dockerfile.release: C.UTF-8 is always
-# present on glibc, no locale-gen. #425 — this pins a dependency that was
-# merely inherited from the host, it does not repair a live defect.
+# present on glibc, no locale-gen. An LC_ALL in the manager environment
+# still outranks LANG (measured) — this pins the default, it does not fight
+# an override. #425.
 Environment=LANG=C.UTF-8
 
 ExecStartPre=@REPO_ROOT@/infra/linux/grappa_beam_wait.sh wait-name-free grappa 15

--- a/infra/linux/systemd/grappa.service
+++ b/infra/linux/systemd/grappa.service
@@ -49,6 +49,16 @@ EnvironmentFile=@ENV_FILE@
 # not because it's known to be needed on this substrate.
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# UTF-8 locale so the BEAM boots with utf8 native name encoding. systemd
+# sets no LANG by default, and without a UTF-8 one Elixir warns "the VM is
+# running with native name encoding of latin1 which may cause Elixir to
+# malfunction" — that setting governs FILENAME handling, and grappa writes
+# user-supplied names to disk (uploads). Same spelling as the packaged unit
+# (infra/packaging/grappa.service) and Dockerfile.release: C.UTF-8 is always
+# present on glibc, no locale-gen. #425 — this pins a dependency that was
+# merely inherited from the host, it does not repair a live defect.
+Environment=LANG=C.UTF-8
+
 ExecStartPre=@REPO_ROOT@/infra/linux/grappa_beam_wait.sh wait-name-free grappa 15
 ExecStart=@RELEASE_ROOT@/bin/grappa start
 

--- a/test/infra/service_locale_pin_test.bats
+++ b/test/infra/service_locale_pin_test.bats
@@ -63,9 +63,27 @@ locale_pin_violations() {
     done < <(service_definitions)
 }
 
+# Violations under $1 that the pristine sandbox did not already have — the
+# DELTA a single mutation caused. Without it, one unpinned shipped file would
+# turn every sensitivity case below red at once, and the suite would say
+# "four things broke" when one did.
+added_violations() {
+    local root="$1" rel
+    while IFS= read -r rel; do
+        printf '%s\n' "$BASELINE_VIOLATIONS" | grep -qxF "$rel" || printf '%s\n' "$rel"
+    done < <(locale_pin_violations "$root")
+}
+
 # Rewrite a sandbox file through a sed expression — one mutation per RED case.
-mutate() {
+# The pre-state is asserted first: mutating a pin out of a file that never had
+# one is a no-op, and a no-op mutation proves nothing.
+mutate_out_the_pin() {
+    pins_utf8_locale "$1" || {
+        printf 'mutate_out_the_pin: %s has no pin to remove — the mutation would be a no-op\n' "$1" >&2
+        return 1
+    }
     sed "$2" "$1" > "$1.mutated" && mv "$1.mutated" "$1"
+    refute pins_utf8_locale "$1"
 }
 
 setup() {
@@ -75,6 +93,8 @@ setup() {
         mkdir -p "$SANDBOX/$(dirname "$rel")"
         cp "$REPO_SRC/$rel" "$SANDBOX/$rel"
     done < <(service_definitions)
+
+    BASELINE_VIOLATIONS="$(locale_pin_violations "$SANDBOX")"
 }
 
 @test "discovery lists exactly the three shipped service definitions" {
@@ -92,36 +112,36 @@ infra/packaging/grappa.service" ]
 }
 
 @test "dropping the pin from the linux systemd unit is a violation" {
-    mutate "$SANDBOX/infra/linux/systemd/grappa.service" '/LANG=C\.UTF-8/d'
+    mutate_out_the_pin "$SANDBOX/infra/linux/systemd/grappa.service" '/LANG=C\.UTF-8/d'
 
-    run locale_pin_violations "$SANDBOX"
+    run added_violations "$SANDBOX"
     [ "$output" = "infra/linux/systemd/grappa.service" ]
 }
 
 @test "dropping the pin from the packaged systemd unit is a violation" {
-    mutate "$SANDBOX/infra/packaging/grappa.service" '/LANG=C\.UTF-8/d'
+    mutate_out_the_pin "$SANDBOX/infra/packaging/grappa.service" '/LANG=C\.UTF-8/d'
 
-    run locale_pin_violations "$SANDBOX"
+    run added_violations "$SANDBOX"
     [ "$output" = "infra/packaging/grappa.service" ]
 }
 
 @test "dropping the pin from the FreeBSD rc.d service is a violation" {
-    mutate "$SANDBOX/infra/freebsd/rc.d/grappa" '/LANG=C\.UTF-8/d'
+    mutate_out_the_pin "$SANDBOX/infra/freebsd/rc.d/grappa" '/LANG=C\.UTF-8/d'
 
-    run locale_pin_violations "$SANDBOX"
+    run added_violations "$SANDBOX"
     [ "$output" = "infra/freebsd/rc.d/grappa" ]
 }
 
 @test "a non-UTF-8 locale (LANG=C) does not satisfy the pin" {
-    mutate "$SANDBOX/infra/linux/systemd/grappa.service" 's/LANG=C\.UTF-8/LANG=C/'
+    mutate_out_the_pin "$SANDBOX/infra/linux/systemd/grappa.service" 's/LANG=C\.UTF-8/LANG=C/'
 
-    run locale_pin_violations "$SANDBOX"
+    run added_violations "$SANDBOX"
     [ "$output" = "infra/linux/systemd/grappa.service" ]
 }
 
 @test "a commented-out pin does not satisfy the pin" {
-    mutate "$SANDBOX/infra/packaging/grappa.service" 's/^\(.*LANG=C\.UTF-8.*\)$/#\1/'
+    mutate_out_the_pin "$SANDBOX/infra/packaging/grappa.service" 's/^\(.*LANG=C\.UTF-8.*\)$/#\1/'
 
-    run locale_pin_violations "$SANDBOX"
+    run added_violations "$SANDBOX"
     [ "$output" = "infra/packaging/grappa.service" ]
 }

--- a/test/infra/service_locale_pin_test.bats
+++ b/test/infra/service_locale_pin_test.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #425 — every shipped service definition that boots the
+# release MUST pin a UTF-8 locale (`LANG=C.UTF-8`).
+#
+# Without one the BEAM boots with `native_name_encoding` = latin1 and Elixir
+# warns on stderr ("the VM is running with native name encoding of latin1
+# which may cause Elixir to malfunction"). That setting governs FILENAME
+# handling, and grappa writes user-supplied names to disk (uploads), so a
+# latin1 VM is a mis-decode waiting for the first non-ASCII filename.
+#
+# This is the drift GUARD, not the pin itself. It is deliberately BOTH:
+#
+#   * dynamic in the SET — it discovers service definitions from the tracked
+#     tree (`*.service`, `*/rc.d/*`) filtered to the ones that actually launch
+#     `bin/grappa`, so a fourth substrate added tomorrow is held to the pin
+#     without anyone remembering to extend this file. The `bin/grappa` filter
+#     is what keeps a non-BEAM unit (e.g. the certbot oneshot #665 writes at
+#     first boot) out of the set — a locale pin there would be noise.
+#
+#   * static in the CURRENT set — the first case asserts the three shipped
+#     paths verbatim. A discovery that silently returns nothing would make
+#     every other case pass vacuously, which is the failure mode this suite
+#     would otherwise be blind to. When a substrate is legitimately added,
+#     that case fails loudly and the author must look.
+#
+# Dockerfile.release pins the same spelling twice (`ENV LANG=C.UTF-8`, builder
+# and runtime) but is not in the set: a Dockerfile is not a service definition
+# and the glob that would catch it also catches the e2e fixtures' images.
+#
+# Every RED case mutates a PRODUCTION copy of a shipped file — a synthetic
+# unit would only prove the guard rejects a shape we do not ship.
+
+load ../bats_helpers
+
+REPO_SRC="$BATS_TEST_DIRNAME/../.."
+
+# Tracked service definitions that boot the release, one relative path per
+# line. The SET is read from the real repo (production truth); the pin is
+# then checked against whichever root the caller passes.
+service_definitions() {
+    local rel
+    git -C "$REPO_SRC" ls-files -- infra | while IFS= read -r rel; do
+        case "$rel" in
+            *.service | */rc.d/*) ;;
+            *) continue ;;
+        esac
+        grep -q 'bin/grappa' "$REPO_SRC/$rel" || continue
+        printf '%s\n' "$rel"
+    done
+}
+
+# A commented-out pin is not a pin: strip comment lines before looking.
+pins_utf8_locale() {
+    grep -v '^[[:space:]]*#' "$1" | grep -q 'LANG=C\.UTF-8'
+}
+
+# Relative paths of the definitions that do NOT pin, under $1.
+locale_pin_violations() {
+    local root="$1" rel
+    while IFS= read -r rel; do
+        pins_utf8_locale "$root/$rel" || printf '%s\n' "$rel"
+    done < <(service_definitions)
+}
+
+# Rewrite a sandbox file through a sed expression — one mutation per RED case.
+mutate() {
+    sed "$2" "$1" > "$1.mutated" && mv "$1.mutated" "$1"
+}
+
+setup() {
+    SANDBOX="$BATS_TEST_TMPDIR/repo"
+    local rel
+    while IFS= read -r rel; do
+        mkdir -p "$SANDBOX/$(dirname "$rel")"
+        cp "$REPO_SRC/$rel" "$SANDBOX/$rel"
+    done < <(service_definitions)
+}
+
+@test "discovery lists exactly the three shipped service definitions" {
+    run service_definitions
+    [ "$status" -eq 0 ]
+    [ "$output" = "infra/freebsd/rc.d/grappa
+infra/linux/systemd/grappa.service
+infra/packaging/grappa.service" ]
+}
+
+@test "every shipped service definition pins LANG=C.UTF-8" {
+    run locale_pin_violations "$REPO_SRC"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "dropping the pin from the linux systemd unit is a violation" {
+    mutate "$SANDBOX/infra/linux/systemd/grappa.service" '/LANG=C\.UTF-8/d'
+
+    run locale_pin_violations "$SANDBOX"
+    [ "$output" = "infra/linux/systemd/grappa.service" ]
+}
+
+@test "dropping the pin from the packaged systemd unit is a violation" {
+    mutate "$SANDBOX/infra/packaging/grappa.service" '/LANG=C\.UTF-8/d'
+
+    run locale_pin_violations "$SANDBOX"
+    [ "$output" = "infra/packaging/grappa.service" ]
+}
+
+@test "dropping the pin from the FreeBSD rc.d service is a violation" {
+    mutate "$SANDBOX/infra/freebsd/rc.d/grappa" '/LANG=C\.UTF-8/d'
+
+    run locale_pin_violations "$SANDBOX"
+    [ "$output" = "infra/freebsd/rc.d/grappa" ]
+}
+
+@test "a non-UTF-8 locale (LANG=C) does not satisfy the pin" {
+    mutate "$SANDBOX/infra/linux/systemd/grappa.service" 's/LANG=C\.UTF-8/LANG=C/'
+
+    run locale_pin_violations "$SANDBOX"
+    [ "$output" = "infra/linux/systemd/grappa.service" ]
+}
+
+@test "a commented-out pin does not satisfy the pin" {
+    mutate "$SANDBOX/infra/packaging/grappa.service" 's/^\(.*LANG=C\.UTF-8.*\)$/#\1/'
+
+    run locale_pin_violations "$SANDBOX"
+    [ "$output" = "infra/packaging/grappa.service" ]
+}


### PR DESCRIPTION
Refs #425.

## What this is, and what it is not

The BEAM decides `native_name_encoding` from the locale it inherits at boot.
That setting governs **filename** handling, and grappa writes user-supplied
names to disk (uploads), so a latin1 VM is a mis-decode waiting for the first
non-ASCII filename.

**This is latent, not live.** Production answers
`:file.native_name_encoding() #=> :utf8` today because the jail's ambient
locale is already `C.UTF-8`, not because anything pins it. This PR pins an
unpinned dependency; it does not repair a running defect, and nothing here
should be read as an incident.

## The change

`LANG=C.UTF-8` in the two service definitions that did not have it:

- `infra/linux/systemd/grappa.service` — `Environment=LANG=C.UTF-8`.
- `infra/freebsd/rc.d/grappa` — the export goes **inside** `grappa_runas`'
  `su -c` string, next to `RELEASE_TMP` and the `PATH` prepend. `su -m` KEEPS
  the invoking environment, so the locale there is root's, whatever rc(8) had.

Same spelling as the two doors that already pin it: #419's packaged unit
(`infra/packaging/grappa.service`) and `Dockerfile.release` (both stages).

## LANG over ELIXIR_ERL_OPTIONS="+fnu" — declared, not hedged

The issue offers both; taking both would be two mechanisms for one property,
which is redundancy that diverges the first time someone edits one of them.

- `LANG=C.UTF-8` is **already** the repo's spelling in two places. A third
  spelling for the same property is the bug of some later afternoon.
- It is the wider fix: `+fnu` sets the VM's own filename encoding and nothing
  else, while the environment variable also reaches the ports the release
  spawns (`exiftool`, `ffmpeg` for `Grappa.Uploads.MetadataStrip`).
- It is honored by construction — it is the process environment, not something
  a boot script has to forward.

Measured, so the choice is on merit: `+fnu` **does** fix `LANG=C`. Declining
it is the one-spelling argument, not a claim that it is broken.

## Measured — and it refines the issue's framing

`elixir -e ':file.native_name_encoding()'` under a controlled environment
(dev container, OTP 28 / glibc):

| environment | result |
| --- | --- |
| `LANG` unset (and `LC_ALL`/`LC_CTYPE` unset) | `:utf8` |
| `LANG=` (empty) | `:utf8` |
| `LANG=C.UTF-8` | `:utf8` |
| `LANG=C` | `:latin1` + the warning, verbatim |
| `LANG=POSIX` | `:latin1` |
| `LANG=C.UTF-8` with `LC_ALL=C` | `:latin1` |
| `LANG=C` with `ELIXIR_ERL_OPTIONS=+fnu` | `:utf8` |

So the trigger is an **effective C/POSIX locale**, not an absent one. The issue
says "without a locale"; what these pins actually remove is a dependency on the
host not setting a C locale. Narrower, and worth saying rather than repeating
unmeasured.

**Declared limit:** an `LC_ALL`/`LC_CTYPE` from the invoking environment still
outranks `LANG` (row 6 above). This pins the default; it does not fight an
override, and pinning `LC_ALL` to win that fight would take the choice away
from an operator who set it deliberately.

## The guard

`test/infra/service_locale_pin_test.bats` — a pin nobody guards is a pin the
next unit gets written without.

- **Dynamic in the set:** it discovers tracked service definitions (`*.service`,
  `*/rc.d/*`) filtered to those that actually launch `bin/grappa`, so a fourth
  substrate is held to the rule without anyone remembering this file. The
  `bin/grappa` filter keeps non-BEAM units (the #665 certbot oneshot) out.
- **Static in the census:** the first case asserts the three current paths
  verbatim, because a discovery that silently returned nothing would make every
  other case pass vacuously.

Mutation matrix — the pin removed from a real shipped file, suite re-run:

| production mutant | red |
| --- | --- |
| pin dropped from `infra/linux/systemd/grappa.service` | tree case + the 2 linux-subject cases |
| pin dropped from `infra/packaging/grappa.service` | tree case + the 2 packaging-subject cases |
| pin dropped from `infra/freebsd/rc.d/grappa` | tree case + the 1 FreeBSD case |
| rc.d file moved out of the discovered set | discovery case + the FreeBSD case |

The first shape of the guard asserted the absolute violation set, so one lost
pin turned four cases red including ones about other substrates. The
sensitivity cases now assert the DELTA against the pristine sandbox and each
mutation asserts its own pre-state first — a pin you cannot remove was never
there, and a no-op mutation proves nothing.

## What I refuse to claim

- That the modified unit boots the BEAM in utf8 **on a real host**. That is
  provable only on a machine, and this branch touched no host.
- That the measurement transfers to FreeBSD. The probe is Linux/glibc in a
  container; a jail under rc(8) has its own libc locale handling.
- That `C.UTF-8` exists on every FreeBSD jail. The support for that is the
  issue's own observation that m42's jail login environment already carries it.

## Gates

- `scripts/check.sh` — rc 0. Bats 390 ok / 0 not ok (383 before, +7 new,
  reconciled against a prediction registered before the run).
- Working tree porcelain empty before and after the gate.