### PR TITLE
feat(#1169): name the mechanism and authzid on a SASL failure line

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -405,6 +405,13 @@ config :logger, :console,
     :numeric,
     :sasl_user,
     :nick,
+    # GH #1169: a 904 is the same numeric for a wrong password and for a
+    # payload the server could not parse, so the failure line names the
+    # mechanism driven and the shape of the authzid field sent
+    # (`Grappa.IRC.AuthFSM.sasl_breadcrumb/0`). Both are constants today,
+    # not secrets — the password never reaches a metadata key.
+    :mechanism,
+    :authzid,
     # UX-6-B1 (2026-05-20): embedded image uploader reaper failure
     # log lines carry the upload row id + slug so operator can grep
     # per-upload across the reaper + GET surface.

--- a/config/config.exs
+++ b/config/config.exs
@@ -408,10 +408,14 @@ config :logger, :console,
     # GH #1169: a 904 is the same numeric for a wrong password and for a
     # payload the server could not parse, so the failure line names the
     # mechanism driven and the shape of the authzid field sent
-    # (`Grappa.IRC.AuthFSM.sasl_breadcrumb/0`). Both are constants today,
-    # not secrets — the password never reaches a metadata key.
+    # (`Grappa.IRC.AuthFSM.sasl_breadcrumb/1`), plus how many fields that
+    # payload really carried — the only one of the three that can differ
+    # between a healthy handshake and the malformed payload #1169 was
+    # about. A count, never the contents: the password and the authcid do
+    # not reach a metadata key.
     :mechanism,
     :authzid,
+    :sasl_fields,
     # UX-6-B1 (2026-05-20): embedded image uploader reaper failure
     # log lines carry the upload row id + slug so operator can grep
     # per-upload across the reaper + GET surface.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38632,3 +38632,55 @@ promise of a reply would have to degrade to empty rather than spin — the
 cheapest way to satisfy that is to promise nothing. Escape also still closes
 the whole menu rather than stepping up one level; the back row is the way up.
 That is a judgement call, not a ruling, and it is one line if it should change.
+
+---
+
+## 2026-08-10 — #1169 part two: the breadcrumb, and why the guard asserts formatted output
+
+The fix for the SASL PLAIN payload ships separately and is HOT. This is
+the other half the issue asked for: the failure line now names the
+mechanism driven and the shape of the authzid sent, so the next opaque
+`904` is one grep from a verdict instead of a packet capture.
+
+**Why a 904 needed help at all.** The numeric is the same for a wrong
+password and for a payload the server could not parse. The line read
+`numeric=904 sasl_user=vjt` and stopped there, which describes the
+credential and says nothing about the message — so the failure mode that
+actually occurred (a malformed payload) was indistinguishable from the
+one everybody assumes.
+
+**A metadata key that is not in the allowlist is dropped at FORMAT
+time.** This is the trap that decides the shape of the guard.
+`config :logger, :console` carries an explicit `:metadata` list; a key
+absent from it is discarded by the formatter, not by the call. So the
+`Logger.error/2` call reads correctly, a test asserting the call
+arguments reads correctly, and the operator gets a line with the field
+missing. The guard therefore captures the log and asserts the FORMATTED
+string. It was run with the emit in place and the allowlist untouched,
+and failed — the captured line was
+`pid=<…> numeric=904 sasl_user=vjt [error] sasl auth failed`, both new
+fields absent. Declaring the two keys was the only change that turned it
+green. That red is what makes it a guard rather than a mirror:
+`ExUnit.CaptureLog` was verified to honour the production allowlist
+rather than formatting every key it is handed.
+
+**`mechanism` is derived; `authzid` is a label, and the difference is
+tied down.** The mechanism reads from the same module attribute that
+writes the `AUTHENTICATE <mech>` line, so it cannot name a mechanism the
+FSM does not drive. The authzid cannot be derived the same way: the
+encoder hard-codes it empty and keeps no state to read it back from.
+Rather than leave a constant that can drift, a second test decodes a
+payload the client actually put on the wire and asserts the first
+NUL-delimited field is empty **exactly when** the breadcrumb says
+`empty` — a correspondence, not a second copy of the constant, so it
+fails in both directions: populating the encoder's authzid without
+relabelling, and relabelling without touching the encoder. Given that
+this whole issue began as a comment describing an encoder shape that was
+never emitted, a breadcrumb held to the encoder only by convention would
+have been the same mistake with a new spelling.
+
+**This change is COLD by construction.** `config/*.exs` is compile-time
+configuration: a reload does not pick it up, the node has to restart.
+That is why it is not bundled with the payload fix, which is HOT and
+repairs a live defect — batching them would have held the repair behind
+a restart window for no gain.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38684,3 +38684,46 @@ configuration: a reload does not pick it up, the node has to restart.
 That is why it is not bundled with the payload fix, which is HOT and
 repairs a live defect — batching them would have held the repair behind
 a restart window for no gain.
+
+**A lamp that lights the same in both worlds is not a lamp.** The first
+draft of this breadcrumb carried `mechanism` and `authzid` and stopped
+there. Both are compile-time constants: `PLAIN` is the only mechanism
+this FSM drives, and `empty` is a hard-coded label. So the line reads
+IDENTICALLY on a healthy handshake and on the malformed payload that
+motivated the issue — which means it could not have diagnosed the very
+incident it was written for. Measured, not reasoned: with the pre-fix
+encoder in place the captured line was
+`numeric=904 sasl_user=vjt mechanism=PLAIN authzid=empty`, and the
+payload on the wire at that moment carried FOUR fields. The breadcrumb
+had nothing to say about the only thing that was wrong.
+
+So the line now also carries `sasl_fields`, the number of NUL-delimited
+fields the payload actually had — the one fact that differed between the
+broken and the healthy encoder (four against three). It is **derived**,
+not declared: `record_sasl_fields/2` decodes the payload the FSM just
+emitted and counts. A restated `3` would have been the same defect with
+a new spelling, and this issue is precisely a story about prose
+restating the encoder and drifting from it. `:none` is a distinct
+answer, not a zero: an upstream that refuses the mechanism answers the
+`AUTHENTICATE PLAIN` line itself, so no payload is ever encoded, and
+that is a materially different failure from a rejected credential. The
+key is emitted rather than omitted because an absent key is
+indistinguishable from one the formatter dropped — the trap described
+above.
+
+**Only the count crosses into the log.** The decoded payload is a local
+that dies with the call; it holds the authcid and the password, and
+neither is stored on the struct, returned, or logged. A field count
+reveals nothing about the fields.
+
+**The premise the issue was filed on was wrong, and the record should
+say so.** #1169 is titled "SASL PLAIN sends a non-empty authzid". It
+never did: the shape was `\0 u \0 u \0 pw`, whose first field is empty.
+The defect was an extra FIELD, not a populated one — established by the
+payload fix (part one) and visible again here, since the authzid
+correspondence guard passes unchanged against both encoders. That is
+also why that guard, which reads only the first field, survived the fix
+untouched: it measures the one thing the bug never touched. It still
+earns its place — it is the only thing that catches the label being
+changed without the encoder — but the count is what catches the encoder
+being changed without anyone noticing.

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -139,8 +139,19 @@ defmodule Grappa.IRC.AuthFSM do
           password: String.t() | nil,
           auth_method: auth_method(),
           phase: phase(),
-          caps_buffer: [String.t()]
+          caps_buffer: [String.t()],
+          sasl_fields: sasl_fields()
         }
