### PR TITLE
fix(#1169): drop the extra field from the SASL PLAIN payload

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36511,6 +36511,9 @@ from an application version the node did not boot raises questions about the
 here. What is proven is the observation set above: empty `reloaded`, live
 controller read, new beam on disk, new versioned lib directory, and the served
 string unchanged until the restart.
+
+---
+
 ## 2026-08-10 — #1169: the SASL PLAIN payload had a field too many, and the comment above it described a shape that was never emitted
 
 `Grappa.IRC.AuthFSM`'s encoder built `<<0, u, 0, u, 0, pw>>`. RFC 4616 §2

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36511,3 +36511,61 @@ from an application version the node did not boot raises questions about the
 here. What is proven is the observation set above: empty `reloaded`, live
 controller read, new beam on disk, new versioned lib directory, and the served
 string unchanged until the restart.
+## 2026-08-10 — #1169: the SASL PLAIN payload had a field too many, and the comment above it described a shape that was never emitted
+
+`Grappa.IRC.AuthFSM`'s encoder built `<<0, u, 0, u, 0, pw>>`. RFC 4616 §2
+fixes the PLAIN message at `[authzid] NUL authcid NUL passwd` — three
+fields, two separators. That payload has three separators and four fields.
+An upstream splits on the first two NULs and treats the entire remainder
+as the password, so atheme received `authcid=u` and a password of
+`u\0pw`, and answered `904 ERR_SASLFAIL` — the same numeric it sends for
+a wrong password, with nothing to distinguish the two. SASL was therefore
+unusable on Libera.Chat and on every atheme-fronted network, and users
+fell back to `nickserv_identify`, which is the path that makes the sidebar
+report `identified: no` on non-bahamut servers (#388).
+
+**The reported cause and the actual cause differ, and the fix is the same
+either way.** The issue is titled "SASL PLAIN sends a non-empty authzid",
+and the comment that stood above the encoder said the same thing: that
+`sasl_user` filled both the authzid and the authcid slot. Neither was
+true at the byte level. A payload that really carried `authzid=authcid=u`
+would be `<<u, 0, u, 0, pw>>`, with no leading NUL; the field this code
+sent empty was already the authzid. What it got wrong was arity, not
+content. The repair — delete the duplicated `0, u` — is exactly what the
+issue proposed, so the mis-attribution cost nothing here; it is recorded
+because the next reader of that encoder would otherwise inherit a wrong
+model of what the bytes meant.
+
+**What the reproduction could not isolate.** The measurement in the issue
+compares `\0acct\0acct\0pass` against `\0acct\0pass` against a live
+Libera account. Those differ in field count AND in the authzid slot at
+once, so the run cannot say whether atheme also rejects an explicitly
+equal authzid. The third variant, `acct\0acct\0pass`, was not sent. That
+question is left open deliberately: an empty authzid is what the RFC
+prescribes for "authorize as the authenticated identity", it is the only
+case the credential schema can express (there is no authzid column
+distinct from `sasl_user`), and it is what mainstream clients send — so
+the answer would not change the code.
+
+**Azzurra's immunity is structural, not measured.** The encoder is
+reachable only from the `phase: :sasl_pending` clause of `step/2`, and
+that phase is entered only where a CAP ACK carrying `sasl` is handled.
+Azzurra advertises no `sasl` cap, so the phase never opens. This is a
+reading of the call graph; nothing was probed against the network to
+confirm it.
+
+**The regression guard asserts structure, not bytes.** Three test sites
+pinned the buggy payload as an exact binary and were corrected. The guard
+added alongside them splits the decoded payload on NUL and compares
+against `["", sasl_user, password]`, which fails on a wrong field count
+or a populated authzid and on nothing else — where a byte-string
+assertion would also fail on a fixture rename, reporting a fold that is
+not the one it is there to catch. It was read failing against the pre-fix
+encoder, printing the four-field payload.
+
+The `authzid=empty` / mechanism log breadcrumb the issue also asks for is
+deliberately NOT in this change: it needs `:mechanism` and `:authzid`
+added to the Logger metadata allowlist in `config/config.exs`, and any
+edit there forces a COLD deploy. The fix above is HOT, and holding it
+behind a restart window would keep a live defect in production for no
+gain. The breadcrumb ships separately, batched with other COLD work.

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -684,10 +684,22 @@ defmodule Grappa.IRC.AuthFSM do
     %{state | phase: new_phase, caps_buffer: []}
   end
 
-  # SASL PLAIN payload is `\0<authzid>\0<authcid>\0<password>`. We use
-  # `sasl_user` for both authzid and authcid — they only differ when the
-  # operator wants to authenticate as one identity but appear as another,
-  # which Grappa doesn't expose in the credential schema.
+  # SASL PLAIN payload is `[authzid] NUL authcid NUL passwd` (RFC 4616 §2)
+  # — exactly two separators. The authzid is left EMPTY, which the RFC
+  # defines as "authorize as the authenticated identity": the only case
+  # Grappa can express, since the credential schema has no authzid column
+  # separate from `sasl_user`.
+  #
+  # GH #1169: this used to emit `<<0, u, 0, u, 0, pw>>` — THREE separators,
+  # four fields. An upstream splits on the first two NULs and takes the
+  # remainder as the password, so atheme (Libera.Chat and every
+  # atheme-fronted network) read `authcid=u` with a password of `u\0pw`
+  # and answered with an opaque 904 ERR_SASLFAIL indistinguishable from a
+  # wrong credential. The comment that stood here claimed the encoder put
+  # `sasl_user` in BOTH fields; it never did — that shape would have been
+  # `<<u, 0, u, 0, pw>>`, with no leading NUL. Whether atheme would also
+  # reject an explicitly-equal authzid is untested and does not matter:
+  # empty is what the RFC calls for and what every mainstream client sends.
   #
   # S29 H10: explicit `is_binary(pw)` guard so a contract violation
   # (state.password somehow nil at the AUTHENTICATE + step) crashes
@@ -719,7 +731,7 @@ defmodule Grappa.IRC.AuthFSM do
               "sasl_plain_payload: NUL byte in password (RFC 4616 forbids; reject at irc/S5 boundary)"
 
       true ->
-        Base.encode64(<<0, u::binary, 0, u::binary, 0, pw::binary>>)
+        Base.encode64(<<0, u::binary, 0, pw::binary>>)
     end
   end
 

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -448,8 +448,31 @@ defmodule Grappa.IRC.AuthFSMTest do
       assert {:cont, ^state, sends} = AuthFSM.step(state, msg)
       [line] = send_lines(sends)
       "AUTHENTICATE " <> b64 = line
-      # PLAIN: \0authzid\0authcid\0password — authzid=authcid=sasl_user
-      assert Base.decode64!(b64) == <<0, "vjt", 0, "vjt", 0, "swordfish">>
+      # PLAIN: \0authzid\0authcid\0password — authzid empty (GH #1169)
+      assert Base.decode64!(b64) == <<0, "vjt", 0, "swordfish">>
+    end
+
+    # GH #1169. RFC 4616 §2 fixes the payload at `[authzid] NUL authcid
+    # NUL passwd` — exactly two separators, three fields. The encoder used
+    # to emit three separators (`\0 u \0 u \0 pw`), so an upstream that
+    # splits on the first two NULs read authzid="", authcid=u and a passwd
+    # of `u\0pw`: the wrong password, answered by atheme with an opaque
+    # 904 ERR_SASLFAIL that looks exactly like a bad credential.
+    #
+    # This asserts the field STRUCTURE rather than a byte string: the
+    # sibling test above pins the exact bytes and would also fail on a
+    # fixture rename, whereas this one can only fail for the reason it
+    # names — a field count other than three, or a non-empty authzid.
+    test "SASL PLAIN payload carries exactly [empty authzid, authcid, passwd] (#1169)",
+         %{state: state} do
+      msg = %Message{command: :authenticate, params: ["+"]}
+
+      assert {:cont, _, sends} = AuthFSM.step(state, msg)
+      [line] = send_lines(sends)
+      "AUTHENTICATE " <> b64 = line
+
+      assert :binary.split(Base.decode64!(b64), <<0>>, [:global]) ==
+               ["", state.sasl_user, state.password]
     end
 
     test "903 SASL ok -> CAP END + phase :pre_register + caps_buffer cleared",
@@ -911,7 +934,7 @@ defmodule Grappa.IRC.AuthFSMTest do
       assert {:cont, ^pending, sends} = AuthFSM.step(pending, msg)
       [line] = send_lines(sends)
       "AUTHENTICATE " <> b64 = line
-      assert Base.decode64!(b64) == <<0, "vjt", 0, "vjt", 0, "swordfish">>
+      assert Base.decode64!(b64) == <<0, "vjt", 0, "swordfish">>
     end
   end
 end

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1048,8 +1048,8 @@ defmodule Grappa.IRC.ClientTest do
       payload_line = Enum.at(lines, auth_payload)
       "AUTHENTICATE " <> b64 = String.trim_trailing(payload_line, "\r\n")
       decoded = Base.decode64!(b64)
-      # PLAIN: \0authzid\0authcid\0password — we use authzid=authcid=sasl_user
-      assert decoded == <<0, "vjt", 0, "vjt", 0, "swordfish">>
+      # PLAIN: \0authzid\0authcid\0password — authzid empty (GH #1169)
+      assert decoded == <<0, "vjt", 0, "swordfish">>
     end
 
     test "sasl-failed: 904 from server crashes the client (let it crash)" do


### PR DESCRIPTION
## What was wrong

`Grappa.IRC.AuthFSM`'s encoder built `<<0, u, 0, u, 0, pw>>`. RFC 4616 §2
fixes the SASL PLAIN message at `[authzid] NUL authcid NUL passwd` —
three fields, **two** separators. That payload has three separators and
four fields. An upstream splits on the first two NULs and takes the whole
remainder as the password, so atheme received `authcid=u` with a password
of `u\0pw` and answered `904 ERR_SASLFAIL` — the same numeric it sends
for a wrong password, with nothing to tell the two apart. SASL was
unusable on Libera.Chat and every atheme-fronted network.

## The reported cause and the actual cause differ

The issue title says "SASL PLAIN sends a non-empty authzid", and the
comment above the encoder claimed `sasl_user` filled both the authzid and
the authcid slot. Neither is true at the byte level: a payload really
carrying `authzid=authcid=u` would be `<<u, 0, u, 0, pw>>`, with no
leading NUL. The field this code sent empty **was already the authzid**.
The defect was arity, not content.

The repair is the one the issue proposed — delete the duplicated `0, u` —
so the mis-attribution costs nothing here. It is called out because the
next reader of that encoder would otherwise inherit a wrong model of what
the bytes meant.

## What is deliberately not claimed

- **The reproduction cannot isolate authzid from field count.** It
  compares `\0acct\0acct\0pass` against `\0acct\0pass`, which differ in
  both at once. The third variant, `acct\0acct\0pass`, was not sent, so
  whether atheme also rejects an explicitly equal authzid is unknown. It
  does not need to be known: empty authzid is what the RFC prescribes,
  the only case the credential schema can express (no authzid column
  distinct from `sasl_user`), and what mainstream clients send.
- **Azzurra's immunity is structural, not measured.** The encoder is
  reachable only from the `phase: :sasl_pending` clause of `step/2`, and
  that phase is entered only where a CAP ACK carrying `sasl` is handled.
  Azzurra advertises no `sasl` cap, so the phase never opens. This is a
  reading of the call graph; nothing was probed against the network.

## The guard

Three test sites pinned the buggy payload as an exact binary and are
corrected. The guard added alongside them asserts the field **structure**:
it splits the decoded payload on NUL and compares against
`["", sasl_user, password]`, so it fails on a wrong field count or a
populated authzid and on nothing else — where a byte-string assertion
would also fail on a fixture rename, reporting a fault that is not the
one it exists to catch.

It was read failing against the pre-fix encoder before the fix was
applied, printing the four-field payload:

```
code:  assert :binary.split(Base.decode64!(b64), <<0>>, [:global]) == ["", state.sasl_user, state.password]
left:  ["", "vjt", "vjt", "swordfish"]
right: ["", "vjt", "swordfish"]
```

Four failures in total on the pre-fix tree (the guard plus the three
corrected byte assertions); 219/219 green after.

## Follow-up, not forgotten

The `authzid=empty` / mechanism log breadcrumb the issue also asks for is
**not** in this PR. It needs `:mechanism` and `:authzid` added to the
Logger metadata allowlist in `config/config.exs` — an undeclared key is
silently dropped by the formatter — and any edit there forces a COLD
deploy. This fix is HOT, and holding a live defect behind a restart
window buys nothing. The breadcrumb ships separately, batched with other
COLD work.

## Gates

`scripts/check.sh` green end to end: credo `no issues`, dialyzer `passed
successfully`, ExUnit `5644 tests, 0 failures`, doctor, sobelow,
`deps.audit` clean, bats 390/390.