### PR TITLE
#1113 — reveal the compose caret wherever it lands, not only at the end

### DIFF
--- a/cicchetto/e2e/tests/issue1113-caret-offset-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1113-caret-offset-visible.spec.ts
@@ -1,0 +1,189 @@
+// #1113 — the OTHER half of #1105: a caret moved to an ARBITRARY offset.
+//
+// #1105 fixed "caret at the end, and visible" and deliberately scoped out the
+// three callers that land the caret somewhere in the middle — paste
+// (`lib/pasteRoute.insertPastedText`) and the two tab-complete doors
+// (`Shell`'s keybinding, `ComposeBox`'s swipe gesture). Its cure,
+// `scrollTop = scrollHeight`, is correct ONLY because the end caret is on the
+// last line; applied to a caret near the top it scrolls PAST it and makes the
+// defect worse. So this spec must separate the right fix from that wrong one,
+// not merely observe "something scrolled".
+//
+// It does that with two arms whose expected scrollTop is EXACT and different:
+//
+//   A. caret on the FIRST line, textarea pre-scrolled to the bottom
+//      → the minimal reveal is `scrollTop === 0`.
+//      `scrollTop = scrollHeight` lands at the bottom here: arm A is what
+//      kills the wrong fix.
+//   B. caret at the END, textarea pre-scrolled to the top
+//      → the minimal reveal is the bottom, i.e. the #1105 oracle
+//      (`expectEndCaretVisible`) verbatim. Reusing it rather than writing a
+//      second copy is the same rule the production fix follows.
+//
+// The two arms also guard each OTHER against a vacuous pass. Arm A asserts
+// `scrollTop === 0`, which would also be true if committing the new draft
+// value reset the scroll position by itself; arm B ends at the BOTTOM through
+// the same value commit, so a commit that forced 0 would red it.
+//
+// WHY e2e and not vitest: jsdom performs no layout, so `scrollHeight` is 0 on
+// every element and every "the caret is in view" assertion passes vacuously —
+// the same split #1105 recorded, and the reason the issue asks for a real
+// viewport. 390px is the width the issue measured at.
+//
+// GATE REALITY: chromium, untagged. Nothing here is touch- or engine-specific;
+// what is asserted is the GEOMETRY the layout engine produces.
+import type { Page } from "@playwright/test";
+import {
+  type ComposeCaretGeometry,
+  composeCaretGeometry,
+  composeTextarea,
+  expectEndCaretVisible,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Several wrapped lines at 390px — the same body shape #1105 used, minus its
+// uniqueness suffix (nothing here reaches the scrollback, so there is no row
+// to disambiguate).
+const FILLER =
+  "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
+  "quindi il caret finisce fuori dalla vista e non si vede piu' nulla";
+
+// Its job is to fail loudly if the fixture ever stops overflowing, because
+// then "the caret is in view" would be true for the wrong reason. Stated
+// per-caller for the reason `expectEndCaretVisible` documents.
+const MIN_OVERFLOW_PX = 40;
+
+const PASTE = "incollato ";
+
+// Blur, then dispatch a real paste on document.body — the #352 global-paste
+// door, which is one of the two ways a paste reaches `insertPastedText` (the
+// other is the flood-confirm dialog). A paste into an ALREADY-focused textarea
+// is performed natively by the browser, which scrolls on its own; these are
+// the doors where cic moves the caret itself and therefore owes the reveal.
+async function pasteWhileUnfocused(page: Page, text: string): Promise<void> {
+  await page.evaluate((t) => {
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    const dt = new DataTransfer();
+    dt.setData("text/plain", t);
+    document.body.dispatchEvent(
+      new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+    );
+  }, text);
+}
+
+// Put the textarea in the state the issue describes: a caret at a known offset
+// while the scroll sits at the opposite edge. Arranging the PRE-state by hand
+// (rather than hoping typing produces it) is what makes the post-state exact.
+async function arrangeCompose(
+  page: Page,
+  args: { caret: number; scrollTo: "top" | "bottom" },
+): Promise<void> {
+  await composeTextarea(page).evaluate((el: HTMLTextAreaElement, a) => {
+    el.setSelectionRange(a.caret, a.caret);
+    el.scrollTop = a.scrollTo === "bottom" ? el.scrollHeight : 0;
+  }, args);
+}
+
+// The caret assignment and the scroll happen in ONE microtask, so the caret
+// landing at its new offset is a truthful barrier for the scroll having been
+// applied too — and it is NOT the assertion: the unfixed code moves the caret
+// exactly the same way, and reds on the geometry below.
+async function afterCaretSettles(page: Page, caret: number): Promise<ComposeCaretGeometry> {
+  await expect
+    .poll(async () => (await composeCaretGeometry(page)).selStart, { timeout: 5_000 })
+    .toBe(caret);
+  return await composeCaretGeometry(page);
+}
+
+function expectOverflowing(g: ComposeCaretGeometry): void {
+  expect(g.scrollHeight).toBeGreaterThan(g.clientHeight + MIN_OVERFLOW_PX);
+}
+
+// The caret sits on the FIRST line, so the minimal reveal is scrollTop 0
+// exactly. The exactness is the point: `> 0 and < max` would also pass under
+// a scroll that overshot, and `scrollTop = scrollHeight` — the wrong fix this
+// issue exists to reject — would land at the bottom.
+function expectCaretLineAtTop(g: ComposeCaretGeometry, caret: number): void {
+  expectOverflowing(g);
+  expect(g.selStart).toBe(caret);
+  expect(g.selEnd).toBe(caret);
+  expect(g.scrollTop).toBe(0);
+}
+
+test("#1113 — a global paste reveals the caret's line, in both directions", async ({ page }) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+  await ta.click();
+  await ta.fill(FILLER);
+  await expect(ta).toHaveValue(FILLER);
+
+  // ── A. caret ABOVE the visible box ──────────────────────────────────
+  await arrangeCompose(page, { caret: 0, scrollTo: "bottom" });
+  const preA = await composeCaretGeometry(page);
+  expectOverflowing(preA);
+  // Without this the outcome would be true for the wrong reason: a textarea
+  // already at the top has nothing to reveal.
+  expect(preA.scrollTop).toBeGreaterThan(0);
+
+  await pasteWhileUnfocused(page, PASTE);
+  await expect(ta).toHaveValue(PASTE + FILLER);
+  expectCaretLineAtTop(await afterCaretSettles(page, PASTE.length), PASTE.length);
+
+  // ── B. caret BELOW the visible box ──────────────────────────────────
+  const full = PASTE + FILLER;
+  await arrangeCompose(page, { caret: full.length, scrollTo: "top" });
+  const preB = await composeCaretGeometry(page);
+  expectOverflowing(preB);
+  expect(preB.scrollTop).toBe(0);
+
+  await pasteWhileUnfocused(page, PASTE);
+  await expect(ta).toHaveValue(full + PASTE);
+  expectEndCaretVisible(await afterCaretSettles(page, full.length + PASTE.length), MIN_OVERFLOW_PX);
+});
+
+test("#1113 — tab-complete reveals the caret's line", async ({ page }) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+
+  // Completing the CHANNEL rather than a member nick: the channel candidate
+  // set is derived from `windowStateByChannel`, which `selectChannel`'s WS
+  // barrier already proves populated, whereas the member list has no barrier
+  // of its own on a 390px viewport (the members pane lives in a drawer).
+  // Same completion engine, same caret placement — #30 keeps ONE of those.
+  const partial = CHANNEL.slice(0, CHANNEL.length - 1);
+  const draft = `${partial} ${FILLER}`;
+  await ta.click();
+  await ta.fill(draft);
+  await expect(ta).toHaveValue(draft);
+
+  // Caret on the partial (first line), scroll parked at the far end.
+  await arrangeCompose(page, { caret: partial.length, scrollTo: "bottom" });
+  const pre = await composeCaretGeometry(page);
+  expectOverflowing(pre);
+  expect(pre.scrollTop).toBeGreaterThan(0);
+
+  // Tab does not re-focus (fill already left focus here), so nothing but the
+  // completion can move the scroll.
+  await ta.press("Tab");
+
+  const completed = `${CHANNEL} ${draft.slice(partial.length)}`;
+  await expect(ta).toHaveValue(completed);
+  const caret = CHANNEL.length + 1;
+  expectCaretLineAtTop(await afterCaretSettles(page, caret), caret);
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -12,7 +12,7 @@ import {
   submit,
   tabComplete,
 } from "./lib/compose";
-import { placeCaretAtEndInView } from "./lib/composeCaret";
+import { placeCaretAtEndInView, placeCaretInView } from "./lib/composeCaret";
 import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { networkBySlug } from "./lib/networks";
@@ -322,8 +322,10 @@ const ComposeBox: Component<Props> = (props) => {
         const ta = e.currentTarget as HTMLTextAreaElement;
         const result = tabComplete(key(), getDraft(key()), ta.selectionEnd, true);
         if (!result) return;
+        // #1113 — same reveal as the keybinding door (Shell.cycleNickComplete):
+        // one completion engine, one caret placement.
         queueMicrotask(() => {
-          ta.setSelectionRange(result.newCursor, result.newCursor);
+          placeCaretInView(ta, result.newCursor);
         });
         break;
       }

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -29,6 +29,7 @@ import { token } from "./lib/auth";
 import { channelKey } from "./lib/channelKey";
 import { getDraft, tabComplete } from "./lib/compose";
 import { appendToCompose } from "./lib/composeAppend";
+import { placeCaretInView } from "./lib/composeCaret";
 import { install, registerHandlers, uninstall } from "./lib/keybindings";
 import { loadLastFocused } from "./lib/lastFocusedChannel";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
@@ -404,8 +405,11 @@ const Shell: Component = () => {
       // tabComplete wrote the draft via writeState (calling setDraft here
       // would null the cycle). We only place the caret. Solid signal write
       // doesn't reflect immediately — schedule on the next microtask.
+      //
+      // #1113 — and reveal it: the completion can sit on any line of a draft
+      // that wraps past the rows=1 textarea, above or below the visible box.
       queueMicrotask(() => {
-        ta.setSelectionRange(result.newCursor, result.newCursor);
+        placeCaretInView(ta, result.newCursor);
       });
     },
   });