+
+  @typedoc """
+  How many NUL-delimited fields the SASL PLAIN payload this FSM emitted
+  actually carried, or `:none` when it never got to emit one (GH #1169).
+
+  Counted from the bytes that went on the wire, NOT from the encoder's
+  declared shape: a restatement of the shape is what the operator already
+  had, and it read the same whether the payload was well-formed or not.
+  """
+  @type sasl_fields :: pos_integer() | :none
 
   @enforce_keys [
     :nick,
@@ -168,7 +179,9 @@ defmodule Grappa.IRC.AuthFSM do
     :phase,
     :nick_cap,
     nick_suffixes: [],
-    caps_buffer: []
+    caps_buffer: [],
+    # GH #1169: unset until the AUTHENTICATE payload is actually emitted.
+    sasl_fields: :none
   ]
 
   @doc """
@@ -322,9 +335,33 @@ defmodule Grappa.IRC.AuthFSM do
   its first field really is empty. Change the encoder's authzid and that
   test fails — which is the point, since the defect this breadcrumb was
   written for was prose about the encoder drifting from the encoder.
+
+  `sasl_fields` is the one field that is neither a label nor a constant,
+  and it is why this function takes a state at all. Both of the others
+  read IDENTICALLY on a healthy handshake and on the malformed payload
+  that motivated #1169, so neither could ever separate two 904s: the
+  defect was a payload carrying one field too many, and the field COUNT
+  is the only thing that differed. It is counted off the payload the FSM
+  really emitted (`record_sasl_fields/2`), so it reports what went out
+  rather than what the encoder is supposed to send. `:none` means no
+  payload was ever encoded — an upstream that refuses the mechanism
+  answers the `AUTHENTICATE PLAIN` line itself, and that is a materially
+  different failure from a rejected credential.
+
+  The count is a number and reveals nothing: the field CONTENTS never
+  reach a metadata key, here or anywhere on this line.
   """
