### PR TITLE
fix(#1161): diagnose the cic bundle root at boot, and never replace it silently

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -78,6 +78,14 @@ services:
       UPLOADS_STORAGE_ROOT: ${UPLOADS_STORAGE_ROOT:-/app/runtime/uploads}
       # The built SPA dist the BEAM self-serves (Plug.Static + history
       # fallback). Same dir the cicchetto-build service writes (#399).
+      #
+      # This default belongs to THIS stack, which builds the bundle here.
+      # Do not point this file at ghcr.io/vjt/grappa: that image bakes the
+      # SPA at /app/cicchetto-dist and sets CIC_DIST_ROOT to match, but a
+      # compose `environment:` key overrides an image ENV — so the line
+      # below would redirect the root to a directory the image does not
+      # have and 404 the frontend on a container that is otherwise healthy
+      # (#1161). Use compose.release.yaml for the published image.
       CIC_DIST_ROOT: ${CIC_DIST_ROOT:-/app/runtime/cicchetto-dist}
       # Literal defaults, NOT the empty-default form used above: an empty
       # string reaches String.to_integer/1 and crashes at boot (#369 X1).

--- a/compose.yaml
+++ b/compose.yaml
@@ -80,12 +80,17 @@ services:
       # fallback). Same dir the cicchetto-build service writes (#399).
       #
       # This default belongs to THIS stack, which builds the bundle here.
-      # Do not point this file at ghcr.io/vjt/grappa: that image bakes the
+      # Do not point this file at the PUBLISHED release image: it bakes the
       # SPA at /app/cicchetto-dist and sets CIC_DIST_ROOT to match, but a
       # compose `environment:` key overrides an image ENV — so the line
-      # below would redirect the root to a directory the image does not
+      # below would redirect the root to a directory that image does not
       # have and 404 the frontend on a container that is otherwise healthy
-      # (#1161). Use compose.release.yaml for the published image.
+      # (#1161). Use compose.release.yaml for it.
+      #
+      # The image is named by description and not by tag on purpose:
+      # test/infra/release_compose_test.bats greps this file for the
+      # registry path, and a mention in prose reads to a grep exactly like
+      # a service that pulls it.
       CIC_DIST_ROOT: ${CIC_DIST_ROOT:-/app/runtime/cicchetto-dist}
       # Literal defaults, NOT the empty-default form used above: an empty
       # string reaches String.to_integer/1 and crashes at boot (#369 X1).

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37068,3 +37068,82 @@ reported state needs a scrolled-back pane whose window is the only unread one,
 which is a geometry the jsdom suite cannot assert and this change did not buy
 the stack time to build. The claim here is the arithmetic plus the wiring, not
 the pixels.
+
+---
+
+## 2026-08-10 — #1161: the bundle root is diagnosed at boot, and never quietly replaced
+
+A self-hoster ran the published release image with the repo's `compose.yaml`
+and got `cicchetto frontend bundle not built` on every document route, from a
+container that was healthy and whose API answered. `Dockerfile.release` bakes
+the SPA at `/app/cicchetto-dist` and sets `CIC_DIST_ROOT` to match; a compose
+`environment:` key overrides an image `ENV`; `compose.yaml` sets that variable
+for the stack that BUILDS the bundle into `runtime/`. So the file redirected
+the root to a directory the image does not have.
+
+**This is the third instance of one class, which is why the fix is a boot
+diagnosis rather than a compose edit.** #526: the FreeBSD jail sets no
+WorkingDirectory, so the repo-relative default resolved somewhere else and
+`/admin/cic-bundle-changed` answered 204 forever. The 2026-07-28 production
+incident recorded in `docs/OPERATIONS.md`: the same relative default out of
+reach of the BEAM's CWD, and a deploy that printed ✓. Now this. Every time,
+the root was resolved at boot into `:persistent_term` and then nobody asked
+about it until a browser did — and what the browser got back named a build
+step instead of the path. `Grappa.Cic.Bundle.boot/1` is the one place that
+holds the resolved root before any request exists, so it warns there, with
+the **expanded** path (a relative root is correct only where the CWD is what
+the operator assumed — that expansion is the #526 half of the class), what
+was missing at it, the variable that moves it, and the symptom:
+
+```
+[warning] cic bundle root does not exist: /tmp/cic-absent-843 — the SPA will
+404 on every document request. Set CIC_DIST_ROOT to the directory holding the
+built SPA (the one with index.html).
+```
+
+**Two arms, because the remedies differ.** A root that does not exist sends
+the operator to fix a path; a root that exists and is empty sends them to
+build or mount a bundle. Collapsing them into one message would send half of
+them to correct a path that is already right.
+
+**It warns and does not raise.** A bundle-less boot is legitimate — dev before
+a cic build, a release between deploy and the first `cicchetto-build` oneshot —
+and the API half of the server is worth serving meanwhile.
+
+**The issue's open question, answered no: an unresolvable `CIC_DIST_ROOT` is
+never replaced by a fallback.** Falling back to the image's baked path would
+rescue exactly the reported case, and it would make the variable advisory: a
+deliberate relocation with a typo would then serve a *different* bundle than
+the one configured, silently and plausibly, which is a worse failure than a
+404. There is also no substrate-neutral value to fall back TO — the baked path
+is a fact of `Dockerfile.release`, and the compile-time anchor is the repo
+checkout, wrong on every packaged install. The variable stays load-bearing and
+the diagnosis is what improves.
+
+**The 404 body changed too, by one clause.** "not built" is true on the dev
+path and misleading on every other, and it is what sent the reporter hunting a
+build step. It now reads `cicchetto frontend bundle not built, or
+CIC_DIST_ROOT names the wrong directory`. The resolved path deliberately does
+NOT go in the response: it belongs in the boot log, where the operator reads
+it and an unauthenticated client does not learn our filesystem layout. The
+test pins both halves — knob present, path absent — and a mutant that
+interpolates the path into the body kills only the absence assertion.
+
+**Which arms discriminate, measured one mutant at a time.** Three of four
+failed before the fix. The fourth — a real bundle boots silently — passed
+vacuously against the unguarded `boot/1` and is only a guard against the
+green one; the mutant that warns unconditionally kills it and nothing else,
+which is what earns it its place. Collapsing the missing-directory branch
+kills only `does not exist`; logging the configured value instead of the
+expanded one kills only the relative-root arm; dropping the variable name
+kills only that assertion; dropping the symptom clause kills only the `404`
+one; accepting any existing directory as a bundle kills only the empty-root
+arm. Six mutants, six single kills.
+
+**What this does not do, stated rather than implied.** It was not reproduced
+against `ghcr.io/vjt/grappa` — no image was pulled and no container booted
+here; the reported chain is read off `Dockerfile.release`, `compose.yaml` and
+compose's documented precedence, and the guard is measured in unit tests
+only. And no path check can catch the failure one step past this one: a root
+that exists and holds a bundle that is simply the wrong one — stale, or from
+another deploy — still boots silently and serves it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37110,8 +37110,11 @@ them to correct a path that is already right.
 a cic build, a release between deploy and the first `cicchetto-build` oneshot —
 and the API half of the server is worth serving meanwhile.
 
-**The issue's open question, answered no: an unresolvable `CIC_DIST_ROOT` is
-never replaced by a fallback.** Falling back to the image's baked path would
+**Ruled, not left to taste: an unresolvable `CIC_DIST_ROOT` is never replaced
+by a fallback.** The issue asked for this to be called explicitly rather than
+allowed to happen, so it is a decision and not a preference — the variable is
+load-bearing, and a root that misses stays missed on every substrate. Falling
+back to the image's baked path would
 rescue exactly the reported case, and it would make the variable advisory: a
 deliberate relocation with a typo would then serve a *different* bundle than
 the one configured, silently and plausibly, which is a worse failure than a
@@ -37140,10 +37143,53 @@ kills only that assertion; dropping the symptom clause kills only the `404`
 one; accepting any existing directory as a bundle kills only the empty-root
 arm. Six mutants, six single kills.
 
-**What this does not do, stated rather than implied.** It was not reproduced
-against `ghcr.io/vjt/grappa` — no image was pulled and no container booted
-here; the reported chain is read off `Dockerfile.release`, `compose.yaml` and
-compose's documented precedence, and the guard is measured in unit tests
-only. And no path check can catch the failure one step past this one: a root
-that exists and holds a bundle that is simply the wrong one — stale, or from
-another deploy — still boots silently and serves it.
+**What was tried against the real image, link by link.**
+`ghcr.io/vjt/grappa:latest` (`sha256:84c15776…`, `linux/arm64`, reporting
+`0.16.0`) was pulled and booted four ways on a loopback port with
+`PHX_HOST=localhost`.
+
+  * Untouched, it serves the SPA: `GET /` → 200, 2468 bytes, the Vite shell
+    with `src="/assets/index-fE-FhJ24.js"`. The image does ship a bundle.
+  * With `CIC_DIST_ROOT=/app/runtime/cicchetto-dist` — the value
+    `compose.yaml` injects, supplied both as `docker run -e` and through a
+    compose file carrying that line verbatim — `GET /` and `GET /a/deep/link`
+    both answer **404 `cicchetto frontend bundle not built`**, while
+    `/healthz` and `/api/config` answer 200. From inside that container:
+    `printenv CIC_DIST_ROOT` reports the compose value (so the
+    `environment:` key does override the image `ENV`, measured rather than
+    cited), `/app/cicchetto-dist/index.html` exists, and
+    `/app/runtime/cicchetto-dist` does not. Every link of the reported chain,
+    observed.
+  * **The silence is measured, not inferred.** That container's boot produced
+    476 log lines, and `grep -i 'cic_dist\|cicchetto-dist\|bundle'` over all
+    of them matches nothing. The only trace is `Sent 404`, which names no
+    path.
+
+Then the same sequence against an image built from this branch
+(`scripts/release-image.sh build`; the guard's message string does not exist
+anywhere else, which is what proves the running container carried the fix).
+Wrong root: `[warning] cic bundle root does not exist:
+/app/runtime/cicchetto-dist — the SPA will 404 on every document request…`,
+emitted 24ms and one line BEFORE `Running GrappaWeb.Endpoint`, i.e. before
+the port could accept the first request; and the 404 body now carries the
+variable. Root pointed at an empty directory: the other arm fires, `cic
+bundle root has no index.html: /emptydist`. Correct root: `GET /` 200 with
+the Vite shell, deep link 200, and the guard silent. Containers and volumes
+torn down; nothing left behind.
+
+**The limits of that, stated rather than implied.** One architecture only
+(`linux/arm64` on an arm64 host) — the amd64 variant of the published image
+was never run. `PHX_HOST=localhost` over plain HTTP on loopback exercises the
+BEAM's own SPA serving, NOT a TLS front door, and therefore not the service
+worker or push, which browsers gate on a secure context. Every request was
+curl; no browser loaded the app and no WebSocket was opened, so "the SPA is
+served" means the shell and its script tag, not a working client. The
+reproduction used a compose file derived from `compose.release.yaml` plus
+`compose.yaml`'s verbatim `CIC_DIST_ROOT` line, not the repo's `compose.yaml`
+itself — that file carries a build context and a bind-mounted tree, and the
+mechanism under test is compose's `environment:` precedence, which the
+derived file isolates. The fix was exercised from a locally built,
+single-arch image, not a published artifact. And no path check can catch the
+failure one step past this one: a root that exists and holds a bundle that is
+simply the wrong one — stale, or from another deploy — still boots silently
+and serves it.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1129,6 +1129,23 @@ silently. `cic_dist_root` is stashed in `:persistent_term` at BEAM boot,
 so a fresh `CIC_DIST_ROOT` only takes effect after a **COLD** deploy
 (BEAM restart) — a hot cic-only deploy will keep returning 204 until then.
 
+**Since #1161 the BEAM says this at boot, before anything asks it for a
+file.** `Grappa.Cic.Bundle.boot/1` warns when the resolved root holds no
+`index.html`, naming the **expanded** path (the part a relative default
+hides), what was missing there, and the variable that moves it:
+
+```
+[warning] cic bundle root does not exist: /home/grappa/runtime/cicchetto-dist
+ — the SPA will 404 on every document request. Set CIC_DIST_ROOT to the
+ directory holding the built SPA (the one with index.html).
+```
+
+So the first grep on a frontend-404 report is the startup log, not the
+deploy wrapper's exit code. It warns and never raises — a bundle-less boot
+is legitimate between a release and the first `cicchetto-build` — and it
+never falls back to another path: a root that misses stays missed, so a
+typo cannot quietly serve a different bundle than the one configured.
+
 ### m42 (FreeBSD bastille jail) — host-side wrapper
 
 The `infra/freebsd/jail_*.sh` scripts run INSIDE the jail as root

--- a/lib/grappa/cic/bundle.ex
+++ b/lib/grappa/cic/bundle.ex
@@ -45,9 +45,32 @@ defmodule Grappa.Cic.Bundle do
   unset so dev/test and the pre-#399 deploy shape keep working. A
   packaged install (deb/rpm/Arch) relocates the dist by setting
   `CIC_DIST_ROOT`.
+
+  ## The root is diagnosed at boot, not at the first request (#1161)
+
+  Getting that path wrong is not a rare typo — it is the recurring
+  failure of this design. #526: the FreeBSD jail sets no working
+  directory, so the relative default resolved off the repo root.
+  #1161: `compose.yaml` sets `CIC_DIST_ROOT` for the *development*
+  stack, and compose's `environment:` overrides the image's `ENV`, so
+  pointing that file at the published release image redirects the root
+  away from the SPA the image bakes at `/app/cicchetto-dist`. Both
+  times the server came up healthy and only the frontend 404'd, with a
+  message that reads like a missing build step — sending the operator
+  to look for a build that this path does not have.
+
+  So `boot/1` warns, naming the RESOLVED path, what was missing there,
+  the variable that moves it, and what the operator will see if they
+  ignore it. **A root that does not resolve is never silently replaced
+  by a fallback** (the release image's baked path, the compile-time
+  anchor): that would make `CIC_DIST_ROOT` advisory, and a deliberate
+  relocation with a typo would then serve a *different* bundle than the
+  one asked for — a plausible wrong answer, which is worse than a 404.
   """
 
   use Boundary, top_level?: true, deps: [], exports: []
+
+  require Logger
 
   # Compile-time default anchor — `lib/grappa/cic/` → repo root →
   # `runtime/cicchetto-dist`. Overridable at boot via `boot/1`
@@ -71,17 +94,46 @@ defmodule Grappa.Cic.Bundle do
   # content up to the closing quote.
   @version_re ~r{<meta[^>]+name="cicchetto-version"[^>]+content="([^"]+)"}
 
+  # #1161 boot diagnosis. Split from the two messages that share them so the
+  # symptom and the remedy read identically whichever way the root is wrong.
+  @symptom "the SPA will 404 on every document request."
+  @knob "Set CIC_DIST_ROOT to the directory holding the built SPA (the one with index.html)."
+
   @doc """
   Stash the built-dist root into `:persistent_term`. Called once from
   `Grappa.Application.start/2` with the boot-resolved path
   (`Application.get_env(:grappa, :cic_dist_root)`, which
   `config/runtime.exs` derives from `CIC_DIST_ROOT`). Idempotent;
   later calls overwrite.
+
+  Warns when the resolved root holds no bundle — see the "#1161" section
+  of the moduledoc. Never raises: a bundle-less boot is legitimate (dev
+  before a cic build, prod before the first `cicchetto-build` oneshot),
+  and the API half of the server is still worth serving.
   """
   @spec boot(Path.t()) :: :ok
   def boot(root) when is_binary(root) do
     :persistent_term.put(@root_key, root)
+    warn_unless_bundled(Path.expand(root))
     :ok
+  end
+
+  # #1161: the root is resolved here and nowhere else asks about it until a
+  # browser does, so this is the only chance to say WHERE we will look before
+  # the first 404 says only that we did not find anything. `Path.expand/1`
+  # first: a relative root is correct only where the CWD is what the operator
+  # assumed, and the resolved path is the part they cannot infer (#526).
+  defp warn_unless_bundled(root) do
+    cond do
+      not File.dir?(root) ->
+        Logger.warning("cic bundle root does not exist: #{root} — #{@symptom} #{@knob}")
+
+      not File.regular?(Path.join(root, "index.html")) ->
+        Logger.warning("cic bundle root has no index.html: #{root} — #{@symptom} #{@knob}")
+
+      true ->
+        :ok
+    end
   end
 
   @doc """

--- a/lib/grappa/cic/bundle.ex
+++ b/lib/grappa/cic/bundle.ex
@@ -94,8 +94,8 @@ defmodule Grappa.Cic.Bundle do
   # content up to the closing quote.
   @version_re ~r{<meta[^>]+name="cicchetto-version"[^>]+content="([^"]+)"}
 
-  # #1161 boot diagnosis. Split from the two messages that share them so the
-  # symptom and the remedy read identically whichever way the root is wrong.
+  # #1161 boot diagnosis. Shared by both arms below, so the symptom and the
+  # remedy read identically whichever way the root turned out to be wrong.
   @symptom "the SPA will 404 on every document request."
   @knob "Set CIC_DIST_ROOT to the directory holding the built SPA (the one with index.html)."
 

--- a/lib/grappa_web/controllers/spa_controller.ex
+++ b/lib/grappa_web/controllers/spa_controller.ex
@@ -107,14 +107,22 @@ defmodule GrappaWeb.SpaController do
     if File.regular?(path) do
       send_file(conn, 200, path)
     else
-      # No bundle on disk (dev/CI before a cic build, or a release
-      # deployed without one). Honest 404 — never a 500. An
+      # No bundle at the resolved root (dev/CI before a cic build, a
+      # release deployed without one — or, #1161, a CIC_DIST_ROOT that
+      # names the wrong directory). Honest 404 — never a 500. An
       # nginx-fronted prod never reaches here: nginx serves the shell
       # itself.
+      #
+      # "not built" alone was true on the first case and misleading on
+      # the last: the release image ships a bundle, so its operator went
+      # hunting a build step this path does not have. Naming the variable
+      # costs nothing and points at the boot warning that carries the
+      # resolved path — which stays out of the response body, where it
+      # would only tell an anonymous client about our filesystem.
       conn
       |> put_status(:not_found)
       |> put_resp_content_type("text/plain")
-      |> text("cicchetto frontend bundle not built")
+      |> text("cicchetto frontend bundle not built, or CIC_DIST_ROOT names the wrong directory")
     end
   end
 

--- a/test/grappa/cic/bundle_boot_diagnosis_test.exs
+++ b/test/grappa/cic/bundle_boot_diagnosis_test.exs
@@ -1,0 +1,78 @@
+defmodule Grappa.Cic.BundleBootDiagnosisTest do
+  @moduledoc """
+  #1161 — a `CIC_DIST_ROOT` that names the wrong directory must be said out
+  loud at BOOT, not discovered on the first document request.
+
+  The reported shape: the published release image bakes the SPA at
+  `/app/cicchetto-dist` and sets `CIC_DIST_ROOT` to match, but compose's
+  `environment:` wins over the image's `ENV` — so pointing the repo's
+  development `compose.yaml` at that image redirects the root to a directory
+  the image does not have. The container is healthy, the API answers, and only
+  the frontend 404s with `cicchetto frontend bundle not built` — a message that
+  reads like a missing build step on a path that has no build step. #526 was
+  the same class through a different door (the FreeBSD jail's CWD, so the
+  relative default resolved somewhere else).
+
+  `boot/1` is the one place that sees the resolved root before anything asks
+  for a file, so it is where the diagnosis belongs. Each arm below pins one
+  fact of that message: WHERE it looked (expanded, because a relative root
+  resolving against an unexpected CWD is half the bug class), WHAT it wanted
+  there, WHICH knob moves it, and WHAT the operator will see if they ignore it.
+
+  `async: false` — `boot/1` mutates the process-global `:persistent_term` root.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Cic.Bundle
+
+  @moduletag :tmp_dir
+
+  setup do
+    original = Bundle.root()
+    on_exit(fn -> Bundle.boot(original) end)
+    :ok
+  end
+
+  test "a root that does not exist is named, with the knob and the symptom", %{tmp_dir: tmp} do
+    missing = Path.join(tmp, "cicchetto-dist")
+
+    log = capture_log(fn -> assert :ok = Bundle.boot(missing) end)
+
+    assert log =~ missing
+    assert log =~ "does not exist"
+    assert log =~ "CIC_DIST_ROOT"
+    assert log =~ "404"
+  end
+
+  test "a root that exists but holds no bundle names index.html", %{tmp_dir: tmp} do
+    log = capture_log(fn -> assert :ok = Bundle.boot(tmp) end)
+
+    assert log =~ tmp
+    assert log =~ "index.html"
+    # Distinct from the arm above: the directory IS there, so a diagnosis that
+    # collapses both cases into "missing directory" sends the operator to fix
+    # a path that is already correct.
+    refute log =~ "does not exist"
+  end
+
+  test "a relative root is reported EXPANDED, against the CWD it will resolve to" do
+    relative = "runtime/cicchetto-dist-1161-absent"
+
+    log = capture_log(fn -> assert :ok = Bundle.boot(relative) end)
+
+    # The #526 door: `runtime/cicchetto-dist` is only correct where the CWD is
+    # the repo root. Echoing the configured value back tells the operator
+    # nothing they did not already type; the resolved path is the finding.
+    assert log =~ Path.expand(relative)
+  end
+
+  test "a root holding a bundle boots silently" do
+    fixture = Path.expand("../../support/fixtures/cic_dist", __DIR__)
+
+    log = capture_log(fn -> assert :ok = Bundle.boot(fixture) end)
+
+    assert log == ""
+  end
+end

--- a/test/grappa_web/spa_serving_test.exs
+++ b/test/grappa_web/spa_serving_test.exs
@@ -230,5 +230,23 @@ defmodule GrappaWeb.SpaServingTest do
       conn = get(html_conn(), "/")
       assert conn.status == 404
     end
+
+    test "the 404 names the knob, so it does not read as a missing build (#1161)" do
+      original = Bundle.root()
+      tmp = Path.join(System.tmp_dir!(), "cic-absent-#{System.unique_integer([:positive])}")
+      on_exit(fn -> Bundle.boot(original) end)
+      Bundle.boot(tmp)
+
+      conn = get(html_conn(), "/")
+
+      assert conn.status == 404
+      # "not built" is true on the dev path and misleading on every other:
+      # the release image ships a bundle, and an operator whose CIC_DIST_ROOT
+      # points elsewhere goes looking for a build step that path does not have.
+      assert conn.resp_body =~ "CIC_DIST_ROOT"
+      # The resolved path stays OUT of the response. It is in the boot log,
+      # where the operator can read it and an anonymous client cannot.
+      refute conn.resp_body =~ tmp
+    end
   end
 end


### PR DESCRIPTION
A self-hoster ran the published release image against the repo's development
`compose.yaml` and got `cicchetto frontend bundle not built` on every document
route, from a container that was healthy and whose API answered. The image
bakes the SPA at `/app/cicchetto-dist` and sets `CIC_DIST_ROOT` to match; a
compose `environment:` key overrides an image `ENV`; `compose.yaml` sets that
variable for the stack that *builds* the bundle into `runtime/`.

## Why a boot guard rather than a compose edit

Third instance of one class. #526: the FreeBSD jail sets no WorkingDirectory,
so the repo-relative default resolved elsewhere and `/admin/cic-bundle-changed`
answered 204 forever. The 2026-07-28 production incident in
`docs/OPERATIONS.md`: the same relative default out of the BEAM's CWD, and a
deploy that printed ✓. Now this. Every time the root is resolved at boot into
`:persistent_term` and nobody asks about it until a browser does.

`Grappa.Cic.Bundle.boot/1` holds the resolved root before any request exists,
so it warns there — with the **expanded** path (a relative root is correct only
where the CWD is what the operator assumed), what was missing at it, the
variable that moves it, and the symptom. Two arms, because the remedies differ:
a missing directory sends the operator to fix a path, an empty one to build or
mount a bundle. It warns and never raises — a bundle-less boot is legitimate
between a release and the first `cicchetto-build` oneshot.

The 404 body changed by one clause, since "not built" is what sent the reporter
hunting a build step: `cicchetto frontend bundle not built, or CIC_DIST_ROOT
names the wrong directory`. The resolved path deliberately stays out of the
response — it is in the boot log, where the operator reads it and an
unauthenticated client does not learn our filesystem layout.

## Ruled: no fallback

An unresolvable `CIC_DIST_ROOT` is **not** replaced by the image's baked path.
That would rescue this exact report and make the variable advisory: a
deliberate relocation with a typo would then serve a *different* bundle than
the one configured — a plausible wrong answer, worse than a 404. There is also
no substrate-neutral value to fall back to; the baked path is a fact of
`Dockerfile.release` and the compile-time anchor is the repo checkout.

## What was tried against the real image

`ghcr.io/vjt/grappa:latest` (`sha256:84c15776…`, `linux/arm64`, reporting
`0.16.0`), pulled and booted on a loopback port with `PHX_HOST=localhost`.

**The defect, before any fix:**

| run | `GET /` | `/healthz` | `/api/config` |
|---|---|---|---|
| image untouched | **200**, 2468 B, `src="/assets/index-fE-FhJ24.js"` | 200 | 200 |
| `CIC_DIST_ROOT=/app/runtime/cicchetto-dist` | **404 `cicchetto frontend bundle not built`** | 200 | 200 |

`GET /a/deep/link` 404s the same way. From inside the failing container:
`printenv CIC_DIST_ROOT` reports the compose value — so the `environment:` key
does override the image `ENV`, measured rather than cited —
`/app/cicchetto-dist/index.html` exists, and `/app/runtime/cicchetto-dist` does
not. Supplied both as `docker run -e` and through a compose file carrying
`compose.yaml`'s line verbatim; same result.

**The silence, measured:** that boot produced **476 log lines**, and
`grep -i 'cic_dist\|cicchetto-dist\|bundle'` over all of them matches
**nothing**. The only trace is `Sent 404`, which names no path. That is the
"silently" in the issue title, and it was the part still resting on an
argument.

**With this branch** (image built by `scripts/release-image.sh build`; the
guard's message string exists nowhere else, which is what proves the container
carried the fix):

```
[warning] cic bundle root does not exist: /app/runtime/cicchetto-dist — the SPA
will 404 on every document request. Set CIC_DIST_ROOT to the directory holding
the built SPA (the one with index.html).
```

emitted 24ms and one log line **before** `Running GrappaWeb.Endpoint`, i.e.
before the port could accept a first request. The 404 body now carries the
variable. Pointed at an empty directory, the other arm fires: `cic bundle root
has no index.html: /emptydist`. Pointed correctly: `GET /` 200 with the Vite
shell, deep link 200, guard silent. Containers, volumes and the temp compose
dir torn down; `docker ps -a` / `volume ls` / `image ls` show nothing left.

## Unit measurements

- Guard read **red first**: 3 of 4 arms failed against the unguarded `boot/1`.
- **Six mutants, six single kills.** Collapsing the missing-directory branch
  kills only `does not exist`; logging the configured value instead of the
  expanded one kills only the relative-root arm; dropping the variable name,
  and dropping the symptom clause, each kill only their own assertion;
  accepting any existing directory kills only the empty-root arm; warning
  unconditionally kills only the silent-boot arm.
- The silent-boot arm passed **vacuously** at red and is labelled as such: it
  only discriminates against the fixed `boot/1`, which the unconditional-warn
  mutant proves.
- A mutant that interpolates the path into the 404 body kills only the
  path-absence assertion.
- Gates: full unit suite 5675 tests / 0 failures; full bats set 402/402;
  Dialyzer 0 (dev, the env `ci.check` uses); Credo strict 0; Sobelow adds no
  finding; formatted.

The compose comment first tripped #1160's own guard — `release_compose_test.bats`
greps `compose.yaml` for the registry path, and to a grep a mention in prose is
indistinguishable from a service that pulls it. Reworded rather than widening
the guard, with a comment recording why the tag is absent.

## Limits, and the failure this does not cover

One architecture only (`linux/arm64` on an arm64 host) — the amd64 variant of
the published image was never run. `PHX_HOST=localhost` over plain HTTP on
loopback exercises the BEAM's own SPA serving, **not** a TLS front door, and
therefore not the service worker or push, which browsers gate on a secure
context. Every request was curl: no browser loaded the app, no WebSocket was
opened, so "the SPA is served" means the shell and its script tag, not a
working client. The reproduction used a compose file derived from
`compose.release.yaml` plus `compose.yaml`'s verbatim `CIC_DIST_ROOT` line, not
the repo's `compose.yaml` itself — that file carries a build context and a
bind-mounted tree, and the mechanism under test is compose's `environment:`
precedence, which the derived file isolates. The fix side ran from a locally
built, single-arch image, not a published artifact.

**Known limit, deliberately not covered:** no path check catches the failure
one step past this one. A root that exists and holds a bundle that is simply
the *wrong* one — stale, or from another deploy — still boots silently and
serves it.