### PR TITLE
#1051: the wallpaper made the pane a stacking context, so 42 never met 41

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -173,7 +173,16 @@ export async function loginVisitor(
 // author-nick e2e. The runner talks to grappa directly on port 4000
 // (bypassing nginx), so these mirror the cic `themesApi` verbs without the
 // browser. Only the fields the spec asserts on are typed.
-export type ThemeWire = { id: number; author: string; built_in: boolean };
+export type ThemeWire = {
+  id: number;
+  author: string;
+  built_in: boolean;
+  // The sanitized token map (`Grappa.Themes.TokenModel`). Left as an open
+  // record: specs that need a palette COPY one off a built-in rather than
+  // spell 27 colour keys, so nothing here is read field-by-field except
+  // `background`, which #1051 rewrites.
+  payload: Record<string, unknown>;
+};
 
 export async function listGalleryThemes(token: string): Promise<ThemeWire[]> {
   const res = await fetch(`${GRAPPA_BASE_URL}/themes`, {
@@ -206,6 +215,80 @@ export async function publishTheme(token: string, id: number): Promise<ThemeWire
     throw new Error(`grappaApi.publishTheme: ${id} → ${res.status} ${await res.text()}`);
   }
   return (await res.json()) as ThemeWire;
+}
+
+// #1051 — give the running subject a theme that carries a WALLPAPER, and make
+// it active, before the browser boots. The wallpaper is what engages
+// `:root.theme-has-bg`, and that class is the variable the whole #1051
+// stacking-context defect turns on: a spec that never sets it measures the
+// half of the userbase that never had the bug.
+//
+// A `builtin` background (#294) rather than an upload: it resolves to a static
+// /backgrounds/<key>.webp the stack already serves, so the spec proves the
+// layer against a REAL image with no upload round-trip and no image bytes in
+// the repo. The palette is COPIED off a built-in theme's payload — 27 colour
+// keys spelled by hand in a fixture would be a second source of truth for the
+// token vocabulary, and would rot the day the model gains a key.
+//
+// Both verbs are subject-scoped writes on a subject `fixtures/test.ts`
+// provisions and destroys per test (#1078), so this spends no shared budget:
+// the theme-create daily quota is per-(bucket, subject, day) and the subject
+// is seconds old.
+export type BuiltinBackground = { key: string; name: string; variant: string; path: string };
+
+export async function listBuiltinBackgrounds(token: string): Promise<BuiltinBackground[]> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes/backgrounds`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.listBuiltinBackgrounds: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { backgrounds: BuiltinBackground[] };
+  return body.backgrounds;
+}
+
+// `builtinKey: null` is not a degenerate call — it is the CONTROL arm. Both
+// arms copy the SAME built-in palette, so a pair of themes differing only in
+// `background.builtin` isolates the wallpaper as the single variable between
+// two renders. Without that, a "with vs without wallpaper" comparison also
+// swaps 27 colours and proves nothing about the layer.
+export async function createThemeWithBuiltinBackground(
+  token: string,
+  name: string,
+  builtinKey: string | null,
+  opacity: number,
+): Promise<ThemeWire> {
+  const base = (await listGalleryThemes(token)).find((theme) => theme.built_in);
+  if (!base) {
+    throw new Error("grappaApi.createThemeWithBuiltinBackground: no built-in theme to copy");
+  }
+
+  const payload = {
+    ...base.payload,
+    background: { image_id: null, builtin: builtinKey, size: "cover", opacity },
+  };
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ name, payload }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `grappaApi.createThemeWithBuiltinBackground: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as ThemeWire;
+}
+
+export async function setActiveTheme(token: string, id: number): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/me/theme`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ light: id }),
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.setActiveTheme: ${id} → ${res.status} ${await res.text()}`);
+  }
 }
 
 // Admin deletes any theme (owner|admin authz) — teardown for the re-homed

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -280,14 +280,25 @@ export async function createThemeWithBuiltinBackground(
   return (await res.json()) as ThemeWire;
 }
 
