### PR TITLE
#388: flavour-agnostic identity — one verdict, three sources

### DIFF
--- a/cicchetto/e2e/tests/registration-wizard.spec.ts
+++ b/cicchetto/e2e/tests/registration-wizard.spec.ts
@@ -154,9 +154,17 @@ async function stubRest(page: import("@playwright/test").Page, sent: SentMessage
 
 // Mock the Phoenix socket. Implements the minimal v2 protocol: reply "ok"
 // to every phx_join + heartbeat + push, and capture the user-topic join
-// so the test can fabricate a server→client `umode_changed` event. Never
-// calls connectToServer() — fully offline.
-type Injector = { pushUmode: (modes: string[]) => void };
+// so the test can fabricate server→client user-topic events. Never calls
+// connectToServer() — fully offline.
+//
+// #388 — ONE real-world identify now produces TWO user-topic events, so the
+// injector offers both. A mock that fabricates only the umode letter is not
+// a simpler mock, it is an INFAITHFUL one: it stimulates a store the product
+// no longer gates on, and it kept a half-finished migration green.
+type Injector = {
+  pushUmode: (modes: string[]) => void;
+  pushIdentity: (identified: boolean, account: string | null) => void;
+};
 
 async function mockSocket(page: import("@playwright/test").Page): Promise<Injector> {
   const state: { send: ((m: string) => void) | null; userJoinRef: string | null } = {
@@ -196,20 +204,29 @@ async function mockSocket(page: import("@playwright/test").Page): Promise<Inject
     });
   });
 
+  const pushEvent = (payload: Record<string, unknown>): void => {
+    if (!state.send) throw new Error("socket not connected — no frame to inject");
+    state.send(JSON.stringify([state.userJoinRef, null, USER_TOPIC, "event", payload]));
+  };
+
   return {
+    // The raw mode-letter list, as Grappa emits it from the self-MODE echo.
+    // Presentation data (the /umode modal, the sidebar) — NOT the identity
+    // signal any launcher or terminator reads since #388.
     pushUmode: (modes: string[]) => {
-      if (!state.send) throw new Error("socket not connected — no frame to inject");
-      // Fabricated server→client broadcast on the user topic (the shape
-      // Grappa emits from its self-MODE +r echo → umode_changed).
-      state.send(
-        JSON.stringify([
-          state.userJoinRef,
-          null,
-          USER_TOPIC,
-          "event",
-          { kind: "umode_changed", network_id: NETWORK_ID, modes },
-        ]),
-      );
+      pushEvent({ kind: "umode_changed", network_id: NETWORK_ID, modes });
+    },
+    // #388 — the NORMALIZED verdict, which is what the product gates on.
+    // Grappa derives it in `Session.IdentityState` and fans it out from
+    // `apply_effects/2`; `account` is nullable even while identified,
+    // because bahamut confirms via the umode and exposes no account name.
+    pushIdentity: (identified: boolean, account: string | null) => {
+      pushEvent({
+        kind: "session_identity_changed",
+        network_id: NETWORK_ID,
+        identified,
+        account,
+      });
     },
   };
 }
