### PR TITLE
Union: #1051 wallpaper stacking context + #1163 admin bind dials + the VERSION-bump finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,11 +645,20 @@ is due. Don't just look at todo.md.
    worktree onto main → merge to main → remove the now-merged worktree +
    delete its branch (step 0) → **bump the repo-root `VERSION` file as the
    LAST commit** → tag → push origin main → deploy-m42 → verify health. The
-   bump rides IN, never after — `Version.base/0` returns a compile-time
-   constant baked from `VERSION` (an `@external_resource`, #652), so the new
-   number travels with the reloaded `Grappa.Version` beam on a HOT deploy;
-   a `VERSION`-only bump is HOT (it no longer touches `mix.exs`, so
-   `Preflight.mix_deps?` no longer forces COLD — the #652 whole point).
+   bump rides IN, never after — and **the tag must exist BEFORE the build**,
+   because `Grappa.Version`'s git facts are a compile-time snapshot: build
+   first and prod reports the unreleased form `X.Y.Z-<sha>` instead of the
+   bare `X.Y.Z` that #391's tag-≡-CTCP-VERSION contract promises.
+   🔴 **A `VERSION`-only bump is COLD, not HOT — measured on m42 2026-08-10,
+   correcting what #652 claimed here.** `Version.base/0` is a compile-time
+   constant baked from `VERSION` (an `@external_resource`), and `mix.exs`
+   reads the same file to stamp the OTP application vsn — so the bump moves
+   the release's lib directory to `lib/grappa-<new>/ebin`, while
+   `Grappa.HotReload.reload_modified/0` walks `:code.lib_dir(:grappa)`, which
+   the RUNNING node resolves to its BOOT directory `lib/grappa-<old>/ebin`.
+   Nothing in the old directory changed, so `/admin/reload` answers
+   `{"failed":[],"reloaded":[]}` and the node keeps serving the old number
+   with the new code on disk. Plan a restart for any release bump.
    Do NOT re-hardcode `@version` in `mix.exs`: it reads `VERSION` at build
    time, and re-inlining a literal silently reinstates the COLD (guarded by
    `version_single_source_test.exs`). Invoke deploy scripts by ABSOLUTE

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -173,7 +173,16 @@ export async function loginVisitor(
 // author-nick e2e. The runner talks to grappa directly on port 4000
 // (bypassing nginx), so these mirror the cic `themesApi` verbs without the
 // browser. Only the fields the spec asserts on are typed.
-export type ThemeWire = { id: number; author: string; built_in: boolean };
+export type ThemeWire = {
+  id: number;
+  author: string;
+  built_in: boolean;
+  // The sanitized token map (`Grappa.Themes.TokenModel`). Left as an open
+  // record: specs that need a palette COPY one off a built-in rather than
+  // spell 27 colour keys, so nothing here is read field-by-field except
+  // `background`, which #1051 rewrites.
+  payload: Record<string, unknown>;
+};
 
 export async function listGalleryThemes(token: string): Promise<ThemeWire[]> {
   const res = await fetch(`${GRAPPA_BASE_URL}/themes`, {
@@ -206,6 +215,80 @@ export async function publishTheme(token: string, id: number): Promise<ThemeWire
     throw new Error(`grappaApi.publishTheme: ${id} → ${res.status} ${await res.text()}`);
   }
   return (await res.json()) as ThemeWire;
+}
+
+// #1051 — give the running subject a theme that carries a WALLPAPER, and make
+// it active, before the browser boots. The wallpaper is what engages
+// `:root.theme-has-bg`, and that class is the variable the whole #1051
+// stacking-context defect turns on: a spec that never sets it measures the
+// half of the userbase that never had the bug.
+//
+// A `builtin` background (#294) rather than an upload: it resolves to a static
+// /backgrounds/<key>.webp the stack already serves, so the spec proves the
+// layer against a REAL image with no upload round-trip and no image bytes in
+// the repo. The palette is COPIED off a built-in theme's payload — 27 colour
+// keys spelled by hand in a fixture would be a second source of truth for the
+// token vocabulary, and would rot the day the model gains a key.
+//
+// Both verbs are subject-scoped writes on a subject `fixtures/test.ts`
+// provisions and destroys per test (#1078), so this spends no shared budget:
+// the theme-create daily quota is per-(bucket, subject, day) and the subject
+// is seconds old.
+export type BuiltinBackground = { key: string; name: string; variant: string; path: string };
+
+export async function listBuiltinBackgrounds(token: string): Promise<BuiltinBackground[]> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes/backgrounds`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.listBuiltinBackgrounds: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { backgrounds: BuiltinBackground[] };
+  return body.backgrounds;
+}
+
+// `builtinKey: null` is not a degenerate call — it is the CONTROL arm. Both
+// arms copy the SAME built-in palette, so a pair of themes differing only in
+// `background.builtin` isolates the wallpaper as the single variable between
+// two renders. Without that, a "with vs without wallpaper" comparison also
+// swaps 27 colours and proves nothing about the layer.
+export async function createThemeWithBuiltinBackground(
+  token: string,
+  name: string,
+  builtinKey: string | null,
+  opacity: number,
+): Promise<ThemeWire> {
+  const base = (await listGalleryThemes(token)).find((theme) => theme.built_in);
+  if (!base) {
+    throw new Error("grappaApi.createThemeWithBuiltinBackground: no built-in theme to copy");
+  }
+
+  const payload = {
+    ...base.payload,
+    background: { image_id: null, builtin: builtinKey, size: "cover", opacity },
+  };
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ name, payload }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `grappaApi.createThemeWithBuiltinBackground: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as ThemeWire;
+}
+
+export async function setActiveTheme(token: string, id: number): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/me/theme`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ light: id }),
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.setActiveTheme: ${id} → ${res.status} ${await res.text()}`);
+  }
 }
 
 // Admin deletes any theme (owner|admin authz) — teardown for the re-homed

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -280,14 +280,25 @@ export async function createThemeWithBuiltinBackground(
   return (await res.json()) as ThemeWire;
 }
 
-export async function setActiveTheme(token: string, id: number): Promise<void> {
+// The #358 pair, both slots explicit. `dark: null` is the single pick (the
+// light theme paints in both modes); a distinct dark id makes the OS
+// colour-scheme media query a LIVE toggle between two payloads, with no reload
+// and no navigation — the only way to change one visual variable in a running
+// page without also changing everything a reload changes.
+export async function setActiveTheme(
+  token: string,
+  light: number,
+  dark: number | null,
+): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/me/theme`, {
     method: "PUT",
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-    body: JSON.stringify({ light: id }),
+    body: JSON.stringify({ light, dark }),
   });
   if (!res.ok) {
-    throw new Error(`grappaApi.setActiveTheme: ${id} → ${res.status} ${await res.text()}`);
+    throw new Error(
+      `grappaApi.setActiveTheme: ${light}/${dark} → ${res.status} ${await res.text()}`,
+    );
   }
 }
 

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -13,16 +13,28 @@
 // vjt's ruling: the card wins, because if a card is open the intent is to close
 // it, and closing it uncovers the ☰ anyway.
 //
-// WHY AN E2E. The stacking NUMBERS are pinned in
-// `src/__tests__/shellChromeFloat.test.ts` — including the guard that fails if
-// the overlay ever drops back under the float, which the pre-existing
-// `40 < z(.shell-chrome) < 89` assertion could not do. What a source-level
-// guard cannot answer is the one thing the operator felt: which element is
-// actually under the finger. jsdom has no layout engine and no hit testing.
+// #1051 REOPENED — WHY THIS FILE HAS TWO ARMS. Raising the overlay to 42 fixed
+// the reporter's corner for half the userbase and did nothing for the other
+// half, and the variable is the themed background image. The #75 wallpaper
+// block declared `:root.theme-has-bg .scrollback-pane { isolation: isolate }`,
+// which makes the pane a STACKING CONTEXT: the overlay's 42 then resolves
+// inside that context and never meets `.shell-chrome` at all — what meets it is
+// the pane, at `z-index: auto`, and the ☰ wins no matter how high 42 goes.
+// The first arm below is the configuration that was already green; the second
+// is the one vjt was actually in. A single-arm spec measured the half that
+// never had the bug — which is exactly how a green suite shipped this twice.
+//
+// WHY AN E2E, AND WHY THE NUMBERS ARE NOT ENOUGH. The stacking NUMBERS are
+// pinned in `src/__tests__/shellChromeFloat.test.ts`, which regex-extracts them
+// from the stylesheet TEXT. Both numbers were correct throughout the defect and
+// the assertion passed the whole time: no text-level assertion can observe a
+// stacking context, because a stacking context is not written next to the
+// numbers it invalidates. It takes a rendered DOM, a real hit test, and the
+// wallpaper class actually engaged.
 //
 // WHY A QUERY WINDOW and not the `$server` one vjt reported from: the issue's
 // own measurement says the radius is EVERY non-channel window — the gate is
-// `Shell.tsx:920`, not a server-specific branch — and the query window has a
+// `Shell.tsx:913`, not a server-specific branch — and the query window has a
 // proven mobile driver in `issue985-mobile-floating-opener`. Same branch, same
 // float, fewer moving parts.
 //
@@ -38,27 +50,56 @@ import {
   selectChannel,
   waitForQueryWindowReady,
 } from "../fixtures/cicchettoPage";
+import {
+  createThemeWithBuiltinBackground,
+  listBuiltinBackgrounds,
+  setActiveTheme,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const PEER = `F1051${crypto.randomUUID().slice(0, 7)}`;
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-test.setTimeout(90_000);
+type PWPage = import("@playwright/test").Page;
 
-test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost element at its own coordinates", async ({
-  page,
-}) => {
-  const vjt = specUser();
-  await loginAs(page, vjt);
+test.setTimeout(120_000);
+
+// Activate a theme carrying a real built-in wallpaper for the running subject,
+// BEFORE the browser boots — `applyCustomTheme` engages `theme-has-bg` off the
+// `GET /me/theme` the shell fetches at start-up, so setting it after the load
+// would race the very class the arm is about. Returns nothing: the class is the
+// contract, and every caller asserts it on the page rather than trusting this.
+async function activateWallpaperTheme(
+  token: string,
+  label: string,
+  opacity: number,
+): Promise<void> {
+  const backgrounds = await listBuiltinBackgrounds(token);
+  const first = backgrounds[0];
+  if (!first) {
+    throw new Error("#1051 — the built-in background catalog is empty");
+  }
+  const theme = await createThemeWithBuiltinBackground(token, label, first.key, opacity);
+  await setActiveTheme(token, theme.id);
+}
+
+// The shared body of both arms: open a WHOIS card on a query window and prove
+// the ✕ is the element under the finger at its own centre. Written once and
+// called twice because the two arms differ ONLY in whether a wallpaper theme is
+// active — a copied body would let the arms drift and hide the asymmetry the
+// whole reopen was about.
+async function assertCardCloseWinsItsCorner(page: PWPage): Promise<void> {
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const peer = await IrcPeer.connect({ nick: PEER });
+  const peer = await IrcPeer.connect({ nick: `F1051${crypto.randomUUID().slice(0, 7)}` });
   try {
     await peer.join(CHANNEL);
-    await composeSend(page, `/q ${PEER}`);
-    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+    // The LIVE nick, not the requested one: #604's collision hardening may have
+    // renamed the peer, and a /q at the constant would open a window nobody is
+    // in (feedback_live_nick_is_authoritative_not_the_constant).
+    await composeSend(page, `/q ${peer.nick}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, peer.nick);
 
     // PRECONDITION — we are on the NON-channel branch, the only one that
     // floats the ☰. Without this the whole test could pass on a channel