-  @spec sasl_breadcrumb() :: [{:mechanism, String.t()} | {:authzid, String.t()}]
-  def sasl_breadcrumb, do: [mechanism: @sasl_mechanism, authzid: "empty"]
+  @spec sasl_breadcrumb(t()) ::
+          [{:mechanism, String.t()} | {:authzid, String.t()} | {:sasl_fields, sasl_fields()}]
+  def sasl_breadcrumb(%__MODULE__{} = state) do
+    [
+      mechanism: @sasl_mechanism,
+      authzid: "empty",
+      # `Map.get` rather than dot-access for the #216 hot-reload contract:
+      # a struct built before this field existed answers `:none`.
+      sasl_fields: Map.get(state, :sasl_fields) || :none
+    ]
+  end
 
   defp maybe_send_pass({%__MODULE__{auth_method: m, password: pw} = state, sends})
        when m in [:auto, :server_pass] and is_binary(pw) and pw != "" do
@@ -414,7 +451,8 @@ defmodule Grappa.IRC.AuthFSM do
   # stray pre-handshake `AUTHENTICATE` lines silently, mirroring the
   # post-`:registered` absorption above (line 227).
   def step(%__MODULE__{phase: :sasl_pending} = state, %Message{command: :authenticate, params: ["+"]}) do
-    {:cont, state, ["AUTHENTICATE #{sasl_plain_payload(state)}\r\n"]}
+    payload = sasl_plain_payload(state)
+    {:cont, record_sasl_fields(state, payload), ["AUTHENTICATE #{payload}\r\n"]}
   end
 
   def step(state, %Message{command: :authenticate}), do: {:cont, state, []}
@@ -760,6 +798,31 @@ defmodule Grappa.IRC.AuthFSM do
       true ->
         Base.encode64(<<0, u::binary, 0, pw::binary>>)
     end
+  end
+
+  # GH #1169 — how many NUL-delimited fields the payload we just emitted
+  # carried, for the failure breadcrumb.
+  #
+  # Derived by decoding the EMITTED base64 rather than by reading the
+  # encoder's shape, and that indirection is the whole point: the defect
+  # this breadcrumb exists for was a comment restating the encoder's shape
+  # and drifting from it, so a count restated the same way would report
+  # the intended payload while the wire carried another. Counting the
+  # bytes that actually went out cannot drift, because there is nothing
+  # left to drift from.
+  #
+  # Only the COUNT is kept. The decoded payload is a local that dies with
+  # the call; its fields hold `sasl_user` and the password and neither is
+  # stored, returned or logged.
+  @spec record_sasl_fields(t(), String.t()) :: t()
+  defp record_sasl_fields(state, payload) do
+    fields =
+      payload
+      |> Base.decode64!()
+      |> :binary.split(<<0>>, [:global])
+      |> length()
+
+    %{state | sasl_fields: fields}
   end
 
   # Parse a CAP LS / CAP ACK cap-list blob: space-separated cap tokens,

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -96,6 +96,13 @@ defmodule Grappa.IRC.AuthFSM do
 
   @auth_methods [:auto, :sasl, :server_pass, :nickserv_identify, :none]
 
+  # GH #1169. The only SASL mechanism this FSM drives. It names the
+  # `AUTHENTICATE <mech>` line AND the operator breadcrumb on a failure
+  # numeric, from one place: the defect that motivated the breadcrumb was
+  # a comment restating the encoder's shape and drifting from it, and a
+  # mechanism string restated at the log site would drift the same way.
+  @sasl_mechanism "PLAIN"
+
   @type auth_method :: :auto | :sasl | :server_pass | :nickserv_identify | :none
 
   @type phase ::
