### PR TITLE
LineSplit: break long messages on word boundaries, not mid-word (#1109)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36779,6 +36779,9 @@ keeps its row until the reaper sweeps, so a total-row canary silently became a
 function of suite execution order. Any count over a row-backed admin list must
 name the population it means, or it is reporting on someone else's cleanup
 timing and calling it a regression.
+
+---
+
 ## 2026-08-10 — #1109: word breaks, and the losslessness they cost
 
 `LineSplit` cut wherever the byte budget ran out, so a long message

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36779,3 +36779,62 @@ keeps its row until the reaper sweeps, so a total-row canary silently became a
 function of suite execution order. Any count over a row-backed admin list must
 name the population it means, or it is reporting on someone else's cleanup
 timing and calling it a regression.
+## 2026-08-10 — #1109: word breaks, and the losslessness they cost
+
+`LineSplit` cut wherever the byte budget ran out, so a long message
+arrived fragmented mid-word. The fix prefers the LAST word boundary at or
+before the budget and keeps the byte cut as the fallback, so a token
+longer than the whole budget — a URL, a base64 blob, a wall of CJK — is
+still emitted rather than looping or being dropped.
+
+**The search only ever shrinks a fragment.** That is not a style note, it
+is what keeps #246 intact: the worst-case relayed-frame budget holds only
+if nothing can make a fragment bigger, and a boundary search that could
+grow one would silently re-open that truncation. Every arm of the new
+suite re-asserts the relayed-frame bound alongside the word assertion for
+exactly this reason.
+
+**The boundary whitespace is CONSUMED — one grapheme, the one the break
+lands on.** This is the reversible half of the change and it was a call,
+not a discovery: keeping the whitespace would have preserved
+byte-identical rejoining, at the price of a trailing space on most
+fragments. Consuming it is what word-wrap does everywhere, and it drops
+no non-whitespace byte. If that trade is ever judged wrong it moves in
+one clause.
+
+What it costs is worth writing down, because it retires a guarantee an
+earlier incident bought: `IO.iodata_to_binary(fragments) == body`, the
+byte-identical reconstruction that guarded #246, is no longer true for
+any body containing spaces. It was replaced rather than deleted. The
+suite now asserts that the fragments **tile** the body — each one is the
+next literal run, with at most a single whitespace grapheme between
+consecutive fragments, and that gap is required to BE whitespace. A lost
+letter, a duplicated run, a reorder, or a two-character gap all still
+fail; the only thing newly admitted is the policy itself. Where a fixture
+has no whitespace, the stronger byte-identical form is kept deliberately.
+
+**A boundary is an ASCII space or tab, not a Unicode whitespace class.**
+NO-BREAK SPACE (U+00A0) and its relatives exist precisely to forbid the
+break we would otherwise take there, so a broader class would invert
+their meaning. A newline cannot appear in a body — it would have ended
+the wire frame.
+
+**Why the old suite never saw the bug.** Nearly every fixture was
+whitespace-free — 800 `a`, 800 `b`, 400 pizza emoji — so it exercised
+only the fallback the change leaves alone. A splitter cutting mid-word
+passes all of them. The new arms use fixed-width words on a 9-byte
+stride that divides neither the plain budget (391) nor the CTCP one
+(382), so a byte cut provably lands inside a word rather than by luck,
+and each asserts that trap before asserting the escape. Read failing
+against the old splitter: it bisected `word0044` into `word` + `0044` in
+the plain arm and `word0043` in the CTCP arm.
+
+**The cic-side "will send as X separate messages" warning is NOT out of
+sync with this** — a point the issue's Related section assumes the other
+way round. `messageLines.ts` splits the job deliberately: newline
+splitting (operator intent) is the client's, length splitting (wire
+limit) is the server's, because only the server knows the per-target
+frame overhead. `pastedMessageCount` therefore counts lines only, and a
+single long line has always been 1 there and N on the wire. Moving the
+breaks changes N; it does not create a divergence, and there is nothing
+to synchronise here.

