### PR TITLE
docs: stop claiming a VERSION-only bump hot-reloads

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1221,13 +1221,18 @@ tagged on that commit, and only THEN deployed — the version bump is the
 is the post-deploy half. WHY version-first still holds after #652: the shipped
 range must self-report the version it IS, and the tag must equal `CTCP VERSION`
 exactly. `Version.base/0` now returns a compile-time constant baked from
-`VERSION` (an `@external_resource`), so a HOT deploy of a `VERSION`-only bump
-DOES refresh the reported string as the recompiled `Grappa.Version` beam
-reloads — a `VERSION`-only bump is HOT (it no longer touches `mix.exs`, so
-`Preflight.mix_deps?` no longer forces COLD; that reversed the pre-#652 rule).
-The one lag: the running node's `.app` vsn stays at its boot value until the
-next cold restart, but `Grappa.Version` is the only thing that ever read it, so
-nothing observes the divergence. Corollary: an **unplanned** prod move (a
+`VERSION` (an `@external_resource`). **Plan a restart for any release bump: a
+`VERSION`-only bump is a COLD deploy** — measured on m42 2026-08-10,
+correcting what #652 claimed here. `mix.exs` reads the same file to stamp the
+OTP application vsn, so the bump moves the release's lib directory to
+`lib/grappa-<new>/ebin`, while the running node keeps resolving
+`:code.lib_dir(:grappa)` — the directory `Grappa.HotReload.reload_modified/0`
+walks — to its BOOT directory `lib/grappa-<old>/ebin`. Nothing in there
+changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}` and the node
+serves the OLD number with the new code already on disk. `Preflight.mix_deps?`
+no longer forces COLD on such a bump, so preflight will offer you a hot deploy
+anyway — that misclassification is a behaviour defect tracked on its own, not
+a licence to ship the bump hot. Corollary: an **unplanned** prod move (a
 migration, a jail cutover) is still something you version BEFORE, not after —
 bump `VERSION` in the range so the artifact self-reports honestly rather than
 patching a string afterward. Do NOT re-hardcode `@version` in `mix.exs`: it
@@ -3628,7 +3633,10 @@ several other sections point at:
 
 - `mix.exs` and `lib/grappa/version.ex` read the SAME file at **compile**
   time (`@external_resource`, #652), so the number is baked into the beam
-  and a `VERSION`-only bump hot-reloads instead of forcing a COLD deploy.
+  and cannot drift from the package metadata. It does NOT make the bump
+  hot-reloadable: `mix.exs` stamps the OTP application vsn from that same
+  read, which moves the release's lib directory out from under the running
+  node — a `VERSION`-only bump is COLD, see § "Release-cutting".
 - `build.sh` sources `version.sh` to export `GRAPPA_VERSION`, which
   `nfpm.yaml` interpolates into `version:` for BOTH the `.deb` and the
   `.rpm`.

--- a/lib/grappa/version.ex
+++ b/lib/grappa/version.ex
@@ -18,23 +18,42 @@ defmodule Grappa.Version do
   whose on-disk md5 changed — it never re-reads `.app`. So after a
   **hot-deployed** version bump, `Application.spec/2` would keep reporting
   the boot-time value while the operator expects the new one. Sourcing
-  `base/0` from a compiled constant instead means the number travels with
-  the recompiled `Grappa.Version` beam and updates on the same reload
-  (#652). This is also NOT the #391 defect: that was a **runtime** read of
+  `base/0` from a compiled constant instead keeps the number inside the
+  artifact, with no runtime filesystem access and no way to drift from the
+  string `mix.exs` stamps (#652). What it does NOT buy is the payoff #652
+  claimed — the new number arriving on a hot reload — because a `VERSION`
+  bump is itself a cold deploy; see "The declared price" below.
+  This is also NOT the #391 defect: that was a **runtime** read of
   a **build** file (`mix.exs`), which a package lacks — it *raised* and
   crashed the `CTCP VERSION` reply. Here the read is at compile time,
   inside the build tree where `VERSION` always exists (source checkout OR
   release tarball), and the artifact carries a plain string — no runtime
   filesystem access, so no fallback to design and no packaging failure.
 
-  ## The declared price (#652)
+  ## The declared price (#652), and what it turned out to be
 
-  After a **hot** bump the running node's `.app` vsn stays at its boot
-  value while `base/0` reports the new number; they reconverge at the next
-  cold restart. `Grappa.Version` is the ONLY `Application.spec(:grappa, …)`
-  consumer in the tree, so nothing else observes the divergence — and a
-  bump that changes only `VERSION` (never `mix.exs` / `mix.lock`) is
-  classified HOT by `Grappa.Deploy.Preflight`, which is the whole point.
+  #652 declared the price as a divergence: after a **hot** bump the running
+  node's `.app` vsn would stay at its boot value while `base/0` reported the
+  new number, reconverging at the next cold restart. `Grappa.Version` is the
+  ONLY `Application.spec(:grappa, …)` consumer in the tree, so nothing else
+  would observe it.
+
+  Measured on m42 on 2026-08-10, the real price is a different one: that
+  divergence never opens, because **a bump that changes only `VERSION` is a
+  COLD deploy**, not the HOT one #652 expected. `mix.exs` reads the same file
+  to stamp the OTP application vsn, so under `mix release` the bump moves the
+  artifact to `lib/grappa-<new>/ebin` while the running node still resolves
+  `:code.lib_dir(:grappa)` — the directory `Grappa.HotReload.reload_modified/0`
+  walks — to its boot directory `lib/grappa-<old>/ebin`. Nothing in there
+  changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}`: neither
+  the `.app` vsn NOR `base/0` moves, and the node serves the old number with
+  the new code already on disk until it is restarted. (In a source checkout
+  `:code.lib_dir/1` is the unversioned `_build/<env>/lib/grappa`, which is why
+  development never showed this.)
+
+  `Grappa.Deploy.Preflight` still classifies such a bump HOT. That
+  misclassification is a behaviour defect with an issue of its own; what is
+  corrected here is only the claim this moduledoc made about it.
 
   ## Suffix — git tag ≡ CTCP VERSION (#391)
 
@@ -86,10 +105,12 @@ defmodule Grappa.Version do
 
   # #652 — the base version is the repo-root `VERSION` file, read at COMPILE
   # time and baked into a module attribute. Registered as an
-  # `@external_resource` so a bump dirties this module → `mix compile` on the
-  # hot path recompiles it → `reload_modified/0` picks up the new beam by md5,
-  # and the reported version updates WITHOUT a cold restart (the `.app` vsn
-  # would not — the node never re-reads the app resource). The read is
+  # `@external_resource` so a bump dirties this module and `mix compile` on the
+  # deploy path recompiles it. That much still holds; what #652 claimed next —
+  # that `reload_modified/0` then picks the new beam up by md5 and the reported
+  # version updates WITHOUT a cold restart — does not, because in a release the
+  # recompiled beam lands under `lib/grappa-<new>/ebin` and the running node
+  # never looks there (moduledoc, "The declared price"). The read is
   # compile-time, inside the build tree where `VERSION` always exists, so —
   # unlike the #391 runtime `mix.exs` read — a package build cannot raise.
   @version_path Path.join(@repo_root, "VERSION")
@@ -121,9 +142,10 @@ defmodule Grappa.Version do
   @doc """
   The canonical base version — the repo-root `VERSION` file, read at compile
   time and baked into `@base_version` (#652). NOT `Application.spec(:grappa,
-  :vsn)`: the `.app` resource is read once at boot and never re-read, so it
-  goes stale across a hot-deployed bump; a compiled constant travels with the
-  reloaded beam. No runtime filesystem access.
+  :vsn)`: the `.app` resource is read once at boot and never re-read, and the
+  constant needs no runtime filesystem access while being the same string
+  `mix.exs` stamps. It does not, however, make a bump land on a hot deploy —
+  a `VERSION`-only bump is COLD (moduledoc, "The declared price").
   """
   @spec base() :: String.t()
   def base, do: @base_version

--- a/mix.exs
+++ b/mix.exs
@@ -4,11 +4,24 @@ defmodule Grappa.MixProject do
   @app :grappa
   # #652 — the version is DECLARED ONCE in the repo-root `VERSION` file and read
   # here at BUILD time (compile-time `File.read!`, never a runtime read — the
-  # #391 defect was a runtime read of this build file). Bumping `VERSION` no
-  # longer touches `mix.exs`, so `Grappa.Deploy.Preflight` classifies a bump as
-  # HOT instead of COLD (its `mix_deps?` clause) — a version bump keeps every
-  # IRC session alive. `Grappa.Version` bakes the SAME file into a module
-  # attribute so the reloaded beam carries the new number across a hot deploy.
+  # #391 defect was a runtime read of this build file). `Grappa.Version` bakes
+  # the SAME file into a module attribute, so the number an operator reads can
+  # never drift from the one stamped into the package metadata.
+  #
+  # A `VERSION`-only bump is nonetheless a COLD deploy — measured on m42
+  # 2026-08-10, correcting what #652 claimed here. Its reasoning was sound in
+  # the abstract (a bump no longer edits `mix.exs`, so `Grappa.Deploy.Preflight`
+  # stops classifying it COLD through `mix_deps?`), but it is defeated by the
+  # coupling the line below introduces: that read stamps the OTP application
+  # vsn, so under `mix release` — how production ships — the bump moves the
+  # artifact to `lib/grappa-<new>/ebin`, while the RUNNING node keeps resolving
+  # `:code.lib_dir(:grappa)` to its boot directory `lib/grappa-<old>/ebin`.
+  # That is the directory `Grappa.HotReload.reload_modified/0` walks; nothing in
+  # it changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}` and the
+  # node serves the old number with the new code already on disk. Plan a restart
+  # for any release bump. Preflight still calls such a bump HOT — that
+  # misclassification is a behaviour defect and belongs to an issue of its own,
+  # not to a comment.
   @version File.read!(Path.join(__DIR__, "VERSION")) |> String.trim()
 
   def project do


### PR DESCRIPTION
## The fact

Measured on m42 on 2026-08-10. A `--force-hot` deploy carrying nothing but a
`VERSION` bump got `{"failed":[],"reloaded":[]}` out of `/admin/reload`, and the
node went on serving the **old** number with the new code already on disk.

`mix.exs` reads the same `VERSION` file to stamp the OTP application vsn, so
under `mix release` the bump moves the artifact to `lib/grappa-<new>/ebin` while
the running node keeps resolving `:code.lib_dir(:grappa)` — the directory
`Grappa.HotReload.reload_modified/0` walks (`lib/grappa/hot_reload.ex:187`) — to
its **boot** directory `lib/grappa-<old>/ebin`. Nothing in there changed, so
nothing reloads. A source checkout resolves that call to the unversioned
`_build/<env>/lib/grappa`, which is why development never showed it.

`#652`'s reasoning is not wrong in the abstract — a bump no longer edits
`mix.exs`, so `Preflight` stops classifying it COLD through `mix_deps?`. It is
defeated by the coupling `#652` itself introduced.

## What this changes

**Prose only.** No behaviour, no tests, no renumbering. `CLAUDE.md` was already
corrected in `9a069a9d`; these are the sites that still asserted the refuted
claim and were therefore traps for the next session:

- `mix.exs` — the header comment above the `@version` read.
- `lib/grappa/version.ex` — the moduledoc's "Base version" paragraph, the
  "declared price" section, `base/0`'s `@doc`, and the `@external_resource`
  inline comment.
- `docs/OPERATIONS.md` — § "Release-cutting" and the § "version single source of
  truth" carrier map.

## Out of scope

`Grappa.Deploy.Preflight` still classifies a `VERSION`-only bump HOT. That is a
real defect, but correcting the classifier is a **behaviour** change and needs an
issue of its own — there is a feature freeze on. The docs now state what
preflight does and warn against acting on it, rather than quietly changing it.

## Note on scope

The two `docs/OPERATIONS.md` sites were not in the list I was given. I included
them because they carry the same refuted claim in the runbook an operator
actually follows while cutting a release; leaving them would have left the
runbook contradicting the source files fixed here. Easy to drop if unwanted.

## Test plan

- [ ] No gates run locally: the compile lane is allocated elsewhere and this
      change is prose inside comments and docstrings. GitHub CI is the gate.