@@ -298,6 +305,26 @@ defmodule Grappa.IRC.AuthFSM do
 
     {final_state, Enum.reverse(reversed_sends)}
   end
+
+  @doc """
+  The SASL parameters an operator needs to read a failure numeric: the
+  mechanism driven, and the form of the authzid field the encoder sends.
+
+  GH #1169. A 904 says only "authentication failed" — a wrong password and
+  a payload the server could not parse are the same numeric. These two
+  fields separate them at a glance.
+
+  `mechanism` comes from the same attribute that writes the `AUTHENTICATE`
+  line, so it cannot name a mechanism the FSM does not drive. `authzid`
+  is a label, not a derivation: the encoder hard-codes an empty authzid
+  and has no state to read it back from, so the tie between the label and
+  the bytes is held by a test that decodes an emitted payload and checks
+  its first field really is empty. Change the encoder's authzid and that
+  test fails — which is the point, since the defect this breadcrumb was
+  written for was prose about the encoder drifting from the encoder.
+  """
+  @spec sasl_breadcrumb() :: [{:mechanism, String.t()} | {:authzid, String.t()}]
+  def sasl_breadcrumb, do: [mechanism: @sasl_mechanism, authzid: "empty"]
 
   defp maybe_send_pass({%__MODULE__{auth_method: m, password: pw} = state, sends})
        when m in [:auto, :server_pass] and is_binary(pw) and pw != "" do
@@ -561,7 +588,7 @@ defmodule Grappa.IRC.AuthFSM do
     acked = parse_cap_list(caps_blob)
 
     if "sasl" in acked do
-      {:cont, %{state | phase: :sasl_pending}, ["AUTHENTICATE PLAIN\r\n"]}
+      {:cont, %{state | phase: :sasl_pending}, ["AUTHENTICATE #{@sasl_mechanism}\r\n"]}
     else
       # SASL not ACK'd — `labeled-response` alone (or CAP END fallback).
       # Session.Server handles the `labeled-response` flag independently;

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -1674,7 +1674,10 @@ defmodule Grappa.IRC.Client do
   # The reason atom carries the structured data; the AuthFSM struct
   # supplies `sasl_user` for the SASL-related lines.
   defp log_stop_reason({:sasl_failed, code}, fsm) do
-    Logger.error("sasl auth failed", numeric: code, sasl_user: fsm.sasl_user)
+    Logger.error(
+      "sasl auth failed",
+      [numeric: code, sasl_user: fsm.sasl_user] ++ AuthFSM.sasl_breadcrumb()
+    )
   end
 
   defp log_stop_reason(:sasl_unavailable, fsm) do

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -1676,7 +1676,7 @@ defmodule Grappa.IRC.Client do
   defp log_stop_reason({:sasl_failed, code}, fsm) do
     Logger.error(
       "sasl auth failed",
-      [numeric: code, sasl_user: fsm.sasl_user] ++ AuthFSM.sasl_breadcrumb()
+      [numeric: code, sasl_user: fsm.sasl_user] ++ AuthFSM.sasl_breadcrumb(fsm)
     )
   end
 

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -441,15 +441,24 @@ defmodule Grappa.IRC.AuthFSMTest do
       %{state: %{state | phase: :sasl_pending}}
     end
 
-    test "AUTHENTICATE + -> AUTHENTICATE <base64 PLAIN payload>; state unchanged",
+    test "AUTHENTICATE + -> AUTHENTICATE <base64 PLAIN payload>; records only the field count",
          %{state: state} do
       msg = %Message{command: :authenticate, params: ["+"]}
 
-      assert {:cont, ^state, sends} = AuthFSM.step(state, msg)
+      assert {:cont, next, sends} = AuthFSM.step(state, msg)
       [line] = send_lines(sends)
       "AUTHENTICATE " <> b64 = line
       # PLAIN: \0authzid\0authcid\0password — authzid empty (GH #1169)
       assert Base.decode64!(b64) == <<0, "vjt", 0, "swordfish">>
+
+      # GH #1169 — emitting the payload is no longer state-free: it records
+      # how many fields actually went out, for the failure breadcrumb. This
+      # pins that the count is the ONLY thing it records, which is what the
+      # `^state` pin used to say. The count is asserted against the payload
+      # decoded above rather than as a literal, so it states a
+      # correspondence instead of a second copy of the byte assertion.
+      assert %{next | sasl_fields: :none} == state
+      assert next.sasl_fields == length(:binary.split(Base.decode64!(b64), <<0>>, [:global]))
     end
 
     # GH #1169. RFC 4616 §2 fixes the payload at `[authzid] NUL authcid