-export async function setActiveTheme(token: string, id: number): Promise<void> {
+// The #358 pair, both slots explicit. `dark: null` is the single pick (the
+// light theme paints in both modes); a distinct dark id makes the OS
+// colour-scheme media query a LIVE toggle between two payloads, with no reload
+// and no navigation — the only way to change one visual variable in a running
+// page without also changing everything a reload changes.
+export async function setActiveTheme(
+  token: string,
+  light: number,
+  dark: number | null,
+): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/me/theme`, {
     method: "PUT",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-    body: JSON.stringify({ light: id }),
+    body: JSON.stringify({ light, dark }),
   });
   if (!res.ok) {
-    throw new Error(`grappaApi.setActiveTheme: ${id} → ${res.status} ${await res.text()}`);
+    throw new Error(
+      `grappaApi.setActiveTheme: ${light}/${dark} → ${res.status} ${await res.text()}`,
+    );
   }
 }
 

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -13,16 +13,28 @@
 // vjt's ruling: the card wins, because if a card is open the intent is to close
 // it, and closing it uncovers the ☰ anyway.
 //
-// WHY AN E2E. The stacking NUMBERS are pinned in
-// `src/__tests__/shellChromeFloat.test.ts` — including the guard that fails if
-// the overlay ever drops back under the float, which the pre-existing
-// `40 < z(.shell-chrome) < 89` assertion could not do. What a source-level
-// guard cannot answer is the one thing the operator felt: which element is
-// actually under the finger. jsdom has no layout engine and no hit testing.
+// #1051 REOPENED — WHY THIS FILE HAS TWO ARMS. Raising the overlay to 42 fixed
+// the reporter's corner for half the userbase and did nothing for the other
+// half, and the variable is the themed background image. The #75 wallpaper
+// block declared `:root.theme-has-bg .scrollback-pane { isolation: isolate }`,
+// which makes the pane a STACKING CONTEXT: the overlay's 42 then resolves
+// inside that context and never meets `.shell-chrome` at all — what meets it is
+// the pane, at `z-index: auto`, and the ☰ wins no matter how high 42 goes.
+// The first arm below is the configuration that was already green; the second
+// is the one vjt was actually in. A single-arm spec measured the half that
+// never had the bug — which is exactly how a green suite shipped this twice.
+//
+// WHY AN E2E, AND WHY THE NUMBERS ARE NOT ENOUGH. The stacking NUMBERS are
+// pinned in `src/__tests__/shellChromeFloat.test.ts`, which regex-extracts them
+// from the stylesheet TEXT. Both numbers were correct throughout the defect and
+// the assertion passed the whole time: no text-level assertion can observe a
+// stacking context, because a stacking context is not written next to the
+// numbers it invalidates. It takes a rendered DOM, a real hit test, and the
+// wallpaper class actually engaged.
 //
 // WHY A QUERY WINDOW and not the `$server` one vjt reported from: the issue's
 // own measurement says the radius is EVERY non-channel window — the gate is
-// `Shell.tsx:920`, not a server-specific branch — and the query window has a
+// `Shell.tsx:913`, not a server-specific branch — and the query window has a
 // proven mobile driver in `issue985-mobile-floating-opener`. Same branch, same
 // float, fewer moving parts.
 //
@@ -38,27 +50,56 @@ import {
   selectChannel,
   waitForQueryWindowReady,
 } from "../fixtures/cicchettoPage";
+import {
+  createThemeWithBuiltinBackground,
+  listBuiltinBackgrounds,
+  setActiveTheme,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const PEER = `F1051${crypto.randomUUID().slice(0, 7)}`;
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-test.setTimeout(90_000);
+type PWPage = import("@playwright/test").Page;
 
-test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost element at its own coordinates", async ({
-  page,
-}) => {
-  const vjt = specUser();
-  await loginAs(page, vjt);
+test.setTimeout(120_000);
+
+// Activate a theme carrying a real built-in wallpaper for the running subject,
+// BEFORE the browser boots — `applyCustomTheme` engages `theme-has-bg` off the
+// `GET /me/theme` the shell fetches at start-up, so setting it after the load
+// would race the very class the arm is about. Returns nothing: the class is the
+// contract, and every caller asserts it on the page rather than trusting this.
+async function activateWallpaperTheme(
+  token: string,
+  label: string,
+  opacity: number,
+): Promise<void> {
+  const backgrounds = await listBuiltinBackgrounds(token);
+  const first = backgrounds[0];
+  if (!first) {
+    throw new Error("#1051 — the built-in background catalog is empty");
+  }
+  const theme = await createThemeWithBuiltinBackground(token, label, first.key, opacity);
+  await setActiveTheme(token, theme.id);
+}
+
+// The shared body of both arms: open a WHOIS card on a query window and prove
+// the ✕ is the element under the finger at its own centre. Written once and
+// called twice because the two arms differ ONLY in whether a wallpaper theme is
+// active — a copied body would let the arms drift and hide the asymmetry the
+// whole reopen was about.
+async function assertCardCloseWinsItsCorner(page: PWPage): Promise<void> {
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const peer = await IrcPeer.connect({ nick: PEER });
+  const peer = await IrcPeer.connect({ nick: `F1051${crypto.randomUUID().slice(0, 7)}` });
   try {
     await peer.join(CHANNEL);
-    await composeSend(page, `/q ${PEER}`);
-    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+    // The LIVE nick, not the requested one: #604's collision hardening may have
+    // renamed the peer, and a /q at the constant would open a window nobody is
+    // in (feedback_live_nick_is_authoritative_not_the_constant).
+    await composeSend(page, `/q ${peer.nick}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, peer.nick);
 
     // PRECONDITION — we are on the NON-channel branch, the only one that
     // floats the ☰. Without this the whole test could pass on a channel
