### PR TITLE
cic(#1178): the » jump scrolls when the only unread window is the one you are in

### DIFF
--- a/cicchetto/src/__tests__/activeWindowsStep.test.ts
+++ b/cicchetto/src/__tests__/activeWindowsStep.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+
+// GH #1178 — the IMPURE half of #235's jump verb: `stepActiveWindow`, reached
+// through `jumpToNextActiveWindow` / `jumpToPrevActiveWindow`.
+//
+// `activeWindows.test.ts` covers the pure ordering (`orderUnreadWindows` and
+// friends) with plain data. It cannot reach the bug this file exists for,
+// because the bug is not in the ORDER — it is in what the verb DOES once the
+// order resolves to the window the operator is already in.
+//
+// Reported state: scrolled back inside the only window with unread. The
+// selected window stays in `activeWindows()` (selection.ts's read-at-the-tail
+// suppression only fires when the pane is geometrically AT the tail), so the
+// list is a single element that IS the current selection — and the resolved
+// target is therefore the current selection, which `setSelectedChannel`
+// short-circuits as a non-transition. Visible badge, nothing happens.
+//
+// The module's reactive singletons are driven by mocking the source modules
+// the `activeWindows` memo reads. The memo caches (the mocks are plain
+// functions, not signals), so each test resets the module registry and
+// re-imports after seeding the holders.
+
+const h = vi.hoisted(() => ({
+  channels: [] as Array<{ name: string }>,
+  unread: {} as Record<string, number>,
+  selected: null as { networkSlug: string; channelName: string; kind: string } | null,
+  setSelectedChannel: vi.fn(),
+  isActiveSelection: vi.fn(),
+  requestScrollToBottom: vi.fn(),
+}));
+
+vi.mock("../lib/networks", () => ({
+  networks: () => [{ id: 1, slug: "net" }],
+  channelsBySlug: () => ({ net: h.channels }),
+}));
+
+vi.mock("../lib/queryWindows", () => ({ queryWindowsByNetwork: () => ({}) }));
+
+vi.mock("../lib/mentions", () => ({ mentionCounts: () => ({}) }));
+
+vi.mock("../lib/notificationPrefs", () => ({
+  notificationPrefs: () => ({ muted_targets: {} }),
+}));
+
+// No local rows: every window's activity id falls back to 0, so the ordering
+// ties and resolves by flat (sidebar) order — deterministic without pinning
+// scrollback shapes this file does not care about.
+vi.mock("../lib/scrollback", () => ({ scrollbackByChannel: () => ({}) }));
+
+vi.mock("../lib/selection", () => ({
+  messagesUnread: () => h.unread,
+  selectedChannel: () => h.selected,
+  setSelectedChannel: h.setSelectedChannel,
+  // Driven per test, mirroring Sidebar.test.tsx / BottomBar.test.tsx: the
+  // equality RULE (`sameSelection`) is pinned in selection.test.ts; what these
+  // tests pin is the WIRING, plus the exact tuple the verb resolved.
+  isActiveSelection: h.isActiveSelection,
+}));
+
+vi.mock("../lib/scrollToBottomCommand", () => ({
+  requestScrollToBottom: h.requestScrollToBottom,
+}));
+
+const chan = (name: string) => ({ networkSlug: "net", channelName: name, kind: "channel" });
+
+const load = () => import("../lib/activeWindows");
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  h.channels = [];
+  h.unread = {};
+  h.selected = null;
+  h.isActiveSelection.mockReturnValue(false);
+});
+
+describe("stepActiveWindow — the resolved target is the window you are already in (#1178)", () => {
+  it("scrolls the pane to the newest message instead of re-selecting it", async () => {
+    h.channels = [{ name: "#grappa" }];
+    h.unread = { [channelKey("net", "#grappa")]: 4 };
+    h.selected = chan("#grappa");
+    h.isActiveSelection.mockReturnValue(true);
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    // The arithmetic: a one-element list containing the current selection
+    // resolves back to it.
+    expect(h.isActiveSelection).toHaveBeenCalledWith(chan("#grappa"));
+    expect(h.requestScrollToBottom).toHaveBeenCalledTimes(1);
+    // Pre-#1178 this was the ONLY thing that happened, and it was a
+    // non-transition the setter drops on the floor.
+    expect(h.setSelectedChannel).not.toHaveBeenCalled();
+  });
+
+  it("does the same for the PREVIOUS direction (Ctrl+P)", async () => {
+    h.channels = [{ name: "#grappa" }];
+    h.unread = { [channelKey("net", "#grappa")]: 4 };
+    h.selected = chan("#grappa");
+    h.isActiveSelection.mockReturnValue(true);
+
+    const { jumpToPrevActiveWindow } = await load();
+    jumpToPrevActiveWindow();
+
+    expect(h.requestScrollToBottom).toHaveBeenCalledTimes(1);
+    expect(h.setSelectedChannel).not.toHaveBeenCalled();
+  });
+});
+
+// Regression guards, not discriminators for the fix: each of these passes both
+// before and after #1178. They exist so the cure cannot be "always scroll".
+describe("stepActiveWindow — a real window switch is untouched", () => {
+  it("steps to the OTHER unread window and does not scroll", async () => {
+    h.channels = [{ name: "#grappa" }, { name: "#other" }];
+    h.unread = {
+      [channelKey("net", "#grappa")]: 1,
+      [channelKey("net", "#other")]: 1,
+    };
+    h.selected = chan("#grappa");
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.setSelectedChannel).toHaveBeenCalledWith(chan("#other"));
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("selects the unread window when the current selection has no unread", async () => {
+    h.channels = [{ name: "#grappa" }, { name: "#quiet" }];
+    h.unread = { [channelKey("net", "#grappa")]: 1 };
+    h.selected = chan("#quiet");
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.setSelectedChannel).toHaveBeenCalledWith(chan("#grappa"));
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("fires neither verb when nothing is unread", async () => {
+    h.channels = [{ name: "#grappa" }];
+    h.selected = chan("#grappa");
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.setSelectedChannel).not.toHaveBeenCalled();
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -7,7 +7,13 @@ import { channelsBySlug, networks } from "./networks";
 import { notificationPrefs } from "./notificationPrefs";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { scrollbackByChannel } from "./scrollback";
-import { messagesUnread, selectedChannel, setSelectedChannel } from "./selection";
+import { requestScrollToBottom } from "./scrollToBottomCommand";
+import {
+  isActiveSelection,
+  messagesUnread,
+  selectedChannel,
+  setSelectedChannel,
+} from "./selection";
 import type { MutedTargets } from "./userSettings";
 
 // GH #235 — "jump to next active window" (irssi Alt+A).
@@ -243,11 +249,47 @@ function stepActiveWindow(dir: 1 | -1): void {
   const nextIdx = (start + dir + list.length) % list.length;
   const target = list[nextIdx];
   if (!target) return;
-  setSelectedChannel({
+  const next = {
     networkSlug: target.networkSlug,
     channelName: target.channelName,
     kind: target.kind,
-  });
+  };
+  // #1178 — the cycle can resolve to the window the operator is already
+  // in: one unread window, and it is this one. That happens exactly when
+  // they are scrolled back with unread below them (the read-at-the-tail
+  // suppression in selection.ts only drops the selected window from the
+  // list once the pane is AT the tail), which is the moment they most
+  // want the jump. Handing that to `setSelectedChannel` is a
+  // non-transition it short-circuits, so the badge said "1" and nothing
+  // moved.
+  //
+  // The unread is not unreachable, it is BELOW: the jump is vertical
+  // rather than lateral. So take the #243 exit — the same
+  // `requestScrollToBottom` a re-tap on the already-active Sidebar row /
+  // BottomBar tab fires — which also advances the read cursor (#310), so
+  // the count that advertised the jump actually falls.
+  //
+  // NOT hidden and NOT disabled: there IS unread and it IS reachable, and
+  // `»` is the only jump affordance on mobile (#235). Hiding it in the
+  // one state where the operator wants it trades a lying button for an
+  // absent one, and would put `activeWindowCount()` at odds with the
+  // sidebar badges counting the same windows.
+  //
+  // NOT #693's `jumpToUnread` either: that verb is far-behind-only
+  // (`farBehindByChannel[key]` or it returns false), so in the reported
+  // state — scrolled back a few screens — it would leave the button just
+  // as dead; and in the state where it does apply, the pane already
+  // renders #693's own in-pane "N unread — jump back" affordance.
+  //
+  // The predicate is `isActiveSelection`, not a local compare: it is the
+  // exact negation of the setter's short-circuit (both route through
+  // `sameSelection`), so this arm cannot drift from the non-transition
+  // rule that makes it necessary.
+  if (isActiveSelection(next)) {
+    requestScrollToBottom();
+    return;
+  }
+  setSelectedChannel(next);
 }
 
 export const jumpToNextActiveWindow = (): void => stepActiveWindow(1);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37001,3 +37001,70 @@ never reached the oracle: deleting the call left the import unused, `tsc
 --noEmit` failed inside the `cicchetto-build-test` oneshot, and the stack died
 before a single test ran. An e2e mutant has to keep the BUNDLE buildable, or the
 harness dies upstream of the thing being measured.
+
+---
+
+## 2026-08-10 — #1178: the `»` cycle can resolve to where you already are, and then it has to scroll
+
+A mobile report: scrolled back inside `#grappa`, the `»N` badge reading `1`,
+the scroll-to-bottom badge reading `4`, and tapping `»` did nothing at all.
+
+The arithmetic is deterministic. `stepActiveWindow` cycles `activeWindows()`,
+and that list is "windows with unread activity" — including the one currently
+selected. One element, and that element is the selection: `curIdx` is 0,
+`(0 + 1 + 1) % 1` is 0, and the target is the window already open.
+`setSelectedChannel` short-circuits identical tuples by design (the #243
+`sameSelection` rule), so the verb ran to completion and changed nothing.
+
+**What made it that state and not another.** The selected window only stays in
+the list while the pane is NOT at the tail: `selection.ts`'s read-at-the-tail
+suppression (#981) zeroes the count for the window the cursor arm is about to
+mark read, and that gate is geometric. So the single-element-is-the-selection
+case fires exactly when the operator is scrolled back with unread below them —
+the moment they most want the jump, and, on mobile, `»` is the only jump
+affordance #235 gives them.
+
+**The decision, stated rather than left to emerge.** The unread was never
+unreachable; it was BELOW. The jump wanted to be vertical, not lateral. So when
+the resolved target IS the current selection the verb takes #243's exit —
+`requestScrollToBottom()`, the same command a re-tap on the already-active
+Sidebar row or BottomBar tab fires — which also advances the read cursor
+(#310), so the count that advertised the jump falls instead of persisting.
+
+Hiding or disabling the button was rejected: it trades a lying affordance for
+an absent one in the state the operator most wants it, and `activeWindowCount()`
+would then have to disagree with the sidebar badges counting the same windows —
+two counters for one question, which is what #280 built the shared
+`isPriorityWindow` predicate to avoid.
+
+#693's `jumpToUnread` was rejected as the landing, though the issue text
+proposed it as the likelier expectation. It is far-behind-only: it returns
+`false` unless `farBehindByChannel[key]` is set, so in the reported state —
+scrolled back a few screens, four rows below — the button would have stayed
+just as dead. And in the state where it does apply the pane already renders
+#693's own in-pane "N unread — jump back" affordance, so routing `»` there
+would be a second door onto one gesture.
+
+The predicate is `isActiveSelection`, not a local compare against `sel`: it is
+the exact negation of the setter's short-circuit, both routing through
+`sameSelection`, so the new arm cannot drift from the non-transition rule that
+makes it necessary. `Ctrl+P` inherits it for free — one verb, both directions.
+
+**The guard is a sibling file, because the existing one structurally cannot
+reach this.** `activeWindows.test.ts` exercises the pure ordering with plain
+data, and the defect is not in the ORDER. `activeWindowsStep.test.ts` drives the
+impure verb by mocking the source modules the reactive memo reads, resetting the
+module registry per case (the mocks are plain functions, so the memo caches).
+
+**Displacement, twice.** Removing the whole guard kills the two single-element
+arms (Alt+A and Ctrl+P) and leaves the other three green — so exactly those two
+measure the cure. Making the scroll UNCONDITIONAL instead kills four of five:
+the two switch guards refuse it, which is the point of carrying regression arms
+that pass either way. Three of the five arms discriminate nothing about #1178 on
+their own and are labelled as such in the file.
+
+**Not measured.** Not reproduced in a live browser, and no e2e spec: the
+reported state needs a scrolled-back pane whose window is the only unread one,
+which is a geometry the jsdom suite cannot assert and this change did not buy
+the stack time to build. The claim here is the arithmetic plus the wiring, not
+the pixels.


### PR DESCRIPTION
## What

`stepActiveWindow` cycles `activeWindows()`, and that list includes the window
currently selected. With one unread window that IS the selection, the modulo
resolves back to it and `setSelectedChannel` short-circuits identical tuples —
so `»1` was visible, badged and inert.

When the resolved target is the current selection the verb now takes #243's
exit: `requestScrollToBottom()`, the same command a re-tap on the
already-active Sidebar row / BottomBar tab fires. It also advances the read
cursor (#310), so the count that advertised the jump falls. `Ctrl+P` inherits
it through the shared verb.

## The decision, stated

The state fires exactly when the operator is scrolled back with unread below
them — `selection.ts`'s read-at-the-tail suppression is geometric, so the
selected window only stays in the cycle while the pane is off the tail. The
unread was never unreachable, only BELOW: the jump wanted to be vertical, not
lateral.

- **Not hidden / not disabled.** That trades a lying affordance for an absent
  one in the state the operator most wants it (`»` is #235's only mobile jump),
  and would put `activeWindowCount()` at odds with the sidebar badges counting
  the same windows.
- **Not #693's `jumpToUnread`**, which the issue text floated as the likelier
  expectation. It is far-behind-only (`farBehindByChannel[key]` or it returns
  `false`), so in the reported state it would leave the button just as dead;
  and where it does apply, the pane already renders #693's own in-pane
  "N unread — jump back" affordance.
- The predicate is `isActiveSelection`, not a local compare: the exact negation
  of the setter's short-circuit, so the arm cannot drift from the
  non-transition rule that makes it necessary.

## Diagnosis

The issue's cause section holds as written, verified against `origin/main`.

## Test plan

- [x] New `cicchetto/src/__tests__/activeWindowsStep.test.ts` — the existing
      `activeWindows.test.ts` covers the pure ordering and structurally cannot
      reach this, since the defect is not in the order.
- [x] Read RED first: 2 failed / 3 passed.
- [x] Displacement A — whole guard removed: only the two single-element arms
      (Alt+A, Ctrl+P) die; the three switch/empty guards stay green.
- [x] Displacement B — scroll made UNCONDITIONAL: 4 of 5 die, the two switch
      guards refusing it.
- [x] `bun run check` rc=0 and `bun run test` rc=0 (273 files, 5037 tests),
      re-run after rebasing onto the current `origin/main`.

## Not measured

Not reproduced in a live browser and no e2e spec: the reported state needs a
scrolled-back pane whose window is the only unread one, a geometry the jsdom
suite cannot assert. The claim is the arithmetic plus the wiring, not the
pixels.