--- a/cicchetto/src/lib/composeCaret.ts
+++ b/cicchetto/src/lib/composeCaret.ts
@@ -68,6 +68,29 @@ const MIRROR_STYLE_PROPS = [
 // only the text BEFORE the caret would let that line end early and could
 // report a line too high. The div lives for one synchronous layout read and
 // is removed before anything can paint it.
+//
+// TWO markers, and the answer is their DIFFERENCE. A single marker's top is
+// not the line's top: an inline span sits inside its line box at an offset of
+// its own, so a caret on the FIRST line reported 1px instead of 0 and the
+// reveal landed one pixel short of the line — with the guard asserting an
+// exact 0, which is what caught it. Measured in chromium at 390px: marker
+// top 1, line-height 19.59375 (computed style rounds it to 19.6), glyph box
+// 16. Note 1 is NOT the half-leading, which is 1.8 — the offset is a font
+// metric that cannot be derived, only cancelled.
+//
+// So an identical span at offset 0 supplies the origin. Both markers carry the
+// same metrics, so their within-line offsets are identical and subtract out
+// EXACTLY: measured `deltaLine0 === 0` and, for the last of five lines,
+// `78.375 === 4 × 19.59375` — an exact multiple of the ACTUAL line height,
+// with no rounding residue. That exactness is the point: it makes the
+// first-line reveal 0 by construction on any engine, rather than a number that
+// happens to round well with one font. Rects, not `offsetTop`, because
+// `offsetTop` is an integer and would round the cancellation back open.
+//
+// The alternative — snapping the single marker's top onto a line grid with
+// `Math.floor(top / lineHeight)` — was rejected on the same measurement:
+// computed `lineHeight` (19.6) is not the laid-out one (19.59375), so the
+// quotient drifts low and a far-enough line floors to its predecessor.
 function caretLineTop(el: HTMLTextAreaElement, caret: number, cs: CSSStyleDeclaration): number {
   const contentWidth =
     el.clientWidth - Number.parseFloat(cs.paddingLeft) - Number.parseFloat(cs.paddingRight);
@@ -84,11 +107,13 @@ function caretLineTop(el: HTMLTextAreaElement, caret: number, cs: CSSStyleDeclar
   mirror.style.visibility = "hidden";
   mirror.style.pointerEvents = "none";
 
+  const origin = document.createElement("span");
+  origin.textContent = "\u200b";
   const marker = document.createElement("span");
   marker.textContent = "\u200b";
-  mirror.append(el.value.slice(0, caret), marker, el.value.slice(caret));
+  mirror.append(origin, el.value.slice(0, caret), marker, el.value.slice(caret));
   document.body.append(mirror);
-  const top = marker.offsetTop;
+  const top = marker.getBoundingClientRect().top - origin.getBoundingClientRect().top;
   mirror.remove();
   return top;
 }

--- a/cicchetto/src/lib/composeCaret.ts
+++ b/cicchetto/src/lib/composeCaret.ts
@@ -14,8 +14,11 @@
 //
 // Scope: END-of-draft callers only. Paste (`pasteRoute.insertPastedText`) and
 // tab-complete land the caret at an arbitrary offset, where
-// `scrollTop = scrollHeight` would scroll past it — those need
-// caret-position-aware scrolling, which is a different mechanism.
+// `scrollTop = scrollHeight` would scroll past it — they take
+// `placeCaretInView` below instead. The two are kept apart on purpose: the
+// end case needs no measurement at all (the caret is on the last line, so the
+// bottom IS the answer), and paying for a mirror layout on every history
+// recall to reach the same number would be a cost with no reader.
 //
 // `queueMicrotask` is load-bearing: a Solid signal write does not reflect in
 // the textarea synchronously, so both the caret and the measurement must run
@@ -28,4 +31,107 @@ export function placeCaretAtEndInView(el: HTMLTextAreaElement): void {
     el.setSelectionRange(end, end);
     el.scrollTop = el.scrollHeight;
   });
+}
+
+// The computed properties that can move a soft wrap. Anything outside this
+// list cannot change where a line breaks, so copying it onto the mirror would
+// be noise — and the mirror deliberately does NOT copy padding or border,
+// because it is sized to the textarea's CONTENT width and measured in content
+// coordinates.
+const MIRROR_STYLE_PROPS = [
+  "fontFamily",
+  "fontSize",
+  "fontStretch",
+  "fontStyle",
+  "fontVariant",
+  "fontWeight",
+  "letterSpacing",
+  "lineHeight",
+  "overflowWrap",
+  "tabSize",
+  "textIndent",
+  "textTransform",
+  "whiteSpace",
+  "wordBreak",
+  "wordSpacing",
+] as const;
+
+// Where the caret's line starts, in the textarea's own content coordinates
+// (0 = the first line), or NaN when the element has no layout to measure —
+// jsdom, or a textarea that is not displayed. NaN rather than null so the
+// caller folds it into the one arithmetic guard it already needs.
+//
+// A textarea exposes no "where does offset N render" API, so the line is
+// measured on a throwaway mirror div carrying the same wrap-deciding styles at
+// the same content width. The REST of the draft rides after the marker so the
+// caret's own line wraps exactly as it does in the textarea; a mirror holding
+// only the text BEFORE the caret would let that line end early and could
+// report a line too high. The div lives for one synchronous layout read and
+// is removed before anything can paint it.
+function caretLineTop(el: HTMLTextAreaElement, caret: number, cs: CSSStyleDeclaration): number {
+  const contentWidth =
+    el.clientWidth - Number.parseFloat(cs.paddingLeft) - Number.parseFloat(cs.paddingRight);
+  if (!(contentWidth > 0)) return Number.NaN;
+
+  const mirror = document.createElement("div");
+  for (const prop of MIRROR_STYLE_PROPS) mirror.style[prop] = cs[prop];
+  mirror.style.position = "absolute";
+  mirror.style.top = "0";
+  mirror.style.left = "0";
+  mirror.style.width = `${contentWidth}px`;
+  mirror.style.padding = "0";
+  mirror.style.border = "0";
+  mirror.style.visibility = "hidden";
+  mirror.style.pointerEvents = "none";
+
+  const marker = document.createElement("span");
+  marker.textContent = "\u200b";
+  mirror.append(el.value.slice(0, caret), marker, el.value.slice(caret));
+  document.body.append(mirror);
+  const top = marker.offsetTop;
+  mirror.remove();
+  return top;
+}
+
+// #1113 — "the caret is at an arbitrary offset, and visible", the ONE copy.
+//
+// Three doors move the compose caret to an offset that is not the end: paste
+// (`pasteRoute.insertPastedText`) and the two tab-complete paths (`Shell`'s
+// keybinding, `ComposeBox`'s swipe gesture). None of them could reuse
+// `placeCaretAtEndInView`: `scrollTop = scrollHeight` is right only for a
+// caret on the LAST line, and on a caret near the top it scrolls past it —
+// the wrong fix that looks like the right one, which is why #1105 scoped
+// these three out rather than guessing. The defect reached three doors
+// because "move the caret" existed in three copies, so the cure is one
+// function, not three patches.
+//
+// Reveal is MINIMAL and two-directional: a caret already inside the box does
+// not move the scroll at all, one above it scrolls up to its line, one below
+// scrolls down to it — never further. Scroll coordinates start at the padding
+// box, which is why the line's position adds `paddingTop` and the two targets
+// subtract the padding back out: revealing the first line then yields exactly
+// 0, and the last line exactly the maximum scroll.
+//
+// Unlike its end-of-draft sibling this is SYNCHRONOUS: the callers already own
+// a `queueMicrotask` (the Solid controlled value has not committed yet when
+// they run) and one of them must `focus()` inside it first, so owning the
+// microtask here would fight the caller for the ordering instead of serving
+// it. Call it after the value has committed.
+export function placeCaretInView(el: HTMLTextAreaElement, caret: number): void {
+  el.setSelectionRange(caret, caret);
+
+  const cs = window.getComputedStyle(el);
+  const top = caretLineTop(el, caret, cs);
+  const paddingTop = Number.parseFloat(cs.paddingTop);
+  const paddingBottom = Number.parseFloat(cs.paddingBottom);
+  const lineHeight = Number.parseFloat(cs.lineHeight);
+  if (Number.isNaN(top + paddingTop + paddingBottom + lineHeight)) return;
+
+  const lineTop = paddingTop + top;
+  const lineBottom = lineTop + lineHeight;
+  if (lineTop < el.scrollTop) {
+    el.scrollTop = lineTop - paddingTop;
+  } else if (lineBottom > el.scrollTop + el.clientHeight) {
+    el.scrollTop = lineBottom + paddingBottom - el.clientHeight;
+  }
 }

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -1,5 +1,6 @@
 import { channelKey } from "./channelKey";
 import { getDraft, isDraining, setDraft } from "./compose";