@@ -68,7 +109,7 @@ test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost el
     const opener = page.getByTestId("shell-chrome-rail-opener");
     await expect(opener).toBeVisible({ timeout: 10_000 });
 
-    await composeSend(page, `/whois ${PEER}`);
+    await composeSend(page, `/whois ${peer.nick}`);
     const card = page.locator(".scrollback-overlay").getByTestId("whois-card");
     await expect(card).toBeVisible({ timeout: 15_000 });
 
@@ -119,4 +160,124 @@ test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost el
   } finally {
     await peer.disconnect("i1051 cleanup").catch(() => {});
   }
+}
+
+test("@webkit #1051 — with no background theme the card's ✕ is the topmost element at its own coordinates", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  // The arm's own premise: NO wallpaper, so the pane is not a stacking context
+  // and the overlay's 42 meets `.shell-chrome`'s 41 directly. Asserted rather
+  // than assumed — a future default theme carrying a background would silently
+  // turn this into a second copy of the arm below.
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+
+  await assertCardCloseWinsItsCorner(page);
+});
+
+test("@webkit #1051 — with a background theme active the card's ✕ still wins its own corner", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await activateWallpaperTheme(vjt.token, `e2e-1051-${vjt.name}`, 0.3);
+  await loginAs(page, vjt);
+
+  // The arm's premise, and the variable the reopen turned on: the class that
+  // used to make `.scrollback-pane` a stacking context is engaged. If this ever
+  // stops engaging, the arm degrades into a duplicate of the one above and must
+  // fail loudly rather than pass cheaply.
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+
+  await assertCardCloseWinsItsCorner(page);
+});
+
+// The other half of the #1051 fix, and the one the candidate measurement on the
+// issue explicitly could NOT make: dropping `isolation: isolate` is only a fix
+// if the wallpaper it was written for still paints, and still paints BEHIND the
+// message text. A hit-test arm cannot see that — an invisible wallpaper, or one
+// painting over the conversation, would leave both arms above green.
+//
+// Measured at opacity 1.0 rather than the 0.3 default, deliberately: at full
+// strength "the layer is under the text" and "the layer is over the text" are
+// the difference between a readable channel and a blank photo, so the oracle
+// below does not have to reason about blending.
+test("@webkit #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  const backgrounds = await listBuiltinBackgrounds(vjt.token);
+  const first = backgrounds[0];
+  if (!first) {
+    throw new Error("#1051 — the built-in background catalog is empty");
+  }
+
+  // CONTROL and SUBJECT differ in ONE field. Both copy the same built-in
+  // palette; only `background.builtin` changes. A control that also swapped 27
+  // colours would make the pixel diff below unattributable.
+  const control = await createThemeWithBuiltinBackground(
+    vjt.token,
+    `e2e-1051-nobg-${vjt.name}`,
+    null,
+    1,
+  );
+  const wallpapered = await createThemeWithBuiltinBackground(
+    vjt.token,
+    `e2e-1051-bg-${vjt.name}`,
+    first.key,
+    1,
+  );
+
+  await setActiveTheme(vjt.token, control.id);
+  await loginAs(page, vjt);
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const scrollback = page.locator(".scrollback");
+  await expect(scrollback).toBeVisible();
+  const withoutWallpaper = await scrollback.screenshot({ animations: "disabled" });
+
+  await setActiveTheme(vjt.token, wallpapered.id);
+  await page.reload();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(scrollback).toBeVisible();
+
+  // The layer is wired to the theme at all — the #294 assertion, kept because
+  // a wallpaper that never resolved its URL would make every pixel claim below
+  // vacuous for a reason that has nothing to do with stacking.
+  const layerImage = await page.evaluate(() => {
+    const pane = document.querySelector(".scrollback-pane");
+    return pane ? getComputedStyle(pane, "::before").backgroundImage : "";
+  });
+  expect(layerImage).toContain("/backgrounds/");
+
+  const withWallpaper = await scrollback.screenshot({ animations: "disabled" });
+
+  // CLAIM 1 — the wallpaper actually PAINTS. Same palette, same conversation,
+  // same element: the only difference between the two renders is the layer.
+  expect(
+    withWallpaper.equals(withoutWallpaper),
+    "#1051 — an opaque wallpaper must change what the scrollback area paints",
+  ).toBe(false);
+
+  // ORACLE CONTROL. Two shots of an untouched pane must be byte-identical, or
+  // "the pixels differed" below means nothing — a caret, a CRT flicker or a
+  // ticking timestamp inside this element would make CLAIM 2 pass on noise.
+  const withWallpaperAgain = await scrollback.screenshot({ animations: "disabled" });
+  expect(
+    withWallpaperAgain.equals(withWallpaper),
+    "#1051 — the scrollback must render deterministically for the pixel oracle to discriminate",
+  ).toBe(true);
+
+  // CLAIM 2 — the conversation paints ABOVE the opaque wallpaper. If the layer
+  // covered the text, the pane would be pure photograph and a new message would
+  // change nothing at all.
+  const marker = `i1051 wallpaper witness ${crypto.randomUUID().slice(0, 8)}`;
+  await composeSend(page, marker);
+  await expect(scrollback.getByText(marker, { exact: false })).toBeVisible({ timeout: 15_000 });
+  const afterMessage = await scrollback.screenshot({ animations: "disabled" });
+  expect(
+    afterMessage.equals(withWallpaper),
+    "#1051 — a message arriving must be visible over the wallpaper, not buried under it",
+  ).toBe(false);
 });

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -81,7 +81,9 @@ async function activateWallpaperTheme(
     throw new Error("#1051 — the built-in background catalog is empty");
   }
   const theme = await createThemeWithBuiltinBackground(token, label, first.key, opacity);