@@ -231,6 +248,46 @@ async function gotoHome(page: import("@playwright/test").Page) {
   await page.locator(".sidebar-home-btn").click();
   await expect(page.locator(".home-pane-registered").first()).toBeVisible({ timeout: 10_000 });
   return page.getByTestId(`home-register-nick-${NETWORK_SLUG}`);
+}
+
+// Shared prologue of the two step-6 terminator arms below: boot offline,
+// open the wizard from Home, and drive it to step 6 (verify). Extracted so
+// the arms differ ONLY in the stimulus they fabricate — which is the whole
+// variable under test.
+async function driveToVerifyStep(page: import("@playwright/test").Page): Promise<{
+  socket: Injector;
+  registerBtn: ReturnType<import("@playwright/test").Page["getByTestId"]>;
+  dialog: ReturnType<import("@playwright/test").Page["getByTestId"]>;
+}> {
+  const sent: SentMessage[] = [];
+  await stubRest(page, sent);
+  const socket = await mockSocket(page);
+  await boot(page);
+
+  const registerBtn = await gotoHome(page);
+  await expect(registerBtn).toBeVisible({ timeout: 10_000 });
+  // Gate on the user-topic subscribe so the fabricated push is delivered
+  // to a joined channel (Phoenix.PubSub doesn't replay to late joiners).
+  await page.waitForFunction(
+    (u) =>
+      (window as unknown as { __cic_userTopicReady?: Set<string> }).__cic_userTopicReady?.has(u) ??
+      false,
+    USER_NAME,
+  );
+
+  await registerBtn.click();
+  const dialog = page.getByTestId("registration-wizard");
+  await page.getByTestId("registration-wizard-next").click(); // 1→2
+  await page.getByTestId("registration-wizard-email").fill(EMAIL);
+  await page.getByTestId("registration-wizard-next").click(); // 2→3
+  await page.getByTestId("registration-wizard-password").fill(PASSWORD);
+  await page.getByTestId("registration-wizard-next").click(); // 3→4
+  await page.getByTestId("registration-wizard-next").click(); // 4→5
+  await page.getByTestId("registration-wizard-code").fill(CODE);
+  await page.getByTestId("registration-wizard-next").click(); // 5→6
+  await expect(dialog).toHaveAttribute("data-step", "6");
+
+  return { socket, registerBtn, dialog };
 }
 
 test.describe("#349 registration wizard (faked, fast lane)", () => {
@@ -284,47 +341,46 @@ test.describe("#349 registration wizard (faked, fast lane)", () => {
     expect(sent.some((m) => m.body === `AUTH ${OWN_NICK} ${CODE}`)).toBe(false);
   });
 
-  test("hides the launch button and auto-completes step 6 when +r is faked over the user topic", async ({
+  test("hides the launch button and auto-completes step 6 on a bahamut identify", async ({
     page,
   }) => {
-    const sent: SentMessage[] = [];
-    await stubRest(page, sent);
-    const socket = await mockSocket(page);
-    await boot(page);
+    const { socket, registerBtn, dialog } = await driveToVerifyStep(page);
 
-    const registerBtn = await gotoHome(page);
-    await expect(registerBtn).toBeVisible({ timeout: 10_000 });
-    // Gate on the user-topic subscribe so the fabricated push is delivered
-    // to a joined channel (Phoenix.PubSub doesn't replay to late joiners).
-    await page.waitForFunction(
-      (u) =>
-        (window as unknown as { __cic_userTopicReady?: Set<string> }).__cic_userTopicReady?.has(
-          u,
-        ) ?? false,
-      USER_NAME,
-    );
-
-    // Drive to step 6 (verify) so we can prove the +r auto-complete.
-    await registerBtn.click();
-    const dialog = page.getByTestId("registration-wizard");
-    await page.getByTestId("registration-wizard-next").click(); // 1→2
-    await page.getByTestId("registration-wizard-email").fill(EMAIL);
-    await page.getByTestId("registration-wizard-next").click(); // 2→3
-    await page.getByTestId("registration-wizard-password").fill(PASSWORD);
-    await page.getByTestId("registration-wizard-next").click(); // 3→4
-    await page.getByTestId("registration-wizard-next").click(); // 4→5
-    await page.getByTestId("registration-wizard-code").fill(CODE);
-    await page.getByTestId("registration-wizard-next").click(); // 5→6
-    await expect(dialog).toHaveAttribute("data-step", "6");
-
-    // Fake the server-pushed +r umode flip — the no-parse success terminator.
+    // Fake what a bahamut identify actually produces on the user topic: the
+    // raw letter AND the verdict Grappa derives from it. Both, because the
+    // server sends both — this arm is the faithful-bahamut case.
     socket.pushUmode(["r"]);
+    socket.pushIdentity(true, null);
 
     // Step 6 celebrates, then auto-closes.
     await expect(page.getByTestId("registration-wizard-success")).toBeVisible({ timeout: 5_000 });
     await expect(dialog).toHaveCount(0, { timeout: 5_000 });
 
-    // The launch button is reactively gone (same +r signal).
+    // The launch button is reactively gone (same signal).
+    await expect(registerBtn).toHaveCount(0);
+  });
+
+  // #388 — the flavour-agnostic arm, and the one that keeps the migration
+  // honest. The stimulus is the verdict ALONE: no `umode_changed`, no letter
+  // anywhere, which is the shape an atheme network genuinely has (solanum
+  // assigns no registered umode at all, so there is no letter to send).
+  //
+  // Both assertions are mutation-killers, and they kill different mutants:
+  // spell the step-6 terminator `umodesForNetwork(id).includes("r")` again
+  // and the celebration never arrives; spell the launcher gate that way and
+  // the button survives. The bahamut arm above cannot catch either, because
+  // there the two signals travel together.
+  test("completes and hides the launcher on the verdict alone, with no umode", async ({ page }) => {
+    const { socket, registerBtn, dialog } = await driveToVerifyStep(page);
+
+    // Pre-state: the launcher is on screen right now, so its later absence
+    // is a transition this test caused and not a button that never rendered.
+    await expect(registerBtn).toHaveCount(1);
+
+    socket.pushIdentity(true, null);
+
+    await expect(page.getByTestId("registration-wizard-success")).toBeVisible({ timeout: 5_000 });
+    await expect(dialog).toHaveCount(0, { timeout: 5_000 });
     await expect(registerBtn).toHaveCount(0);
   });
 });

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -19,13 +19,13 @@ import {
   homeSessionLifetime,
   type SessionLifetimeCopy,
 } from "./lib/homeSessionCopy";
+import { identifiedForNetwork } from "./lib/identity";
 import { networkIdBySlug, refetchNetworks, refetchUser, user } from "./lib/networks";
 import { flavorForSlug, registerableFlavor } from "./lib/registrationTemplates";
 import { openRegistrationWizard } from "./lib/registrationWizard";
 import { setSelectedChannel } from "./lib/selection";
 import { openShareModal, SHARE_SESSION_LABEL } from "./lib/shareModal";
 import { pushLinks, pushRecover } from "./lib/socket";
-import { umodesForNetwork } from "./lib/umodes";
 import { confirmDisconnectNetwork } from "./lib/windowClose";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./lib/windowKinds";
 import { windowStateByChannel } from "./lib/windowState";
@@ -311,31 +311,34 @@ const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
   // #349 — the "Register nick" launcher is gated on TWO reactive signals:
   // (a) the network runs a services suite cic has a REGISTER template for
   // (registerable services_flavor, resolved from the networks store — the
-  // HomeRow itself doesn't carry it), and (b) we're NOT already registered
-  // (no live +r umode). Both are reactive, so the button auto-hides the
-  // instant registration completes (the +r flip) or on an unknown flavor —
-  // zero polling. `networkIdBySlug` can be undefined before the networks
-  // resource lands; treat that as "no umodes seeded yet" (button shows).
+  // HomeRow itself doesn't carry it), and (b) we're NOT already identified
+  // to services. Both are reactive, so the button auto-hides the instant
+  // registration completes or on an unknown flavor — zero polling.
+  // `networkIdBySlug` can be undefined before the networks resource lands;
+  // treat that as "not seeded yet" (button shows).
+  //
+  // #388 — (b) asks the server's NORMALIZED verdict instead of spelling
+  // `umodes.includes("r")` here. That spelling was bahamut-only: on Libera
+  // there is no registered umode at all, so the button never hid and the
+  // wizard could not tell registration had succeeded.
   const canRegister = () => {
     const slug = props.row.slug;
     if (!registerableFlavor(flavorForSlug(slug))) return false;
     const id = networkIdBySlug(slug);
-    const umodes = id === undefined ? [] : umodesForNetwork(id);
-    return !umodes.includes("r");
+    return id === undefined ? true : !identifiedForNetwork(id);
   };
   // #581 — the "Recover identity" launcher, sibling of canRegister(): shown
   // when (a) the credential carries a NickServ secret (`recoverable`, D2),
   // (b) this is a VISITOR session (recover is visitor-only server-side — a
   // user seeing it would only earn a `forbidden`), and (c) we're NOT already
-  // identified (no live +r umode). All reactive, so the button auto-hides the
-  // instant recovery lands the +r flip. Mirrors canRegister's undefined-id
-  // "no umodes seeded yet" tolerance (button shows).
+  // identified. All reactive, so the button auto-hides the instant recovery
+  // lands. Mirrors canRegister's undefined-id "not seeded yet" tolerance
+  // (button shows), and reads the same #388 normalized verdict.
   const canRecover = () => {
     if (!props.row.recoverable) return false;
     if (!isVisitorSubject()) return false;
     const id = networkIdBySlug(props.row.slug);
-    const umodes = id === undefined ? [] : umodesForNetwork(id);
-    return !umodes.includes("r");
+    return id === undefined ? true : !identifiedForNetwork(id);
   };
   // Fire-and-forget like onTopology: the RecoverModal opens off the SERVER's
   // first recover_progress event (cic never originates state), and the

--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -12,6 +12,7 @@ import {
 } from "solid-js";
 import { sendBodyLines } from "./lib/compose";
 import { friendlyError } from "./lib/friendlyError";
+import { identifiedForNetwork } from "./lib/identity";
 import { networkBySlug, networkIdBySlug } from "./lib/networks";
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -30,13 +31,12 @@ import {
   wizardNext,
 } from "./lib/registrationWizard";
 import { serviceMirrorRows } from "./lib/serviceModal";
-import { umodesForNetwork } from "./lib/umodes";
 import { MircBody } from "./MircText";
 
 // #349 — guided NickServ registration wizard. Launched from the Home
 // pane's ConnectedRow ("📝 Register nick"), one per network, gated on a
-// registerable services_flavor AND no live +r (see HomePane + the launch
-// button's Show guard).
+// registerable services_flavor AND not already identified (see HomePane +
+// the launch button's Show guard).
 //
 // Six steps (see registrationWizard.ts). The wizard mirrors the proven
 // ServiceModal shell (backdrop scrim + role=dialog + createOverlayLock +
@@ -49,9 +49,10 @@ import { MircBody } from "./MircText";
 //   * Step 4 (REGISTER) has no structural terminator (register-accepted ≠
 //     +r), so it is USER-advanced with a bounded timeout guard — never an
 //     auto-detected success/fail.
-//   * Step 6 (verify) auto-completes ONLY on the server-pushed +r umode
-//     flip (`umodesForNetwork(id).includes("r")`) — the same signal that
-//     reactively hides the launch button. No optimistic success.
+//   * Step 6 (verify) auto-completes ONLY on the server's normalized
+//     services-identity verdict (`identifiedForNetwork(id)`, #388) — the
+//     same signal that reactively hides the launch button. No optimistic
+//     success.
 //
 // SECURITY: email + password are held in the store for the modal lifetime
 // only and dropped on close. The REGISTER/verify sends go wire-only (the
@@ -170,15 +171,22 @@ const RegistrationWizardModal: Component = () => {
           }),
         );
 
-        // Step-6 auto-complete: the ONLY success terminator is the server
-        // +r umode flip (no NickServ text parse). Memoized (same reason as
-        // currentStep — `on` doesn't value-dedupe) so the effect fires only
-        // on a real +r change; when it flips false→true, celebrate +
-        // auto-close (the launch button is already reactively hidden by the
-        // same signal).
+        // Step-6 auto-complete: the ONLY success terminator is the server's
+        // normalized identity verdict (no NickServ text parse). Memoized
+        // (same reason as currentStep — `on` doesn't value-dedupe) so the
+        // effect fires only on a real change; when it flips false→true,
+        // celebrate + auto-close (the launch button is already reactively
+        // hidden by the same signal).
+        //
+        // #388 — this read used to be `umodesForNetwork(id).includes("r")`.
+        // That is bahamut's spelling, not a portable one: atheme emits no
+        // registered umode at all, so the terminator could never fire there,
+        // and on OFTC lowercase `r` is an oper notice mode that would have
+        // celebrated a registration that never happened. Which letter (if
+        // any) means identity is the SERVER's judgement — cic mirrors it.
         const registeredNow = createMemo(() => {
           const id = networkIdBySlug(st().networkSlug);
-          return id !== undefined && umodesForNetwork(id).includes("r");
+          return id !== undefined && identifiedForNetwork(id);
         });
         createEffect(
           on(registeredNow, (isReg) => {

--- a/cicchetto/src/__tests__/HomePane.test.tsx
+++ b/cicchetto/src/__tests__/HomePane.test.tsx
@@ -67,11 +67,14 @@ const networksMock = vi.fn<() => unknown[]>(() => []);
 // asserts the row REUSES that path (not raw disconnectNetwork / patchNetwork).
 const confirmDisconnectNetworkMock = vi.fn<(slug: string) => void>();
 // #349 — the "Register nick" launcher's three lib boundaries: the flavor
-// resolver, the umode (+r) source, and the wizard open verb. Defaults
+// resolver, the identity source, and the wizard open verb. Defaults
 // hide the button (no flavor), so the pre-#349 row assertions are
-// unaffected. `networkIdBySlugMock` drives the +r lookup path.
+// unaffected. `networkIdBySlugMock` drives the identity lookup path.
+//
+// #388 — the identity source is the server's NORMALIZED verdict, not a
+// umode letter list. The launcher no longer knows what `+r` is.
 const flavorForSlugMock = vi.fn<(slug: string) => string | null>(() => null);
-const umodesForNetworkMock = vi.fn<(id: number) => string[]>(() => []);
+const identifiedForNetworkMock = vi.fn<(id: number) => boolean>(() => false);
 const openRegistrationWizardMock = vi.fn<(slug: string) => void>();
 const networkIdBySlugMock = vi.fn<(slug: string) => number | undefined>(() => undefined);
 // #392 — the home "open on another device" button flips the shared share-
@@ -127,7 +130,8 @@ vi.mock("../lib/networks", () => ({
   refetchUser: () => refetchUserMock(),
   refetchNetworks: () => refetchNetworksMock(),
   // #349 — the registration button resolves the network id here to look
-  // up the +r umode. Controllable so a test can exercise the +r branch.
+  // up the identity verdict. Controllable so a test can exercise the
+  // identified branch.
   networkIdBySlug: (slug: string) => networkIdBySlugMock(slug),
 }));
 // channelKey is a pure fn — use the real one (mock at boundaries, not
@@ -165,8 +169,8 @@ vi.mock("../lib/socket", () => ({
   pushRecover: (id: number) => pushRecoverMock(id),
 }));
 
-vi.mock("../lib/umodes", () => ({
-  umodesForNetwork: (id: number) => umodesForNetworkMock(id),
+vi.mock("../lib/identity", () => ({
+  identifiedForNetwork: (id: number) => identifiedForNetworkMock(id),
 }));
 
 vi.mock("../lib/selection", () => ({
@@ -206,7 +210,7 @@ describe("HomePane", () => {
     networksMock.mockReturnValue([]);
     confirmDisconnectNetworkMock.mockClear();
     flavorForSlugMock.mockReturnValue(null);
-    umodesForNetworkMock.mockReturnValue([]);
+    identifiedForNetworkMock.mockReturnValue(false);
     openRegistrationWizardMock.mockClear();
     networkIdBySlugMock.mockReturnValue(undefined);
     openShareModalMock.mockClear();
@@ -284,11 +288,11 @@ describe("HomePane", () => {
   });
 
   describe("#349 register-nick launcher", () => {
-    it("shows the button on a connected row for a registerable flavor with no +r, and opens the wizard", async () => {
+    it("shows the button on a connected row for a registerable flavor while unidentified, and opens the wizard", async () => {
       homeDataMock.mockReturnValue(connectedNetworks("azzurra"));
       flavorForSlugMock.mockReturnValue("azzurra");
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue([]); // not registered yet
+      identifiedForNetworkMock.mockReturnValue(false); // not registered yet
       render(() => <HomePane />);
 
       const btn = await screen.findByTestId("home-register-nick-azzurra");
@@ -302,11 +306,11 @@ describe("HomePane", () => {
       expect(openRegistrationWizardMock).toHaveBeenCalledWith("azzurra");
     });
 
-    it("hides the button once the +r umode is set (registration complete)", () => {
+    it("hides the button once the server reports identified (registration complete)", () => {
       homeDataMock.mockReturnValue(connectedNetworks("azzurra"));
       flavorForSlugMock.mockReturnValue("azzurra");
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue(["r"]); // registered → hidden
+      identifiedForNetworkMock.mockReturnValue(true); // registered → hidden
       render(() => <HomePane />);
 
       expect(screen.queryByTestId("home-register-nick-azzurra")).toBeNull();
@@ -337,11 +341,11 @@ describe("HomePane", () => {
       available_networks: [],
     });
 
-    it("shows the button for a visitor with a recoverable credential and no +r, and pushes recover", async () => {
+    it("shows the button for a visitor with a recoverable credential while unidentified, and pushes recover", async () => {
       userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
       homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue([]); // not identified yet
+      identifiedForNetworkMock.mockReturnValue(false); // not identified yet
       render(() => <HomePane />);
 
       const btn = await screen.findByTestId("home-recover-identity-azzurra");
@@ -354,11 +358,11 @@ describe("HomePane", () => {
       expect(pushRecoverMock).toHaveBeenCalledWith(7);
     });
 
-    it("hides the button once the +r umode is set (identified)", () => {
+    it("hides the button once the server reports identified", () => {
       userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
       homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue(["r"]); // identified → hidden
+      identifiedForNetworkMock.mockReturnValue(true); // identified → hidden
       render(() => <HomePane />);
 
       expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
@@ -368,7 +372,7 @@ describe("HomePane", () => {
       userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
       homeDataMock.mockReturnValue(recoverableHome("azzurra", false));
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue([]);
+      identifiedForNetworkMock.mockReturnValue(false);
       render(() => <HomePane />);
 
       expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
@@ -378,7 +382,7 @@ describe("HomePane", () => {
       userMock.mockReturnValue({ kind: "user", id: "u1", name: "vjt" });
       homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue([]);
+      identifiedForNetworkMock.mockReturnValue(false);
       render(() => <HomePane />);
 
       expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
@@ -833,7 +837,7 @@ describe("HomePane", () => {
       homeDataMock.mockReturnValue(connectedNetworks("azzurra"));
       flavorForSlugMock.mockReturnValue("azzurra");
       networkIdBySlugMock.mockReturnValue(7);
-      umodesForNetworkMock.mockReturnValue([]);
+      identifiedForNetworkMock.mockReturnValue(false);
       render(() => <HomePane />);
 
       const register = await screen.findByTestId("home-register-nick-azzurra");

--- a/cicchetto/src/__tests__/RegistrationWizardModal.test.tsx
+++ b/cicchetto/src/__tests__/RegistrationWizardModal.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // #349 — RegistrationWizardModal reactive regression guard.
@@ -15,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // over-counts if the loop ever comes back.
 //
 // Boundaries mocked: the wire send (`sendBodyLines` — the spy under test),
-// the reactive stores it reads (networks / umodes / scrollback), the
+// the reactive stores it reads (networks / identity / scrollback), the
 // overlay lock, and MircBody (the NOTICE renderer). registrationTemplates
 // and the registrationWizard store stay REAL — the send body + step machine
 // are exactly what we're guarding.
@@ -23,7 +24,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const sendBodyLinesMock = vi.fn<
   (slug: string, target: string, body: string, notice: boolean) => Promise<void>
 >(() => Promise.resolve());
-const umodesForNetworkMock = vi.fn<(id: number) => string[]>(() => []);
+// Reactive on purpose: the step-6 terminator is a `createMemo`, so a plain
+// `mockReturnValue` would change the answer without ever waking the memo and
+// the guard below could not distinguish "reads the wrong source" from "is not
+// reactive at all".
+const [identifiedSignal, setIdentifiedSignal] = createSignal(false);
+const identifiedForNetworkMock = vi.fn<(id: number) => boolean>(() => identifiedSignal());
 
 vi.mock("../lib/compose", () => ({
   sendBodyLines: (slug: string, target: string, body: string, notice: boolean) =>
@@ -31,14 +37,19 @@ vi.mock("../lib/compose", () => ({
 }));
 
 // networkBySlug feeds both flavorForSlug (real registrationTemplates) and
-// the modal's ownNick; networkIdBySlug feeds the +r umode lookup.
+// the modal's ownNick; networkIdBySlug feeds the identity lookup.
 vi.mock("../lib/networks", () => ({
   networkBySlug: (slug: string) => ({ slug, nick: "wiz-reg-nick", services_flavor: "azzurra" }),
   networkIdBySlug: () => 7,
 }));
 
-vi.mock("../lib/umodes", () => ({
-  umodesForNetwork: (id: number) => umodesForNetworkMock(id),
+// #388 — the step-6 terminator reads the server's NORMALIZED identity
+// verdict. This mock used to stand in for `umodesForNetwork`, the
+// bahamut-only `+r` spelling #388 exists to abolish: pinning the test to
+// that module is what let the modal keep reading a mode letter while the
+// rest of the migration moved on, with the whole unit suite green.
+vi.mock("../lib/identity", () => ({
+  identifiedForNetwork: (id: number) => identifiedForNetworkMock(id),
 }));
 
 // Empty $server scrollback — the NOTICE mirror stays in its waiting state
@@ -64,7 +75,7 @@ const REG_PASSWORD = "wizregpw1";
 describe("RegistrationWizardModal", () => {
   beforeEach(() => {
     sendBodyLinesMock.mockClear();
-    umodesForNetworkMock.mockReturnValue([]);
+    setIdentifiedSignal(false);
   });
 
   afterEach(() => {
@@ -107,5 +118,48 @@ describe("RegistrationWizardModal", () => {
     fireEvent.click(screen.getByTestId("registration-wizard-next"));
     await waitFor(() => expect(dialog).toHaveAttribute("data-step", "5"));
     expect(sendBodyLinesMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #388 — step 6 completes on the server's normalized identity VERDICT,
+  // with no umode anywhere in the stimulus.
+  //
+  // This is the arm that was missing, and its absence is why the migration
+  // shipped half-done: the suite drove the wizard to step 5 and stopped, so
+  // the terminator had no coverage at all while a mock of `umodesForNetwork`
+  // sat in the file looking like it did.
+  //
+  // Flavour-agnosticism is the whole point of #388. On atheme there is no
+  // registered umode to emit, so a terminator spelled `+r` can never fire
+  // there — and this test cannot pass unless the modal reads the verdict.
+  it("completes step 6 on the identity verdict alone (no umode in the stimulus)", async () => {
+    render(() => <RegistrationWizardModal />);
+    openRegistrationWizard("azzurra-reg");
+
+    const dialog = await screen.findByTestId("registration-wizard");
+    fireEvent.click(screen.getByTestId("registration-wizard-next"));
+    fireEvent.input(screen.getByTestId("registration-wizard-email"), {
+      target: { value: REG_EMAIL },
+    });
+    fireEvent.click(screen.getByTestId("registration-wizard-next"));
+    fireEvent.input(screen.getByTestId("registration-wizard-password"), {
+      target: { value: REG_PASSWORD },
+    });
+    fireEvent.click(screen.getByTestId("registration-wizard-next"));
+    await waitFor(() => expect(dialog).toHaveAttribute("data-step", "4"));
+    fireEvent.click(screen.getByTestId("registration-wizard-next"));
+    await waitFor(() => expect(dialog).toHaveAttribute("data-step", "5"));
+    fireEvent.input(screen.getByTestId("registration-wizard-code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByTestId("registration-wizard-next"));
+    await waitFor(() => expect(dialog).toHaveAttribute("data-step", "6"));
+
+    // Pre-state: the celebration is NOT already on screen, so the assertion
+    // below witnesses the flip rather than a banner that was always there.
+    expect(screen.queryByTestId("registration-wizard-success")).toBeNull();
+
+    setIdentifiedSignal(true);
+
+    await waitFor(() => expect(screen.queryByTestId("registration-wizard-success")).not.toBeNull());
   });
 });

--- a/cicchetto/src/__tests__/identity.test.ts
+++ b/cicchetto/src/__tests__/identity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+// #388 — per-network SERVICES-IDENTITY store. Seeded by the
+// `session_identity_changed` user-topic event, which carries the server's ONE
+// normalized verdict (bahamut `+r`, OFTC `+R`, IRCv3 `account-notify` and
+// numeric 330 all folded server-side). cic mirrors the verdict; it never
+// derives identity from a umode letter, which is what the registration and
+// recover launchers used to do and why they only worked on Azzurra.
+
+import { accountForNetwork, identifiedForNetwork, identityByNetwork, seedIdentity } from "../lib/identity";
+
+describe("identity store", () => {
+  it("reads as NOT identified before any seed", () => {
+    // The launcher-gate tolerance: an unseeded network shows the register /
+    // recover affordance rather than hiding the only way out of an
+    // unidentified session.
+    expect(identifiedForNetwork(9999)).toBe(false);
+    expect(accountForNetwork(9999)).toBeNull();
+  });
+
+  it("seeds the verdict and the account keyed by network id", () => {
+    seedIdentity(7, true, "vjt");
+    expect(identityByNetwork()[7]).toEqual({ identified: true, account: "vjt" });
+    expect(identifiedForNetwork(7)).toBe(true);
+    expect(accountForNetwork(7)).toBe("vjt");
+  });
+
+  it("carries identified with a null account — the normal bahamut case", () => {
+    // bahamut confirms identity via the +r umode and exposes no account
+    // name, so a null account must NOT read as unidentified.
+    seedIdentity(8, true, null);
+    expect(identifiedForNetwork(8)).toBe(true);
+    expect(accountForNetwork(8)).toBeNull();
+  });
+
+  it("is last-write-wins per network, so a logout clears the verdict", () => {
+    seedIdentity(9, true, "vjt");
+    seedIdentity(9, false, null);
+    expect(identifiedForNetwork(9)).toBe(false);
+    expect(accountForNetwork(9)).toBeNull();
+  });
+
+  it("keys per network — one identified network does not identify another", () => {
+    seedIdentity(10, true, "vjt");
+    expect(identifiedForNetwork(11)).toBe(false);
+  });
+});

--- a/cicchetto/src/__tests__/identity.test.ts
+++ b/cicchetto/src/__tests__/identity.test.ts
@@ -7,7 +7,12 @@ import { describe, expect, it } from "vitest";
 // derives identity from a umode letter, which is what the registration and
 // recover launchers used to do and why they only worked on Azzurra.
 
-import { accountForNetwork, identifiedForNetwork, identityByNetwork, seedIdentity } from "../lib/identity";
+import {
+  accountForNetwork,
+  identifiedForNetwork,
+  identityByNetwork,
+  seedIdentity,
+} from "../lib/identity";
 
 describe("identity store", () => {
   it("reads as NOT identified before any seed", () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -978,6 +978,26 @@ export type WireUserEvent =
       modes: string[];
     }
   | {
+      // #388 — the NORMALIZED services-identity verdict. The server folds
+      // every flavour's evidence (bahamut `+r`, OFTC `+R`, IRCv3
+      // `account-notify`, numeric 330) into ONE boolean via
+      // `Grappa.Session.IdentityState`, so cic never has to know what a
+      // "registered umode" is. The registration + recover launchers gate on
+      // this; reading `umode_changed`'s letters instead was a bahamut-only
+      // spelling that never hid the button on Libera. Rides `Topic.user/1`
+      // and is cold-snapshotted on the user-topic after-join push, so a
+      // reload re-learns it. userTopic.ts dispatches into
+      // `seedIdentity(network_id, identified, account)`.
+      //
+      // `account` is the services account name when known, `null` otherwise
+      // — including while identified on an ircd that exposes no account.
+      // Display data only: `identified` is the verdict.
+      kind: "session_identity_changed";
+      network_id: number;
+      identified: boolean;
+      account: string | null;
+    }
+  | {
       // #249 — per-session SUPPORTED user-mode set, parsed from 004 RPL_MYINFO
       // server-side. The AVAILABILITY set (distinct from umode_changed's ACTIVE
       // set): the `/umode` modal drives its togglable letters from this, exactly

--- a/cicchetto/src/lib/identity.ts
+++ b/cicchetto/src/lib/identity.ts
@@ -1,0 +1,67 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #388 — per-network SERVICES-IDENTITY store: is this session identified to
+// the network's NickServ, and under which account.
+//
+// Seeded by the `session_identity_changed` user-topic event (userTopic.ts),
+// which the server emits from ONE normalized verdict
+// (`Grappa.Session.IdentityState`) folding every flavour's evidence: bahamut's
+// `+r` umode, OFTC's `+R`, IRCv3 `account-notify`, and numeric 330. Both the
+// live edge and the cold user-topic snapshot ride that same event, so a reload
+// mid-session re-learns the verdict.
+//
+// This store exists to stop cic deriving identity itself. It used to read
+// `umodesForNetwork(id).includes("r")`, which is a bahamut-only spelling: on
+// Libera (no registered umode at all) it read "never identified", and on OFTC
+// lowercase `r` is an unrelated oper notice mode, so it would have read
+// "identified" for the wrong reason. Whether a mode letter means identity is
+// the SERVER's business — cic mirrors the verdict, it never re-derives it.
+//
+// Keyed by network id, like the umodes / isupport stores. Module-singleton
+// reactive signal, harmlessly overwritten on the next seed.
+
+type NetworkIdentity = {
+  identified: boolean;
+  account: string | null;
+};
+
+const exports_ = moduleRoot(() => {
+  const [identityByNetwork, setIdentityByNetwork] = createSignal<Record<number, NetworkIdentity>>(
+    {},
+  );
+
+  const seedIdentity = (networkId: number, identified: boolean, account: string | null): void => {
+    setIdentityByNetwork((prev) => ({ ...prev, [networkId]: { identified, account } }));
+  };
+
+  return { identityByNetwork, seedIdentity };
+});
+
+export const identityByNetwork = exports_.identityByNetwork;
+export const seedIdentity = exports_.seedIdentity;
+
+/**
+ * Whether we are identified to services on this network.
+ *
+ * Returns `false` for a network that has not been seeded yet (no live
+ * session, or pre-snapshot). That is the deliberate tolerance the launcher
+ * gates want: an unseeded network shows the "Register nick" / "Recover
+ * identity" affordance rather than hiding it, matching the pre-#388
+ * "no umodes seeded yet" posture. Offering an action that turns out to be
+ * unnecessary is recoverable; hiding the only way out of an unidentified
+ * session is not.
+ */
+export function identifiedForNetwork(networkId: number): boolean {
+  return identityByNetwork()[networkId]?.identified ?? false;
+}
+
+/**
+ * The services account name for this network, or `null` when unknown —
+ * including when we ARE identified but the ircd exposes no account (the
+ * normal bahamut case). Display data only: never infer identity from it,
+ * ask `identifiedForNetwork` instead.
+ */
+export function accountForNetwork(networkId: number): string | null {
+  return identityByNetwork()[networkId]?.account ?? null;
+}

--- a/cicchetto/src/lib/registrationTemplates.ts
+++ b/cicchetto/src/lib/registrationTemplates.ts
@@ -18,24 +18,27 @@ import { networkBySlug } from "./networks";
 //
 // ## Why Azzurra ONLY (for now)
 //
-// grappa's ENTIRE registration-success signal is the lowercase `+r`
-// umode echo (`event_router.ex` self-MODE → `:umode_changed` →
-// `umodesForNetwork(id).includes("r")`), which drives step-6
-// auto-complete, the button auto-hide, and the commit-on-+r credential
-// save. Only **bahamut (Azzurra IRC Services)** emits lowercase `+r`:
-//   * **atheme (Libera / solanum)** has NO registered umode at all —
-//     identity is account-only (WHOIS 330 / `account-notify`), so `+r`
-//     never fires and none of the wizard's success logic would work.
-//   * **oftc (oftc-ircservices / oftc-hybrid)** uses UPPERCASE `+R`
-//     (different meaning on bahamut) AND its confirmation is an
-//     out-of-band web link with no shipped verifier — impraticabile.
-// So #349 ships the Azzurra flavor only. Making the wizard flavor-
-// agnostic needs a new server signal (negotiate IRCv3 `account-notify`,
-// handle self `ACCOUNT`, broadcast an identity event) — tracked as a
-// follow-up issue; when it lands, this table gains the `atheme` entry
-// (verified verb: `VERIFY REGISTER <nick> <key>`) + `registerableFlavor`
-// widens. OFTC is a further follow-up (needs that signal + a bespoke
-// local verifier).
+// #349 shipped here because grappa's ENTIRE registration-success signal
+// was then the lowercase `+r` umode echo, which only bahamut (Azzurra IRC
+// Services) emits: atheme (Libera / solanum) assigns no registered umode
+// at all, and on OFTC lowercase `r` is an unrelated oper notice mode. The
+// success logic could not have worked anywhere else.
+//
+// **That blocker is gone.** #388 built the signal this comment asked for:
+// the server negotiates `account-notify`, handles self `ACCOUNT` and
+// numeric 330, folds them with the per-flavour umode in
+// `Grappa.Session.IdentityState`, and broadcasts ONE normalized
+// `session_identity_changed` verdict. All three consumers named here —
+// step-6 auto-complete, the launcher auto-hide, and the commit-on-identity
+// credential save — read that verdict now; none of them knows what a umode
+// is. Do not re-derive identity from a mode letter to widen this table.
+//
+// What still gates each flavour is therefore only its VERBS:
+//   * **atheme** needs its table entry (verb verified:
+//     `VERIFY REGISTER <nick> <key>`), after which `registerableFlavor`
+//     can widen.
+//   * **oftc** needs more than a verb: confirmation is an out-of-band web
+//     link with no shipped verifier.
 //
 // Verbs are SOURCE-VERIFIED (azzurra/services GPLv2 source: REGISTER
 // takes the password FIRST then the email; confirmation is `AUTH <code>`

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -24,6 +24,7 @@ import { diagPush } from "./diagLog";
 import { setSeveredForFlood } from "./floodSever";
 import { refreshHighlights } from "./highlightList";
 import { patchHomeNetwork } from "./home";
+import { seedIdentity } from "./identity";
 import { appendInviteAck } from "./inviteAck";
 import { isupportEntryFromWire, seedIsupport } from "./isupport";
 import { setLinksReply } from "./linksModal";
@@ -461,6 +462,19 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       if (typeof r.network_id !== "number" || !Array.isArray(r.modes)) return null;
       if (!r.modes.every((m) => typeof m === "string")) return null;
       return { kind: "umode_changed", network_id: r.network_id, modes: r.modes as string[] };
+    }
+    case "session_identity_changed": {
+      // #388 — the NORMALIZED services-identity verdict. User-topic-only, so
+      // narrowed inline here (mirror of umode_changed). `account` is
+      // nullable and is display data only — `identified` is the verdict.
+      if (typeof r.network_id !== "number" || typeof r.identified !== "boolean") return null;
+      if (r.account !== null && typeof r.account !== "string") return null;
+      return {
+        kind: "session_identity_changed",
+        network_id: r.network_id,
+        identified: r.identified,
+        account: r.account,
+      };
     }
     case "supported_umodes_changed": {
       // #249 — per-session SUPPORTED umode set. User-topic-only, narrowed
@@ -1194,6 +1208,14 @@ moduleRoot(() => {
           // snapshot (user-topic after-join) both flow here; last-write-wins
           // idempotent.
           seedUmodes(payload.network_id, payload.modes);
+          return;
+
+        case "session_identity_changed":
+          // #388 — seed the per-network services-identity verdict the
+          // registration + recover launchers gate on. Live edge (any of the
+          // server's identity sources) + cold snapshot (user-topic
+          // after-join) both flow here; last-write-wins idempotent.
+          seedIdentity(payload.network_id, payload.identified, payload.account);
           return;
 
         case "supported_umodes_changed":

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1160,6 +1160,16 @@ export const S_SessionWireServerReplyPayload = {
   },
 } as const;
 
+// Grappa.Session.Wire.session_identity_changed_payload/0
+export const S_SessionWireSessionIdentityChangedPayload = {
+  o: {
+    kind: { l: "session_identity_changed" },
+    network_id: "i",
+    identified: "b",
+    account: { u: ["s", "z"] },
+  },
+} as const;
+
 // Grappa.Session.Wire.supported_umodes_changed_payload/0
 export const S_SessionWireSupportedUmodesChangedPayload = {
   o: { kind: { l: "supported_umodes_changed" }, network_id: "i", modes: { a: "s" } },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -856,6 +856,7 @@ export const SESSION_WIRE_WIRE_EVENT_KIND = [
   "own_nick_changed",
   "isupport_changed",
   "umode_changed",
+  "session_identity_changed",
   "supported_umodes_changed",
   "topic_changed",
   "channel_modes_changed",
@@ -916,6 +917,13 @@ export type SessionWireUmodeChangedPayload = {
   kind: "umode_changed";
   network_id: number;
   modes: string[];
+};
+
+export type SessionWireSessionIdentityChangedPayload = {
+  kind: "session_identity_changed";
+  network_id: number;
+  identified: boolean;
+  account: string | null;
 };
 
 export type SessionWireSupportedUmodesChangedPayload = {
@@ -1275,6 +1283,7 @@ export type WireSessionEvent =
   | SessionWireOwnNickChangedPayload
   | SessionWireIsupportChangedPayload
   | SessionWireUmodeChangedPayload
+  | SessionWireSessionIdentityChangedPayload
   | SessionWireSupportedUmodesChangedPayload
   | SessionWirePresenceChangedPayload
   | SessionWirePresenceErrorPayload

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -180,6 +180,29 @@ is the one member of the family that still fans out to every connection,
 because the server also emits it unsolicited at connect — gate it on your own
 consume-once request flag.
 
+**Never re-derive services identity from a mode letter (#388).** Whether
+the operator is identified to NickServ arrives as one user-topic event:
+
+```json
+{"kind": "session_identity_changed", "network_id": 3,
+ "identified": true, "account": "vjt"}
+```
+
+`identified` is the verdict and the ONLY thing to gate on; the server folds
+every flavour's evidence behind it (bahamut's `+r` umode, OFTC's `+R`,
+IRCv3 `account-notify`, numeric 330 RPL_WHOISLOGGEDIN). `account` is the
+services account name when the ircd exposes one and `null` otherwise —
+including while `identified` is `true`, which is the normal bahamut case.
+It is display data; absence of an account is not absence of identity.
+
+A client that instead reads the `umode_changed` letters and tests for `"r"`
+gets a bahamut-only answer: solanum (Libera) assigns no registered umode at
+all, so it reads permanently unidentified, and on OFTC lowercase `r` is an
+unrelated oper notice mode, so it reads identified for the wrong reason.
+The event is pushed on both the live edge and the user-topic cold snapshot,
+so a reload re-learns the verdict; the REST twin is the `registered` field
+of `GET /networks`' `connection` object.
+
 ---
 
 ## 5. Wire format

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38893,6 +38893,31 @@ still has: after a page reload nothing re-seeded the letters, so cic
 re-showed the "Register nick" and "Recover identity" buttons on an
 already-identified session.
 
+**The migration shipped half-done first, and a mock is why nobody saw it.**
+The launchers in `HomePane` moved to `identifiedForNetwork/1` while
+`RegistrationWizardModal`'s step-6 terminator kept reading
+`umodesForNetwork(id).includes("r")` — in the very commit titled "let the
+wizard read the verdict instead of a mode letter", whose diff does not
+contain the modal. The e2e caught it, but only by accident and only on the
+launcher: its socket mock fabricated `umode_changed` alone, so the old store
+was fed and the new one was not, and the arm asserting the button asserted
+the half that had moved.
+
+The unit suite could not have caught it at all. `RegistrationWizardModal`'s
+test mocked `umodesForNetwork` — the exact module the migration existed to
+remove — and drove the wizard only as far as step 5, so the terminator had
+no coverage while a mock sat in the file looking like it did. **A mock
+pinned to the spelling you are replacing cannot witness the replacement**,
+and 4997 green unit tests said nothing. The rule this leaves: when a
+migration removes a source, the tests that MOCK that source are part of the
+migration, not bystanders.
+
+Both stimulus sites are now faithful to what the server actually sends —
+one identify produces `umode_changed` AND `session_identity_changed`, so
+the mocks send both — and each suite gained an arm whose stimulus is the
+verdict ALONE, no letter anywhere. That arm is the atheme shape, and it is
+what fails if either reader regresses to a mode letter.
+
 **What was NOT claimed.** Whether OFTC's services actually set `+R` at the
 identify instant is taken from the `UMODE_NICKSERVREG` declaration comment,
 not observed on the wire — grappa has never connected to OFTC. The gate

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38841,7 +38841,8 @@ takes whole STATES, not the axis that changed, and asks `identified?/1`
 twice. Passing only your own axis is precisely how the old readers drifted,
 and it also gets the cross-axis cases right for free: an account-identified
 session survives the #581 rename umode strip, because a nick change does
-not clear a services account.
+not clear a services account. (Narrowed the next day — that survival now
+holds only where `account-notify` is ACKed. See the 2026-08-11 entry.)
 
 **A gap fell out of the collapse.** 221 RPL_UMODEIS replaces the umode set
 wholesale and emitted no transition at all pre-#388, so a session that
@@ -38924,3 +38925,79 @@ not observed on the wire — grappa has never connected to OFTC. The gate
 limits the blast radius to networks an operator explicitly classified
 `:oftc`. Peer identities are also out of scope: inbound `ACCOUNT` for
 another user is dropped rather than folded into the members map.
+
+---
+
+## 2026-08-11 — #388: the account axis is proof only where account-notify is ACKed
+
+vjt's ruling, narrowing the entry above the day after it was written. The
+services account still feeds the WHOIS card everywhere; it counts toward
+the identity VERDICT only on a network that ACKed `account-notify`.
+
+**The reason is retractability, not flavour.** An account name is a live
+identity only where the ircd promises to tell us when it ends, and
+`account-notify` IS that promise — it is the cap that delivers
+`ACCOUNT *` on logout. Learn an account without it and we will never hear
+that it stopped being true, so the verdict can go up and never come down.
+A verdict that only rises is not a verdict.
+
+That is not a thought experiment. bahamut (Azzurra, all of prod) offers no
+such cap, and strips `+r` on a genuine rename (#581). Ungated, a single
+330 naming us pinned the session "identified" for the rest of its life:
+the `+r` strip stopped moving the verdict, and #581's re-identify
+affordance — the button whose entire job is to tell the operator they need
+to identify again — never came back. Gated, prod behaves exactly as it did
+before #388: `+r` decides, nothing else. The narrowing costs Azzurra
+nothing because Azzurra never had the axis to begin with.
+
+On solanum/OFTC the cap IS ACKed, so the axis is live there and behaves as
+designed: it survives a rename, and `ACCOUNT *` retracts it. A 330 with
+neither cap nor umode degrades to "not identified" — the safe direction,
+and the tolerance `identity.ts` already declares.
+
+**Where the gate lives, and why not at the call sites.** In
+`IdentityState`, the module that exists so a caller cannot forget an axis.
+A per-caller cap check would be exactly the drift it was written to end.
+The `caps_active` default is an empty set, so a hot-reloaded process whose
+state predates the key falls back to the umode axis (#216) rather than
+crashing — again the safe direction.
+
+**The seam was already there, and was throwing the answer away.**
+`Session.Server`'s CAP ACK handler parsed the whole ACK list and kept only
+`labeled-response`; every other grant went on the floor. `account-notify`
+was requested by `AuthFSM`, granted by the upstream, and then forgotten.
+It now records the ACKed subset of a declared `@tracked_caps` — the set of
+caps that change how this process behaves — so adding one is a list edit
+rather than another `if` waiting to drift.
+
+**This contradicts the checklist on purpose.** Box 2 said "parse WHOIS-330
+for account", full stop. The checklist predates the measurement; where the
+two disagree, the measured design wins.
+
+**A green test was holding the defect in place.** The pre-ruling
+`event_router_test.exs` asserted that an account-identified `:azzurra`
+session survives the rename strip — the un-narrowed behaviour, stated as
+an invariant. That is why this blocked a merge instead of becoming a
+follow-up: a test must never encode a bug, because it converts the bug
+into a promise. It was rewritten to assert the ruled behaviour, not
+deleted and not weakened, and the fixtures that describe solanum now seed
+the cap those ircds actually ACK.
+
+**What the mutation run proved, and what it refused to.** Five mutants
+were attempted; two — replacing the membership test with a bare `true` or
+`false` — do not COMPILE under `--warnings-as-errors` (an unused module
+attribute in one case, the type checker proving the branch constant in the
+other), so they are not measurements and were not counted. The three valid
+ones kill disjoint sets: dropping `account-notify` from `@tracked_caps`
+kills exactly one test, the new one that drives a real `CAP ACK` line
+through the fake ircd; defaulting the absent `caps_active` to a populated
+set kills the three "absent cap is not proof" claims; pointing the gate at
+a cap name nobody ACKs kills all nine "present cap is proof" claims. The
+first of those is the one worth having: every other identity test seeds
+`caps_active` by hand, so without it the gate could have been correct
+above a dead wire and nothing would have said so.
+
+**Still unobserved.** Whether Azzurra emits a 330 for a logged-in target
+at all. The narrowing is safe under either answer — that is part of why it
+is the right call — but it means the display-only path on bahamut is
+reasoned, not witnessed.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38814,3 +38814,88 @@ untouched: it measures the one thing the bug never touched. It still
 earns its place — it is the only thing that catches the label being
 changed without the encoder — but the count is what catches the encoder
 being changed without anyone noticing.
+
+---
+
+## 2026-08-10 — #388: identity is one verdict with three sources, and the mode letter is not portable
+
+The #349 registration wizard shipped on Azzurra keyed off the lowercase
+`+r` user mode. That is a bahamut spelling, so the wizard could not detect
+completion anywhere else, and #388 was filed to make detection
+flavour-agnostic. Four boxes: negotiate `account-notify` and handle inbound
+`ACCOUNT`, read numeric 330 for self, recognise OFTC's uppercase `+R`, and
+have the wizard consume a normalized event rather than a raw mode.
+
+**The fourth box was the actual work; the first three are its sources.**
+"Is this session identified?" was answered independently in four places —
+`EventRouter.session_identity_effects/2`, a second detector
+(`set_r_mode?/1`) re-walking the same MODE bytes for the visitor
+secret-commit, `Session.Server`'s `registered:` wire field, and cicchetto's
+own `umodes.includes("r")`. Four spellings of one predicate is how the
+definition forks. `Grappa.Session.IdentityState` now owns it: pure
+functions over the session state, asked via `identified?/1`. Adding a
+source cannot fork the definition because no caller spells the rule.
+
+**Every source funnels through one prev/next diff.** `identity_effects/2`
+takes whole STATES, not the axis that changed, and asks `identified?/1`
+twice. Passing only your own axis is precisely how the old readers drifted,
+and it also gets the cross-axis cases right for free: an account-identified
+session survives the #581 rename umode strip, because a nick change does
+not clear a services account.
+
+**A gap fell out of the collapse.** 221 RPL_UMODEIS replaces the umode set
+wholesale and emitted no transition at all pre-#388, so a session that
+first learned its identity from the connect-time snapshot never logged
+`:identified` and never released the #347 deferred autojoin. It now emits
+the transition — but deliberately does NOT confirm a staged secret. A
+snapshot reconciles current state; the identity it reports may predate the
+staged secret entirely, and committing off it would bind a password the
+network never accepted. Confirmation needs an event, reconciliation is not
+one.
+
+**The umode letter is per-flavour and EXCLUSIVE — verified at source, not
+assumed.** The issue asserted OFTC uses `+R`; that is true, and the
+tempting shortcut of accepting `r` OR `R` everywhere is wrong in both
+directions:
+
+- OFTC (`oftc/oftc-hybrid@36f0431`, `src/s_user.c`, blob `e325095`):
+  `s_user.c:114` maps `R` to `UMODE_NICKSERVREG` — "user is registered with
+  nickserv and identified" (`include/client.h:401`). But `s_user.c:142`
+  maps lowercase `r` to `UMODE_REJ`, an oper bot-rejection notice mode. A
+  union would mark an OFTC oper identified and let the wizard commit a
+  registration that never happened.
+- solanum (`ircd/s_user.c`, `user_modes[256]`): `/* R */ 0` — unassigned in
+  core, the table being `D/Q/S/Z/a/i/o/s/w/z`. Uppercase `R` being free is
+  exactly why honouring it off OFTC is unsafe: an extension may claim it
+  for anything.
+
+So `registered_umode/1` returns ONE letter per flavour, defaulting to
+lowercase `r` for `nil` and for any flavour added later — an unclassified
+network therefore behaves exactly as it did pre-#388. This is also why
+`services_flavor` is now threaded into the session, via
+`Networks.SessionPlan.base_plan/6` (shared by the user and visitor paths so
+both subject kinds detect identity identically).
+
+**Libera needs no letter at all**, which is the point of the account axis:
+solanum has no registered umode, so `ACCOUNT` / 330 is the only evidence an
+identify landed there. `account-notify` joins `labeled-response` as an
+opportunistic cap; a server that does not advertise it produces a
+byte-identical `CAP REQ` line, so the handshake on every production network
+is unchanged. The known edge is that the H9 combined-NAK fallback
+re-requests `:sasl` alone and would drop `account-notify` — that fallback
+exists for bahamut-family servers, which do not offer the cap.
+
+**What the client sees.** One additive user-topic event,
+`session_identity_changed`, carrying `identified` (the verdict) and
+`account` (display data, `null` even while identified on bahamut). It rides
+the cold user-topic snapshot too, which closes a defect the umode store
+still has: after a page reload nothing re-seeded the letters, so cic
+re-showed the "Register nick" and "Recover identity" buttons on an
+already-identified session.
+
+**What was NOT claimed.** Whether OFTC's services actually set `+R` at the
+identify instant is taken from the `UMODE_NICKSERVREG` declaration comment,
+not observed on the wire — grappa has never connected to OFTC. The gate
+limits the blast radius to networks an operator explicitly classified
+`:oftc`. Peer identities are also out of scope: inbound `ACCOUNT` for
+another user is dropped rather than folded into the members map.

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -680,27 +680,54 @@ defmodule Grappa.IRC.AuthFSM do
   #     NAK declares `:sasl_unavailable` immediately — no labeled-response involved
   #     so no fallback shape applies)
   #   - Neither → fall through to cap_unavailable (existing behaviour)
+  #
+  # GH #388 generalised the "opportunistic" half from the single
+  # `labeled-response` entry to the `@opportunistic_caps` list, adding
+  # `account-notify`: the flavour-agnostic identity signal (inbound
+  # `ACCOUNT` → `EventRouter`), which is how a solanum/atheme network tells
+  # us an identify landed at all — it has no registered umode to watch.
+  # Like `labeled-response` it is requested purely because it is advertised,
+  # needs no follow-up exchange, and a NAK is non-fatal.
+  #
+  # The four shapes above are unchanged in BYTES for every existing case:
+  # the list is ordered `labeled-response` first, and a server that does not
+  # advertise `account-notify` (bahamut / all of prod) produces exactly the
+  # pre-#388 REQ line.
+  #
+  # KNOWN EDGE: the H9 combined-NAK fallback re-requests `:sasl` ALONE, so
+  # an ircd that both offers `account-notify` and NAKs the combined blob
+  # loses it. That fallback exists for bahamut-family servers, which do not
+  # offer `account-notify` in the first place, and SASL is the cap we cannot
+  # trade away — so the loss is theoretical and the alternative (an extra
+  # per-cap REQ ladder) buys nothing real.
+  @opportunistic_caps ["labeled-response", "account-notify"]
+
   defp finalize_cap_ls(caps, state) do
     sasl_wanted = "sasl" in caps and state.auth_method in [:auto, :sasl]
-    labeled_response = "labeled-response" in caps
+    opportunistic = Enum.filter(@opportunistic_caps, &(&1 in caps))
 
-    cond do
-      sasl_wanted and labeled_response ->
-        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack_combined), ["CAP REQ :sasl labeled-response\r\n"]}
+    case {sasl_wanted, opportunistic} do
+      {true, []} ->
+        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack), [cap_req(["sasl"])]}
 
-      sasl_wanted ->
-        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack), ["CAP REQ :sasl\r\n"]}
+      {true, extras} ->
+        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack_combined),
+         [cap_req(["sasl" | extras])]}
 
-      labeled_response ->
-        # No SASL, but labeled-response is available. Request it and close
-        # CAP negotiation with CAP END — labeled-response has no follow-up
-        # exchange (unlike SASL). Session.Server detects the ACK independently.
-        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack), ["CAP REQ :labeled-response\r\n"]}
-
-      true ->
+      {false, []} ->
         cap_unavailable(state)
+
+      {false, extras} ->
+        # No SASL, but at least one opportunistic cap is available. Request
+        # it and close CAP negotiation with CAP END — none of them has a
+        # follow-up exchange (unlike SASL). Session.Server detects the ACK
+        # independently.
+        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack), [cap_req(extras)]}
     end
   end
+
+  @spec cap_req([String.t()]) :: String.t()
+  defp cap_req(caps), do: "CAP REQ :#{Enum.join(caps, " ")}\r\n"
 
   # SASL not on offer (or NAK'd). Mandatory SASL (`:sasl`) crashes;
   # `:auto` falls back to the PASS-handoff path (PASS already sent at

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -711,8 +711,7 @@ defmodule Grappa.IRC.AuthFSM do
         {:cont, leave_cap_negotiation(state, :awaiting_cap_ack), [cap_req(["sasl"])]}
 
       {true, extras} ->
-        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack_combined),
-         [cap_req(["sasl" | extras])]}
+        {:cont, leave_cap_negotiation(state, :awaiting_cap_ack_combined), [cap_req(["sasl" | extras])]}
 
       {false, []} ->
         cap_unavailable(state)

--- a/lib/grappa/irc/message.ex
+++ b/lib/grappa/irc/message.ex
@@ -68,6 +68,7 @@ defmodule Grappa.IRC.Message do
           | :oper
           | :away
           | :ison
+          | :account
           | {:numeric, 1..999}
           | {:unknown, String.t()}
 

--- a/lib/grappa/irc/parser.ex
+++ b/lib/grappa/irc/parser.ex
@@ -56,7 +56,7 @@ defmodule Grappa.IRC.Parser do
     * Anything else becomes `{:unknown, "UPPERCASED"}` so consumers can
       pattern-match on the tagged shape without atom-table-DoS risk.
 
-  The allowlist is closed (~24 verbs) and lives in this module's
+  The allowlist is closed (~25 verbs) and lives in this module's
   `@known_commands` attribute; expanding it for a new RFC verb is a
   one-line edit.
   """
@@ -90,7 +90,11 @@ defmodule Grappa.IRC.Parser do
     "KILL" => :kill,
     "OPER" => :oper,
     "AWAY" => :away,
-    "ISON" => :ison
+    "ISON" => :ison,
+    # GH #388 — IRCv3 `account-notify`. Delivered for any user sharing a
+    # channel with us; `EventRouter` keeps only the self-targeted one, as
+    # the flavour-agnostic half of the identity signal.
+    "ACCOUNT" => :account
   }
 
   @doc """

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -232,6 +232,13 @@ defmodule Grappa.Networks.SessionPlan do
       subject: subject,
       subject_label: subject_label,
       network_slug: network.slug,
+      # GH #388 — the operator-set services flavour, threaded into the
+      # session so `Session.IdentityState` knows which umode letter means
+      # "registered" on this network (uppercase `R` on OFTC, lowercase `r`
+      # everywhere else). Set HERE, in the plan shared by the user AND
+      # visitor paths, so both subject kinds detect identity identically.
+      # nil for an unclassified network — the lowercase default.
+      services_flavor: network.services_flavor,
       nick: cred.nick,
       ident: Credential.effective_ident(cred),
       realname: Identity.effective_realname(cred.realname, realname_fallback),

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -184,6 +184,13 @@ defmodule Grappa.Session do
           required(:subject) => subject(),
           required(:subject_label) => String.t(),
           required(:network_slug) => String.t(),
+          # GH #388 — the network's operator-set NickServ services flavour
+          # (mirrors `Grappa.Networks.Network.services_flavor/0`; typed as a
+          # bare atom to avoid a Session → Networks Boundary cycle). Drives
+          # the per-flavour registered-umode letter in
+          # `Grappa.Session.IdentityState`. Optional: pure session tests and
+          # any plan predating #388 omit it and inherit the lowercase default.
+          optional(:services_flavor) => atom() | nil,
           required(:nick) => String.t(),
           required(:ident) => String.t(),
           required(:realname) => String.t(),
@@ -1504,6 +1511,8 @@ defmodule Grappa.Session do
            %{
              umodes: [String.t()],
              supported_umodes: [String.t()],
+             identified: boolean(),
+             account: String.t() | nil,
              invited_windows: [Grappa.Session.Wire.window_invited_payload()]
            }}
           | {:error, :no_session}

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -3023,9 +3023,13 @@ defmodule Grappa.Session.EventRouter do
   # `%{... | umodes:}`) for the #216 hot-reload contract.
   #
   # The stripped umode is the only fact this touches: a services ACCOUNT is
-  # NOT cleared by a rename (the account survives a nick change), so a
-  # session identified via the account axis correctly stays identified —
-  # which is also why the transition must be computed from whole states.
+  # NOT cleared by a rename. Whether that keeps the session identified is
+  # `IdentityState`'s call, not this function's — and since vjt's ruling of
+  # 2026-08-11 the answer differs per network: where `account-notify` is
+  # ACKed the account axis carries the session across the strip, and where
+  # it is not (bahamut, all of prod) the verdict correctly returns to
+  # `:lost` and #581's re-identify affordance comes back. Computing the
+  # transition from whole states is what lets one gate decide both.
   @spec strip_r_on_self_rename(state(), state(), String.t(), String.t()) ::
           {state(), [effect()]}
   defp strip_r_on_self_rename(state, new_state, old_nick, new_nick) do

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -90,7 +90,7 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, Message}
   alias Grappa.{Scrollback, Session}
-  alias Grappa.Session.{ISupport, NumericRouter, Presence}
+  alias Grappa.Session.{IdentityState, ISupport, NumericRouter, Presence}
 
   @typedoc """
   The Session.Server state subset this module reads + mutates. The
@@ -191,7 +191,7 @@ defmodule Grappa.Session.EventRouter do
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
           | {:reply, iodata()}
-          | {:visitor_r_observed, String.t()}
+          | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}
           | {:topic_changed, String.t(), topic_entry()}
           | {:channel_modes_changed, String.t(), channel_mode_entry()}
@@ -663,6 +663,28 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
+  # GH #388 — IRCv3 `account-notify`: `:nick!user@host ACCOUNT <account>`,
+  # where a literal `*` means "logged out". The ircd relays it for every
+  # user sharing a channel with us; only the SELF one is an identity signal
+  # here (a peer's account is not tracked — out of scope for #388).
+  #
+  # This is the FLAVOUR-AGNOSTIC identity axis, and the reason #388 exists:
+  # solanum/atheme networks (Libera) have no registered umode whatsoever, so
+  # on those this event IS the identify confirmation — there is nothing else
+  # to watch. `nick_eq?` rather than `==` for the #121/#525 fold, so a
+  # different-cased echo of our own nick still routes here.
+  defp do_route(%Message{command: :account, params: [account | _]} = msg, state)
+       when is_binary(account) do
+    if nick_eq?(Message.sender_nick(msg), state.nick) do
+      next_state = Map.put(state, :account, IdentityState.normalize_account(account))
+      effects = identity_effects(state, next_state)
+
+      {:cont, next_state, identity_secret_effects(next_state, effects) ++ effects}
+    else
+      {:cont, state, []}
+    end
+  end
+
   # MODE on a 2+-param target. The leading param is either the session's
   # OWN nick (user-MODE-on-self, Task 15) or a channel — discriminated by
   # ASCII nick-equality (#121/#525), NOT an exact-match dispatch guard, so a
@@ -688,22 +710,18 @@ defmodule Grappa.Session.EventRouter do
       {_, self_server_persist} =
         build_persist(state, :mode, "$server", sender, nil, %{modes: modes, args: args})
 
-      # The +r case is special: when NickServ-as-IDP confirms a visitor's
-      # IDENTIFY (or register→auth-code) it sets +r on the nick. +r is the
-      # cryptographic-proof signal that the captured secret was accepted;
-      # `visitor_r_effects/3` emits `:visitor_r_observed` carrying it so
-      # `Session.Server.apply_effects/2` can commit it atomically into the
-      # visitors row. Orthogonal to the confirmation row above — both
-      # effects coexist.
-      #
-      # #279 — ONE validity verdict for the token, shared by BOTH readers
-      # below (the +r detector and the umode fold). A mode string that is
+      # #279 — ONE validity verdict for the token. A mode string that is
       # not signs + mode letters is a malformed LINE, not a partially
-      # usable delta: neither reader may draw a conclusion from it. Parsed
-      # once here because `set_r_mode?/1` walks the same bytes.
+      # usable delta: no reader may draw a conclusion from it.
+      #
+      # #388 — the mode string is no longer READ for identity. Pre-#388 a
+      # second detector (`set_r_mode?/1`) re-walked these same bytes hunting
+      # a literal `+r`, which is a bahamut-only spelling. Identity is now
+      # derived from the folded umode SET via `IdentityState`, so this arm
+      # only has to fold; the transition falls out of the prev/next diff
+      # below, exactly like every other identity source.
       prev_umodes = Map.get(state, :umodes, [])
       parsed_umodes = apply_umode_string(prev_umodes, modes)
-      r_effects = visitor_r_effects(state, parsed_umodes, modes)
 
       # #229: fold the delta into the queryable per-session umode set so the
       # /mode <nick> modal reflects mid-session changes (an explicit
@@ -716,18 +734,19 @@ defmodule Grappa.Session.EventRouter do
       # `:umode_changed` only on an actual change to keep fan-out minimal.
       next_umodes = umodes_or_unchanged(parsed_umodes, prev_umodes)
       umode_effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
-      state = Map.put(state, :umodes, next_umodes)
+      next_state = Map.put(state, :umodes, next_umodes)
 
-      # #215 — the +r bit flip IS the session identity transition (NickServ
-      # confirmed / lost). Detected HERE where BOTH prev + next umode sets
-      # are in hand (the `:umode_changed` apply_effects arm only sees the
-      # post-state). Session.Server.apply_effects turns this into an
-      # `:identified` / `:deidentified` session-log event. Orthogonal to
-      # `:visitor_r_observed` (which only fires when a secret is staged —
-      # this covers ALL sessions, including already-SASL-authed users).
-      identity_effects = session_identity_effects(prev_umodes, next_umodes)
+      # #215 / #388 — the identity transition (services confirmed / lost).
+      # Detected HERE where BOTH the prev and next facts are in hand (the
+      # `:umode_changed` apply_effects arm only sees the post-state).
+      # Session.Server turns this into an `:identified` / `:deidentified`
+      # session-log event. Orthogonal to `:identity_secret_confirmed` (which
+      # only fires when a secret is staged — this covers ALL sessions,
+      # including already-SASL-authed users).
+      identity = identity_effects(state, next_state)
+      secret_effects = identity_secret_effects(next_state, identity)
 
-      {:cont, state, [self_server_persist | r_effects] ++ umode_effects ++ identity_effects}
+      {:cont, next_state, [self_server_persist | secret_effects] ++ umode_effects ++ identity}
     else
       sender = Message.sender_nick(msg)
 
@@ -1029,7 +1048,20 @@ defmodule Grappa.Session.EventRouter do
     prev_umodes = Map.get(state, :umodes, [])
     next_umodes = umodes_or_unchanged(apply_umode_string([], mode_str), prev_umodes)
     effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
-    {:cont, Map.put(state, :umodes, next_umodes), effects}
+    next_state = Map.put(state, :umodes, next_umodes)
+
+    # #388 — a 221 snapshot that reveals (or retracts) the registered umode
+    # is an identity transition like any other, and pre-#388 it emitted
+    # none: only the self-MODE echo did. That was a real gap — a session
+    # whose identity is first learned from the connect-time snapshot never
+    # logged `:identified` and never released the deferred autojoin.
+    #
+    # Deliberately does NOT feed `identity_secret_effects/2`: 221 is a
+    # RECONCILIATION of current state, not a confirmation of something we
+    # just sent. The identity it reports may predate the staged secret
+    # entirely, so committing that secret off a snapshot would bind a
+    # password the network never accepted.
+    {:cont, next_state, effects ++ identity_effects(state, next_state)}
   end
 
   # 004 RPL_MYINFO (#249): the connection-registration line advertising the
@@ -1420,12 +1452,27 @@ defmodule Grappa.Session.EventRouter do
   # in as`. The account name is the MIDDLE param (structured — NO localized
   # parse needed), emitted by modules/m_services.c:375
   # (form_str "%s %s :is logged in as").
+  #
+  # GH #388 — when the 330 is about US it is also a post-identify identity
+  # confirmation (the issue's "parse WHOIS-330 for self"), so it feeds the
+  # `:account` axis on top of the whois fold. 330 has no logged-OUT form:
+  # services simply omit the numeric for an unidentified target, so this is
+  # a set-only signal and absence of a 330 must never be read as a logout.
   defp do_route(
          %Message{command: {:numeric, 330}, params: [_, target, account | _]},
          state
        )
        when is_binary(target) and is_binary(account) do
-    {:cont, whois_fold(state, target, %{account: account}), []}
+    folded = whois_fold(state, target, %{account: account})
+
+    if nick_eq?(target, state.nick) do
+      next_state = Map.put(folded, :account, IdentityState.normalize_account(account))
+      effects = identity_effects(folded, next_state)
+
+      {:cont, next_state, identity_secret_effects(next_state, effects) ++ effects}
+    else
+      {:cont, folded, []}
+    end
   end
 
   # 671 RPL_WHOISSECURE: `:server 671 own_nick target :is using a secure
@@ -2936,66 +2983,67 @@ defmodule Grappa.Session.EventRouter do
   defp pop_arg([h | t]), do: {h, t}
   defp pop_arg([]), do: {nil, []}
 
-  # Sign-walking +r detector for user-MODE strings. IRC mode blocks
-  # have sticky-sign semantics: `"+ir"` means "set i AND set r" in
-  # one block, `"+i-r"` means "set i, unset r". `String.contains?` is
-  # semantically wrong on both shapes (the second would even false-
-  # positive on naive `"+r"` substring search). Mirrors the
-  # `walk_modes/4` recursive-pattern-match shape (CLAUDE.md
-  # "Recursive pattern match over `Enum.reduce_while/3`").
-  @spec set_r_mode?(String.t()) :: boolean()
-  defp set_r_mode?(modes), do: walk_for_set_r(modes, :add)
-
-  # #215 — session identity transition from the +r bit flip. Compares the
-  # per-session umode sets before/after the self-MODE echo: gaining "r" is
-  # `:acquired` (NickServ/SASL confirmed), losing it is `:lost`. Emits at
-  # most one effect; no change → `[]`.
-  @spec session_identity_effects([String.t()], [String.t()]) :: [{:session_identity_changed, :acquired | :lost}]
-  defp session_identity_effects(prev_umodes, next_umodes) do
-    cond do
-      "r" in next_umodes and "r" not in prev_umodes -> [{:session_identity_changed, :acquired}]
-      "r" in prev_umodes and "r" not in next_umodes -> [{:session_identity_changed, :lost}]
-      true -> []
+  # #215 / #388 — THE session identity transition. Every identity source
+  # funnels through this one diff: the self-MODE echo, the 221 RPL_UMODEIS
+  # snapshot, the self-rename +r strip, inbound IRCv3 `ACCOUNT`, and the
+  # self-targeted 330 RPL_WHOISLOGGEDIN. Each mutates its own fact on the
+  # state and then asks THIS function what changed, so there is exactly one
+  # place that decides what "identified" means — `IdentityState.identified?/1`
+  # — and adding a source can never fork the definition.
+  #
+  # Takes whole states rather than the changed axis: a caller passing only
+  # its own axis is how the pre-#388 `"r" in umodes` readers drifted apart.
+  # Emits at most one effect; no change → `[]`.
+  @spec identity_effects(state(), state()) :: [{:session_identity_changed, :acquired | :lost}]
+  defp identity_effects(prev_state, next_state) do
+    case {IdentityState.identified?(prev_state), IdentityState.identified?(next_state)} do
+      {false, true} -> [{:session_identity_changed, :acquired}]
+      {true, false} -> [{:session_identity_changed, :lost}]
+      _ -> []
     end
   end
 
-  # #581 — bahamut strips +r SILENTLY on a genuine nick change (m_nick.c:
-  # `mycmp(old,new) != 0 → umode &= ~UMODE_r`, no MODE echo — the same invariant
-  # Credentials.bind_identified_visitor_nick/3 documents). Mirror it so a
-  # self-rename leaves `state.umodes` truthful: on OUR OWN genuine rename drop
-  # "r" and emit `:umode_changed` + the identity transition (→ :lost, via
-  # session_identity_effects/2). A pure case-change is NOT a rename (mycmp is
-  # case-insensitive), so gate on `not nick_eq?(old, new)` — the #373
-  # rename-vs-fold distinction. Detection reads the ORIGINAL `state.nick` (the
-  # already-built `new_state.nick` holds the post-rename value); the strip
-  # applies to `new_state`. Without this a visitor who /nick's away from their
-  # registered nick keeps a PHANTOM +r and the #581 recover button
-  # (`canRecover() = recoverable && !"r"`) never appears. Drop ONLY "r" (the
-  # documented invariant), not other umodes; `Map.get`/`Map.put` (never
+  # #581 — bahamut strips the registered umode SILENTLY on a genuine nick
+  # change (m_nick.c: `mycmp(old,new) != 0 → umode &= ~UMODE_r`, no MODE echo —
+  # the same invariant Credentials.bind_identified_visitor_nick/3 documents).
+  # Mirror it so a self-rename leaves `state.umodes` truthful: on OUR OWN
+  # genuine rename drop the letter and emit `:umode_changed` + the identity
+  # transition (→ :lost, via identity_effects/2). A pure case-change is NOT a
+  # rename (mycmp is case-insensitive), so gate on `not nick_eq?(old, new)` —
+  # the #373 rename-vs-fold distinction. Detection reads the ORIGINAL
+  # `state.nick` (the already-built `new_state.nick` holds the post-rename
+  # value); the strip applies to `new_state`. Without this a visitor who
+  # /nick's away from their registered nick keeps a PHANTOM registered umode
+  # and the #581 recover button never appears.
+  #
+  # #388 — the letter stripped is the FLAVOUR's letter, not a hard-coded "r":
+  # on OFTC that is `+R`, and lowercase `r` there is an unrelated oper notice
+  # mode that must survive the rename untouched. Drop ONLY that one letter
+  # (the documented invariant), not other umodes; `Map.get`/`Map.put` (never
   # `%{... | umodes:}`) for the #216 hot-reload contract.
+  #
+  # The stripped umode is the only fact this touches: a services ACCOUNT is
+  # NOT cleared by a rename (the account survives a nick change), so a
+  # session identified via the account axis correctly stays identified —
+  # which is also why the transition must be computed from whole states.
   @spec strip_r_on_self_rename(state(), state(), String.t(), String.t()) ::
           {state(), [effect()]}
   defp strip_r_on_self_rename(state, new_state, old_nick, new_nick) do
     if nick_eq?(old_nick, state.nick) and not nick_eq?(old_nick, new_nick) do
       prev_umodes = Map.get(new_state, :umodes, [])
-      next_umodes = prev_umodes -- ["r"]
+      letter = IdentityState.registered_umode(Map.get(new_state, :services_flavor))
+      next_umodes = prev_umodes -- [letter]
 
       changed_effects =
         if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
 
-      {Map.put(new_state, :umodes, next_umodes), changed_effects ++ session_identity_effects(prev_umodes, next_umodes)}
+      stripped_state = Map.put(new_state, :umodes, next_umodes)
+
+      {stripped_state, changed_effects ++ identity_effects(new_state, stripped_state)}
     else
       {new_state, []}
     end
   end
-
-  defp walk_for_set_r("", _), do: false
-  defp walk_for_set_r("+" <> rest, _), do: walk_for_set_r(rest, :add)
-  defp walk_for_set_r("-" <> rest, _), do: walk_for_set_r(rest, :remove)
-  defp walk_for_set_r("r" <> _, :add), do: true
-
-  defp walk_for_set_r(<<_::utf8, rest::binary>>, dir),
-    do: walk_for_set_r(rest, dir)
 
   defp update_member_mode(ch_members, nil, _, _), do: ch_members
 
@@ -3299,23 +3347,31 @@ defmodule Grappa.Session.EventRouter do
   defp toggle_umode(set, letter, :add), do: MapSet.put(set, letter)
   defp toggle_umode(set, letter, :remove), do: MapSet.delete(set, letter)
 
-  # #279 — the two readers of a self-MODE token, each gated by the SAME
-  # parse verdict so a malformed line can never yield a conclusion.
+  # The capture-confirmation slot (#90/#129): ONE identity-confirmation
+  # primitive serves both staged secrets. If BOTH are staged, REGISTER wins
+  # — it is correct-by-construction (a wrong register never gets confirmed),
+  # whereas a stale wrong identify could still be inside its 10s window.
+  # Both fields are optional from the pure router's POV (pure unit tests on
+  # user sessions skip them → `Map.get` nil).
   #
-  # `visitor_r_effects/3` is the +r capture-confirmation slot (#90/#129):
-  # ONE +r-observation primitive serves both staged secrets. If BOTH are
-  # staged, REGISTER wins — it is correct-by-construction (a wrong register
-  # never gets +r), whereas a stale wrong identify could still be inside
-  # its 10s window. Both fields are optional from the pure router's POV
-  # (pure unit tests on user sessions skip them → `Map.get` nil).
-  @spec visitor_r_effects(state(), {:ok, [String.t()]} | :error, String.t()) :: [effect()]
-  defp visitor_r_effects(_, :error, _), do: []
-
-  defp visitor_r_effects(state, {:ok, _}, modes) do
-    case {set_r_mode?(modes), Map.get(state, :pending_registration_secret), Map.get(state, :pending_auth)} do
-      {true, reg, _} when is_binary(reg) -> [{:visitor_r_observed, reg}]
-      {true, _, {pwd, _}} -> [{:visitor_r_observed, pwd}]
-      _ -> []
+  # #388 — driven by the NORMALIZED `:acquired` transition rather than a
+  # `+r` re-scan of the raw mode string. Two consequences, both wanted:
+  # a secret staged on a solanum/OFTC network now commits (it never could
+  # before — those ircds do not emit bahamut's `+r`), and a REDUNDANT
+  # re-assertion of an already-held identity no longer re-commits, because
+  # an edge is required rather than a mode letter's mere presence. The #279
+  # malformed-token gate is inherited for free: a rejected parse leaves the
+  # umode set unchanged, so there is no edge and no conclusion is drawn.
+  @spec identity_secret_effects(state(), [effect()]) :: [effect()]
+  defp identity_secret_effects(state, identity_effects) do
+    if {:session_identity_changed, :acquired} in identity_effects do
+      case {Map.get(state, :pending_registration_secret), Map.get(state, :pending_auth)} do
+        {reg, _} when is_binary(reg) -> [{:identity_secret_confirmed, reg}]
+        {_, {pwd, _}} -> [{:identity_secret_confirmed, pwd}]
+        _ -> []
+      end
+    else
+      []
     end
   end
 
@@ -3605,7 +3661,7 @@ defmodule Grappa.Session.EventRouter do
     # for a visitor subject, emit the persist-side effect so
     # `Session.Server.apply_effects/2` rotates `visitors.nick` via the
     # injected `visitor_nick_persister` callback. Mirror of the
-    # `:visitor_r_observed` shape — the closure-injection avoids a
+    # `:identity_secret_confirmed` shape — the closure-injection avoids a
     # static `Session → Visitors` Boundary alias that would close a
     # cycle (Visitors deps Session via Login). User subjects don't
     # carry a persister; their nick lives in `Networks.Credential`,

--- a/lib/grappa/session/identity_state.ex
+++ b/lib/grappa/session/identity_state.ex
@@ -1,0 +1,137 @@
+defmodule Grappa.Session.IdentityState do
+  @moduledoc """
+  The single source of truth for one question (GH #388): **is this session
+  identified to the network's services?**
+
+  Before #388 that question was answered by three separate readers, each
+  spelling `"r" in umodes` by hand — `EventRouter.session_identity_effects/2`,
+  `EventRouter`'s `set_r_mode?/1` mode-string walker, and `Session.Server`'s
+  `registered:` wire field — plus a fourth in cicchetto. `+r` is emitted
+  only by bahamut, so every one of them was an Azzurra-shaped answer and the
+  #349 registration wizard could not ship anywhere else. This module replaces
+  all of them: callers ask `identified?/1`, never a mode letter.
+
+  ## The two axes
+
+  A session counts as identified when EITHER holds:
+
+    * **account** — the services account name, from IRCv3 `account-notify`
+      (`ACCOUNT <name>` / `ACCOUNT *`) or numeric 330 RPL_WHOISLOGGEDIN for
+      self. Flavour-agnostic, and the ONLY axis solanum/atheme networks
+      offer (see below).
+    * **registered umode** — the per-flavour umode letter the ircd sets when
+      services confirm an identify.
+
+  They are OR'd: a bahamut network supplies only the umode, a solanum one
+  only the account, and an ircd offering both may deliver either first.
+
+  ## Why the umode letter is per-flavour and EXCLUSIVE
+
+  The letter is not a portable constant, and accepting a union of `r` and
+  `R` would be actively wrong in both directions. Verified at source:
+
+    * **bahamut** (Azzurra, all of prod) — lowercase `+r` is the registered
+      state; this is the pre-#388 behaviour and the invariant #561/#581
+      already lean on (`m_nick.c` strips it on a genuine rename).
+    * **OFTC** (`oftc/oftc-hybrid@36f0431`, `src/s_user.c`, blob
+      `e325095`) — uppercase `R` is `UMODE_NICKSERVREG`, "user is registered
+      with nickserv and identified" (`s_user.c:114`, `include/client.h:401`).
+      Lowercase `r` on the SAME ircd is `UMODE_REJ`, an oper bot-rejection
+      server-notice mode (`s_user.c:142`). Treating `r` as identity there
+      would mark an oper identified and let the wizard commit a registration
+      that never happened.
+    * **solanum** (Libera, `ircd/s_user.c` `user_modes[256]`) — neither
+      letter is assigned in core (`/* R */ 0`; the table is
+      `D/Q/S/Z/a/i/o/s/w/z`). Identity arrives purely via account, which is
+      why `:atheme` gets no usable umode and needs none. Uppercase `R` being
+      free in core is also why it must NOT be honoured off OFTC: an
+      extension is at liberty to assign it something unrelated.
+
+  So `registered_umode/1` returns ONE letter per flavour and callers test
+  membership of exactly that letter. An unclassified network (`nil`, the
+  operator never set `services_flavor`) and any flavour added later default
+  to lowercase `r` — the pre-#388 answer, so classifying nothing changes
+  nothing.
+
+  ## Shape
+
+  Pure functions over the session-state map; this module stores nothing.
+  The three facts already live on `Grappa.Session.Server`'s state
+  (`:umodes`, `:account`, `:services_flavor`) and are read here with
+  `Map.get` defaults, so a hot-reloaded process whose state predates any of
+  them answers "not identified" instead of `KeyError`-crashing (the #216
+  contract). Reading all three in ONE place is the point: a caller cannot
+  forget an axis, which is precisely how the `+r`-only readers drifted.
+  """
+
+  @typedoc """
+  The operator-set services flavour, mirroring
+  `Grappa.Networks.Network.services_flavor/0`. Declared as a plain `atom()`
+  rather than aliased: `Networks` already depends on `Session`, so naming
+  that type here would close a Boundary cycle (the same indirection
+  `Session.Server`'s committer typedocs use). Unrecognised atoms are not an
+  error — they take the lowercase default.
+  """
+  @type flavor :: atom() | nil
+
+  @typedoc """
+  The subset of the session state this module reads. Every key is optional
+  for the #216 hot-reload contract, and the open tail lets the full
+  `Session.Server` state be passed straight in.
+  """
+  @type facts :: %{
+          optional(:umodes) => [String.t()],
+          optional(:account) => String.t() | nil,
+          optional(:services_flavor) => flavor(),
+          optional(any()) => any()
+        }
+
+  # Flavours whose registered umode is NOT the lowercase default. One entry
+  # per divergence, so adding an ircd is a one-line edit here rather than a
+  # new detector somewhere downstream.
+  @registered_umode_by_flavor %{oftc: "R"}
+  @default_registered_umode "r"
+
+  # IRCv3 account-notify spells "logged out" as a literal asterisk.
+  @logged_out_account "*"
+
+  @doc """
+  Whether the session is identified to services — the normalized signal
+  every consumer keys off, replacing all direct umode reads.
+  """
+  @spec identified?(facts()) :: boolean()
+  def identified?(facts) when is_map(facts) do
+    account_identified?(facts) or umode_identified?(facts)
+  end
+
+  @doc """
+  The umode letter meaning "registered and identified" on the given
+  services flavour. Exactly one letter, never a set — see the moduledoc for
+  why a union of `r` and `R` is wrong on both OFTC and solanum.
+  """
+  @spec registered_umode(flavor()) :: String.t()
+  def registered_umode(flavor) do
+    Map.get(@registered_umode_by_flavor, flavor, @default_registered_umode)
+  end
+
+  @doc """
+  Folds an account name off the wire into the stored value: the
+  `account-notify` logout sentinel `"*"` and an empty string both mean "no
+  account", so they normalize to `nil` rather than being stored as a blank
+  identity that would read as identified.
+  """
+  @spec normalize_account(String.t() | nil) :: String.t() | nil
+  def normalize_account(@logged_out_account), do: nil
+  def normalize_account(""), do: nil
+  def normalize_account(account) when is_binary(account), do: account
+  def normalize_account(nil), do: nil
+
+  @spec account_identified?(facts()) :: boolean()
+  defp account_identified?(facts), do: is_binary(Map.get(facts, :account))
+
+  @spec umode_identified?(facts()) :: boolean()
+  defp umode_identified?(facts) do
+    letter = registered_umode(Map.get(facts, :services_flavor))
+    letter in Map.get(facts, :umodes, [])
+  end
+end

--- a/lib/grappa/session/identity_state.ex
+++ b/lib/grappa/session/identity_state.ex
@@ -18,12 +18,39 @@ defmodule Grappa.Session.IdentityState do
     * **account** — the services account name, from IRCv3 `account-notify`
       (`ACCOUNT <name>` / `ACCOUNT *`) or numeric 330 RPL_WHOISLOGGEDIN for
       self. Flavour-agnostic, and the ONLY axis solanum/atheme networks
-      offer (see below).
+      offer (see below). **Counts as proof only where `account-notify` is
+      ACKed** — see the next section.
     * **registered umode** — the per-flavour umode letter the ircd sets when
       services confirm an identify.
 
   They are OR'd: a bahamut network supplies only the umode, a solanum one
   only the account, and an ircd offering both may deliver either first.
+
+  ## Why the account axis is gated on the cap (vjt's ruling, 2026-08-11)
+
+  An account name is only a *live* identity where the ircd promises to
+  retract it, and `account-notify` IS that promise: it is the cap that
+  delivers `ACCOUNT *` on logout. Without it we can learn an account (a
+  330 naming us) but we will never be told it ended, so treating it as
+  proof means a verdict that can go up and never come down.
+
+  That is not hypothetical. bahamut (Azzurra, all of prod) offers no such
+  cap and strips `+r` on a genuine rename (#581). Ungated, a 330 would
+  pin the session "identified" forever: the `+r` strip would stop moving
+  the verdict, and #581's re-identify affordance — the button that tells
+  the operator they need to identify again — would never come back. So on
+  bahamut a 330 is **display only**: still folded onto the state for the
+  WHOIS card, no longer part of the verdict, and `+r` alone decides.
+  Behaviour on prod is therefore exactly the pre-#388 behaviour.
+
+  On solanum/OFTC the cap IS ACKed, so the account axis is live: it
+  survives a rename, as it should, and `ACCOUNT *` retracts it. A 330 with
+  neither cap nor umode degrades to "not identified" — the safe direction,
+  and the tolerance `identity.ts` already declares.
+
+  This reads box 2 of the #388 checklist ("parse WHOIS-330 for account")
+  more narrowly than written. The checklist predates the measurement;
+  where the two disagree, the measured design wins.
 
   ## Why the umode letter is per-flavour and EXCLUSIVE
 
@@ -83,6 +110,7 @@ defmodule Grappa.Session.IdentityState do
           optional(:umodes) => [String.t()],
           optional(:account) => String.t() | nil,
           optional(:services_flavor) => flavor(),
+          optional(:caps_active) => MapSet.t(String.t()),
           optional(any()) => any()
         }
 
@@ -94,6 +122,10 @@ defmodule Grappa.Session.IdentityState do
 
   # IRCv3 account-notify spells "logged out" as a literal asterisk.
   @logged_out_account "*"
+
+  # The cap that makes the account axis retractable, and therefore usable
+  # as proof. Same string the CAP ACK seam records into `caps_active`.
+  @account_notify_cap "account-notify"
 
   @doc """
   Whether the session is identified to services — the normalized signal
@@ -126,8 +158,15 @@ defmodule Grappa.Session.IdentityState do
   def normalize_account(account) when is_binary(account), do: account
   def normalize_account(nil), do: nil
 
+  # An account counts only where the ircd promised to retract it. The
+  # `Map.get` default is an empty set, so a hot-reloaded state predating
+  # the key falls back to the umode axis — the pre-#388 answer, and the
+  # safe direction (#216).
   @spec account_identified?(facts()) :: boolean()
-  defp account_identified?(facts), do: is_binary(Map.get(facts, :account))
+  defp account_identified?(facts) do
+    is_binary(Map.get(facts, :account)) and
+      MapSet.member?(Map.get(facts, :caps_active, MapSet.new()), @account_notify_cap)
+  end
 
   @spec umode_identified?(facts()) :: boolean()
   defp umode_identified?(facts) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -102,6 +102,7 @@ defmodule Grappa.Session.Server do
     Broadcaster,
     EventRouter,
     GhostRecovery,
+    IdentityState,
     ISupport,
     ModeChunker,
     NSInterceptor,
@@ -229,7 +230,7 @@ defmodule Grappa.Session.Server do
   @typedoc """
   Optional opaque callback the visitor-side `SessionPlan` injects into
   every visitor plan. Invoked by `apply_effects/2` when EventRouter emits
-  `:visitor_r_observed` so the confirmed NickServ password AND the nick held
+  `:identity_secret_confirmed` so the confirmed NickServ password AND the nick held
   at the identify instant land on the credential (#561). The function shape
   mirrors `Grappa.Visitors.commit_identity/4` (the closure captures
   `network_id`, so the args are `(visitor_id, password, nick)`). Carried as
@@ -764,6 +765,23 @@ defmodule Grappa.Session.Server do
           # cic as `umode_changed` on Topic.user for the `/mode <nick>` modal.
           # Defaults to `[]` until the 221 arrives.
           umodes: [String.t()],
+          # #388: the services ACCOUNT name this session is logged in as, or
+          # nil when logged out. Seeded by IRCv3 `account-notify` (inbound
+          # `ACCOUNT`, with `*` normalized to nil) and by a self-targeted 330
+          # RPL_WHOISLOGGEDIN. This is the FLAVOUR-AGNOSTIC half of the
+          # identity signal: solanum/atheme networks have no registered
+          # umode, so on those it is the only evidence an identify landed.
+          # Never read directly for an identity verdict — ask
+          # `IdentityState.identified?/1`, which folds it with the umode axis.
+          account: String.t() | nil,
+          # #388: the network's operator-set NickServ services flavour,
+          # injected at spawn by `Networks.SessionPlan.base_plan/6` (shared by
+          # user + visitor plans). Its ONLY job in the session is telling
+          # `IdentityState` which umode letter means "registered": lowercase
+          # `r` everywhere by default, uppercase `R` on OFTC — where the
+          # lowercase letter is an unrelated oper notice mode. nil for a
+          # network the operator never classified (treated as the default).
+          services_flavor: atom() | nil,
           # #249: per-session SUPPORTED user-mode set — the umode letters the
           # server advertises in 004 RPL_MYINFO (param index 3), a sorted list
           # of single-letter strings. Unlike `umodes` (the operator's ACTIVE
@@ -1261,6 +1279,12 @@ defmodule Grappa.Session.Server do
       presence_mechanism: nil,
       # #229: empty umode set until the 221 RPL_UMODEIS reply arrives.
       umodes: [],
+      # #388: no services account until an `ACCOUNT` or a self 330 says so.
+      account: nil,
+      # #388: which umode letter means "registered" on this network. `Map.get`
+      # (not a required fetch) so a plan predating the key — or a pure test
+      # opts map — takes the lowercase default rather than crashing at spawn.
+      services_flavor: Map.get(opts, :services_flavor),
       # #249: empty supported-umode set until the 004 RPL_MYINFO arrives.
       supported_umodes: [],
       # C2 — pending WHOIS accumulators keyed by lowercased target nick.
@@ -2396,7 +2420,11 @@ defmodule Grappa.Session.Server do
       server: state.peer_address,
       port: state.peer_port,
       tls: Map.get(state, :tls, false),
-      registered: "r" in Map.get(state, :umodes, []),
+      # #388 — the normalized verdict, not a hand-spelled `"r" in umodes`:
+      # this field is what cic's registration + recover launchers gate on,
+      # so on a solanum/OFTC network the bahamut-only spelling reported a
+      # permanent "not identified".
+      registered: IdentityState.identified?(state),
       connected_at: Map.get(state, :connected_at)
     }
 
@@ -2604,6 +2632,14 @@ defmodule Grappa.Session.Server do
       %{
         umodes: Map.get(state, :umodes, []),
         supported_umodes: Map.get(state, :supported_umodes, []),
+        # #388 — the normalized identity verdict rides the SAME snapshot, so
+        # a client that reloads mid-session re-learns it without a second
+        # round-trip. Without it cic's registration + recover launchers would
+        # reappear on every reload of an already-identified session: the live
+        # `session_identity_changed` edge fired long before the browser
+        # subscribed, and nothing else on the user topic carries the verdict.
+        identified: IdentityState.identified?(state),
+        account: Map.get(state, :account),
         invited_windows: WindowState.invited_windows(state.window_state, state.network_slug)
       }}, state}
   end
@@ -5130,25 +5166,45 @@ defmodule Grappa.Session.Server do
     apply_effects(rest, next_state)
   end
 
-  # #215 — the +r bit flipped (EventRouter self-MODE branch). Emit the
-  # `:identified` / `:deidentified` session-lifecycle event. Pure side
-  # effect (Logger + telemetry) — no state mutation.
+  # #215 — the session's services identity flipped (any of the #388 sources:
+  # self-MODE echo, 221 snapshot, self-rename strip, inbound `ACCOUNT`, self
+  # 330). Emit the `:identified` / `:deidentified` session-lifecycle event.
   defp apply_effects([{:session_identity_changed, transition} | rest], state) do
     event = if transition == :acquired, do: :identified, else: :deidentified
     SessionLog.emit(event, state, [])
 
-    # On +r acquisition, TWO consumers fire (both gated on `:acquired`,
-    # nested under one rebind — Credo VariableRebinding):
-    #   #347 — +r is the identify-confirmed signal the deferred
+    # #388 — fan the NORMALIZED verdict out to cic on Topic.user. This is
+    # what the registration + recover launchers gate on; before #388 cic
+    # re-derived it from the `umode_changed` letter list, which is a
+    # bahamut-only spelling AND is never re-seeded after a page reload.
+    # Re-reads `identified?/1` rather than mapping the transition atom so
+    # the pushed value and the `GET /networks` cold twin cannot disagree.
+    :ok =
+      Broadcaster.to_user(
+        state,
+        SessionWire.session_identity_changed(
+          state.network_id,
+          IdentityState.identified?(state),
+          Map.get(state, :account)
+        )
+      )
+
+    # On identity acquisition, TWO consumers fire (both gated on
+    # `:acquired`, nested under one rebind — Credo VariableRebinding):
+    #   #347 — acquisition is the identify-confirmed signal the deferred
     #   `:nickserv_identify` autojoin waits for. Fire the JOINs now
     #   (cancelling the fallback timer) so they land AFTER identify — +R
     #   channels accept and ChanServ ops. No-op for any path that didn't
     #   defer (latch nil): SASL/:none fired on 001.
-    #   #581 — +r IS the recover FSM's `:r_observed` signal. Reuse
-    #   EventRouter's `set_r_mode?` detection (it already produced this
-    #   effect) instead of re-parsing the MODE echo; only feed while a
-    #   recover is armed (`advance_recover/2` no-ops the FSM off-phase).
+    #   #581 — acquisition IS the recover FSM's `:r_observed` signal. Reuse
+    #   the transition EventRouter already computed instead of re-parsing
+    #   the MODE echo; only feed while a recover is armed
+    #   (`advance_recover/2` no-ops the FSM off-phase).
     # A `:lost` transition triggers neither.
+    #
+    # #388 — both consumers now also fire for an identity learned from
+    # `ACCOUNT` or a self 330, so the deferred autojoin is released and a
+    # recover completes on networks that never emit a registered umode.
     state =
       if transition == :acquired do
         after_autojoin = fire_deferred_autojoin(state)
@@ -5682,7 +5738,7 @@ defmodule Grappa.Session.Server do
   # cycle. User sessions don't carry a committer; if a {:user, _}
   # somehow staged pending_auth (e.g. operator manually issued
   # NickServ IDENTIFY), the +r is logged and dropped.
-  defp apply_effects([{:visitor_r_observed, password} | rest], state) do
+  defp apply_effects([{:identity_secret_confirmed, password} | rest], state) do
     # #561 — bind the password AND the nick this +r confirms. Normally
     # that is `state.nick`: bahamut clears +r on a genuine nick change
     # (`m_nick.c:594-602`) and services set it only on `sameNick`, so at
@@ -5694,7 +5750,7 @@ defmodule Grappa.Session.Server do
     # is robust if that invariant ever weakens (binding the worn nick
     # instead of the identity is wrong regardless).
     # #229 hot-reload safety — `Map.get`, never `state.recover_identity`
-    # dot-access: `visitor_r_observed` fires on EVERY visitor +r (whenever
+    # dot-access: `identity_secret_confirmed` fires on EVERY visitor +r (whenever
     # `pending_auth` was staged), so a session predating the #581 field
     # (force-hot-reloaded) would KeyError here on the common identify path.
     # Absent key → nil → the `state.nick` fallback (pre-#581 behaviour).
@@ -5729,7 +5785,7 @@ defmodule Grappa.Session.Server do
         )
 
       {{:user, user_id}, _} ->
-        commit_user_registration_on_r(user_id, password, state)
+        commit_user_registration(user_id, password, state)
     end
 
     :ok = cancel_and_drain(state.pending_auth_timer, :pending_auth_timeout)
@@ -5954,7 +6010,7 @@ defmodule Grappa.Session.Server do
   # is NOT a registration — leave the credential's auth posture untouched
   # (#124's territory), same drop-and-log as before. Multi-clause so the
   # apply_effects +r arm stays flat.
-  defp commit_user_registration_on_r(user_id, password, %{
+  defp commit_user_registration(user_id, password, %{
          pending_registration_secret: secret,
          registration_committer: committer
        })
@@ -5971,15 +6027,15 @@ defmodule Grappa.Session.Server do
     end
   end
 
-  defp commit_user_registration_on_r(user_id, _, %{pending_registration_secret: secret})
+  defp commit_user_registration(user_id, _, %{pending_registration_secret: secret})
        when is_binary(secret) do
     Logger.error("user +r observed with staged registration but no committer — drop",
       user_id: user_id
     )
   end
 
-  defp commit_user_registration_on_r(_, _, _) do
-    Logger.warning("visitor_r_observed effect on user session — ignored")
+  defp commit_user_registration(_, _, _) do
+    Logger.warning("identity_secret_confirmed effect on user session — ignored")
   end
 
   # #116: on a 473 (+i) / 475 (+k) failure for a channel in the boot

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3407,27 +3407,36 @@ defmodule Grappa.Session.Server do
     end
   end
 
-  # S4.2 — CAP ACK: detect labeled-response being granted by the upstream.
+  # The caps whose ACK changes how this process behaves, and therefore the
+  # ones worth remembering. Recording the ACKed subset of THIS set — rather
+  # than one `if` per cap — is deliberate: the pre-#388 shape kept only
+  # `labeled-response` and silently dropped every other ACK on the floor,
+  # so `account-notify` was negotiated, granted, and then forgotten.
+  #
+  #   * `labeled-response` (S4.2) — gates whether we tag outbound commands.
+  #   * `account-notify` (#388) — gates whether the services ACCOUNT counts
+  #     as proof of identity. See `Grappa.Session.IdentityState`.
+  @tracked_caps MapSet.new(["labeled-response", "account-notify"])
+
+  # S4.2 / #388 — CAP ACK: record which of the caps we act on were granted.
   # IRC.Client dispatches ALL parsed messages to Session.Server (including
-  # CAP messages that AuthFSM also processes). This handler fires for any
-  # CAP ACK that contains "labeled-response" in the ACK'd caps list. It
-  # is not phase-guarded — a stray post-registration CAP ACK from a CAP
-  # NEW or similar extension is benign here (we just add the cap name to
-  # caps_active, which is a no-op if it's already there or useless if
-  # the session never issues labeled commands).
+  # CAP messages that AuthFSM also processes). Not phase-guarded — a stray
+  # post-registration CAP ACK from a CAP NEW or similar extension is benign,
+  # because a cap can only be ADDED here and adding one we already hold is a
+  # no-op. Caps outside `@tracked_caps` are ignored rather than stored: this
+  # set is "what changes our behaviour", not an inventory of the session.
   def handle_info(
         {:irc, %Message{command: :cap, params: [_, "ACK", caps_blob | _]}},
         state
       )
       when is_binary(caps_blob) do
-    acked = caps_blob |> String.split(" ", trim: true) |> Enum.map(&String.trim/1)
-
     caps_active =
-      if "labeled-response" in acked do
-        MapSet.put(state.caps_active, "labeled-response")
-      else
-        state.caps_active
-      end
+      caps_blob
+      |> String.split(" ", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> MapSet.new()
+      |> MapSet.intersection(@tracked_caps)
+      |> MapSet.union(state.caps_active)
 
     {:noreply, %{state | caps_active: caps_active}}
   end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -71,6 +71,7 @@ defmodule Grappa.Session.Wire do
           | :own_nick_changed
           | :isupport_changed
           | :umode_changed
+          | :session_identity_changed
           | :supported_umodes_changed
           | :topic_changed
           | :channel_modes_changed
@@ -156,6 +157,37 @@ defmodule Grappa.Session.Wire do
           kind: :umode_changed,
           network_id: integer(),
           modes: [String.t()]
+        }
+
+  @typedoc """
+  The NORMALIZED services-identity signal (#388): whether this session is
+  identified to the network's services, and under which account.
+
+  This is the event a client gates registration / recovery affordances on.
+  It exists so no client has to know what a "registered umode" is: the
+  server folds bahamut's `+r`, OFTC's `+R`, and the flavour-agnostic
+  account signals (IRCv3 `account-notify`, numeric 330) into ONE verdict
+  via `Grappa.Session.IdentityState`. cicchetto previously spelled
+  `umodes.includes("r")` itself, which was correct on Azzurra and wrong
+  everywhere else.
+
+  `account` is the services account name when known and `nil` otherwise —
+  including when `identified` is `true` via the umode axis alone, which is
+  the normal bahamut case (it exposes no account). So `account` is
+  supplementary display data; `identified` is the verdict, and a client
+  MUST NOT infer identity from `account` being present or absent.
+
+  Carries `:network_id` (not slug) and rides `Topic.user/1` — per
+  (subject, network), the same carrier as `umode_changed/2` +
+  `isupport_changed/2`. The COLD twin of this event is the `registered`
+  field of `GET /networks`' `connection` object, which reports the same
+  `IdentityState.identified?/1` verdict for a client that just loaded.
+  """
+  @type session_identity_changed_payload :: %{
+          kind: :session_identity_changed,
+          network_id: integer(),
+          identified: boolean(),
+          account: String.t() | nil
         }
 
   @typedoc """
@@ -877,6 +909,24 @@ defmodule Grappa.Session.Wire do
   def umode_changed(network_id, modes)
       when is_integer(network_id) and is_list(modes) do
     %{kind: :umode_changed, network_id: network_id, modes: modes}
+  end
+
+  @doc """
+  The normalized services-identity verdict (#388) — see
+  `t:session_identity_changed_payload/0` for why clients gate on this
+  instead of reading a umode letter.
+  """
+  @spec session_identity_changed(integer(), boolean(), String.t() | nil) ::
+          session_identity_changed_payload()
+  def session_identity_changed(network_id, identified, account)
+      when is_integer(network_id) and is_boolean(identified) and
+             (is_binary(account) or is_nil(account)) do
+    %{
+      kind: :session_identity_changed,
+      network_id: network_id,
+      identified: identified,
+      account: account
+    }
   end
 
   @doc """

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -331,7 +331,7 @@ defmodule Grappa.Visitors do
   #561 — the `+r`-observed identity commit: writes the confirmed NickServ
   password AND binds the nick held at the identify instant onto the
   `(visitor_id, network_id)` Credential. Called from
-  `Grappa.Session.Server`'s `apply_effects/2` on `:visitor_r_observed` (the
+  `Grappa.Session.Server`'s `apply_effects/2` on `:identity_secret_confirmed` (the
   visitor branch) via the injected `visitor_committer` closure.
 
   Both bindings matter. The password promotes the credential to

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -1407,6 +1407,19 @@ defmodule GrappaWeb.GrappaChannel do
             SessionWire.supported_umodes_changed(network.id, snapshot.supported_umodes)
           )
 
+          # #388 — the normalized services-identity verdict, reusing the same
+          # Wire verb the live edge emits so cic's dispatch never branches on
+          # snapshot-vs-event.
+          push(
+            socket,
+            "event",
+            SessionWire.session_identity_changed(
+              network.id,
+              snapshot.identified,
+              snapshot.account
+            )
+          )
+
           Enum.each(snapshot.invited_windows, &push(socket, "event", &1))
 
         {:error, _} ->

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -352,6 +352,39 @@ defmodule Grappa.IRC.AuthFSMTest do
       assert send_lines(sends) == ["CAP REQ :sasl labeled-response"]
     end
 
+    # GH #388 — `account-notify` joins `labeled-response` as an opportunistic
+    # cap: it carries the flavour-agnostic identity signal (inbound `ACCOUNT`),
+    # which is the only identify evidence a solanum/atheme network offers.
+    test "CAP LS advertising account-notify requests it alongside sasl", %{state: state} do
+      msg = %Message{
+        command: :cap,
+        params: ["*", "LS", "sasl=PLAIN labeled-response account-notify"]
+      }
+
+      assert {:cont, %AuthFSM{phase: :awaiting_cap_ack_combined}, sends} =
+               AuthFSM.step(state, msg)
+
+      assert send_lines(sends) == ["CAP REQ :sasl labeled-response account-notify"]
+    end
+
+    test "account-notify without labeled-response still rides the combined REQ", %{state: state} do
+      msg = %Message{command: :cap, params: ["*", "LS", "sasl=PLAIN account-notify"]}
+
+      assert {:cont, %AuthFSM{phase: :awaiting_cap_ack_combined}, sends} =
+               AuthFSM.step(state, msg)
+
+      assert send_lines(sends) == ["CAP REQ :sasl account-notify"]
+    end
+
+    test "a server advertising NEITHER opportunistic cap sends the pre-#388 line", %{state: state} do
+      # The Azzurra/bahamut shape — all of prod. #388 must be byte-identical
+      # here or it changes the handshake on every production network.
+      msg = %Message{command: :cap, params: ["*", "LS", "sasl=PLAIN"]}
+
+      assert {:cont, %AuthFSM{phase: :awaiting_cap_ack}, sends} = AuthFSM.step(state, msg)
+      assert send_lines(sends) == ["CAP REQ :sasl"]
+    end
+
     test "combined CAP REQ NAK -> fallback CAP REQ :sasl + phase :awaiting_cap_ack_sasl_only (NO :stop)",
          %{state: state} do
       combined_state = %{state | phase: :awaiting_cap_ack_combined}

--- a/test/grappa/irc/parser_test.exs
+++ b/test/grappa/irc/parser_test.exs
@@ -83,6 +83,23 @@ defmodule Grappa.IRC.ParserTest do
                Parser.parse(":irc.azzurra.chat CAP * LS :sasl message-tags server-time")
     end
 
+    # GH #388 — IRCv3 `account-notify`. Without the allowlist entry this
+    # parses as `{:unknown, "ACCOUNT"}` and EventRouter's identity arm is
+    # unreachable, so the verb is load-bearing, not decorative.
+    test "ACCOUNT (IRCv3 account-notify) parses to the :account verb" do
+      assert {:ok,
+              %Message{
+                prefix: {:nick, "vjt", "u", "h"},
+                command: :account,
+                params: ["vjt"]
+              }} = Parser.parse(":vjt!u@h ACCOUNT vjt")
+    end
+
+    test "ACCOUNT * (the logout form) keeps the sentinel as a param" do
+      assert {:ok, %Message{command: :account, params: ["*"]}} =
+               Parser.parse(":vjt!u@h ACCOUNT *")
+    end
+
     test "trailing CRLF is stripped" do
       assert {:ok, %Message{command: :ping, params: ["x"]}} = Parser.parse("PING :x\r\n")
     end

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -192,7 +192,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
           assert is_binary(target)
           assert is_map(accum)
 
-        {:visitor_r_observed, nick} ->
+        {:identity_secret_confirmed, nick} ->
           assert is_binary(nick)
 
         {:visitor_nick_changed, nick} ->

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -43,6 +43,15 @@ defmodule Grappa.Session.EventRouterTest do
     %Message{command: command, params: params, prefix: prefix, tags: %{}}
   end
 
+  # #388 — the solanum/OFTC shape. Those ircds ACK `account-notify`, and
+  # since vjt's ruling of 2026-08-11 that ACK is what makes the services
+  # ACCOUNT count as proof of identity rather than mere display. Every
+  # account-axis fixture needs it; the bahamut fixtures deliberately do
+  # NOT have it, which is the whole contrast the ruling draws.
+  defp account_notify_state(overrides) do
+    base_state(Map.put(overrides, :caps_active, MapSet.new(["account-notify"])))
+  end
+
   # CP15 B2: helper for in_flight_joins fixture state. Records `channel`
   # case-preserved with key `String.downcase(channel)` to match the
   # production insert path in `record_in_flight_join/2`.
@@ -4290,7 +4299,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "inbound self ACCOUNT emits :acquired with no umode in sight" do
       # The solanum/atheme case: no registered umode exists on that ircd, so
       # this event IS the identify confirmation.
-      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      state = account_notify_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
       m = msg(:account, ["vjt"], {:nick, "vjt", "u", "h"})
       {:cont, next, effects} = EventRouter.route(m, state)
       assert {:session_identity_changed, :acquired} in effects
@@ -4298,7 +4307,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "ACCOUNT * is a logout — emits :lost and clears the account" do
-      state = base_state(%{nick: "vjt", account: "vjt", services_flavor: :atheme})
+      state = account_notify_state(%{nick: "vjt", account: "vjt", services_flavor: :atheme})
       m = msg(:account, ["*"], {:nick, "vjt", "u", "h"})
       {:cont, next, effects} = EventRouter.route(m, state)
       assert {:session_identity_changed, :lost} in effects
@@ -4315,7 +4324,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a differently-cased echo of our own nick still routes to self" do
-      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      state = account_notify_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
       m = msg(:account, ["VJT"], {:nick, "VJT", "u", "h"})
       {:cont, _, effects} = EventRouter.route(m, state)
       assert {:session_identity_changed, :acquired} in effects
@@ -4332,7 +4341,7 @@ defmodule Grappa.Session.EventRouterTest do
       # The #349 wizard commit, now reachable on a network that never emits
       # a registered umode — the whole point of #388.
       state =
-        base_state(%{
+        account_notify_state(%{
           nick: "vjt",
           umodes: [],
           services_flavor: :atheme,
@@ -4347,7 +4356,7 @@ defmodule Grappa.Session.EventRouterTest do
 
   describe "#388 — self 330 RPL_WHOISLOGGEDIN as an identity confirmation" do
     test "a 330 about US emits :acquired and records the account" do
-      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      state = account_notify_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
       m = msg({:numeric, 330}, ["vjt", "vjt", "acct", "is logged in as"])
       {:cont, next, effects} = EventRouter.route(m, state)
       assert {:session_identity_changed, :acquired} in effects
@@ -4393,17 +4402,52 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
-  describe "#388 — the two axes are OR'd across a self-rename" do
-    test "an account-identified session survives the rename umode strip" do
-      # bahamut strips the registered umode on a genuine rename (#581), but
-      # an account is not cleared by a nick change — so a session identified
-      # via the account axis must NOT report :lost.
+  describe "#388 — the account axis counts only where account-notify is ACKed" do
+    test "on bahamut the rename umode strip returns the verdict to :lost, account or not" do
+      # vjt's ruling, 2026-08-11. bahamut never ACKs `account-notify`, so a
+      # 330 naming us is display only and `+r` alone decides. bahamut strips
+      # that letter on a genuine rename (#581), so the verdict has to come
+      # back to :lost — and #581's re-identify affordance with it. Before
+      # the narrowing the account kept this session "identified" and the
+      # button never came back.
       state =
         base_state(%{nick: "vjt", umodes: ["r"], account: "vjt", services_flavor: :azzurra})
 
       m = msg(:nick, ["vjt2"], {:nick, "vjt", "u", "h"})
       {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :lost} in effects
+    end
+
+    test "with account-notify ACKed the account survives the same rename" do
+      # The one-variable contrast with the test above: same flavour, same
+      # message, same umode strip, and the ONLY difference is the cap. The
+      # fixture is deliberately counterfactual for bahamut — it isolates the
+      # gate rather than changing two things at once. Where the cap IS real
+      # (solanum, OFTC) this is the behaviour: a nick change does not clear
+      # an account, only `ACCOUNT *` retracts it.
+      state =
+        base_state(%{
+          nick: "vjt",
+          umodes: ["r"],
+          account: "vjt",
+          services_flavor: :azzurra,
+          caps_active: MapSet.new(["account-notify"])
+        })
+
+      m = msg(:nick, ["vjt2"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
       refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
+    test "a self 330 with neither the cap nor the umode records the account but does not identify" do
+      # The ruling's safe direction, and the distinction that matters: the
+      # account is still FOLDED onto the state (the WHOIS card reads it),
+      # it just stops being proof. "Display only" is not "discarded".
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :azzurra})
+      m = msg({:numeric, 330}, ["vjt", "vjt", "acct", "is logged in as"])
+      {:cont, next, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+      assert next.account == "acct"
     end
 
     test "a umode-only identity IS lost on a genuine rename" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -180,6 +180,30 @@ defmodule Grappa.Session.EventRouterTest do
       refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
     end
 
+    # #388 — the registered umode letter is per-flavour and EXCLUSIVE.
+    # Sources: oftc/oftc-hybrid@36f0431 src/s_user.c:114 (`R` =
+    # UMODE_NICKSERVREG) and :142 (`r` = UMODE_REJ, an oper notice mode).
+    test "OFTC self-MODE +R emits :acquired" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :oftc})
+      m = msg(:mode, ["vjt", "+R"], {:nick, "NickServ", "s", "s"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+    end
+
+    test "OFTC self-MODE +r is NOT identity — it is the oper bot-rejection mode" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :oftc})
+      m = msg(:mode, ["vjt", "+r"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
+    test "bahamut self-MODE +R is NOT identity — uppercase is not its letter" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :azzurra})
+      m = msg(:mode, ["vjt", "+R"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
     test "PRIVMSG to DM target (nick) preserves nick case" do
       state = base_state(%{nick: "vjt"})
       m = msg(:privmsg, ["CristoBOT", "hi"], {:nick, "vjt", "u", "h"})
@@ -2481,7 +2505,7 @@ defmodule Grappa.Session.EventRouterTest do
     # responds by setting +r on the nick. The Server's pending_auth
     # state holds the in-flight password (S9 Task 14); when EventRouter
     # observes +r MODE on the session's own nick it emits
-    # :visitor_r_observed carrying the password so the Server can
+    # :identity_secret_confirmed carrying the password so the Server can
     # commit it atomically into the visitors row.
     #
     # #154(b): every own-nick MODE ALSO emits a `{:persist, :mode,
@@ -2491,7 +2515,7 @@ defmodule Grappa.Session.EventRouterTest do
     # `refute Enum.any?`) rather than an exact effect-list match — the
     # confirmation persist is expected but not this block's subject.
 
-    test "+r set with pending_auth emits :visitor_r_observed" do
+    test "+r set with pending_auth emits :identity_secret_confirmed" do
       deadline = System.monotonic_time(:millisecond) + 10_000
 
       state =
@@ -2507,7 +2531,7 @@ defmodule Grappa.Session.EventRouterTest do
       # `^state` (unchanged) pin no longer holds — the +r OBSERVATION
       # effect is this test's subject, asserted via membership.
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      assert {:visitor_r_observed, "s3cret"} in effects
+      assert {:identity_secret_confirmed, "s3cret"} in effects
     end
 
     test "+r set without pending_auth → no observed effect" do
@@ -2521,7 +2545,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+r"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:visitor_r_observed, _}, &1))
+      refute Enum.any?(effects, &match?({:identity_secret_confirmed, _}, &1))
     end
 
     test "+i (no +r) with pending_auth → no observed effect" do
@@ -2535,7 +2559,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+i"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:visitor_r_observed, _}, &1))
+      refute Enum.any?(effects, &match?({:identity_secret_confirmed, _}, &1))
     end
 
     test "+ir mixed mode block detects r set" do
@@ -2549,7 +2573,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+ir"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      assert {:visitor_r_observed, "s3cret"} in effects
+      assert {:identity_secret_confirmed, "s3cret"} in effects
     end
 
     test "+i-r (set i, unset r) does NOT emit observed effect" do
@@ -2563,7 +2587,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+i-r"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:visitor_r_observed, _}, &1))
+      refute Enum.any?(effects, &match?({:identity_secret_confirmed, _}, &1))
     end
 
     test "+r MODE on a different nick (channel-MODE path) does NOT emit observed effect" do
@@ -2580,7 +2604,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
       assert Enum.any?(effects, &match?({:persist, :mode, _}, &1))
-      refute Enum.any?(effects, &match?({:visitor_r_observed, _}, &1))
+      refute Enum.any?(effects, &match?({:identity_secret_confirmed, _}, &1))
     end
 
     # #129: the register→auth-code flow grants +r minutes-to-hours after
@@ -2588,7 +2612,7 @@ defmodule Grappa.Session.EventRouterTest do
     # `pending_registration_secret` slot holds the captured REGISTER
     # password until this +r transition. The same +r-observation primitive
     # commits it — no second detector.
-    test "+r set with only pending_registration_secret emits :visitor_r_observed" do
+    test "+r set with only pending_registration_secret emits :identity_secret_confirmed" do
       state =
         base_state(%{
           nick: "vjt",
@@ -2600,7 +2624,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+r"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      assert {:visitor_r_observed, "regpass"} in effects
+      assert {:identity_secret_confirmed, "regpass"} in effects
     end
 
     test "+r with BOTH slots populated → register wins (commits the register secret)" do
@@ -2617,7 +2641,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:mode, ["vjt", "+r"], {:server, "irc.azzurra.chat"})
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
-      assert {:visitor_r_observed, "regpass"} in effects
+      assert {:identity_secret_confirmed, "regpass"} in effects
     end
   end
 
@@ -2795,9 +2819,10 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a garbage self-MODE echo cannot flip the +r identity signal" do
-      # session_identity_effects keys off the +r bit; a malformed string
-      # that happens to contain an `r` must not synthesise an identity
-      # transition out of upstream garbage.
+      # #388 — the identity verdict reads the FOLDED umode set, and #279
+      # rejects a malformed token wholesale, so the set never changes and no
+      # edge exists. A malformed string that happens to contain an `r` must
+      # not synthesise an identity transition out of upstream garbage.
       state = base_state(%{nick: "vjt", umodes: []})
       m = msg(:mode, ["vjt", "+r ?"], {:nick, "vjt", "u", "h"})
 
@@ -4257,6 +4282,138 @@ defmodule Grappa.Session.EventRouterTest do
   #                          shapes both occur.
   #   320 RPL_WHOISSPECIAL   "%s :%s"                   → free-form line;
   #                          folds into extra_lines for verbatim relay.
+  # GH #388 — the flavour-agnostic identity sources. These exist because the
+  # pre-#388 signal was bahamut's `+r` alone, so the #349 registration wizard
+  # could not detect completion on any other ircd. Every source below folds
+  # into the SAME normalized `:session_identity_changed` effect.
+  describe "#388 — account-notify / ACCOUNT as an identity source" do
+    test "inbound self ACCOUNT emits :acquired with no umode in sight" do
+      # The solanum/atheme case: no registered umode exists on that ircd, so
+      # this event IS the identify confirmation.
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      m = msg(:account, ["vjt"], {:nick, "vjt", "u", "h"})
+      {:cont, next, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+      assert next.account == "vjt"
+    end
+
+    test "ACCOUNT * is a logout — emits :lost and clears the account" do
+      state = base_state(%{nick: "vjt", account: "vjt", services_flavor: :atheme})
+      m = msg(:account, ["*"], {:nick, "vjt", "u", "h"})
+      {:cont, next, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :lost} in effects
+      assert next.account == nil
+    end
+
+    test "a PEER's ACCOUNT never touches our identity" do
+      # account-notify is relayed for every user sharing a channel with us.
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      m = msg(:account, ["someone"], {:nick, "otherguy", "u", "h"})
+      {:cont, next, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+      assert Map.get(next, :account) == nil
+    end
+
+    test "a differently-cased echo of our own nick still routes to self" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      m = msg(:account, ["VJT"], {:nick, "VJT", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+    end
+
+    test "re-asserting an already-held account emits nothing (edge, not level)" do
+      state = base_state(%{nick: "vjt", account: "vjt", services_flavor: :atheme})
+      m = msg(:account, ["vjt"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
+    test "a staged secret is confirmed by an ACCOUNT-driven acquisition" do
+      # The #349 wizard commit, now reachable on a network that never emits
+      # a registered umode — the whole point of #388.
+      state =
+        base_state(%{
+          nick: "vjt",
+          umodes: [],
+          services_flavor: :atheme,
+          pending_registration_secret: "s3cret"
+        })
+
+      m = msg(:account, ["vjt"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:identity_secret_confirmed, "s3cret"} in effects
+    end
+  end
+
+  describe "#388 — self 330 RPL_WHOISLOGGEDIN as an identity confirmation" do
+    test "a 330 about US emits :acquired and records the account" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      m = msg({:numeric, 330}, ["vjt", "vjt", "acct", "is logged in as"])
+      {:cont, next, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+      assert next.account == "acct"
+    end
+
+    test "a 330 about someone else does not touch our identity" do
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :atheme})
+      m = msg({:numeric, 330}, ["vjt", "otherguy", "acct", "is logged in as"])
+      {:cont, next, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+      assert Map.get(next, :account) == nil
+    end
+  end
+
+  describe "#388 — 221 RPL_UMODEIS is an identity source too" do
+    test "a snapshot revealing the registered umode emits :acquired" do
+      # Pre-#388 ONLY the self-MODE echo emitted a transition, so a session
+      # that first learned its identity from the connect-time snapshot never
+      # logged :identified and never released the deferred autojoin.
+      state = base_state(%{nick: "vjt", umodes: [], services_flavor: :azzurra})
+      m = msg({:numeric, 221}, ["vjt", "+ir"])
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+    end
+
+    test "a snapshot does NOT confirm a staged secret" do
+      # A reconciliation reports current state; the identity it describes may
+      # predate the staged secret entirely, so committing off it would bind a
+      # password the network never accepted.
+      state =
+        base_state(%{
+          nick: "vjt",
+          umodes: [],
+          services_flavor: :azzurra,
+          pending_registration_secret: "s3cret"
+        })
+
+      m = msg({:numeric, 221}, ["vjt", "+ir"])
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :acquired} in effects
+      refute Enum.any?(effects, &match?({:identity_secret_confirmed, _}, &1))
+    end
+  end
+
+  describe "#388 — the two axes are OR'd across a self-rename" do
+    test "an account-identified session survives the rename umode strip" do
+      # bahamut strips the registered umode on a genuine rename (#581), but
+      # an account is not cleared by a nick change — so a session identified
+      # via the account axis must NOT report :lost.
+      state =
+        base_state(%{nick: "vjt", umodes: ["r"], account: "vjt", services_flavor: :azzurra})
+
+      m = msg(:nick, ["vjt2"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
+    test "a umode-only identity IS lost on a genuine rename" do
+      state = base_state(%{nick: "vjt", umodes: ["r"], services_flavor: :azzurra})
+      m = msg(:nick, ["vjt2"], {:nick, "vjt", "u", "h"})
+      {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:session_identity_changed, :lost} in effects
+    end
+  end
+
   describe "#221 — solanum WHOIS-leg numeric folds (330/671/276/338/320)" do
     test "330 RPL_WHOISLOGGEDIN folds account from the middle param" do
       state = whois_pending_state("alice")

--- a/test/grappa/session/identity_state_test.exs
+++ b/test/grappa/session/identity_state_test.exs
@@ -51,17 +51,72 @@ defmodule Grappa.Session.IdentityStateTest do
   describe "identified?/1 — account axis (flavour-agnostic)" do
     test "a services account identifies with no registered umode in sight" do
       # solanum/atheme (Libera) has no registered umode at all: the account
-      # IS the only signal, which is the whole point of #388.
-      assert IdentityState.identified?(%{umodes: [], account: "vjt", services_flavor: :atheme})
+      # IS the only signal, which is the whole point of #388. That ircd ACKs
+      # `account-notify`, and per vjt's ruling of 2026-08-11 the ACK is what
+      # makes the account count — so the cap is part of the fixture, not
+      # decoration.
+      assert IdentityState.identified?(%{
+               umodes: [],
+               account: "vjt",
+               services_flavor: :atheme,
+               caps_active: MapSet.new(["account-notify"])
+             })
     end
 
     test "a nil account alone does not identify" do
-      refute IdentityState.identified?(%{umodes: [], account: nil, services_flavor: :atheme})
+      refute IdentityState.identified?(%{
+               umodes: [],
+               account: nil,
+               services_flavor: :atheme,
+               caps_active: MapSet.new(["account-notify"])
+             })
+    end
+
+    test "an account without the cap is display only, never proof" do
+      # The ruling's narrowing, at the unit. bahamut hands us a 330 but no
+      # `account-notify`, so it never promises to retract the account — and
+      # a verdict that can go up and never come down is not a verdict.
+      refute IdentityState.identified?(%{
+               umodes: [],
+               account: "vjt",
+               services_flavor: :azzurra,
+               caps_active: MapSet.new()
+             })
+    end
+
+    test "the umode axis is untouched by the cap gate" do
+      # The gate is on the account axis ALONE: bahamut identifies off `+r`
+      # with no cap in sight, exactly as it did before #388.
+      assert IdentityState.identified?(%{
+               umodes: ["r"],
+               account: nil,
+               services_flavor: :azzurra,
+               caps_active: MapSet.new()
+             })
     end
 
     test "either axis alone suffices — they are OR'd, not AND'd" do
+      assert IdentityState.identified?(%{
+               umodes: ["r"],
+               account: nil,
+               services_flavor: :azzurra,
+               caps_active: MapSet.new(["account-notify"])
+             })
+
+      assert IdentityState.identified?(%{
+               umodes: [],
+               account: "vjt",
+               services_flavor: :azzurra,
+               caps_active: MapSet.new(["account-notify"])
+             })
+    end
+
+    test "a state predating caps_active falls back to the umode axis (#216)" do
+      # The hot-reload contract: a process whose state has no `caps_active`
+      # key answers "not identified" off the account rather than crashing,
+      # and its umode axis still works.
+      refute IdentityState.identified?(%{umodes: [], account: "vjt", services_flavor: :atheme})
       assert IdentityState.identified?(%{umodes: ["r"], account: nil, services_flavor: :azzurra})
-      assert IdentityState.identified?(%{umodes: [], account: "vjt", services_flavor: :azzurra})
     end
   end
 

--- a/test/grappa/session/identity_state_test.exs
+++ b/test/grappa/session/identity_state_test.exs
@@ -1,0 +1,92 @@
+defmodule Grappa.Session.IdentityStateTest do
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.IdentityState
+
+  describe "registered_umode/1 — the per-flavour letter" do
+    test "defaults to lowercase r (bahamut/Azzurra, and any unclassified network)" do
+      assert IdentityState.registered_umode(nil) == "r"
+      assert IdentityState.registered_umode(:azzurra) == "r"
+      assert IdentityState.registered_umode(:unknown) == "r"
+    end
+
+    test "is uppercase R on OFTC" do
+      assert IdentityState.registered_umode(:oftc) == "R"
+    end
+
+    test "an unrecognised flavour falls back to the lowercase default" do
+      assert IdentityState.registered_umode(:some_future_ircd) == "r"
+    end
+  end
+
+  describe "identified?/1 — umode axis" do
+    test "no facts at all reads as not identified" do
+      refute IdentityState.identified?(%{})
+    end
+
+    test "the flavour's own letter identifies" do
+      assert IdentityState.identified?(%{umodes: ["i", "r"], services_flavor: :azzurra})
+      assert IdentityState.identified?(%{umodes: ["R", "i"], services_flavor: :oftc})
+    end
+
+    test "the letter is EXCLUSIVE per flavour, never a union of r and R" do
+      # OFTC's lowercase r is UMODE_REJ (bot-rejection server notices), an
+      # oper display mode — NOT identity. Accepting it would mark an oper
+      # identified and let the wizard commit a registration that never
+      # happened. oftc/oftc-hybrid@36f0431 src/s_user.c:142.
+      refute IdentityState.identified?(%{umodes: ["r"], services_flavor: :oftc})
+
+      # Conversely uppercase R is unassigned in solanum core and is NOT
+      # bahamut's registered letter, so it must not identify off OFTC.
+      refute IdentityState.identified?(%{umodes: ["R"], services_flavor: :azzurra})
+      refute IdentityState.identified?(%{umodes: ["R"], services_flavor: :atheme})
+      refute IdentityState.identified?(%{umodes: ["R"], services_flavor: nil})
+    end
+
+    test "unrelated umodes never identify" do
+      refute IdentityState.identified?(%{umodes: ["i", "w", "S"], services_flavor: :azzurra})
+    end
+  end
+
+  describe "identified?/1 — account axis (flavour-agnostic)" do
+    test "a services account identifies with no registered umode in sight" do
+      # solanum/atheme (Libera) has no registered umode at all: the account
+      # IS the only signal, which is the whole point of #388.
+      assert IdentityState.identified?(%{umodes: [], account: "vjt", services_flavor: :atheme})
+    end
+
+    test "a nil account alone does not identify" do
+      refute IdentityState.identified?(%{umodes: [], account: nil, services_flavor: :atheme})
+    end
+
+    test "either axis alone suffices — they are OR'd, not AND'd" do
+      assert IdentityState.identified?(%{umodes: ["r"], account: nil, services_flavor: :azzurra})
+      assert IdentityState.identified?(%{umodes: [], account: "vjt", services_flavor: :azzurra})
+    end
+  end
+
+  describe "normalize_account/1" do
+    test "keeps a real account name" do
+      assert IdentityState.normalize_account("vjt") == "vjt"
+    end
+
+    test "maps the ACCOUNT logout sentinel to nil" do
+      # IRCv3 account-notify signals a logout as `ACCOUNT *`.
+      assert IdentityState.normalize_account("*") == nil
+    end
+
+    test "maps an empty account to nil rather than a blank identity" do
+      assert IdentityState.normalize_account("") == nil
+    end
+
+    test "passes nil through" do
+      assert IdentityState.normalize_account(nil) == nil
+    end
+  end
+
+  describe "hot-reload tolerance (#216 contract)" do
+    test "a state map predating any of the three fields still answers" do
+      refute IdentityState.identified?(%{nick: "vjt", network_id: 1})
+    end
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2147,6 +2147,52 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #388 — the CAP ACK seam is what grants the account axis, and until now
+  # nothing exercised it: every identity test seeds `caps_active` by hand,
+  # so the path from the wire to the gate was unproven in both directions.
+  # vjt's ruling of 2026-08-11 made that path load-bearing — without the ACK
+  # a services ACCOUNT is display only — so it gets a test that drives real
+  # bytes rather than a hand-built state.
+  describe "CAP ACK grants the account axis (#388)" do
+    test "an ACKed account-notify turns a self ACCOUNT into an identity acquisition" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
+
+      # The blob carries a second cap because a real ACK does; the tracked
+      # one must survive the company. Then the ACCOUNT arrives — the same
+      # line that, without the ACK, moves nothing but the WHOIS card.
+      IRCServer.feed(server, ":irc CAP #{own_nick} ACK :account-notify labeled-response\r\n")
+      IRCServer.feed(server, ":#{own_nick}!u@h ACCOUNT vjtaccount\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :session_identity_changed,
+                         identified: true,
+                         account: "vjtaccount"
+                       }
+                     },
+                     1_000
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "PING/PONG" do
     test "responds to server PING with matching PONG" do
       {server, port} = start_server()

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -6861,7 +6861,7 @@ defmodule Grappa.Session.ServerTest do
           assert is_nil(SessionStateHelpers.pending_auth_timer(state))
         end)
 
-      assert log =~ "visitor_r_observed effect on user session"
+      assert log =~ "identity_secret_confirmed effect on user session"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -6989,7 +6989,7 @@ defmodule Grappa.Session.ServerTest do
           assert is_nil(SessionStateHelpers.pending_auth(SessionStateHelpers.fetch(pid)))
         end)
 
-      assert log =~ "visitor_r_observed effect on user session"
+      assert log =~ "identity_secret_confirmed effect on user session"
 
       reloaded = Credentials.get_credential!(user, network)
       assert reloaded.auth_method == :none


### PR DESCRIPTION
Refs #388. Unblocks the non-Azzurra rollout of the #349 registration wizard.

## The problem, restated

All four boxes in the issue are real, but the fourth is the one that
matters: while the wizard reads a mode letter, every new ircd is a patch.
"Am I identified?" had **four** independent answers, each spelling
`"r" in umodes` by hand — `EventRouter.session_identity_effects/2`, a
second detector (`set_r_mode?/1`) re-walking the same MODE bytes for the
visitor secret-commit, `Session.Server`'s `registered:` wire field, and
cicchetto's own `umodes.includes("r")`.

## The shape

`Grappa.Session.IdentityState` owns the predicate. Every source funnels
into one prev/next diff that takes **whole states**, never the axis that
changed — passing only your own axis is exactly how the old readers
drifted. Sources: self-MODE echo, 221 RPL_UMODEIS, the #581 rename strip,
inbound IRCv3 `ACCOUNT`, and a self-targeted 330.

Clients get one additive user-topic event, `session_identity_changed`,
carrying `identified` (the verdict) and `account` (display data, nullable
even while identified). It rides the cold user-topic snapshot too.

## The umode letter is per-flavour and EXCLUSIVE — read at source

The issue's OFTC claim is correct, but the tempting shortcut of accepting
`r` OR `R` everywhere is wrong in **both** directions:

- **OFTC** (`oftc/oftc-hybrid@36f0431`, `src/s_user.c`, blob `e325095`):
  `:114` maps `R` to `UMODE_NICKSERVREG` — "registered with nickserv and
  identified". But `:142` maps lowercase `r` to `UMODE_REJ`, an oper
  bot-rejection notice mode. A union would mark an OFTC oper identified
  and let the wizard commit a registration that never happened.
- **solanum** (`ircd/s_user.c`, `user_modes[256]`): `/* R */ 0` —
  unassigned in core. Uppercase being free is why honouring it off OFTC
  is unsafe: an extension may claim it for anything. It also has no
  registered umode at all, which is why the account axis is not a bonus
  but the only evidence an identify landed on Libera.

So one letter per flavour, defaulting to lowercase `r` — an unclassified
network behaves exactly as before. `services_flavor` is threaded in via
the shared `base_plan`, so user and visitor subjects detect identically.

## Two things that fell out

- **A pre-existing gap.** 221 RPL_UMODEIS emitted no transition at all, so
  a session that first learned its identity from the connect-time snapshot
  never logged `:identified` and never released the #347 deferred
  autojoin. It now emits — but deliberately does **not** confirm a staged
  secret: a reconciliation may describe an identity that predates the
  secret, and committing off it would bind a password the network never
  accepted.
- **A reload defect in cic.** Nothing re-seeded the umode letters after a
  page reload, so both launchers reappeared on an already-identified
  session. The new event rides the cold snapshot, which closes it.

`:visitor_r_observed` became `:identity_secret_confirmed`: the old name was
itself the patch, naming a bahamut mode letter for a flavour-agnostic
event.

## Not claimed

Whether OFTC's services set `+R` **at the identify instant** is taken from
the `UMODE_NICKSERVREG` declaration comment, not observed on the wire —
grappa has never connected to OFTC. The per-flavour gate limits the blast
radius to networks an operator explicitly classified `:oftc`. Peer
identities stay out of scope: an inbound `ACCOUNT` for another user is
dropped, not folded into the members map.

## Gates

- `scripts/check.sh` — **RC=0**. Credo `5483 mods/funs, found no issues`;
  Dialyzer `Total errors: 0`; Sobelow + Doctor pass; ExUnit
  `8 doctests, 57 properties, 5682 tests, 0 failures`; bats 363 ok; and
  `wireTypes.ts is in sync` + `wireSchema.ts is in sync` — both generated
  files were hand-edited and are proven character-identical to codegen.
- cic — `bun run check` RC=0; `bun run test` RC=0,
  `271 passed (271)` files / `4997 passed (4997)` tests.
- **The green is earned, not assumed.** The Elixir tests were written after
  the code (no compile lane at the time), so both axes were mutation-tested:
  emptying the per-flavour letter table killed 5 tests (all OFTC), and
  disabling the account axis killed 8 (all ACCOUNT/330/OR-across-rename).
  Reverted, tree clean, `383 tests, 0 failures` restored. The cic gate was
  mutated too — forcing `canRegister` true killed exactly one assertion.

## The half-migration, and why 4997 unit tests did not see it

CI caught this branch red on `integration`, and it was a real regression,
not a flake: `home-register-nick-azzurra` expected 0, received 1.
`HomePane` had moved to the identity verdict while
`RegistrationWizardModal`'s step-6 terminator still read
`umodesForNetwork(id).includes("r")` — a migration finished on one side
only. The unit suite could not see it, because
`RegistrationWizardModal.test.tsx` **mocked `umodesForNetwork`**: the test
was pinned to the very spelling the migration existed to remove, so it
kept passing precisely while the product was half-moved. That is the
general lesson worth carrying: a mock of the OLD collaborator makes a
half-finished migration look complete.

The fix migrates the terminator, makes the wizard's socket mock send what
the server actually sends (one identify produces BOTH the umode letter and
the normalized verdict — a mock that fabricates only the letter is not
simpler, it is unfaithful), and corrects `registrationTemplates.ts`, whose
prose invited the next author to re-derive identity from a mode letter.

## The e2e arms are mutation-killers — measured, not asserted

The two step-6 arms were put through a red→green cycle on the real
Playwright harness (`--grep "#349 registration wizard"`, full stack, bundle
rebuilt each run so no stale dist could fake a result):

| run | result | dies where |
|---|---|---|
| terminator respelled `umodesForNetwork(id).includes("r")` | 3 passed / **1 failed** | verdict-alone arm, **line 382** — the celebration never arrives |
| launcher gate `canRegister` respelled the same way | 3 passed / **1 failed** | verdict-alone arm, **line 384** — `home-register-nick-azzurra` expected 0, received 1 |
| clean HEAD | **4 passed** | — |

One mutant, one assertion: the first kills only 382, the second only 384
(382 and 383 still pass under it). **The bahamut arm survives both**, and so
does the real-services spec — which is exactly why the flavour-agnostic arm
has to exist. Where the letter and the verdict travel together, neither
mutant is visible.

**Same assertion, two roads.** The launcher mutant reproduces the original
CI failure signature exactly — same locator, expected 0, received 1 — but
the cause is the *dual*, not the same. The original red was a **faithful
product against an unfaithful mock** (migrated `HomePane`, a mock pushing
only the umode); the mutant is an **unfaithful product against a faithful
mock** (un-migrated `canRegister`, a mock pushing the verdict). The two
failures are indistinguishable at the assertion and opposite in origin —
worth knowing before anyone reads that signature again and assumes they
already know which side broke.

## Notes for review

- Touches `lib/grappa/irc/auth_fsm.ex` (`finalize_cap_ls/2` only), which
  #1169 is also editing (`sasl_plain_payload/1`) — disjoint functions.
  #1169 has since landed; this branch now sits on `cbe6cb9a`, which
  contains it, and the two edits remain disjoint.
- `account-notify` is opportunistic like `labeled-response`. A server that
  does not advertise it produces a **byte-identical** `CAP REQ` line, so
  the handshake on every production network is unchanged. Known edge, in a
  comment: the H9 combined-NAK fallback re-requests `:sasl` alone and would
  drop the cap — that fallback exists for bahamut-family servers, which do
  not offer it.
