### PR TITLE
test/infra(#1162): deploy the release image for real, then probe it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,14 @@ name: release
 #              standalone leg — it publishes to the container registry itself,
 #              NOT a GitHub Release asset, so it is NOT in `publish`'s needs and
 #              runs in parallel with the package jobs.
+#   * smoke  — DEPLOYS the image the docker job just produced and probes it
+#              (#1162). Every other gate in this repo tests the deploy SCRIPTS
+#              with `docker` stubbed; this one boots the artifact and asks it
+#              questions over HTTP. On a tag it pulls the PUBLISHED
+#              ghcr.io/<owner>/grappa:v<version> — the thing operators run; on
+#              a docker_validation dry-run it re-exports the amd64 image from
+#              the build cache, so the pre-tag smoke finally smokes something.
+#              amd64 only: the arm64 leg is proven by the build.
 #   * publish — attaches deb + rpm + pkg.tar.zst + the regenerated
 #              PKGBUILD/.SRCINFO to the GitHub Release. Runs even if a package
 #              job FAILED and attaches ONLY what built (#504): a broken distro
@@ -634,6 +642,80 @@ jobs:
           # so `docker pull ghcr.io/<owner>/grappa` resolves cleanly on both
           # arches without the extra unknown/unknown provenance entry.
           provenance: false
+
+  smoke:
+    name: deploy + probe the release image (amd64)
+    needs: [docker]
+    # Exactly the docker job's trigger set: a real tag (probe what was just
+    # published) or a docker_validation dry-run (probe what was just built).
+    # There is no third mode and no skip — if the image cannot be obtained,
+    # this job FAILS. A smoke test that quietly passes having tested nothing
+    # is worse than not having one.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout (the TRIGGERING ref — it carries the smoke driver)
+        uses: actions/checkout@v7
+        with:
+          # Same reasoning as the docker job: the pushed TAG on a release, the
+          # DISPATCHED BRANCH on a dry-run. submodules:false + fetch-depth 1 —
+          # the driver is shell over infra/ and reads no git history.
+          submodules: false
+
+      - name: Resolve version (repo-root VERSION file = SSOT)
+        id: ver
+        run: echo "version=$(infra/packaging/version.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ghcr.io
+        # Only the tag path pulls from the registry; the dry-run builds locally.
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull the PUBLISHED image (tag path)
+        id: pull
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/grappa:v${{ steps.ver.outputs.version }}"
+          # The honest subject: the exact ref an operator's deploy.sh resolves.
+          docker pull "$image"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx (dry-run path)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: docker/setup-buildx-action@v4
+
+      - name: Re-export the amd64 image from the build cache (dry-run path)
+        id: build
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.release
+          # amd64 ONLY and load:true — a multi-arch manifest cannot be loaded
+          # into the local docker daemon, and this job has to RUN the thing.
+          # The docker job wrote the full cache moments ago (needs:), so this
+          # re-exports cached layers rather than rebuilding.
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: grappa-release:smoke
+          cache-from: type=gha
+          provenance: false
+
+      - name: Deploy the image for real and probe it
+        env:
+          # Whichever path ran; the other's output is empty.
+          GRAPPA_IMAGE: ${{ steps.pull.outputs.image || 'grappa-release:smoke' }}
+          GRAPPA_SMOKE_VERSION: ${{ steps.ver.outputs.version }}
+        run: scripts/smoke-release-image.sh
 
   publish:
     name: publish GitHub Release assets

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37285,3 +37285,77 @@ recorder, plus `Grappa.Release.seed_themes/0` being the same entry point four
 other substrates already call in production. The end-to-end "install the
 package, open the gallery, count the themes" check is the packaging suites'
 job (`infra/packaging/README.md` § Caveat) and remains a manual step.
+
+---
+
+## 2026-08-10 — #1162: the deploy tests all stubbed docker, so one of them stopped
+
+Twenty-odd bats suites cover `infra/docker/`, and every one of them stubs
+`docker` on `PATH` — the header of `deploy_docker_release_image_test.bats`
+says so in as many words. They are good at what they are: assertions about
+which file a verb writes and which flags it would pass. They are
+structurally incapable of seeing a deployment where every script did its job
+and the result is broken anyway, which is the whole of #1161. So
+`scripts/smoke-release-image.sh` brings a box up through the real `get.sh` →
+`deploy.sh` release path and asks it questions over HTTP.
+
+**The subject is the PUBLISHED image, and the pre-tag door already existed.**
+On a tag the `smoke` job pulls `ghcr.io/<owner>/grappa:v<version>` — the ref
+`deploy.sh` resolves for an operator; a locally-built image proves less. But
+post-publication is a late place to learn the image is broken, and this
+workflow already had the right door: the `docker_validation` dispatch, which
+the header of `release.yml` has been calling "the mandatory
+workflow_dispatch smoke before a real tag" while it only ever ran a build.
+It now re-exports the amd64 image from the cache the `docker` job wrote
+moments earlier and probes that. No new mode, no new trigger — an existing
+promise made true. amd64 only, because a multi-arch manifest cannot be
+loaded into a daemon and the arm64 leg is what the build proves.
+
+**`GRAPPA_RAW_BASE=file://<checkout>` puts get.sh itself under test.** The
+one substitution the smoke makes is where get.sh fetches from; the mirror
+step still runs, so a file get.sh forgets to mirror — the shape that made
+`gen-secrets.sh` an eager fetch in #862 — fails the smoke rather than an
+operator's first install.
+
+**Two reads of one file are not a cross-check.** The first cut asked the
+running node for `Cic.Bundle.current_hash()` and grepped the response body
+for it. That reads like an independent oracle and is not one: both sides
+resolve `Bundle.root()` and open the same `index.html`, so they cannot
+disagree and the assertion can never fail — a vacuity wearing a comparison's
+clothes. What survived is three claims with three oracles: `GET /` is 2xx,
+the RECEIVED BYTES parse to a bundle hash (shipped back into the container
+and fed to `Cic.Bundle.parse_hash/1`, which exists for exactly this —
+borrowing the parser is fine, borrowing the FILE was the bug), and the chunk
+the shell names comes back as JavaScript.
+
+**A missing hashed chunk answers 200 with the SPA shell.** Measured on a
+mutant image with `cicchetto-dist/assets` deleted: `Plug.Static` misses, the
+history fallback answers, and `GET /assets/index-<hash>.js` returns
+`content-type: text/html`. A browser loads the page, fetches the module, is
+handed HTML and white-screens. A status-only assertion passed that mutant
+clean, which is why the probe reads the content type. Worth knowing outside
+this test: the failure is silent by construction.
+
+**The never-rotate rule needs a second container shape.** Under `deploy.sh`
+every secret rides in from the host env file, so the entrypoint's first-boot
+bootstrap (#862) never fires and a rotation regression would be invisible on
+that path. Only a bare `docker run` with nothing but `PHX_HOST` generates
+them onto `/data`, so the third probe boots one. A rotation there is silent
+data loss — every Cloak-encrypted credential stops decrypting — not a failed
+boot, so nothing louder would notice.
+
+**Every assertion has a mutant that killed it**, each mutation applied at
+the layer the real bug would live in (image `ENV`, image contents, the
+entrypoint script, the deployed tag) rather than in the test: a
+one-directory-off `CIC_DIST_ROOT` for #1161 verbatim (404), a mangled
+`<script type="module">` tag (200, no tag), a deleted `assets/` (200
+`text/html`), an older published tag against the current expected version
+(and probe 1 stays green there, so the version arm is what discriminates),
+and the entrypoint with its `[ ! -f "$secrets_file" ]` guard removed (the
+hash moves). The matrix is in `docs/TESTING.md`; reproducing a row is a
+two-line `FROM ghcr.io/vjt/grappa:latest`.
+
+**What it refuses to claim.** One architecture, no IRC at all, no TLS front
+door or real `PHX_HOST`, and no `update` verb — only `install` plus a
+bare-run restart. A missing image fails the job and never skips it: a smoke
+test that quietly passes having tested nothing is worse than not having one.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1389,7 +1389,10 @@ D** — see **Running the published image** below.
   which is why it works pre-merge, when only the branch carries the file) with
   `push:false` and no registry login: it proves the build (arm64 QEMU + the
   ABI-lockstep assertion + cic + `mix release`) and pushes nothing, moves no
-  `:latest`. deb/arch/rpm/publish are skipped for this run. The default
+  `:latest`. Since #1162 it then DEPLOYS that image and probes it (the `smoke`
+  job, below) instead of only proving it compiles — so the dry-run is a smoke
+  test in fact and not just in name. deb/arch/rpm/publish are skipped for this
+  run. The default
   (`docker_validation=false`) tag-push path is unchanged — it publishes. The
   arm64 leg is QEMU-emulated on the amd64 runner; a stale QEMU crashes the
   emulated BEAM JIT at the first `mix` call, so the job pins a recent
