### PR TITLE
cic(#1107): !addquote item that pre-fills the compose box

### DIFF
--- a/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
+++ b/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
@@ -4,11 +4,15 @@
 // only fills the box.
 //
 // Harness + limits:
-//   * chromium, DESKTOP viewport, no `hasTouch` — the item is reached through
-//     #1115's right-click door, which is the cheapest real opener. The touch
-//     long-press reaches the SAME item list from the SAME store
-//     (`openMessageMenu`), and duplicating it here would drift against
+//   * chromium, no `hasTouch` throughout — the item is reached through #1115's
+//     right-click door, which is the cheapest real opener. The touch long-press
+//     reaches the SAME item list from the SAME store (`openMessageMenu`), and
+//     duplicating it here would drift against
 //     issue1067-swipe-reply-message-menu.spec.ts rather than add coverage.
+//   * TWO viewports, for a measured reason. The payload arms run at 1280px;
+//     the caret arm runs at 390px because a wide compose box does not overflow
+//     enough for the oracle's own non-vacuity guard to let it run. See the
+//     comment on that describe block.
 //   * The caret arm reuses `expectEndCaretVisible`, the oracle #173 and #1105
 //     already share. #1107's blocker was exactly that geometry: `!addquote `
 //     plus a body overflows the rows=1 textarea nearly every time, and before
@@ -94,10 +98,6 @@ test("issue1107 — !addquote fills the compose box with the command and the mes
   // The payload ruling, at the only place it is observable end to end: the
   // command, one space, the body — and no `<nick>` head.
   await expect(ta).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
-
-  // The #1105/#1113 dependency the issue names, on the real engine that jsdom
-  // cannot stand in for.
-  expectEndCaretVisible(await composeCaretGeometry(page), 40);
 });
 
 test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
@@ -118,6 +118,49 @@ test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
   await expect(
     page.locator('[data-testid="scrollback-line"]', { hasText: "!addquote" }),
   ).toHaveCount(0);
+});
+
+// The caret arm needs a NARROW viewport, and that is a statement about the
+// defect rather than a convenience. `expectEndCaretVisible` refuses to run
+// unless the draft actually overflows the compose box, and at 1280px it
+// refused: the fixture body reached `scrollHeight` 73 against a required
+// `clientHeight + 40` = 82, because a wide compose wraps this text only twice.
+// The honest fix is the viewport, not the threshold — the overflow #1107 waited
+// on is a PHONE phenomenon, which is why #1105 measured it at 390px and why the
+// issue says the item is "unusable-feeling" until #1105/#1113 land. Lowering
+// `minOverflowPx` would have bought a green by disarming the one guard that
+// stops "the caret is in view" from passing on a draft that never left line one.
+//
+// `hasTouch: true` here, unlike the arms above, and NOT as a stylistic choice:
+// at this width `selectChannel` takes the mobile branch and reaches the window
+// with `tap()`, which throws outright on a context without touch support. The
+// menu is still opened by the #1115 right-click door — chromium serves both
+// input types in one touch-enabled context — so what changes between the two
+// describes is how much the text wraps, not how the item is reached.
+test.describe("the caret, where the overflow is real", () => {
+  test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+  test("issue1107 — !addquote scrolls the overflowing compose box down to the caret", async ({
+    page,
+  }) => {
+    const body = uniqueBody("caret");
+    await postMessage(page, body);
+
+    // Pre-state: an already-scrolled compose would make the outcome true for
+    // the wrong reason.
+    await expect(composeTextarea(page)).toHaveValue("");
+    expect((await composeCaretGeometry(page)).scrollTop).toBe(0);
+
+    await openMenuOnRow(page, body);
+    await menuItem(page, "!addquote").click();
+    await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+
+    // The #1105/#1113 dependency the issue names, on the real engine jsdom
+    // cannot stand in for. The oracle's own overflow guard is what makes this
+    // non-vacuous, so the margin stays at the value the desktop viewport could
+    // not meet.
+    expectEndCaretVisible(await composeCaretGeometry(page), 40);
+  });
 });
 
 // NOT covered here, deliberately: the disabled-but-visible posture on a