-  await setActiveTheme(token, theme.id);
+  // Single pick: the same wallpapered theme paints in both OS modes, so this
+  // arm cannot depend on which scheme the runner happens to boot in.
+  await setActiveTheme(token, theme.id, null);
 }
 
 // The shared body of both arms: open a WHOIS card on a query window and prove
@@ -200,7 +202,20 @@ test("@webkit #1051 — with a background theme active the card's ✕ still wins
 // Measured at opacity 1.0 rather than the 0.3 default, deliberately: at full
 // strength "the layer is under the text" and "the layer is over the text" are
 // the difference between a readable channel and a blank photo, so the oracle
-// below does not have to reason about blending.
+// does not have to reason about blending.
+//
+// HOW THE WALLPAPER IS TOGGLED, and why not with a reload. The first version
+// of this test screenshotted the pane before and after a `page.reload()` that
+// swapped the active theme, and it was a FALSE GREEN: mutating the wallpaper to
+// `opacity: 0` — invisible, the exact failure the claim exists to catch — still
+// produced two different images, because a reload changes the pane for reasons
+// of its own. So the swap now rides the #358 day/night pair instead: the light
+// slot is the control theme, the dark slot the wallpapered one, and
+// `emulateMedia` flips between them LIVE — same document, same scroll offset,
+// same conversation, one variable. The base `[data-theme]` block an OS flip
+// also swaps declares exactly the 27 colour vars the custom payload overrides,
+// so the flip is inert on everything except the layer under test; PHASE A
+// measures that rather than asserting it.
 test("@webkit #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
   page,
 }) => {
@@ -227,23 +242,45 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
     1,
   );
 
-  await setActiveTheme(vjt.token, control.id);
-  await loginAs(page, vjt);
-  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
-  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
-
   const scrollback = page.locator(".scrollback");
-  await expect(scrollback).toBeVisible();
-  const withoutWallpaper = await scrollback.screenshot({ animations: "disabled" });
+  const shoot = () => scrollback.screenshot({ animations: "disabled" });
+  const isDark = () => page.evaluate(() => document.documentElement.dataset.theme === "irssi-dark");
 
