### PR TITLE
Warn before sending when the draft exceeds one IRC frame (#1108)

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -1,4 +1,4 @@
-import { type Component, createSignal, onCleanup, Show } from "solid-js";
+import { type Component, createMemo, createSignal, onCleanup, Show } from "solid-js";
 import { isDiagEnabled } from "./DiagFloat";
 import { channelKey } from "./lib/channelKey";
 import {
@@ -388,11 +388,14 @@ const ComposeBox: Component<Props> = (props) => {
   // parked session, or a server older than the field. Both affordances below
   // then stay dark — a warning computed from an invented budget would be a
   // number the operator cannot act on.
-  const framePreviewNow = () => {
+  // A memo, not a plain accessor: both surfaces below read it, and the work
+  // behind it is a `parseSlash` plus a full grapheme walk of the draft — per
+  // keystroke, twice, if each caller recomputed it.
+  const framePreviewNow = createMemo(() => {
     const base = frameBudgetBaseForNetwork(networkBySlug(props.networkSlug)?.id ?? null);
     const budget = frameBudgetForTarget(base, props.channelName);
-    return budget === null ? null : draftFramePreview(getDraft(key()), budget);
-  };
+    return budget === null ? null : draftFramePreview(props.channelName, getDraft(key()), budget);
+  });
 
   // The seam's third state: the draft no longer fits one frame. Copy states
   // the message COUNT and nothing else — a character tally in the seam was

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -2,6 +2,7 @@ import { type Component, createSignal, onCleanup, Show } from "solid-js";
 import { isDiagEnabled } from "./DiagFloat";
 import { channelKey } from "./lib/channelKey";
 import {
+  draftFramePreview,
   getDraft,
   isDraining,
   isQueueFull,
@@ -15,6 +16,8 @@ import {
 import { placeCaretAtEndInView, placeCaretInView } from "./lib/composeCaret";
 import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
+import { frameBudgetForTarget } from "./lib/frameBudget";
+import { frameBudgetBaseForNetwork } from "./lib/isupport";
 import { networkBySlug } from "./lib/networks";
 import { routeClipboardPaste } from "./lib/pasteRoute";
 import {
@@ -91,6 +94,11 @@ export type Props = {
   channelName: string;
 };
 
+// #1108 — how close to the frame's edge the byte countdown appears. Ten
+// bytes, per the request: enough warning to finish a word, short enough that
+// it is not on screen while composing normally.
+const COUNTDOWN_FROM = 10;
+
 const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
@@ -117,6 +125,19 @@ type Feedback = { text: string; severity: "error" | "notice" };
 function releasedInside(rect: DOMRect, x: number, y: number): boolean {
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
 }
+
+// The amber seam line. Its own component only so the feedback `Show`'s
+// fallback stays a single expression; the copy and the precedence live at
+// the call site.
+const SplitWarningLine: Component<{ text: string | null }> = (props) => (
+  <Show when={props.text}>
+    {(text) => (
+      <p class="compose-box-warning" role="status">
+        {text()}
+      </p>
+    )}
+  </Show>
+);
 
 const ComposeBox: Component<Props> = (props) => {
   const key = () => channelKey(props.networkSlug, props.channelName);
@@ -360,6 +381,44 @@ const ComposeBox: Component<Props> = (props) => {
     return s !== undefined && NOT_JOINED_STATES.has(s);
   };
 
+  // #1108 — what this draft will do to the wire, from the budget the SERVER
+  // published for this network (`frame_budget_base`; cic never computes the
+  // #246 relay reserve itself) minus this target's own byte length. `null`
+  // all the way through when no budget has arrived: an unseeded network, a
+  // parked session, or a server older than the field. Both affordances below
+  // then stay dark — a warning computed from an invented budget would be a
+  // number the operator cannot act on.
+  const framePreviewNow = () => {
+    const base = frameBudgetBaseForNetwork(networkBySlug(props.networkSlug)?.id ?? null);
+    const budget = frameBudgetForTarget(base, props.channelName);
+    return budget === null ? null : draftFramePreview(getDraft(key()), budget);
+  };
+
+  // The seam's third state: the draft no longer fits one frame. Copy states
+  // the message COUNT and nothing else — a character tally in the seam was
+  // ruled out as a distraction (#1108), and the countdown below is where the
+  // arithmetic belongs.
+  const splitWarning = (): string | null => {
+    const preview = framePreviewNow();
+    if (preview === null || preview.messages < 2) return null;
+    return `your message will send as ${preview.messages} separate messages`;
+  };
+
+  // The last ten bytes of the frame, counted down. Hidden until then, and
+  // hidden again the moment the draft splits — past the edge the seam line is
+  // the honest surface. Zero is shown: at exactly the budget the draft is
+  // still ONE message, so leaving it out would blink the counter off for one
+  // byte before the warning appears.
+  // Formatted here, not in the markup: zero is a legal value and a bare
+  // number would be swallowed by the `Show` below as falsy — the one byte of
+  // room where the counter must be MOST visible.
+  const frameCountdown = (): string | null => {
+    const preview = framePreviewNow();
+    const remaining = preview?.remainingBytes ?? null;
+    if (remaining === null || remaining > COUNTDOWN_FROM) return null;
+    return remaining === 0 ? "0" : `-${remaining}`;
+  };
+
   const onInput = (e: Event) => {
     const value = (e.currentTarget as HTMLTextAreaElement).value;
     setDraft(key(), value);
@@ -493,6 +552,21 @@ const ComposeBox: Component<Props> = (props) => {
 
   return (
     <>
+      {/* #1108 — bytes left in the frame, for the last ten of them. Purely
+          visual: aria-hidden, because a live region that changes on every
+          keystroke is noise, and the thing worth ANNOUNCING (the draft will
+          split) is the polite seam line below. */}
+      <Show when={frameCountdown()} keyed>
+        {(label) => (
+          <p
+            class="compose-box-frame-countdown"
+            data-testid="compose-frame-countdown"
+            aria-hidden="true"
+          >
+            {label}
+          </p>
+        )}
+      </Show>
       <form
         class={`compose-box${greyed() ? " compose-box-greyed" : ""}`}
         onSubmit={(e) => {
@@ -763,7 +837,15 @@ const ComposeBox: Component<Props> = (props) => {
           green notice) and the ARIA live role: role=alert (assertive) for
           errors the operator must read, role=status (polite) for the
           auto-dismissing success notice. */}
-      <Show when={feedback()}>
+      {/* #1108 — the seam's THIRD state, amber, and the one that loses the
+          line: submit feedback (error OR notice) outranks it. An error is
+          the more urgent read and the geometry is shared, so both cannot be
+          up at once; the collision is real rather than theoretical, because
+          a paced send that fails puts its residue back in the draft (#666)
+          while its error is still sticky. A notice cannot collide in
+          practice — the submit that produced one just emptied the draft, and
+          any keystroke clears feedback. */}
+      <Show when={feedback()} fallback={<SplitWarningLine text={splitWarning()} />}>
         {(fb) => (
           <p
             class={fb().severity === "error" ? "compose-box-error" : "compose-box-notice"}

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1707,7 +1707,9 @@ describe("ComposeBox", () => {
       // NOT guess one (the #246 reserve is not the client's to compute), so
       // both surfaces stay dark rather than warn from an invented number.
       mockFrameBudgetBase = null;
-      mockFramePreview = null;
+      // A preview that WOULD warn, so the only thing keeping the seam dark
+      // is the missing budget — not an empty preview the mock handed back.
+      mockFramePreview = { messages: 5, remainingBytes: 2 };
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
       expect(screen.queryByTestId("compose-frame-countdown")).toBeNull();
       expect(screen.queryByText(/separate messages/i)).toBeNull();

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -22,6 +22,18 @@ vi.mock("../lib/compose", () => ({
   // #904 — per-window in-flight state + the one-deep queue's full signal.
   isSending: () => mockSending(),
   isQueueFull: () => mockQueueFull(),
+  // #1108 — what the draft becomes on the wire. Resolved in the store (it
+  // needs the same verb dispatch the send path runs) and pinned there; here
+  // it is a boundary, so the view's two affordances can be driven from a
+  // known preview.
+  draftFramePreview: vi.fn(() => mockFramePreview),
+}));
+
+let mockFramePreview: { messages: number; remainingBytes: number | null } | null = null;
+let mockFrameBudgetBase: number | null = 393;
+
+vi.mock("../lib/isupport", () => ({
+  frameBudgetBaseForNetwork: () => mockFrameBudgetBase,
 }));
 
 vi.mock("../lib/channelKey", () => ({
@@ -109,6 +121,8 @@ beforeEach(() => {
   dismissConfirm();
   setMockSending(false);
   setMockQueueFull(false);
+  mockFramePreview = null;
+  mockFrameBudgetBase = 393;
 });
 
 describe("ComposeBox", () => {
@@ -1612,6 +1626,91 @@ describe("ComposeBox", () => {
 
       expect(paste.defaultPrevented).toBe(false);
       expect(confirmRequest()).toBeNull();
+    });
+  });
+  // ----------------------------------------------------------------
+  // #1108 — tell the operator, BEFORE sending, that the draft no longer
+  // fits one IRC frame. Two surfaces: an amber third state on the #356
+  // feedback seam, and a byte countdown above the box for the last ten
+  // bytes of the frame.
+  // ----------------------------------------------------------------
+  describe("#1108 — frame budget warning + byte countdown", () => {
+    it("renders the amber seam line, polite, when the draft will split", async () => {
+      mockFramePreview = { messages: 2, remainingBytes: null };
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.getDraft).mockReturnValue("a very long draft");
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+
+      const warning = screen.getByText(/will send as 2 separate messages/i);
+      expect(warning).toHaveClass("compose-box-warning");
+      expect(warning.getAttribute("role")).toBe("status");
+      // An error is the assertive severity; a split is not one.
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("states the message count and NOTHING about characters", () => {
+      // vjt, on the copy: "magari no senza (xx) chars nel seam, distrae
+      // troppo". The seam says what will happen, the countdown does the
+      // arithmetic.
+      mockFramePreview = { messages: 4, remainingBytes: null };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+
+      const warning = screen.getByText(/separate messages/i);
+      expect(warning.textContent).toBe("your message will send as 4 separate messages");
+    });
+
+    it("shows no seam line while the draft still fits one frame", () => {
+      mockFramePreview = { messages: 1, remainingBytes: 200 };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.queryByText(/separate messages/i)).toBeNull();
+    });
+
+    it("an ERROR outranks the split warning on the shared seam line", async () => {
+      // Declared precedence: the seam is ONE line and an error is the more
+      // urgent thing to read. This is not hypothetical — a paced send that
+      // fails puts its residue BACK in the draft (#666), so a long residue
+      // and a sticky error are live together by construction.
+      mockFramePreview = { messages: 3, remainingBytes: null };
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.submit).mockResolvedValue({ error: "send failed" });
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      fireEvent.keyDown(screen.getByPlaceholderText(/message #a/i), { key: "Enter" });
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent(/send failed/i);
+      expect(screen.queryByText(/separate messages/i)).toBeNull();
+    });
+
+    it("counts down the last ten bytes of the frame", () => {
+      mockFramePreview = { messages: 1, remainingBytes: 3 };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByTestId("compose-frame-countdown")).toHaveTextContent("-3");
+    });
+
+    it("shows a 0 at the exact edge — the last byte that still fits", () => {
+      // Not a gap: at zero the draft is still ONE message, so the seam
+      // warning is not up yet and this is the only thing on screen.
+      mockFramePreview = { messages: 1, remainingBytes: 0 };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByTestId("compose-frame-countdown")).toHaveTextContent("0");
+      expect(screen.queryByText(/separate messages/i)).toBeNull();
+    });
+
+    it("stays hidden while there is more than ten bytes of room", () => {
+      mockFramePreview = { messages: 1, remainingBytes: 11 };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.queryByTestId("compose-frame-countdown")).toBeNull();
+    });
+
+    it("is silent about a decision it cannot make — no budget, no affordance", () => {
+      // No live session has published a budget for this network. cic does
+      // NOT guess one (the #246 reserve is not the client's to compute), so
+      // both surfaces stay dark rather than warn from an invented number.
+      mockFrameBudgetBase = null;
+      mockFramePreview = null;
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.queryByTestId("compose-frame-countdown")).toBeNull();
+      expect(screen.queryByText(/separate messages/i)).toBeNull();
     });
   });
 });

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -36,6 +36,11 @@ vi.mock("../lib/isupport", () => ({
   frameBudgetBaseForNetwork: () => mockFrameBudgetBase,
 }));
 
+// #1108 — `frameBudgetForTarget` is NOT mocked: turning the published base
+// into this window's budget is the view's own job, and mocking it would
+// leave the only place the target's byte length is ever subtracted with no
+// test at all.
+
 vi.mock("../lib/channelKey", () => ({
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
 }));
@@ -1700,6 +1705,19 @@ describe("ComposeBox", () => {
       mockFramePreview = { messages: 1, remainingBytes: 11 };
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
       expect(screen.queryByTestId("compose-frame-countdown")).toBeNull();
+    });
+
+    it("budgets against THIS window's target, counted in bytes", async () => {
+      // The wiring nothing else witnesses: base minus the target's own UTF-8
+      // length. "#caffè" is 6 characters and 7 bytes, so a view that reached
+      // for `.length` would hand the preview one byte too many — and every
+      // number the operator reads would be off by it.
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.getDraft).mockReturnValue("ciao");
+      mockFrameBudgetBase = 400;
+      render(() => <ComposeBox networkSlug="freenode" channelName="#caffè" />);
+
+      expect(compose.draftFramePreview).toHaveBeenCalledWith("#caffè", "ciao", 393);
     });
 
     it("is silent about a decision it cannot make — no budget, no affordance", () => {

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -150,6 +150,7 @@ describe("ModeModal", () => {
     seedIsupport(1, {
       chanmodes: DEFAULT_ISUPPORT.chanmodes,
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      frameBudgetBase: null,
     });
     mockModes[KEY] = { modes: [], params: {} };
     mockMembers[KEY] = [{ nick: "vjt-grappa", modes: ["~"] }];

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -167,6 +167,7 @@ describe("WireChannelEvent canonical union (H3)", () => {
         chanmodes_c: ["l"],
         chanmodes_d: ["n", "t", "s"],
         prefix: { o: "@", h: "%", v: "+" },
+        frame_budget_base: 393,
       },
       expectedKind: "isupport_changed",
     },

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -90,6 +90,7 @@ describe("availableModes", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t", "Z"] },
       prefix: {},
+      frameBudgetBase: null,
     };
     const modes = availableModes(isupport);
     const z = modes.find((m) => m.letter === "Z");
@@ -130,6 +131,7 @@ describe("editorSigils", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t"] },
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      frameBudgetBase: null,
     };
     const e = editorSigils(isupport);
     expect(e.has("~")).toBe(true); // founder
@@ -143,6 +145,7 @@ describe("editorSigils", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: [] },
       prefix: { v: "+" },
+      frameBudgetBase: null,
     };
     const e = editorSigils(isupport);
     expect(e.has("@")).toBe(true);

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -288,12 +288,15 @@ describe("compose draft state", () => {
 describe("compose draftFramePreview (#1108)", () => {
   it("counts a plain draft that still fits, and the bytes left in the frame", async () => {
     const compose = await import("../lib/compose");
-    expect(compose.draftFramePreview("hello", 10)).toEqual({ messages: 1, remainingBytes: 5 });
+    expect(compose.draftFramePreview("#a", "hello", 10)).toEqual({
+      messages: 1,
+      remainingBytes: 5,
+    });
   });
 
   it("counts the frames of a draft past the budget, with no countdown", async () => {
     const compose = await import("../lib/compose");
-    expect(compose.draftFramePreview("a".repeat(25), 10)).toEqual({
+    expect(compose.draftFramePreview("#a", "a".repeat(25), 10)).toEqual({
       messages: 3,
       remainingBytes: null,
     });
@@ -302,35 +305,51 @@ describe("compose draftFramePreview (#1108)", () => {
   it("charges /me its CTCP ACTION envelope, like the send path does", async () => {
     const compose = await import("../lib/compose");
     // 15 bytes of text fit a 20-byte frame as a plain message…
-    expect(compose.draftFramePreview("a".repeat(15), 20)).toMatchObject({ messages: 1 });
+    expect(compose.draftFramePreview("#a", "a".repeat(15), 20)).toMatchObject({ messages: 1 });
     // …but `/me` puts `\x01ACTION `…`\x01` around EVERY fragment, so the same
     // text no longer does. Ten of the twenty bytes are envelope.
-    expect(compose.draftFramePreview(`/me ${"a".repeat(15)}`, 20)).toMatchObject({ messages: 2 });
+    expect(compose.draftFramePreview("#a", `/me ${"a".repeat(15)}`, 20)).toMatchObject({
+      messages: 2,
+    });
   });
 
   it("counts a pasted multi-line draft as the messages it fans out to", async () => {
     const compose = await import("../lib/compose");
     // Newline splitting is the client's half; a blank line yields no frame.
-    expect(compose.draftFramePreview("one\n\ntwo", 100)).toMatchObject({ messages: 2 });
+    expect(compose.draftFramePreview("#a", "one\n\ntwo", 100)).toMatchObject({ messages: 2 });
   });
 
   it("previews nothing for a command that is not a message", async () => {
     const compose = await import("../lib/compose");
     // `/join #x` sends no PRIVMSG, and `/msg peer …` addresses a DIFFERENT
     // target whose budget is not this window's. Neither gets a warning.
-    expect(compose.draftFramePreview("/join #x", 100)).toBeNull();
-    expect(compose.draftFramePreview("/msg gigi hello", 100)).toBeNull();
+    expect(compose.draftFramePreview("#a", "/join #x", 100)).toBeNull();
+    expect(compose.draftFramePreview("#a", "/msg gigi hello", 100)).toBeNull();
   });
 
   it("previews nothing when the server has published no budget", async () => {
     const compose = await import("../lib/compose");
-    expect(compose.draftFramePreview("hello", null)).toBeNull();
+    expect(compose.draftFramePreview("#a", "hello", null)).toBeNull();
+  });
+
+  it("previews nothing for plain text in the server window, which refuses it", async () => {
+    const compose = await import("../lib/compose");
+    // CP13 S9: $server accepts only slash-commands, and submit says so. A
+    // "will send as 3 separate messages" over a message that will never be
+    // sent — budgeted against a target that is not one — is worse than
+    // silence.
+    expect(compose.draftFramePreview("$server", "a".repeat(25), 10)).toBeNull();
+    // A slash-command there is the normal case and was never previewed.
+    expect(compose.draftFramePreview("$server", "/raw PING x", 10)).toBeNull();
   });
 
   it("previews the literal text of a //-escaped draft, not the escape", async () => {
     const compose = await import("../lib/compose");
     // `//foo` sends the five bytes `/foo`, so that is what gets counted.
-    expect(compose.draftFramePreview("//foo", 10)).toEqual({ messages: 1, remainingBytes: 6 });
+    expect(compose.draftFramePreview("#a", "//foo", 10)).toEqual({
+      messages: 1,
+      remainingBytes: 6,
+    });
   });
 });
 

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -278,6 +278,62 @@ describe("compose draft state", () => {
   });
 });
 
+// #1108 — what the compose box owes the operator BEFORE the send: how many
+// messages this draft becomes, and how many bytes are left in the frame it is
+// filling. The counting itself lives in frameBudget.ts; what is pinned here is
+// that the preview is taken over the bytes the SEND PATH would POST — the same
+// `parseSlash` verb dispatch, the same newline split, the same CTCP framing.
+// A preview built from the raw draft instead would be a promise about a
+// different string than the one that goes out.
+describe("compose draftFramePreview (#1108)", () => {
+  it("counts a plain draft that still fits, and the bytes left in the frame", async () => {
+    const compose = await import("../lib/compose");
+    expect(compose.draftFramePreview("hello", 10)).toEqual({ messages: 1, remainingBytes: 5 });
+  });
+
+  it("counts the frames of a draft past the budget, with no countdown", async () => {
+    const compose = await import("../lib/compose");
+    expect(compose.draftFramePreview("a".repeat(25), 10)).toEqual({
+      messages: 3,
+      remainingBytes: null,
+    });
+  });
+
+  it("charges /me its CTCP ACTION envelope, like the send path does", async () => {
+    const compose = await import("../lib/compose");
+    // 15 bytes of text fit a 20-byte frame as a plain message…
+    expect(compose.draftFramePreview("a".repeat(15), 20)).toMatchObject({ messages: 1 });
+    // …but `/me` puts `\x01ACTION `…`\x01` around EVERY fragment, so the same
+    // text no longer does. Ten of the twenty bytes are envelope.
+    expect(compose.draftFramePreview(`/me ${"a".repeat(15)}`, 20)).toMatchObject({ messages: 2 });
+  });
+
+  it("counts a pasted multi-line draft as the messages it fans out to", async () => {
+    const compose = await import("../lib/compose");
+    // Newline splitting is the client's half; a blank line yields no frame.
+    expect(compose.draftFramePreview("one\n\ntwo", 100)).toMatchObject({ messages: 2 });
+  });
+
+  it("previews nothing for a command that is not a message", async () => {
+    const compose = await import("../lib/compose");
+    // `/join #x` sends no PRIVMSG, and `/msg peer …` addresses a DIFFERENT
+    // target whose budget is not this window's. Neither gets a warning.
+    expect(compose.draftFramePreview("/join #x", 100)).toBeNull();
+    expect(compose.draftFramePreview("/msg gigi hello", 100)).toBeNull();
+  });
+
+  it("previews nothing when the server has published no budget", async () => {
+    const compose = await import("../lib/compose");
+    expect(compose.draftFramePreview("hello", null)).toBeNull();
+  });
+
+  it("previews the literal text of a //-escaped draft, not the escape", async () => {
+    const compose = await import("../lib/compose");
+    // `//foo` sends the five bytes `/foo`, so that is what gets counted.
+    expect(compose.draftFramePreview("//foo", 10)).toEqual({ messages: 1, remainingBytes: 6 });
+  });
+});
+
 // #772 — an unsent draft used to die with the document. `vi.resetModules()` +
 // a fresh import re-executes the module exactly as a page load does, so it is
 // the reload these tests are about: whatever survives it is what the operator

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_ISUPPORT,
+  frameBudgetBaseForNetwork,
   type IsupportEntry,
   isupportByNetwork,
   isupportForNetwork,
@@ -27,10 +28,30 @@ describe("isupport store", () => {
     expect(isupportForNetwork(9999)).toEqual(DEFAULT_ISUPPORT);
   });
 
+  // #1108 — the capability table has an honest default (bahamut's, which is
+  // what every prod network advertises anyway); the frame BUDGET has none.
+  // It is a projection of LINELEN plus the #246 worst-case relay reserve, so
+  // a guess is a wrong number the compose box would warn from. Absent means
+  // absent, and the affordances stay dark.
+  it("DEFAULT_ISUPPORT carries NO frame budget — there is no honest default", () => {
+    expect(DEFAULT_ISUPPORT.frameBudgetBase).toBeNull();
+    expect(frameBudgetBaseForNetwork(9999)).toBeNull();
+  });
+
+  it("frameBudgetBaseForNetwork serves the seeded budget", () => {
+    seedIsupport(11, { ...DEFAULT_ISUPPORT, frameBudgetBase: 393 });
+    expect(frameBudgetBaseForNetwork(11)).toBe(393);
+  });
+
+  it("frameBudgetBaseForNetwork is null for an unknown network id", () => {
+    expect(frameBudgetBaseForNetwork(null)).toBeNull();
+  });
+
   it("seedIsupport stores the entry keyed by network id", () => {
     const entry: IsupportEntry = {
       chanmodes: { a: ["b", "e", "I"], b: ["k"], c: ["l"], d: ["i", "m", "n", "s", "t"] },
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      frameBudgetBase: 393,
     };
     seedIsupport(7, entry);
     expect(isupportByNetwork()[7]).toEqual(entry);

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -3977,3 +3977,45 @@ describe("subscribe — #868 the beep obeys the notification prefs", () => {
     expect(beep.playBeep).not.toHaveBeenCalled();
   });
 });
+
+// #1108 — the COLD door. A client joining long after the 005 burst gets the
+// frame budget only through the per-channel after-join snapshot, and on an
+// always-on bouncer that is every client. Asserted against the REAL isupport
+// store rather than a `seedIsupport` spy: the second killer for a wire→store
+// fold that drops the field, which is otherwise caught by exactly one test on
+// the OTHER door (userTopic) while the compose box goes dark for good.
+describe("subscribe — #1108 the cold snapshot seeds the frame budget", () => {
+  it("lands the published budget in the isupport store", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    await loadStores();
+    const isupport = await import("../lib/isupport");
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+
+    // Pre-state: no 005 has been seen on this network, so cic must have no
+    // budget to warn from — the state the whole `null` path exists for.
+    expect(isupport.frameBudgetBaseForNetwork(1)).toBeNull();
+
+    const handler = mockChannel.on.mock.calls.find((c) => c[0] === "event")?.[1] as (
+      p: unknown,
+    ) => void;
+    handler({
+      kind: "isupport_changed",
+      network_id: 1,
+      chanmodes_a: ["b", "e", "I"],
+      chanmodes_b: ["k"],
+      chanmodes_c: ["l"],
+      chanmodes_d: ["n", "t", "s"],
+      prefix: { o: "@", v: "+" },
+      frame_budget_base: 481,
+    });
+
+    expect(isupport.frameBudgetBaseForNetwork(1)).toBe(481);
+  });
+});

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -137,7 +137,11 @@ vi.mock("../lib/channelDirectory", () => ({
   onDirectoryFailed: vi.fn(),
 }));
 
-vi.mock("../lib/isupport", () => ({
+// Only the SEED is stubbed. `isupportEntryFromWire` is the pure wire→store
+// fold both doors share (#1108), and stubbing it would make the assertion
+// below about the mock instead of about what lands in the store.
+vi.mock("../lib/isupport", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/isupport")>()),
   seedIsupport: vi.fn(),
 }));
 
@@ -413,7 +417,29 @@ describe("userTopic", () => {
       expect(isupport.seedIsupport).toHaveBeenCalledWith(7, {
         chanmodes: { a: ["b", "e", "I"], b: ["k"], c: ["l"], d: ["n", "t", "s"] },
         prefix: { q: "~", o: "@", v: "+" },
+        // #1108 — this envelope carried no budget, so none is seeded.
+        frameBudgetBase: null,
       });
+    });
+
+    // #1108 — the LIVE 005 door. The frame budget rides the same event, and
+    // the compose box's warning is dark until it lands here.
+    it("seeds the frame budget the 005 published", async () => {
+      const isupport = await import("../lib/isupport");
+      channelMock.fireEvent({
+        kind: "isupport_changed",
+        network_id: 7,
+        chanmodes_a: ["b", "e", "I"],
+        chanmodes_b: ["k"],
+        chanmodes_c: ["l"],
+        chanmodes_d: ["n", "t", "s"],
+        prefix: { q: "~", o: "@", v: "+" },
+        frame_budget_base: 393,
+      });
+      expect(isupport.seedIsupport).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ frameBudgetBase: 393 }),
+      );
     });
 
     it("drops isupport_changed with a non-number network_id (narrower rejects)", async () => {

--- a/cicchetto/src/__tests__/wireNarrow.test.ts
+++ b/cicchetto/src/__tests__/wireNarrow.test.ts
@@ -222,6 +222,28 @@ describe("narrowChannelEvent (bucket G H4+U3)", () => {
     it("rejects a prefix map with a non-string sigil", () => {
       expect(narrowChannelEvent({ ...valid, prefix: { o: 1 } })).toBeNull();
     });
+
+    // #1108 — the frame budget rides this payload. It must narrow through…
+    it("carries the frame budget base through", () => {
+      const out = narrowChannelEvent({ ...valid, frame_budget_base: 393 });
+      expect(out).toMatchObject({ frame_budget_base: 393 });
+    });
+
+    // …and its ABSENCE must not reject the envelope. The wire is
+    // additive-only in BOTH directions: a client talking to a server from
+    // before the field exists still needs its `/mode` toggles seeded, so a
+    // missing budget is a missing budget, never a dropped event.
+    it("narrows fine when the server sent no budget at all", () => {
+      const out = narrowChannelEvent(valid);
+      expect(out?.kind).toBe("isupport_changed");
+      expect(out).toMatchObject({ frame_budget_base: null });
+    });
+
+    it("treats a non-number budget as absent rather than dropping the event", () => {
+      const out = narrowChannelEvent({ ...valid, frame_budget_base: "393" });
+      expect(out?.kind).toBe("isupport_changed");
+      expect(out).toMatchObject({ frame_budget_base: null });
+    });
   });
 
   // UX-5 BJ (2026-05-19) — JoinBanner was killed but the narrower keeps

--- a/cicchetto/src/lib/__tests__/frameBudget.test.ts
+++ b/cicchetto/src/lib/__tests__/frameBudget.test.ts
@@ -60,6 +60,15 @@ describe("frameBudget — frameBudgetForTarget", () => {
     // would over-promise by exactly the bytes the wire actually spends.
     expect(frameBudgetForTarget(400, "#café")).toBe(394);
   });
+
+  it("has no budget to report when the frame cannot hold a body at all", () => {
+    // A LINELEN small enough to be eaten whole by the relay reserve makes
+    // the base negative, and the server's own fast path then sends the body
+    // UNSPLIT. There is nothing to warn about and nothing to count down —
+    // and a negative "remaining" would render as `--118`.
+    expect(frameBudgetForTarget(-118, "#a")).toBeNull();
+    expect(frameBudgetForTarget(2, "#ab")).toBeNull();
+  });
 });
 
 describe("frameBudget — frameCount", () => {
@@ -77,6 +86,23 @@ describe("frameBudget — frameCount", () => {
 
   it("treats a tab as a word boundary, like the server", () => {
     expect(frameCount("aaaaa\tbbbbbbbb cc", 10)).toBe(3);
+  });
+
+  it("does not break on a boundary that would emit an empty fragment", () => {
+    // The chunk's only whitespace is its FIRST grapheme, so breaking there
+    // would emit nothing and carry everything — the server falls back to the
+    // byte cut instead. Without this case a `k >= 0` off-by-one in the
+    // boundary scan passes the whole suite.
+    expect(frameCount(` ${"a".repeat(12)}`, 10)).toBe(2);
+  });
+
+  it("keeps a multi-codepoint grapheme cluster whole", () => {
+    // The server splits on `String.graphemes/1` — EXTENDED grapheme
+    // clusters. A ZWJ family is 25 bytes and ONE of those; counting code
+    // points instead would report seven frames for a single indivisible
+    // one. This is the one place the two runtimes' segmentation tables
+    // have to agree, and 🍕 (a lone codepoint) does not exercise it.
+    expect(frameCount("👩‍👩‍👧‍👦", 4)).toBe(1);
   });
 
   it("falls back to the byte cut for a token with no boundary in it", () => {

--- a/cicchetto/src/lib/__tests__/frameBudget.test.ts
+++ b/cicchetto/src/lib/__tests__/frameBudget.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { frameBudgetForTarget, frameCount, framePreview, utf8ByteLength } from "../frameBudget";
+
+// #1108 — the compose box warns, BEFORE sending, that the draft no longer
+// fits one IRC frame. Two numbers drive that: how many bytes are left in the
+// frame, and how many messages the draft would become.
+//
+// The BUDGET is not computed here — the server publishes it
+// (`frame_budget_base` on `isupport_changed`), because it reserves the #246
+// worst-case relayed source prefix and a client-side copy of those ceilings
+// drifts in the direction that loses bytes.
+//
+// The COUNT is a mirror of `Grappa.IRC.LineSplit`'s chunker, and the cases
+// below are written against the WORD-BOUNDARY semantics (#1109): the cut
+// prefers the last ASCII space/tab at or before the budget, and the boundary
+// grapheme is CONSUMED. `wordBoundaryCase` is the one that a naive byte cut
+// gets wrong — it is the reason this file exists rather than a ceil() call.
+
+// budget 10, "aaaaa bbbbbbbb cc" (17 bytes):
+//   byte cut  → "aaaaa bbbb" | "bbbb cc"                        = 2
+//   word cut  → "aaaaa" | "bbbbbbbb" | "cc"                     = 3
+const wordBoundaryBody = "aaaaa bbbbbbbb cc";
+
+describe("frameBudget — utf8ByteLength", () => {
+  // The count is in UTF-8 BYTES, never UTF-16 units: a draft of accented
+  // text or emoji splits well before its character count suggests. Pinned
+  // against the platform encoder so the hand-rolled walk cannot drift.
+  const corpus = [
+    "",
+    "plain ascii",
+    "café",
+    "naïve résumé",
+    "日本語のテキスト",
+    "🍕🍕🍕",
+    "👩‍👩‍👧‍👦",
+    "é combining",
+    " nbsp",
+    "\x01ACTION waves\x01",
+  ];
+
+  for (const s of corpus) {
+    it(`agrees with TextEncoder for ${JSON.stringify(s)}`, () => {
+      expect(utf8ByteLength(s)).toBe(new TextEncoder().encode(s).length);
+    });
+  }
+});
+
+describe("frameBudget — frameBudgetForTarget", () => {
+  it("subtracts the target's UTF-8 byte length from the published base", () => {
+    expect(frameBudgetForTarget(400, "#sniffo")).toBe(393);
+  });
+
+  it("charges a multibyte target its BYTES, not its characters", () => {
+    // "#café" is 5 characters but 6 bytes; budgeting by character length
+    // would over-promise by exactly the bytes the wire actually spends.
+    expect(frameBudgetForTarget(400, "#café")).toBe(394);
+  });
+});
+
+describe("frameBudget — frameCount", () => {
+  it("counts a body that exactly fills the budget as one frame", () => {
+    expect(frameCount("a".repeat(10), 10)).toBe(1);
+  });
+
+  it("counts one byte past the budget as two frames", () => {
+    expect(frameCount("a".repeat(11), 10)).toBe(2);
+  });
+
+  it("breaks at the last word boundary and consumes it (#1109)", () => {
+    expect(frameCount(wordBoundaryBody, 10)).toBe(3);
+  });
+
+  it("treats a tab as a word boundary, like the server", () => {
+    expect(frameCount("aaaaa\tbbbbbbbb cc", 10)).toBe(3);
+  });
+
+  it("falls back to the byte cut for a token with no boundary in it", () => {
+    // A URL / base64 blob / CJK wall must still split rather than loop.
+    expect(frameCount("a".repeat(20), 10)).toBe(2);
+  });
+
+  it("emits a single grapheme larger than the budget as its own frame", () => {
+    expect(frameCount("🍕🍕", 2)).toBe(2);
+  });
+
+  it("measures multibyte text in bytes", () => {
+    expect(frameCount("é".repeat(5), 10)).toBe(1);
+    expect(frameCount("é".repeat(6), 10)).toBe(2);
+  });
+
+  it("charges the CTCP ACTION envelope on every fragment", () => {
+    // Envelope is 10 bytes, so a budget of 20 leaves 10 for the inner text.
+    const inner = "a".repeat(15);
+    expect(frameCount(`\x01ACTION ${inner}\x01`, 20)).toBe(2);
+    // …and the same 15 bytes as a PLAIN body fit the same budget whole.
+    expect(frameCount(inner, 20)).toBe(1);
+  });
+
+  it("gives up on a budget too small to frame anything", () => {
+    // Mirrors the server's non-positive-budget fast path: one body, unsplit.
+    expect(frameCount("hello", 0)).toBe(1);
+    expect(frameCount(`\x01ACTION hello\x01`, 5)).toBe(1);
+  });
+});
+
+describe("frameBudget — framePreview", () => {
+  it("reports one message and the bytes left while the draft still fits", () => {
+    expect(framePreview(["hello"], 10)).toEqual({ messages: 1, remainingBytes: 5 });
+  });
+
+  it("reports zero bytes left at the exact edge, still one message", () => {
+    expect(framePreview(["a".repeat(10)], 10)).toEqual({ messages: 1, remainingBytes: 0 });
+  });
+
+  it("drops the countdown once the draft no longer fits one frame", () => {
+    // Past the edge the seam warning takes over: a "bytes remaining" number
+    // for a body that has already split would be about nothing.
+    expect(framePreview([wordBoundaryBody], 10)).toEqual({ messages: 3, remainingBytes: null });
+  });
+
+  it("sums the frames of a multi-line draft and shows no countdown", () => {
+    // Newline splitting is the client's half (user intent, messageLines.ts);
+    // length splitting is the server's. The operator is owed the total.
+    expect(framePreview(["short", "a".repeat(11)], 10)).toEqual({
+      messages: 3,
+      remainingBytes: null,
+    });
+  });
+
+  it("reports nothing to send for an empty draft", () => {
+    expect(framePreview([], 10)).toEqual({ messages: 0, remainingBytes: null });
+  });
+});

--- a/cicchetto/src/lib/__tests__/frameBudget.test.ts
+++ b/cicchetto/src/lib/__tests__/frameBudget.test.ts
@@ -13,8 +13,13 @@ import { frameBudgetForTarget, frameCount, framePreview, utf8ByteLength } from "
 // The COUNT is a mirror of `Grappa.IRC.LineSplit`'s chunker, and the cases
 // below are written against the WORD-BOUNDARY semantics (#1109): the cut
 // prefers the last ASCII space/tab at or before the budget, and the boundary
-// grapheme is CONSUMED. `wordBoundaryCase` is the one that a naive byte cut
+// grapheme is CONSUMED. `wordBoundaryBody` is the one that a naive byte cut
 // gets wrong — it is the reason this file exists rather than a ceil() call.
+//
+// Every (budget, body) below appears VERBATIM in the server's own table,
+// `test/grappa/irc/line_split_test.exs` → "#1108: the fragment counts cic's
+// preview mirrors". That pairing is what keeps the mirror a mirror: change
+// either splitter and its own suite goes red. Add a case here, add it there.
 
 // budget 10, "aaaaa bbbbbbbb cc" (17 bytes):
 //   byte cut  → "aaaaa bbbb" | "bbbb cc"                        = 2

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -711,6 +711,10 @@ export type WireChannelEvent =
       chanmodes_c: string[];
       chanmodes_d: string[];
       prefix: Record<string, string>;
+      // #1108 — `null` when the server published no budget. Narrowed
+      // permissively on purpose: the wire is additive-only, so a server
+      // predating the field must still seed the capability table.
+      frame_budget_base: number | null;
     }
   // UX-5 BJ (2026-05-19) — recognized-but-ignored. Pre-BJ the JoinBanner
   // consumed this via `seedChannelCreated` for the "Channel was created
@@ -1002,6 +1006,10 @@ export type WireUserEvent =
       chanmodes_c: string[];
       chanmodes_d: string[];
       prefix: Record<string, string>;
+      // #1108 — `null` when the server published no budget. Narrowed
+      // permissively on purpose: the wire is additive-only, so a server
+      // predating the field must still seed the capability table.
+      frame_budget_base: number | null;
     }
   | {
       // CP17 — server-driven `:pending` window-state origination.

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -17,6 +17,7 @@ import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { scrubCtcpDelimiters } from "./ctcpAction";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
+import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
@@ -212,6 +213,17 @@ const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
 export const ctcpFrame = (verb: string, args: string): string =>
   args === "" ? `\x01${verb}\x01` : `\x01${verb} ${args}\x01`;
 
+// The lines a free-text body fans out to — one PRIVMSG each, after the exit
+// scrub. Shared by the send path and #1108's pre-send preview so the count
+// the operator reads is produced by the code that does the sending.
+export const draftLines = (body: string): string[] => splitMessageLines(scrubCtcpDelimiters(body));
+
+// The exact bytes ONE of those lines becomes on the wire: `/me` wraps every
+// line in its own CTCP ACTION envelope, and that envelope is charged against
+// the frame budget on every fragment the server splits it into.
+export const wireBody = (line: string, action: boolean): string =>
+  action ? ctcpFrame("ACTION", line) : line;
+
 // #666 — resumable, self-pacing multiline fan-out.
 //
 // A paste sends one PRIVMSG per line, but the server's send door (the
@@ -291,7 +303,7 @@ export const sendBodyLines = async (
   // compose box by another verb is text, never framing. Scrubbing here rather
   // than at each writer means the next path that learns to fill the compose box
   // inherits the guarantee instead of having to remember it.
-  const lines = splitMessageLines(scrubCtcpDelimiters(body));
+  const lines = draftLines(body);
   const total = lines.length;
   let sent = 0;
   // Consecutive paced retries of the CURRENT line; reset when `sent` advances.
@@ -300,7 +312,7 @@ export const sendBodyLines = async (
     // `?? ""` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
     const line = lines[sent] ?? "";
     try {
-      await sendPrivmsg(slug, target, action ? ctcpFrame("ACTION", line) : line);
+      await sendPrivmsg(slug, target, wireBody(line, action));
       sent += 1;
       retries = 0;
       onProgress?.(sent, total, lines.slice(sent).join("\n"));
@@ -324,6 +336,28 @@ export const sendBodyLines = async (
       }
     }
   }
+};
+
+/**
+ * #1108 — what the current draft will do to the wire, or `null` when there is
+ * nothing honest to say: the server has published no budget for this network
+ * (`budget === null`), or the draft is a command that sends no PRIVMSG to
+ * THIS window. `/msg peer …` is excluded on purpose — it addresses a
+ * different target, whose budget is a different number.
+ *
+ * Resolved through the same `parseSlash` dispatch, line split and CTCP
+ * framing the submit path runs, so the preview is a statement about the bytes
+ * that will actually be POSTed rather than about the raw draft.
+ */
+export const draftFramePreview = (draft: string, budget: number | null): FramePreview | null => {
+  if (budget === null) return null;
+  const cmd = parseSlash(draft, aliases());
+  if (cmd.kind !== "privmsg" && cmd.kind !== "me") return null;
+  const action = cmd.kind === "me";
+  return framePreview(
+    draftLines(cmd.body).map((line) => wireBody(line, action)),
+    budget,
+  );
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -342,17 +342,26 @@ export const sendBodyLines = async (
  * #1108 — what the current draft will do to the wire, or `null` when there is
  * nothing honest to say: the server has published no budget for this network
  * (`budget === null`), or the draft is a command that sends no PRIVMSG to
- * THIS window. `/msg peer …` is excluded on purpose — it addresses a
- * different target, whose budget is a different number.
+ * `target`. `/msg peer …` is excluded on purpose — it addresses a DIFFERENT
+ * target, whose budget is a different number.
+ *
+ * The `$server` window refuses plain text outright (CP13 S9, the same
+ * refusal `submit` returns below), so a draft there is previewed as nothing
+ * rather than as a split of a message that will never be sent.
  *
  * Resolved through the same `parseSlash` dispatch, line split and CTCP
  * framing the submit path runs, so the preview is a statement about the bytes
  * that will actually be POSTed rather than about the raw draft.
  */
-export const draftFramePreview = (draft: string, budget: number | null): FramePreview | null => {
+export const draftFramePreview = (
+  target: string,
+  draft: string,
+  budget: number | null,
+): FramePreview | null => {
   if (budget === null) return null;
   const cmd = parseSlash(draft, aliases());
   if (cmd.kind !== "privmsg" && cmd.kind !== "me") return null;
+  if (target === SERVER_WINDOW_NAME && cmd.kind === "privmsg") return null;
   const action = cmd.kind === "me";
   return framePreview(
     draftLines(cmd.body).map((line) => wireBody(line, action)),

--- a/cicchetto/src/lib/frameBudget.ts
+++ b/cicchetto/src/lib/frameBudget.ts
@@ -71,10 +71,17 @@ export function utf8ByteLength(s: string): number {
  * server published. `null` when there is no base (no live session has
  * reported one yet) — the caller must then show no warning at all rather
  * than guess a budget.
+ *
+ * Also `null` when the frame cannot hold a body at all: a LINELEN small
+ * enough to be eaten whole by the relay reserve (an ircd may advertise any
+ * positive one) makes this non-positive, and the server's own fast path then
+ * sends the body UNSPLIT. Nothing to warn about, nothing to count down — and
+ * a negative remainder would render as `--118`.
  */
 export function frameBudgetForTarget(base: number | null, target: string): number | null {
   if (base === null) return null;
-  return base - utf8ByteLength(target);
+  const budget = base - utf8ByteLength(target);
+  return budget <= 0 ? null : budget;
 }
 
 /**

--- a/cicchetto/src/lib/frameBudget.ts
+++ b/cicchetto/src/lib/frameBudget.ts
@@ -1,0 +1,179 @@
+// #1108 — how many IRC frames the current draft will become, and how many
+// bytes are left in the one it is filling.
+//
+// ## What is the server's and what is ours
+//
+// The BUDGET is the server's. `Grappa.IRC.LineSplit` sizes a fragment as
+// `LINELEN - relay_frame_overhead(target)`, where the overhead reserves the
+// #246 WORST-CASE relayed source prefix (`:nick!user@host `, at the ceilings
+// grappa validates its own identity against). Those ceilings are exactly the
+// numbers a second copy gets silently wrong, in the direction that TRUNCATES
+// the wire — so cic never computes them. The server publishes
+// `frame_budget_base` on `isupport_changed`, and the only arithmetic left
+// here is subtracting the byte length of a target string cic already holds
+// (`frameBudgetForTarget`) — the overhead is affine in that length, which is
+// what makes one per-network scalar enough.
+//
+// The COUNT is ours, and it is a MIRROR, deliberately: the warning has to be
+// on screen BEFORE the POST, so there is no round trip to ask with. What is
+// mirrored is `LineSplit`'s chunker — greedy fill to the budget, preferring
+// the last ASCII space/tab in the chunk and CONSUMING it (#1109), falling
+// back to the byte cut for a token that holds no boundary. A drift between
+// the two costs an advisory number that is off by a frame; it can never cost
+// a byte, because the split that actually reaches the wire is still the
+// server's. That asymmetry is the whole reason this mirror is allowed to
+// exist while a mirror of `relay_frame_overhead` is not.
+//
+// Everything here is pure: no store reads, no DOM. `compose.ts` resolves what
+// the draft would actually POST (`draftLines` + `wireBody` — the same calls
+// the send path makes), and this module counts it.
+
+import { CTCP_DELIMITER, stripCtcpAction } from "./ctcpAction";
+
+// `\x01ACTION ` + the closing `\x01` — the per-fragment envelope the server
+// re-adds to EVERY fragment of an action, so it is charged once per frame,
+// not once per message. Derived from the same delimiter the composer frames
+// with rather than written as `10`.
+const CTCP_ACTION_ENVELOPE_BYTES =
+  utf8ByteLength(`${CTCP_DELIMITER}ACTION `) + utf8ByteLength(CTCP_DELIMITER);
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Bytes `s` occupies once UTF-8 encoded — what IRC framing counts, as opposed
+ * to `String.length`, which counts UTF-16 units. Walks the string instead of
+ * round-tripping a `TextEncoder`, because the chunker below asks this per
+ * grapheme and an allocation per grapheme is a keystroke-path cost.
+ */
+export function utf8ByteLength(s: string): number {
+  let bytes = 0;
+  for (let i = 0; i < s.length; i += 1) {
+    const unit = s.charCodeAt(i);
+    if (unit < 0x80) {
+      bytes += 1;
+    } else if (unit < 0x800) {
+      bytes += 2;
+    } else if (unit >= 0xd800 && unit <= 0xdbff && (s.charCodeAt(i + 1) & 0xfc00) === 0xdc00) {
+      // A well-formed surrogate PAIR is one astral codepoint: 4 bytes, two
+      // units. A lone surrogate falls through to 3 — what the encoder emits
+      // for the replacement character it substitutes.
+      bytes += 4;
+      i += 1;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+/**
+ * The per-frame body budget for `target`, from the per-network base the
+ * server published. `null` when there is no base (no live session has
+ * reported one yet) — the caller must then show no warning at all rather
+ * than guess a budget.
+ */
+export function frameBudgetForTarget(base: number | null, target: string): number | null {
+  if (base === null) return null;
+  return base - utf8ByteLength(target);
+}
+
+/**
+ * How many wire frames `wireBody` — the bytes as they will be POSTed,
+ * envelope included — becomes at `budget` bytes per frame.
+ */
+export function frameCount(wireBody: string, budget: number): number {
+  // A budget too small to frame anything: the server sends the body unsplit
+  // rather than loop, and so must the number the operator reads.
+  if (budget <= 0) return 1;
+  if (utf8ByteLength(wireBody) <= budget) return 1;
+
+  if (wireBody.startsWith(`${CTCP_DELIMITER}ACTION `)) {
+    const innerBudget = budget - CTCP_ACTION_ENVELOPE_BYTES;
+    if (innerBudget <= 0) return 1;
+    return chunkCount(stripCtcpAction(wireBody), innerBudget);
+  }
+
+  return chunkCount(wireBody, budget);
+}
+
+export type FramePreview = {
+  /** Wire frames the whole draft becomes — 0 when there is nothing to send. */
+  messages: number;
+  /**
+   * Bytes still free in the frame. `null` unless the draft is exactly one
+   * frame: past that edge the split warning is the honest surface, and a
+   * "bytes remaining" number would be about nothing.
+   */
+  remainingBytes: number | null;
+};
+
+/**
+ * What the compose box owes the operator about `bodies` — the wire bodies a
+ * submit would POST, in order (one per line; `compose.ts` builds them).
+ */
+export function framePreview(bodies: readonly string[], budget: number): FramePreview {
+  const messages = bodies.reduce((total, body) => total + frameCount(body, budget), 0);
+  const only = bodies.length === 1 ? bodies[0] : undefined;
+  return {
+    messages,
+    remainingBytes: only !== undefined && messages === 1 ? budget - utf8ByteLength(only) : null,
+  };
+}
+
+// The mirror of `LineSplit.chunk_by_bytes/5`, counting fragments instead of
+// building them. Greedy fill; on overflow the chunk is cut at its last word
+// boundary and the overflowing grapheme is RE-READ against the carry-over,
+// which may already leave no room for it.
+function chunkCount(body: string, budget: number): number {
+  const graphemes = [...graphemeSegmenter.segment(body)].map((s) => s.segment);
+  let chunks = 0;
+  let current: string[] = [];
+  let size = 0;
+  let i = 0;
+
+  while (i < graphemes.length) {
+    const grapheme = graphemes[i] ?? "";
+    const graphemeSize = utf8ByteLength(grapheme);
+
+    if (graphemeSize > budget) {
+      // Indivisible and oversized: the server emits it intact as its own
+      // fragment rather than dropping or bisecting it.
+      if (current.length > 0) chunks += 1;
+      chunks += 1;
+      current = [];
+      size = 0;
+      i += 1;
+      continue;
+    }
+
+    if (size + graphemeSize > budget) {
+      current = carryAfterLastBreak(current);
+      chunks += 1;
+      size = utf8ByteLength(current.join(""));
+      continue;
+    }
+
+    current.push(grapheme);
+    size += graphemeSize;
+    i += 1;
+  }
+
+  if (current.length > 0) chunks += 1;
+  return chunks === 0 ? 1 : chunks;
+}
+
+// What carries over into the next chunk once `current` is cut at its LAST
+// word boundary — the boundary grapheme itself is consumed. Empty when there
+// is no usable boundary (none at all, or only at the very start, where the
+// cut would emit an empty fragment): the whole chunk is then emitted as-is,
+// which is the byte cut.
+//
+// ASCII space and tab only, matching the server: NO-BREAK SPACE and its
+// relatives exist to FORBID a break, so counting them as boundaries would
+// invert their meaning.
+function carryAfterLastBreak(current: readonly string[]): string[] {
+  for (let k = current.length - 1; k > 0; k -= 1) {
+    if (current[k] === " " || current[k] === "\t") return current.slice(k + 1);
+  }
+  return [];
+}

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -30,6 +30,12 @@ export type IsupportEntry = {
     d: string[];
   };
   prefix: Record<string, string>;
+  // #1108 — the target-independent per-frame body budget, from the same 005
+  // (see `frameBudget.ts` for what cic may and may not derive from it).
+  // `null` when the server published none: unlike the capability table, this
+  // has no honest default, because it is LINELEN minus the #246 worst-case
+  // relay reserve and a guess is just a wrong number to warn from.
+  frameBudgetBase: number | null;
 };
 
 // Keep in lockstep with `Grappa.Session.ISupport.default/0` (server).
@@ -41,6 +47,7 @@ export const DEFAULT_ISUPPORT: IsupportEntry = {
     d: ["C", "D", "R", "c", "d", "i", "m", "n", "p", "r", "s", "t"],
   },
   prefix: { o: "@", h: "%", v: "+" },
+  frameBudgetBase: null,
 };
 
 const exports_ = moduleRoot(() => {
@@ -63,4 +70,44 @@ export const seedIsupport = exports_.seedIsupport;
  */
 export function isupportForNetwork(networkId: number): IsupportEntry {
   return isupportByNetwork()[networkId] ?? DEFAULT_ISUPPORT;
+}
+
+/**
+ * Folds the flat `isupport_changed` wire shape into the nested store entry.
+ *
+ * Both doors go through here — the live 005 edge on the user topic and the
+ * per-channel cold-snapshot — so a new 005 fact cannot reach one of them and
+ * not the other, which is exactly how the two hand-copied literals this
+ * replaced would have taken the #1108 budget.
+ */
+export function isupportEntryFromWire(payload: {
+  chanmodes_a: string[];
+  chanmodes_b: string[];
+  chanmodes_c: string[];
+  chanmodes_d: string[];
+  prefix: Record<string, string>;
+  frame_budget_base: number | null;
+}): IsupportEntry {
+  return {
+    chanmodes: {
+      a: payload.chanmodes_a,
+      b: payload.chanmodes_b,
+      c: payload.chanmodes_c,
+      d: payload.chanmodes_d,
+    },
+    prefix: payload.prefix,
+    frameBudgetBase: payload.frame_budget_base,
+  };
+}
+
+/**
+ * The per-frame body budget base this network published (#1108), or `null`
+ * when none has arrived — an unseeded network, a parked session, or a server
+ * older than the field. Callers must treat `null` as "say nothing": the
+ * budget reserves the #246 worst-case relayed prefix and is not cic's to
+ * invent.
+ */
+export function frameBudgetBaseForNetwork(networkId: number | null): number | null {
+  if (networkId === null) return null;
+  return isupportForNetwork(networkId).frameBudgetBase;
 }

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -8,7 +8,7 @@ import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { dropChannelTopicState, seedModes, seedTopic } from "./channelTopic";
 import { isDocumentVisible } from "./documentVisibility";
 import { highlightPatterns } from "./highlightList";
-import { seedIsupport } from "./isupport";
+import { isupportEntryFromWire, seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
 import { setServerMention } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
@@ -420,15 +420,7 @@ moduleRoot(() => {
           // path: the live 005 fired long before this client subscribed).
           // Seed the same store userTopic.ts's live arm feeds — keyed by
           // network id, last-write-wins idempotent.
-          seedIsupport(payload.network_id, {
-            chanmodes: {
-              a: payload.chanmodes_a,
-              b: payload.chanmodes_b,
-              c: payload.chanmodes_c,
-              d: payload.chanmodes_d,
-            },
-            prefix: payload.prefix,
-          });
+          seedIsupport(payload.network_id, isupportEntryFromWire(payload));
           return;
         // UX-5 BJ (2026-05-19) — recognized-but-ignored. JoinBanner was
         // the only consumer; killed in BJ. Server still emits per-channel

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -24,7 +24,7 @@ import { setSeveredForFlood } from "./floodSever";
 import { refreshHighlights } from "./highlightList";
 import { patchHomeNetwork } from "./home";
 import { appendInviteAck } from "./inviteAck";
-import { seedIsupport } from "./isupport";
+import { isupportEntryFromWire, seedIsupport } from "./isupport";
 import { setLinksReply } from "./linksModal";
 import { applyLusersBundle, clearLusersRequested } from "./lusersBundle";
 import { setMentionsBundle } from "./mentionsWindow";
@@ -1173,15 +1173,7 @@ moduleRoot(() => {
           // reads. Live edge (005 mid-session) + cold snapshot (per-channel
           // after-join) both flow here; last-write-wins idempotent. Fold
           // the flat wire fields into the nested store shape.
-          seedIsupport(payload.network_id, {
-            chanmodes: {
-              a: payload.chanmodes_a,
-              b: payload.chanmodes_b,
-              c: payload.chanmodes_c,
-              d: payload.chanmodes_d,
-            },
-            prefix: payload.prefix,
-          });
+          seedIsupport(payload.network_id, isupportEntryFromWire(payload));
           return;
 
         case "umode_changed":

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -187,6 +187,11 @@ export function narrowIsupportChanged(
     chanmodes_c: c,
     chanmodes_d: d,
     prefix,
+    // #1108 — absent or malformed means ABSENT, never a rejected envelope:
+    // the /mode toggles this payload seeds must survive a server that
+    // predates the budget, and cic's own rule for an unknown budget is to
+    // show no warning at all.
+    frame_budget_base: typeof r.frame_budget_base === "number" ? r.frame_budget_base : null,
   };
 }
 

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -941,6 +941,7 @@ export const S_SessionWireIsupportChangedPayload = {
     chanmodes_c: { a: "s" },
     chanmodes_d: { a: "s" },
     prefix: { r: "s" },
+    frame_budget_base: "i",
   },
 } as const;
 

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -900,6 +900,7 @@ export type SessionWireIsupportChangedPayload = {
   chanmodes_c: string[];
   chanmodes_d: string[];
   prefix: Record<string, string>;
+  frame_budget_base: number;
 };
 
 export type SessionWireUmodeChangedPayload = {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3470,25 +3470,48 @@ html.resize-dragging * {
   animation: login-spin 0.9s linear infinite;
 }
 
-.compose-box-error {
-  color: var(--mode-op);
+/* The compose feedback seam: ONE line, three severities, and they must be
+   geometrically identical or the line reflows when one swaps for another
+   (#356 error↔notice on submit, #1108 warning↔error as a draft grows). The
+   geometry is therefore stated ONCE, here, and each severity contributes
+   nothing but its colour token — a third hand-copied block is exactly how
+   that invariant would have started to drift. */
+.compose-box-error,
+.compose-box-notice,
+.compose-box-warning {
   margin: 0;
   padding: 0.25rem 1rem;
   font-size: 0.85rem;
   border-top: 1px solid var(--border);
 }
 
-/* #356 — success/notice seam: the green sibling of .compose-box-error.
-   Same geometry (so the line never reflows when a submit swaps error↔notice);
-   the ONLY difference is the color token — var(--mode-voiced) is the theme's
-   green (the +voiced-nick hue), read as "success / affirmative" here. Carries
-   role=status (polite) at the markup layer; this rule is colour-only. */
+.compose-box-error {
+  color: var(--mode-op);
+}
+
+/* #356 — success/notice: var(--mode-voiced) is the theme's green (the
+   +voiced-nick hue), read as "success / affirmative" here. */
 .compose-box-notice {
   color: var(--mode-voiced);
+}
+
+/* #1108 — "this will split": var(--mode-halfop) is the theme's amber (the
+   %halfop hue), between the notice's green and the error's red exactly as
+   the severity is. Carries role=status (polite) at the markup layer. */
+.compose-box-warning {
+  color: var(--mode-halfop);
+}
+
+/* #1108 — bytes left in the frame, sitting above the box. Right-aligned and
+   quiet: it is a glanceable number during normal typing, not an alert, and
+   the amber it turns is the same token the seam warning it precedes uses. */
+.compose-box-frame-countdown {
   margin: 0;
-  padding: 0.25rem 1rem;
-  font-size: 0.85rem;
-  border-top: 1px solid var(--border);
+  padding: 0 1rem;
+  text-align: right;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--mode-halfop);
 }
 
 /* Image upload — picker button + TTL select + progress + modal.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37584,13 +37584,20 @@ it, fall back to the byte cut for a token that holds none.
 What makes that acceptable where a mirror of `relay_frame_overhead` is not:
 the split that reaches the wire is still the server's, so a drift costs an
 advisory number off by a frame and can never cost a byte. The two failure
-modes are not the same kind of thing. The mirror is written against #1109's
-semantics and its twelve cases were measured against that splitter's own
-fragment counts, one for one — but that is a measurement taken once, NOT a
-gate. There is no CI step that will notice the day the two diverge. The honest
-containment is a twin case table on the Elixir side asserting the same counts;
-it is owed, and it cannot be written until #1109 lands, because main's
-splitter still answers differently.
+modes are not the same kind of thing.
+
+**And the mirror is gated, not merely measured.** Twelve `(budget, body)`
+cases live verbatim in BOTH suites — `frameBudget.test.ts` and
+`line_split_test.exs`'s "#1108: the fragment counts cic's preview mirrors" —
+so each side pins its own splitter and neither can move quietly. Verified in
+both directions: dropping the word-boundary rule from the TS chunker fails
+exactly the two boundary cases there, and dropping it from `break_space?/1`
+fails exactly the same two here. Add a case to one table, add it to the other.
+This was written only because #1109 landed first: against the byte-cut
+splitter the shared table could only have been written red. What a count
+table still cannot witness is the NO-BREAK SPACE policy — treating U+00A0 as
+a boundary moves WHERE the cut lands without changing how many fragments come
+out — so that stays pinned by #1109's own arms, server-side only.
 
 **cic invents no budget.** `DEFAULT_ISUPPORT` has an honest default for the
 capability table (bahamut's, which is what prod advertises) and none for the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37535,6 +37535,9 @@ container, `actionlint` was clean, and ten mutants in the workflow each killed
 exactly one bats case. The tag logic, the label set and the push gate are held
 by derivation-and-compare against the bouncer's, never by a re-typed copy — so
 they follow the bouncer when it moves. Nothing here proves a byte reached ghcr.
+
+---
+
 ## 2026-08-10 — #1108: the frame budget is published; the split PREVIEW is a declared mirror
 
 The compose box now tells the operator, before a send, that the draft no
@@ -37591,8 +37594,10 @@ cases live verbatim in BOTH suites — `frameBudget.test.ts` and
 `line_split_test.exs`'s "#1108: the fragment counts cic's preview mirrors" —
 so each side pins its own splitter and neither can move quietly. Verified in
 both directions: dropping the word-boundary rule from the TS chunker fails
-exactly the two boundary cases there, and dropping it from `break_space?/1`
-fails exactly the same two here. Add a case to one table, add it to the other.
+exactly the two boundary cases of the table there, and dropping it from
+`break_space?/1` fails exactly the same two cases of the table here (plus
+three of #1109's own arms, which is the point of those arms). Add a case to
+one table, add it to the other.
 This was written only because #1109 landed first: against the byte-cut
 splitter the shared table could only have been written red. What a count
 table still cannot witness is the NO-BREAK SPACE policy — treating U+00A0 as
@@ -37622,3 +37627,32 @@ keystroke is noise; the event worth announcing is "this will split", and the
 seam line carries it politely. Zero is rendered rather than skipped — at
 exactly the budget the draft is still one message, so hiding it would blink
 the counter off for one byte before the warning appears.
+
+**A published number must be checked against the wire, not against the
+arithmetic that produced it.** An audit of this branch's own guards found two
+that could not fail: they asserted
+`base - byte_size(target) == LineSplit.frame_budget(target, linelen)` where
+`base` was itself `frame_budget_base/1`, so a `+ 1` inside `frame_budget/2`
+moved BOTH sides and left them green (measured: 22 reds in
+`line_split_test.exs`, 0 in `server_test.exs` and `grappa_channel_test.exs`).
+The replacement oracle is `Grappa.RelayFrameHelpers` — the #246 worst-case
+relayed frame, built from the identity ceilings and forbidden to call
+`LineSplit` — asserting EQUALITY between the framed body and LINELEN. Equality
+is what makes it two-sided in one line: `<=` would accept every under-count,
+which is the half of the space a budget drifts into. Hand-deriving the
+constant instead (the `512 - 119` this replaced) does discriminate, but only
+by writing the same sum twice — it re-checks the arithmetic rather than the
+behaviour, and it invites "fix the test" when a ceiling legitimately moves.
+The session-level arms are kept, relabelled for what they actually witness:
+that the LIVE linelen reaches the payload (a narrowed broadcast trigger and a
+hardcoded snapshot linelen each kill exactly one of them). **General rule: if
+both sides of an assertion come from the same function, the arm is about
+plumbing, and the number needs an oracle from somewhere else.**
+
+**Both isupport doors are gated, deliberately one test each.** A wire→store
+fold that dropped `frame_budget_base` used to die in exactly one test, on the
+live-005 door, while the cold snapshot — the only door a client joining an
+always-on bouncer long after the 005 burst ever uses — had no isupport arm at
+all. `subscribe.test.ts` now asserts the budget lands in the REAL store
+(`frameBudgetBaseForNetwork`), not on a `seedIsupport` spy, so the shared fold
+has one killer per door and the door itself has its first guard.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37535,3 +37535,83 @@ container, `actionlint` was clean, and ten mutants in the workflow each killed
 exactly one bats case. The tag logic, the label set and the push gate are held
 by derivation-and-compare against the bouncer's, never by a re-typed copy — so
 they follow the bouncer when it moves. Nothing here proves a byte reached ghcr.
+## 2026-08-10 — #1108: the frame budget is published; the split PREVIEW is a declared mirror
+
+The compose box now tells the operator, before a send, that the draft no
+longer fits one IRC frame: an amber third state on the #356 feedback seam
+("your message will send as N separate messages"), and a byte countdown above
+the box for the last ten bytes of the frame.
+
+**The budget is a published number, not a client computation.** The per-frame
+body budget is `LINELEN - relay_frame_overhead(target)`, and that overhead
+reserves the #246 WORST-CASE relayed source prefix at grappa's own identity
+ceilings (nick ≤ 30, ident ≤ 10, host ≤ 63). Those ceilings are precisely what
+a second copy gets silently wrong, in the direction that TRUNCATES the wire —
+the data loss #246 exists to have fixed. So `LineSplit` grew
+`frame_budget_base/1` and the server publishes it. Because
+`relay_frame_overhead/1` is affine in the target's byte length, ONE
+per-network scalar is enough for any target: cic sizes a specific one with
+`base - byte_size(target)`, arithmetic over a string it already holds.
+`split_privmsg_body/3` now goes through the same `frame_budget/2`, so the
+published number and the number the splitter uses cannot come apart.
+
+**It rides `isupport_changed`, not a new endpoint.** The budget is a 005 fact,
+so it belongs on the payload already carrying the 005 capability table: same
+per-network carrier, same two doors (the live broadcast and the cold
+after-join snapshot), one additive snake_case field, no `protocol_version`
+bump. The broadcast trigger had to widen from "the capability table changed"
+to "or LINELEN changed" — a network may advertise LINELEN on a 005 line
+carrying no CHANMODES or PREFIX, and gating on the table alone would leave
+every connected client sizing its warning against the previous frame for the
+rest of the session.
+
+**Rejected: folding LINELEN into `Grappa.Session.ISupport`.** It is a 005
+token and the table is "the per-network 005 capability set", so the parse
+sitting in `Session.Server` instead is a genuine wart, and folding it in would
+have collapsed the broadcast trigger back to one condition and saved the
+second GenServer call the cold snapshot now makes. It also rewrites the SEND
+path (`state.linelen` feeds `split_privmsg_body/3`), which is #246 territory,
+for a display feature. Left alone deliberately; it is worth its own change.
+
+**The COUNT is a mirror, and this is the part to argue with.** The warning has
+to be on screen BEFORE the POST, so there is no round trip to ask the
+authority with, and the fragment count under word-boundary splitting (#1109)
+is not derivable from the budget by arithmetic — it depends on where the
+spaces fall. `cicchetto/src/lib/frameBudget.ts` therefore reimplements
+`LineSplit`'s chunker: greedy fill, prefer the last ASCII space/tab, consume
+it, fall back to the byte cut for a token that holds none.
+
+What makes that acceptable where a mirror of `relay_frame_overhead` is not:
+the split that reaches the wire is still the server's, so a drift costs an
+advisory number off by a frame and can never cost a byte. The two failure
+modes are not the same kind of thing. The mirror is written against #1109's
+semantics and its twelve cases were measured against that splitter's own
+fragment counts, one for one — but that is a measurement taken once, NOT a
+gate. There is no CI step that will notice the day the two diverge. The honest
+containment is a twin case table on the Elixir side asserting the same counts;
+it is owed, and it cannot be written until #1109 lands, because main's
+splitter still answers differently.
+
+**cic invents no budget.** `DEFAULT_ISUPPORT` has an honest default for the
+capability table (bahamut's, which is what prod advertises) and none for the
+budget: `frameBudgetBase: null`. An unseeded network, a parked session, or a
+server predating the field leaves both affordances dark rather than warning
+from a number nobody published. For the same reason the narrower takes the
+field permissively — absent or malformed means absent, never a rejected
+envelope, or an older server would stop seeding `/mode`'s toggles too.
+
+**Precedence on the seam is declared: an error outranks the split warning.**
+One line, and an error is the more urgent read. The collision is real rather
+than theoretical — a paced send that fails puts its residue back in the draft
+(#666) while its error is still sticky. A notice cannot collide in practice
+(the submit that produced one just emptied the draft, and any keystroke clears
+feedback), so it inherits the same precedence for free. The three severities
+now share ONE geometry rule: identical geometry is what keeps the line from
+reflowing when one swaps for another, and a third hand-copied block is how
+that would have started to drift.
+
+**The countdown is aria-hidden.** A live region that changes on every
+keystroke is noise; the event worth announcing is "this will split", and the
+seam line carries it politely. Zero is rendered rather than skipped — at
+exactly the budget the draft is still one message, so hiding it would blink
+the counter off for one byte before the warning appears.

--- a/lib/grappa/irc/line_split.ex
+++ b/lib/grappa/irc/line_split.ex
@@ -133,6 +133,33 @@ defmodule Grappa.IRC.LineSplit do
   end
 
   @doc """
+  The per-frame body budget for `target` on a `linelen`-byte wire: the bytes a
+  fragment may hold once the worst-case relayed framing is reserved. Can go
+  non-positive on an absurdly small `linelen` — `split_privmsg_body/3` treats
+  that as "no useful split".
+  """
+  @spec frame_budget(String.t(), pos_integer()) :: integer()
+  def frame_budget(target, linelen) when is_binary(target) and is_integer(linelen) do
+    linelen - relay_frame_overhead(target)
+  end
+
+  @doc """
+  The TARGET-INDEPENDENT part of `frame_budget/2`, published to clients (#1108).
+
+  `frame_budget(target, linelen) == frame_budget_base(linelen) - byte_size(target)`,
+  because `relay_frame_overhead/1` is affine in the target's byte length. So one
+  per-network scalar is enough for a client to size the budget of any target it
+  can name, without owning a second copy of the #246 worst-case ceilings — the
+  numbers whose whole reason for living here is that a client-side copy drifts
+  silently in the direction that LOSES bytes.
+
+  The client's half of the arithmetic is the length of a string it already
+  holds; the ceilings stay here.
+  """
+  @spec frame_budget_base(pos_integer()) :: integer()
+  def frame_budget_base(linelen) when is_integer(linelen), do: frame_budget("", linelen)
+
+  @doc """
   Splits `body` into fragments that fit within `linelen` bytes
   per wire frame, given the target prefix.
 
@@ -153,7 +180,7 @@ defmodule Grappa.IRC.LineSplit do
   @spec split_privmsg_body(String.t(), String.t(), pos_integer()) :: [String.t(), ...]
   def split_privmsg_body(body, target, linelen)
       when is_binary(body) and is_binary(target) and is_integer(linelen) and linelen > 0 do
-    budget = linelen - relay_frame_overhead(target)
+    budget = frame_budget(target, linelen)
 
     cond do
       budget <= 0 -> [body]

--- a/lib/grappa/irc/line_split.ex
+++ b/lib/grappa/irc/line_split.ex
@@ -92,6 +92,26 @@ defmodule Grappa.IRC.LineSplit do
   own upstream PRIVMSG, matching what every other IRC client
   renders + what the operator's own past view will reconstruct.
 
+  ## cic PREVIEWS this, and that is a mirror you must maintain (#1108)
+
+  The compose box warns before a send that the draft will split, and
+  states how many messages it becomes. That number cannot be asked for —
+  it has to be on screen before any POST — and it is not derivable from
+  the budget by arithmetic once breaks land on words. So
+  `cicchetto/src/lib/frameBudget.ts` reimplements the chunker below.
+
+  The wire split is still ONLY this module's; a drift costs an advisory
+  count off by a frame, never a byte. But the two are pinned to each
+  other by one shared table of `(budget, body) → fragment count` cases,
+  duplicated verbatim in `line_split_test.exs` ("#1108: the fragment
+  counts cic's preview mirrors") and `frameBudget.test.ts`. **Changing
+  `chunk_by_bytes/5` or `break_at_word/1` turns that table red here, and
+  the fix is not complete until the cic side moves with it.**
+
+  What cic does NOT own is the BUDGET: the worst-case ceilings above stay
+  here, published as `frame_budget_base/1` on the `isupport_changed`
+  payload. A second copy of THOSE is the #246 data loss again.
+
   ## CTCP awareness
 
   A body beginning with `\\x01ACTION ` is a CTCP ACTION (classified

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1377,6 +1377,21 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  Returns the session's live wire line length (#1108).
+
+  The `LINELEN=` the network advertised in 005, or the RFC 2812 default of
+  512 before/without one. Bounds the WHOLE relayed frame, so it is a raw
+  IRC fact, not a body budget — `Grappa.IRC.LineSplit` owns that projection.
+  Returns `{:error, :no_session}` when no session is registered for
+  `(subject, network_id)`.
+  """
+  @spec get_linelen(subject(), integer()) :: {:ok, pos_integer()} | {:error, :no_session}
+  def get_linelen(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :get_linelen)
+  end
+
+  @doc """
   Returns the per-session USER-mode set (#229).
 
   Serves the in-memory `umodes` list — the operator's own umodes on this

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -91,7 +91,7 @@ defmodule Grappa.Session.Server do
     UserSettings
   }
 
-  alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, Message}
+  alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, LineSplit, Message}
   alias Grappa.Net.SourceAliasManager
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire
@@ -2475,6 +2475,13 @@ defmodule Grappa.Session.Server do
     {:reply, {:ok, Map.get(state, :isupport, ISupport.default())}, state}
   end
 
+  # #1108: the live LINELEN, for the cold WS after-join snapshot — whose
+  # sibling `:get_isupport` covers the rest of the same payload. Raw, not a
+  # budget: the wire builder owns that projection, so there is exactly one.
+  def handle_call(:get_linelen, _, state) do
+    {:reply, {:ok, state.linelen}, state}
+  end
+
   # #229: returns the per-session umode set. Always succeeds ([] before the
   # 221 arrives). `Map.get` default (not `state.umodes`) so a live proc
   # whose state predates the :umodes field — a plain hot module reload does
@@ -3361,10 +3368,14 @@ defmodule Grappa.Session.Server do
     prev_isupport = Map.get(state, :isupport, ISupport.default())
     isupport = ISupport.merge_isupport(msg.params, prev_isupport)
 
-    if isupport != prev_isupport do
+    # #1108 — LINELEN is in the same broadcast, so a 005 line that advertises
+    # ONLY LINELEN (no CHANMODES/PREFIX) must still reach the client: gating
+    # on the capability table alone would leave every connected cic sizing
+    # its "this will split" warning against the previous frame all session.
+    if isupport != prev_isupport or linelen != state.linelen do
       broadcast_window_state(
         state,
-        SessionWire.isupport_changed(state.network_id, isupport)
+        SessionWire.isupport_changed(state.network_id, isupport, linelen)
       )
     end
 
@@ -3645,7 +3656,7 @@ defmodule Grappa.Session.Server do
     # HERE (the facade now passes `target` RAW); the wire + `dm_with`
     # display keep the raw casing. Fold once and thread both forms.
     key = fold_key(state, target)
-    fragments = Grappa.IRC.LineSplit.split_privmsg_body(body, target, state.linelen)
+    fragments = LineSplit.split_privmsg_body(body, target, state.linelen)
 
     case persist_and_send_fragments(target, key, fragments, state, nil) do
       {:ok, last_message} ->

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -57,6 +57,7 @@ defmodule Grappa.Session.Wire do
   both shapes use one field name.
   """
 
+  alias Grappa.IRC.LineSplit
   alias Grappa.Scrollback.Message
   alias Grappa.Session.{EventRouter, ISupport}
 
@@ -120,6 +121,15 @@ defmodule Grappa.Session.Wire do
   reflows; keeping it flat sidesteps that formatter tug-of-war. PREFIX
   stays a letter→sigil map. Rides `Topic.user/1` (ISUPPORT is
   per (subject, network), not per-channel).
+
+  `frame_budget_base` (#1108) is the second 005 fact on this payload: the
+  target-INDEPENDENT part of the per-frame body budget, which a client
+  turns into a per-target budget with
+  `frame_budget_base - <target's UTF-8 byte length>`. It is published
+  rather than derivable because the budget reserves the #246 worst-case
+  relayed source prefix, and a client-side copy of those ceilings drifts
+  silently in the direction that LOSES bytes. See
+  `Grappa.IRC.LineSplit.frame_budget_base/1`.
   """
   @type isupport_changed_payload :: %{
           kind: :isupport_changed,
@@ -128,7 +138,8 @@ defmodule Grappa.Session.Wire do
           chanmodes_b: [String.t()],
           chanmodes_c: [String.t()],
           chanmodes_d: [String.t()],
-          prefix: %{String.t() => String.t()}
+          prefix: %{String.t() => String.t()},
+          frame_budget_base: integer()
         }
 
   @typedoc """
@@ -829,16 +840,20 @@ defmodule Grappa.Session.Wire do
   end
 
   @doc """
-  Per-network ISUPPORT channel-mode capability set (#216). Projects
+  Per-network ISUPPORT facts (#216). Projects
   `Grappa.Session.ISupport.t/0` to a JSON-encodable payload: the four
   CHANMODES MapSet classes become sorted lists, PREFIX stays a
   letter→sigil map. Carries `:network_id` (not slug) and rides
   `Topic.user/1` — the same rationale as `own_nick_changed/2` (per
   (subject, network) state on a non-network-scoped user topic).
+
+  `linelen` is the session's live LINELEN (005, or the RFC 2812 default);
+  it is published as the derived per-frame budget, never raw, so cic never
+  holds a second copy of the #246 framing reserve (#1108).
   """
-  @spec isupport_changed(integer(), ISupport.t()) :: isupport_changed_payload()
-  def isupport_changed(network_id, %{chanmodes: cm, prefix: prefix})
-      when is_integer(network_id) do
+  @spec isupport_changed(integer(), ISupport.t(), pos_integer()) :: isupport_changed_payload()
+  def isupport_changed(network_id, %{chanmodes: cm, prefix: prefix}, linelen)
+      when is_integer(network_id) and is_integer(linelen) do
     %{
       kind: :isupport_changed,
       network_id: network_id,
@@ -846,7 +861,8 @@ defmodule Grappa.Session.Wire do
       chanmodes_b: Enum.sort(cm.b),
       chanmodes_c: Enum.sort(cm.c),
       chanmodes_d: Enum.sort(cm.d),
-      prefix: prefix
+      prefix: prefix,
+      frame_budget_base: LineSplit.frame_budget_base(linelen)
     }
   end
 

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -1560,12 +1560,11 @@ defmodule GrappaWeb.GrappaChannel do
   # back to its own bahamut default until a session is live.
   @spec push_isupport_if_live(Session.subject(), Network.t(), Phoenix.Socket.t()) :: :ok
   defp push_isupport_if_live(subject, %Network{} = network, socket) do
-    case Session.get_isupport(subject, network.id) do
-      {:ok, isupport} ->
-        push(socket, "event", SessionWire.isupport_changed(network.id, isupport))
-
-      {:error, _} ->
-        :ok
+    with {:ok, isupport} <- Session.get_isupport(subject, network.id),
+         {:ok, linelen} <- Session.get_linelen(subject, network.id) do
+      push(socket, "event", SessionWire.isupport_changed(network.id, isupport, linelen))
+    else
+      {:error, _} -> :ok
     end
   end
 

--- a/test/grappa/irc/line_split_test.exs
+++ b/test/grappa/irc/line_split_test.exs
@@ -2,8 +2,6 @@ defmodule Grappa.IRC.LineSplitTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias Grappa.IRC.{CTCP, LineSplit}
-
   # #246 — worst-case source prefix the RELAYING server prepends to our
   # outbound line before fanning it out to other channel members:
   #
@@ -14,22 +12,15 @@ defmodule Grappa.IRC.LineSplitTest do
   # on grappa's wire yet exceed linelen once relayed → the server truncates
   # the tail → the next fragment resumes past the cut → a silent byte hole.
   # The budget MUST reserve the WORST-CASE prefix (host/cloak grows between
-  # messages; never budget against the live prefix). Ceilings are the
-  # protocol maxima grappa validates its own identity against —
-  # Grappa.IRC.Identifier @nick_regex (≤30, Azzurra NICKLEN=30) and
-  # @ident_regex (≤10, common USERLEN) — plus the common ircd HOSTLEN 63
-  # (covers cloaks + bracketed IPv6 literals). Restated here as an
-  # INDEPENDENT statement of the on-wire worst case: the test builds the
-  # actual relayed bytes and checks byte_size, rather than trusting the
-  # splitter's own budget arithmetic.
-  @wc_nick String.duplicate("n", 30)
-  @wc_ident String.duplicate("u", 10)
-  @wc_host String.duplicate("h", 63)
-  @wc_source_prefix ":" <> @wc_nick <> "!" <> @wc_ident <> "@" <> @wc_host <> " "
+  # messages; never budget against the live prefix). The frame builder and
+  # its ceilings live in `Grappa.RelayFrameHelpers` — an INDEPENDENT
+  # restatement of the on-wire worst case, shared with `wire_test.exs` since
+  # #1108 so that the number this module publishes is checked against the
+  # bytes rather than against its own arithmetic.
+  import Grappa.RelayFrameHelpers, only: [worst_case_relayed_frame: 2]
 
-  # The concrete worst-case relayed wire frame around a fragment body.
-  defp worst_case_relayed_frame(target, fragment),
-    do: @wc_source_prefix <> "PRIVMSG #{target} :" <> fragment <> "\r\n"
+  alias Grappa.IRC.{CTCP, LineSplit}
+  alias Grappa.RelayFrameHelpers
 
   defp single_grapheme?(s), do: match?([_], String.graphemes(s))
 
@@ -322,10 +313,22 @@ defmodule Grappa.IRC.LineSplitTest do
   # tests pin the linearity AND pin the number against the splitter's actual
   # behaviour rather than against its internal arithmetic.
   describe "#1108: the per-frame body budget as a published number" do
-    test "a body of exactly the budget is one fragment; one byte more is two" do
+    # The published budget is checked against the WIRE, never against the
+    # arithmetic that produced it. Both halves matter and they fail apart:
+    # `assert_budget_fills_the_frame/3` builds the worst-case relayed frame
+    # from the #246 ceilings and demands EQUALITY with linelen, so a budget
+    # off by one in either direction dies there; the fragment counts below
+    # then say the splitter actually honours the number it published.
+    #
+    # Sizing the body from `frame_budget_base/1` and splitting with
+    # `frame_budget/2` would otherwise move BOTH sides of a defect together
+    # — measured: a `+ 1` inside `frame_budget/2` left the counts green.
+    test "the published budget fills the relayed frame exactly, and the splitter honours it" do
       target = "#sniffo"
       linelen = 512
       budget = LineSplit.frame_budget_base(linelen) - byte_size(target)
+
+      RelayFrameHelpers.assert_budget_fills_the_frame(budget, target, linelen)
 
       # Space-free so the #1109 word-boundary preference has no boundary to
       # take: the fragment count is then a pure statement about the budget.
@@ -333,6 +336,14 @@ defmodule Grappa.IRC.LineSplitTest do
 
       assert [_, _] =
                LineSplit.split_privmsg_body(String.duplicate("a", budget + 1), target, linelen)
+    end
+
+    test "the budget tracks LINELEN, not a hardcoded RFC default" do
+      RelayFrameHelpers.assert_budget_fills_the_frame(
+        LineSplit.frame_budget_base(1024) - byte_size("#a"),
+        "#a",
+        1024
+      )
     end
 
     property "base minus the target's own bytes IS the per-target budget" do

--- a/test/grappa/irc/line_split_test.exs
+++ b/test/grappa/irc/line_split_test.exs
@@ -346,6 +346,48 @@ defmodule Grappa.IRC.LineSplitTest do
     end
   end
 
+  # #1108 — the CROSS-STACK pin, and the reason it is here rather than only
+  # in cic. The compose box must say how many messages a draft becomes BEFORE
+  # the POST, so there is no round trip to ask this module with: cic mirrors
+  # the chunker in `cicchetto/src/lib/frameBudget.ts`. A mirror measured once
+  # is a snapshot; this table is the gate. Every case below is duplicated
+  # verbatim in `frameBudget.test.ts`, keyed on the same (budget, body), and
+  # the two suites hold each other honest — change either splitter and its
+  # own side goes red.
+  #
+  # `linelen` is derived from the budget through the production function, so
+  # the table states budgets (what cic is handed) and not wire lengths.
+  #
+  # Not covered by count alone, and deliberately not faked: the NO-BREAK
+  # SPACE policy. Treating U+00A0 as a boundary changes WHERE the cut lands
+  # but not how many fragments come out, so a count table cannot witness it —
+  # the #1109 arms above are what pin that.
+  describe "#1108: the fragment counts cic's preview mirrors" do
+    for {budget, body, expected} <- [
+          {10, String.duplicate("a", 10), 1},
+          {10, String.duplicate("a", 11), 2},
+          {10, "aaaaa bbbbbbbb cc", 3},
+          {10, "aaaaa\tbbbbbbbb cc", 3},
+          {10, String.duplicate("a", 20), 2},
+          {2, "🍕🍕", 2},
+          {10, String.duplicate("é", 5), 1},
+          {10, String.duplicate("é", 6), 2},
+          {20, "\x01ACTION " <> String.duplicate("a", 15) <> "\x01", 2},
+          {20, String.duplicate("a", 15), 1},
+          {0, "hello", 1},
+          {5, "\x01ACTION hello\x01", 1}
+        ] do
+      test "budget #{budget}: #{inspect(body)} is #{expected} fragment(s)" do
+        budget = unquote(budget)
+        body = unquote(body)
+        linelen = budget + LineSplit.relay_frame_overhead("")
+
+        assert LineSplit.frame_budget("", linelen) == budget
+        assert length(LineSplit.split_privmsg_body(body, "", linelen)) == unquote(expected)
+      end
+    end
+  end
+
   describe "property: relay-safe, lossless, codepoint-whole splitting" do
     property "tiles the body, every fragment relay-safe + valid UTF-8" do
       check all(

--- a/test/grappa/irc/line_split_test.exs
+++ b/test/grappa/irc/line_split_test.exs
@@ -358,6 +358,12 @@ defmodule Grappa.IRC.LineSplitTest do
   # `linelen` is derived from the budget through the production function, so
   # the table states budgets (what cic is handed) and not wire lengths.
   #
+  # Two of the cases exist for the MIRROR rather than for this module: the
+  # leading-space one is where an off-by-one in the boundary scan would break
+  # at index 0 and emit an empty fragment, and the ZWJ family is the only
+  # place `String.graphemes/1` and cic's `Intl.Segmenter` have to agree on
+  # what one grapheme IS (a lone-codepoint emoji does not exercise that).
+  #
   # Not covered by count alone, and deliberately not faked: the NO-BREAK
   # SPACE policy. Treating U+00A0 as a boundary changes WHERE the cut lands
   # but not how many fragments come out, so a count table cannot witness it —
@@ -369,6 +375,8 @@ defmodule Grappa.IRC.LineSplitTest do
           {10, "aaaaa bbbbbbbb cc", 3},
           {10, "aaaaa\tbbbbbbbb cc", 3},
           {10, String.duplicate("a", 20), 2},
+          {10, " " <> String.duplicate("a", 12), 2},
+          {4, "👩‍👩‍👧‍👦", 1},
           {2, "🍕🍕", 2},
           {10, String.duplicate("é", 5), 1},
           {10, String.duplicate("é", 6), 2},

--- a/test/grappa/irc/line_split_test.exs
+++ b/test/grappa/irc/line_split_test.exs
@@ -314,6 +314,38 @@ defmodule Grappa.IRC.LineSplitTest do
     end
   end
 
+  # #1108 — the budget cic needs in order to warn, BEFORE sending, that the
+  # draft no longer fits one frame. The client may not re-derive it: the #246
+  # worst-case ceilings are exactly the numbers that drift silently in the
+  # byte-losing direction. So the server publishes ONE per-network scalar and
+  # the client subtracts its own target's byte length — which is why these
+  # tests pin the linearity AND pin the number against the splitter's actual
+  # behaviour rather than against its internal arithmetic.
+  describe "#1108: the per-frame body budget as a published number" do
+    test "a body of exactly the budget is one fragment; one byte more is two" do
+      target = "#sniffo"
+      linelen = 512
+      budget = LineSplit.frame_budget_base(linelen) - byte_size(target)
+
+      # Space-free so the #1109 word-boundary preference has no boundary to
+      # take: the fragment count is then a pure statement about the budget.
+      assert [_] = LineSplit.split_privmsg_body(String.duplicate("a", budget), target, linelen)
+
+      assert [_, _] =
+               LineSplit.split_privmsg_body(String.duplicate("a", budget + 1), target, linelen)
+    end
+
+    property "base minus the target's own bytes IS the per-target budget" do
+      check all(
+              target <- string(:utf8, min_length: 1, max_length: 60),
+              linelen <- integer(200..600)
+            ) do
+        assert LineSplit.frame_budget_base(linelen) - byte_size(target) ==
+                 linelen - LineSplit.relay_frame_overhead(target)
+      end
+    end
+  end
+
   describe "property: relay-safe, lossless, codepoint-whole splitting" do
     property "tiles the body, every fragment relay-safe + valid UTF-8" do
       check all(

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -4426,6 +4426,46 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
+
+    # #1108 — the budget cic warns from is a projection of LINELEN, and a
+    # network may advertise LINELEN in a 005 line that carries no CHANMODES
+    # or PREFIX at all. Gating the broadcast on the capability table alone
+    # would leave every connected client sizing its warning against the
+    # previous (usually RFC-default) frame for the rest of the session.
+    test "005 that changes ONLY LINELEN still republishes the frame budget" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # No CHANMODES / PREFIX / STATUSMSG / CASEMAPPING token: the isupport
+      # capability table is byte-for-byte what it was.
+      IRCServer.feed(server, ":irc.test.org 005 grappa-test LINELEN=600 :are supported\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :isupport_changed, frame_budget_base: base}
+                     },
+                     1_000
+
+      # The published budget follows the advertised LINELEN, and it is the
+      # budget the splitter will actually use for a target of that name.
+      assert base - byte_size("#sniffo") ==
+               Grappa.IRC.LineSplit.frame_budget("#sniffo", 600)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
   end
 
   describe "#229 — umode viewer (own user modes visible from connect)" do

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -20,6 +20,7 @@ defmodule Grappa.Session.WireTest do
   """
   use ExUnit.Case, async: true
 
+  alias Grappa.RelayFrameHelpers
   alias Grappa.Scrollback.Message
   alias Grappa.Session.{ISupport, Wire}
 
@@ -88,14 +89,23 @@ defmodule Grappa.Session.WireTest do
       assert payload.prefix == %{"o" => "@", "h" => "%", "v" => "+"}
     end
 
-    # #1108 — the builder takes LINELEN and publishes the BUDGET, so the
-    # projection is stated here independently of `LineSplit`: 512 minus the
-    # worst-case relayed framing for an empty target, which is the 107-byte
-    # source prefix `:nick!user@host ` (1+30+1+10+1+63+1) plus `PRIVMSG  :`
-    # (10) plus CRLF (2) = 119.
-    test "publishes the per-frame budget base derived from LINELEN" do
-      assert Wire.isupport_changed(7, ISupport.default(), 512).frame_budget_base == 512 - 119
-      assert Wire.isupport_changed(7, ISupport.default(), 1024).frame_budget_base == 1024 - 119
+    # #1108 — the builder takes LINELEN and publishes the BUDGET, and the
+    # number is checked the way a CLIENT will spend it: subtract the target's
+    # bytes, fill a body with that many, and the worst-case relayed frame
+    # (#246 ceilings, `Grappa.RelayFrameHelpers`) must come out EXACTLY at
+    # LINELEN. The oracle is the wire, not a second copy of the framing
+    # arithmetic — an expected value re-derived by hand would only check that
+    # the same sum can be written twice.
+    test "publishes a budget a client can spend to the last byte of the frame" do
+      for {linelen, target} <- [{512, "#sniffo"}, {1024, "#a"}, {512, "#café"}] do
+        base = Wire.isupport_changed(7, ISupport.default(), linelen).frame_budget_base
+
+        RelayFrameHelpers.assert_budget_fills_the_frame(
+          base - byte_size(target),
+          target,
+          linelen
+        )
+      end
     end
 
     test "the payload is JSON-encodable (no MapSet leaks)" do

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -69,7 +69,7 @@ defmodule Grappa.Session.WireTest do
     end
   end
 
-  describe "isupport_changed/2" do
+  describe "isupport_changed/3" do
     test "projects ISupport.t() to a JSON-encodable payload (MapSets → sorted lists)" do
       isupport =
         ISupport.merge_isupport(
@@ -77,7 +77,7 @@ defmodule Grappa.Session.WireTest do
           ISupport.default()
         )
 
-      payload = Wire.isupport_changed(7, isupport)
+      payload = Wire.isupport_changed(7, isupport, 512)
 
       assert payload.kind == :isupport_changed
       assert payload.network_id == 7
@@ -88,8 +88,18 @@ defmodule Grappa.Session.WireTest do
       assert payload.prefix == %{"o" => "@", "h" => "%", "v" => "+"}
     end
 
+    # #1108 — the builder takes LINELEN and publishes the BUDGET, so the
+    # projection is stated here independently of `LineSplit`: 512 minus the
+    # worst-case relayed framing for an empty target, which is the 107-byte
+    # source prefix `:nick!user@host ` (1+30+1+10+1+63+1) plus `PRIVMSG  :`
+    # (10) plus CRLF (2) = 119.
+    test "publishes the per-frame budget base derived from LINELEN" do
+      assert Wire.isupport_changed(7, ISupport.default(), 512).frame_budget_base == 512 - 119
+      assert Wire.isupport_changed(7, ISupport.default(), 1024).frame_budget_base == 1024 - 119
+    end
+
     test "the payload is JSON-encodable (no MapSet leaks)" do
-      payload = Wire.isupport_changed(1, ISupport.default())
+      payload = Wire.isupport_changed(1, ISupport.default(), 512)
       assert {:ok, _} = Jason.encode(payload)
     end
   end

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -361,6 +361,34 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert prefix["q"] == "~"
     end
 
+    # #1108 — the cold snapshot is the ONLY door for a client that connects
+    # long after the 005 burst, which on an always-on bouncer is every
+    # client. Without the budget here the compose-box warning stays dark
+    # until the network happens to re-advertise.
+    test "after-join snapshot: carries the per-frame budget base (#1108)" do
+      {irc_server, port} = start_irc_server()
+      {user, network} = setup_user_and_network_with_session(port)
+
+      welcome_session_on_channel(irc_server, "#snap")
+
+      # A non-default LINELEN so the pushed number can only have come from
+      # the live session's 005, not from a hardcoded RFC default.
+      IRCServer.feed(irc_server, ":irc.test.org 005 grappa-snap LINELEN=600 :are supported\r\n")
+
+      flush_server(irc_server)
+
+      topic = Topic.channel(user.name, network.slug, "#snap")
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{})
+
+      assert_push("event", %{kind: :isupport_changed, frame_budget_base: base})
+
+      assert base - byte_size("#snap") == Grappa.IRC.LineSplit.frame_budget("#snap", 600)
+    end
+
     test "after-join snapshot: no push when no session is running for channel" do
       user_name = "ch-nosession-#{System.unique_integer([:positive])}"
       net_slug = "nosession-net-#{System.unique_integer([:positive])}"

--- a/test/support/relay_frame_helpers.ex
+++ b/test/support/relay_frame_helpers.ex
@@ -1,0 +1,54 @@
+defmodule Grappa.RelayFrameHelpers do
+  @moduledoc """
+  The worst-case RELAYED wire frame (#246), built from the protocol
+  ceilings — a deliberate INDEPENDENT restatement of what the server puts
+  on the wire around a body.
+
+  Nothing here may call `Grappa.IRC.LineSplit`. That is the whole point: a
+  budget assertion whose expected value comes from the same arithmetic it
+  is checking moves WITH a defect instead of catching it (#1108). Assert
+  against the bytes this module builds and the oracle is the wire, not the
+  splitter's own opinion of the wire.
+
+  The ceilings are the protocol maxima grappa validates its own identity
+  against — `Grappa.IRC.Identifier` `@nick_regex` (≤30, Azzurra
+  NICKLEN=30) and `@ident_regex` (≤10, common USERLEN) — plus the common
+  ircd HOSTLEN 63 (covers cloaks and bracketed IPv6 literals). They are
+  spelled out rather than imported so that moving a ceiling in production
+  is a visible, deliberate edit here too.
+  """
+
+  @wc_nick String.duplicate("n", 30)
+  @wc_ident String.duplicate("u", 10)
+  @wc_host String.duplicate("h", 63)
+  @wc_source_prefix ":" <> @wc_nick <> "!" <> @wc_ident <> "@" <> @wc_host <> " "
+
+  @doc "The concrete worst-case relayed wire frame around `fragment`."
+  @spec worst_case_relayed_frame(String.t(), String.t()) :: String.t()
+  def worst_case_relayed_frame(target, fragment)
+      when is_binary(target) and is_binary(fragment) do
+    @wc_source_prefix <> "PRIVMSG #{target} :" <> fragment <> "\r\n"
+  end
+
+  @doc """
+  Asserts that `budget` is EXACTLY the largest body that survives a relay
+  on a `linelen`-byte wire for `target`: a body of that many bytes fills
+  the worst-case frame to the brim.
+
+  EQUALITY, not `<=`, and that is what makes it two-sided in one line: a
+  budget one byte too generous overruns the frame, one byte too mean
+  leaves a byte unused. `<=` would accept every under-count, which is the
+  half of the space a published budget is most likely to drift into.
+  """
+  @spec assert_budget_fills_the_frame(integer(), String.t(), pos_integer()) :: true
+  def assert_budget_fills_the_frame(budget, target, linelen)
+      when is_integer(budget) and is_binary(target) and is_integer(linelen) do
+    framed = byte_size(worst_case_relayed_frame(target, String.duplicate("a", budget)))
+
+    ExUnit.Assertions.assert(
+      framed == linelen,
+      "a body of the published budget (#{budget}B) must fill the #{linelen}B relayed " <>
+        "frame for #{target} exactly — got #{framed}B"
+    )
+  end
+end


### PR DESCRIPTION
Tells the operator, before a send, that the draft no longer fits one IRC
message. Two surfaces, per the issue: an amber third state on the compose
seam — `your message will send as N separate messages`, no character count,
`role="status"` — and a byte countdown above the box for the last ten bytes
of the frame.

## The budget is published, not computed client-side

The per-frame body budget is `LINELEN - relay_frame_overhead(target)`, and
that overhead reserves the #246 **worst-case relayed source prefix** at
grappa's own identity ceilings. Those ceilings are exactly what a second copy
gets silently wrong, in the direction that truncates the wire — which is the
data loss #246 exists to have fixed. So option 1 of the issue: the server
publishes the number.

Because `relay_frame_overhead/1` is affine in the target's byte length, ONE
per-network scalar covers every target — cic sizes a specific one with
`base - byteLength(target)`, arithmetic over a string it already holds.
`split_privmsg_body/3` now goes through the same `frame_budget/2`, so the
published number and the number the splitter uses cannot come apart.

**No new endpoint.** The budget is a 005 fact, so it rides the payload already
carrying the 005 capability table — `isupport_changed` — as one additive
snake_case field, on both existing doors (the live broadcast and the cold
after-join snapshot). No `protocol_version` bump. The broadcast trigger had to
widen from "the capability table changed" to "or LINELEN changed": a network
may advertise LINELEN on a 005 line carrying no CHANMODES or PREFIX, and
gating on the table alone would leave every connected client sizing its
warning against the previous frame all session.

**Deliberately not done:** folding LINELEN into `Grappa.Session.ISupport`. It
is a 005 token and that module is "the per-network 005 capability table", so
the parse living in `Session.Server` instead is a real wart — folding it in
would also collapse the broadcast trigger back to one condition and remove the
second GenServer call the cold snapshot makes. It rewrites the SEND path for a
display feature, which is #246 territory. Worth its own change.

## The message COUNT is a mirror, and it is gated

The warning must render before any POST, so there is no round trip to ask the
authority with — and under word-boundary splitting the fragment count is not
derivable from the budget arithmetically. `frameBudget.ts` therefore
reimplements `LineSplit`'s chunker. What makes that acceptable where a mirror
of `relay_frame_overhead` is not: the split that reaches the wire is still the
server's, so a drift costs an advisory number off by a frame and can never
cost a byte.

It is not left on trust. Fourteen `(budget, body) -> count` cases live
verbatim in **both** suites, so each side pins its own splitter. Verified in
both directions: dropping the word-boundary rule from the TS chunker fails
exactly the two boundary cases there, and dropping it from `break_space?/1`
fails exactly the same two here. `line_split.ex`'s moduledoc now says so where
the person editing `chunk_by_bytes` will read it.

**Ordering:** this is written against #1109's semantics. #1188 landed while it
was in flight, which is what made the shared table writable at all — against
the byte-cut splitter it could only have been written red.

## Method

Guard first, read red, then one mutation at a time: an invented budget, a
target measured in UTF-16 units, the word boundary dropped (both stacks), a
boundary accepted at index 0, the CTCP envelope not charged, codepoints
instead of graphemes, the countdown kept past the split edge, a narrower that
rejects the envelope, the `$server` refusal not mirrored, slash commands
previewed as text, the countdown window widened, the seam precedence
inverted, the warning firing at one frame, a narrowed broadcast trigger, a
hardcoded snapshot linelen, a shifted #246 ceiling, and the budget off by one
in both directions. Every one of them is killed, and each mutant's killers
were read individually rather than inferred from a green suite.

**Three arms were rewritten after the audit caught them passing vacuously.**
Two asserted `base - byte_size(target) == LineSplit.frame_budget(target,
linelen)` with `base` taken from `frame_budget_base/1` — the same function on
both sides, so a `+ 1` inside `frame_budget/2` moved them together and left
them green (22 reds elsewhere, 0 in those two). The third,
`wire_test`'s `512 - 119`, did discriminate, but only by writing the framing
sum a second time by hand: it re-checked the arithmetic, not the behaviour.
The oracle is the wire now — `Grappa.RelayFrameHelpers` builds the #246
worst-case relayed frame from the identity ceilings, may not call
`LineSplit`, and the assertion is EQUALITY with LINELEN, which is what makes
it two-sided in one line (`<=` waves through every under-count). `+ 1`, `- 1`
and a moved `@max_host_bytes` each kill it.

The two session-level arms are kept and relabelled for what they actually
witness — that the LIVE linelen reaches the payload. That is deliberate, not
a gap: a narrowed broadcast trigger kills the `server_test` one and a
hardcoded snapshot linelen kills the `grappa_channel_test` one, each exactly
one red, while the NUMBER is owned by the frame oracle above. **If both sides
of an assertion come from the same function, the arm is about plumbing.**

**Both isupport doors are gated, one killer each.** A fold that drops
`frame_budget_base` used to die in exactly one test, on the live-005 door,
while the cold snapshot — the only door a client joining an always-on bouncer
ever uses — had no isupport arm at all, before this branch or after it.
`subscribe.test.ts` now asserts the budget lands in the REAL store, not on a
`seedIsupport` spy.

## Declared, not fixed

- **No e2e spec.** Repo rule says UX e2e is mandatory for cic UX; this ran
  without an e2e lane, and a guard I cannot read red is not a guard. Owed.
- **The two tables are paired by prose.** Each gates its own splitter, but
  nothing fails if a case is added to one side only. The stronger form is one
  shared fixture both suites read — the clearest remaining improvement here.
- **`push_isupport_if_live` makes two GenServer calls** that can straddle a
  005. Self-healing (the same 005 broadcasts the corrected payload), so it did
  not seem worth a new context function in this change.
- **The countdown appearing shifts the layout** by one line at the threshold,
  as the seam line's own appear/disappear already does. If it reads as jumpy
  on a real device, reserving the row is a one-line CSS change.
- **`Intl.Segmenter` is constructed at module scope** with no fallback. It is
  baseline in every browser that can run this PWA; a guard for a runtime that
  cannot exist would be noise.

## Gates

All re-run after the rebase onto `7ab87925`, on the committed tree:

- `scripts/check.sh` rc=0 — 5689 tests, 58 properties, 8 doctests, 0
  failures; 402 bats ok, 0 not ok; wireTypes.ts and wireSchema.ts both in
  sync. `git status --porcelain` identical before and after.
- `scripts/bun.sh run check` rc=0, `run test` 5086 passed / 273 files.
- No integration or e2e run (no lane).
- The rebase dropped the separator-restoration commit as `patch contents
  already upstream` — for the fourth time today — so the `---` before this
  entry in DESIGN_NOTES is folded into the docs commit instead. Contribution
  measured `--numstat` before and after: identical, 32 files.