--- a/lib/grappa/irc/line_split.ex
+++ b/lib/grappa/irc/line_split.ex
@@ -59,6 +59,30 @@ defmodule Grappa.IRC.LineSplit do
   loses data. For a silent-data-loss bug, worst-case is the only
   safe budget. See `relay_frame_overhead/1`.
 
+  ## Word boundaries and the whitespace policy (#1109)
+
+  Within the byte budget the cut prefers the LAST word boundary at or
+  before the budget; only when the chunk holds no boundary does it fall
+  back to the byte cut. A single token longer than the budget — a URL, a
+  base64 blob, a wall of CJK — therefore still splits mid-token rather
+  than looping or being dropped.
+
+  The boundary search may only ever SHRINK a fragment, never grow one, so
+  the #246 relay-safety guarantee above is preserved by construction: no
+  fragment can gain a byte from this.
+
+  **The boundary whitespace is CONSUMED** — exactly one grapheme, the one
+  the break lands on. That is what every word-wrap does, and it drops no
+  non-whitespace byte, so the fragments no longer rejoin byte-identically:
+  they TILE the body, separated by at most that one consumed grapheme.
+  Callers that need the original bytes back must keep the original.
+
+  A boundary is an ASCII space or tab, deliberately and not a broader
+  Unicode whitespace class: NO-BREAK SPACE (U+00A0) and its relatives
+  exist precisely to forbid a break, so treating them as boundaries would
+  invert their meaning. A newline cannot appear in a body — it would have
+  ended the wire frame.
+
   ## Why server-side
 
   Per CLAUDE.md "IRC is bytes; the web is UTF-8" + "one parser,
@@ -120,6 +144,11 @@ defmodule Grappa.IRC.LineSplit do
   Returns a non-empty list of UTF-8 strings, each one a valid
   PRIVMSG body for `target`. Single-fragment input returns
   `[body]` unchanged (fast path).
