### PR TITLE
fix(#1163): an admin credential bind dials the upstream

### DIFF
--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -11,10 +11,31 @@
 // That spec binds against networks it creates with `POST /admin/networks` and
 // no server row. A server-less network fails plan resolution, so even the
 // FIXED code does not dial there — the scenario is blind to this bug by
-// construction. This spec therefore adds the one thing that was missing: an
-// enabled server, pointed at the same `bahamut-test:6667` testnet the seeder
-// uses. Everything else stays throwaway (own user, own network, own nick), so
-// nothing here touches the seeded vjt / m9b credentials other specs depend on.
+// construction. What this spec needs, and it has to get it somewhere, is a
+// network with an ENABLED SERVER.
+//
+// ## Why it borrows the seeded network instead of building its own
+//
+// The first version of this spec built a throwaway network and attached a
+// server to it. It passed — and 26 minutes later, in the same run, it failed
+// two assertions in `ux-6-g-admin-mobile-h-scroll.spec.ts`, which measures
+// that no admin table is wider than a phone panel: 393px against a 365px
+// panel, 28px of overflow, read identically by that spec's scrollLeft clamp.
+//
+// The throwaway network could not be deleted. `Networks.delete_network/1`
+// refuses a network that has scrollback, and this is the only spec whose
+// network gets a LIVE session — the moment it dials, the server's `$server`
+// notices are persisted against that network. The teardown's DELETE was
+// refused, the best-effort `catch` swallowed the refusal, and a row with a
+// 27-character slug sat in the Networks tab for the rest of the run
+// (`workers: 1`, so every later spec saw it). The width failure was this
+// spec's leak, arriving late and wearing another spec's name.
+//
+// So it binds a throwaway USER to the SEEDED `bahamut-test` network instead.
+// That network is already in the Networks tab and the baseline already fits
+// it, so this spec adds nothing to any measured table. The seeded vjt / m9b
+// CREDENTIALS other specs depend on are untouched: a second credential on the
+// same network is additive, and unbind removes it and stops its session.
 //
 // ## The oracle
 //
@@ -35,14 +56,8 @@
 
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { getSeededAdmin } from "../fixtures/seedData";
+import { getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-// The testnet endpoint the compose seeder binds `vjt` to. Reaching it by its
-// docker alias is what makes the spawn real: a dial that resolves, connects
-// and registers.
-const TESTNET_HOST = "bahamut-test";
-const TESTNET_PORT = 6667;
 
 type Admin = ReturnType<typeof getSeededAdmin>;
 
@@ -82,35 +97,64 @@ async function createUser(token: string, name: string): Promise<string> {
   return ((await res.json()) as { id: string }).id;
 }
 
-async function createNetwork(token: string, slug: string): Promise<number> {
-  const res = await api(token, "POST", "/admin/networks", { slug });
-  if (!res.ok) throw new Error(`createNetwork: ${slug} → ${res.status}`);
-  return ((await res.json()) as { id: number }).id;
+// The seeded network is the one with an enabled server (`bahamut-test:6667`),
+// which is the whole reason this spec can dial at all. Resolved by slug rather
+// than hardcoded: the id is assigned by whichever order the seeder ran in.
+async function seededNetworkId(token: string): Promise<number> {
+  const res = await api(token, "GET", "/admin/networks");
+  if (!res.ok) throw new Error(`seededNetworkId: ${res.status}`);
+  const body = (await res.json()) as { networks: { id: number; slug: string }[] };
+  const net = body.networks.find((n) => n.slug === NETWORK_SLUG);
+  if (net === undefined) throw new Error(`seededNetworkId: no network ${NETWORK_SLUG}`);
+  return net.id;
 }
 
-// The step that separates this spec from the existing bind coverage: without
-// an enabled server the bind cannot dial even when the code is correct.
-async function addTestnetServer(token: string, networkId: number): Promise<void> {
-  const res = await api(token, "POST", `/admin/networks/${networkId}/servers`, {
-    host: TESTNET_HOST,
-    port: TESTNET_PORT,
-    tls: false,
-  });
-  if (!res.ok) throw new Error(`addTestnetServer: ${networkId} → ${res.status}`);
-}
-
-// Unbind is the teardown that matters: it stops the live session, so the
-// throwaway upstream connection does not outlive the test and count against
-// the next one. Best-effort — a failed cleanup must not mask the verdict.
-async function cleanup(token: string, userId: string | null, networkId: number | null) {
+// Unbind is the teardown that matters: it stops the live session this spec
+// started, so the upstream connection does not outlive the test.
+//
+// It reports instead of swallowing. A silent best-effort teardown is what
+// turned the first version of this spec into a cascade poisoner — the cleanup
+// was refused, said nothing, and a later spec paid for it. A leak here cannot
+// be allowed to fail the test (that would mask the real verdict), so it lands
+// as a test annotation: visible in the report, attached to the spec that
+// caused it, and not to the one that trips over it 26 minutes later.
+async function unbind(
+  token: string,
+  userId: string,
+  networkId: number,
+  testInfo: import("@playwright/test").TestInfo,
+): Promise<void> {
   try {
-    if (userId !== null && networkId !== null) {
-      await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    const res = await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    if (!res.ok) {
+      testInfo.annotations.push({
+        type: "leak",
+        description: `unbind ${userId}:${networkId} → ${res.status}; a live session may survive this spec`,
+      });
     }
-    if (networkId !== null) await api(token, "DELETE", `/admin/networks/${networkId}`);
-    if (userId !== null) await api(token, "DELETE", `/admin/users/${userId}`);
-  } catch {
-    // best-effort
+  } catch (err) {
+    testInfo.annotations.push({ type: "leak", description: `unbind threw: ${String(err)}` });
+  }
+}
+
+// The user carries this spec's scrollback (the `$server` notices its session
+// receives), which CASCADEs away with the row. Deleting the user is therefore
+// what keeps the seeded network free of this spec's residue.
+async function deleteUser(
+  token: string,
+  userId: string,
+  testInfo: import("@playwright/test").TestInfo,
+): Promise<void> {
+  try {
+    const res = await api(token, "DELETE", `/admin/users/${userId}`);
+    if (!res.ok) {
+      testInfo.annotations.push({
+        type: "leak",
+        description: `deleteUser ${userId} → ${res.status}; a throwaway user survives this spec`,
+      });
+    }
+  } catch (err) {
+    testInfo.annotations.push({ type: "leak", description: `deleteUser threw: ${String(err)}` });
   }
 }
 
@@ -125,18 +169,15 @@ test("admin binds a credential from the console and the session dials out", asyn
   // repeat indices disambiguate runs that land in the same millisecond.
   const stamp = `${Date.now()}-${testInfo.workerIndex}-${testInfo.repeatEachIndex}`;
   const userName = `e2e1163-u-${stamp}`;
-  const netSlug = `e2e1163-n-${stamp}`;
   // An IRC nick caps at 30 chars, so the stamp is shortened here rather than
   // reused whole.
   const nick = `b1163-${Date.now() % 1_000_000}-${testInfo.workerIndex}${testInfo.repeatEachIndex}`;
 
+  const networkId = await seededNetworkId(admin.token);
   let userId: string | null = null;
-  let networkId: number | null = null;
 
   try {
     userId = await createUser(admin.token, userName);
-    networkId = await createNetwork(admin.token, netSlug);
-    await addTestnetServer(admin.token, networkId);
 
     await adminLogin(page, admin);
     await openCredentialsTab(page);
@@ -150,7 +191,7 @@ test("admin binds a credential from the console and the session dials out", asyn
     // in the issue actually used, and the one that had no other door on a
     // release image (#1158).
     await page.getByTestId("admin-credentials-bind-user").selectOption({ label: userName });
-    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: netSlug });
+    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: NETWORK_SLUG });
     await page.getByTestId("admin-credentials-bind-nick").fill(nick);
     await page.getByTestId("admin-credentials-bind-auth-method").selectOption("none");
     await page.getByTestId("admin-credentials-bind-submit").click();
@@ -177,6 +218,9 @@ test("admin binds a credential from the console and the session dials out", asyn
     await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
     await expect(reloadedRow).toContainText("connected");
   } finally {
-    await cleanup(admin.token, userId, networkId);
+    if (userId !== null) {
+      await unbind(admin.token, userId, networkId, testInfo);
+      await deleteUser(admin.token, userId, testInfo);
+    }
   }
 });

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -1,0 +1,182 @@
+// #1163 — binding a credential from the admin CONSOLE dials the upstream.
+//
+// The defect: `POST /admin/credentials` wrote the row, returned 201 and never
+// spawned a session, while writing `connection_state: :connected` (the schema
+// default). The operator saw a credential that claimed a live session, had
+// nothing to press, and got "That network or resource doesn't exist." from
+// every send until the node was restarted.
+//
+// ## Why admin-credentials.spec.ts could not have caught it
+//
+// That spec binds against networks it creates with `POST /admin/networks` and
+// no server row. A server-less network fails plan resolution, so even the
+// FIXED code does not dial there — the scenario is blind to this bug by
+// construction. This spec therefore adds the one thing that was missing: an
+// enabled server, pointed at the same `bahamut-test:6667` testnet the seeder
+// uses. Everything else stays throwaway (own user, own network, own nick), so
+// nothing here touches the seeded vjt / m9b credentials other specs depend on.
+//
+// ## The oracle
+//
+// The Credentials tab renders two independent readings per row, and #1163 is
+// precisely the case where they disagreed:
+//
+//   * CONNECTION — the DB intent (`connection_state`).
+//   * LIVE — the BEAM truth, rendered verbatim as `alive` or `BEAM has no pid`.
+//
+// Before the fix the row read `connected` + `BEAM has no pid`: the U-0 lie,
+// visible in the console itself. After it, `connected` + `alive`. Asserting
+// BOTH is what makes this a regression test rather than a smoke test —
+// `alive` alone would still pass an implementation that spawned the session
+// and forgot to commit the state, and `connected` alone is what shipped.
+//
+// The assertions are repeated after a full page reload so the witness is a
+// second server round-trip, not a client-side artifact of the bind response.
+
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// The testnet endpoint the compose seeder binds `vjt` to. Reaching it by its
+// docker alias is what makes the spawn real: a dial that resolves, connects
+// and registers.
+const TESTNET_HOST = "bahamut-test";
+const TESTNET_PORT = 6667;
+
+type Admin = ReturnType<typeof getSeededAdmin>;
+
+async function adminLogin(page: import("@playwright/test").Page, seed: Admin): Promise<void> {
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+async function openCredentialsTab(page: import("@playwright/test").Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-credentials").click();
+  await expect(page.getByTestId("admin-credentials-table")).toBeVisible({ timeout: 10_000 });
+}
+
+async function api(token: string, method: string, path: string, body?: unknown): Promise<Response> {
+  return await fetch(`${GRAPPA_BASE_URL}${path}`, {
+    method,
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function createUser(token: string, name: string): Promise<string> {
+  const res = await api(token, "POST", "/admin/users", {
+    name,
+    password: "test-password-not-secret",
+  });
+  if (!res.ok) throw new Error(`createUser: ${name} → ${res.status}`);
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function createNetwork(token: string, slug: string): Promise<number> {
+  const res = await api(token, "POST", "/admin/networks", { slug });
+  if (!res.ok) throw new Error(`createNetwork: ${slug} → ${res.status}`);
+  return ((await res.json()) as { id: number }).id;
+}
+
+// The step that separates this spec from the existing bind coverage: without
+// an enabled server the bind cannot dial even when the code is correct.
+async function addTestnetServer(token: string, networkId: number): Promise<void> {
+  const res = await api(token, "POST", `/admin/networks/${networkId}/servers`, {
+    host: TESTNET_HOST,
+    port: TESTNET_PORT,
+    tls: false,
+  });
+  if (!res.ok) throw new Error(`addTestnetServer: ${networkId} → ${res.status}`);
+}
+
+// Unbind is the teardown that matters: it stops the live session, so the
+// throwaway upstream connection does not outlive the test and count against
+// the next one. Best-effort — a failed cleanup must not mask the verdict.
+async function cleanup(token: string, userId: string | null, networkId: number | null) {
+  try {
+    if (userId !== null && networkId !== null) {
+      await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    }
+    if (networkId !== null) await api(token, "DELETE", `/admin/networks/${networkId}`);
+    if (userId !== null) await api(token, "DELETE", `/admin/users/${userId}`);
+  } catch {
+    // best-effort
+  }
+}
+
+test("admin binds a credential from the console and the session dials out", async ({
+  page,
+}, testInfo) => {
+  const admin = getSeededAdmin();
+
+  // Stamped per run, not fixed: this spec registers a nick on a persistent
+  // testnet, and a fixed identifier makes it once-per-container — `docs/TESTING.md`
+  // iso-rerun triage (`--repeat-each`) has to stay available on it. Worker and
+  // repeat indices disambiguate runs that land in the same millisecond.
+  const stamp = `${Date.now()}-${testInfo.workerIndex}-${testInfo.repeatEachIndex}`;
+  const userName = `e2e1163-u-${stamp}`;
+  const netSlug = `e2e1163-n-${stamp}`;
+  // An IRC nick caps at 30 chars, so the stamp is shortened here rather than
+  // reused whole.
+  const nick = `b1163-${Date.now() % 1_000_000}-${testInfo.workerIndex}${testInfo.repeatEachIndex}`;
+
+  let userId: string | null = null;
+  let networkId: number | null = null;
+
+  try {
+    userId = await createUser(admin.token, userName);
+    networkId = await createNetwork(admin.token, netSlug);
+    await addTestnetServer(admin.token, networkId);
+
+    await adminLogin(page, admin);
+    await openCredentialsTab(page);
+
+    // Pre-state: the binding does not exist yet, so the row this test is about
+    // to assert on cannot be a leftover from an earlier run.
+    const credKey = `${userId}:${networkId}`;
+    await expect(page.getByTestId(`admin-credential-row-${credKey}`)).toHaveCount(0);
+
+    // The bind goes through the CONSOLE, not the API — the door the operator
+    // in the issue actually used, and the one that had no other door on a
+    // release image (#1158).
+    await page.getByTestId("admin-credentials-bind-user").selectOption({ label: userName });
+    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: netSlug });
+    await page.getByTestId("admin-credentials-bind-nick").fill(nick);
+    await page.getByTestId("admin-credentials-bind-auth-method").selectOption("none");
+    await page.getByTestId("admin-credentials-bind-submit").click();
+
+    const row = page.getByTestId(`admin-credential-row-${credKey}`);
+    await expect(row).toHaveCount(1, { timeout: 10_000 });
+
+    // The witness. `alive` is the BEAM reading: a Session.Server exists for
+    // this (user, network). Before #1163 this cell read `BEAM has no pid` and
+    // stayed that way until the node restarted.
+    await expect(row).toContainText("alive", { timeout: 10_000 });
+    await expect(row).not.toContainText("BEAM has no pid");
+
+    // The other half of U-0: the DB intent agrees with the BEAM. A row that
+    // says `connected` is only honest when the pid above exists.
+    await expect(row).toContainText("connected");
+
+    // Same two readings after a fresh load, so the verdict rests on a second
+    // GET /admin/credentials rather than on the bind response the tab just
+    // rendered.
+    await page.reload();
+    await openCredentialsTab(page);
+    const reloadedRow = page.getByTestId(`admin-credential-row-${credKey}`);
+    await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
+    await expect(reloadedRow).toContainText("connected");
+  } finally {
+    await cleanup(admin.token, userId, networkId);
+  }
+});

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -20,6 +20,7 @@ import {
   LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD,
   NETWORKS_CREDENTIAL_CONNECTION_STATE,
   NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION,
+  NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR,
   NETWORKS_NETWORK_SERVICES_FLAVOR,
   SCROLLBACK_MESSAGE_KIND,
   SESSION_LOG_EVENT,
@@ -580,6 +581,11 @@ export const S_NetworksCredentialsAdminWireLiveStateJson = {
 // Grappa.Networks.Credentials.AdminWire.session_action/0
 export const S_NetworksCredentialsAdminWireSessionAction = {
   e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION],
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.spawn_error/0
+export const S_NetworksCredentialsAdminWireSpawnError = {
+  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR],
 } as const;
 
 // Grappa.Networks.Credentials.AdminWire.t/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -11,6 +11,7 @@ export const ADMISSION_FLOW = [
   "bootstrap_visitor",
   "patch_network_connect",
   "visitor_reconnect",
+  "admin_credential_bind",
 ] as const;
 export type AdmissionFlow = (typeof ADMISSION_FLOW)[number];
 
@@ -572,9 +573,26 @@ export type NetworksCredentialsAdminWireT = {
   live_state: NetworksCredentialsAdminWireLiveStateJson | null;
 };
 
-export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION = ["left_alone", "stopped"] as const;
+export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION = [
+  "left_alone",
+  "stopped",
+  "spawned",
+  "not_spawned",
+] as const;
 export type NetworksCredentialsAdminWireSessionAction =
   (typeof NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION)[number];
+
+export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR = [
+  "resolve_failed",
+  "not_found",
+  "ip_cap_exceeded",
+  "visitor_cap_exceeded",
+  "user_cap_exceeded",
+  "network_circuit_open",
+  "start_failed",
+] as const;
+export type NetworksCredentialsAdminWireSpawnError =
+  (typeof NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR)[number];
 
 // === Grappa.Networks.FeaturedChannels.AdminWire ===
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36219,3 +36219,71 @@ clones` over the 237 MB grappa container log returned **0**, with a sanity
 count of 126,802 `privmsg` lines from the same grep on the same file — so in
 that run they never appeared anywhere. That is one run's observation, not a
 general claim that the bump is inert.
+
+---
+
+## 2026-08-10 — #1163: the bind door never learned the sequence every other spawn surface knows
+
+`POST /admin/credentials` wrote the credential, returned `201`, and stopped.
+Its success path read `LiveIntrospection.lookup_session/2` — which only ever
+*asks* whether a session happens to be live — so nothing dialled until the
+node restarted. `DELETE` on the same resource has always stopped the live
+session. Two halves of one control, disagreeing.
+
+The issue as filed pointed the fix at `Grappa.Bootstrap`. That was the wrong
+name for the right idea: the runtime spawn door is
+`Grappa.SpawnOrchestrator.spawn/4` (admission → `Backoff.reset` → spawn), and
+Bootstrap is one of its five callers. `POST /admin/credentials` was the odd
+surface out — the only one that creates a session-relevant row without ever
+reaching the shared verb.
+
+**The `:connected` default made it worse than "no session".**
+`Credential.connection_state` defaults to `:connected`, so every console bind
+wrote a row that *claimed* a session it did not have. cic rendered CONNECTED —
+nothing to press — while `POST /messages` answered *"That network or resource
+doesn't exist."* That is verbatim the pre-U-0 state
+`NetworksController.apply_transition/5` was written to eliminate on the PATCH
+door. The fix is therefore the U-0 ordering, not a spawn bolted on after the
+insert: bind `:parked`, spawn, and let only a live `Session.Server` promote
+the row to `:connected`.
+
+**Why not `GrappaWeb.NetworkSpawn.orchestrate/4`**, the web-layer helper the
+two self-serve doors use. It builds the capacity input from the *request's*
+IP, which is correct when a user connects their own network and wrong when an
+admin acts for somebody else: the admin's IP would be counted against the
+target user's per-IP cap, and a busy evening of provisioning would start
+refusing binds for a reason having nothing to do with the user being bound. So
+the verb lands in `Grappa.Operator` — `connect_credential/1`, the user twin of
+the Visitors-tab `reconnect_session/2` — with `source_ip: nil` and a new
+`:admin_credential_bind` flow, exactly the shape the visitor reconnect already
+uses for the same on-behalf-of reason.
+
+**A refused spawn does not roll the bind back.** Accretion
+(`SessionController.spawn_or_rollback/4`) unbinds on refusal, and that is right
+*there*: the user asked to JOIN a network, and a network they cannot reach
+should not stay attached. Here the operator asked to PROVISION a credential —
+the row is their input, and deleting it would discard work the 201 already
+acknowledged. It stays `:parked`, which is a recoverable state (the owning user
+can `PATCH /networks/:id`), and the response says why: additive
+`session_action` + `session_error`, snake_case, no `protocol_version` bump. The
+alternative — a 500 on a row that exists — would lie about the write; silence
+would leave the operator debugging IRC connectivity for a network that was
+never dialled, which is the failure mode the issue was filed about.
+
+The servers-bound invariant did not move: the resolver is Bootstrap's own
+`SessionPlan.resolve/1`, so "no enabled server" fails at bind time the same way
+it fails at boot, not through a softer second copy of the rule.
+
+**The agreement test needed a 2×2, not a pair of assertions.** The acceptance
+criterion asks to prove the bind-time and boot-time spawns are one path. Simply
+asserting that each door spawns would leave the plausible wrong implementation
+— an inline copy that skips admission — fully green. So both doors are run
+against the same network under the same gate: with the circuit closed both
+bring a session up, with it open neither does. The skip-admission mutant passes
+the first and fails the second.
+
+**Not covered.** No browser-level check of the admin console; the tests drive
+the HTTP door. cic renders no copy for the two new fields yet — it casts the
+response without validating, so they are inert there, and the honest signal it
+*does* now show is the row reading `parked` instead of a fictitious
+`connected`.

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -68,6 +68,7 @@ defmodule Grappa.Admission do
           | :bootstrap_visitor
           | :patch_network_connect
           | :visitor_reconnect
+          | :admin_credential_bind
 
   @type capacity_input :: %{
           network_id: integer(),
@@ -196,6 +197,7 @@ defmodule Grappa.Admission do
   defp subject_kind_for_flow(:visitor_reconnect), do: :visitor
   defp subject_kind_for_flow(:bootstrap_user), do: :user
   defp subject_kind_for_flow(:patch_network_connect), do: :user
+  defp subject_kind_for_flow(:admin_credential_bind), do: :user
 
   defp check_circuit(network_id) do
     case NetworkCircuit.check(network_id) do

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -215,6 +215,6 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   end
 
   @spec error_tag(spawn_error() | {spawn_error(), term()}) :: spawn_error()
-  defp error_tag({tag, _payload}) when is_atom(tag), do: tag
+  defp error_tag({tag, _}) when is_atom(tag), do: tag
   defp error_tag(tag) when is_atom(tag), do: tag
 end

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -107,6 +107,9 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       must `/connect` to bring it back under the new creds. We don't
       auto-respawn — the `POST /networks/:slug/connect` verb is
       the operator-facing path that re-runs admission + spawn.
+
+  The POST bind writes the SAME wire key with its own disjoint set
+  (`:spawned` / `:not_spawned`) — see `t:bind_outcome/0`.
   """
   @type session_action :: :left_alone | :stopped
 
@@ -155,6 +158,31 @@ defmodule Grappa.Networks.Credentials.AdminWire do
     }
   end
 
+  @typedoc """
+  #1163 — what the POST bind did to the session, and why it did not do
+  it. `:spawned` means a `Session.Server` is running and the row was
+  committed `:connected`; `:not_spawned` means the row was created and
+  left `:parked`, with `session_error` naming the refusal.
+
+  The error tags are `Grappa.Operator.connect_credential/1`'s union with
+  its payloads dropped (a `{:network_circuit_open, retry_after}` renders
+  as `:network_circuit_open`) — spelled out rather than aliased because
+  `Grappa.Networks` must not depend on `Grappa.Admission`. Runtime tag
+  extraction is generic, so a tag added to
+  `Admission.capacity_error_atoms/0` still renders correctly; only this
+  type would go stale.
+  """
+  @type spawn_error ::
+          :resolve_failed
+          | :not_found
+          | :ip_cap_exceeded
+          | :visitor_cap_exceeded
+          | :user_cap_exceeded
+          | :network_circuit_open
+          | :start_failed
+
+  @type bind_outcome :: :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}
+
   @doc """
   Attaches a `session_action:` field to a credential JSON map (the
   bucket-3 PUT response shape). Defined here, not at the controller,
@@ -165,4 +193,28 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       when action in [:left_alone, :stopped] do
     Map.put(json, :session_action, action)
   end
+
+  @doc """
+  #1163 — attaches `session_action:` + `session_error:` to the POST bind
+  response. Sibling of `with_session_action/2` on the same key: both
+  answer "what happened to the session because of this admin verb", for
+  the two verbs that can move it.
+
+  `session_error` is `nil` on `:spawned`, so the operator reads one
+  field to tell "bound and connected" from "bound, and here is why it is
+  not dialling" — the alternative (a 201 that says nothing) is the
+  silent-swallow this endpoint shipped before #1163.
+  """
+  @spec with_bind_outcome(t(), bind_outcome()) :: map()
+  def with_bind_outcome(%{} = json, :spawned) do
+    Map.merge(json, %{session_action: :spawned, session_error: nil})
+  end
+
+  def with_bind_outcome(%{} = json, {:not_spawned, reason}) do
+    Map.merge(json, %{session_action: :not_spawned, session_error: error_tag(reason)})
+  end
+
+  @spec error_tag(spawn_error() | {spawn_error(), term()}) :: spawn_error()
+  defp error_tag({tag, _payload}) when is_atom(tag), do: tag
+  defp error_tag(tag) when is_atom(tag), do: tag
 end

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -94,8 +94,14 @@ defmodule Grappa.Networks.Credentials.AdminWire do
         }
 
   @typedoc """
-  Admin-panel bucket 3 — outcome of the PUT credential update against
-  any running `Session.Server` for `{:user, user_id} × network_id`.
+  What the admin verb did to the session for
+  `{:user, user_id} × network_id`. ONE wire key, `session_action`, so ONE
+  union — the codegen publishes it to cic as a single string-literal set,
+  and splitting the values across two types would have shipped cic a
+  union that omits half the values the field can carry.
+
+  PATCH (admin-panel bucket 3 — the credential update against any running
+  session):
 
     * `:left_alone` — no live session, OR the change set didn't include
       `:password` / `:auth_method` (cosmetic-only fields like autojoin or
@@ -108,10 +114,17 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       auto-respawn — the `POST /networks/:slug/connect` verb is
       the operator-facing path that re-runs admission + spawn.
 
-  The POST bind writes the SAME wire key with its own disjoint set
-  (`:spawned` / `:not_spawned`) — see `t:bind_outcome/0`.
+  POST (#1163 — the bind that dials):
+
+    * `:spawned` — a `Session.Server` is running and the row was committed
+      `:connected`. `session_error` is `nil`.
+    * `:not_spawned` — the row was created and left `:parked`;
+      `session_error` names the refusal.
+
+  A consumer keys off the endpoint it called: the two pairs are disjoint
+  and neither verb can emit the other's values.
   """
-  @type session_action :: :left_alone | :stopped
+  @type session_action :: :left_alone | :stopped | :spawned | :not_spawned
 
   @doc """
   Render a Credential row + optional live SessionEntry to the admin
@@ -159,14 +172,12 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   end
 
   @typedoc """
-  #1163 — what the POST bind did to the session, and why it did not do
-  it. `:spawned` means a `Session.Server` is running and the row was
-  committed `:connected`; `:not_spawned` means the row was created and
-  left `:parked`, with `session_error` naming the refusal.
+  #1163 — the `session_error` value space: why a bind did not dial.
+  `nil` when it did.
 
-  The error tags are `Grappa.Operator.connect_credential/1`'s union with
-  its payloads dropped (a `{:network_circuit_open, retry_after}` renders
-  as `:network_circuit_open`) — spelled out rather than aliased because
+  These are `Grappa.Operator.connect_credential/1`'s error union with the
+  payloads dropped (a `{:network_circuit_open, retry_after}` renders as
+  `:network_circuit_open`) — spelled out rather than aliased because
   `Grappa.Networks` must not depend on `Grappa.Admission`. Runtime tag
   extraction is generic, so a tag added to
   `Admission.capacity_error_atoms/0` still renders correctly; only this
@@ -180,8 +191,6 @@ defmodule Grappa.Networks.Credentials.AdminWire do
           | :user_cap_exceeded
           | :network_circuit_open
           | :start_failed
-
-  @type bind_outcome :: :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}
 
   @doc """
   Attaches a `session_action:` field to a credential JSON map (the
@@ -204,8 +213,16 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   field to tell "bound and connected" from "bound, and here is why it is
   not dialling" — the alternative (a 201 that says nothing) is the
   silent-swallow this endpoint shipped before #1163.
+
+  The outcome argument is spelled INLINE, deliberately: a named public
+  type in a `*Wire` module is a wire CONTRACT — `mix grappa.gen_wire_types`
+  publishes every one of them to `cicchetto/src/lib/wireTypes.ts`. This
+  tuple is an internal Elixir hand-off between the controller and this
+  renderer; naming it shipped cic a `["not_spawned", …]` array type for a
+  payload the wire never carries.
   """
-  @spec with_bind_outcome(t(), bind_outcome()) :: map()
+  @spec with_bind_outcome(t(), :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}) ::
+          map()
   def with_bind_outcome(%{} = json, :spawned) do
     Map.merge(json, %{session_action: :spawned, session_error: nil})
   end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -766,6 +766,102 @@ defmodule Grappa.Operator do
   end
 
   @doc """
+  #1163: dial the upstream for a USER credential the operator has just
+  bound, and commit `:connected` only if it comes up. The user twin of
+  `reconnect_session/2` — same admission → backoff-reset → spawn core
+  through `SpawnOrchestrator.spawn/4`, so the bind door and the boot
+  door (`Grappa.Bootstrap`) cannot drift.
+
+  ## Why not `GrappaWeb.NetworkSpawn.orchestrate/4`
+
+  That helper builds the capacity input from the REQUEST's IP, which is
+  right for the two self-serve doors it serves (a user connecting their
+  own network) and wrong here: the requester is an admin, the subject is
+  somebody else. Counting the admin's IP against the target user's cap
+  would refuse the fifth bind of an evening for a reason that has nothing
+  to do with the user being bound. `source_ip: nil` +
+  `requesting_subject: {:user, _}` is the shape `reconnect_session/2`
+  already uses for the same admin-on-behalf-of reason.
+
+  ## U-0 ordering
+
+  Spawn FIRST, commit `:connected` only on success (the invariant
+  `NetworksController.apply_transition/5` upholds for PATCH /connect and
+  `SessionController.spawn_or_rollback/4` for accretion). The caller binds
+  the row `:parked`; a refused spawn therefore leaves a `:parked`
+  credential — a normal, recoverable state — never the
+  `:connected`-with-no-Session.Server wedge where the UI reads CONNECTED
+  and every `POST /messages` 404s.
+
+  Errors mirror `reconnect_session/2` verbatim:
+
+    * `{:error, :resolve_failed}` — no enabled server on the network, or
+      the user row is gone (`SessionPlan.resolve/1`). The servers-bound
+      rule stays where it is: this is Bootstrap's resolver, not a softer
+      copy of it.
+    * `{:error, :not_found}` — the credential was unbound between the
+      admission check and the spawn (`Session.Server.init/1` → `:ignore`).
+    * `Admission.capacity_error()` / `{:start_failed, term()}` — verbatim
+      from `SpawnOrchestrator.spawn/4`.
+  """
+  @spec connect_credential(Credential.t()) ::
+          {:ok, Credential.t()}
+          | {:error, :resolve_failed | :not_found | Admission.capacity_error() | {:start_failed, term()}}
+  def connect_credential(%Credential{user_id: user_id, network_id: network_id} = credential)
+      when is_binary(user_id) do
+    with {:ok, plan} <- resolve_user_plan(credential),
+         :ok <- spawn_user_bind({:user, user_id}, network_id, plan) do
+      Networks.connect(credential)
+    end
+  end
+
+  # Mirror of `resolve_visitor_plan/2` on the user arm: collapse every
+  # `SessionPlan.resolve/1` failure (`:no_server` / `:user_not_found`) to
+  # the uniform `:resolve_failed`.
+  @spec resolve_user_plan(Credential.t()) ::
+          {:ok, Session.start_opts()} | {:error, :resolve_failed}
+  defp resolve_user_plan(%Credential{} = credential) do
+    case Networks.SessionPlan.resolve(credential) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "admin bind: user session plan resolve failed " <>
+            "(user_id=#{credential.user_id} network_id=#{credential.network_id} " <>
+            "reason=#{inspect(reason)})"
+        )
+
+        {:error, :resolve_failed}
+    end
+  end
+
+  # The admission → backoff-reset → spawn dance for an admin bind.
+  # `:admin_credential_bind` flow (subject_kind `:user`) so the network
+  # total + circuit gate the user pool under a tag that names the surface;
+  # `source_ip: nil` because the admin's IP is not the subject's (see
+  # `connect_credential/1`). `:already_started` collapses to `:ok` — a
+  # rebind of a network the user is somehow already live on keeps the live
+  # session, it does not bounce it.
+  @spec spawn_user_bind(Session.subject(), integer(), Session.start_opts()) ::
+          :ok | {:error, :not_found | Admission.capacity_error() | {:start_failed, term()}}
+  defp spawn_user_bind(subject, network_id, plan) do
+    capacity_input = %{
+      network_id: network_id,
+      source_ip: nil,
+      flow: :admin_credential_bind,
+      requesting_subject: subject
+    }
+
+    case SpawnOrchestrator.spawn(subject, network_id, plan, capacity_input) do
+      {:ok, :spawned, _} -> :ok
+      {:ok, :already_started, _} -> :ok
+      {:ok, :ignored} -> {:error, :not_found}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
   Print active visitors (anon TTL not yet elapsed + identified
   never-expires rows) as a tab-separated table: header + one row per
   visitor. #211 phase 7 — identity-wide columns only (id, expires_at,

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -153,7 +153,9 @@ defmodule GrappaWeb.Admin.CredentialsController do
   # the outcome rides out in the response body: no exception, but no
   # silence either.
   @spec connect_bound_credential(Credential.t()) ::
-          {Credential.t(), AdminWire.bind_outcome()}
+          {Credential.t(),
+           :spawned
+           | {:not_spawned, AdminWire.spawn_error() | {AdminWire.spawn_error(), term()}}}
   defp connect_bound_credential(cred) do
     case Operator.connect_credential(cred) do
       {:ok, connected} -> {connected, :spawned}

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -47,9 +47,9 @@ defmodule GrappaWeb.Admin.CredentialsController do
   """
   use GrappaWeb, :controller
 
-  alias Grappa.{Accounts, AdminEvents, LiveIntrospection, Networks}
+  alias Grappa.{Accounts, AdminEvents, LiveIntrospection, Networks, Operator}
   alias Grappa.AdminEvents.Wire, as: AdminEventsWire
-  alias Grappa.Networks.Credentials
+  alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.Networks.Credentials.AdminWire
   alias GrappaWeb.Admin.AuthPlug
   alias GrappaWeb.Validation
@@ -105,6 +105,12 @@ defmodule GrappaWeb.Admin.CredentialsController do
   optional `password`, `sasl_user`, `realname`, `auth_command_template`,
   `autojoin_channels`. Returns `201 Created` with the credential JSON
   shape (no password / password_encrypted leakage).
+
+  #1163 — the bind also DIALS: the row is written `:parked`, the session
+  is spawned through the shared orchestrator, and only a live
+  `Session.Server` promotes the row to `:connected`. A refused spawn
+  still returns `201` (the row exists) with
+  `session_action: "not_spawned"` + `session_error:` naming the refusal.
   """
   @spec create(Plug.Conn.t(), map()) ::
           Plug.Conn.t() | {:error, :not_found | :already_exists | :bad_request | Ecto.Changeset.t()}
@@ -116,11 +122,42 @@ defmodule GrappaWeb.Admin.CredentialsController do
          {:ok, network} <- fetch_network(network_id),
          {:ok, cred} <- bind_with_conflict_classification(user, network, attrs) do
       :ok = emit_credential_bound(user, network, cred, conn)
+      {cred, outcome} = connect_bound_credential(cred)
       live = LiveIntrospection.lookup_session({:user, cred.user_id}, cred.network_id)
 
       conn
       |> put_status(:created)
-      |> json(AdminWire.credential_to_admin_json(cred, live))
+      |> json(
+        cred
+        |> AdminWire.credential_to_admin_json(live)
+        |> AdminWire.with_bind_outcome(outcome)
+      )
+    end
+  end
+
+  # #1163 — the bind DIALS. Before this, `create/2` only ever *read*
+  # whether a session happened to be live, so a credential bound from the
+  # console sat there doing nothing until the node restarted; unbind, the
+  # other half of the same control, was live all along.
+  #
+  # The spawn is `Grappa.Operator.connect_credential/1` — the same
+  # admission → backoff-reset → spawn core Bootstrap and every other
+  # runtime spawn surface reach through `SpawnOrchestrator.spawn/4`, so
+  # bind-time and boot-time cannot drift.
+  #
+  # A refused spawn is NOT a failed bind: the row is written, so the 201
+  # stands and the credential stays (unlike accretion, which rolls its
+  # bind back — there the user asked to JOIN a network, here the operator
+  # asked to PROVISION a credential, and deleting it would discard their
+  # input). It stays `:parked` per the U-0 ordering the caller set up, and
+  # the outcome rides out in the response body: no exception, but no
+  # silence either.
+  @spec connect_bound_credential(Credential.t()) ::
+          {Credential.t(), AdminWire.bind_outcome()}
+  defp connect_bound_credential(cred) do
+    case Operator.connect_credential(cred) do
+      {:ok, connected} -> {connected, :spawned}
+      {:error, reason} -> {cred, {:not_spawned, reason}}
     end
   end
 
@@ -288,7 +325,17 @@ defmodule GrappaWeb.Admin.CredentialsController do
     extra = keys -- @allowed_create_keys
 
     if extra == [] and Map.has_key?(params, "nick") and Map.has_key?(params, "auth_method") do
-      {:ok, Validation.take_atomized(params, @allowed_create_keys, &maybe_atomize_auth_method/2)}
+      attrs = Validation.take_atomized(params, @allowed_create_keys, &maybe_atomize_auth_method/2)
+
+      # #1163 — bind `:parked`, NEVER the schema default `:connected`.
+      # `connect_bound_credential/1` promotes the row only once a
+      # `Session.Server` is actually running (the U-0 ordering). The
+      # default made every admin bind write a row that CLAIMED a session
+      # it never had: cic rendered CONNECTED, so there was nothing to
+      # press, while `POST /messages` answered "That network or resource
+      # doesn't exist." Same invariant `SessionController` binds accretion
+      # under, for the same reason.
+      {:ok, Map.put(attrs, :connection_state, :parked)}
     else
       {:error, :bad_request}
     end

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -549,7 +549,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
     end
 
     test "circuit open: neither door brings a session up", %{conn: conn} do
-      {_server, port} = start_irc_server()
+      {_, port} = start_irc_server()
       {network, _} = network_with_server(port: port, slug: "bind-agree-open-#{uniq()}")
       :ok = AdmissionStateHelpers.open_circuit!(network.id)
 
@@ -594,7 +594,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   end
 
   defp run_bootstrap do
-    {result, _log} = with_log(fn -> Bootstrap.run() end)
+    {result, _} = with_log(fn -> Bootstrap.run() end)
     result
   end
 

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -19,14 +19,16 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   """
   use GrappaWeb.ConnCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Networks}
-  alias Grappa.Networks.Credentials
+  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Bootstrap, IRCServer, Networks, Session}
+  alias Grappa.Bootstrap.Result
+  alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
   setup do
-    AdmissionStateHelpers.reset_session_supervisor()
+    AdmissionStateHelpers.reset_all()
     :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
     :ok
   end
@@ -480,6 +482,138 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
       assert json_response(conn, 422)["error"] == "validation_failed"
     end
+  end
+
+  describe "POST /admin/credentials — session spawn (#1163)" do
+    test "201 + the bound session dials out with no restart", %{conn: conn} do
+      {server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-spawn-#{uniq()}")
+      target_user = user_fixture(name: "bind-spawn-#{uniq()}")
+      stop_session_on_exit(target_user, network)
+
+      body = bind(conn, target_user, network, "vjt")
+
+      assert {:ok, "NICK vjt\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK"), 5_000)
+
+      assert is_pid(Session.whereis({:user, target_user.id}, network.id))
+
+      assert body["session_action"] == "spawned"
+      assert body["session_error"] == nil
+      assert body["live_state"] != nil
+
+      assert {:ok, %Credential{connection_state: :connected}} =
+               Credentials.get_credential(target_user, network)
+    end
+
+    test "201 + a network with no enabled server keeps the row :parked and says so", %{conn: conn} do
+      {:ok, network} = Networks.find_or_create_network(%{slug: "bind-noserver-#{uniq()}"})
+      target_user = user_fixture(name: "bind-noserver-#{uniq()}")
+
+      body = bind(conn, target_user, network, "vjt")
+
+      assert body["session_action"] == "not_spawned"
+      assert body["session_error"] == "resolve_failed"
+      assert body["live_state"] == nil
+      # U-0: the row never claims :connected without a live Session.Server.
+      assert body["connection_state"] == "parked"
+
+      assert {:ok, %Credential{connection_state: :parked}} =
+               Credentials.get_credential(target_user, network)
+
+      refute Session.whereis({:user, target_user.id}, network.id)
+    end
+  end
+
+  # The acceptance criterion the issue words as "the bind-time and boot-time
+  # spawn go through one code path — a test that proves the two agree". Both
+  # doors are run against the SAME network under the SAME admission gate: with
+  # the circuit closed both bring a session up, with it open neither does. A
+  # bind-time inline copy of the dance fails one half or the other — skipping
+  # admission passes the first test and fails the second.
+  describe "POST /admin/credentials — bind door and boot door are one path (#1163)" do
+    test "circuit closed: both doors bring a session up", %{conn: conn} do
+      {server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-agree-ok-#{uniq()}")
+
+      boot_user = boot_bound_user(network, "booted")
+      assert {:ok, %Result{spawned: 1}} = run_bootstrap()
+      assert is_pid(Session.whereis({:user, boot_user.id}, network.id))
+      assert {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK"), 5_000)
+
+      bind_user = user_fixture(name: "bind-agree-ok-#{uniq()}")
+      stop_session_on_exit(bind_user, network)
+
+      assert %{"session_action" => "spawned"} = bind(conn, bind_user, network, "bound")
+      assert is_pid(Session.whereis({:user, bind_user.id}, network.id))
+    end
+
+    test "circuit open: neither door brings a session up", %{conn: conn} do
+      {_server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-agree-open-#{uniq()}")
+      :ok = AdmissionStateHelpers.open_circuit!(network.id)
+
+      boot_user = boot_bound_user(network, "booted")
+      assert {:ok, %Result{spawned: 0, capacity_rejected: 1}} = run_bootstrap()
+      refute Session.whereis({:user, boot_user.id}, network.id)
+
+      bind_user = user_fixture(name: "bind-agree-open-#{uniq()}")
+
+      assert %{"session_action" => "not_spawned", "session_error" => "network_circuit_open"} =
+               bind(conn, bind_user, network, "bound")
+
+      refute Session.whereis({:user, bind_user.id}, network.id)
+    end
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp start_irc_server do
+    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {server, IRCServer.port(server)}
+  end
+
+  defp stop_session_on_exit(user, network) do
+    on_exit(fn -> Session.stop_session({:user, user.id}, network.id, "test teardown") end)
+  end
+
+  # A credential the BOOT door will pick up: bound and left at the schema
+  # default `:connected`, exactly as a pre-#1163 deploy's rows read.
+  defp boot_bound_user(network, nick) do
+    user = user_fixture(name: "boot-#{uniq()}")
+
+    {:ok, _} =
+      Credentials.bind_credential(user, network, %{
+        nick: nick,
+        auth_method: :none,
+        autojoin_channels: []
+      })
+
+    stop_session_on_exit(user, network)
+    user
+  end
+
+  defp run_bootstrap do
+    {result, _log} = with_log(fn -> Bootstrap.run() end)
+    result
+  end
+
+  defp bind(conn, target_user, network, nick) do
+    session = admin_session()
+
+    conn
+    |> put_bearer(session.id)
+    |> put_req_header("content-type", "application/json")
+    |> post(
+      "/admin/credentials",
+      Jason.encode!(%{
+        user_id: target_user.id,
+        network_id: network.id,
+        nick: nick,
+        auth_method: "none"
+      })
+    )
+    |> json_response(201)
   end
 
   describe "DELETE /admin/credentials/:user_id/:network_id — admin-panel bucket 3" do


### PR DESCRIPTION
Fixes the asymmetry in #1163: `DELETE /admin/credentials/:user_id/:network_id`
stops the live session immediately, while `POST /admin/credentials` wrote the
row, returned `201`, and never dialled. Its success path only *read* whether a
session happened to be live (`LiveIntrospection.lookup_session/2`).

## What was actually broken

Worse than "no session": `Credential.connection_state` defaults to
`:connected`, so a console bind wrote a row that **claimed** a session it did
not have. cic rendered CONNECTED — nothing for the operator to press — while
`POST /messages` answered *"That network or resource doesn't exist."* That is
the state the U-0 fix eliminated on the `PATCH /networks/:id` door
(`networks_controller.ex:395` records it verbatim), reproduced by construction
on every admin bind.

## The door

`Grappa.Operator.connect_credential/1`, the user twin of the Visitors-tab
`reconnect_session/2`, reaching the shared
`Grappa.SpawnOrchestrator.spawn/4` (admission -> `Backoff.reset` -> spawn) that
`Bootstrap`, `NetworksController`, `Admin.SessionsController`, `Operator` and
`Visitors` already reach. No second copy of the sequence, so bind-time and
boot-time cannot drift.

`GrappaWeb.NetworkSpawn.orchestrate/4` — the web-layer helper — was the wrong
door despite being the closer one: it builds the capacity input from the
*request's* IP, correct when a user connects their own network, wrong when an
admin acts for somebody else (the admin's IP would count against the target
user's per-IP cap). `source_ip: nil` + a new `:admin_credential_bind` flow,
exactly as `reconnect_session/2` does for the same on-behalf-of reason.

## Ordering and failure posture

* **U-0 ordering.** Bind `:parked`, spawn, and only a live `Session.Server`
  promotes the row to `:connected`.
* **A refused spawn is not a failed bind.** The row is the operator's input, so
  it stays — unlike accretion (`SessionController.spawn_or_rollback/4`), which
  unbinds on refusal because there the *user* asked to join a network. It stays
  `:parked` (recoverable via the owning user's `PATCH /networks/:id`), the
  response is still `201`, and it says why.
* **Wire, additive, snake_case, no `protocol_version` bump** — proposed shape,
  mirroring the `session_action` the PATCH response already carries:
  * `session_action`: `"spawned" | "not_spawned"`
  * `session_error`: `null`, or the refusal tag (`"resolve_failed"`,
    `"user_cap_exceeded"`, `"network_circuit_open"`, `"start_failed"`, ...)
* **The servers-bound invariant did not move**: the resolver is Bootstrap's own
  `SessionPlan.resolve/1`, so "no enabled server" fails at bind time the same
  way it fails at boot — not through a softer second copy of the rule.

## Tests — declared red before the fix, and observed red

| test | failure without the fix |
|---|---|
| bind dials out (fake upstream sees `NICK`, pid registered, row `:connected`) | `wait_for_line` -> `{:error, :timeout}` |
| network with no enabled server: `201`, row kept `:parked`, body says not-spawned | `session_action` absent (`nil`); row reads `"connected"` with `live_state: null` — the U-0 lie, visible in the failure output |
| circuit **closed**: both the boot door (`Bootstrap.run/0`) and the bind door bring a session up | bind half: no pid |
| circuit **open**: neither door brings a session up | `session_error` absent |

The last two are the "one code path" acceptance criterion. Asserting only that
each door spawns would leave the plausible wrong implementation — an inline
copy that skips admission — fully green; running both doors against the same
network under the same gate kills it.

## Gates

* **Correction to an earlier claim in this PR body.** It said `scripts/check.sh`
  was green *including* the wireTypes drift gate. That was wrong, and CI caught
  it. The drift gate is the LAST step of `check.sh`, and I read the final run as
  green from the ABSENCE of test-failure headers in a filtered log — absence of
  a failure I never proved the run had reached. Re-run directly, the gate was
  red. Now green, verified by the gate's own words: `wireTypes.ts is in sync.` /
  `wireSchema.ts is in sync.`
* Regenerating exposed more than a stale file — see the third commit: a named
  public type in a `*Wire` module IS a wire contract, and `session_action` is
  one key that must carry one union.
* What is green, and on which tree — stated precisely, because the claim above
  went wrong by being vague:
  * On the tree at commit 2 (`style(#1163)`): full `scripts/check.sh` stage 1 —
    format, credo --strict, sobelow, deps.audit, doctor, **dialyzer**, docs —
    plus the suite, 5647 tests / 0 failures.
  * On the tree at commit 3 (the regeneration): the drift gate
    (`in sync.` twice), the admin credentials test file (39/39), and cic
    `bun run check` (biome + tsc + e2e tsc) exit 0, 0 TS errors.
  * **Not re-run against commit 3: dialyzer, the full suite, bats.** Commit 3
    changes two `@spec`s and one `@type`, no runtime code, so I expect them to
    hold — but expecting is not measuring, and CI is paying for it rather than
    the host, which is busy with another worker's e2e.
  One earlier `check.sh` run of the same tree reported 3 failures that were not
  captured and did not reproduce across two subsequent runs — recorded rather
  than dropped; the shared test DB is contended across worktrees on this host.
* e2e not run locally (STACK lane not held). Blast radius looks nil by
  inspection: every e2e spec that binds a credential creates a **server-less**
  network, so the new spawn stops at `resolve_failed` and never dials the
  testnet. The only visible change there is the badge reading `parked` instead
  of a fictitious `connected`.

## Not covered

* No browser-level check of the admin console; the tests drive the HTTP door.
* cic renders no copy for the two new fields yet — it casts the response
  without validating, so they are inert client-side. The honest signal it
  *does* now show is `parked` instead of the fictitious `connected`. Wiring
  the toast is a follow-up, pending the wire shape being accepted.
* `PATCH /admin/credentials/...` against a live session (issue's point 3) is
  untouched — out of scope here.