@@ -1397,6 +1400,18 @@ D** — see **Running the published image** below.
   unreliable on CI, the fallback (needs vjt's sign-off — it deviates from the
   buildx+QEMU decision) is native arm64 runners (`ubuntu-24.04-arm`) +
   `docker manifest`.
+- **The image is DEPLOYED and PROBED, not just built (#1162).** A fifth job,
+  `smoke`, `needs: [docker]` and brings a real box up from the image through the
+  same `infra/docker/get.sh` → `deploy.sh` path an operator runs, then asks it
+  questions over HTTP: `GET /` serves a shell whose chunk actually loads as
+  JavaScript, `GET /api/config` reports this version, and a restart does not
+  rotate the generated `/data/grappa.env`. On a tag it pulls the PUBLISHED
+  `:v<version>` — the ref operators resolve; on a dry-run it probes the amd64
+  image re-exported from the build cache. amd64 only (the arm64 leg is proven by
+  the build). **An unobtainable image fails the job; it never skips.** The driver
+  is `scripts/smoke-release-image.sh`, runnable by hand — probes, mutation
+  evidence and the explicit non-coverage list are in
+  `docs/TESTING.md` § "The release-image smoke".
 - **Local build** (validate the Dockerfile without CI):
   `docker buildx build -f Dockerfile.release --load -t grappa-release:test .`
   builds the native arch; add `--platform linux/amd64,linux/arm64` for the

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,11 @@ scripts/mix.sh --env=dev doctor
 scripts/bats.sh                          # all bats specs: test/bin/ test/infra/ test/scripts/
 scripts/bats.sh test/bin/grappa_test.bats
 
+# Release image — deploy it for real and probe it (#1162)
+docker pull ghcr.io/vjt/grappa:v0.16.0
+GRAPPA_IMAGE=ghcr.io/vjt/grappa:v0.16.0 GRAPPA_SMOKE_VERSION=0.16.0 \
+  scripts/smoke-release-image.sh
+
 # E2E (Playwright + real testnet)
 scripts/integration.sh                   # full suite, cold bring-up + tear-down
 scripts/integration.sh --grep "UX-6 K"   # one spec or pattern
@@ -188,6 +193,7 @@ The authoritative source is the comment block at the top of each
 * **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
 * **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer). There is no compose involvement in the runner: the container is reached only transitively, when a test exercises a verb that shells out to docker, and those tests stub `docker` on `PATH` rather than touching a real one. So this gate needs no stack up.
 * **`scripts/release-image.sh`** → the RELEASE image (`Dockerfile.release`), not the compose dev stack. `build` buildx-loads it locally; `fresh-boot` wipes the scratch volume and bare-runs it with nothing but `PHX_HOST` (the documented one-liner — the point is that everything else must come from the image and the volume); `warm-boot` does the same on the EXISTING volume; `oneshot <args…>` runs a throwaway container against that volume; `logs` / `down [--volume]` clean up. This is the reproduction for #862 and #867, both of which were found by hand-typing docker commands because no wrapper reached this artifact.