-  await setActiveTheme(vjt.token, wallpapered.id);
-  await page.reload();
-  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+  // PHASE A — the oracle's own control. Both slots hold the CONTROL theme, so
+  // the light→dark flip changes the OS scheme and nothing else. If these two
+  // images are not byte-identical, the flip is not inert and every difference
+  // measured in phase B would be unattributable — this must fail LOUDLY rather
+  // than let phase B pass on the flip's own noise.
+  await setActiveTheme(vjt.token, control.id, control.id);
+  await page.emulateMedia({ colorScheme: "light" });
+  await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await expect(scrollback).toBeVisible();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
 
-  // The layer is wired to the theme at all — the #294 assertion, kept because
-  // a wallpaper that never resolved its URL would make every pixel claim below
+  const controlLight = await shoot();
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect.poll(isDark, { timeout: 10_000 }).toBe(true);
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  expect(
+    (await shoot()).equals(controlLight),
+    "#1051 — the OS-scheme flip must be inert under one theme, or it cannot isolate the wallpaper",
+  ).toBe(true);
+
+  // PHASE B — same flip, but now the dark slot carries the wallpaper.
+  await setActiveTheme(vjt.token, control.id, wallpapered.id);
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.reload();
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(scrollback).toBeVisible();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  const withoutWallpaper = await shoot();
+
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 10_000 });
+
+  // The layer is wired to the theme at all — the #294 assertion, kept because a
+  // wallpaper that never resolved its URL would make every pixel claim below
   // vacuous for a reason that has nothing to do with stacking.
   const layerImage = await page.evaluate(() => {
     const pane = document.querySelector(".scrollback-pane");
@@ -251,23 +288,14 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
   });
   expect(layerImage).toContain("/backgrounds/");
 
-  const withWallpaper = await scrollback.screenshot({ animations: "disabled" });
+  const withWallpaper = await shoot();
 
-  // CLAIM 1 — the wallpaper actually PAINTS. Same palette, same conversation,
-  // same element: the only difference between the two renders is the layer.
+  // CLAIM 1 — the wallpaper actually PAINTS. Phase A established that the flip
+  // alone changes nothing, so the difference is the layer and only the layer.
   expect(
     withWallpaper.equals(withoutWallpaper),
     "#1051 — an opaque wallpaper must change what the scrollback area paints",
   ).toBe(false);
-
-  // ORACLE CONTROL. Two shots of an untouched pane must be byte-identical, or
-  // "the pixels differed" below means nothing — a caret, a CRT flicker or a
-  // ticking timestamp inside this element would make CLAIM 2 pass on noise.
-  const withWallpaperAgain = await scrollback.screenshot({ animations: "disabled" });
-  expect(
-    withWallpaperAgain.equals(withWallpaper),
-    "#1051 — the scrollback must render deterministically for the pixel oracle to discriminate",
-  ).toBe(true);
 
   // CLAIM 2 — the conversation paints ABOVE the opaque wallpaper. If the layer
   // covered the text, the pane would be pure photograph and a new message would
@@ -275,9 +303,8 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
   const marker = `i1051 wallpaper witness ${crypto.randomUUID().slice(0, 8)}`;
   await composeSend(page, marker);
   await expect(scrollback.getByText(marker, { exact: false })).toBeVisible({ timeout: 15_000 });
-  const afterMessage = await scrollback.screenshot({ animations: "disabled" });
   expect(
-    afterMessage.equals(withWallpaper),
+    (await shoot()).equals(withWallpaper),
     "#1051 — a message arriving must be visible over the wallpaper, not buried under it",
   ).toBe(false);
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2664,9 +2664,12 @@ html.resize-dragging * {
    the cards undismissable on a non-channel window: `.shell-chrome` floats its
    lone ☰ over the pane's top-RIGHT corner (#985) at 41, each card puts its ✕
    in that same corner (`margin-left: auto` in the card header), and 41 > 5, so
-   the ☰ won the hit test. 42 is the whole fix — vjt's ruling is that the card
-   wins, because if a card is open the intent is to close it, and closing it
-   uncovers the ☰ anyway. Ceiling is NOT the 89/90 drawer tier: `.toast-stack`
+   the ☰ won the hit test. vjt's ruling is that the card wins, because if a card
+   is open the intent is to close it, and closing it uncovers the ☰ anyway.
+   42 is only HALF the fix, and shipping it alone is why #1051 was reopened: a
+   number can only decide a hit test between elements in the SAME stacking
+   context, and the #75 wallpaper block used to make `.scrollback-pane` one (see
+   that block — it no longer does). Ceiling is NOT the 89/90 drawer tier: `.toast-stack`
    sits at 60 and must keep painting over a card, or a toast raised while a
    WHOIS is up is invisible. Consequence worth stating, since 42 also clears
    `.scrollback-float-stack` (40): a full-height card now covers the