@@ -68,7 +109,7 @@ test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost el
     const opener = page.getByTestId("shell-chrome-rail-opener");
     await expect(opener).toBeVisible({ timeout: 10_000 });
 
-    await composeSend(page, `/whois ${PEER}`);
+    await composeSend(page, `/whois ${peer.nick}`);
     const card = page.locator(".scrollback-overlay").getByTestId("whois-card");
     await expect(card).toBeVisible({ timeout: 15_000 });
 
@@ -119,4 +160,124 @@ test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost el
   } finally {
     await peer.disconnect("i1051 cleanup").catch(() => {});
   }
+}
+
+test("@webkit #1051 — with no background theme the card's ✕ is the topmost element at its own coordinates", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  // The arm's own premise: NO wallpaper, so the pane is not a stacking context
+  // and the overlay's 42 meets `.shell-chrome`'s 41 directly. Asserted rather
+  // than assumed — a future default theme carrying a background would silently
+  // turn this into a second copy of the arm below.
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+
+  await assertCardCloseWinsItsCorner(page);
+});
+
+test("@webkit #1051 — with a background theme active the card's ✕ still wins its own corner", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await activateWallpaperTheme(vjt.token, `e2e-1051-${vjt.name}`, 0.3);
+  await loginAs(page, vjt);
+
+  // The arm's premise, and the variable the reopen turned on: the class that
+  // used to make `.scrollback-pane` a stacking context is engaged. If this ever
+  // stops engaging, the arm degrades into a duplicate of the one above and must
+  // fail loudly rather than pass cheaply.
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+
+  await assertCardCloseWinsItsCorner(page);
+});
+
+// The other half of the #1051 fix, and the one the candidate measurement on the
+// issue explicitly could NOT make: dropping `isolation: isolate` is only a fix
+// if the wallpaper it was written for still paints, and still paints BEHIND the
+// message text. A hit-test arm cannot see that — an invisible wallpaper, or one
+// painting over the conversation, would leave both arms above green.
+//
+// Measured at opacity 1.0 rather than the 0.3 default, deliberately: at full
+// strength "the layer is under the text" and "the layer is over the text" are
+// the difference between a readable channel and a blank photo, so the oracle
+// below does not have to reason about blending.
+test("@webkit #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  const backgrounds = await listBuiltinBackgrounds(vjt.token);
+  const first = backgrounds[0];
+  if (!first) {
+    throw new Error("#1051 — the built-in background catalog is empty");
+  }
+
+  // CONTROL and SUBJECT differ in ONE field. Both copy the same built-in
+  // palette; only `background.builtin` changes. A control that also swapped 27
+  // colours would make the pixel diff below unattributable.
+  const control = await createThemeWithBuiltinBackground(
+    vjt.token,
+    `e2e-1051-nobg-${vjt.name}`,
+    null,
+    1,
+  );
+  const wallpapered = await createThemeWithBuiltinBackground(
+    vjt.token,
+    `e2e-1051-bg-${vjt.name}`,
+    first.key,
+    1,
+  );
+
+  await setActiveTheme(vjt.token, control.id);
+  await loginAs(page, vjt);
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const scrollback = page.locator(".scrollback");
+  await expect(scrollback).toBeVisible();
+  const withoutWallpaper = await scrollback.screenshot({ animations: "disabled" });
+
+  await setActiveTheme(vjt.token, wallpapered.id);
+  await page.reload();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(scrollback).toBeVisible();
+
+  // The layer is wired to the theme at all — the #294 assertion, kept because
+  // a wallpaper that never resolved its URL would make every pixel claim below
+  // vacuous for a reason that has nothing to do with stacking.
+  const layerImage = await page.evaluate(() => {
+    const pane = document.querySelector(".scrollback-pane");
+    return pane ? getComputedStyle(pane, "::before").backgroundImage : "";
+  });
+  expect(layerImage).toContain("/backgrounds/");
+
+  const withWallpaper = await scrollback.screenshot({ animations: "disabled" });
+
+  // CLAIM 1 — the wallpaper actually PAINTS. Same palette, same conversation,
+  // same element: the only difference between the two renders is the layer.
+  expect(
+    withWallpaper.equals(withoutWallpaper),
+    "#1051 — an opaque wallpaper must change what the scrollback area paints",
+  ).toBe(false);
+
+  // ORACLE CONTROL. Two shots of an untouched pane must be byte-identical, or
+  // "the pixels differed" below means nothing — a caret, a CRT flicker or a
+  // ticking timestamp inside this element would make CLAIM 2 pass on noise.
+  const withWallpaperAgain = await scrollback.screenshot({ animations: "disabled" });
+  expect(
+    withWallpaperAgain.equals(withWallpaper),
+    "#1051 — the scrollback must render deterministically for the pixel oracle to discriminate",
+  ).toBe(true);
+
+  // CLAIM 2 — the conversation paints ABOVE the opaque wallpaper. If the layer
+  // covered the text, the pane would be pure photograph and a new message would
+  // change nothing at all.
+  const marker = `i1051 wallpaper witness ${crypto.randomUUID().slice(0, 8)}`;
+  await composeSend(page, marker);
+  await expect(scrollback.getByText(marker, { exact: false })).toBeVisible({ timeout: 15_000 });
+  const afterMessage = await scrollback.screenshot({ animations: "disabled" });
+  expect(
+    afterMessage.equals(withWallpaper),
+    "#1051 — a message arriving must be visible over the wallpaper, not buried under it",
+  ).toBe(false);
 });

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -81,7 +81,9 @@ async function activateWallpaperTheme(
     throw new Error("#1051 — the built-in background catalog is empty");
   }
   const theme = await createThemeWithBuiltinBackground(token, label, first.key, opacity);
-  await setActiveTheme(token, theme.id);
+  // Single pick: the same wallpapered theme paints in both OS modes, so this
+  // arm cannot depend on which scheme the runner happens to boot in.
+  await setActiveTheme(token, theme.id, null);
 }
 
 // The shared body of both arms: open a WHOIS card on a query window and prove
@@ -200,7 +202,20 @@ test("@webkit #1051 — with a background theme active the card's ✕ still wins
 // Measured at opacity 1.0 rather than the 0.3 default, deliberately: at full
 // strength "the layer is under the text" and "the layer is over the text" are
 // the difference between a readable channel and a blank photo, so the oracle
-// below does not have to reason about blending.
+// does not have to reason about blending.
+//
+// HOW THE WALLPAPER IS TOGGLED, and why not with a reload. The first version
+// of this test screenshotted the pane before and after a `page.reload()` that
+// swapped the active theme, and it was a FALSE GREEN: mutating the wallpaper to
+// `opacity: 0` — invisible, the exact failure the claim exists to catch — still
+// produced two different images, because a reload changes the pane for reasons
+// of its own. So the swap now rides the #358 day/night pair instead: the light
+// slot is the control theme, the dark slot the wallpapered one, and
+// `emulateMedia` flips between them LIVE — same document, same scroll offset,
+// same conversation, one variable. The base `[data-theme]` block an OS flip
+// also swaps declares exactly the 27 colour vars the custom payload overrides,
+// so the flip is inert on everything except the layer under test; PHASE A
+// measures that rather than asserting it.
 test("@webkit #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
   page,
 }) => {
@@ -227,23 +242,45 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
     1,
   );
 
-  await setActiveTheme(vjt.token, control.id);
-  await loginAs(page, vjt);
-  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
-  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
-
   const scrollback = page.locator(".scrollback");
-  await expect(scrollback).toBeVisible();
-  const withoutWallpaper = await scrollback.screenshot({ animations: "disabled" });
+  const shoot = () => scrollback.screenshot({ animations: "disabled" });
+  const isDark = () => page.evaluate(() => document.documentElement.dataset.theme === "irssi-dark");
 
-  await setActiveTheme(vjt.token, wallpapered.id);
-  await page.reload();
-  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 15_000 });
+  // PHASE A — the oracle's own control. Both slots hold the CONTROL theme, so
+  // the light→dark flip changes the OS scheme and nothing else. If these two
+  // images are not byte-identical, the flip is not inert and every difference
+  // measured in phase B would be unattributable — this must fail LOUDLY rather
+  // than let phase B pass on the flip's own noise.
+  await setActiveTheme(vjt.token, control.id, control.id);
+  await page.emulateMedia({ colorScheme: "light" });
+  await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await expect(scrollback).toBeVisible();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
 
-  // The layer is wired to the theme at all — the #294 assertion, kept because
-  // a wallpaper that never resolved its URL would make every pixel claim below
+  const controlLight = await shoot();
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect.poll(isDark, { timeout: 10_000 }).toBe(true);
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  expect(
+    (await shoot()).equals(controlLight),
+    "#1051 — the OS-scheme flip must be inert under one theme, or it cannot isolate the wallpaper",
+  ).toBe(true);
+
+  // PHASE B — same flip, but now the dark slot carries the wallpaper.
+  await setActiveTheme(vjt.token, control.id, wallpapered.id);
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.reload();
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(scrollback).toBeVisible();
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(0);
+  const withoutWallpaper = await shoot();
+
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(page.locator("html.theme-has-bg")).toHaveCount(1, { timeout: 10_000 });
+
+  // The layer is wired to the theme at all — the #294 assertion, kept because a
+  // wallpaper that never resolved its URL would make every pixel claim below
   // vacuous for a reason that has nothing to do with stacking.
   const layerImage = await page.evaluate(() => {
     const pane = document.querySelector(".scrollback-pane");
@@ -251,23 +288,14 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
   });
   expect(layerImage).toContain("/backgrounds/");
 
-  const withWallpaper = await scrollback.screenshot({ animations: "disabled" });
+  const withWallpaper = await shoot();
 