+* **`scripts/smoke-release-image.sh`** → brings a box up from `$GRAPPA_IMAGE` through the real `infra/docker/get.sh` → `deploy.sh` release path (`GRAPPA_RAW_BASE=file://<checkout>`, so get.sh's mirror list is under test too), then probes it over HTTP and tears everything down. Dedicated container/volume names (`grappa-smoke*`), so it cannot eat an operator box. Requires the image to be present locally — **an unavailable image fails the run, it never skips it**. See "The release-image smoke" below.
 * **`scripts/integration.sh`** → `scripts/testnet.sh up` → `docker compose run --rm playwright-runner npx playwright test "$@"` → trap-on-exit `scripts/testnet.sh down`. `KEEP_STACK=1` opts out of tear-down.
 * **`scripts/testnet.sh`** → manages the stack standalone. `up` boots hub + leaves + services + grappa-test + nginx-test + seeder. `down` tears down + wipes `runtime/e2e/`. `probe` connects an oper-up client to leaf4 for `/links` + `/stats l`.
 
@@ -206,6 +212,51 @@ undocumented. Making the alias's run the `:test` one collapses them into
 a single honest run identical to the workflow's single `mix doctor` step
 — local equals CI by construction rather than by hand. Re-adding the
 second run re-opens both defects.
+
+## The release-image smoke (#1162)
+
+`test/infra/`'s 20+ bats suites cover the deploy **scripts** with `docker`
+stubbed on `PATH`: every assertion is about which file a verb writes and
+which flags it would pass. That leaves one class completely uncovered —
+the deployment that succeeds at every script step and is still broken,
+which is exactly #1161 (container up, API answering, env well-formed,
+frontend 404 because a variable pointed one directory to the left).
+
+`scripts/smoke-release-image.sh` is the gate for that class. It runs in
+`release.yml`'s `smoke` job — on a tag against the **published**
+`ghcr.io/<owner>/grappa:v<version>`, and on a `docker_validation` dry-run
+against the amd64 image re-exported from that run's build cache (which is
+what finally makes the documented "mandatory workflow_dispatch smoke
+before a real tag" smoke something). It is also runnable by hand, see the
+quick reference.
+
+Three probes, and every assertion has a mutant that kills it — measured,
+not asserted. Reproduce any row by deriving a one-line mutant image
+`FROM ghcr.io/vjt/grappa:latest` and pointing `GRAPPA_IMAGE` at it:
+
+| Assertion | Mutation that kills it | Observed |
+|---|---|---|
+| `GET /` is 2xx | `ENV CIC_DIST_ROOT=/app/cicchetto-dist/assets` (#1161 verbatim) | 404 |
+| the body parses to a bundle hash | mangle the `<script type="module">` tag in `index.html` | 200, no tag |
+| the named chunk arrives as JavaScript | `RUN rm -rf /app/cicchetto-dist/assets` | 200 `text/html` |
+| `/api/config` reports the expected version | deploy an older published tag | reports the older version |
+| a restart keeps `/data/grappa.env` | drop the `[ ! -f "$secrets_file" ]` guard from the entrypoint | hash changes |
+
+Two of those are worth knowing on their own. **A missing hashed chunk is
+served as the SPA shell with 200 and `content-type: text/html`** —
+`Plug.Static` misses and the history fallback answers, so a browser gets
+HTML where it expects a module and white-screens; status-only assertions
+are blind to it. And **the never-rotate probe needs a second container
+shape**: under `deploy.sh` every secret rides in from the host env file,
+so the entrypoint's first-boot bootstrap (#862) never fires there. Only a
+bare `docker run` with just `PHX_HOST` generates them onto `/data`.
+
+What it deliberately does NOT cover: one architecture (whatever the host
+runs — the arm64 leg of the manifest is proven by the build, not here);
+no IRC at all (no upstream connect, SASL or scrollback — that is
+`scripts/integration.sh`'s job, against the SOURCE image); no TLS front
+door or real `PHX_HOST`; and the `update` verb (only `install` plus a
+bare-run restart).
 
 ## The e2e stack
 

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -126,7 +126,13 @@ PHX_HOST=localhost \
 #   (a) GET / is 2xx            — #1161's 404 SPA (a missing bundle is a 404;
 #                                 the "not built" text rides WITH that status)
 #   (b) the body parses to a hash — a shell served 200 that boots nothing
-#   (c) the chunk it names is 2xx — a shell pointing at bytes nobody serves
+#   (c) the chunk it names arrives AS JAVASCRIPT — a shell pointing at bytes
+#       nobody serves. Status alone is blind here, MEASURED: delete
+#       cicchetto-dist/assets from the image and GET /assets/index-<hash>.js
+#       still answers 200, because Plug.Static misses and the SPA history
+#       fallback hands back the shell with content-type text/html. The
+#       browser then loads the page, fetches the module, gets HTML, and
+#       white-screens — the exact silent shape of #1161.
 say "probe 1: the SPA served at / can boot"
 body="$SMOKE_HOME/index.html"
 curl -fsS --max-time 20 -o "$body" "http://$PUBLISH/" \
@@ -142,9 +148,14 @@ hash="$(docker exec "$BOX" bin/grappa rpc \
     die "GET / returned 200 but carries no SPA bundle tag"
 }
 
-curl -fsS --max-time 20 -o /dev/null "http://$PUBLISH/assets/index-${hash}.js" \
+chunk_type="$(curl -fsS --max-time 20 -o /dev/null \
+    -w '%{content_type}' "http://$PUBLISH/assets/index-${hash}.js")" \
     || die "the shell names /assets/index-${hash}.js and the box does not serve it"
-pass "GET / serves a shell that boots index-${hash}.js"
+case "$chunk_type" in
+    *javascript*) ;;
+    *) die "/assets/index-${hash}.js came back as '${chunk_type}', not JavaScript — the shell boots nothing" ;;
+esac
+pass "GET / serves a shell that boots index-${hash}.js (${chunk_type})"
 
 # ---- probe 2: /api/config answers, and the node is the image under test ----
 #

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -112,34 +112,39 @@ GRAPPA_IMAGE="$GRAPPA_IMAGE" \
 PHX_HOST=localhost \
     sh "$REPO_ROOT/infra/docker/get.sh" install
 
