### PR TITLE
A NICK with a blank parameter is not a rename

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35985,3 +35985,56 @@ null", not "absent".
 `protocol_version` bump, and a client that ignores it is unaffected.
 
 _Deploy: **HOT** — server logic + `--cic`. No migration._
+## 2026-08-09 — a NICK with a blank parameter is not a rename
+
+`NICK` with no parameter has always fallen through `EventRouter`'s catch-all
+with no effects — the clause head matches `params: [new_nick | _]`, and an
+empty list does not. `NICK :` — a trailing parameter present but empty — parses
+to `params: [""]` and did match, so the router treated it as a rename to the
+empty name. Two spellings of the same malformed line, two different outcomes.
+That asymmetry, not the empty string on its own, is the defect.
+
+**The reachability was measured before the cure, because it decides how much
+of the story is real.** The two answers — the parser produces this from a
+genuine wire line, versus the value exists only because a property generator
+builds the struct by hand — lead to different cures. Measured against
+`Grappa.IRC.Parser`: `NICK` and `NICK ` both yield `params: []`; `NICK :`
+yields `params: [""]`; `NICK : ` yields `params: [" "]`. So the blank
+parameter is on the wire, not merely in a generator, and the whitespace
+variant comes with it for free.
+
+**The guard rejects at the boundary, where the effects are coined.**
+`{:own_nick_renamed, old, new}` and `{:peer_nick_renamed, old, new}` carry
+IDENTITIES; putting the check in `apply_effects/2` would mean every consumer
+re-validates a shape the producer already promised. One guard sits ahead of the
+self/peer split — the two arms descend from a single `do_route(:nick, ...)`
+clause, so this is one door, not two guards to keep in sync. The message is
+ignored entirely: state unchanged, no effects, exactly what a parameter-less
+`NICK` already does.
+
+**The predicate is narrow on purpose.** Not `Identifier.valid_nick?/1`: that
+one is anchored ASCII, capped at 30, and correct for what we send upstream —
+applying it to what an upstream sends us would refuse legitimate renames and
+leave `state.nick` on a name the server no longer knows us by, a worse failure
+than the one being fixed. Blank means empty or whitespace-only, and nothing
+more. A parameter with an interior space (`NICK :foo bar`) still passes; this
+guard makes no claim that every accepted parameter is a valid nick.
+
+**What the property test could and could not say.** The shape property's effect
+allowlist had drifted narrower than `@type effect` again — `{:own_nick_renamed,
+_, _}` had no arm at all — so its `flunk` fires on any self-rename the
+generator draws, blank or not, and the empty string in the reported
+counterexample is the shrinker's minimisation rather than the trigger. Measured
+after the guard and before the arm: 48 of 48 seeds green, because the property
+reaches the NICK boundary only when a prefix nick collides with the state's.
+The arm was added anyway (a contract mirror should not lie), asserting a
+non-blank name on both sides rather than `is_binary/1` — the certificate of
+nothing the #279 and #878 arms already exist to stop repeating. The witness,
+though, is a second property that puts a NICK on both rename branches for
+every generated example, plus unit tests that name the input.
+
+**Mutation matrix.** Guard removed: 5 unit tests and the per-example property
+red, shape property green. `String.trim/1` narrowed to `== ""`: exactly the two
+whitespace-only unit tests red, both properties green — so the whitespace
+sub-class is pinned by the named-input tests alone, which is the reason they
+exist rather than leaving the class to the fuzzer.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35985,6 +35985,7 @@ null", not "absent".
 `protocol_version` bump, and a client that ignores it is unaffected.
 
 _Deploy: **HOT** — server logic + `--cic`. No migration._
