### PR TITLE
e2e(#1066): bump azzurra-testnet to the CLONEKILL fix

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36184,3 +36184,38 @@ on FreeBSD rests on the issue's own observation that the jail's login
 environment already carries it. What is proven here is the content of the
 definitions, the guard's sensitivity, the mechanism on one substrate, and the
 spelling's agreement with the two doors that already had it.
+
+---
+
+## 2026-08-09 — #1066: the e2e testnet's clone threshold changed directive, and the value's meaning changed with it
+
+`cicchetto/e2e/infra` moved from `0c235dc3` to `687c73bd` — one pointer line.
+The value in `cicchetto/e2e/compose.yaml` did **not** move: it is still
+`SVC_AKILL_CLONES: "0"`. Its **meaning** did. Upstream now writes the setting
+into `CLONEKILL` instead of `CLONES`, and in azzurra's services those are two
+different directives. `CLONES` (`CONF_SET_CLONE`) is a boolean master switch,
+so `CLONES:0` turned clone detection off entirely — no scan, no globops, no
+autokill. `CLONEKILL` (`CONF_AKILL_CLONES`) is the numeric threshold, so
+`CLONEKILL:0` leaves detection **on** and disables only the autokill.
+
+The consequence is the part a future reader will actually trip over: the e2e
+testnet now emits `Clones: N from …` globops where nothing was emitted before.
+Anyone who meets those lines and greps for a cause should land here. It is
+also why the bump was gated on the full e2e suite instead of a scoped
+`--grep`: a behaviour change, not a version bump.
+
+**The #1142 bats guard adapted with no edit**, which is what was predicted when
+it was written. `test/scripts/e2e_clone_directive_test.bats` reads the
+directive out of the template rather than naming it, so the accepted set became
+the numeric one on its own. Green alone proved nothing there, since `0` is
+valid for both directives — so the arm was pinned with a one-shot mutant:
+`"1"`, legal for `CLONES` (boolean 0|1) and illegal for `CLONEKILL` (0, or
+5..50). It kills exactly the third assertion and leaves the other two green.
+
+**Not proven, and deliberately recorded as such.** That the new globops reach
+grappa at all is unverified: it depends on the `+g` umode of an opered session,
+which no test asserts. In the full e2e gate run for this bump, `grep -a -i
+clones` over the 237 MB grappa container log returned **0**, with a sanity
+count of 126,802 `privmsg` lines from the same grep on the same file — so in
+that run they never appeared anywhere. That is one run's observation, not a
+general claim that the bump is inert.


### PR DESCRIPTION
Second half of #1066. The submodule half was fixed upstream in
`vjt/azzurra-testnet` (`687c73b`); this moves the superproject's pointer
onto it. Nothing in that repo was touched from here.

## This is a behaviour change, not a version bump

`cicchetto/e2e/compose.yaml` keeps `SVC_AKILL_CLONES: "0"`. The value does
not move — its **meaning** does, because the template now feeds it to a
different directive:

| | directive | kind | `0` means |
|---|---|---|---|
| before | `CLONES` (conf.c:782 → `CONF_SET_CLONE`) | boolean master switch | clone detection **off entirely** — no scan, no globops, no autokill |
| after | `CLONEKILL` (conf.c:936 → `CONF_AKILL_CLONES`) | numeric threshold | detection **on**, autokill disabled |

So the e2e testnet now emits `Clones: N from …` globops where it
previously emitted nothing. That is the state #349 actually wanted:
grappa is a bouncer opening every session from one container IP, so the
autokill cliff has to stay closed — but it should not be bought by
blinding the detector. #1078 will multiply the traffic further, since a
per-spec subject means one upstream session per test instead of a handful
for the whole suite.

Because it changes what the stack emits, this was gated on the **full**
e2e suite, not a scoped `--grep`.

## The #1142 guard adapted on its own

`test/scripts/e2e_clone_directive_test.bats` is **unchanged** and still
passes. It reads the directive out of the template instead of naming it,
precisely so the accepted set would become the numeric one without an
edit — the prediction made when it was written held.

Green alone would not have proved it was evaluating the new arm, since
`0` is valid for both directives. Verified with a one-shot mutant that
discriminates: `SVC_AKILL_CLONES: "1"` is **legal** for `CLONES` (boolean)
and **illegal** for `CLONEKILL` (0, or 5..50). It fails exactly one
assertion — "the value the e2e sets is one the directive it reaches
accepts" — and leaves the other two green. Mutant reverted, green
reconfirmed.

## Verification

- `test/scripts/e2e_clone_directive_test.bats` → 3/3, guard untouched
- full bats set → 383 ok / 0 failures
- upstream commit read rather than trusted: it touches only
  `services/conf.tmpl` (the directive line plus its comment) and
  `services/entrypoint.sh` (comment only)
- full e2e suite

## Not claimed

Whether the new globops actually reach grappa depends on the `+g` umode
of an opered session, which was not verified here — the at-risk spec list
used to plan the gate was an ordering, not a prediction of failures.