-# ---- probe 1: GET / serves the SPA shell, not the not-built fallback -------
+# ---- probe 1: the SPA the box serves can actually boot ---------------------
 #
-# The oracle is the RUNNING NODE's own answer: Grappa.Cic.Bundle.current_hash()
-# parses the deployed index.html with the production regex, so this compares
-# what the node believes it serves against what HTTP actually returned — no
-# copy of the regex here to drift. #1161 fails BOTH halves at once (a wrong
-# CIC_DIST_ROOT means a nil hash and a fallback body), which is why the empty
-# hash is its own assertion rather than a silently-matching empty string.
-say "probe 1: GET / carries the SPA shell"
+# Three claims, three INDEPENDENT oracles — deliberately not a comparison
+# between two reads of one file. Asking the node for Cic.Bundle.current_hash()
+# and grepping the response for it looks like a cross-check and is not: both
+# sides resolve Bundle.root() and open the same index.html, so they cannot
+# disagree and the assertion can never fail. So the hash is parsed FROM THE
+# HTTP RESPONSE, by shipping the received bytes back into the container and
+# running the production parser (Cic.Bundle.parse_hash/1, exposed for exactly
+# this) over them — no second copy of the Vite regex to drift.
+#
+#   (a) GET / is 2xx            — #1161's 404 SPA (a missing bundle is a 404;
+#                                 the "not built" text rides WITH that status)
+#   (b) the body parses to a hash — a shell served 200 that boots nothing
+#   (c) the chunk it names is 2xx — a shell pointing at bytes nobody serves
+say "probe 1: the SPA served at / can boot"
 body="$SMOKE_HOME/index.html"
 curl -fsS --max-time 20 -o "$body" "http://$PUBLISH/" \
     || die "GET / did not return 2xx"
 