@@ -931,10 +940,16 @@ defmodule Grappa.IRC.AuthFSMTest do
 
       msg = %Message{command: :authenticate, params: ["+"]}
 
-      assert {:cont, ^pending, sends} = AuthFSM.step(pending, msg)
+      assert {:cont, next, sends} = AuthFSM.step(pending, msg)
       [line] = send_lines(sends)
       "AUTHENTICATE " <> b64 = line
       assert Base.decode64!(b64) == <<0, "vjt", 0, "swordfish">>
+
+      # GH #1169 — the legitimate transition now records the emitted field
+      # count. Everything else stays put, which is the invariant the
+      # `^pending` match used to carry: the phase guard must not disturb
+      # anything beyond what the emit is entitled to record.
+      assert %{next | sasl_fields: :none} == pending
     end
   end
 end

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1196,7 +1196,10 @@ defmodule Grappa.IRC.ClientTest do
       # empty exactly when the breadcrumb says "empty". Populating the
       # encoder's authzid without relabelling fails this, and so does
       # relabelling without touching the encoder.
-      assert (authzid == "") == (breadcrumb == "empty"),
+      sent_empty? = authzid == ""
+      claims_empty? = breadcrumb == "empty"
+
+      assert sent_empty? == claims_empty?,
              "breadcrumb says authzid=#{breadcrumb} but the payload sent #{inspect(authzid)}"
     end
   end

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -20,7 +20,7 @@ defmodule Grappa.IRC.ClientTest do
 
   import ExUnit.CaptureLog
 
-  alias Grappa.IRC.{Client, FakeLag, Message}
+  alias Grappa.IRC.{AuthFSM, Client, FakeLag, Message}
   alias Grappa.IRCServer
 
   # Default handler: ignore everything; tests that need scripted replies
@@ -1127,6 +1127,77 @@ defmodule Grappa.IRC.ClientTest do
       lines = IRCServer.sent_lines(server)
       assert Enum.any?(lines, &(&1 == "AUTHENTICATE PLAIN\r\n"))
       assert Enum.any?(lines, &String.starts_with?(&1, "AUTHENTICATE "))
+    end
+
+    # GH #1169. A 904 is the same numeric for a wrong password and for a
+    # payload the server could not parse, so the failure line has to say
+    # which mechanism was driven and what shape of authzid went out.
+    #
+    # This asserts the FORMATTED output, not the call arguments, because
+    # the failure mode being guarded against is the formatter silently
+    # dropping a metadata key that is absent from the `config :logger,
+    # :console` allowlist — the call site and the test would both read
+    # correctly while the operator gets nothing.
+    test "a 904 failure line carries the mechanism and authzid as metadata (#1169)" do
+      {_server, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, client} =
+            Client.start_link(%{
+              host: "127.0.0.1",
+              port: port,
+              tls: false,
+              dispatch_to: self(),
+              logger_metadata: [],
+              nick: "grappa-test",
+              ident: "grappa-test",
+              realname: "grappa-test",
+              sasl_user: "vjt",
+              password: "wrong",
+              auth_method: :sasl
+            })
+
+          assert_receive {:EXIT, ^client, {:sasl_failed, 904}}, 1_000
+        end)
+
+      assert log =~ "sasl auth failed"
+      assert log =~ "numeric=904"
+      assert log =~ "mechanism=PLAIN"
+      assert log =~ "authzid=empty"
+    end
+
+    # The `authzid=empty` label is a constant: the encoder hard-codes an
+    # empty authzid and keeps no state to read it back from. This is the
+    # tie that stops the label drifting from the bytes — decode what the
+    # client actually put on the wire and check the first NUL-delimited
+    # field is empty, exactly when the breadcrumb claims it is.
+    test "the authzid breadcrumb describes the payload the client really sent (#1169)" do
+      {server, port} = start_server(sasl_handler())
+
+      _ = start_client(port, %{auth_method: :sasl, sasl_user: "vjt", password: "swordfish"})
+
+      assert {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "CAP END\r\n"), 1_000)
+
+      "AUTHENTICATE " <> b64 =
+        server
+        |> IRCServer.sent_lines()
+        |> Enum.find(fn line ->
+          String.starts_with?(line, "AUTHENTICATE ") and line != "AUTHENTICATE PLAIN\r\n"
+        end)
+        |> String.trim_trailing("\r\n")
+
+      [authzid | _] = :binary.split(Base.decode64!(b64), <<0>>, [:global])
+      breadcrumb = Keyword.fetch!(AuthFSM.sasl_breadcrumb(), :authzid)
+
+      # Correspondence, not a second copy of the constant: the field is
+      # empty exactly when the breadcrumb says "empty". Populating the
+      # encoder's authzid without relabelling fails this, and so does
+      # relabelling without touching the encoder.
+      assert (authzid == "") == (breadcrumb == "empty"),
+             "breadcrumb says authzid=#{breadcrumb} but the payload sent #{inspect(authzid)}"
     end
   end
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1190,7 +1190,20 @@ defmodule Grappa.IRC.ClientTest do
         |> String.trim_trailing("\r\n")
 
       [authzid | _] = :binary.split(Base.decode64!(b64), <<0>>, [:global])