+import { placeCaretInView } from "./composeCaret";
 import { requestConfirm } from "./confirmDialog";
 import { dropUpload } from "./dropUpload";
 import { classifyPaste, PASTE_HARD_MESSAGE_LIMIT, pastedMessageCount } from "./pasteFlood";
@@ -29,6 +30,11 @@ import { categoryOf } from "./uploadCategory";
 // off the textarea, and the operator wants to keep typing / hit Enter.
 // queueMicrotask mirrors the recall-caret precedent — run AFTER the controlled
 // value re-render commits to the DOM.
+//
+// #1113 — and REVEAL that caret. The draft may already wrap past the rows=1
+// textarea, in which case the paste point can land outside the visible box in
+// either direction, so the scroll has to follow the caret. `focus()` stays
+// first: it is what restores the selection this then overwrites.
 export function insertPastedText(
   ta: HTMLTextAreaElement,
   networkSlug: string,
@@ -44,7 +50,7 @@ export function insertPastedText(
   const caret = start + text.length;
   queueMicrotask(() => {
     ta.focus();
-    ta.setSelectionRange(caret, caret);
+    placeCaretInView(ta, caret);
   });
 }
 


### PR DESCRIPTION
## What

`#1105` fixed "caret at the end, and visible" and deliberately scoped out the
three callers that place the caret at an **arbitrary** offset — paste
(`lib/pasteRoute.insertPastedText`) and the two tab-complete doors
(`Shell.cycleNickComplete`, `ComposeBox`'s swipe gesture). They stop at
`setSelectionRange`, which does not scroll, so on a draft that wraps past the
`rows={1}` textarea the caret lands outside the visible box — above it after a
paste near the start, below it after a completion near the end.

One shared `lib/composeCaret.placeCaretInView(el, caret)` now serves all three.
It is **not** the existing `placeCaretAtEndInView`: that helper's
`scrollTop = scrollHeight` is correct only because the end caret is on the last
line, and applying it to a caret near the top scrolls *past* it and makes the
defect worse — the wrong fix that looks like the right one, which is why the
issue exists at all. The new one reveals minimally and in both directions; a
caret already in view does not move the scroll.

A textarea exposes no "where does offset N render" API, so the caret's line is
measured on a throwaway mirror div carrying the wrap-deciding computed styles at
the same content width, with the draft split at the caret by a zero-width
marker. The rest of the draft rides after the marker so the caret's own line
wraps exactly as it does in the textarea. One synchronous layout read, removed
before it can paint. Where there is no layout to read (jsdom) the measurement is
`NaN` and the scroll is left alone.

The two helpers stay separate on purpose: the end case needs no measurement, and
paying for a mirror layout on every history recall to reach the same number
would be a cost with no reader.

## Guard

`e2e/tests/issue1113-caret-offset-visible.spec.ts`, committed **before** the fix
and expected to fail at that commit. jsdom performs no layout — `scrollHeight`
is `0` on every element there, so any "the caret is in view" assertion passes
vacuously; the oracle has to run in a real viewport (390px, the width the issue
measured at).

Two arms with **exact and opposite** expected scroll positions, covering both
directions the issue names:

- **A — caret above the box.** Global paste at offset 0 with the textarea
  pre-scrolled to the bottom → `scrollTop === 0` exactly. `scrollTop =
  scrollHeight` lands at the bottom here, so arm A is what rejects the wrong fix.
- **B — caret below the box.** Paste at the end with the textarea pre-scrolled to
  the top → the bottom, asserted with `#1105`'s `expectEndCaretVisible` reused
  verbatim rather than copied.

The arms also guard each other against a vacuous pass: arm A's zero would also
hold if committing the new draft value reset the scroll by itself, and arm B
reaches the bottom through that same commit. A third test covers the
tab-complete door.

## Test plan

- [x] `bun run check` (biome + tsc + e2e tsc) — clean; proven to be typechecking
      this worktree by planting a deliberate type error and reading the three
      call sites red.
- [x] `bun run test` — 270 files / 4991 tests pass.
- [ ] `scripts/integration.sh` — needs the exclusive e2e lane; pending
      allocation. The guard has **not** been read red yet.

---

## Update: the guard was read red, and it caught a defect in this very fix

The e2e lane arrived. Reading the guard red did its job — it failed the fix
that was already on this branch.

**Red, fix stripped** (guard commit alone, no production change):
`Running 2 tests using 1 worker` → `2 failed`.

| oracle | expected | received |
|---|---|---|
| tab-complete, `expectCaretLineAtTop` | `0` | **70** |
| paste arm B, `expectEndCaretVisible` | `>= 107` | **90** |

**Then the fix went back on, and the run was still not green:** `1 passed`,
`1 failed`. Tab-complete had moved 70 → **1**. The line was genuinely being
revealed, but one pixel short of the exact 0 the fix's own comment promised.

### Root cause, measured rather than deduced

`caretLineTop` returned the mirror marker's own top. An inline span sits inside
its line box at an offset of its own, so the number was the glyph's top, never
the line's.

The first hypothesis — half-leading — was **wrong**, and measuring is what
showed it. Measured in chromium at 390px:

| quantity | value |
|---|---|
| `marker.offsetTop` | 1 |
| half-leading `(lineHeight − glyphBox) / 2` | **1.8** |
| laid-out line-height | 19.59375 |
| `getComputedStyle().lineHeight` | 19.6 |

So the offset is a font metric that cannot be derived — only cancelled. A
second candidate, snapping onto a line grid with `Math.floor(top / lineHeight)`,
was rejected on the same measurement: the computed line-height is not the
laid-out one, so the quotient drifts low until a far enough line floors onto its
predecessor.

### The correction

An identical span at offset 0 supplies the origin, and the answer is the
difference between the two rects. Both markers carry the same metrics, so their
within-line offsets subtract out exactly — measured `0` for a line-0 caret and
`78.375 = 4 × 19.59375` for the last of five lines, an exact multiple of the
actual line height with no residue.

That answers the question the exactness raised: the first-line reveal is `0`
**by construction on any engine**, not a number that happens to round well under
one font. So the guard keeps asserting an exact `0` — the assertion was never
widened, which matters because that exactness is precisely what rejects
`scrollTop = scrollHeight`.

**Green, fix restored:** `2 passed`.

### What I am not claiming

- **Arm A of the paste test does not discriminate.** It passed with the fix
  stripped: committing the pasted value resets the scroll on its own, exactly as
  the spec header predicted. The top-caret oracle IS proven — by the
  tab-complete test — but arm A should not be read as coverage.
- The red/green pair was measured at base `109f2a4f`. The branch has since been
  rebased onto `cbe6cb9a`; the one intervening commit touches only
  `docs/OPERATIONS.md`, `lib/grappa/version.ex` and `mix.exs` — no cic file — so
  it cannot move a browser-side outcome, but the pair was not re-run after the
  rebase. CI on the rebased head is the gate for the union.
- The measurement is chromium-only. The construction is engine-independent by
  argument (a difference of two identical spans), not by measurement on webkit.