+docker cp "$body" "$BOX:/tmp/smoke-index.html" >/dev/null
 hash="$(docker exec "$BOX" bin/grappa rpc \
-    'IO.puts("cic-hash=" <> to_string(Grappa.Cic.Bundle.current_hash()))' \
+    'IO.puts("cic-hash=" <> to_string(Grappa.Cic.Bundle.parse_hash(File.read!("/tmp/smoke-index.html"))))' \
     | sed -n 's/^cic-hash=//p' | tail -n1 | tr -d '\r')"
 [ -n "$hash" ] || {
     printf '\n----- GET / returned (first 300 bytes) -----\n' >&2
     head -c 300 "$body" >&2; printf '\n' >&2
-    die "the running node reports NO cic bundle hash — it cannot read its own dist (CIC_DIST_ROOT?)"
+    die "GET / returned 200 but carries no SPA bundle tag"
 }
 
-grep -q "src=\"/assets/index-${hash}\.js\"" "$body" || {
-    printf '\n----- GET / returned (first 300 bytes) -----\n' >&2
-    head -c 300 "$body" >&2; printf '\n' >&2
-    die "GET / does not carry the bundle the node reports (index-${hash}.js)"
-}
-pass "GET / serves index-${hash}.js"
+curl -fsS --max-time 20 -o /dev/null "http://$PUBLISH/assets/index-${hash}.js" \
+    || die "the shell names /assets/index-${hash}.js and the box does not serve it"
+pass "GET / serves a shell that boots index-${hash}.js"
 
 # ---- probe 2: /api/config answers, and the node is the image under test ----
 #

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# smoke-release-image.sh — deploy the published release image FOR REAL, then
+# ask it questions (#1162).
+#
+# test/infra/*.bats covers the deploy SCRIPTS with `docker` stubbed on PATH:
+# every assertion there is about which file a verb writes and which flags it
+# would pass. Nothing boots the image. #1161 is the bug class that costs:
+# the container starts, the API answers, the env is well-formed, every script
+# did its job — and the frontend is 404 because a variable pointed one
+# directory to the left. No script-level assertion can see it; one HTTP GET
+# can.
+#
+# This is that GET, plus three more probes, against a container that was
+# brought up by the SAME infra/docker/get.sh -> deploy.sh path an operator
+# runs (GRAPPA_RAW_BASE points get.sh at this checkout instead of GitHub raw,
+# so the mirror step is exercised too — a file get.sh forgets to mirror is
+# itself a shipped-deploy bug).
+#
+#   usage:  docker pull ghcr.io/vjt/grappa:vX.Y.Z
+#           GRAPPA_IMAGE=ghcr.io/vjt/grappa:vX.Y.Z \
+#           GRAPPA_SMOKE_VERSION=X.Y.Z \
+#             scripts/smoke-release-image.sh
+#
+#   GRAPPA_IMAGE          (required) the image ref under test, already local.
+#   GRAPPA_SMOKE_VERSION  (required) the version the running node must report.
+#   GRAPPA_SMOKE_PUBLISH  host:port to publish on (default 127.0.0.1:14000).
+#
+# A MISSING IMAGE IS A FAILURE, NEVER A SKIP: a smoke test that quietly passes
+# when it tested nothing is worse than no smoke test. Same for every probe —
+# the first one that fails dumps the container log and exits non-zero.
+#
+# What this does NOT cover, deliberately:
+#   * one arch only — whatever the host runs. The arm64 leg of a multi-arch
+#     manifest is proven by the build, not by this.
+#   * no IRC: no upstream connect, no SASL, no scrollback. Those are
+#     scripts/integration.sh's job, against the SOURCE image.
+#   * no TLS front door, no reverse proxy, no real PHX_HOST — the box is
+#     probed on the published loopback port.
+#   * `update` is not exercised, only `install` + a bare-run restart.
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+
+say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+pass() { printf '\033[1;32mok\033[0m  %s\n' "$*"; }
+
+: "${GRAPPA_IMAGE:?set GRAPPA_IMAGE to the image ref under test}"
+: "${GRAPPA_SMOKE_VERSION:?set GRAPPA_SMOKE_VERSION to the version the node must report}"
+PUBLISH="${GRAPPA_SMOKE_PUBLISH:-127.0.0.1:14000}"
+
+# Dedicated names, never the operator defaults (`grappa` / `grappa-data`): the
+# teardown below force-removes them, and it must not be able to eat a real box.
+BOX=grappa-smoke
+BOX_VOLUME=grappa-smoke-data
+BARE=grappa-smoke-bare
+BARE_VOLUME=grappa-smoke-bare-data
+
+command -v docker >/dev/null 2>&1 || die "docker not found."
+docker image inspect "$GRAPPA_IMAGE" >/dev/null 2>&1 \
+    || die "$GRAPPA_IMAGE is not present locally — 'docker pull' it first. An unavailable image fails this job; it never skips it."
+
+SMOKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/grappa-smoke.XXXXXX")"
+
+teardown() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        # The server half of the failure: a probe that failed on the HTTP side
+        # says nothing about why. 200 lines, not 30.
+        for c in "$BOX" "$BARE"; do
+            if docker inspect "$c" >/dev/null 2>&1; then
+                printf '\n----- docker logs %s (tail 200) -----\n' "$c" >&2
+                docker logs --tail 200 "$c" >&2 2>&1 || true
+            fi
+        done
+    fi
+    docker rm -f "$BOX" "$BARE" >/dev/null 2>&1 || true
+    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" >/dev/null 2>&1 || true
+    rm -rf "$SMOKE_HOME"
+    exit "$status"
+}
+trap teardown EXIT
+
+# A crashed earlier run leaves the box behind, and `install` refuses to run
+# onto an existing container. Clear the dedicated names before, not just after.
+docker rm -f "$BOX" "$BARE" >/dev/null 2>&1 || true
+docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" >/dev/null 2>&1 || true
+
+# wait_healthz CONTAINER — poll /healthz from INSIDE, so this works for the
+# bare container too (no published port).
+wait_healthz() {
+    deadline=$((SECONDS + 300))
+    until docker exec "$1" curl -fsS -o /dev/null http://localhost:4000/healthz 2>/dev/null; do
+        [ "$SECONDS" -lt "$deadline" ] || die "$1 never answered /healthz"
+        printf '.'; sleep 2
+    done
+    printf '\n'
+}
+
+say "ARM A — install via infra/docker/get.sh (release mode) from $GRAPPA_IMAGE"
+# get.sh mirrors deploy_common.sh + gen-secrets.sh + deploy.sh into
+# GRAPPA_HOME and execs deploy.sh, exactly as `curl … | bash` does; the
+# file:// base is the only substitution, so the mirror list is under test.
+GRAPPA_RAW_BASE="file://$REPO_ROOT" \
+GRAPPA_HOME="$SMOKE_HOME" \
+GRAPPA_CONTAINER="$BOX" \
+GRAPPA_DATA_VOLUME="$BOX_VOLUME" \
+GRAPPA_PUBLISH="$PUBLISH" \
+GRAPPA_IMAGE="$GRAPPA_IMAGE" \
+PHX_HOST=localhost \
+    sh "$REPO_ROOT/infra/docker/get.sh" install
+
+# ---- probe 1: GET / serves the SPA shell, not the not-built fallback -------
+#
+# The oracle is the RUNNING NODE's own answer: Grappa.Cic.Bundle.current_hash()
+# parses the deployed index.html with the production regex, so this compares
+# what the node believes it serves against what HTTP actually returned — no
+# copy of the regex here to drift. #1161 fails BOTH halves at once (a wrong
+# CIC_DIST_ROOT means a nil hash and a fallback body), which is why the empty
+# hash is its own assertion rather than a silently-matching empty string.
+say "probe 1: GET / carries the SPA shell"
+body="$SMOKE_HOME/index.html"
+curl -fsS --max-time 20 -o "$body" "http://$PUBLISH/" \
+    || die "GET / did not return 2xx"
+
+hash="$(docker exec "$BOX" bin/grappa rpc \
+    'IO.puts("cic-hash=" <> to_string(Grappa.Cic.Bundle.current_hash()))' \
+    | sed -n 's/^cic-hash=//p' | tail -n1 | tr -d '\r')"
+[ -n "$hash" ] || {
+    printf '\n----- GET / returned (first 300 bytes) -----\n' >&2
+    head -c 300 "$body" >&2; printf '\n' >&2
+    die "the running node reports NO cic bundle hash — it cannot read its own dist (CIC_DIST_ROOT?)"
+}
+
+grep -q "src=\"/assets/index-${hash}\.js\"" "$body" || {
+    printf '\n----- GET / returned (first 300 bytes) -----\n' >&2
+    head -c 300 "$body" >&2; printf '\n' >&2
+    die "GET / does not carry the bundle the node reports (index-${hash}.js)"
+}
+pass "GET / serves index-${hash}.js"
+
+# ---- probe 2: /api/config answers, and the node is the image under test ----
+#
+# One request, two claims: the unauthenticated discovery endpoint is reachable
+# at all, and the version it reports is the one this image was built for. The
+# version half is what catches "the tag you think you deployed is not the
+# image that is running".
+say "probe 2: GET /api/config is the discovery JSON for $GRAPPA_SMOKE_VERSION"
+config="$(curl -fsS --max-time 20 "http://$PUBLISH/api/config")" \
+    || die "GET /api/config did not return 2xx"
+grep -Fq '"server":"grappa"' <<<"$config" \
+    || die "GET /api/config is not grappa's discovery JSON: $config"
+grep -Fq "\"version\":\"$GRAPPA_SMOKE_VERSION\"" <<<"$config" \
+    || die "the running node does not report $GRAPPA_SMOKE_VERSION: $config"
+pass "/api/config reports $GRAPPA_SMOKE_VERSION"
+
+# ---- probe 3: a restart never rotates the generated secrets ----------------
+#
+# A SECOND container shape, and it has to be: under deploy.sh every secret
+# rides in from the host env file, so the entrypoint's first-boot bootstrap
+# (#862) never fires there. A bare `docker run` with only PHX_HOST set is the
+# path that generates them onto /data — and rotating GRAPPA_ENCRYPTION_KEY on
+# a restart is silent data loss (every stored credential stops decrypting),
+# not a failed boot, so nothing louder than this would notice.
+say "probe 3: bare 'docker run' bootstraps secrets, and a restart reuses them"
+docker run -d --name "$BARE" -e PHX_HOST=localhost \
+    -v "${BARE_VOLUME}:/data" "$GRAPPA_IMAGE" >/dev/null
+wait_healthz "$BARE"
+before="$(docker exec "$BARE" sha256sum /data/grappa.env | cut -d' ' -f1)"
+[ -n "$before" ] || die "no /data/grappa.env after first boot — the bootstrap never ran"
+
+docker restart "$BARE" >/dev/null
+wait_healthz "$BARE"
+after="$(docker exec "$BARE" sha256sum /data/grappa.env | cut -d' ' -f1)"
+[ "$before" = "$after" ] \
+    || die "the restart ROTATED /data/grappa.env ($before -> $after) — every stored credential is now undecryptable"
+pass "/data/grappa.env survived the restart byte-for-byte ($before)"
+
+say "release image $GRAPPA_IMAGE deployed and answered every probe 🎉"

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -72,7 +72,7 @@ teardown() {
         for c in "$BOX" "$BARE"; do
             if docker inspect "$c" >/dev/null 2>&1; then
                 printf '\n----- docker logs %s (tail 200) -----\n' "$c" >&2
-                docker logs --tail 200 "$c" >&2 2>&1 || true
+                docker logs --tail 200 "$c" >&2 || true
             fi
         done
     fi
@@ -99,7 +99,7 @@ wait_healthz() {
     printf '\n'
 }
 
-say "ARM A — install via infra/docker/get.sh (release mode) from $GRAPPA_IMAGE"
+say "installing via infra/docker/get.sh (release mode) from $GRAPPA_IMAGE"
 # get.sh mirrors deploy_common.sh + gen-secrets.sh + deploy.sh into
 # GRAPPA_HOME and execs deploy.sh, exactly as `curl … | bash` does; the
 # file:// base is the only substitution, so the mirror list is under test.
@@ -139,23 +139,23 @@ curl -fsS --max-time 20 -o "$body" "http://$PUBLISH/" \
     || die "GET / did not return 2xx"
 
 docker cp "$body" "$BOX:/tmp/smoke-index.html" >/dev/null
-hash="$(docker exec "$BOX" bin/grappa rpc \
+bundle_hash="$(docker exec "$BOX" bin/grappa rpc \
     'IO.puts("cic-hash=" <> to_string(Grappa.Cic.Bundle.parse_hash(File.read!("/tmp/smoke-index.html"))))' \
     | sed -n 's/^cic-hash=//p' | tail -n1 | tr -d '\r')"
-[ -n "$hash" ] || {
+[ -n "$bundle_hash" ] || {
     printf '\n----- GET / returned (first 300 bytes) -----\n' >&2
     head -c 300 "$body" >&2; printf '\n' >&2
     die "GET / returned 200 but carries no SPA bundle tag"
 }
 
 chunk_type="$(curl -fsS --max-time 20 -o /dev/null \
-    -w '%{content_type}' "http://$PUBLISH/assets/index-${hash}.js")" \
-    || die "the shell names /assets/index-${hash}.js and the box does not serve it"
+    -w '%{content_type}' "http://$PUBLISH/assets/index-${bundle_hash}.js")" \
+    || die "the shell names /assets/index-${bundle_hash}.js and the box does not serve it"
 case "$chunk_type" in
     *javascript*) ;;