+
 ## 2026-08-09 — a NICK with a blank parameter is not a rename
 
 `NICK` with no parameter has always fallen through `EventRouter`'s catch-all

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -759,109 +759,30 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
+  # A NICK whose parameter is blank names nobody, so it is not a rename.
+  # RFC 2812 §2.3.1's `nickname` is at least one character and admits no
+  # space: there is nothing to rename TO. A parameter-less `NICK` already
+  # falls through to the catch-all clause; the parser distinguishes it
+  # (`params: []`) from an empty TRAILING param (`params: [""]`), but the
+  # router must not — both are the same malformed line, and treating them
+  # differently is the whole defect.
+  #
+  # The rejection belongs HERE, where the rename effects are coined, and
+  # not in their consumers: `{:own_nick_renamed, old, new}` and
+  # `{:peer_nick_renamed, old, new}` carry IDENTITIES, and a consumer is
+  # entitled to trust that shape rather than re-validate it. Same reason
+  # one guard covers both branches — one malformed line, one door.
+  #
+  # Deliberately narrow: the blank class only, NOT `Identifier.valid_nick?/1`.
+  # That predicate is anchored ASCII and capped at 30 — right for what WE
+  # send upstream, wrong for what an upstream may send us. Refusing a
+  # legitimate rename would leave `state.nick` on a name the server no
+  # longer knows us by, a worse failure than the one being fixed.
   defp do_route(%Message{command: :nick, params: [new_nick | _]} = msg, state)
        when is_binary(new_nick) do
-    old_nick = Message.sender_nick(msg)
-    channels = channels_with_member(state.members, old_nick)
-
-    members = rename_member_everywhere(state.members, channels, old_nick, new_nick)
-
-    # S2.4: NICK rename migrates the userhost entry from old_nick to new_nick.
-    # user+host don't change with a nick change — only the key moves.
-    userhost_cache =
-      rename_userhost_entry(
-        Map.get(state, :userhost_cache, %{}),
-        old_nick,
-        new_nick,
-        casemapping(state)
-      )
-
-    new_state =
-      if nick_eq?(old_nick, state.nick) do
-        %{state | nick: new_nick, members: members, userhost_cache: userhost_cache}
-      else
-        %{state | members: members, userhost_cache: userhost_cache}
-      end
-
-    persist_effects =
-      for ch <- channels do
-        {_, eff} =
-          build_persist(new_state, :nick_change, ch, old_nick, nil, %{new_nick: new_nick})
-
-        eff
-      end
-
-    # #61: the per-channel fan-out above is EMPTY when the operator shares
-    # no channel with their old nick — a self-rename then produced zero
-    # visible feedback. Always surface the operator's OWN rename on the
-    # synthetic "$server" window (which always exists, independent of
-    # channel membership) so confirmation appears even with zero channels
-    # joined, and in the always-reachable server tab when channels exist.
-    # cic renders it via the existing `:nick_change` line in the server
-    # tab. Like the per-channel self-rename rows it counts as an "event"
-    # (not a message) in cic's cursor-derived unread until the operator
-    # views the server tab — and the OS/notify badge ignores it (presence
-    # kinds fail `should_notify?`). Consistent with how a self-rename
-    # already surfaces in channel windows; the goal here is exactly that
-    # always-visible confirmation, zero channels or not.
-    self_server_effects =
-      if nick_eq?(old_nick, state.nick) do
-        {_, eff} =
-          build_persist(new_state, :nick_change, "$server", old_nick, nil, %{new_nick: new_nick})
-
-        [eff]
-      else
-        []
-      end
-
-    # V9 (visitor-parity cluster, 2026-05-15): on a self-NICK echo
-    # for a visitor subject, emit the persist-side effect so
-    # `Session.Server.apply_effects/2` rotates `visitors.nick` via the
-    # injected `visitor_nick_persister` callback. Mirror of the
-    # `:visitor_r_observed` shape — the closure-injection avoids a
-    # static `Session → Visitors` Boundary alias that would close a
-    # cycle (Visitors deps Session via Login). User subjects don't
-    # carry a persister; their nick lives in `Networks.Credential`,
-    # which is operator-driven.
-    visitor_persist_effects =
-      case state.subject do
-        {:visitor, _} ->
-          # ASCII self-rename detection (#121/#525) — can't fold inside a
-          # case-clause guard, so branch in the body.
-          if nick_eq?(old_nick, state.nick),
-            do: [{:visitor_nick_changed, new_nick}],
-            else: []
-
-        _ ->
-          []
-      end
-
-    # #373: a PEER rename (not our own) must migrate that peer's open query
-    # window + its DM scrollback old -> new, so the window follows the nick
-    # and outbound sends stop routing to the now-vanished old nick (401).
-    # Emitted only when the renamer is a tracked member (`channels != []`) —
-    # that is the only case IRC delivers a peer's NICK to us, and it mirrors
-    # the per-channel fan-out gate above. `Session.Server.apply_effects/2`
-    # gates the actual DB migration on a query window existing (no-op
-    # otherwise), so a peer we never queried costs one indexed lookup.
-    peer_rename_effects =
-      if not nick_eq?(old_nick, state.nick) and channels != [] do
-        [{:peer_nick_renamed, old_nick, new_nick}]
-      else
-        []
-      end
-
-    own_rename_effects = own_nick_rename_effects(state, old_nick, new_nick)
-
-    # #581 — mirror bahamut's SILENT +r-strip on our own genuine self-rename
-    # (see strip_r_on_self_rename/4) so the per-session umode set stays truthful.
-    {final_state, self_umode_effects} =
-      strip_r_on_self_rename(state, new_state, old_nick, new_nick)
-
-    {:cont, final_state,
-     persist_effects ++
-       self_server_effects ++
-       visitor_persist_effects ++ peer_rename_effects ++ own_rename_effects ++ self_umode_effects}
+    if blank_token?(new_nick),
+      do: {:cont, state, []},
+      else: route_nick(msg, new_nick, state)
   end
 
   # Unsolicited TOPIC: a channel operator changed the topic mid-session.