@@ -8587,14 +8590,34 @@ html.resize-dragging * {
  * + chrome stay solid for legibility, and the ComposeBox (a sibling OUTSIDE
  * the pane) stays opaque. Gated on the `theme-has-bg` class
  * (applyCustomTheme) because CSS can't branch on the var being "none".
- * `isolation` makes the pane a stacking context so the ::before layer sits
- * below the (transparent) scrollback text but above the pane backdrop.
  * NEVER an <img> — the text-only-scrollback rule holds; this is a CSS
- * background-image only. */
-:root.theme-has-bg .scrollback-pane {
-  isolation: isolate;
-}
-
+ * background-image only.
+ *
+ * THE PANE MUST NOT BECOME A STACKING CONTEXT (#1051). The two rules below
+ * order the layer explicitly — `::before` at 0, `.scrollback` at 1 — and this
+ * block used to ALSO declare `isolation: isolate` here. That ordered these two
+ * correctly, and trapped every other z-index in the pane while doing it: the
+ * #133 pinned card overlay (42) stopped competing with the floated ☰ in
+ * `.shell-chrome` (41) and the pane itself competed instead, at `z-index:
+ * auto`. The ☰ therefore won the pane's top-right corner unconditionally and
+ * the WHOIS / WHOWAS / LUSERS ✕ that lives in that same corner could not be
+ * tapped — but ONLY for operators running a background image, which is why
+ * raising the overlay's number twice fixed the corner for half the userbase
+ * and did nothing for the other half. Do NOT reintroduce `isolation` here, nor
+ * `contain` / `filter` / `opacity` / `transform` / `will-change`: each of them
+ * re-creates the context and puts the card back under the ☰.
+ *
+ * What isolation was buying, and how it is paid for now: `::before` is
+ * positioned, so it paints above the pane's in-flow content unless that
+ * content is lifted — hence `.scrollback` at 1, which is a rule in its own
+ * right and not decoration. The tempting alternative, `::before` at -1, is the
+ * one shape that genuinely NEEDS a stacking context: resolved against the root
+ * instead, a negative layer slides under the shell's opaque background and the
+ * wallpaper disappears. Guarded by
+ * `e2e/tests/issue1051-card-close-above-float.spec.ts` — its second arm runs
+ * with a wallpaper theme active, and its third asserts the wallpaper still
+ * paints and still paints behind the conversation. No source-level assertion
+ * can see a stacking context, which is how this shipped twice. */
 :root.theme-has-bg .scrollback-pane::before {
   content: "";
   position: absolute;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -8611,9 +8611,12 @@ html.resize-dragging * {
  * positioned, so it paints above the pane's in-flow content unless that
  * content is lifted — hence `.scrollback` at 1, which is a rule in its own
  * right and not decoration. The tempting alternative, `::before` at -1, is the
- * one shape that genuinely NEEDS a stacking context: resolved against the root
- * instead, a negative layer slides under the shell's opaque background and the
- * wallpaper disappears. Guarded by
+ * one shape that genuinely NEEDS a stacking context, and it was measured
+ * rather than reasoned about: mutated to -1, the guard's pixel oracle reports
+ * the wallpaper stops painting altogether — resolved against the root the
+ * negative layer lands under an opaque box the isolated pane used to keep it
+ * above. Which box was not established and is not the point; -1 is simply not
+ * available here. Guarded by
  * `e2e/tests/issue1051-card-close-above-float.spec.ts` — its second arm runs
  * with a wallpaper theme active, and its third asserts the wallpaper still
  * paints and still paints behind the conversation. No source-level assertion

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36219,3 +36219,102 @@ clones` over the 237 MB grappa container log returned **0**, with a sanity
 count of 126,802 `privmsg` lines from the same grep on the same file — so in
 that run they never appeared anywhere. That is one run's observation, not a
 general claim that the bump is inert.
+
+---
+
+### 2026-08-09 — #1051 — a z-index cannot decide a hit test across a stacking context
+
+**The report that outlived its own fix.** The floated ☰ (#985) overflows a
+zero-height row into the pane's top-right corner; the #133 pinned lookup cards
+(WHOIS / WHOWAS / LUSERS) put their ✕ in that same corner. `c9333004` raised
+`.scrollback-overlay` from 5 to 42, over `.shell-chrome`'s 41, and shipped in
+v0.15.0 — and the person who filed the issue still could not tap the ✕.
+
+**Cause.** `:root.theme-has-bg .scrollback-pane { isolation: isolate }`, three
+thousand lines away in the #75 wallpaper block. `isolation` makes the pane a
+stacking context, so the overlay's 42 resolves INSIDE the pane and never meets
+`.shell-chrome`. What meets it is the pane, at `z-index: auto` — so the ☰ wins
+at any number the overlay could carry. The class is present only for operators
+running a background image. That is the whole shape of the incident: the same
+build was fixed for half the userbase and untouched for the other half, and
+every re-measurement that did not toggle that one class read green.
+
+**The general rule, which is why this is written down.** A z-index comparison
+is meaningful only between two elements in the same stacking context, and CSS
+gives no warning when they are not. The declaration that creates the context —
+`isolation`, `contain`, `filter`, `opacity`, `transform`, `will-change`, or a
+positioned ancestor carrying any z-index — is normally written in another
+block, for another feature, by someone who never heard of the two numbers it
+silently invalidates. When a z-index "does not work", the first question is
+which context it resolved in, not which number it should have been.
+
+**Fix.** Drop the isolation. The block already carried the two rules that do
+the ordering — `::before` at 0, `.scrollback` at 1 — and against the root they
+resolve in the same relative order they did inside the isolated pane, so the
+wallpaper is unchanged and the overlay is free to outrank the chrome.
+Rejected: keeping the isolation and moving the overlay or the ☰ so the two
+share a context. That is DOM surgery in `Shell.tsx` for a one-declaration
+cause, and it leaves the trap armed for the next in-pane layer that needs to
+outrank the chrome. Not available: `::before` at -1 (see below).
+
+**Why a green suite shipped it twice.** `src/__tests__/shellChromeFloat.test.ts`
+regex-extracts the two z-index values from the stylesheet TEXT and compares
+them. Both values were correct throughout the defect and the assertion passed
+the whole time. No text-level assertion can observe a stacking context: the
+declaration that creates one is not written next to the numbers it breaks, and
+a regex has no notion of an ancestor. The vitest file is kept — the numbers are
+still a contract — but it is not the guard.
+
+**Guard, and the matrix that makes it one.**
+`cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts` runs one shared
+body twice, parametrised on whether a theme carrying a real built-in wallpaper
+is active before boot; each arm asserts its own premise (`html.theme-has-bg`
+absent / present) so neither can decay into a copy of the other. Measured on
+`webkit-iphone-15`:
+
+| | no-wallpaper arm | wallpaper arm |
+|---|---|---|
+| before the fix | pass | **fail** — `elementFromPoint` at the ✕'s centre returns `.shell-chrome-rail-opener` |
+| after the fix | pass | pass |
+
+**The half the fix put at risk.** Removing the isolation is a fix only if the
+wallpaper still paints and still paints BEHIND the conversation, which no hit
+test can see. A third test measures it in pixels at opacity 1.0, where "behind"
+and "in front" are the difference between a readable channel and a blank
+photograph. The wallpaper is toggled by the #358 day/night pair — control theme
+in the light slot, wallpapered theme in the dark slot, `emulateMedia` flipping
+between them live — so the two renders share a document, a scroll offset and a
+conversation, and differ in one variable. Both themes copy the same built-in
+palette, so only `background.builtin` changes; and a first phase runs the same
+flip with the control theme in BOTH slots and requires the two images to be
+byte-identical, which measures the flip's inertness instead of arguing it.
+
+**The oracle was wrong first, and that is the reusable part.** The original
+version compared screenshots either side of a `page.reload()` that swapped the
+theme. Mutating the layer to `opacity: 0` — an invisible wallpaper, the exact
+failure the claim exists to catch — left it GREEN: a reload changes the pane
+for reasons of its own, so the difference was never attributable. A pixel
+oracle whose two samples straddle a navigation is not measuring the variable
+it names.
+
+Mutations run against the corrected oracle, each killing exactly one assertion:
+
+* `::before { opacity: 0 }` → only *"an opaque wallpaper must change what the
+  scrollback area paints"* fails.
+* `::before { z-index: 2 }` → the layer buries the text; only *"a message
+  arriving must be visible over the wallpaper"* fails, with the first claim and
+  the inertness phase passing on the way.
+* `::before { z-index: -1 }` → the first claim fails: the wallpaper stops
+  painting entirely. So -1 really is the shape that needs the stacking context
+  this change removes, and it is off the table. (Under the pre-correction
+  oracle this same mutation read green — the retraction is the point.)
+
+**What is NOT established.** The e2e is `webkit-iphone-15` only, because the
+float is mobile-only; the desktop shell never mounts it, which is an argument
+from `Shell.tsx`, not a measurement. The pixel claims cover ONE catalogue
+background at opacity 1.0 on one viewport — nothing here says anything about
+blending at the 0.3 default or about the other thirteen entries. Nothing here
+was verified against a production install. And #1042 — whether the pane's
+top-right corner is a contract for every window kind — is still open and still
+untouched: #1050 denies the rail to one window kind, #1051 lets a card cover
+the ☰, and neither settles the question.


### PR DESCRIPTION
## What was wrong

`c9333004` raised `.scrollback-overlay` from 5 to 42, over `.shell-chrome`'s
41, and shipped in v0.15.0. The reporter still could not tap the ✕ of a WHOIS
card on a non-channel window.

The number was never the deciding factor. `:root.theme-has-bg
.scrollback-pane { isolation: isolate }` — the #75 wallpaper block, three
thousand lines away — makes the pane a **stacking context**, so the overlay's
42 resolves inside the pane and never meets `.shell-chrome` at all. What meets
it is the pane, at `z-index: auto`, and the ☰ therefore wins the corner at any
number the overlay could carry.

That class is present only for operators running a background image, which is
the whole shape of this incident: one build, fixed for half the userbase,
untouched for the other half, with every re-measurement that did not toggle
that one class reading green.

## The change

Drop the isolation. The block already carried the two rules that do the
ordering — `::before` at 0, `.scrollback` at 1 — and against the root they
resolve in the same relative order they did inside the isolated pane. The
wallpaper is unchanged; the overlay is free to outrank the chrome.

Rejected: keeping the isolation and moving the overlay or the ☰ so the two
share a context. DOM surgery in `Shell.tsx` for a one-declaration cause, and it
leaves the trap armed for the next in-pane layer that has to outrank the
chrome.

Not available: `::before { z-index: -1 }`. Measured, not assumed — see below.

## Why the guard had to change too

`src/__tests__/shellChromeFloat.test.ts` regex-extracts the two z-index values
from the stylesheet text and compares them. Both were correct throughout the
defect and the assertion passed the whole time. No text-level assertion can
observe a stacking context. That file stays (the numbers are still a contract)
but it is not the guard.

`e2e/tests/issue1051-card-close-above-float.spec.ts` now runs one shared body
twice, parametrised on whether a theme carrying a real built-in wallpaper is
active before boot. Each arm asserts its own premise (`html.theme-has-bg`
absent / present) so neither can decay into a copy of the other.

Measured on `webkit-iphone-15`:

| | no-wallpaper arm | wallpaper arm |
|---|---|---|
| before the CSS change | pass | **fail** — `elementFromPoint` at the ✕'s centre returns `.shell-chrome-rail-opener` |
| after | pass | pass |

## The half the fix put at risk

Removing the isolation is a fix only if the wallpaper still paints, and still
paints behind the conversation — which no hit test can see. A third test
measures it in pixels at opacity 1.0, toggling the wallpaper through the #358
day/night pair (`emulateMedia` flips light↔dark live: same document, same
scroll offset, one variable). Both themes copy the same built-in palette, so
only `background.builtin` differs, and a first phase runs the identical flip
with the control theme in *both* slots and requires byte-identical images —
measuring the flip's inertness instead of asserting it.

The first version of that oracle compared screenshots either side of a
`page.reload()` and was a **false green**: mutating the layer to `opacity: 0`
still passed it, because a reload changes the pane for reasons of its own. The
corrected oracle was then re-mutated, each mutation killing exactly one
assertion:

- `::before { opacity: 0 }` → only *"an opaque wallpaper must change what the scrollback area paints"* fails.
- `::before { z-index: 2 }` → only *"a message arriving must be visible over the wallpaper"* fails.
- `::before { z-index: -1 }` → the first claim fails; the wallpaper stops painting entirely. That mutation read **green** under the pre-correction oracle, which is why -1 is ruled out on measurement rather than on reasoning.

## What this does not establish

- `webkit-iphone-15` only — the float is mobile-only, and that the desktop shell never mounts it is an argument from `Shell.tsx`, not a measurement.
- The pixel claims cover one catalogue background at opacity 1.0 on one viewport. Nothing here speaks to blending at the 0.3 default or to the other thirteen entries.
- Nothing was verified against a production install.
- #1042 stays open and untouched: whether the pane's top-right corner is a contract for every window kind is still undecided.