+
+  Fragments break on word boundaries where the chunk has one, and the
+  boundary whitespace is consumed — see the moduledoc's whitespace
+  policy. Rejoining the fragments therefore reproduces the body only up
+  to those consumed graphemes.
   """
   @spec split_privmsg_body(String.t(), String.t(), pos_integer()) :: [String.t(), ...]
   def split_privmsg_body(body, target, linelen)
@@ -175,13 +204,55 @@ defmodule Grappa.IRC.LineSplit do
         chunk_by_bytes(rest, budget, [], [g | acc], 0)
 
       current_size + g_size > budget ->
-        chunk_str = IO.iodata_to_binary(Enum.reverse(current_chunk))
-        chunk_by_bytes(rest, budget, [g], [chunk_str | acc], g_size)
+        # Budget reached. Prefer the last word boundary inside the chunk
+        # (#1109); `g` goes back on the input because the carry-over may
+        # already leave no room for it.
+        {chunk_str, carry, carry_size} = break_at_word(current_chunk)
+        chunk_by_bytes([g | rest], budget, carry, [chunk_str | acc], carry_size)
 
       true ->
         chunk_by_bytes(rest, budget, [g | current_chunk], acc, current_size + g_size)
     end
   end
+
+  # Cut `reversed_chunk` at its LAST word boundary, returning the fragment
+  # to emit plus the graphemes that carry over into the next chunk (still
+  # reversed, with their byte size). The boundary whitespace is CONSUMED.
+  #
+  # Falls back to the byte cut — emit the whole chunk, carry nothing — when
+  # there is no boundary to use, which is both the single-oversized-token
+  # case (URL, base64, CJK wall) and the case where the only whitespace is
+  # the chunk's first grapheme, since breaking there would emit an empty
+  # fragment. This can only ever SHRINK a fragment, never grow one, so the
+  # #246 relay-safety budget is untouched by construction.
+  defp break_at_word(reversed_chunk) do
+    case split_at_last_break(reversed_chunk, []) do
+      {[_ | _] = before_reversed, carry_in_order} ->
+        fragment = IO.iodata_to_binary(Enum.reverse(before_reversed))
+        {fragment, Enum.reverse(carry_in_order), IO.iodata_length(carry_in_order)}
+
+      _ ->
+        {IO.iodata_to_binary(Enum.reverse(reversed_chunk)), [], 0}
+    end
+  end
+
+  # Walks the reversed chunk head-first, so the FIRST break grapheme it
+  # meets is the LAST one in reading order. Returns the graphemes before
+  # the boundary (still reversed) and those after it (in order); `:none`
+  # when the chunk holds no boundary at all.
+  defp split_at_last_break([], _carry), do: :none
+
+  defp split_at_last_break([g | rest], carry) do
+    if break_space?(g), do: {rest, carry}, else: split_at_last_break(rest, [g | carry])
+  end
+
+  # ASCII space and tab only, deliberately. A broader Unicode class would
+  # drag in NO-BREAK SPACE (U+00A0) and friends, whose entire purpose is to
+  # forbid the break we would then take — and IRC's own word separator is
+  # the space. A newline cannot reach here: it would have ended the frame.
+  defp break_space?(" "), do: true
+  defp break_space?("\t"), do: true
+  defp break_space?(_), do: false
 
   defp flush_chunk([], acc), do: acc
 

--- a/lib/grappa/irc/line_split.ex
+++ b/lib/grappa/irc/line_split.ex
@@ -240,7 +240,7 @@ defmodule Grappa.IRC.LineSplit do
   # meets is the LAST one in reading order. Returns the graphemes before
   # the boundary (still reversed) and those after it (in order); `:none`
   # when the chunk holds no boundary at all.
-  defp split_at_last_break([], _carry), do: :none
+  defp split_at_last_break([], _), do: :none
 
   defp split_at_last_break([g | rest], carry) do
     if break_space?(g), do: {rest, carry}, else: split_at_last_break(rest, [g | carry])

--- a/test/grappa/irc/line_split_test.exs
+++ b/test/grappa/irc/line_split_test.exs
@@ -33,6 +33,67 @@ defmodule Grappa.IRC.LineSplitTest do
 
   defp single_grapheme?(s), do: match?([_], String.graphemes(s))
 
+  # #1109 — the whitespace policy, ASSERTED rather than assumed: a
+  # word-boundary break consumes exactly the one whitespace grapheme it
+  # breaks on, and nothing else is ever lost. So the fragments TILE the
+  # body: each one is the next literal run, and two consecutive fragments
+  # are separated by at most a single whitespace grapheme.
+  #
+  # This replaces the byte-identical `IO.iodata_to_binary(fragments) ==
+  # body` that guarded #246 before word breaks existed. It is not the
+  # weaker statement it looks like: a lost letter, a duplicated run, a
+  # reordering, or a gap of two characters all fail here, and the gap is
+  # additionally required to BE whitespace. The only thing it newly
+  # tolerates is precisely the policy — one consumed whitespace per break.
+  defp assert_tiles(body, fragments) do
+    leftover =
+      Enum.reduce(fragments, body, fn fragment, rest ->
+        rest = skip_consumed_whitespace(rest, fragment)
+
+        assert String.starts_with?(rest, fragment)
+
+        binary_part(rest, byte_size(fragment), byte_size(rest) - byte_size(fragment))
+      end)
+
+    assert leftover == ""
+  end
+
+  # Fixed-width words make a fixture arithmetic rather than luck: an
+  # 8-byte word plus one space is a 9-byte stride, and 9 divides neither
+  # the plain budget nor the CTCP one, so a byte-only cut lands strictly
+  # INSIDE a word in both arms.
+  defp numbered_words(count),
+    do: for(i <- 1..count, do: "word" <> String.pad_leading(Integer.to_string(i), 4, "0"))
+
+  # An oversized token is emitted in budget-sized byte pieces; spelled out
+  # here so the expectation is a statement of the contract, not a mirror
+  # of whatever the splitter happened to do.
+  defp hard_cut_pieces(token, budget) do
+    token
+    |> String.graphemes()
+    |> Enum.chunk_every(budget)
+    |> Enum.map(&Enum.join/1)
+  end
+
+  # A break consumed a whitespace grapheme iff the remaining body does not
+  # already start with this fragment. At most ONE may be skipped, and it
+  # must be whitespace — that is the policy under test.
+  defp skip_consumed_whitespace(rest, fragment) do
+    if String.starts_with?(rest, fragment) do
+      rest
+    else
+      case String.next_grapheme(rest) do
+        {gap, tail} ->
+          # The gap MUST be whitespace: that is the policy under test.
+          assert String.trim(gap) == ""
+          tail
+
+        nil ->
+          flunk("ran out of body before fragment #{inspect(fragment)}")
+      end
+    end
+  end
+
   describe "#246: split budget reserves the worst-case relayed source prefix" do
     test "every fragment stays ≤ linelen once framed with the relayed prefix" do
       # 600 bytes of ASCII — the exact repro shape from issue #246.
@@ -50,8 +111,10 @@ defmodule Grappa.IRC.LineSplitTest do
         assert byte_size(worst_case_relayed_frame(target, fragment)) <= 512
       end
 
-      # And no bytes are lost or duplicated at the boundaries.
-      assert IO.iodata_to_binary(fragments) == body
+      # And no bytes are lost or duplicated at the boundaries. This body
+      # has spaces, so since #1109 the breaks land on them and consume
+      # one each — the tiling check is the exact statement of that.
+      assert_tiles(body, fragments)
     end
 
     test "reserves the prefix even for a body that fits the client-side frame" do
@@ -72,6 +135,9 @@ defmodule Grappa.IRC.LineSplitTest do
         assert byte_size(worst_case_relayed_frame(target, fragment)) <= 512
       end
 
+      # This body is whitespace-free, so there is no boundary to consume:
+      # byte-identical reconstruction still holds exactly, and asserting
+      # the stronger form here is deliberate.
       assert IO.iodata_to_binary(fragments) == body
     end
   end
@@ -148,17 +214,116 @@ defmodule Grappa.IRC.LineSplitTest do
     end
   end
 
+  describe "#1109: breaks land on word boundaries, not mid-word" do
+    test "a long run of words is cut at spaces, never through a word" do
+      target = "#c"
+      linelen = 512
+      budget = linelen - LineSplit.relay_frame_overhead(target)
+      words = numbered_words(100)
+      body = Enum.join(words, " ")
+
+      # Pre-state: prove the trap is real BEFORE asserting the escape. A
+      # hard cut keeps bytes [0, budget); it bisects a word exactly when
+      # neither the last byte kept nor the first byte dropped is a space.
+      assert byte_size(body) > budget
+      refute binary_part(body, budget - 1, 1) == " "
+      refute binary_part(body, budget, 1) == " "
+
+      fragments = LineSplit.split_privmsg_body(body, target, linelen)
+      assert length(fragments) >= 2
+
+      # The discriminating assertion: the word SEQUENCE survives intact. A
+      # mid-word cut turns one word into two shorter ones, which fails
+      # here on both the count and the values.
+      assert Enum.flat_map(fragments, &String.split(&1, " ", trim: true)) == words
+
+      # The #246 guarantee is untouched by the new break rule.
+      for fragment <- fragments do
+        assert byte_size(worst_case_relayed_frame(target, fragment)) <= linelen
+      end
+
+      assert_tiles(body, fragments)
+    end
+
+    test "a CTCP ACTION breaks on words too, envelope intact on every fragment" do
+      target = "#c"
+      linelen = 512
+      words = numbered_words(100)
+      inner = Enum.join(words, " ")
+      action = "\x01ACTION " <> inner <> "\x01"
+
+      fragments = LineSplit.split_privmsg_body(action, target, linelen)
+      assert length(fragments) >= 2
+
+      inners =
+        Enum.map(fragments, fn f ->
+          assert String.starts_with?(f, "\x01ACTION ")
+          assert String.ends_with?(f, "\x01")
+          assert byte_size(worst_case_relayed_frame(target, f)) <= linelen
+          f |> String.replace_prefix("\x01ACTION ", "") |> String.replace_suffix("\x01", "")
+        end)
+
+      # Same discriminator as the plain arm, applied to the payload inside
+      # the envelope: the envelope must not buy itself a mid-word cut.
+      assert Enum.flat_map(inners, &String.split(&1, " ", trim: true)) == words
+
+      assert_tiles(inner, inners)
+    end
+
+    test "a single token longer than the budget is hard-cut, never dropped or looped" do
+      # The fallback the issue requires: a URL / base64 blob / CJK wall
+      # has no whitespace to break on, so the byte cut still applies. This
+      # arm is a REGRESSION guard — it passes before the change too.
+      target = "#c"
+      linelen = 512
+      budget = linelen - LineSplit.relay_frame_overhead(target)
+      body = String.duplicate("z", budget * 2 + 5)
+
+      fragments = LineSplit.split_privmsg_body(body, target, linelen)
+
+      assert length(fragments) == 3
+      # No whitespace anywhere means nothing can be consumed: the
+      # reconstruction stays byte-identical.
+      assert IO.iodata_to_binary(fragments) == body
+
+      for fragment <- fragments do
+        assert byte_size(worst_case_relayed_frame(target, fragment)) <= linelen
+      end
+    end
+
+    test "a word longer than the budget does not starve the words around it" do
+      # The carry case: breaking at the last space leaves the oversized
+      # token to be hard-cut on the next pass. Nothing may be lost and the
+      # search may only ever SHRINK a fragment, never grow one.
+      target = "#c"
+      linelen = 512
+      budget = linelen - LineSplit.relay_frame_overhead(target)
+      giant = String.duplicate("Z", budget + 40)
+      body = "alpha beta " <> giant <> " omega tail"
+
+      fragments = LineSplit.split_privmsg_body(body, target, linelen)
+
+      assert Enum.flat_map(fragments, &String.split(&1, " ", trim: true)) ==
+               ["alpha", "beta"] ++ hard_cut_pieces(giant, budget) ++ ["omega", "tail"]
+
+      for fragment <- fragments do
+        assert byte_size(worst_case_relayed_frame(target, fragment)) <= linelen
+      end
+
+      assert_tiles(body, fragments)
+    end
+  end
+
   describe "property: relay-safe, lossless, codepoint-whole splitting" do
-    property "reconstructs byte-identical, every fragment relay-safe + valid UTF-8" do
+    property "tiles the body, every fragment relay-safe + valid UTF-8" do
       check all(
               # Plain (non-CTCP) bodies only: a CTCP ACTION re-wraps its
               # `\x01ACTION …\x01` envelope on EVERY fragment, so its
-              # fragments don't concatenate back to the input — that path
-              # has its own byte-identical (inner) unit test above. Filtering
-              # via the production predicate keeps the byte-identical
-              # reconstruction assertion below airtight (a random :utf8 body
-              # would hit the CTCP branch only ~never, but never is not
-              # "impossible").
+              # fragments don't tile the input — that path has its own
+              # inner-payload unit tests above. Filtering via the production
+              # predicate keeps the tiling assertion below airtight (a random
+              # :utf8 body would hit the CTCP branch only ~never, but never is
+              # not "impossible").
               body <-
                 filter(string(:utf8, min_length: 1, max_length: 800), &(not CTCP.action?(&1))),
               linelen <- integer(200..600)
@@ -168,8 +333,12 @@ defmodule Grappa.IRC.LineSplitTest do
 
         assert fragments != []
 
-        # (a) byte-identical reconstruction — no hole, no duplication.
-        assert IO.iodata_to_binary(fragments) == body
+        # (a) lossless up to the DECLARED whitespace policy (#1109): a
+        # word-boundary break consumes exactly the one whitespace grapheme
+        # it breaks on, and nothing else is ever dropped, duplicated or
+        # reordered. Written out rather than inferred, because "modulo the
+        # whitespace policy" is only a guarantee if the policy is stated.
+        assert_tiles(body, fragments)
 
         for fragment <- fragments do
           # (c) whole codepoints — a fragment is never a bisected multibyte


### PR DESCRIPTION
## What

`LineSplit` cut wherever the byte budget ran out, so a long message
arrived fragmented mid-word. It now prefers the LAST word boundary at or
before the budget, and keeps the byte cut as the fallback so a token
longer than the whole budget — a URL, a base64 blob, a wall of CJK — is
still emitted rather than looping or being dropped.

`split_ctcp_action/2` inherits it for free: it splits through the same
function, so every fragment stays a self-contained `\x01ACTION …\x01`.

## How

The search walks the accumulated chunk head-first. That chunk is already
held reversed for O(1) prepend, so the first boundary the walk meets IS
the last one in reading order — no second pass, no index arithmetic. The
graphemes after it carry into the next chunk; the grapheme that triggered
the flush goes back on the input rather than into the new chunk, because
the carry-over may already leave no room for it.

Termination is structural rather than bounded: the emitted fragment is
non-empty by guard, and the carry can never contain a boundary, so the
next flush can only be the byte cut.

**The search may only ever SHRINK a fragment**, which is what keeps #246
intact — that budget holds only if nothing can make a fragment bigger.
Every arm re-asserts the worst-case relayed-frame bound next to the word
assertion for exactly this reason.

## The whitespace policy, and what it costs

**The boundary whitespace is CONSUMED** — one grapheme, the one the break
lands on. It is what word-wrap does everywhere and drops no
non-whitespace byte. Reversible in one clause.

It retires a guarantee an earlier incident bought:
`IO.iodata_to_binary(fragments) == body` — the byte-identical
reconstruction that guarded #246 — no longer holds for any body with
spaces. It was replaced, not deleted. The suite now asserts the fragments
**tile** the body: each is the next literal run, with at most one
whitespace grapheme between consecutive fragments, and that gap is
required to BE whitespace. A lost letter, a duplicated run, a reorder or
a two-character gap all still fail; the only thing newly admitted is the
policy. Where a fixture has no whitespace the stronger byte-identical
form is kept deliberately.

A boundary is an ASCII space or tab, not a Unicode whitespace class:
NO-BREAK SPACE and its relatives exist precisely to forbid the break we
would otherwise take there.

## Measured

Red read before green, by restoring only `line_split.ex` to its
pre-implementation state and leaving the new tests in place:

| run | result |
|---|---|
| tests at `f6666491`, splitter unchanged | **3 failures** / 12 tests + 1 property |
| after the fix | **0 failures** / 12 tests + 1 property |
| full unit suite | 8 doctests, 57 properties, **5652 tests, 0 failures** |
| `mix format --check-formatted` | rc=0 |
| Credo strict | `5487 mods/funs, found no issues` |
| Dialyzer | `passed successfully` |

The red was the right red: the old splitter bisected `word0044` into
`word` + `0044` in the plain arm and `word0043` in the CTCP arm.

**Which arms discriminate.** The three above. The single-oversized-token
arm is a REGRESSION guard and passed before the change too — stated
rather than counted as evidence. Worth noting why the old suite was
blind: nearly every existing fixture was whitespace-free (800 `a`, 800
`b`, 400 pizza emoji), so it exercised only the fallback this change
leaves alone, and a mid-word splitter passes all of them. The new
fixtures use fixed-width words on a 9-byte stride that divides neither
the plain budget (391) nor the CTCP one (382), and each asserts that trap
before asserting the escape.

## One correction to the issue

The Related section assumes the cic "will send as X separate messages"
warning has to be resynchronised with the fragment count. It does not,
and it never modelled length splitting: `messageLines.ts` splits the job
deliberately — newline splitting (operator intent) is the client's,
length splitting (wire limit) is the server's — and `pastedMessageCount`
is `splitMessageLines(text).length`, lines only. A single long line has
always been 1 there and N on the wire. Re-verified against `664751f0`,
which touched `pasteRoute.ts` for #1113's caret while this branch was
open; the count is untouched.

## Not claimed

No e2e ran: this is server-side unit work and the STACK lane was held
elsewhere. The rebase onto `664751f0` brought in cic-only and docs
commits — zero Elixir — so the suite green carries; the scoped file and
the format check were re-run on the rebased tree regardless.