--- a/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
+++ b/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
@@ -1,0 +1,128 @@
+// #1107 — the message menu's `!addquote` item puts `!addquote ` plus the
+// message text into the compose box, with the caret at the end and visible,
+// and sends NOTHING. The command is for whatever bot is in the channel; cic
+// only fills the box.
+//
+// Harness + limits:
+//   * chromium, DESKTOP viewport, no `hasTouch` — the item is reached through
+//     #1115's right-click door, which is the cheapest real opener. The touch
+//     long-press reaches the SAME item list from the SAME store
+//     (`openMessageMenu`), and duplicating it here would drift against
+//     issue1067-swipe-reply-message-menu.spec.ts rather than add coverage.
+//   * The caret arm reuses `expectEndCaretVisible`, the oracle #173 and #1105
+//     already share. #1107's blocker was exactly that geometry: `!addquote `
+//     plus a body overflows the rows=1 textarea nearly every time, and before
+//     #1105/#1113 the operator would have been typing under the fold. A second
+//     copy of the assertion would repeat, on the test side, the duplication
+//     that let #1105 ship.
+//   * "Sends nothing" is asserted as the ABSENCE of a second scrollback row
+//     bearing the command, after the compose value has already settled — so
+//     the wait is on a state that has arrived, not on a bare timeout.
+import type { Page } from "@playwright/test";
+import {
+  composeCaretGeometry,
+  composeSend,
+  composeTextarea,
+  expectEndCaretVisible,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Long enough to wrap the rows=1 compose box several times over once the
+// command is prepended, so the caret arm's overflow is a wide margin rather
+// than a coin toss on font metrics — and still one PRIVMSG, so the server-side
+// split budget (#246) never turns it into two scrollback rows.
+const FILLER =
+  "una battuta abbastanza lunga da mandare a capo il compose piu' volte, " +
+  "cosi' il caret finisce sotto la piega se nessuno lo va a ripescare";
+
+// Unique per run: the e2e sqlite scrollback persists across KEEP_STACK=1
+// re-runs, and a static string would match two rows on the second run and trip
+// Playwright strict mode.
+function uniqueBody(tag: string): string {
+  return `issue1107 ${tag} ${Date.now()} ${FILLER}`;
+}
+
+const menu = (page: Page) => page.locator(".context-menu");
+const menuItem = (page: Page, label: string) =>
+  page.locator(".context-menu .context-menu-item", { hasText: label });
+const rowWith = (page: Page, body: string) =>
+  page.locator('[data-testid="scrollback-line"]', { hasText: body });
+
+async function postMessage(page: Page, body: string): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await composeSend(page, body);
+  await expect(rowWith(page, body)).toBeVisible({ timeout: 5_000 });
+}
+
+// Right-click at mid-width of the row's OWN measured box. Measured rather than
+// a pixel constant because the pane's width depends on the sidebar and members
+// rail; a hardcoded x could land on the nick span, which owns its own
+// right-click (#1115) and would open the wrong menu.
+async function openMenuOnRow(page: Page, body: string): Promise<void> {
+  const box = await rowWith(page, body).boundingBox();
+  if (box === null) throw new Error("message row has no box");
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height / 2, { button: "right" });
+  await expect(menu(page)).toBeVisible();
+}
+
+test("issue1107 — !addquote fills the compose box with the command and the message", async ({
+  page,
+}) => {
+  const body = uniqueBody("fill");
+  await postMessage(page, body);
+
+  // Pre-state: a non-empty or already-scrolled compose would make both
+  // outcomes below true for the wrong reason.
+  const ta = composeTextarea(page);
+  await expect(ta).toHaveValue("");
+  expect((await composeCaretGeometry(page)).scrollTop).toBe(0);
+
+  await openMenuOnRow(page, body);
+  await expect(menuItem(page, "!addquote")).toBeEnabled();
+  await menuItem(page, "!addquote").click();
+
+  // The payload ruling, at the only place it is observable end to end: the
+  // command, one space, the body — and no `<nick>` head.
+  await expect(ta).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+
+  // The #1105/#1113 dependency the issue names, on the real engine that jsdom
+  // cannot stand in for.
+  expectEndCaretVisible(await composeCaretGeometry(page), 40);
+});
+
+test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
+  const body = uniqueBody("nosend");
+  await postMessage(page, body);
+
+  await openMenuOnRow(page, body);
+  await menuItem(page, "!addquote").click();
+
+  // Barrier first: the compose value settling is the durable state that says
+  // the item has fully run. Only then is the absence below an absence rather
+  // than a race with an insertion still in flight.
+  await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+
+  // The original row is still the ONLY row carrying this text. A sent command
+  // would echo back as a second scrollback line containing the same body.
+  await expect(rowWith(page, body)).toHaveCount(1);
+  await expect(
+    page.locator('[data-testid="scrollback-line"]', { hasText: "!addquote" }),
+  ).toHaveCount(0);
+});
+
+// NOT covered here, deliberately: the disabled-but-visible posture on a
+// presence row. It is a pure item-list predicate with no geometry, no wire and
+// no engine behaviour in it, and `src/__tests__/MessageContextMenu.test.tsx`
+// pins it against a measured mutant. Reaching a presence row from here would
+// need a locator that guesses which scrollback line is a JOIN, which is a
+// fragile way to re-prove something already proven.

--- a/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
+++ b/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
@@ -159,6 +159,11 @@ test.describe("the caret, where the overflow is real", () => {
     // cannot stand in for. The oracle's own overflow guard is what makes this
     // non-vacuous, so the margin stays at the value the desktop viewport could
     // not meet.
+    // Measured here, not assumed: clientHeight 42, scrollHeight 151 — 109px of
+    // overflow against the 40 this call demands, where the 1280px viewport
+    // managed 31 and the guard refused. The margin is ~1.5 wrapped lines at
+    // this width, so the compose box would have to grow about 1.8x wider at
+    // the same font before the fixture stopped overflowing.
     expectEndCaretVisible(await composeCaretGeometry(page), 40);
   });
 });

--- a/cicchetto/src/MessageContextMenu.tsx
+++ b/cicchetto/src/MessageContextMenu.tsx
@@ -1,5 +1,6 @@
 import { type Component, Show } from "solid-js";
 import ContextMenu, { type ContextMenuItem } from "./ContextMenu";