-    *) die "/assets/index-${hash}.js came back as '${chunk_type}', not JavaScript — the shell boots nothing" ;;
+    *) die "/assets/index-${bundle_hash}.js came back as '${chunk_type}', not JavaScript — the shell boots nothing" ;;
 esac
-pass "GET / serves a shell that boots index-${hash}.js (${chunk_type})"
+pass "GET / serves a shell that boots index-${bundle_hash}.js (${chunk_type})"
 
 # ---- probe 2: /api/config answers, and the node is the image under test ----
 #


### PR DESCRIPTION
## What

`test/infra/` has 20+ bats suites over the deploy scripts, and every one of
them stubs `docker` on `PATH` — the header of
`deploy_docker_release_image_test.bats` says so outright. They assert which
file a verb writes and which flags it would pass. Nothing boots the image.

That leaves one class uncovered: the deployment where every script did its
job and the result is still broken. #1161 is that class — container up, API
answering, env well-formed, frontend 404 because a variable pointed one
directory to the left.

`scripts/smoke-release-image.sh` brings a real box up through the same
`infra/docker/get.sh` -> `deploy.sh` release path an operator runs
(`GRAPPA_RAW_BASE=file://<checkout>` is the only substitution, so get.sh's
mirror list is under test too) and probes it. A new `smoke` job in
`release.yml` runs it: on a tag against the **published** ghcr ref, on a
`docker_validation` dry-run against the amd64 image re-exported from that
run's build cache.