-  // CLAIM 1 — the wallpaper actually PAINTS. Same palette, same conversation,
-  // same element: the only difference between the two renders is the layer.
+  // CLAIM 1 — the wallpaper actually PAINTS. Phase A established that the flip
+  // alone changes nothing, so the difference is the layer and only the layer.
   expect(
     withWallpaper.equals(withoutWallpaper),
     "#1051 — an opaque wallpaper must change what the scrollback area paints",
   ).toBe(false);
-
-  // ORACLE CONTROL. Two shots of an untouched pane must be byte-identical, or
-  // "the pixels differed" below means nothing — a caret, a CRT flicker or a
-  // ticking timestamp inside this element would make CLAIM 2 pass on noise.
-  const withWallpaperAgain = await scrollback.screenshot({ animations: "disabled" });
-  expect(
-    withWallpaperAgain.equals(withWallpaper),
-    "#1051 — the scrollback must render deterministically for the pixel oracle to discriminate",
-  ).toBe(true);
 
   // CLAIM 2 — the conversation paints ABOVE the opaque wallpaper. If the layer
   // covered the text, the pane would be pure photograph and a new message would
@@ -275,9 +303,8 @@ test("@webkit #1051 — the wallpaper still paints, and still paints behind the 
   const marker = `i1051 wallpaper witness ${crypto.randomUUID().slice(0, 8)}`;
   await composeSend(page, marker);
   await expect(scrollback.getByText(marker, { exact: false })).toBeVisible({ timeout: 15_000 });
-  const afterMessage = await scrollback.screenshot({ animations: "disabled" });
   expect(
-    afterMessage.equals(withWallpaper),
+    (await shoot()).equals(withWallpaper),
     "#1051 — a message arriving must be visible over the wallpaper, not buried under it",
   ).toBe(false);
 });

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -11,10 +11,31 @@
 // That spec binds against networks it creates with `POST /admin/networks` and
 // no server row. A server-less network fails plan resolution, so even the
 // FIXED code does not dial there — the scenario is blind to this bug by
-// construction. This spec therefore adds the one thing that was missing: an
-// enabled server, pointed at the same `bahamut-test:6667` testnet the seeder
-// uses. Everything else stays throwaway (own user, own network, own nick), so
-// nothing here touches the seeded vjt / m9b credentials other specs depend on.
+// construction. What this spec needs, and it has to get it somewhere, is a
+// network with an ENABLED SERVER.
+//
+// ## Why it borrows the seeded network instead of building its own
+//
+// The first version of this spec built a throwaway network and attached a
+// server to it. It passed — and 26 minutes later, in the same run, it failed
+// two assertions in `ux-6-g-admin-mobile-h-scroll.spec.ts`, which measures
+// that no admin table is wider than a phone panel: 393px against a 365px
+// panel, 28px of overflow, read identically by that spec's scrollLeft clamp.
+//
+// The throwaway network could not be deleted. `Networks.delete_network/1`
+// refuses a network that has scrollback, and this is the only spec whose
+// network gets a LIVE session — the moment it dials, the server's `$server`
+// notices are persisted against that network. The teardown's DELETE was
+// refused, the best-effort `catch` swallowed the refusal, and a row with a
+// 27-character slug sat in the Networks tab for the rest of the run
+// (`workers: 1`, so every later spec saw it). The width failure was this
+// spec's leak, arriving late and wearing another spec's name.
+//
+// So it binds a throwaway USER to the SEEDED `bahamut-test` network instead.
+// That network is already in the Networks tab and the baseline already fits
+// it, so this spec adds nothing to any measured table. The seeded vjt / m9b
+// CREDENTIALS other specs depend on are untouched: a second credential on the
+// same network is additive, and unbind removes it and stops its session.
 //
 // ## The oracle
 //
