### PR TITLE
cicchetto(#1115): open the message context menu on desktop right-click

### DIFF
--- a/cicchetto/e2e/tests/issue1115-desktop-right-click-message-menu.spec.ts
+++ b/cicchetto/e2e/tests/issue1115-desktop-right-click-message-menu.spec.ts
@@ -1,0 +1,153 @@
+// #1115 — right-clicking a message row on DESKTOP opens the message menu
+// (Copy / Reply / Select…) at the cursor, and the browser's own menu does not
+// appear. #1067 shipped that menu with exactly one opener, a touch long-press,
+// so a mouse user reached none of it.
+//
+// Harness + limits:
+//   * chromium, DESKTOP viewport and NO `hasTouch` — the point of the spec is
+//     the modality #1067 left out, and a touch-capable context would let a
+//     green here be earned by the wrong door.
+//   * The click is a REAL right button press (`click({ button: "right" })`),
+//     so the `contextmenu` event is the browser's own, not a synthesized one.
+//     That is what makes the suppression arm meaningful: `defaultPrevented`
+//     is read off the event the engine actually dispatched.
+//   * Whether the OS-drawn native menu is truly absent is not observable from
+//     Playwright. `defaultPrevented` is the contract the engine honours, and
+//     it is the strongest oracle available in-page; the drawn menu is a
+//     dogfood call.
+//   * Touch long-press is NOT re-tested here — it is unchanged code with its
+//     own live guard in issue1067-swipe-reply-message-menu.spec.ts, and a
+//     second copy would drift.
+import type { Locator, Page } from "@playwright/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// A body unique per run: the e2e sqlite scrollback persists across KEEP_STACK=1
+// re-runs, and a static string would match two rows on the second run and trip
+// Playwright strict mode.
+function uniqueBody(tag: string): string {
+  return `issue1115 ${tag} ${Date.now()}`;
+}
+
+const menu = (page: Page) => page.locator(".context-menu");
+const menuItem = (page: Page, label: string) =>
+  page.locator(".context-menu .context-menu-item", { hasText: label });
+const rowWith = (page: Page, body: string) =>
+  page.locator('[data-testid="scrollback-line"]', { hasText: body });
+
+async function postMessage(page: Page, body: string): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await composeSend(page, body);
+  await expect(rowWith(page, body)).toBeVisible({ timeout: 5_000 });
+}
+
+// Right-click at `frac` across the row's OWN measured width. Measured rather
+// than a pixel constant because the pane's width depends on the sidebar and
+// members rail; a hardcoded x could land on the nick span (which owns its own
+// right-click) and turn a real regression into a green.
+async function rightClickRow(page: Page, row: Locator, frac: number): Promise<void> {
+  const box = await row.boundingBox();
+  if (box === null) throw new Error("message row has no box");
+  await page.mouse.click(box.x + box.width * frac, box.y + box.height / 2, { button: "right" });
+}
+
+// Arm a WINDOW-level bubble listener: it is the last hop of the bubble path,
+// so it observes `defaultPrevented` AFTER both the scrollback container
+// listener (#1115) and Solid's document-level delegated handlers (the nick
+// menu) have had their say. A capture-phase listener would run first and
+// always read `false`, proving nothing.
+async function watchContextMenu(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as { __ctxPrevented: boolean | null };
+    w.__ctxPrevented = null;
+    window.addEventListener("contextmenu", (e) => {
+      w.__ctxPrevented = e.defaultPrevented;
+    });
+  });
+}
+
+async function nativeMenuSuppressed(page: Page): Promise<boolean | null> {
+  return await page.evaluate(
+    () => (window as unknown as { __ctxPrevented: boolean | null }).__ctxPrevented,
+  );
+}
+
+test("issue1115 — right-clicking a message row opens the message menu and suppresses the browser's", async ({
+  page,
+}) => {
+  const body = uniqueBody("open");
+  await postMessage(page, body);
+
+  // Assert the pre-state: an already-open menu would make the outcome below
+  // true for the wrong reason.
+  await expect(menu(page)).toHaveCount(0);
+  await watchContextMenu(page);
+
+  await rightClickRow(page, rowWith(page, body), 0.5);
+
+  await expect(menu(page)).toBeVisible();
+  await expect(menuItem(page, "Copy")).toBeVisible();
+  await expect(menuItem(page, "Reply")).toBeVisible();
+  await expect(menuItem(page, "Select…")).toBeVisible();
+  // The nick menu is NOT what opened: its verbs are absent.
+  await expect(menuItem(page, "WHOIS")).toHaveCount(0);
+
+  expect(await nativeMenuSuppressed(page)).toBe(true);
+});
+
+// "At the cursor" without pinning a pixel constant: the same row, two
+// different press points, two different menu origins. A menu parked at a
+// fixed corner passes neither half.
+test("issue1115 — the menu opens where the cursor is, not at a fixed spot", async ({ page }) => {
+  const body = uniqueBody("position");
+  await postMessage(page, body);
+  const row = rowWith(page, body);
+
+  await rightClickRow(page, row, 0.5);
+  await expect(menu(page)).toBeVisible();
+  const near = await menu(page).boundingBox();
+
+  await page.locator(".context-menu-backdrop").click();
+  await expect(menu(page)).toHaveCount(0);
+
+  await rightClickRow(page, row, 0.75);
+  await expect(menu(page)).toBeVisible();
+  const far = await menu(page).boundingBox();
+
+  if (near === null || far === null) throw new Error("menu has no box");
+  // A quarter of the pane's width apart, and the menu is ~180px wide at a
+  // 1280px viewport, so neither press is near the #487 clamp.
+  expect(far.x - near.x).toBeGreaterThan(100);
+});
+
+// The nick span lives INSIDE the row, so a row-level door would swallow the
+// nick's own right-click. Both menus are reachable from the same pixel
+// neighbourhood; the nick has to keep winning.
+test("issue1115 — right-clicking a nick still opens the nick menu, not the message menu", async ({
+  page,
+}) => {
+  const body = uniqueBody("nick");
+  await postMessage(page, body);
+  await watchContextMenu(page);
+
+  await rowWith(page, body).locator(".scrollback-sender").click({ button: "right" });
+
+  await expect(menu(page)).toBeVisible();
+  // The nick menu's verbs, none of which the message menu has…
+  await expect(menuItem(page, "WHOIS")).toBeVisible();
+  await expect(menuItem(page, "Query")).toBeVisible();
+  // …and none of the message menu's.
+  await expect(menuItem(page, "Select…")).toHaveCount(0);
+
+  // The nick's own handler preventDefaults too — #1115 must not have made the
+  // event dead before it got there.
+  expect(await nativeMenuSuppressed(page)).toBe(true);
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -26,6 +26,7 @@ import {
   mentionsBelowViewport,
   type ScrollbackLineGeom,
 } from "./lib/mentionScroll";
+import { bindMessageContextMenu } from "./lib/messageContextMenu";
 import { bindMessageGestures } from "./lib/messageGestures";
 import { closeMessageMenu, openMessageMenu } from "./lib/messageMenu";
 import { networks, user } from "./lib/networks";
@@ -58,6 +59,7 @@ import {
 } from "./lib/scrollback";
 import { scrollToBottomRequest } from "./lib/scrollToBottomCommand";
 import { setCursorIfAdvances, setSelectedChannel } from "./lib/selection";
+import type { Point } from "./lib/swipe";
 import { isMobile } from "./lib/theme";
 import { formatTimestamp } from "./lib/timeFormat";
 import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
@@ -1834,6 +1836,24 @@ const ScrollbackPane: Component<Props> = (props) => {
     // each claims a disjoint drag: #230 owns a VERTICAL drag on an underfilled
     // pane, `bindMessageGestures` only ever claims a rightward HORIZONTAL one
     // (and never in the edge zones #1041/#308 reserve).
+    //
+    // #1115 — and the desktop door to the SAME menu, bound on the SAME
+    // container. One menu for both modalities, opened by whichever door the
+    // operator's hardware reaches: the items are all row verbs (Copy, Reply,
+    // Select…) and none of them means something different under a mouse, so
+    // trimming per modality would only buy a "which input am I" signal that
+    // lies on a touchscreen laptop.
+    const openMenuForRow = (row: HTMLElement, at: Point): void => {
+      const msg = messageForRow(row);
+      if (msg === null) return;
+      openMessageMenu({
+        msg,
+        row,
+        networkSlug: props.networkSlug,
+        channelName: props.channelName,
+        at,
+      });
+    };
     if (listRef) {
       const disposeGestures = bindMessageGestures(listRef, {
         viewportWidth: () => window.innerWidth,
@@ -1842,19 +1862,10 @@ const ScrollbackPane: Component<Props> = (props) => {
           if (msg === null) return;
           replyToMessage(msg, props.networkSlug, props.channelName);
         },
-        onLongPress: (row, at) => {
-          const msg = messageForRow(row);
-          if (msg === null) return;
-          openMessageMenu({
-            msg,
-            row,
-            networkSlug: props.networkSlug,
-            channelName: props.channelName,
-            at,
-          });
-        },
+        onLongPress: openMenuForRow,
       });
       onCleanup(disposeGestures);
+      onCleanup(bindMessageContextMenu(listRef, { onContextMenu: openMenuForRow }));
     }
     // A menu left open over a row this pane is about to destroy would float
     // above the next channel, still holding a detached element.

--- a/cicchetto/src/__tests__/messageContextMenu.test.ts
+++ b/cicchetto/src/__tests__/messageContextMenu.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { bindMessageContextMenu } from "../lib/messageContextMenu";
+
+// #1115 — the scrollback's DESKTOP door to the message menu. #1067 gave the
+// menu one opener, a touch long-press, so a mouse user got the browser's own
+// menu and none of ours. This binder is the second door, not a replacement:
+// it owns `contextmenu` (right-click, Ctrl+click on macOS, and the keyboard
+// Menu key — all one event) while `bindMessageGestures` keeps the touch
+// stream untouched.
+//
+// jsdom proves the DECISION path: which right-clicks we claim, which we hand
+// straight back to the browser, and where the menu is asked to appear. It
+// does NOT prove that the native menu is really suppressed — that is the
+// browser's response to `preventDefault`, which only a real browser can
+// show, so the e2e spec carries that half.
+
+let pane: HTMLDivElement;
+let row: HTMLDivElement;
+let body: HTMLSpanElement;
+let nick: HTMLButtonElement;
+let link: HTMLAnchorElement;
+let onContextMenu: Mock<(row: HTMLElement, at: { x: number; y: number }) => void>;
+let dispose: () => void;
+
+beforeEach(() => {
+  pane = document.createElement("div");
+  pane.className = "scrollback";
+  row = document.createElement("div");
+  row.className = "scrollback-line";
+  body = document.createElement("span");
+  body.className = "scrollback-body";
+  nick = document.createElement("button");
+  nick.className = "scrollback-sender nick-clickable";
+  link = document.createElement("a");
+  link.className = "scrollback-link";
+  row.append(nick, body, link);
+  pane.appendChild(row);
+  document.body.appendChild(pane);
+  onContextMenu = vi.fn<(row: HTMLElement, at: { x: number; y: number }) => void>();
+  dispose = bindMessageContextMenu(pane, { onContextMenu });
+});
+
+afterEach(() => {
+  dispose();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks(); // the live-selection test spies on window.getSelection
+});
+
+// A right-click at (x, y) on `target`. Returns the event so the caller can
+// read `defaultPrevented` — the signal that decides whose menu the browser
+// is about to show.
+function rightClick(target: HTMLElement, x: number, y: number): MouseEvent {
+  const e = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+  });
+  target.dispatchEvent(e);
+  return e;
+}
+
+// Pretend a selection is live. jsdom's Selection is real but has no layout to
+// select over, so the flag the binder reads is stubbed directly.
+function stubSelection(collapsed: boolean): void {
+  vi.spyOn(window, "getSelection").mockReturnValue({
+    isCollapsed: collapsed,
+  } as unknown as Selection);
+}
+
+describe("bindMessageContextMenu — the desktop door", () => {
+  it("opens the message menu at the cursor for a right-click on the row body", () => {
+    rightClick(body, 412, 268);
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    expect(onContextMenu.mock.calls[0]?.[0]).toBe(row);
+    expect(onContextMenu.mock.calls[0]?.[1]).toEqual({ x: 412, y: 268 });
+  });
+
+  it("claims the event so the browser's own menu never opens", () => {
+    const e = rightClick(body, 412, 268);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("resolves the row from a right-click on the row's own padding", () => {
+    rightClick(row, 30, 90);
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    expect(onContextMenu.mock.calls[0]?.[0]).toBe(row);
+  });
+});
+
+describe("bindMessageContextMenu — what it refuses to claim", () => {
+  // The nick span sits INSIDE the row, and it already owns right-click (it
+  // opens UserContextMenu). Ours must not swallow it — and must not
+  // preventDefault either, or the nick's own handler inherits a dead event.
+  it("leaves a right-click on a nick to the nick menu", () => {
+    const e = rightClick(nick, 100, 100);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  // Same exclude list the touch owner and keepKeyboard use, so the three
+  // policies cannot drift: a link's native menu (open in new tab, copy link
+  // address) is worth more than ours.
+  it("leaves a right-click on a link to the browser", () => {
+    const e = rightClick(link, 100, 100);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("ignores a right-click on the pane outside any message row", () => {
+    const e = rightClick(pane, 100, 100);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  // A live selection means the operator wants the browser's copy/search/
+  // spellcheck menu — the same reason the touch owner stands down mid-
+  // selection.
+  it("yields to the browser while a selection is live", () => {
+    stubSelection(false);
+    const e = rightClick(body, 412, 268);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("claims again once the selection is collapsed", () => {
+    stubSelection(true);
+    rightClick(body, 412, 268);
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bindMessageContextMenu — lifecycle", () => {
+  it("stops claiming after the disposer runs", () => {
+    dispose();
+    const e = rightClick(body, 412, 268);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+});

--- a/cicchetto/src/lib/messageContextMenu.ts
+++ b/cicchetto/src/lib/messageContextMenu.ts
@@ -1,0 +1,62 @@
+// #1115 — the scrollback's DESKTOP door to the message menu. #1067 built the
+// menu (Copy / Reply / Select…) and gave it exactly ONE opener, a touch
+// long-press, so a mouse user got the browser's own menu and none of ours.
+// This is the second door, not a replacement: the touch stream stays entirely
+// with `bindMessageGestures`.
+//
+// A separate binder rather than a branch inside that one. `bindMessageGestures`
+// documents itself as the scrollback's one TOUCH-gesture owner and exists
+// because a swipe and a hold share `touchstart→move→end` state; a `contextmenu`
+// handler shares none of it and would sit inert through every touch event it
+// was handed.
+//
+// One event covers the whole input matrix: right-click, Ctrl+click on macOS,
+// and the keyboard Menu key all arrive as `contextmenu`. We never look at
+// `button` or synthesize from `mouse*`/`pointer*`, so no modality is
+// special-cased and none is missed.
+//
+// Bound ONCE on the scroll container and resolving the row via `closest`, for
+// the same reason the touch owner is: a listener per rendered row would be
+// hundreds of registrations churning on every append. Not delegated through
+// Solid's JSX `onContextMenu` either — Solid's delegated handlers run at the
+// document, i.e. AFTER this container listener in the bubble path, which is
+// exactly the ordering that lets the nick's own right-click keep working (see
+// the exclude below).
+import { SELECTABLE_TEXT_EXCLUDE } from "./keepKeyboard";
+import { MESSAGE_ROW_SELECTOR } from "./messageGestures";
+import type { Point } from "./swipe";
+
+export type MessageContextMenuParams = {
+  onContextMenu: (row: HTMLElement, at: Point) => void;
+};
+
+export function bindMessageContextMenu(
+  el: HTMLElement,
+  params: MessageContextMenuParams,
+): () => void {
+  const onContextMenu = (e: MouseEvent): void => {
+    const target = e.target instanceof Element ? e.target : null;
+    if (target === null) return;
+    // The inline controls own their own right-click: the nick opens
+    // UserContextMenu, and a link's native menu (open in new tab, copy link
+    // address) beats anything we could offer. The SAME exclude the touch owner
+    // and keepKeyboard use, so the three policies cannot drift. Returning
+    // WITHOUT preventDefault is load-bearing — the nick's Solid-delegated
+    // handler runs after us and must inherit a live event.
+    if (target.closest(SELECTABLE_TEXT_EXCLUDE) !== null) return;
+    // A live selection means the operator wants the browser's own copy /
+    // search / spellcheck menu over that selection — the same stand-down the
+    // touch owner takes mid-selection. Deliberately ANY live selection, not
+    // just one covering the cursor: it is the predicate already in use here,
+    // and "covers the cursor" is not something the platforms agree on.
+    const selection = window.getSelection();
+    if (selection !== null && !selection.isCollapsed) return;
+    const row = target.closest<HTMLElement>(MESSAGE_ROW_SELECTOR);
+    if (row === null) return;
+    e.preventDefault();
+    params.onContextMenu(row, { x: e.clientX, y: e.clientY });
+  };
+
+  el.addEventListener("contextmenu", onContextMenu);
+  return () => el.removeEventListener("contextmenu", onContextMenu);
+}

--- a/cicchetto/src/lib/messageGestures.ts
+++ b/cicchetto/src/lib/messageGestures.ts
@@ -44,7 +44,10 @@ export const HOLD_MOVE_TOLERANCE_PX = 10;
 // so the slide tracks the finger instead of easing behind it.
 export const SWIPING_CLASS = "scrollback-line-swiping";
 
-const MESSAGE_ROW_SELECTOR = ".scrollback-line";
+// Exported since #1115: the desktop `contextmenu` door resolves the row the
+// same way this binder does, and two copies of the selector would let the two
+// doors open over different elements.
+export const MESSAGE_ROW_SELECTOR = ".scrollback-line";
 
 export type MessageGestureParams = {
   // Injected (not read off the element) so the zone geometry is testable in

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36572,3 +36572,54 @@ added to the Logger metadata allowlist in `config/config.exs`, and any
 edit there forces a COLD deploy. The fix above is HOT, and holding it
 behind a restart window would keep a live defect in production for no
 gain. The breadcrumb ships separately, batched with other COLD work.
+## 2026-08-10 — #1115: the message menu got a second door, and the exclude list decided who wins
+
+#1067 built the scrollback's message menu (Copy / Reply / Select…) and hung it
+off exactly one opener: a touch long-press. On a desktop the row therefore had
+no menu at all — right-clicking it produced the browser's own. The whole fix is
+a door, not a menu: `lib/messageContextMenu.ts` binds `contextmenu` on the
+scroll container, resolves the row with `closest`, and calls the same
+`openMessageMenu` the long-press calls.
+
+**One menu for both modalities.** #1115 offered trimming or reordering the
+items per input type — `Select…` exists because selecting by touch is awkward,
+`Copy` overlaps a mouse user's own selection. Rejected: every item is a verb on
+the ROW, none of them means something different under a mouse, and branching
+would require an "am I touch" signal that lies on the first touchscreen laptop.
+The two doors share one `openMenuForRow` closure at the call site so they
+cannot drift into two menus.
+
+**A separate binder, not a branch in `bindMessageGestures`.** That module is
+the scrollback's one TOUCH-gesture owner and exists because the swipe and the
+hold share `touchstart→move→end` state. A `contextmenu` handler shares none of
+it and would sit inert through every touch event it was handed.
+
+**`contextmenu` is the whole input matrix.** Right-click, Ctrl+click on macOS,
+and the keyboard Menu key all arrive as that one event, so nothing looks at
+`button` and no modality is special-cased. **Not claimed:** keyboard parity is
+not actually reachable today — a scrollback row is not focusable, so the Menu
+key can never target one. Making rows focusable is an a11y change with its own
+roving-tabindex questions and is deliberately not in this diff; the handler is
+written against the ELEMENT, so it inherits the fix if that ever lands.
+
+**Nick precedence falls out of `SELECTABLE_TEXT_EXCLUDE`, not out of event
+ordering.** The nick span is inside the row, and the row-level listener runs
+BEFORE the nick's — Solid delegates `contextmenu` to the document, which is the
+last hop of the bubble path, while ours sits on the container. Rather than race
+that with `stopPropagation`, the door reuses the exclude list `keepKeyboard`
+and the touch owner already share: inside a nick, a link, a channel or the
+[Join] CTA, we return WITHOUT `preventDefault`, so the nick's delegated handler
+inherits a live event and opens the nick menu. The same line hands a link's
+right-click back to the browser, where "open in new tab / copy link address"
+is worth more than anything we offer — a `stopPropagation` on the nick alone
+would not have covered that.
+
+**Yielding to a live selection is deliberately coarse.** #1115 asked whether to
+suppress the native menu unconditionally or yield when a selection covers the
+cursor. We yield on ANY non-collapsed selection: it is the predicate
+`bindMessageGestures` already uses for the same judgement ("the operator is
+adjusting a selection, stay out of the way"), so the two cannot drift, and
+"covers the cursor" is not something the engines agree on. The cost is a stale
+selection elsewhere in the pane suppressing our menu until it is dismissed —
+accepted, because the browser's copy/search menu is the reasonable answer while
+any selection is live.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36572,6 +36572,9 @@ added to the Logger metadata allowlist in `config/config.exs`, and any
 edit there forces a COLD deploy. The fix above is HOT, and holding it
 behind a restart window would keep a live defect in production for no
 gain. The breadcrumb ships separately, batched with other COLD work.
+
+---
+
 ## 2026-08-10 — #1115: the message menu got a second door, and the exclude list decided who wins
 
 #1067 built the scrollback's message menu (Copy / Reply / Select…) and hung it


### PR DESCRIPTION
Refs #1115.

## What

The message menu (Copy / Reply / Select…) that #1067 built had exactly one
opener: a touch long-press. On a desktop, right-clicking a message row
produced the browser's own menu and none of ours. This adds the second door.

`cicchetto/src/lib/messageContextMenu.ts` binds `contextmenu` on the scroll
container, resolves the row with `closest`, and calls the same
`openMenuForRow` closure the long-press calls. The menu itself is untouched;
so is the touch path.

## What I measured myself, rather than taking from the issue

The issue's line numbers have drifted (main moved 390 commits since it was
written) — the substance holds, the coordinates do not:

| Issue says | Actually on `origin/main` (`4d9c245f`) |
|---|---|
| `openMessageMenu` call site at `ScrollbackPane.tsx:1852` | `:1848` |
| nick `onContextMenu` at `:681` / `:698` | `:666` / `:683` |
| `handleNickContextMenu` at `:1302-1305` | `:1298-1300` |
| `messageGestures.ts:180-183` registers only `touch*` | confirmed verbatim, and `grep` finds no `contextmenu` / `mouse*` / `pointer*` anywhere in that module |

Confirmed independently: `openMessageMenu` has exactly one production call
site, and `MessageContextMenu.tsx` is complete and modality-agnostic.

## Decisions the issue asked for, and how they went

**One menu on both modalities.** Every item is a verb on the ROW, and none
means something different under a mouse. Branching per input type would need
an "am I touch" signal that lies on the first touchscreen laptop.

**Yield to a live selection.** Any non-collapsed selection stands the door
down, not just one covering the cursor — that is the predicate
`bindMessageGestures` already uses for the same judgement, so the two cannot
drift, and "covers the cursor" is not something the engines agree on.
Accepted cost: a stale selection elsewhere in the pane suppresses our menu
until it is dismissed.

**Nick precedence comes from the shared exclude list, not event ordering.**
Solid delegates `contextmenu` to the document, so the nick's handler runs
AFTER the container listener. Rather than race that with `stopPropagation`,
the door reuses `SELECTABLE_TEXT_EXCLUDE`: inside a nick / link / channel /
[Join] CTA it returns **without** `preventDefault`, so the delegated handler
inherits a live event. The same line hands a link's right-click back to the
browser, which `stopPropagation` on the nick alone would not have done.

## What I am NOT claiming

- **Keyboard parity is not delivered.** `contextmenu` is the Menu key's event
  too, so the handler is input-agnostic by construction — but a scrollback row
  is not focusable, so the key can never target one today. Making rows
  focusable is an a11y change with its own roving-tabindex questions and is
  deliberately out of this diff.
- **The nick-precedence arm does not discriminate.** It passes with the fix
  stripped, because the nick menu already worked before #1115. It is a
  REGRESSION guard, not evidence that this feature works — do not read it as
  coverage.
- **"The native menu does not appear" is asserted via `defaultPrevented`,**
  read from a window-level bubble listener (the last hop, so it observes the
  verdict after both the container listener and Solid's delegated handlers).
  Whether the OS actually draws nothing is not observable from Playwright.
- **Keyboard parity is not delivered.** `contextmenu` is the Menu key's event
  too, so the handler is input-agnostic by construction — but a scrollback row
  is not focusable, so the key can never target one today. Making rows
  focusable is an a11y change with its own roving-tabindex questions and is
  deliberately out of this diff.
- **Touch long-press is not re-tested here.** It is unchanged code with a live
  guard in `issue1067-swipe-reply-message-menu.spec.ts`; a second copy would
  drift.

## Gates

Guard-before-fix, every red read before the green.

**jsdom, the decision path:**
- RED 1 (guard alone) — `Failed to resolve import "../lib/messageContextMenu"`,
  `Test Files 1 failed | 1 passed`, `exited with code 1`.
- RED 2 (inert binder, real assertions) — `Tests 4 failed | 6 passed`. The four
  failures are the positive arms; the six passes are the refusal arms, which a
  do-nothing binder satisfies vacuously.
- GREEN — `Tests 30 passed (30)`.

**Playwright, the visible outcome** (`scripts/integration.sh --grep issue1115`):
- RED — `Running 3 tests using 1 worker` → `2 failed, 1 passed`. Both feature
  arms fail with `.context-menu` `element(s) not found`; the passing one is the
  nick-precedence regression arm named above.
- GREEN — `3 passed`.

Isolating that red needed care worth recording: at the guard commit the bundle
does not build at all. The vitest file imports a module that does not exist
yet, `tsc --noEmit` fails, and `cicchetto-build-test` exits 1 before a browser
ever starts — a red that proves nothing about the product. The red above was
therefore taken with the vitest file removed and the e2e spec left standing, so
what failed was the missing door and nothing else.

**Full suites on the final tree:**
- `scripts/bun.sh run check` → `EXIT=0` (biome + `tsc --noEmit` + e2e tsconfig;
  61 warnings, all pre-existing CSS-specificity notes)
- `scripts/bun.sh run test` → `Test Files 271 passed (271)`, `Tests 5000 passed (5000)`, `EXIT=0`

`docs/DESIGN_NOTES.md`: +54 / −0, one separator added, file 217 → 218.