-      breadcrumb = Keyword.fetch!(AuthFSM.sasl_breadcrumb(), :authzid)
+
+      # Any valid FSM will do: the authzid label is a constant, unlike the
+      # sibling `sasl_fields` that made this function take a state at all.
+      {:ok, fsm} =
+        AuthFSM.new(%{
+          nick: "grappa-test",
+          ident: "grappa-test",
+          realname: "grappa-test",
+          sasl_user: "vjt",
+          password: "swordfish",
+          auth_method: :sasl
+        })
+
+      breadcrumb = Keyword.fetch!(AuthFSM.sasl_breadcrumb(fsm), :authzid)
 
       # Correspondence, not a second copy of the constant: the field is
       # empty exactly when the breadcrumb says "empty". Populating the
@@ -1201,6 +1214,110 @@ defmodule Grappa.IRC.ClientTest do
 
       assert sent_empty? == claims_empty?,
              "breadcrumb says authzid=#{breadcrumb} but the payload sent #{inspect(authzid)}"
+    end
+
+    # GH #1169. `mechanism` and `authzid` are both compile-time constants:
+    # they read the same on a healthy handshake and on the malformed
+    # payload this breadcrumb was written for, so neither can separate two
+    # 904s. The field COUNT is what actually differed — the defect was a
+    # payload with one field too many — so the line has to carry it,
+    # DERIVED from the bytes the client really emitted rather than restated
+    # as a third constant.
+    #
+    # A correspondence, not a literal: this pins that the operator reads
+    # the count of the payload the server really received. WHAT that count
+    # ought to be (three, RFC 4616 §2) is pinned by the encoder's own guard
+    # in `auth_fsm_test.exs`; asserting the number here too would be a
+    # second copy of someone else's assertion, failing for their reason.
+    test "the 904 line reports the field count of the payload really sent (#1169)" do
+      {server, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, client} =
+            Client.start_link(%{
+              host: "127.0.0.1",
+              port: port,
+              tls: false,
+              dispatch_to: self(),
+              logger_metadata: [],
+              nick: "grappa-test",
+              ident: "grappa-test",
+              realname: "grappa-test",
+              sasl_user: "vjt",
+              password: "wrong",
+              auth_method: :sasl
+            })
+
+          # The 904 is the server's answer TO the payload, so this exit is
+          # a durable barrier: the line is already in `sent_lines`.
+          assert_receive {:EXIT, ^client, {:sasl_failed, 904}}, 1_000
+        end)
+
+      "AUTHENTICATE " <> b64 =
+        server
+        |> IRCServer.sent_lines()
+        |> Enum.find(fn line ->
+          String.starts_with?(line, "AUTHENTICATE ") and line != "AUTHENTICATE PLAIN\r\n"
+        end)
+        |> String.trim_trailing("\r\n")
+
+      sent_fields = length(:binary.split(Base.decode64!(b64), <<0>>, [:global]))
+
+      assert log =~ "sasl_fields=#{sent_fields}"
+    end
+
+    # A 904 can also arrive BEFORE any payload: an upstream that refuses
+    # the mechanism answers the `AUTHENTICATE PLAIN` line itself. The count
+    # is then neither three nor zero — nothing was encoded — and the line
+    # has to SAY that rather than omit the key. An absent key is
+    # indistinguishable from the formatter dropping one, which is the exact
+    # trap the allowlist above guards against.
+    test "a 904 before any payload reports the count as none (#1169)" do
+      refuse_mechanism = fn state, line ->
+        cond do
+          String.starts_with?(line, "CAP LS") ->
+            {:reply, ":server CAP * LS :sasl=PLAIN\r\n", state}
+
+          String.starts_with?(line, "CAP REQ") ->
+            {:reply, ":server CAP * ACK :sasl\r\n", state}
+
+          line == "AUTHENTICATE PLAIN\r\n" ->
+            {:reply, ":server 904 grappa-test :SASL mechanism unavailable\r\n", state}
+
+          true ->
+            {:reply, nil, state}
+        end
+      end
+
+      {_, port} = start_server(refuse_mechanism)
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, client} =
+            Client.start_link(%{
+              host: "127.0.0.1",
+              port: port,
+              tls: false,
+              dispatch_to: self(),
+              logger_metadata: [],
+              nick: "grappa-test",
+              ident: "grappa-test",
+              realname: "grappa-test",
+              sasl_user: "vjt",
+              password: "swordfish",
+              auth_method: :sasl
+            })
+
+          assert_receive {:EXIT, ^client, {:sasl_failed, 904}}, 1_000
+        end)
+
+      assert log =~ "numeric=904"
+      assert log =~ "sasl_fields=none"
     end
   end
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1139,7 +1139,7 @@ defmodule Grappa.IRC.ClientTest do
     # :console` allowlist — the call site and the test would both read
     # correctly while the operator gets nothing.
     test "a 904 failure line carries the mechanism and authzid as metadata (#1169)" do
