### PR TITLE
cic(#1106): release the compose field before Select… installs its range

### DIFF
--- a/cicchetto/src/__tests__/messageMenu.test.ts
+++ b/cicchetto/src/__tests__/messageMenu.test.ts
@@ -145,4 +145,94 @@ describe("selectMessageText", () => {
     document.dispatchEvent(new Event("selectionchange"));
     expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
   });
+
+  // #1106 — the keyboard-open half. Measured in jsdom against the shipped
+  // keepKeyboard handler: the tap that chooses Select… lands on a menu button
+  // portalled to <body>, so it is neither a text entry, nor inside
+  // `.scrollback`, nor a <select> — it falls to `handleMouseDown`'s final
+  // always-fire `preventDefault`, which cancels the focus shift and leaves the
+  // COMPOSE FIELD focused. With the keyboard closed nothing is focused, the
+  // same mousedown is not prevented, and the operator reports the selection
+  // appearing. That divergence is the whole bug surface, and it is ours.
+  //
+  // So the range must be installed with no editable holding focus. What
+  // follows is a regression guard on OUR behaviour — releasing focus and the
+  // order it happens in. It is NOT evidence that iOS then paints the
+  // selection: the final link ("WebKit paints one selection at a time, and a
+  // focused editable wins") is reproducible in neither jsdom nor Playwright
+  // webkit, and the issue's own Chromium measurement paints the range even
+  // with a focused textarea. Device verification is outstanding.
+  function focusedField(tag: "input" | "textarea"): HTMLElement {
+    const field = document.createElement(tag);
+    document.body.append(field);
+    field.focus();
+    return field;
+  }
+
+  it("releases a focused textarea before installing the range (#1106)", () => {
+    stubSelection("12:34 <vjt> ciao");
+    const compose = focusedField("textarea");
+    expect(document.activeElement).toBe(compose);
+
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+
+    expect(document.activeElement).not.toBe(compose);
+  });
+
+  it("releases a focused input too — the compose box is an input in its other mode (#1106)", () => {
+    stubSelection("12:34 <vjt> ciao");
+    const compose = focusedField("input");
+
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+
+    expect(document.activeElement).not.toBe(compose);
+  });
+
+  it("releases focus BEFORE adding the range, not after (#1106)", () => {
+    // Order is the claim, not a detail: the point is that the engine never
+    // sees the range while an editable still owns the selection. A blur that
+    // lands after `addRange` would satisfy the two assertions above and still
+    // install the range under a focused field.
+    const order: string[] = [];
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn(() => order.push("addRange")),
+      toString: () => "12:34 <vjt> ciao",
+      isCollapsed: false,
+    } as unknown as Selection);
+    const compose = focusedField("textarea");
+    compose.addEventListener("blur", () => order.push("blur"));
+
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+
+    expect(order).toEqual(["blur", "addRange"]);
+  });
+
+  it("leaves a focused NON-editable alone — only a text entry blocks the paint (#1106)", () => {
+    // Keyboard-closed path: the menu button itself takes focus, and blurring
+    // it buys nothing while costing focus position on every platform that
+    // never had the bug. The release is aimed at the editable, not at whatever
+    // happens to be focused.
+    stubSelection("12:34 <vjt> ciao");
+    const button = document.createElement("button");
+    document.body.append(button);
+    button.focus();
+
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("still installs the range when it had to release a field (#1106)", () => {
+    // Non-regression rather than discrimination: this passes before the fix
+    // too. It exists so a future blur cannot buy focus release at the cost of
+    // the selection it was there to make visible.
+    const { addRange, ranges } = stubSelection("12:34 <vjt> ciao");
+    focusedField("textarea");
+    const row = scrollbackRow("12:34 <vjt> ciao");
+
+    expect(selectMessageText(row)).toBe(true);
+    expect(addRange).toHaveBeenCalledTimes(1);
+    expect(ranges[0]?.commonAncestorContainer).toBe(row);
+  });
 });

--- a/cicchetto/src/lib/keepKeyboard.ts
+++ b/cicchetto/src/lib/keepKeyboard.ts
@@ -127,7 +127,12 @@ export const SELECTABLE_TEXT_EXCLUDE =
 // for one handler and a tap for the other.
 export const LONG_PRESS_MS = 500;
 