@@ -3608,6 +3529,118 @@ defmodule Grappa.Session.EventRouter do
       []
     end
   end
+
+  @spec route_nick(Message.t(), String.t(), state()) :: {:cont, state(), [effect()]}
+  defp route_nick(msg, new_nick, state) do
+    old_nick = Message.sender_nick(msg)
+    channels = channels_with_member(state.members, old_nick)
+
+    members = rename_member_everywhere(state.members, channels, old_nick, new_nick)
+
+    # S2.4: NICK rename migrates the userhost entry from old_nick to new_nick.
+    # user+host don't change with a nick change — only the key moves.
+    userhost_cache =
+      rename_userhost_entry(
+        Map.get(state, :userhost_cache, %{}),
+        old_nick,
+        new_nick,
+        casemapping(state)
+      )
+
+    new_state =
+      if nick_eq?(old_nick, state.nick) do
+        %{state | nick: new_nick, members: members, userhost_cache: userhost_cache}
+      else
+        %{state | members: members, userhost_cache: userhost_cache}
+      end
+
+    persist_effects =
+      for ch <- channels do
+        {_, eff} =
+          build_persist(new_state, :nick_change, ch, old_nick, nil, %{new_nick: new_nick})
+
+        eff
+      end
+
+    # #61: the per-channel fan-out above is EMPTY when the operator shares
+    # no channel with their old nick — a self-rename then produced zero
+    # visible feedback. Always surface the operator's OWN rename on the
+    # synthetic "$server" window (which always exists, independent of
+    # channel membership) so confirmation appears even with zero channels
+    # joined, and in the always-reachable server tab when channels exist.
+    # cic renders it via the existing `:nick_change` line in the server
+    # tab. Like the per-channel self-rename rows it counts as an "event"
+    # (not a message) in cic's cursor-derived unread until the operator
+    # views the server tab — and the OS/notify badge ignores it (presence
+    # kinds fail `should_notify?`). Consistent with how a self-rename
+    # already surfaces in channel windows; the goal here is exactly that
+    # always-visible confirmation, zero channels or not.
+    self_server_effects =
+      if nick_eq?(old_nick, state.nick) do
+        {_, eff} =
+          build_persist(new_state, :nick_change, "$server", old_nick, nil, %{new_nick: new_nick})
+
+        [eff]
+      else
+        []
+      end
+
+    # V9 (visitor-parity cluster, 2026-05-15): on a self-NICK echo
+    # for a visitor subject, emit the persist-side effect so
+    # `Session.Server.apply_effects/2` rotates `visitors.nick` via the
+    # injected `visitor_nick_persister` callback. Mirror of the
+    # `:visitor_r_observed` shape — the closure-injection avoids a
+    # static `Session → Visitors` Boundary alias that would close a
+    # cycle (Visitors deps Session via Login). User subjects don't
+    # carry a persister; their nick lives in `Networks.Credential`,
+    # which is operator-driven.
+    visitor_persist_effects =
+      case state.subject do
+        {:visitor, _} ->
+          # ASCII self-rename detection (#121/#525) — can't fold inside a
+          # case-clause guard, so branch in the body.
+          if nick_eq?(old_nick, state.nick),
+            do: [{:visitor_nick_changed, new_nick}],
+            else: []
+
+        _ ->
+          []
+      end
+
+    # #373: a PEER rename (not our own) must migrate that peer's open query
+    # window + its DM scrollback old -> new, so the window follows the nick
+    # and outbound sends stop routing to the now-vanished old nick (401).
+    # Emitted only when the renamer is a tracked member (`channels != []`) —
+    # that is the only case IRC delivers a peer's NICK to us, and it mirrors
+    # the per-channel fan-out gate above. `Session.Server.apply_effects/2`
+    # gates the actual DB migration on a query window existing (no-op
+    # otherwise), so a peer we never queried costs one indexed lookup.
+    peer_rename_effects =
+      if not nick_eq?(old_nick, state.nick) and channels != [] do
+        [{:peer_nick_renamed, old_nick, new_nick}]
+      else
+        []
+      end
+
+    own_rename_effects = own_nick_rename_effects(state, old_nick, new_nick)
+
+    # #581 — mirror bahamut's SILENT +r-strip on our own genuine self-rename
+    # (see strip_r_on_self_rename/4) so the per-session umode set stays truthful.
+    {final_state, self_umode_effects} =
+      strip_r_on_self_rename(state, new_state, old_nick, new_nick)
+
+    {:cont, final_state,
+     persist_effects ++
+       self_server_effects ++
+       visitor_persist_effects ++ peer_rename_effects ++ own_rename_effects ++ self_umode_effects}
+  end
+
+  # Blank = empty or whitespace-only. `String.trim/1` (not `== ""`) because
+  # `NICK : ` is on the wire exactly as reachable as `NICK :` and yields a
+  # one-space param; a space is not part of any nick grammar, so both
+  # spellings are the same non-name.
+  @spec blank_token?(String.t()) :: boolean()
+  defp blank_token?(token) when is_binary(token), do: String.trim(token) == ""
 
   defp nick_eq?(_, nil), do: false
 

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -260,10 +260,19 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         {:presence_command_unknown, cmd} ->
           assert cmd in [:monitor, :watch]
 