@@ -35,14 +56,8 @@
 
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { getSeededAdmin } from "../fixtures/seedData";
+import { getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-// The testnet endpoint the compose seeder binds `vjt` to. Reaching it by its
-// docker alias is what makes the spawn real: a dial that resolves, connects
-// and registers.
-const TESTNET_HOST = "bahamut-test";
-const TESTNET_PORT = 6667;
 
 type Admin = ReturnType<typeof getSeededAdmin>;
 
@@ -82,35 +97,64 @@ async function createUser(token: string, name: string): Promise<string> {
   return ((await res.json()) as { id: string }).id;
 }
 
-async function createNetwork(token: string, slug: string): Promise<number> {
-  const res = await api(token, "POST", "/admin/networks", { slug });
-  if (!res.ok) throw new Error(`createNetwork: ${slug} → ${res.status}`);
-  return ((await res.json()) as { id: number }).id;
+// The seeded network is the one with an enabled server (`bahamut-test:6667`),
+// which is the whole reason this spec can dial at all. Resolved by slug rather
+// than hardcoded: the id is assigned by whichever order the seeder ran in.
+async function seededNetworkId(token: string): Promise<number> {
+  const res = await api(token, "GET", "/admin/networks");
+  if (!res.ok) throw new Error(`seededNetworkId: ${res.status}`);
+  const body = (await res.json()) as { networks: { id: number; slug: string }[] };
+  const net = body.networks.find((n) => n.slug === NETWORK_SLUG);
+  if (net === undefined) throw new Error(`seededNetworkId: no network ${NETWORK_SLUG}`);
+  return net.id;
 }
 
-// The step that separates this spec from the existing bind coverage: without
-// an enabled server the bind cannot dial even when the code is correct.
-async function addTestnetServer(token: string, networkId: number): Promise<void> {
-  const res = await api(token, "POST", `/admin/networks/${networkId}/servers`, {
-    host: TESTNET_HOST,
-    port: TESTNET_PORT,
-    tls: false,
-  });
-  if (!res.ok) throw new Error(`addTestnetServer: ${networkId} → ${res.status}`);
-}
-
-// Unbind is the teardown that matters: it stops the live session, so the
-// throwaway upstream connection does not outlive the test and count against
-// the next one. Best-effort — a failed cleanup must not mask the verdict.
-async function cleanup(token: string, userId: string | null, networkId: number | null) {
+// Unbind is the teardown that matters: it stops the live session this spec
+// started, so the upstream connection does not outlive the test.
+//
+// It reports instead of swallowing. A silent best-effort teardown is what
+// turned the first version of this spec into a cascade poisoner — the cleanup
+// was refused, said nothing, and a later spec paid for it. A leak here cannot
+// be allowed to fail the test (that would mask the real verdict), so it lands
+// as a test annotation: visible in the report, attached to the spec that
+// caused it, and not to the one that trips over it 26 minutes later.
+async function unbind(
+  token: string,
+  userId: string,
+  networkId: number,
+  testInfo: import("@playwright/test").TestInfo,
+): Promise<void> {
   try {
-    if (userId !== null && networkId !== null) {
-      await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    const res = await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    if (!res.ok) {
+      testInfo.annotations.push({
+        type: "leak",
+        description: `unbind ${userId}:${networkId} → ${res.status}; a live session may survive this spec`,
+      });
     }
-    if (networkId !== null) await api(token, "DELETE", `/admin/networks/${networkId}`);
-    if (userId !== null) await api(token, "DELETE", `/admin/users/${userId}`);
-  } catch {
-    // best-effort
+  } catch (err) {
+    testInfo.annotations.push({ type: "leak", description: `unbind threw: ${String(err)}` });
+  }
+}
+
+// The user carries this spec's scrollback (the `$server` notices its session
+// receives), which CASCADEs away with the row. Deleting the user is therefore
+// what keeps the seeded network free of this spec's residue.
+async function deleteUser(
+  token: string,
+  userId: string,
+  testInfo: import("@playwright/test").TestInfo,
+): Promise<void> {
+  try {
+    const res = await api(token, "DELETE", `/admin/users/${userId}`);
+    if (!res.ok) {
+      testInfo.annotations.push({
+        type: "leak",
+        description: `deleteUser ${userId} → ${res.status}; a throwaway user survives this spec`,
+      });
+    }
+  } catch (err) {
+    testInfo.annotations.push({ type: "leak", description: `deleteUser threw: ${String(err)}` });
   }
 }
 
@@ -125,18 +169,15 @@ test("admin binds a credential from the console and the session dials out", asyn
   // repeat indices disambiguate runs that land in the same millisecond.
   const stamp = `${Date.now()}-${testInfo.workerIndex}-${testInfo.repeatEachIndex}`;
   const userName = `e2e1163-u-${stamp}`;
-  const netSlug = `e2e1163-n-${stamp}`;
   // An IRC nick caps at 30 chars, so the stamp is shortened here rather than
   // reused whole.
   const nick = `b1163-${Date.now() % 1_000_000}-${testInfo.workerIndex}${testInfo.repeatEachIndex}`;
 
+  const networkId = await seededNetworkId(admin.token);
   let userId: string | null = null;
-  let networkId: number | null = null;
 
   try {
     userId = await createUser(admin.token, userName);
-    networkId = await createNetwork(admin.token, netSlug);
-    await addTestnetServer(admin.token, networkId);
 
     await adminLogin(page, admin);
     await openCredentialsTab(page);
@@ -150,7 +191,7 @@ test("admin binds a credential from the console and the session dials out", asyn
     // in the issue actually used, and the one that had no other door on a
     // release image (#1158).
     await page.getByTestId("admin-credentials-bind-user").selectOption({ label: userName });
-    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: netSlug });
+    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: NETWORK_SLUG });
     await page.getByTestId("admin-credentials-bind-nick").fill(nick);
     await page.getByTestId("admin-credentials-bind-auth-method").selectOption("none");
     await page.getByTestId("admin-credentials-bind-submit").click();
@@ -177,6 +218,9 @@ test("admin binds a credential from the console and the session dials out", asyn
     await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
     await expect(reloadedRow).toContainText("connected");
   } finally {
-    await cleanup(admin.token, userId, networkId);
+    if (userId !== null) {
+      await unbind(admin.token, userId, networkId, testInfo);
+      await deleteUser(admin.token, userId, testInfo);
+    }
   }
 });

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -1,0 +1,182 @@
+// #1163 — binding a credential from the admin CONSOLE dials the upstream.
+//
+// The defect: `POST /admin/credentials` wrote the row, returned 201 and never
+// spawned a session, while writing `connection_state: :connected` (the schema
+// default). The operator saw a credential that claimed a live session, had
+// nothing to press, and got "That network or resource doesn't exist." from
+// every send until the node was restarted.
+//
+// ## Why admin-credentials.spec.ts could not have caught it
+//
+// That spec binds against networks it creates with `POST /admin/networks` and
+// no server row. A server-less network fails plan resolution, so even the
+// FIXED code does not dial there — the scenario is blind to this bug by
+// construction. This spec therefore adds the one thing that was missing: an
+// enabled server, pointed at the same `bahamut-test:6667` testnet the seeder
+// uses. Everything else stays throwaway (own user, own network, own nick), so
+// nothing here touches the seeded vjt / m9b credentials other specs depend on.
+//
+// ## The oracle
+//
+// The Credentials tab renders two independent readings per row, and #1163 is
+// precisely the case where they disagreed:
+//
+//   * CONNECTION — the DB intent (`connection_state`).
+//   * LIVE — the BEAM truth, rendered verbatim as `alive` or `BEAM has no pid`.
+//
+// Before the fix the row read `connected` + `BEAM has no pid`: the U-0 lie,
+// visible in the console itself. After it, `connected` + `alive`. Asserting
+// BOTH is what makes this a regression test rather than a smoke test —
+// `alive` alone would still pass an implementation that spawned the session
+// and forgot to commit the state, and `connected` alone is what shipped.
+//
+// The assertions are repeated after a full page reload so the witness is a
+// second server round-trip, not a client-side artifact of the bind response.
+
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// The testnet endpoint the compose seeder binds `vjt` to. Reaching it by its
+// docker alias is what makes the spawn real: a dial that resolves, connects
+// and registers.
+const TESTNET_HOST = "bahamut-test";
+const TESTNET_PORT = 6667;
+
+type Admin = ReturnType<typeof getSeededAdmin>;
+
+async function adminLogin(page: import("@playwright/test").Page, seed: Admin): Promise<void> {
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+async function openCredentialsTab(page: import("@playwright/test").Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-credentials").click();
+  await expect(page.getByTestId("admin-credentials-table")).toBeVisible({ timeout: 10_000 });
+}
+
+async function api(token: string, method: string, path: string, body?: unknown): Promise<Response> {
+  return await fetch(`${GRAPPA_BASE_URL}${path}`, {
+    method,
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function createUser(token: string, name: string): Promise<string> {
+  const res = await api(token, "POST", "/admin/users", {
+    name,
+    password: "test-password-not-secret",
+  });
+  if (!res.ok) throw new Error(`createUser: ${name} → ${res.status}`);
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function createNetwork(token: string, slug: string): Promise<number> {
+  const res = await api(token, "POST", "/admin/networks", { slug });
+  if (!res.ok) throw new Error(`createNetwork: ${slug} → ${res.status}`);
+  return ((await res.json()) as { id: number }).id;
+}
+
+// The step that separates this spec from the existing bind coverage: without
+// an enabled server the bind cannot dial even when the code is correct.
+async function addTestnetServer(token: string, networkId: number): Promise<void> {
+  const res = await api(token, "POST", `/admin/networks/${networkId}/servers`, {
+    host: TESTNET_HOST,
+    port: TESTNET_PORT,
+    tls: false,
+  });
+  if (!res.ok) throw new Error(`addTestnetServer: ${networkId} → ${res.status}`);
+}
+
+// Unbind is the teardown that matters: it stops the live session, so the
+// throwaway upstream connection does not outlive the test and count against
+// the next one. Best-effort — a failed cleanup must not mask the verdict.
+async function cleanup(token: string, userId: string | null, networkId: number | null) {
+  try {
+    if (userId !== null && networkId !== null) {
+      await api(token, "DELETE", `/admin/credentials/${userId}/${networkId}`);
+    }
+    if (networkId !== null) await api(token, "DELETE", `/admin/networks/${networkId}`);
+    if (userId !== null) await api(token, "DELETE", `/admin/users/${userId}`);
+  } catch {
+    // best-effort
+  }
+}
+
+test("admin binds a credential from the console and the session dials out", async ({
+  page,
+}, testInfo) => {
+  const admin = getSeededAdmin();
+
+  // Stamped per run, not fixed: this spec registers a nick on a persistent
+  // testnet, and a fixed identifier makes it once-per-container — `docs/TESTING.md`
+  // iso-rerun triage (`--repeat-each`) has to stay available on it. Worker and
+  // repeat indices disambiguate runs that land in the same millisecond.
+  const stamp = `${Date.now()}-${testInfo.workerIndex}-${testInfo.repeatEachIndex}`;
+  const userName = `e2e1163-u-${stamp}`;
+  const netSlug = `e2e1163-n-${stamp}`;
+  // An IRC nick caps at 30 chars, so the stamp is shortened here rather than
+  // reused whole.
+  const nick = `b1163-${Date.now() % 1_000_000}-${testInfo.workerIndex}${testInfo.repeatEachIndex}`;
+
+  let userId: string | null = null;
+  let networkId: number | null = null;
+
+  try {
+    userId = await createUser(admin.token, userName);
+    networkId = await createNetwork(admin.token, netSlug);
+    await addTestnetServer(admin.token, networkId);
+
+    await adminLogin(page, admin);
+    await openCredentialsTab(page);
+
+    // Pre-state: the binding does not exist yet, so the row this test is about
+    // to assert on cannot be a leftover from an earlier run.
+    const credKey = `${userId}:${networkId}`;
+    await expect(page.getByTestId(`admin-credential-row-${credKey}`)).toHaveCount(0);
+
+    // The bind goes through the CONSOLE, not the API — the door the operator
+    // in the issue actually used, and the one that had no other door on a
+    // release image (#1158).
+    await page.getByTestId("admin-credentials-bind-user").selectOption({ label: userName });
+    await page.getByTestId("admin-credentials-bind-network").selectOption({ label: netSlug });
+    await page.getByTestId("admin-credentials-bind-nick").fill(nick);
+    await page.getByTestId("admin-credentials-bind-auth-method").selectOption("none");
+    await page.getByTestId("admin-credentials-bind-submit").click();
+
+    const row = page.getByTestId(`admin-credential-row-${credKey}`);
+    await expect(row).toHaveCount(1, { timeout: 10_000 });
+
+    // The witness. `alive` is the BEAM reading: a Session.Server exists for
+    // this (user, network). Before #1163 this cell read `BEAM has no pid` and
+    // stayed that way until the node restarted.
+    await expect(row).toContainText("alive", { timeout: 10_000 });
+    await expect(row).not.toContainText("BEAM has no pid");
+
+    // The other half of U-0: the DB intent agrees with the BEAM. A row that
+    // says `connected` is only honest when the pid above exists.
+    await expect(row).toContainText("connected");
+
+    // Same two readings after a fresh load, so the verdict rests on a second
+    // GET /admin/credentials rather than on the bind response the tab just
+    // rendered.
+    await page.reload();
+    await openCredentialsTab(page);
+    const reloadedRow = page.getByTestId(`admin-credential-row-${credKey}`);
+    await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
+    await expect(reloadedRow).toContainText("connected");
+  } finally {
+    await cleanup(admin.token, userId, networkId);
+  }
+});

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -20,6 +20,7 @@ import {
   LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD,
   NETWORKS_CREDENTIAL_CONNECTION_STATE,
   NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION,
+  NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR,
   NETWORKS_NETWORK_SERVICES_FLAVOR,
   SCROLLBACK_MESSAGE_KIND,
   SESSION_LOG_EVENT,
@@ -580,6 +581,11 @@ export const S_NetworksCredentialsAdminWireLiveStateJson = {
 // Grappa.Networks.Credentials.AdminWire.session_action/0
 export const S_NetworksCredentialsAdminWireSessionAction = {
   e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION],
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.spawn_error/0
+export const S_NetworksCredentialsAdminWireSpawnError = {
+  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR],
 } as const;
 
 // Grappa.Networks.Credentials.AdminWire.t/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -11,6 +11,7 @@ export const ADMISSION_FLOW = [
   "bootstrap_visitor",
   "patch_network_connect",
   "visitor_reconnect",
+  "admin_credential_bind",
 ] as const;
 export type AdmissionFlow = (typeof ADMISSION_FLOW)[number];
 
@@ -572,9 +573,26 @@ export type NetworksCredentialsAdminWireT = {
   live_state: NetworksCredentialsAdminWireLiveStateJson | null;
 };
 
-export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION = ["left_alone", "stopped"] as const;
+export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION = [
+  "left_alone",
+  "stopped",
+  "spawned",
+  "not_spawned",
+] as const;
 export type NetworksCredentialsAdminWireSessionAction =
   (typeof NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION)[number];
+
+export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR = [
+  "resolve_failed",
+  "not_found",
+  "ip_cap_exceeded",
+  "visitor_cap_exceeded",
+  "user_cap_exceeded",
+  "network_circuit_open",
+  "start_failed",
+] as const;
+export type NetworksCredentialsAdminWireSpawnError =
+  (typeof NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR)[number];
 
 // === Grappa.Networks.FeaturedChannels.AdminWire ===
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2664,9 +2664,12 @@ html.resize-dragging * {
    the cards undismissable on a non-channel window: `.shell-chrome` floats its
    lone ☰ over the pane's top-RIGHT corner (#985) at 41, each card puts its ✕
    in that same corner (`margin-left: auto` in the card header), and 41 > 5, so
-   the ☰ won the hit test. 42 is the whole fix — vjt's ruling is that the card
-   wins, because if a card is open the intent is to close it, and closing it
-   uncovers the ☰ anyway. Ceiling is NOT the 89/90 drawer tier: `.toast-stack`
+   the ☰ won the hit test. vjt's ruling is that the card wins, because if a card
+   is open the intent is to close it, and closing it uncovers the ☰ anyway.
+   42 is only HALF the fix, and shipping it alone is why #1051 was reopened: a
+   number can only decide a hit test between elements in the SAME stacking
+   context, and the #75 wallpaper block used to make `.scrollback-pane` one (see
+   that block — it no longer does). Ceiling is NOT the 89/90 drawer tier: `.toast-stack`
    sits at 60 and must keep painting over a card, or a toast raised while a
    WHOIS is up is invisible. Consequence worth stating, since 42 also clears
    `.scrollback-float-stack` (40): a full-height card now covers the
@@ -8587,14 +8590,34 @@ html.resize-dragging * {
  * + chrome stay solid for legibility, and the ComposeBox (a sibling OUTSIDE
  * the pane) stays opaque. Gated on the `theme-has-bg` class
  * (applyCustomTheme) because CSS can't branch on the var being "none".
- * `isolation` makes the pane a stacking context so the ::before layer sits
- * below the (transparent) scrollback text but above the pane backdrop.
  * NEVER an <img> — the text-only-scrollback rule holds; this is a CSS
- * background-image only. */
-:root.theme-has-bg .scrollback-pane {
-  isolation: isolate;
-}
-
+ * background-image only.
+ *
+ * THE PANE MUST NOT BECOME A STACKING CONTEXT (#1051). The two rules below
+ * order the layer explicitly — `::before` at 0, `.scrollback` at 1 — and this
+ * block used to ALSO declare `isolation: isolate` here. That ordered these two
+ * correctly, and trapped every other z-index in the pane while doing it: the
+ * #133 pinned card overlay (42) stopped competing with the floated ☰ in
+ * `.shell-chrome` (41) and the pane itself competed instead, at `z-index:
+ * auto`. The ☰ therefore won the pane's top-right corner unconditionally and
+ * the WHOIS / WHOWAS / LUSERS ✕ that lives in that same corner could not be
+ * tapped — but ONLY for operators running a background image, which is why
+ * raising the overlay's number twice fixed the corner for half the userbase
+ * and did nothing for the other half. Do NOT reintroduce `isolation` here, nor
+ * `contain` / `filter` / `opacity` / `transform` / `will-change`: each of them
+ * re-creates the context and puts the card back under the ☰.
+ *
+ * What isolation was buying, and how it is paid for now: `::before` is
+ * positioned, so it paints above the pane's in-flow content unless that
+ * content is lifted — hence `.scrollback` at 1, which is a rule in its own
+ * right and not decoration. The tempting alternative, `::before` at -1, is the
+ * one shape that genuinely NEEDS a stacking context: resolved against the root
+ * instead, a negative layer slides under the shell's opaque background and the
+ * wallpaper disappears. Guarded by
+ * `e2e/tests/issue1051-card-close-above-float.spec.ts` — its second arm runs
+ * with a wallpaper theme active, and its third asserts the wallpaper still
+ * paints and still paints behind the conversation. No source-level assertion
+ * can see a stacking context, which is how this shipped twice. */
 :root.theme-has-bg .scrollback-pane::before {
   content: "";
   position: absolute;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -8611,9 +8611,12 @@ html.resize-dragging * {
  * positioned, so it paints above the pane's in-flow content unless that
  * content is lifted — hence `.scrollback` at 1, which is a rule in its own
  * right and not decoration. The tempting alternative, `::before` at -1, is the
- * one shape that genuinely NEEDS a stacking context: resolved against the root
- * instead, a negative layer slides under the shell's opaque background and the
- * wallpaper disappears. Guarded by
+ * one shape that genuinely NEEDS a stacking context, and it was measured
+ * rather than reasoned about: mutated to -1, the guard's pixel oracle reports
+ * the wallpaper stops painting altogether — resolved against the root the
+ * negative layer lands under an opaque box the isolated pane used to keep it
+ * above. Which box was not established and is not the point; -1 is simply not
+ * available here. Guarded by
  * `e2e/tests/issue1051-card-close-above-float.spec.ts` — its second arm runs
  * with a wallpaper theme active, and its third asserts the wallpaper still
  * paints and still paints behind the conversation. No source-level assertion

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36384,3 +36384,68 @@ was verified against a production install. And #1042 — whether the pane's
 top-right corner is a contract for every window kind — is still open and still
 untouched: #1050 denies the rail to one window kind, #1051 lets a card cover
 the ☰, and neither settles the question.
+## 2026-08-10 — #1163: the bind door never learned the sequence every other spawn surface knows
+
+`POST /admin/credentials` wrote the credential, returned `201`, and stopped.
+Its success path read `LiveIntrospection.lookup_session/2` — which only ever
+*asks* whether a session happens to be live — so nothing dialled until the
+node restarted. `DELETE` on the same resource has always stopped the live
+session. Two halves of one control, disagreeing.
+
+The issue as filed pointed the fix at `Grappa.Bootstrap`. That was the wrong
+name for the right idea: the runtime spawn door is
+`Grappa.SpawnOrchestrator.spawn/4` (admission → `Backoff.reset` → spawn), and
+Bootstrap is one of its five callers. `POST /admin/credentials` was the odd
+surface out — the only one that creates a session-relevant row without ever
+reaching the shared verb.
+
+**The `:connected` default made it worse than "no session".**
+`Credential.connection_state` defaults to `:connected`, so every console bind
+wrote a row that *claimed* a session it did not have. cic rendered CONNECTED —
+nothing to press — while `POST /messages` answered *"That network or resource
+doesn't exist."* That is verbatim the pre-U-0 state
+`NetworksController.apply_transition/5` was written to eliminate on the PATCH
+door. The fix is therefore the U-0 ordering, not a spawn bolted on after the
+insert: bind `:parked`, spawn, and let only a live `Session.Server` promote
+the row to `:connected`.
+
+**Why not `GrappaWeb.NetworkSpawn.orchestrate/4`**, the web-layer helper the
+two self-serve doors use. It builds the capacity input from the *request's*
+IP, which is correct when a user connects their own network and wrong when an
+admin acts for somebody else: the admin's IP would be counted against the
+target user's per-IP cap, and a busy evening of provisioning would start
+refusing binds for a reason having nothing to do with the user being bound. So
+the verb lands in `Grappa.Operator` — `connect_credential/1`, the user twin of
+the Visitors-tab `reconnect_session/2` — with `source_ip: nil` and a new
+`:admin_credential_bind` flow, exactly the shape the visitor reconnect already
+uses for the same on-behalf-of reason.
+
+**A refused spawn does not roll the bind back.** Accretion
+(`SessionController.spawn_or_rollback/4`) unbinds on refusal, and that is right
+*there*: the user asked to JOIN a network, and a network they cannot reach
+should not stay attached. Here the operator asked to PROVISION a credential —
+the row is their input, and deleting it would discard work the 201 already
+acknowledged. It stays `:parked`, which is a recoverable state (the owning user
+can `PATCH /networks/:id`), and the response says why: additive
+`session_action` + `session_error`, snake_case, no `protocol_version` bump. The
+alternative — a 500 on a row that exists — would lie about the write; silence
+would leave the operator debugging IRC connectivity for a network that was
+never dialled, which is the failure mode the issue was filed about.
+
+The servers-bound invariant did not move: the resolver is Bootstrap's own
+`SessionPlan.resolve/1`, so "no enabled server" fails at bind time the same way
+it fails at boot, not through a softer second copy of the rule.
+
+**The agreement test needed a 2×2, not a pair of assertions.** The acceptance
+criterion asks to prove the bind-time and boot-time spawns are one path. Simply
+asserting that each door spawns would leave the plausible wrong implementation
+— an inline copy that skips admission — fully green. So both doors are run
+against the same network under the same gate: with the circuit closed both
+bring a session up, with it open neither does. The skip-admission mutant passes
+the first and fails the second.
+
+**Not covered.** No browser-level check of the admin console; the tests drive
+the HTTP door. cic renders no copy for the two new fields yet — it casts the
+response without validating, so they are inert there, and the honest signal it
+*does* now show is the row reading `parked` instead of a fictitious
+`connected`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36288,3 +36288,99 @@ docs gained more than that. Relocation was the ruling, not shrinkage, and
 a runbook is the right place for prose that a config file is the wrong
 place for — but the total volume of English in the repo went up, and if
 that is not the intended end state the docs want their own pass.
+### 2026-08-09 — #1051 — a z-index cannot decide a hit test across a stacking context
+
+**The report that outlived its own fix.** The floated ☰ (#985) overflows a
+zero-height row into the pane's top-right corner; the #133 pinned lookup cards
+(WHOIS / WHOWAS / LUSERS) put their ✕ in that same corner. `c9333004` raised
+`.scrollback-overlay` from 5 to 42, over `.shell-chrome`'s 41, and shipped in
+v0.15.0 — and the person who filed the issue still could not tap the ✕.
+
+**Cause.** `:root.theme-has-bg .scrollback-pane { isolation: isolate }`, three
+thousand lines away in the #75 wallpaper block. `isolation` makes the pane a
+stacking context, so the overlay's 42 resolves INSIDE the pane and never meets
+`.shell-chrome`. What meets it is the pane, at `z-index: auto` — so the ☰ wins
+at any number the overlay could carry. The class is present only for operators
+running a background image. That is the whole shape of the incident: the same
+build was fixed for half the userbase and untouched for the other half, and
+every re-measurement that did not toggle that one class read green.
+
+**The general rule, which is why this is written down.** A z-index comparison
+is meaningful only between two elements in the same stacking context, and CSS
+gives no warning when they are not. The declaration that creates the context —
+`isolation`, `contain`, `filter`, `opacity`, `transform`, `will-change`, or a
+positioned ancestor carrying any z-index — is normally written in another
+block, for another feature, by someone who never heard of the two numbers it
+silently invalidates. When a z-index "does not work", the first question is
+which context it resolved in, not which number it should have been.
+
+**Fix.** Drop the isolation. The block already carried the two rules that do
+the ordering — `::before` at 0, `.scrollback` at 1 — and against the root they
+resolve in the same relative order they did inside the isolated pane, so the
+wallpaper is unchanged and the overlay is free to outrank the chrome.
+Rejected: keeping the isolation and moving the overlay or the ☰ so the two
+share a context. That is DOM surgery in `Shell.tsx` for a one-declaration
+cause, and it leaves the trap armed for the next in-pane layer that needs to
+outrank the chrome. Not available: `::before` at -1 (see below).
+
+**Why a green suite shipped it twice.** `src/__tests__/shellChromeFloat.test.ts`
+regex-extracts the two z-index values from the stylesheet TEXT and compares
+them. Both values were correct throughout the defect and the assertion passed
+the whole time. No text-level assertion can observe a stacking context: the
+declaration that creates one is not written next to the numbers it breaks, and
+a regex has no notion of an ancestor. The vitest file is kept — the numbers are
+still a contract — but it is not the guard.
+
+**Guard, and the matrix that makes it one.**
+`cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts` runs one shared
+body twice, parametrised on whether a theme carrying a real built-in wallpaper
+is active before boot; each arm asserts its own premise (`html.theme-has-bg`
+absent / present) so neither can decay into a copy of the other. Measured on
+`webkit-iphone-15`:
+
+| | no-wallpaper arm | wallpaper arm |
+|---|---|---|
+| before the fix | pass | **fail** — `elementFromPoint` at the ✕'s centre returns `.shell-chrome-rail-opener` |
+| after the fix | pass | pass |
+
+**The half the fix put at risk.** Removing the isolation is a fix only if the
+wallpaper still paints and still paints BEHIND the conversation, which no hit
+test can see. A third test measures it in pixels at opacity 1.0, where "behind"
+and "in front" are the difference between a readable channel and a blank
+photograph. The wallpaper is toggled by the #358 day/night pair — control theme
+in the light slot, wallpapered theme in the dark slot, `emulateMedia` flipping
+between them live — so the two renders share a document, a scroll offset and a
+conversation, and differ in one variable. Both themes copy the same built-in
+palette, so only `background.builtin` changes; and a first phase runs the same
+flip with the control theme in BOTH slots and requires the two images to be
+byte-identical, which measures the flip's inertness instead of arguing it.
+
+**The oracle was wrong first, and that is the reusable part.** The original
+version compared screenshots either side of a `page.reload()` that swapped the
+theme. Mutating the layer to `opacity: 0` — an invisible wallpaper, the exact
+failure the claim exists to catch — left it GREEN: a reload changes the pane
+for reasons of its own, so the difference was never attributable. A pixel
+oracle whose two samples straddle a navigation is not measuring the variable
+it names.
+
+Mutations run against the corrected oracle, each killing exactly one assertion:
+
+* `::before { opacity: 0 }` → only *"an opaque wallpaper must change what the
+  scrollback area paints"* fails.
+* `::before { z-index: 2 }` → the layer buries the text; only *"a message
+  arriving must be visible over the wallpaper"* fails, with the first claim and
+  the inertness phase passing on the way.
+* `::before { z-index: -1 }` → the first claim fails: the wallpaper stops
+  painting entirely. So -1 really is the shape that needs the stacking context
+  this change removes, and it is off the table. (Under the pre-correction
+  oracle this same mutation read green — the retraction is the point.)
+
+**What is NOT established.** The e2e is `webkit-iphone-15` only, because the
+float is mobile-only; the desktop shell never mounts it, which is an argument
+from `Shell.tsx`, not a measurement. The pixel claims cover ONE catalogue
+background at opacity 1.0 on one viewport — nothing here says anything about
+blending at the 0.3 default or about the other thirteen entries. Nothing here
+was verified against a production install. And #1042 — whether the pane's
+top-right corner is a contract for every window kind — is still open and still
+untouched: #1050 denies the rail to one window kind, #1051 lets a card cover
+the ☰, and neither settles the question.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36288,6 +36288,9 @@ docs gained more than that. Relocation was the ruling, not shrinkage, and
 a runbook is the right place for prose that a config file is the wrong
 place for — but the total volume of English in the repo went up, and if
 that is not the intended end state the docs want their own pass.
+
+---
+
 ### 2026-08-09 — #1051 — a z-index cannot decide a hit test across a stacking context
 
 **The report that outlived its own fix.** The floated ☰ (#985) overflows a
@@ -36384,6 +36387,9 @@ was verified against a production install. And #1042 — whether the pane's
 top-right corner is a contract for every window kind — is still open and still
 untouched: #1050 denies the rail to one window kind, #1051 lets a card cover
 the ☰, and neither settles the question.
+
+---
+
 ## 2026-08-10 — #1163: the bind door never learned the sequence every other spawn surface knows
 
 `POST /admin/credentials` wrote the credential, returned `201`, and stopped.
@@ -36449,6 +36455,9 @@ the HTTP door. cic renders no copy for the two new fields yet — it casts the
 response without validating, so they are inert there, and the honest signal it
 *does* now show is the row reading `parked` instead of a fictitious
 `connected`.
+
+---
+
 ## 2026-08-10 — a `VERSION`-only bump is a COLD deploy: the hot-reload walks the boot directory, not the built one
 
 #652 recorded that bumping the repo-root `VERSION` file is hot-deployable: the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36449,3 +36449,56 @@ the HTTP door. cic renders no copy for the two new fields yet — it casts the
 response without validating, so they are inert there, and the honest signal it
 *does* now show is the row reading `parked` instead of a fictitious
 `connected`.
+## 2026-08-10 — a `VERSION`-only bump is a COLD deploy: the hot-reload walks the boot directory, not the built one
+
+#652 recorded that bumping the repo-root `VERSION` file is hot-deployable: the
+constant is baked at compile time via `@external_resource`, the bump dirties
+`Grappa.Version`, `mix compile` rebuilds it, and `reload_modified/0` picks the
+new beam up by md5 — "the reported version updates WITHOUT a cold restart".
+The v0.16.0 cut measured that claim and it is **false on the release
+substrate**.
+
+What happened: the batch shipped on a cold deploy with the bump forgotten, so
+prod came up reporting `0.15.0-76df5fd9` with the right code. The bump was
+committed and deployed `--force-hot`. `/admin/reload` answered
+`{"failed":[],"reloaded":[]}` and `/api/config` — which calls
+`Grappa.Version.current/0` per request, so it is a live read, not a cached one
+— kept reporting `0.15.0`. On disk, `_build/prod/lib/grappa/ebin/Elixir.Grappa.Version.beam`
+already carried `0.16.0`, and a **new** release directory `lib/grappa-0.16.0/ebin`
+had appeared beside the old `lib/grappa-0.15.0/ebin`.
+
+That last observation is the whole mechanism. `mix.exs` reads the same
+`VERSION` file to stamp the OTP application version, so a bump renames the
+release's lib directory. `HotReload.reload_modified/0` walks
+`:code.lib_dir(:grappa)`, and a running node resolves that to the directory it
+**booted** from. The new beams land in a directory the node's code path has
+never heard of; the old directory is genuinely unchanged; so the reload is
+honest when it reports that it reloaded nothing. `reloaded: []` was the product
+telling the truth, and the temptation to write it off as the known "`/api/config`
+is stale after a hot deploy" folklore was the trap — that folklore is also
+wrong, since the controller reads the module live.
+
+The consequence for the deploy path: **a release bump needs a restart**, and
+`Grappa.Deploy.Preflight` classifying a `VERSION`-only diff as HOT is a
+mis-classification, not a feature. #652's narrower point still stands — the
+bump must not force a *rebuild-from-scratch* cold via `mix.exs`/`mix.lock`
+churn — but "no new deps" and "no restart" are different claims and #652
+conflated them.
+
+A second, independent ordering constraint surfaced in the same cut. The git
+facts behind the version suffix (`@git_facts`) are a **build-time** snapshot,
+so a build made before the tag exists reports the unreleased form
+`X.Y.Z-<shortsha>` even when its tree is exactly the tagged commit. v0.16.0
+therefore runs in production as `0.16.0-9632e34d`. The cure is ordering, not
+code: cut and push the tag **before** the deploy builds, which is what
+CLAUDE.md's bump → tag → push → deploy sequence already prescribes. A third
+restart to buy the bare string was refused: the suffix is cosmetic, corrects
+itself at the next cold deploy, and every restart drops every live IRC session.
+
+**Not proven.** Whether `reload_modified/0` should follow the newest
+`lib/grappa-*/ebin` instead of the boot directory is left open — loading beams
+from an application version the node did not boot raises questions about the
+`.app` resource and about half-migrated code paths that nobody has measured
+here. What is proven is the observation set above: empty `reloaded`, live
+controller read, new beam on disk, new versioned lib directory, and the served
+string unchanged until the restart.

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -68,6 +68,7 @@ defmodule Grappa.Admission do
           | :bootstrap_visitor
           | :patch_network_connect
           | :visitor_reconnect
+          | :admin_credential_bind
 
   @type capacity_input :: %{
           network_id: integer(),
@@ -196,6 +197,7 @@ defmodule Grappa.Admission do
   defp subject_kind_for_flow(:visitor_reconnect), do: :visitor
   defp subject_kind_for_flow(:bootstrap_user), do: :user
   defp subject_kind_for_flow(:patch_network_connect), do: :user
+  defp subject_kind_for_flow(:admin_credential_bind), do: :user
 
   defp check_circuit(network_id) do
     case NetworkCircuit.check(network_id) do

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -215,6 +215,6 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   end
 
   @spec error_tag(spawn_error() | {spawn_error(), term()}) :: spawn_error()
-  defp error_tag({tag, _payload}) when is_atom(tag), do: tag
+  defp error_tag({tag, _}) when is_atom(tag), do: tag
   defp error_tag(tag) when is_atom(tag), do: tag
 end

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -107,6 +107,9 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       must `/connect` to bring it back under the new creds. We don't
       auto-respawn — the `POST /networks/:slug/connect` verb is
       the operator-facing path that re-runs admission + spawn.
+
+  The POST bind writes the SAME wire key with its own disjoint set
+  (`:spawned` / `:not_spawned`) — see `t:bind_outcome/0`.
   """
   @type session_action :: :left_alone | :stopped
 
@@ -155,6 +158,31 @@ defmodule Grappa.Networks.Credentials.AdminWire do
     }
   end
 
+  @typedoc """
+  #1163 — what the POST bind did to the session, and why it did not do
+  it. `:spawned` means a `Session.Server` is running and the row was
+  committed `:connected`; `:not_spawned` means the row was created and
+  left `:parked`, with `session_error` naming the refusal.
+
+  The error tags are `Grappa.Operator.connect_credential/1`'s union with
+  its payloads dropped (a `{:network_circuit_open, retry_after}` renders
+  as `:network_circuit_open`) — spelled out rather than aliased because
+  `Grappa.Networks` must not depend on `Grappa.Admission`. Runtime tag
+  extraction is generic, so a tag added to
+  `Admission.capacity_error_atoms/0` still renders correctly; only this
+  type would go stale.
+  """
+  @type spawn_error ::
+          :resolve_failed
+          | :not_found
+          | :ip_cap_exceeded
+          | :visitor_cap_exceeded
+          | :user_cap_exceeded
+          | :network_circuit_open
+          | :start_failed
+
+  @type bind_outcome :: :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}
+
   @doc """
   Attaches a `session_action:` field to a credential JSON map (the
   bucket-3 PUT response shape). Defined here, not at the controller,
@@ -165,4 +193,28 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       when action in [:left_alone, :stopped] do
     Map.put(json, :session_action, action)
   end
+
+  @doc """
+  #1163 — attaches `session_action:` + `session_error:` to the POST bind
+  response. Sibling of `with_session_action/2` on the same key: both
+  answer "what happened to the session because of this admin verb", for
+  the two verbs that can move it.
+
+  `session_error` is `nil` on `:spawned`, so the operator reads one
+  field to tell "bound and connected" from "bound, and here is why it is
+  not dialling" — the alternative (a 201 that says nothing) is the
+  silent-swallow this endpoint shipped before #1163.
+  """
+  @spec with_bind_outcome(t(), bind_outcome()) :: map()
+  def with_bind_outcome(%{} = json, :spawned) do
+    Map.merge(json, %{session_action: :spawned, session_error: nil})
+  end
+
+  def with_bind_outcome(%{} = json, {:not_spawned, reason}) do
+    Map.merge(json, %{session_action: :not_spawned, session_error: error_tag(reason)})
+  end
+
+  @spec error_tag(spawn_error() | {spawn_error(), term()}) :: spawn_error()
+  defp error_tag({tag, _payload}) when is_atom(tag), do: tag
+  defp error_tag(tag) when is_atom(tag), do: tag
 end

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -94,8 +94,14 @@ defmodule Grappa.Networks.Credentials.AdminWire do
         }
 
   @typedoc """
-  Admin-panel bucket 3 — outcome of the PUT credential update against
-  any running `Session.Server` for `{:user, user_id} × network_id`.
+  What the admin verb did to the session for
+  `{:user, user_id} × network_id`. ONE wire key, `session_action`, so ONE
+  union — the codegen publishes it to cic as a single string-literal set,
+  and splitting the values across two types would have shipped cic a
+  union that omits half the values the field can carry.
+
+  PATCH (admin-panel bucket 3 — the credential update against any running
+  session):
 
     * `:left_alone` — no live session, OR the change set didn't include
       `:password` / `:auth_method` (cosmetic-only fields like autojoin or
@@ -108,10 +114,17 @@ defmodule Grappa.Networks.Credentials.AdminWire do
       auto-respawn — the `POST /networks/:slug/connect` verb is
       the operator-facing path that re-runs admission + spawn.
 
-  The POST bind writes the SAME wire key with its own disjoint set
-  (`:spawned` / `:not_spawned`) — see `t:bind_outcome/0`.
+  POST (#1163 — the bind that dials):
+
+    * `:spawned` — a `Session.Server` is running and the row was committed
+      `:connected`. `session_error` is `nil`.
+    * `:not_spawned` — the row was created and left `:parked`;
+      `session_error` names the refusal.
+
+  A consumer keys off the endpoint it called: the two pairs are disjoint
+  and neither verb can emit the other's values.
   """
-  @type session_action :: :left_alone | :stopped
+  @type session_action :: :left_alone | :stopped | :spawned | :not_spawned
 
   @doc """
   Render a Credential row + optional live SessionEntry to the admin
@@ -159,14 +172,12 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   end
 
   @typedoc """
-  #1163 — what the POST bind did to the session, and why it did not do
-  it. `:spawned` means a `Session.Server` is running and the row was
-  committed `:connected`; `:not_spawned` means the row was created and
-  left `:parked`, with `session_error` naming the refusal.
+  #1163 — the `session_error` value space: why a bind did not dial.
+  `nil` when it did.
 
-  The error tags are `Grappa.Operator.connect_credential/1`'s union with
-  its payloads dropped (a `{:network_circuit_open, retry_after}` renders
-  as `:network_circuit_open`) — spelled out rather than aliased because
+  These are `Grappa.Operator.connect_credential/1`'s error union with the
+  payloads dropped (a `{:network_circuit_open, retry_after}` renders as
+  `:network_circuit_open`) — spelled out rather than aliased because
   `Grappa.Networks` must not depend on `Grappa.Admission`. Runtime tag
   extraction is generic, so a tag added to
   `Admission.capacity_error_atoms/0` still renders correctly; only this
@@ -180,8 +191,6 @@ defmodule Grappa.Networks.Credentials.AdminWire do
           | :user_cap_exceeded
           | :network_circuit_open
           | :start_failed
-
-  @type bind_outcome :: :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}
 
   @doc """
   Attaches a `session_action:` field to a credential JSON map (the
@@ -204,8 +213,16 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   field to tell "bound and connected" from "bound, and here is why it is
   not dialling" — the alternative (a 201 that says nothing) is the
   silent-swallow this endpoint shipped before #1163.
+
+  The outcome argument is spelled INLINE, deliberately: a named public
+  type in a `*Wire` module is a wire CONTRACT — `mix grappa.gen_wire_types`
+  publishes every one of them to `cicchetto/src/lib/wireTypes.ts`. This
+  tuple is an internal Elixir hand-off between the controller and this
+  renderer; naming it shipped cic a `["not_spawned", …]` array type for a
+  payload the wire never carries.
   """
-  @spec with_bind_outcome(t(), bind_outcome()) :: map()
+  @spec with_bind_outcome(t(), :spawned | {:not_spawned, spawn_error() | {spawn_error(), term()}}) ::
+          map()
   def with_bind_outcome(%{} = json, :spawned) do
     Map.merge(json, %{session_action: :spawned, session_error: nil})
   end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -766,6 +766,102 @@ defmodule Grappa.Operator do
   end
 
   @doc """
+  #1163: dial the upstream for a USER credential the operator has just
+  bound, and commit `:connected` only if it comes up. The user twin of
+  `reconnect_session/2` — same admission → backoff-reset → spawn core
+  through `SpawnOrchestrator.spawn/4`, so the bind door and the boot
+  door (`Grappa.Bootstrap`) cannot drift.
+
+  ## Why not `GrappaWeb.NetworkSpawn.orchestrate/4`
+
+  That helper builds the capacity input from the REQUEST's IP, which is
+  right for the two self-serve doors it serves (a user connecting their
+  own network) and wrong here: the requester is an admin, the subject is
+  somebody else. Counting the admin's IP against the target user's cap
+  would refuse the fifth bind of an evening for a reason that has nothing
+  to do with the user being bound. `source_ip: nil` +
+  `requesting_subject: {:user, _}` is the shape `reconnect_session/2`
+  already uses for the same admin-on-behalf-of reason.
+
+  ## U-0 ordering
+
+  Spawn FIRST, commit `:connected` only on success (the invariant
+  `NetworksController.apply_transition/5` upholds for PATCH /connect and
+  `SessionController.spawn_or_rollback/4` for accretion). The caller binds
+  the row `:parked`; a refused spawn therefore leaves a `:parked`
+  credential — a normal, recoverable state — never the
+  `:connected`-with-no-Session.Server wedge where the UI reads CONNECTED
+  and every `POST /messages` 404s.
+
+  Errors mirror `reconnect_session/2` verbatim:
+
+    * `{:error, :resolve_failed}` — no enabled server on the network, or
+      the user row is gone (`SessionPlan.resolve/1`). The servers-bound
+      rule stays where it is: this is Bootstrap's resolver, not a softer
+      copy of it.
+    * `{:error, :not_found}` — the credential was unbound between the
+      admission check and the spawn (`Session.Server.init/1` → `:ignore`).
+    * `Admission.capacity_error()` / `{:start_failed, term()}` — verbatim
+      from `SpawnOrchestrator.spawn/4`.
+  """
+  @spec connect_credential(Credential.t()) ::
+          {:ok, Credential.t()}
+          | {:error, :resolve_failed | :not_found | Admission.capacity_error() | {:start_failed, term()}}
+  def connect_credential(%Credential{user_id: user_id, network_id: network_id} = credential)
+      when is_binary(user_id) do
+    with {:ok, plan} <- resolve_user_plan(credential),
+         :ok <- spawn_user_bind({:user, user_id}, network_id, plan) do
+      Networks.connect(credential)
+    end
+  end
+
+  # Mirror of `resolve_visitor_plan/2` on the user arm: collapse every
+  # `SessionPlan.resolve/1` failure (`:no_server` / `:user_not_found`) to
+  # the uniform `:resolve_failed`.
+  @spec resolve_user_plan(Credential.t()) ::
+          {:ok, Session.start_opts()} | {:error, :resolve_failed}
+  defp resolve_user_plan(%Credential{} = credential) do
+    case Networks.SessionPlan.resolve(credential) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "admin bind: user session plan resolve failed " <>
+            "(user_id=#{credential.user_id} network_id=#{credential.network_id} " <>
+            "reason=#{inspect(reason)})"
+        )
+
+        {:error, :resolve_failed}
+    end
+  end
+
+  # The admission → backoff-reset → spawn dance for an admin bind.
+  # `:admin_credential_bind` flow (subject_kind `:user`) so the network
+  # total + circuit gate the user pool under a tag that names the surface;
+  # `source_ip: nil` because the admin's IP is not the subject's (see
+  # `connect_credential/1`). `:already_started` collapses to `:ok` — a
+  # rebind of a network the user is somehow already live on keeps the live
+  # session, it does not bounce it.
+  @spec spawn_user_bind(Session.subject(), integer(), Session.start_opts()) ::
+          :ok | {:error, :not_found | Admission.capacity_error() | {:start_failed, term()}}
+  defp spawn_user_bind(subject, network_id, plan) do
+    capacity_input = %{
+      network_id: network_id,
+      source_ip: nil,
+      flow: :admin_credential_bind,
+      requesting_subject: subject
+    }
+
+    case SpawnOrchestrator.spawn(subject, network_id, plan, capacity_input) do
+      {:ok, :spawned, _} -> :ok
+      {:ok, :already_started, _} -> :ok
+      {:ok, :ignored} -> {:error, :not_found}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
   Print active visitors (anon TTL not yet elapsed + identified
   never-expires rows) as a tab-separated table: header + one row per
   visitor. #211 phase 7 — identity-wide columns only (id, expires_at,

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -153,7 +153,9 @@ defmodule GrappaWeb.Admin.CredentialsController do
   # the outcome rides out in the response body: no exception, but no
   # silence either.
   @spec connect_bound_credential(Credential.t()) ::
-          {Credential.t(), AdminWire.bind_outcome()}
+          {Credential.t(),
+           :spawned
+           | {:not_spawned, AdminWire.spawn_error() | {AdminWire.spawn_error(), term()}}}
   defp connect_bound_credential(cred) do
     case Operator.connect_credential(cred) do
       {:ok, connected} -> {connected, :spawned}

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -47,9 +47,9 @@ defmodule GrappaWeb.Admin.CredentialsController do
   """
   use GrappaWeb, :controller
 
-  alias Grappa.{Accounts, AdminEvents, LiveIntrospection, Networks}
+  alias Grappa.{Accounts, AdminEvents, LiveIntrospection, Networks, Operator}
   alias Grappa.AdminEvents.Wire, as: AdminEventsWire
-  alias Grappa.Networks.Credentials
+  alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.Networks.Credentials.AdminWire
   alias GrappaWeb.Admin.AuthPlug
   alias GrappaWeb.Validation
@@ -105,6 +105,12 @@ defmodule GrappaWeb.Admin.CredentialsController do
   optional `password`, `sasl_user`, `realname`, `auth_command_template`,
   `autojoin_channels`. Returns `201 Created` with the credential JSON
   shape (no password / password_encrypted leakage).
+
+  #1163 — the bind also DIALS: the row is written `:parked`, the session
+  is spawned through the shared orchestrator, and only a live
+  `Session.Server` promotes the row to `:connected`. A refused spawn
+  still returns `201` (the row exists) with
+  `session_action: "not_spawned"` + `session_error:` naming the refusal.
   """
   @spec create(Plug.Conn.t(), map()) ::
           Plug.Conn.t() | {:error, :not_found | :already_exists | :bad_request | Ecto.Changeset.t()}
@@ -116,11 +122,42 @@ defmodule GrappaWeb.Admin.CredentialsController do
          {:ok, network} <- fetch_network(network_id),
          {:ok, cred} <- bind_with_conflict_classification(user, network, attrs) do
       :ok = emit_credential_bound(user, network, cred, conn)
+      {cred, outcome} = connect_bound_credential(cred)
       live = LiveIntrospection.lookup_session({:user, cred.user_id}, cred.network_id)
 
       conn
       |> put_status(:created)
-      |> json(AdminWire.credential_to_admin_json(cred, live))
+      |> json(
+        cred
+        |> AdminWire.credential_to_admin_json(live)
+        |> AdminWire.with_bind_outcome(outcome)
+      )
+    end
+  end
+
+  # #1163 — the bind DIALS. Before this, `create/2` only ever *read*
+  # whether a session happened to be live, so a credential bound from the
+  # console sat there doing nothing until the node restarted; unbind, the
+  # other half of the same control, was live all along.
+  #
+  # The spawn is `Grappa.Operator.connect_credential/1` — the same
+  # admission → backoff-reset → spawn core Bootstrap and every other
+  # runtime spawn surface reach through `SpawnOrchestrator.spawn/4`, so
+  # bind-time and boot-time cannot drift.
+  #
+  # A refused spawn is NOT a failed bind: the row is written, so the 201
+  # stands and the credential stays (unlike accretion, which rolls its
+  # bind back — there the user asked to JOIN a network, here the operator
+  # asked to PROVISION a credential, and deleting it would discard their
+  # input). It stays `:parked` per the U-0 ordering the caller set up, and
+  # the outcome rides out in the response body: no exception, but no
+  # silence either.
+  @spec connect_bound_credential(Credential.t()) ::
+          {Credential.t(), AdminWire.bind_outcome()}
+  defp connect_bound_credential(cred) do
+    case Operator.connect_credential(cred) do
+      {:ok, connected} -> {connected, :spawned}
+      {:error, reason} -> {cred, {:not_spawned, reason}}
     end
   end
 
@@ -288,7 +325,17 @@ defmodule GrappaWeb.Admin.CredentialsController do
     extra = keys -- @allowed_create_keys
 
     if extra == [] and Map.has_key?(params, "nick") and Map.has_key?(params, "auth_method") do
-      {:ok, Validation.take_atomized(params, @allowed_create_keys, &maybe_atomize_auth_method/2)}
+      attrs = Validation.take_atomized(params, @allowed_create_keys, &maybe_atomize_auth_method/2)
+
+      # #1163 — bind `:parked`, NEVER the schema default `:connected`.
+      # `connect_bound_credential/1` promotes the row only once a
+      # `Session.Server` is actually running (the U-0 ordering). The
+      # default made every admin bind write a row that CLAIMED a session
+      # it never had: cic rendered CONNECTED, so there was nothing to
+      # press, while `POST /messages` answered "That network or resource
+      # doesn't exist." Same invariant `SessionController` binds accretion
+      # under, for the same reason.
+      {:ok, Map.put(attrs, :connection_state, :parked)}
     else
       {:error, :bad_request}
     end

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -549,7 +549,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
     end
 
     test "circuit open: neither door brings a session up", %{conn: conn} do
-      {_server, port} = start_irc_server()
+      {_, port} = start_irc_server()
       {network, _} = network_with_server(port: port, slug: "bind-agree-open-#{uniq()}")
       :ok = AdmissionStateHelpers.open_circuit!(network.id)
 
@@ -594,7 +594,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   end
 
   defp run_bootstrap do
-    {result, _log} = with_log(fn -> Bootstrap.run() end)
+    {result, _} = with_log(fn -> Bootstrap.run() end)
     result
   end
 

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -19,14 +19,16 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   """
   use GrappaWeb.ConnCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Networks}
-  alias Grappa.Networks.Credentials
+  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Bootstrap, IRCServer, Networks, Session}
+  alias Grappa.Bootstrap.Result
+  alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
   setup do
-    AdmissionStateHelpers.reset_session_supervisor()
+    AdmissionStateHelpers.reset_all()
     :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
     :ok
   end
@@ -480,6 +482,138 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
       assert json_response(conn, 422)["error"] == "validation_failed"
     end
+  end
+
+  describe "POST /admin/credentials — session spawn (#1163)" do
+    test "201 + the bound session dials out with no restart", %{conn: conn} do
+      {server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-spawn-#{uniq()}")
+      target_user = user_fixture(name: "bind-spawn-#{uniq()}")
+      stop_session_on_exit(target_user, network)
+
+      body = bind(conn, target_user, network, "vjt")
+
+      assert {:ok, "NICK vjt\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK"), 5_000)
+
+      assert is_pid(Session.whereis({:user, target_user.id}, network.id))
+
+      assert body["session_action"] == "spawned"
+      assert body["session_error"] == nil
+      assert body["live_state"] != nil
+
+      assert {:ok, %Credential{connection_state: :connected}} =
+               Credentials.get_credential(target_user, network)
+    end
+
+    test "201 + a network with no enabled server keeps the row :parked and says so", %{conn: conn} do
+      {:ok, network} = Networks.find_or_create_network(%{slug: "bind-noserver-#{uniq()}"})
+      target_user = user_fixture(name: "bind-noserver-#{uniq()}")
+
+      body = bind(conn, target_user, network, "vjt")
+
+      assert body["session_action"] == "not_spawned"
+      assert body["session_error"] == "resolve_failed"
+      assert body["live_state"] == nil
+      # U-0: the row never claims :connected without a live Session.Server.
+      assert body["connection_state"] == "parked"
+
+      assert {:ok, %Credential{connection_state: :parked}} =
+               Credentials.get_credential(target_user, network)
+
+      refute Session.whereis({:user, target_user.id}, network.id)
+    end
+  end
+
+  # The acceptance criterion the issue words as "the bind-time and boot-time
+  # spawn go through one code path — a test that proves the two agree". Both
+  # doors are run against the SAME network under the SAME admission gate: with
+  # the circuit closed both bring a session up, with it open neither does. A
+  # bind-time inline copy of the dance fails one half or the other — skipping
+  # admission passes the first test and fails the second.
+  describe "POST /admin/credentials — bind door and boot door are one path (#1163)" do
+    test "circuit closed: both doors bring a session up", %{conn: conn} do
+      {server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-agree-ok-#{uniq()}")
+
+      boot_user = boot_bound_user(network, "booted")
+      assert {:ok, %Result{spawned: 1}} = run_bootstrap()
+      assert is_pid(Session.whereis({:user, boot_user.id}, network.id))
+      assert {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK"), 5_000)
+
+      bind_user = user_fixture(name: "bind-agree-ok-#{uniq()}")
+      stop_session_on_exit(bind_user, network)
+
+      assert %{"session_action" => "spawned"} = bind(conn, bind_user, network, "bound")
+      assert is_pid(Session.whereis({:user, bind_user.id}, network.id))
+    end
+
+    test "circuit open: neither door brings a session up", %{conn: conn} do
+      {_server, port} = start_irc_server()
+      {network, _} = network_with_server(port: port, slug: "bind-agree-open-#{uniq()}")
+      :ok = AdmissionStateHelpers.open_circuit!(network.id)
+
+      boot_user = boot_bound_user(network, "booted")
+      assert {:ok, %Result{spawned: 0, capacity_rejected: 1}} = run_bootstrap()
+      refute Session.whereis({:user, boot_user.id}, network.id)
+
+      bind_user = user_fixture(name: "bind-agree-open-#{uniq()}")
+
+      assert %{"session_action" => "not_spawned", "session_error" => "network_circuit_open"} =
+               bind(conn, bind_user, network, "bound")
+
+      refute Session.whereis({:user, bind_user.id}, network.id)
+    end
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp start_irc_server do
+    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {server, IRCServer.port(server)}
+  end
+
+  defp stop_session_on_exit(user, network) do
+    on_exit(fn -> Session.stop_session({:user, user.id}, network.id, "test teardown") end)
+  end
+
+  # A credential the BOOT door will pick up: bound and left at the schema
+  # default `:connected`, exactly as a pre-#1163 deploy's rows read.
+  defp boot_bound_user(network, nick) do
+    user = user_fixture(name: "boot-#{uniq()}")
+
+    {:ok, _} =
+      Credentials.bind_credential(user, network, %{
+        nick: nick,
+        auth_method: :none,
+        autojoin_channels: []
+      })
+
+    stop_session_on_exit(user, network)
+    user
+  end
+
+  defp run_bootstrap do
+    {result, _log} = with_log(fn -> Bootstrap.run() end)
+    result
+  end
+
+  defp bind(conn, target_user, network, nick) do
+    session = admin_session()
+
+    conn
+    |> put_bearer(session.id)
+    |> put_req_header("content-type", "application/json")
+    |> post(
+      "/admin/credentials",
+      Jason.encode!(%{
+        user_id: target_user.id,
+        network_id: network.id,
+        nick: nick,
+        auth_method: "none"
+      })
+    )
+    |> json_response(201)
   end
 
   describe "DELETE /admin/credentials/:user_id/:network_id — admin-panel bucket 3" do


### PR DESCRIPTION
Replays PR #1166 (#1051) and PR #1171 (#1163) onto current `main`, plus one
docs commit of my own, so the three land under **one** gate instead of three.

Each of the two PRs was green against `3383abf6`, which attests `branch + base`
— never `branch + the other branch beside it`. This branch is what actually
merges, so this is where the suite should run.

## What is in it

- **#1051** — the #75 wallpaper made `.scrollback-pane` a stacking context, so
  the overlay's 42 resolved inside the pane and never met the chrome's 41. The
  fix drops `isolation`; the e2e guard swaps a real wallpaper in live, because
  the first oracle compared screenshots across a reload and an invisible
  wallpaper passed it.
- **#1163** — an admin credential bind wrote the row and stopped, so the UI
  showed a session that did not exist. The bind now goes through
  `Operator.connect_credential/1` to the same `SpawnOrchestrator.spawn/4`
  Bootstrap uses, and the row no longer defaults to `connected`.
- **docs** — a `VERSION`-only bump is a COLD deploy, not a hot one: the bump
  moves the release's beams to a new `lib/grappa-<new>/ebin` while the reload
  walks the directory the running node booted from. Measured on the v0.16.0
  cut.

## Replay verification

Per-file `--numstat` of this branch against `main` equals the summed
`--numstat` of the three source ranges, file by file.

`docs/DESIGN_NOTES.md` did not, at first: sources add 223 lines, the replay
produced 214, and the file kept exactly its previous 213 separators although
each source added one. Every non-blank line was present, so the deficit was
the three `---` entry boundaries, which git had matched away as context. They
are restored in their own commit, and the file now reconciles at 223 lines and
216 separators.

Supersedes #1166 and #1171 by content; both are closed against this branch.