-function isTextEntry(el: Element | null): boolean {
+// Exported since #1106: `lib/messageMenu`'s Select… has to release a focused
+// editable before it installs its range, and "what counts as a text entry" must
+// be ONE predicate — a second copy would drift the moment a contenteditable
+// composer lands (ComposeBox already contemplates one). Narrowing predicate so
+// callers can reach `.blur()` without re-testing the type.
+export function isTextEntry(el: Element | null): el is HTMLInputElement | HTMLTextAreaElement {
   return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement;
 }
 

--- a/cicchetto/src/lib/messageMenu.ts
+++ b/cicchetto/src/lib/messageMenu.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import type { ScrollbackMessage } from "./api";
 import { copyText } from "./clipboard";
+import { isTextEntry } from "./keepKeyboard";
 import type { Point } from "./swipe";
 import { createToastQueue } from "./toasts";
 
@@ -73,6 +74,25 @@ export const SELECTING_CLASS = "is-selecting";
 export function selectMessageText(row: HTMLElement): boolean {
   const selection = window.getSelection();
   if (selection === null) return false;
+  // #1106 — release the compose field FIRST, or on iOS the range goes in
+  // while an editable still owns the paint and nothing appears.
+  //
+  // The tap that chose this item landed on a menu button portalled to <body>:
+  // not a text entry, not inside `.scrollback`, not a <select>, so
+  // keepKeyboard's final always-fire `preventDefault` cancelled its focus
+  // shift and the compose box KEPT focus. With the keyboard down nothing is
+  // focused, that mousedown is not prevented, and the selection is reported
+  // working — the difference between the two is ours, not WebKit's.
+  //
+  // Aimed at the editable rather than at whatever holds focus: on the
+  // keyboard-down path the focused thing is the menu button itself, and
+  // blurring that buys nothing while moving focus on platforms that never had
+  // the bug. This does NOT contradict #79 — that duration-gates the long-press
+  // on `.scrollback` to keep the keyboard through the GESTURE; this is the
+  // explicit command the gesture leads to, where the operator has asked for a
+  // selection and the keyboard is what is in its way.
+  const focused = document.activeElement;
+  if (isTextEntry(focused)) focused.blur();
   const range = document.createRange();
   range.selectNodeContents(row);
   selection.removeAllRanges();

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36841,3 +36841,68 @@ frame overhead. `pastedMessageCount` therefore counts lines only, and a
 single long line has always been 1 there and N on the wire. Moving the
 breaks changes N; it does not create a divergence, and there is nothing
 to synchronise here.
+## 2026-08-10 — #1106: Select… installed its range under a focused compose box, and three of the four links are measured
+
+The report is narrow: on iOS, long-press → **Select…** with the keyboard UP
+produces no visible selection; with the keyboard down the same gesture works.
+
+**The divergence is ours, not WebKit's, and it is measured.** The tap that
+chooses the item lands on a menu button portalled to `<body>`. That is not a
+text entry, not inside `.scrollback`, and not a `<select>` — so it falls
+through `keepKeyboard`'s `handleMouseDown` to the final always-fire
+`preventDefault`, which cancels the focus shift. In jsdom against the shipped
+handler: with the compose field focused that mousedown reports
+`defaultPrevented = true`; with nothing focused, `false`. So on the broken path
+the compose box KEEPS focus and `selectMessageText` installs its range while an
+editable owns the selection, and on the working path focus moves to the button
+and no editable is involved. The fix removes that difference:
+`selectMessageText` releases a focused text entry before installing the range.
+
+**Aimed at the editable, not at whatever holds focus.** On the keyboard-down
+path the focused element is the menu button itself; blurring that buys nothing
+and moves focus on platforms that never had the bug. `isTextEntry` moved from
+private to exported rather than being copied — one predicate for "what is a
+text entry", so a contenteditable composer lands in one place.
+
+**This does NOT contradict #79**, and the issue's framing of the fork ("drop
+the keyboard before selecting, contradicting #79's whole premise") over-states
+it. #79 duration-gates the long-press on `.scrollback` to hold the keyboard
+through the GESTURE. This is the explicit command the gesture leads to, on a
+different branch of the same handler, where the operator has asked for a
+selection and the keyboard is what is in the way. Accepted cost, stated up
+front: the keyboard closes and the layout reflows under the finger as the
+selection appears. The alternative — excluding `.context-menu` from the generic
+preventDefault — was rejected on the merits: it would take the keyboard away
+from **Reply**, which fills the compose box and wants it up, and Copy has no
+reason to lose it either.
+
+**The fourth link is not measured and this entry does not claim it.** That
+WebKit paints one selection at a time, so a document range under a focused
+editable never gets drawn, is reproducible in neither jsdom nor Playwright
+webkit — and the issue's own Chromium run paints the range *with* a focused
+textarea, which is why the bug is engine-specific in the first place. So: a
+causal chain that explains the symptom, and NO evidence that removing it makes
+the symptom go away on a phone. **Device verification is outstanding debt**,
+not something this change did. What landed is a regression guard on our own
+behaviour.
+
+**Which arms discriminate.** Three failed before the fix — a focused textarea
+surviving the call, a focused input surviving it, and the order being `addRange`
+with no blur at all. Two passed already and are labelled in the file as what
+they are, but neither is vacuous: single-mutation runs against the green
+implementation kill each arm alone. Blurring any focused element instead of
+only editables kills the non-editable arm and nothing else; blurring after
+`addRange` kills the order arm and nothing else; blurring only a textarea kills
+the input arm and nothing else; installing no range kills the non-regression
+arm. The order arm is the load-bearing one — a blur that lands after the range
+satisfies both focus assertions while still installing under a focused field.
+
+**A false premise in the issue, for whoever picks this up.** Its diagnostic
+plan proposes reading `kb: scrollback md held=<n>ms → HOLD keep-kbd` off a
+failing device to learn "whether the long-press arm is even reached", and to
+separate its lead 1 from leads 2-3 that way. But `keepKeyboard.ts` states in
+its own comment that on real iOS a long-press synthesizes NO mousedown at all —
+only taps do — and that the arm survives as a cross-platform net. If that is
+true, the line will never print for a long-press on device and the plan cannot
+separate anything. Not verified on device either: this is the code contradicting
+the issue text, which is a result worth recording rather than a measurement.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36841,6 +36841,9 @@ frame overhead. `pastedMessageCount` therefore counts lines only, and a
 single long line has always been 1 there and N on the wire. Moving the
 breaks changes N; it does not create a divergence, and there is nothing
 to synchronise here.
+
+---
+
 ## 2026-08-10 — #1106: Select… installed its range under a focused compose box, and three of the four links are measured
 
 The report is narrow: on iOS, long-press → **Select…** with the keyboard UP


### PR DESCRIPTION
Refs #1106.

On iOS, long-press → **Select…** with the keyboard UP produces no visible
selection; with the keyboard down the same gesture works.

## The divergence is ours, and it is measured

The tap that chooses the item lands on a menu button portalled to `<body>`:
not a text entry, not inside `.scrollback`, not a `<select>`, so it falls
through `keepKeyboard`'s `handleMouseDown` to the final always-fire
`preventDefault`, which cancels the focus shift. Measured in jsdom against the
shipped handler:

| case | mousedown `defaultPrevented` |
|---|---|
| compose focused (keyboard up) | `true` |
| nothing focused (keyboard down) | `false` |

So on the broken path the compose box **keeps** focus and the range is
installed while an editable owns the selection; on the working path focus moves
to the button and no editable is involved. `selectMessageText` now releases a
focused text entry before installing the range, which removes the difference.

Aimed at the editable rather than at whatever holds focus: on the
keyboard-down path the focused element is the menu button, and blurring it
would move focus on platforms that never had the bug. `isTextEntry` is exported
instead of copied, so "what is a text entry" stays one predicate.

**Not a contradiction of #79.** That duration-gates the long-press on
`.scrollback` to hold the keyboard through the *gesture*; this is the explicit
command the gesture leads to, on a different branch of the same handler.
Accepted cost: the keyboard closes and the layout reflows under the finger as
the selection appears. Excluding `.context-menu` from the generic
preventDefault was rejected — it would take the keyboard away from **Reply**,
which fills the compose box and wants it up.

## What this does NOT prove

Three of four links are measured. The fourth — that WebKit paints one selection
at a time, so a document range under a focused editable is never drawn — is
**reproducible in neither jsdom nor Playwright webkit**, and the issue's own
Chromium run paints the range *with* a focused textarea. So this is a causal
chain that explains the symptom and **no evidence that removing it makes the
symptom go away on a phone**. What landed is a regression guard on our own
behaviour; **device verification is outstanding debt**, not something this
change did.

## A false premise in the issue, for whoever picks up the thread

The diagnostic plan proposes reading `kb: scrollback md held=<n>ms → HOLD
keep-kbd` off a failing device to learn whether the long-press arm is reached,
and to separate lead 1 from leads 2-3 that way. But `keepKeyboard.ts` states in
its own comment that on real iOS a long-press synthesizes **no mousedown at
all** — only taps do. If that holds, the line can never print for a long-press
and the plan cannot separate anything. Code contradicting the issue text, not a
device measurement.

## Test plan

- [x] Guard committed before the fix and **read failing**: three arms red —
      focused textarea survives, focused input survives, order is `addRange`
      with no blur.
- [x] Every arm discriminates, proven by single mutations of the green
      implementation: blur-anything kills only the non-editable arm; blur after
      `addRange` kills only the order arm; blur only a textarea kills only the
      input arm; installing no range kills the non-regression arm. The order
      arm is load-bearing — a late blur satisfies both focus assertions while
      still installing under a focused field.
- [x] `bun run check` (biome + both `tsc` passes) green.
- [x] Full vitest suite green: 271 files, 5005 tests.
- [ ] On-device check on iOS Safari with the keyboard up — **outstanding**.