-        # #373 — a peer NICK migrates its query window; both nicks binary.
+        # #373 — a peer NICK migrates its query window; #948's self twin
+        # re-keys the DM tag. Both are IDENTITIES, so `is_binary/1` alone
+        # would be the certificate of nothing this file has already been
+        # burned by twice (see the #279 and #878 arms above): a blank name
+        # satisfies it while naming nobody. Assert the class the effects
+        # actually promise — a non-blank nick on both sides.
         {:peer_nick_renamed, old_nick, new_nick} ->
-          assert is_binary(old_nick)
-          assert is_binary(new_nick)
+          assert String.trim(old_nick) != ""
+          assert String.trim(new_nick) != ""
+
+        {:own_nick_renamed, old_nick, new_nick} ->
+          assert String.trim(old_nick) != ""
+          assert String.trim(new_nick) != ""
 
         other ->
           flunk("malformed effect: #{inspect(other)}")
@@ -365,6 +374,47 @@ defmodule Grappa.Session.EventRouterPropertyTest do
 
       for {:supported_umodes_changed, modes} <- effects do
         assert umode_letters?(modes), "malformed supported set from token #{inspect(token)}"
+      end
+    end
+  end
+
+  # What the shape property above does NOT reach on its own is the NICK
+  # boundary: it fires only when the seed draws a prefix nick equal to the
+  # state's — a collision between two independent 16-char draws — which is
+  # WHY a rename to a blank nick could sit on main as an intermittent red
+  # (it took 47 runs to surface once, and 48 seeds produced none at all).
+  # This one puts a NICK on both rename branches for EVERY generated
+  # example, so the class is pinned by the test set rather than by the seed.
+  property "no NICK param renames anyone to a blank nick" do
+    check all(
+            param <- string(:ascii, min_length: 0, max_length: 32),
+            renamer <- member_of(["self", "alice"])
+          ) do
+      state = %{min_state() | members: %{"#chan" => %{"self" => [], "alice" => []}}}
+
+      m = %Message{
+        command: :nick,
+        params: [param],
+        prefix: {:nick, renamer, "u", "h"},
+        tags: %{}
+      }
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      assert String.trim(new_state.nick) != "",
+             "state.nick blanked by param #{inspect(param)}"
+
+      assert Enum.all?(Map.keys(new_state.members["#chan"]), &(String.trim(&1) != "")),
+             "members key blanked by param #{inspect(param)}"
+
+      for {:own_nick_renamed, old, new} <- effects do
+        assert String.trim(old) != "" and String.trim(new) != "",
+               "blank own rename from param #{inspect(param)}"
+      end
+
+      for {:peer_nick_renamed, old, new} <- effects do
+        assert String.trim(old) != "" and String.trim(new) != "",
+               "blank peer rename from param #{inspect(param)}"
       end
     end
   end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -11,7 +11,7 @@ defmodule Grappa.Session.EventRouterTest do
   """
   use ExUnit.Case, async: true
 
-  alias Grappa.IRC.Message
+  alias Grappa.IRC.{Message, Parser}
   alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, Wire}
 
   @user_id "00000000-0000-0000-0000-000000000001"
@@ -2130,6 +2130,52 @@ defmodule Grappa.Session.EventRouterTest do
     test "NICK-other for stranger emits no effects + no mutation" do
       state = base_state(%{members: %{"#italia" => %{"vjt" => []}}})
       m = msg(:nick, ["stranger_"], {:nick, "stranger", "u", "h"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+  end
+
+  # A NICK whose parameter is blank names nobody, so it is not a rename.
+  # These tests name the INPUT rather than the seed: the shape property in
+  # `event_router_property_test.exs` reaches this class only when the
+  # generator happens to draw it, so it cannot be the only witness.
+  describe "route/2 — :nick with a blank parameter" do
+    test "the wire line `NICK :` reaches route/2 with an empty param and is rejected" do
+      state = base_state(%{nick: "vjt", members: %{"#italia" => %{"vjt" => ["@"]}}})
+
+      assert {:ok, %Message{command: :nick, params: [""]} = m} =
+               Parser.parse(":vjt!u@h NICK :")
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    test "NICK-self with an empty param leaves state.nick and the members map alone" do
+      state = base_state(%{nick: "vjt", members: %{"#italia" => %{"vjt" => ["@"], "alice" => []}}})
+      m = msg(:nick, [""], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    test "NICK-self with a whitespace-only param leaves state.nick and the members map alone" do
+      state = base_state(%{nick: "vjt", members: %{"#italia" => %{"vjt" => ["@"]}}})
+      m = msg(:nick, [" "], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    # Same input shape, same class of consequence: the peer arm re-keys a
+    # query window and its DM scrollback (#373), so a blank param there is
+    # the same defect wearing the other branch.
+    test "NICK-peer with an empty param leaves the members map alone" do
+      state = base_state(%{nick: "vjt", members: %{"#italia" => %{"vjt" => [], "alice" => ["@"]}}})
+      m = msg(:nick, [""], {:nick, "alice", "u", "h"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    test "NICK-peer with a whitespace-only param leaves the members map alone" do
+      state = base_state(%{nick: "vjt", members: %{"#italia" => %{"vjt" => [], "alice" => ["@"]}}})
+      m = msg(:nick, ["  "], {:nick, "alice", "u", "h"})
 
       assert {:cont, ^state, []} = EventRouter.route(m, state)
     end


### PR DESCRIPTION
## The asymmetry

`NICK` with no parameter has always fallen through `EventRouter`'s
catch-all with no effects — the clause head matches `params: [new_nick | _]`,
and an empty list does not. `NICK :` — a trailing parameter present but
empty — parses to `params: [""]` and did match, so the router accepted it as
a rename to the empty name. RFC 2812 §2.3.1's `nickname` is at least one
character and admits no space: there is nothing to rename to.

Two spellings of the same malformed line, two different outcomes. That
asymmetry, not the empty string on its own, is what this closes.

Measured against `Grappa.IRC.Parser` before writing the cure, because the
answer decides whether this is a boundary rejection or a test-only artefact:

| line | params |
| --- | --- |
| `:a!u@h NICK` | `[]` |
| `:a!u@h NICK ` | `[]` |
| `:a!u@h NICK :` | `[""]` |
| `:a!u@h NICK : ` | `[" "]` |

## The guard

Rejection at the boundary, in `EventRouter`, where the rename effects are
coined — not in `apply_effects/2`. `{:own_nick_renamed, old, new}` and
`{:peer_nick_renamed, old, new}` carry identities, and a consumer is entitled
to trust that shape rather than re-validate it. One guard sits ahead of the
self/peer split: both arms descend from a single `do_route(:nick, ...)`
clause, so this is one door, not two guards to keep in sync. The message is
ignored entirely — state unchanged, no effects, exactly what a
parameter-less `NICK` already does.

The predicate is deliberately narrow: blank means empty or whitespace-only,
and nothing more. **Not** `Identifier.valid_nick?/1` — that one is anchored
ASCII and capped at 30, right for what we send upstream and wrong for what
an upstream may send us. Refusing a legitimate rename would leave
`state.nick` on a name the server no longer knows us by, a worse failure
than the one being fixed. A parameter with an interior space still passes;
this makes no claim that every accepted parameter is a valid nick.

## The tests

The shape property's effect allowlist had drifted narrower than
`@type effect` again — `{:own_nick_renamed, _, _}` had no arm — so its
`flunk` fires on any self-rename the generator draws, blank or not. The arm
is added, asserting a non-blank name on both sides rather than
`is_binary/1`: the certificate of nothing the #279 and #878 arms above
already exist to stop repeating.

That arm is a contract mirror, not a witness. Measured with the guard in
place and the arm absent: **48 of 48 seeds green**, because the shape
property reaches the NICK boundary only when a generated prefix nick
collides with the state's. So the witnesses are a second property that puts
a NICK on both rename branches for *every* generated example, and unit tests
that name the input.

Mutation matrix:

| mutant | unit file | property file |
| --- | --- | --- |
| guard removed | 5 red | 1 red (per-example property); shape property green |
| `String.trim/1` → `== ""` | 2 red (whitespace only) | green |

The second row is why the named-input tests exist: the whitespace sub-class
is pinned by them alone, not by the fuzzer.

## Gate

`scripts/check.sh` green — `8 doctests, 57 properties, 5618 tests, 0 failures`,
Dialyzer `Total errors: 0`.