-      {_server, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+      {_, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
 
       Process.flag(:trap_exit, true)
 


### PR DESCRIPTION
> **COLD deploy.** This touches `config/config.exs`, which is compile-time
> configuration: `/admin/reload` does not pick it up and the node has to
> restart. Do not try to ship it hot. The payload fix it completes (#1181)
> is HOT and independent — this PR branches from `main`, not from that one.

## What it adds

A `904` is the same numeric for a wrong password and for a payload the
server could not parse. #1169 was the second case and read as the first
for months: the line said `numeric=904 sasl_user=vjt` and nothing else,
so there was no way to tell a credential problem from a malformed
`AUTHENTICATE` without a packet capture. The failure line now also
carries `mechanism` and `authzid`.

## The trap that shapes the guard

**A metadata key absent from the `config :logger, :console` allowlist is
dropped by the FORMATTER, not by the call.** The `Logger.error/2` call
reads correctly, a test asserting the call arguments reads correctly, and
the operator still gets a line with the field missing.

So the guard captures the log and asserts the **formatted string**. It
was run with the emit in place and the allowlist untouched, and failed:

```
code:  assert log =~ "mechanism=PLAIN"
left:  "08:08:14.670 pid=<0.1696.0> numeric=904 sasl_user=vjt [error] sasl auth failed\n…"
right: "mechanism=PLAIN"
```

Declaring the two keys was the only change between that red and green,
which also establishes something worth knowing: `ExUnit.CaptureLog`
honours the production allowlist rather than formatting every key it is
handed. Had the test asserted the call arguments, it would have passed in
both states and guarded nothing.

## `mechanism` is derived; `authzid` is a label, and the difference is tied down

`mechanism` reads from the same module attribute that writes the
`AUTHENTICATE <mech>` line, so it cannot name a mechanism the FSM does
not drive.

`authzid` cannot be derived the same way — the encoder hard-codes it
empty and keeps no state to read it back from. Rather than leave a
constant free to drift, a second test decodes a payload the client
actually put on the wire and asserts the first NUL-delimited field is
empty **exactly when** the breadcrumb says `empty`. It is a
correspondence, not a second copy of the constant, so it fails in both
directions: populating the encoder's authzid without relabelling, and
relabelling without touching the encoder.

**Stated plainly: that second test passes today without any mutation.**
It is a guard against future drift, not a red that was read. Given this
whole issue began as a comment describing an encoder shape that was never
emitted, a breadcrumb tied to the encoder only by convention would have
been the same mistake with a new spelling.

## Gates

`scripts/check.sh` green end to end on `4d9c245f`: credo `no issues`,
dialyzer `passed successfully`, ExUnit `5649 tests, 0 failures`, doctor,
sobelow, `deps.audit` clean, bats 390/390.