The dry-run half is not new surface — `release.yml`'s header has been
calling that dispatch "the mandatory workflow_dispatch smoke before a real
tag" while it only ever ran a build. It smokes something now.

## Probes, and the mutant that kills each

Measured locally against `ghcr.io/vjt/grappa:latest` (green) and five mutant
images. Each mutation is applied at the layer the real bug would live in —
image `ENV`, image contents, the entrypoint, the deployed tag — never in the
test.

| Assertion | Mutation | Observed |
|---|---|---|
| `GET /` is 2xx | `ENV CIC_DIST_ROOT=/app/cicchetto-dist/assets` (#1161 verbatim) | 404 |
| the body parses to a bundle hash | mangle the `<script type="module">` tag | 200, no tag |
| the named chunk arrives as JavaScript | `RUN rm -rf /app/cicchetto-dist/assets` | 200 `text/html` |
| `/api/config` reports the expected version | deploy an older published tag | reports `0.15.0`; probe 1 stays green |
| a restart keeps `/data/grappa.env` | drop the `[ ! -f "$secrets_file" ]` guard | hash moves |

## Two findings worth reading

**A missing hashed chunk answers 200 with the SPA shell.** `Plug.Static`
misses, the history fallback answers, and `GET /assets/index-<hash>.js`
comes back `content-type: text/html`. A browser loads the page, fetches the
module, gets HTML, white-screens. A status-only assertion passed that mutant
clean — hence the content-type check. This is grappa behaviour, not test
behaviour, and it is untouched here.

**The first cut of probe 1 was vacuous.** It asked the node for
`Cic.Bundle.current_hash()` and grepped the response body for it. Both sides
resolve `Bundle.root()` and open the same `index.html`, so they cannot
disagree and the assertion could never fail. Rewritten as three claims with
three independent oracles; the production parser is still used, but over the
RECEIVED BYTES.

## What it refuses to claim

One architecture (the arm64 leg is proven by the build). No IRC at all — no
upstream connect, SASL or scrollback; that stays `scripts/integration.sh`'s
job against the SOURCE image. No TLS front door, no real `PHX_HOST`. Not the
`update` verb — only `install` plus a bare-run restart.

An unobtainable image fails the job and never skips it.

## Test plan

- [x] green against `ghcr.io/vjt/grappa:latest`, exit 0, zero container/volume/tmp residue
- [x] five mutants, each killing exactly its own assertion (table above)
- [x] `scripts/shellcheck.sh` clean (the gate derives its set, so the new script joined it automatically)
- [x] `scripts/bats.sh` full set, 402 ok / 0 not ok
- [x] `actionlint` clean on the workflows
- [x] `curl file://` verified on Ubuntu (the runner path), not just macOS
- [ ] the `smoke` job itself has never executed on GitHub — it can only run from a tag push or a `docker_validation` dispatch