+import { addQuoteCommand, addQuoteToCompose } from "./lib/addQuote";
 import {
   closeMessageMenu,
   copyMessageRow,
@@ -36,6 +37,18 @@ const MessageContextMenu: Component = () => {
       // so the menu's shape does not jump between rows.
       enabled: replyQuote(target.msg) !== null,
       action: () => replyToMessage(target.msg, target.networkSlug, target.channelName),
+    },
+    {
+      // #1107 — the bot command, spelled the way it goes on the wire so there
+      // is nothing to learn from the label. Next to Reply because it is the
+      // other quoting verb, and before Select… because that one is the escape
+      // hatch out of the menu entirely.
+      label: "!addquote",
+      // Same disabled-but-visible posture as Reply, and the same predicate
+      // underneath (`quotableBody`) — a row Reply refuses has nothing for a
+      // quote database either.
+      enabled: addQuoteCommand(target.msg) !== null,
+      action: () => addQuoteToCompose(target.msg, target.networkSlug, target.channelName),
     },
     {
       label: "Select…",

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -2,6 +2,8 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+import { getDraft, setDraft } from "../lib/compose";
 import { closeMessageMenu, openMessageMenu, SELECTING_CLASS } from "../lib/messageMenu";
 import MessageContextMenu from "../MessageContextMenu";
 
@@ -101,5 +103,69 @@ describe("Select… with the compose keyboard up", () => {
     // And it survived because the guard found a LIVE selection, not because
     // nothing ever looked.
     expect(delivered.at(-1)).toBe("12:34 <vjt> ciao");
+  });
+});
+
+// #1107 — the `!addquote` item. It only fills the compose box; cic never sends
+// it and never interprets it, so what is asserted here is the item's presence,
+// its place in the list, and the text it deposits.
+
+const NET = "azzurra";
+const CHAN = "#grappa";
+const KEY = channelKey(NET, CHAN);
+
+function mountCompose(): HTMLTextAreaElement {
+  const box = document.createElement("div");
+  box.className = "compose-box";
+  const ta = document.createElement("textarea");
+  box.appendChild(ta);
+  document.body.appendChild(box);
+  return ta;
+}
+
+function openOver(row: HTMLElement, over: Partial<ScrollbackMessage>): void {
+  openMessageMenu({
+    msg: { ...msg(), ...over } as ScrollbackMessage,
+    row,
+    networkSlug: NET,
+    channelName: CHAN,
+    at: { x: 10, y: 20 },
+  });
+}
+
+function labels(): string[] {
+  return [...document.querySelectorAll(".context-menu-item")].map((b) => b.textContent ?? "");
+}
+
+describe("the !addquote item", () => {
+  beforeEach(() => setDraft(KEY, ""));
+
+  // Position included: `!addquote` is a quoting verb, so it belongs next to
+  // Reply, and Select… stays last as the escape hatch back to a native
+  // selection. Asserting the whole list makes a missing item and a misplaced
+  // one the same failure.
+  it("sits between Reply and Select…", () => {
+    render(() => <MessageContextMenu />);
+    openOver(scrollbackRow("12:34 <vjt> ciao"), {});
+    expect(labels()).toEqual(["Copy", "Reply", "!addquote", "Select…"]);
+  });
+
+  it("drops the command plus the message text into the compose box", () => {
+    mountCompose();
+    render(() => <MessageContextMenu />);
+    openOver(scrollbackRow("12:34 <vjt> ciao"), { body: "ciao mondo" });
+    fireEvent.click(screen.getByText("!addquote"));
+    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+  });
+
+  // Disabled but VISIBLE, the posture Reply already takes: the menu's shape
+  // must not jump between rows. A conditionally-rendered item would pass a
+  // "does nothing" assertion and still fail this one.
+  it("stays visible but disabled on a row with nothing to quote", () => {
+    render(() => <MessageContextMenu />);
+    openOver(scrollbackRow("12:34 → vjt joined"), { kind: "join", body: null });
+    const item = screen.getByText("!addquote");
+    expect(item).toBeTruthy();
+    expect((item as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -66,10 +66,17 @@ describe("addQuoteCommand", () => {
     expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote bold plain");
   });
 
-  // A presence row has no author speaking, and a PART carries its reason in
-  // `body` — a bare body check would happily quote `!addquote Leaving`.
   it("refuses a presence row", () => {
     expect(addQuoteCommand(msg({ kind: "join", body: null }))).toBeNull();
+  });
+
+  // The arm above is VACUOUS with respect to the content-kind gate, measured:
+  // deleting `isContentKind` from `quotableBody` leaves it green, because a
+  // JOIN's null body is refused one line later by the empty-body check. A PART
+  // is the row that separates them — it carries its reason in `body`, so only
+  // the kind gate stands between `!addquote Leaving` and the quote database.
+  it("refuses a PART even though it carries a reason in its body", () => {
+    expect(addQuoteCommand(msg({ kind: "part", body: "Leaving" }))).toBeNull();
   });
 
   it("refuses a row whose body is empty or whitespace", () => {
@@ -155,16 +162,24 @@ describe("addQuoteToCompose", () => {
     expect(getDraft(KEY)).toBe("");
   });
 
-  // The caret must land at the END and be VISIBLE: `!addquote ` plus a body
+  // The caret must land at the END and be REVEALED: `!addquote ` plus a body
   // overflows the rows=1 textarea essentially every time, which is why #1107
-  // was blocked on #1105/#1113. Shared through `appendToCompose`, so this pins
-  // that the item uses that verb rather than writing the draft by hand.
-  it("leaves the caret at the end of the filled draft", async () => {
+  // waited on #1105/#1113.
+  //
+  // A `selectionStart` assertion alone is VACUOUS here, measured: jsdom already
+  // parks the caret at the end of a freshly assigned `value`, so it stays green
+  // with the reveal deleted from `appendToCompose`. jsdom does no layout either
+  // — `scrollHeight` is 0 on every element — so the overflow is stubbed, which
+  // is what makes the scroll ASSIGNMENT observable. That a real engine then
+  // shows the caret is the e2e's job, not this one's.
+  it("reveals the caret by scrolling the overflowing textarea", async () => {
     const ta = mountCompose();
+    Object.defineProperty(ta, "scrollHeight", { value: 75, configurable: true });
+    setDraft(KEY, "x".repeat(110));
     addQuoteToCompose(msg({}), NET, CHAN);
     ta.value = getDraft(KEY);
     await Promise.resolve();
-    expect(ta.selectionStart).toBe("!addquote ciao mondo".length);
+    expect(ta.scrollTop).toBe(75);
     expect(document.activeElement).toBe(ta);
   });
 });

--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { addQuoteCommand, addQuoteToCompose } from "../lib/addQuote";
+import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+import { getDraft, setDraft } from "../lib/compose";
+
+// #1107 — the `!addquote` menu item: it drops `!addquote ` plus the message
+// text into the compose box and stops there. cic never sends it and never
+// interprets it; whatever bot sits in the channel does.
+//
+// THE PAYLOAD IS THE BARE BODY — no `<nick>` head, no `<< ` tail. That is the
+// issue's open question, ruled on the requester's literal words ("mette nel
+// composebox '!addquote' e poi il messaggio"). The rule is pinned by its own
+// assertion below so a later reshaping cannot take it silently.
+
+const NET = "azzurra";
+const CHAN = "#grappa";
+const KEY = channelKey(NET, CHAN);
+
+function msg(over: Partial<ScrollbackMessage>): ScrollbackMessage {
+  return {
+    id: 1,
+    network: NET,
+    channel: CHAN,
+    server_time: 1_700_000_000_000,
+    kind: "privmsg",
+    sender: "vjt",
+    body: "ciao mondo",
+    meta: {},
+    ...over,
+  } as ScrollbackMessage;
+}
+
+function mountCompose(): HTMLTextAreaElement {
+  const box = document.createElement("div");
+  box.className = "compose-box";
+  const ta = document.createElement("textarea");
+  box.appendChild(ta);
+  document.body.appendChild(box);
+  return ta;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  setDraft(KEY, "");
+});
+
+describe("addQuoteCommand", () => {
+  it("prefixes the message text with the bot command", () => {
+    expect(addQuoteCommand(msg({}))).toBe("!addquote ciao mondo");
+  });
+
+  // The ruling, pinned on its own. Co-killed with the shape assertion above by
+  // a "carry the nick" implementation, and kept anyway: it is the answer to the
+  // issue's open question, and a future reshaping of the payload must trip over
+  // it explicitly rather than quietly reword the string above.
+  it("carries no nick — the payload is the bare body", () => {
+    expect(addQuoteCommand(msg({ sender: "vjt", body: "ciao mondo" }))).not.toContain("vjt");
+  });
+
+  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
+  // operator is quoting what they SEE, and a control byte round-tripped through
+  // compose would be re-sent as formatting they never chose.
+  it("strips mIRC control codes out of the quoted body", () => {
+    expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote bold plain");
+  });
+
+  // A presence row has no author speaking, and a PART carries its reason in
+  // `body` — a bare body check would happily quote `!addquote Leaving`.
+  it("refuses a presence row", () => {
+    expect(addQuoteCommand(msg({ kind: "join", body: null }))).toBeNull();
+  });
+
+  it("refuses a row whose body is empty or whitespace", () => {
+    expect(addQuoteCommand(msg({ body: "" }))).toBeNull();
+    expect(addQuoteCommand(msg({ body: "   " }))).toBeNull();
+    expect(addQuoteCommand(msg({ body: null }))).toBeNull();
+  });
+
+  // Same posture as Reply: an authorless content row is not somebody being
+  // quoted, so the item stays disabled rather than producing an orphan quote.
+  it("refuses a row with no sender", () => {
+    expect(addQuoteCommand(msg({ sender: "" }))).toBeNull();
+  });
+
+  it("quotes a notice like speech — it has an author and a body", () => {
+    expect(addQuoteCommand(msg({ kind: "notice" }))).toBe("!addquote ciao mondo");
+  });
+
+  // An action's stored body is the raw `\x01ACTION …\x01` wire form (the
+  // CLAUDE.md "preserved as-is" rule). `mircPlainText` deliberately leaves \x01
+  // alone, so without the unwrap both delimiters and the verb would ride into
+  // the compose box — the #1126 defect, at a second door.
+  it("unwraps a CTCP action down to its text", () => {
+    expect(addQuoteCommand(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
+      "!addquote si dà alla fuga",
+    );
+  });
+
+  // The protocol half of the same defect, asserted separately: a \x01 we
+  // generated inside an ordinary PRIVMSG. Co-killed with the shape above by a
+  // missing unwrap, kept because it is the byte-level statement.
+  it("leaves no \\x01 and no ACTION verb in the command", () => {
+    const cmd = addQuoteCommand(msg({ kind: "action", body: "\x01ACTION waves\x01" })) ?? "";
+    expect(cmd).not.toContain("\x01");
+    expect(cmd).not.toContain("ACTION");
+  });
+
+  it("refuses an action whose envelope is empty", () => {
+    expect(addQuoteCommand(msg({ kind: "action", body: "\x01ACTION \x01" }))).toBeNull();
+  });
+
+  // #1123's rule, inherited: the body being quoted may itself be a reply,
+  // carrying the quote it answered plus the `<< ` tail. Quoting the whole hop
+  // into a quote DATABASE is worse than into a reply — the stored quote would
+  // attribute someone else's line to this sender forever.
+  it("drops a previous reply-quote out of the body", () => {
+    expect(addQuoteCommand(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "!addquote answer",
+    );
+  });
+
+  it("refuses a body that is only a previous reply-quote", () => {
+    expect(addQuoteCommand(msg({ sender: "alice", body: "<bob> original<< " }))).toBeNull();
+  });
+
+  // `<<` is ordinary text and must not be mistaken for a quote tail.
+  it("leaves a shift expression alone", () => {
+    expect(addQuoteCommand(msg({ body: "shift << 2 gives four" }))).toBe(
+      "!addquote shift << 2 gives four",
+    );
+  });
+});
+
+describe("addQuoteToCompose", () => {
+  it("fills an empty compose with exactly the command", () => {
+    mountCompose();
+    addQuoteToCompose(msg({}), NET, CHAN);
+    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+  });
+
+  // Never destroy work in progress: the command lands AFTER what is already
+  // there, the same posture Reply takes.
+  it("does not clobber an existing draft", () => {
+    mountCompose();
+    setDraft(KEY, "bozza ");
+    addQuoteToCompose(msg({}), NET, CHAN);
+    expect(getDraft(KEY)).toBe("bozza !addquote ciao mondo");
+  });
+
+  it("writes nothing for an unquotable row", () => {
+    mountCompose();
+    addQuoteToCompose(msg({ kind: "part", body: null }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("");
+  });
+
+  // The caret must land at the END and be VISIBLE: `!addquote ` plus a body
+  // overflows the rows=1 textarea essentially every time, which is why #1107
+  // was blocked on #1105/#1113. Shared through `appendToCompose`, so this pins
+  // that the item uses that verb rather than writing the draft by hand.
+  it("leaves the caret at the end of the filled draft", async () => {
+    const ta = mountCompose();
+    addQuoteToCompose(msg({}), NET, CHAN);
+    ta.value = getDraft(KEY);
+    await Promise.resolve();
+    expect(ta.selectionStart).toBe("!addquote ciao mondo".length);
+    expect(document.activeElement).toBe(ta);
+  });
+});

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -1,0 +1,43 @@
+import type { ScrollbackMessage } from "./api";
+import { appendToCompose } from "./composeAppend";
+import { quotableBody } from "./quotableBody";
+
+// #1107 — the `!addquote` verb behind the message menu's fourth item. It fills
+// the compose box and stops: nothing is sent, and cic does not know or care
+// what `!addquote` means. Whatever bot sits in the channel interprets it, and
+// the operator gets to read the line before pressing enter.
+//
+// THE PAYLOAD IS THE BARE BODY. The issue leaves that open ("whether the
+// payload is the bare body or carries the nick") because bots differ; it is
+// ruled on the requester's literal words — `!addquote` and then the message.
+// A wrapper is one line away in either direction, and guessing WIDER is the
+// worse guess: a bot that wants attribution can read the nick off the channel,
+// while a bot that stores its input verbatim would put `<vjt>` inside every
+// stored quote with no way for the operator to know until it is recalled.
+export const ADDQUOTE_COMMAND = "!addquote ";
+
+// The command line for a message, or null when the row has nothing to quote —
+// the same refusals Reply makes, because they are the same question ("did
+// somebody say something here?") and `quotableBody` is where they live.
+//
+// An ACTION contributes its text without the `* nick` form Reply gives it: the
+// payload carries no attribution at all, so half of one for one kind would be
+// a shape the operator cannot predict from the menu.
+export function addQuoteCommand(msg: ScrollbackMessage): string | null {
+  const body = quotableBody(msg);
+  return body === null ? null : `${ADDQUOTE_COMMAND}${body}`;
+}
+
+// Drop the command into the window's compose box with the caret at the end and
+// REVEALED — `!addquote ` plus a body overflows the rows=1 textarea nearly
+// every time, which is why #1107 waited on #1105/#1113. `appendToCompose` owns
+// that dance; going around it is how the caret got lost the first time.
+export function addQuoteToCompose(
+  msg: ScrollbackMessage,
+  networkSlug: string,
+  channelName: string,
+): void {
+  const command = addQuoteCommand(msg);
+  if (command === null) return;
+  appendToCompose(networkSlug, channelName, command);
+}

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -1,0 +1,64 @@
+import { isContentKind, type ScrollbackMessage } from "./api";
+import { stripCtcpAction } from "./ctcpAction";
+import { mircPlainText } from "./mircFormat";
+
+// What a scrollback row contributes to a quote: the words its sender actually
+// wrote, as the operator SAW them, or null when the row has nothing to quote.
+//
+// #1107 — lifted out of `replyQuote` when the `!addquote` item needed the same
+// answer with a different wrapper. Every clause below is a ruling that took an
+// issue to reach (#1067's presence gate, #1123's nesting cut, #1126's CTCP
+// unwrap); copying them into a second module would be copying five bugs'
+// worth of history and would let the two doors drift apart on the next one.
+//
+// The WRAPPER is the caller's business — `replyQuote` puts a `<nick> …<< `
+// around this, `addQuoteCommand` puts `!addquote ` in front of it.
+
+// #1123 — the nick charset, mirrored from the server's
+// `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
+// letter-or-special, the tail adds digits and `-`, 30 chars total). Derived
+// rather than invented: a narrower guess would refuse to strip a real
+// `<foo[1]> ` head, and a wider one starts eating ordinary prose.
+const NICK = "[A-Za-z\\[\\]\\\\`_^{|}][\\w\\[\\]\\\\`_^{|}-]{0,29}";
+
+// A previous reply-quote sitting at the head of a body. Anchored at position 0
+// and shaped like what `replyQuote` emits — `<nick> ` for speech, `* nick ` for
+// an action (#1126) — because a bare `<<` search would eat ordinary text
+// (`shift << 2`, `cat <<EOF`), which is worse than the nesting it fixes.
+//
+// `[\s\S]*` is greedy on purpose: the cut lands on the LAST tail, so a body
+// persisted before this fix sheds every hop it accumulated, not just the
+// oldest. The tail also counts flush against the end of the body — a sender
+// whose whole message was a quote wrote nothing of their own.
+const PREVIOUS_QUOTE = new RegExp(`^(?:<${NICK}>|\\* ${NICK}) [\\s\\S]*<<(?: |$)`);
+
+// What the sender actually wrote: their body minus the quote they were
+// answering. Returns the body untouched when it is not quote-shaped.
+function withoutPreviousQuote(body: string): string {
+  return body.replace(PREVIOUS_QUOTE, "").trim();
+}
+
+// Only CONTENT kinds quote (`isContentKind` — privmsg/notice/action, the same
+// classifier the unread/badge math uses). A presence row is not somebody
+// speaking: a PART carries a reason in `body`, so a bare body check would
+// happily quote `Leaving`.
+export function quotableBody(msg: ScrollbackMessage): string | null {
+  if (!isContentKind(msg.kind)) return null;
+  if (msg.sender === "") return null;
+  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
+  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
+  // holds the text the operator actually saw. `mircPlainText` deliberately
+  // leaves \x01 alone (its call sites need the envelope to round-trip), so
+  // stripping there would have been the wrong door.
+  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
+  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
+  // operator is quoting what they SEE, and a control byte round-tripped through
+  // compose would be re-sent as formatting they never chose.
+  // #1123 — the body being quoted may itself be a reply, carrying its own
+  // quote plus the `<< ` tail. Left in, every hop drags the whole history
+  // forward and the line actually being answered ends up buried mid-string.
+  // Dropping it can empty the body: a sender whose message was nothing but a
+  // quote said nothing to quote back.
+  const body = withoutPreviousQuote(mircPlainText(raw).trim());
+  return body === "" ? null : body;
+}

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,7 +1,6 @@
-import { isContentKind, type ScrollbackMessage } from "./api";
+import type { ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
-import { stripCtcpAction } from "./ctcpAction";
-import { mircPlainText } from "./mircFormat";
+import { quotableBody } from "./quotableBody";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
 // the long-press menu's Reply item. Both doors, one code path.
@@ -14,55 +13,14 @@ import { mircPlainText } from "./mircFormat";
 // space included, so the answer is typed straight after the caret.
 export const REPLY_QUOTE_TAIL = "<< ";
 
-// #1123 — the nick charset, mirrored from the server's
-// `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
-// letter-or-special, the tail adds digits and `-`, 30 chars total). Derived
-// rather than invented: a narrower guess would refuse to strip a real
-// `<foo[1]> ` head, and a wider one starts eating ordinary prose.
-const NICK = "[A-Za-z\\[\\]\\\\`_^{|}][\\w\\[\\]\\\\`_^{|}-]{0,29}";
-
-// A previous reply-quote sitting at the head of a body. Anchored at position 0
-// and shaped like what THIS module emits — `<nick> ` for speech, `* nick ` for
-// an action (#1126) — because a bare `<<` search would eat ordinary text
-// (`shift << 2`, `cat <<EOF`), which is worse than the nesting it fixes.
-//
-// `[\s\S]*` is greedy on purpose: the cut lands on the LAST tail, so a body
-// persisted before this fix sheds every hop it accumulated, not just the
-// oldest. The tail also counts flush against the end of the body — a sender
-// whose whole message was a quote wrote nothing of their own.
-const PREVIOUS_QUOTE = new RegExp(`^(?:<${NICK}>|\\* ${NICK}) [\\s\\S]*<<(?: |$)`);
-
-// What the sender actually wrote: their body minus the quote they were
-// answering. Returns the body untouched when it is not quote-shaped.
-function withoutPreviousQuote(body: string): string {
-  return body.replace(PREVIOUS_QUOTE, "").trim();
-}
-
 // The quote for a message, or null when there is nothing to reply to.
 //
-// Only CONTENT kinds quote (`isContentKind` — privmsg/notice/action, the same
-// classifier the unread/badge math uses). A presence row is not somebody
-// speaking: a PART carries a reason in `body`, so a bare body check would
-// happily quote `<vjt> Leaving<< `.
+// #1107 — the gate and the plain-text extraction moved to `quotableBody`, which
+// `addQuoteCommand` now shares. What stays here is the WRAPPER, which is the
+// only part reply owns.
 export function replyQuote(msg: ScrollbackMessage): string | null {
-  if (!isContentKind(msg.kind)) return null;
-  if (msg.sender === "") return null;
-  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
-  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
-  // holds the text the operator actually saw. `mircPlainText` deliberately
-  // leaves \x01 alone (its call sites need the envelope to round-trip), so
-  // stripping there would have been the wrong door.
-  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
-  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
-  // operator is quoting what they SEE, and a control byte round-tripped through
-  // compose would be re-sent as formatting they never chose.
-  // #1123 — the body being quoted may itself be a reply, carrying its own
-  // quote plus the `<< ` tail. Left in, every hop drags the whole history
-  // forward and the line actually being answered ends up buried mid-string.
-  // Dropping it can empty the body: a sender whose message was nothing but a
-  // quote said nothing to reply to, which the check below already refuses.
-  const body = withoutPreviousQuote(mircPlainText(raw).trim());
-  if (body === "") return null;
+  const body = quotableBody(msg);
+  if (body === null) return null;
   // #1126 — an action is NOT speech. Quoting `* vjt waves` as `<vjt> waves`
   // puts a sentence in someone's mouth that they never said, so the quote keeps
   // the `* nick …` form the scrollback renders. Ruled on the least-surprise

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36909,6 +36909,9 @@ only taps do — and that the arm survives as a cross-platform net. If that is
 true, the line will never print for a long-press on device and the plan cannot
 separate anything. Not verified on device either: this is the code contradicting
 the issue text, which is a result worth recording rather than a measurement.
+
+---
+
 ## 2026-08-10 — #1107: `!addquote` fills the box and stops, and the payload carries no nick
 
 A fourth item in the scrollback's message menu, beside Copy / Reply / Select….

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36968,10 +36968,36 @@ nothing and returned rc=1 every time. A run with no unmutated baseline cannot
 tell a kill from a broken runner. The baseline came second and should have come
 first.
 
-**The e2e spec is written and has NOT been run** — this branch had no e2e lane.
-It covers the two things jsdom is structurally blind to: that a real engine
-scrolls the overflowing compose box down to the caret (the #1105/#1113
-dependency the issue names — `!addquote ` plus a body overflows the rows=1
-textarea nearly every time), and that nothing goes out on the wire. The static
-half of the gate did run: `bun run check` is biome plus tsc over
-`e2e/tsconfig.json`, rc=0.
+**The e2e spec covers the two things jsdom is structurally blind to**: that a
+real engine scrolls the overflowing compose box down to the caret (the
+#1105/#1113 dependency the issue names), and that nothing goes out on the wire.
+It was read RED by displacement and then green, 3 passed.
+
+**Its first red was the spec's own setup, and the oracle is what caught it.**
+`expectEndCaretVisible` refuses to run unless the draft really overflows —
+`scrollHeight > clientHeight + minOverflowPx` — and at a 1280px viewport it
+refused: 73 against a required 82. A wide compose wraps the fixture twice, and
+the guard exists precisely so "the caret is in view" cannot pass on a draft that
+never left line one. Lowering the threshold would have bought a green by
+disarming the guard.
+
+The cure was the VIEWPORT, not the body, and the arithmetic is why. Clearing the
+margin at 1280px needs four wrapped lines, roughly 330 characters; the line
+budget is 512 bytes less `LineSplit`'s source-prefix reserve (1 + 30 + 1 + 10 +
+1 + 63 + 1 = 107) less the `PRIVMSG #channel :` envelope and CRLF, so about 380
+for the body. A 330-byte fixture inside a 380-byte budget overflows on this host
+and splits into two scrollback rows on one with a longer nick. Moving the arm to
+390px instead measures 109px of overflow against the 40 required — and 390px is
+where the defect lives anyway, which is why #1105 measured it there. `hasTouch`
+comes along out of necessity: `selectChannel` takes the mobile branch at that
+width and reaches the window with `tap()`, which throws on a context without it.
+
+**Displacement, not deduction.** With `placeCaretAtEndInView` removed from
+`appendToCompose`, the overflow guard PASSES and `selStart == valueLen` PASSES —
+the fixture does overflow, the caret is at the end — and only `scrollTop > 0`
+fails, receiving 0. The other two arms stay green under the same displacement,
+so exactly one arm measures the reveal. A first attempt at that displacement
+never reached the oracle: deleting the call left the import unused, `tsc
+--noEmit` failed inside the `cicchetto-build-test` oneshot, and the stack died
+before a single test ran. An e2e mutant has to keep the BUNDLE buildable, or the
+harness dies upstream of the thing being measured.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -36909,3 +36909,66 @@ only taps do — and that the arm survives as a cross-platform net. If that is
 true, the line will never print for a long-press on device and the plan cannot
 separate anything. Not verified on device either: this is the code contradicting
 the issue text, which is a result worth recording rather than a measurement.
+## 2026-08-10 — #1107: `!addquote` fills the box and stops, and the payload carries no nick
+
+A fourth item in the scrollback's message menu, beside Copy / Reply / Select….
+Picking it puts `!addquote ` plus the message text into the compose box and
+does nothing else: cic does not send it and does not know what it means. The
+command is interpreted by whatever bot sits in the channel, and the operator
+reads the line before pressing enter.
+
+**The payload is the BARE BODY — no nick.** The issue left this open because
+bots differ, and it is settled on the requester's literal words: the command,
+and then the message. The tiebreak that made it easy is that the two guesses
+are not symmetric. A bot that wants attribution can read the nick off the
+channel it received the command on; a bot that stores its input verbatim would
+bake `<vjt>` into every stored quote, invisible until someone recalls it months
+later. Guessing narrow is recoverable, guessing wide is not, and reversing the
+ruling is one string constant either way. An ACTION contributes its text
+without the `* nick` form Reply gives it, for the same reason: the payload
+carries no attribution for any kind, so attributing exactly one would be a
+shape the operator cannot predict from the menu.
+
+**The quotable-body rules moved out of `replyQuote` into
+`lib/quotableBody.ts`.** Deciding whether a row has anything quotable in it,
+and extracting the words the operator actually saw, is now shared; what stays
+in `replyQuote` is the `<nick> …<< ` wrapper, which is the only part reply
+owns. This is not tidying: every clause in that shared half is a ruling that
+cost an issue — #1067's content-kind gate, #1123's previous-quote cut and the
+nick charset it is anchored on, #1126's CTCP unwrap. Copying them would have
+copied five bugs' worth of history into a second module and let the two doors
+drift on the sixth. It is a named module rather than an export from
+`replyQuote` because importing "reply" from an addquote path is a name that
+lies.
+
+Nesting matters MORE here than it does for a reply. A reply that drags
+`<bob> original<< ` forward is ugly for one message; the same body handed to a
+quote DATABASE attributes bob's line to alice permanently.
+
+**Two guards were passing vacuously, and the mutation run is what said so.**
+Fourteen single-point mutations, twelve killed, two survivors — both mine.
+`refuses a presence row` fed a JOIN with a null body, so deleting the
+content-kind gate left it green: the empty-body check one line down refused the
+row instead. The input that separates them is a PART, which carries its reason
+in `body` — without the gate, parting a channel offers `!addquote Leaving`.
+And `leaves the caret at the end` asserted `selectionStart` in jsdom, which
+already parks the caret at the end of a freshly assigned `value`, so deleting
+the caret reveal from `appendToCompose` left it green too. The general lesson
+is the one worth keeping: an assertion whose subject is refused one line
+EARLIER by a different rule is not testing the rule it is named after, and the
+only way to find out is to delete the rule and watch.
+
+**A harness has to prove itself first.** The first pass of that mutation run
+reported all fourteen mutants killed, which was an artifact: it passed
+repo-relative test paths while bun's cwd is `cicchetto/`, so vitest matched
+nothing and returned rc=1 every time. A run with no unmutated baseline cannot
+tell a kill from a broken runner. The baseline came second and should have come
+first.
+
+**The e2e spec is written and has NOT been run** — this branch had no e2e lane.
+It covers the two things jsdom is structurally blind to: that a real engine
+scrolls the overflowing compose box down to the caret (the #1105/#1113
+dependency the issue names — `!addquote ` plus a body overflows the rows=1
+textarea nearly every time), and that nothing goes out on the wire. The static
+half of the gate did run: `bun run check` is biome plus tsc over
+`e2e/tsconfig.json`, rc=0.


### PR DESCRIPTION
Issue #1107. A fourth item in the scrollback's message menu, beside Copy / Reply / Select…. Picking it puts `!addquote ` plus the message text into the compose box and stops: cic does not send it and does not know what it means. The command is for whatever bot is in the channel, and the operator reads the line before pressing enter.

## The open question, answered: the payload is the bare body

The issue leaves it open ("whether the payload is the bare body or carries the nick") because bots differ. Ruled on the requester's literal words — the command, then the message — with this tiebreak: the two guesses are not symmetric. A bot that wants attribution can read the nick off the channel it received the command on; a bot that stores its input verbatim bakes `<vjt>` into every stored quote, invisible until someone recalls it months later. Guessing narrow is recoverable, guessing wide is not. Reversing it is one string constant.

An ACTION contributes its text without the `* nick` form Reply gives it, for the same reason: the payload carries no attribution for any kind, so attributing exactly one would be a shape the operator cannot predict from the menu.

## The shared half moved out of `replyQuote`

Deciding whether a row has anything quotable in it, and extracting the words the operator actually saw, now lives in `lib/quotableBody.ts`; `replyQuote` keeps only the `<nick> …<< ` wrapper. Not tidying — every clause in that shared half is a ruling that cost an issue (#1067's content-kind gate, #1123's previous-quote cut, #1126's CTCP unwrap), and a second copy would have carried five bugs' worth of history into a new module. `replyQuote`'s 26 existing assertions pass unmodified, which is what makes it a lift rather than a rewrite.

Nesting matters more here than for a reply: a body dragged forward as `<bob> original<< ` is ugly for one message, but handed to a quote DATABASE it attributes bob's line to alice permanently.

## Two guards were passing vacuously

Fourteen single-point mutations against the committed source. Twelve killed, two survivors, both mine:

- `refuses a presence row` fed a JOIN with a null body, so deleting `isContentKind` left it green — the empty-body check one line down refused the row instead. A PART is the separating input: it carries its reason in `body`, so without the gate, parting offers `!addquote Leaving`.
- `leaves the caret at the end` asserted `selectionStart` in jsdom, which already parks the caret at the end of a freshly assigned `value`, so deleting the caret reveal from `appendToCompose` left it green too.

Both were rewritten and both mutations re-run: each now kills exactly one assertion against a 22-passing unmutated baseline.

The harness itself needed correcting first. Its first pass reported all fourteen killed — an artifact of passing repo-relative test paths while bun's cwd is `cicchetto/`, so vitest matched no files and returned rc=1 every time. It now runs an unmutated baseline before anything else and refuses to report when no test files match.

## Gates

- `scripts/bun.sh run test` — **rc=0**, 272 files / 5021 tests passed.
- `scripts/bun.sh run check` (biome + tsc over `src` and `e2e/tsconfig.json`) — **rc=0**, 978 files, no new diagnostic on top of the 61 warnings already standing.
- The guard was read RED before the implementation: `addQuote.test.ts` failed to resolve `../lib/addQuote`, and the three menu arms reported the live item list as `['Copy', 'Reply', 'Select…']`.
- `scripts/integration.sh --project chromium --grep issue1107` — **3 passed**, on the rebased tree, gated on the parsed summary line rather than on `$?`.

### The e2e's first red was mine, not the product's

CI and my local run agreed: `expectEndCaretVisible` failed its own non-vacuity guard at a 1280px viewport — `scrollHeight` 73 against a required `clientHeight` (42) + 40 = 82. That guard exists so "the caret is in view" cannot pass on a draft that never left line one, so lowering `minOverflowPx` was not on the table.

The cure is the VIEWPORT, not a longer body, and the arithmetic decides it. Clearing the margin at 1280px needs four wrapped lines — roughly 330 characters. The line budget is 512 bytes less `LineSplit`'s source-prefix reserve (1 + 30 nick + 1 + 10 ident + 1 + 63 host + 1 = 107) less the `PRIVMSG #channel :` envelope and CRLF, so about 380 for the body. A 330-byte fixture inside a 380-byte budget overflows here and splits into two scrollback rows on a host with a longer nick. Moving the arm to 390px measures **109px of overflow against the 40 required** — and 390px is where the defect lives anyway, which is why #1105 measured it there. `hasTouch: true` rides along out of necessity: `selectChannel` takes the mobile branch at that width and reaches the window with `tap()`, which throws on a context without touch support.

**Read red by displacement, not deduction.** With `placeCaretAtEndInView` removed from `appendToCompose`: the overflow guard PASSES, `selStart == valueLen` PASSES, and only `scrollTop > 0` fails, receiving 0 — the #1105 defect itself. The other two arms stay green under the same displacement, so exactly one arm measures the reveal.

A first attempt at that displacement never reached the oracle: deleting the call left the import unused, `tsc --noEmit` failed inside the `cicchetto-build-test` oneshot, and the stack died before a single test ran. An e2e mutant has to keep the bundle compiling, or the harness dies upstream of the thing being measured.

## What is NOT claimed

Nothing about how the item feels under a real finger: the e2e synthesises no touch for it, and the touch long-press reaches the same item list from the same store, so that path is argued rather than measured.

Nothing here says how the item feels under a real finger on iOS; the touch long-press reaches the same item list from the same store, and re-testing it would drift against the #1067 spec rather than add coverage.

**Three assertions have no unique killer in the mutant set, and are not offered as proof.** They stay because they document a case, and deleting them would lose the record of why a rule exists — but nothing below should be read as evidence that the rule holds:

- `refuses a presence row` (a JOIN with a null body) is subsumed by the PART arm: no mutation kills it. A presence row is still the case the content-kind gate exists FOR, so it documents the gate; the PART arm is what proves it.
- `quotes a notice like speech` pins only that `notice` is in `CONTENT_KINDS`. No mutation in the set separates it from the exact-shape arm.
- `leaves a shift expression alone` guards against a bare `<<` substring search eating ordinary text. **That mutant was not written**, so the arm is a stated intention rather than a measured one.

Arms were not padded out to cover mutants that were never run. Where the killer is missing, it is said so here.

