### PR TITLE
#1167: let the packaged install finish installing itself

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37193,3 +37193,95 @@ single-arch image, not a published artifact. And no path check can catch the
 failure one step past this one: a root that exists and holds a bundle that is
 simply the wrong one — stale, or from another deploy — still boots silently
 and serves it.
+
+---
+
+## 2026-08-10 — #1167: the package has to finish installing itself
+
+**The gap was never the assets.** The curated built-in palettes are compiled
+into the release (`Grappa.Themes.Builtins`) and their wallpapers are static
+WebP files inside the cic bundle — nothing is fetched at runtime, nothing is a
+DB blob. But the gallery READS the database, so until something turns the
+compiled data into rows the theme section is empty. `.deb`/`.rpm`, the AUR
+package and a bare `docker run` all migrated and stopped. This is #435
+recurring through the doors #435 did not cover: it taught
+`infra/linux/install.sh` to seed, and every path with a deploy script behind
+it already seeded via #440's `substrate_seed` hook, but the three doors that
+have no deploy script at all were never wired.
+
+**The issue's diagnosis held; its line numbers did not, and checking which is
+which is the point.** Every claim re-measured true on `origin/main`
+(`1aa0ae94`): the four files, the two seeding entry points, and
+`Themes.seed_builtins/0`'s idempotence — an `insert!` with
+`on_conflict: {:replace, [:payload, :published, :updated_at]}` against the
+partial unique index on `(user_id, name) WHERE user_id IS NOT NULL`, so
+re-running it converges rather than duplicating. The CITED LINES are stale:
+the issue measured at `3383abf6`, where they were exact, and `install.sh` has
+since gone from 351 lines to 284, moving its seed from `:299` to `:232`. A
+premise verified at a commit is not a premise verified today, and the cheap
+half of that check is re-running it.
+
+**One knob, not two.** The container seed rides `GRAPPA_AUTO_MIGRATE` instead
+of gaining a symmetric `GRAPPA_AUTO_SEED`. An operator who sets that flag to 0
+did so to keep boot from writing to the database, and seeding IS a write, so
+the coherent reading is one switch over "boot may touch the DB" rather than
+two over the same intent — and a second knob is new operator surface nobody
+asked for.
+
+**Seeding is NON-FATAL where migrating is fatal, and that reverses what the
+issue suggested.** The issue proposed failing loud "in the same style" as the
+packaged migrate. `docs/OPERATIONS.md` already records the opposite posture
+for this exact operation, held on every substrate since #440: a seed failure
+WARNS and continues, because the gallery is cosmetic and the upsert converges
+on the next run, while the warning carries the retry command. Adopting the
+issue's wording would have let a missing colour scheme abort a pacman
+transaction or refuse a container boot. The split is not an inconsistency —
+it tracks what the failure COSTS: a half-applied schema is a correctness
+defect, an empty gallery is a cosmetic one. Loud-and-continue is not a silent
+swallow; the operator gets the failure and `sudo grappa seed-themes`.
+
+**`seed-themes` is a verb, not sugar.** `/usr/bin/grappa` gains it as the twin
+of `migrate`, and both scriptlets INVOKE it — so it is the packaged host's
+only door to the gallery, not a convenience alias over an eval string.
+
+**Three scriptlets that had no automated gate of any kind now execute under
+bats.** `test/infra/packaging_seed_themes_test.bats` copies each into a
+sandbox with its host-absolute paths (`/usr/bin/grappa`, `/etc/grappa`,
+`/var/lib/grappa`) re-rooted, proves the rewrite was TOTAL before running
+anything, and drives them against a recorder stub of the packaged CLI. Two
+properties made the harness trustworthy rather than decorative. The
+re-root-totality check exists because a leaked absolute path would abort the
+run as an unprivileged user and leave every assertion below failing for the
+wrong reason — or, as root, touch the real host. And the migrate call doubles
+as a SANITY TOKEN in each case: without asserting that the scriptlet reached
+the recorder at all, "no seed was recorded" and "the script never ran" read
+identically, and the second one passes green for free once the assertion is
+inverted.
+
+**Read red first: 9 of 27 failed before the fix.** The other 18 included seven
+arms that were VACUOUS at that moment — every "never seeds" assertion is
+trivially satisfied by a product that cannot seed. Ten single-point mutants,
+one at a time, say which of them became real: all ten were killed, none
+survived. Removing the seed from each door kills that door's arms (postinstall
+1/2/4, Arch 6/7/8, container 22/24); dropping the wrapper verb, or pointing it
+at the migrator instead, kills 10; hoisting the container seed out of the
+`GRAPPA_AUTO_MIGRATE` guard kills 23 and 26; making either seed fatal kills 4
+and 24 respectively; seeding before migrating kills 1 and 5; gating the
+postinstall seed on the dpkg spelling kills 2 — the rpm arm exists because
+`case $1 in configure)` silently no-ops the entire rpm path, the trap
+`docs/OPERATIONS.md` already names.
+
+**Four arms have no killer, and are labelled as regression guards rather than
+counted as coverage**: "a dpkg rollback neither migrates nor seeds", "a failed
+Arch migrate aborts before the seed", "a failed migration never reaches the
+seed" (container), and "grappa migrate still reaches
+`Grappa.Release.migrate()`". No single-point mutation of this change can break
+them; they exist so a LATER edit cannot.
+
+**Not measured.** No real `.deb`/`.rpm` was installed, no pacman transaction
+and no `docker run` of the release image was executed — the container lane was
+held elsewhere. What is proven is the scriptlets' decision logic against a
+recorder, plus `Grappa.Release.seed_themes/0` being the same entry point four
+other substrates already call in production. The end-to-end "install the
+package, open the gallery, count the themes" check is the packaging suites'
+job (`infra/packaging/README.md` § Caveat) and remains a manual step.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1043,6 +1043,16 @@ downtime):
   WARNS and continues — the gallery is cosmetic, the upsert converges,
   and the next deploy heals it; the warning names the gallery, carries
   the retry command, and is repeated after the ✓ banner.
+  **Since #1167 the same seed also runs on the doors that have no deploy
+  script at all** — the `.deb`/`.rpm` postinstall, the Arch `_bootstrap`
+  (both through the `grappa seed-themes` verb) and `release-entrypoint.sh`
+  for a bare `docker run` — each right after its own migrate, and each
+  keeping the non-fatal posture above. In the container it rides
+  `GRAPPA_AUTO_MIGRATE` rather than taking a knob of its own: an operator
+  who sets that to 0 did so to keep boot from writing to the database, and
+  seeding is a write. Guarded by
+  `test/infra/packaging_seed_themes_test.bats` and the seed arms of
+  `test/infra/release_entrypoint_migrate_test.bats`.
   Deploy orchestrators
   (`scripts/deploy.sh`, `infra/freebsd/deploy.sh`),
   operator-on-demand verbs (`infra/freebsd/jail_*.sh`) and
@@ -3814,6 +3824,16 @@ BOTH `.deb`/`.rpm` postinstall and the Arch `_bootstrap`, because only
 PENDING migrations apply — and it FAILS LOUD in all three, so a broken
 migrate surfaces as a failed package transaction instead of a silently
 half-migrated install.
+
+**`grappa seed-themes` is its twin over `Grappa.Release.seed_themes()`
+(#1167)**, and it is not sugar alone: the two install scriptlets INVOKE
+this verb, so it is the packaged host's only door to the built-in gallery
+and the command an operator re-runs to heal a failed seed. It sits right
+after the migrate in both, schema-then-data, and unlike the migrate it is
+NON-FATAL — see the seed posture under the hot/cold classification above
+(#440). Before #1167 neither scriptlet seeded at all, so a `.deb`/`.rpm`
+or AUR install landed with an empty theme section while the palettes sat
+compiled inside the release it had just installed.
 
 ### The maintainer scripts — dpkg's `$1` is not rpm's
 

--- a/infra/docker/release-entrypoint.sh
+++ b/infra/docker/release-entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # release-entrypoint.sh — container entrypoint for the self-contained grappa
 # RELEASE image (Dockerfile.release). It caps BEAM resources, bootstraps the
-# prod secrets on first boot, migrates, then execs the release.
+# prod secrets on first boot, migrates, seeds the built-in themes, then execs
+# the release.
 #
 # The caps mirror bin/start.sh's (see its header for the per-user derivation)
 # and travel via ERL_ZFLAGS, APPENDED to (never clobbering) any operator value:
@@ -123,6 +124,26 @@ if [ "$auto_migrate" = 1 ] && [ "$boots_the_release" = 1 ]; then
              "back with: docker run --rm -v <volume>:/data <image> eval" \
              "'Grappa.Release.rollback(Grappa.Repo, <version>)'" >&2
         exit 1
+    fi
+
+    # ── Built-in theme gallery (#1167) ─────────────────────────────────
+    # Same argument as the migration above: the palettes are compiled into
+    # this image and their wallpapers ride the cic bundle, but the gallery
+    # reads the DB and a bare `docker run` has no other door to the seeder.
+    # It rides GRAPPA_AUTO_MIGRATE rather than taking a knob of its own —
+    # an operator who sets that to 0 did so to keep boot from writing to
+    # the database, and seeding is a write.
+    # NON-FATAL, unlike the migration: a half-applied schema is a
+    # correctness defect, an empty gallery is cosmetic and the idempotent
+    # upsert converges on the next boot. Refusing to start here would
+    # trade a working bouncer for a missing colour scheme (the posture
+    # deploy_common has held on every substrate since #440).
+    if ! bin/grappa eval 'Grappa.Release.seed_themes()'; then
+        echo "grappa: built-in theme seeding FAILED — starting anyway." >&2
+        echo "grappa: the schema is applied and the bouncer is usable; the" \
+             "theme gallery may be empty or stale. The upsert converges, so" \
+             "the next boot heals it. Retry now with: docker run --rm" \
+             "-v <volume>:/data <image> eval 'Grappa.Release.seed_themes()'" >&2
     fi
 fi
 

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -144,7 +144,10 @@ curl http://127.0.0.1:4000/healthz
 ```
 
 `postinstall` creates the state dirs, copies the env template, generates
-the secrets (openssl), runs migrations, and **enables but does not start**
+the secrets (openssl), runs migrations, seeds the built-in theme gallery
+(#1167 — the palettes ship compiled into the release, but the gallery
+reads the DB, so the package has to unpack them itself), and **enables
+but does not start**
 the service (it cannot start until you set a real `PHX_HOST`).
 
 ## First user
@@ -168,6 +171,7 @@ Grappa.Accounts.create_user(%{name: "you", password: "change-me"})
 
 ```sh
 sudo grappa migrate        # apply pending migrations (no mix needed)
+sudo grappa seed-themes    # (re)materialise the built-in theme gallery
 sudo grappa gen-secrets    # (re)generate missing secrets in the env file
 sudo grappa version        # release version
 sudo grappa remote         # IEx into the running node

--- a/infra/packaging/aur/README.md
+++ b/infra/packaging/aur/README.md
@@ -63,7 +63,8 @@ makepkg -sf
 `regen.sh` rewrites `PKGBUILD`/`.SRCINFO` in place; do **not** commit the
 result — the committed recipe stays the `@GRAPPA_VERSION@` sentinel template.
 
-Install what you built (runs the scriptlet: user, secrets, migrate, enable):
+Install what you built (runs the scriptlet: user, secrets, migrate, theme
+seed, enable):
 
 ```sh
 sudo pacman -U grappa-*-x86_64.pkg.tar.zst

--- a/infra/packaging/aur/grappa.install
+++ b/infra/packaging/aur/grappa.install
@@ -42,6 +42,19 @@ _bootstrap() {
 		echo "        Fix the cause and re-run: sudo grappa migrate" >&2
 		return 1
 	fi
+
+	# Built-in theme gallery (#1167): the palettes are compiled into the
+	# release and their wallpapers ride the cic bundle, but the gallery reads
+	# the DB, so without this the package lands with an empty theme section.
+	# Idempotent upsert — which is also how an upgrade picks up built-ins
+	# added since. NON-FATAL, unlike migrate: a cosmetic gallery must not
+	# abort a pacman transaction, and the upsert converges on the next run.
+	if ! /usr/bin/grappa seed-themes; then
+		echo "grappa: built-in theme seeding FAILED (see error above)." >&2
+		echo "        The install is complete and the schema is applied;" >&2
+		echo "        the theme gallery may be empty or stale." >&2
+		echo "        Retry with: sudo grappa seed-themes" >&2
+	fi
 }
 
 post_install() {

--- a/infra/packaging/grappa-wrapper.sh
+++ b/infra/packaging/grappa-wrapper.sh
@@ -9,6 +9,7 @@
 #
 # Usage:
 #   sudo grappa migrate          run pending Ecto migrations (no mix needed)
+#   sudo grappa seed-themes      materialise the built-in theme gallery
 #   sudo grappa gen-secrets      (re)generate missing secrets in the env file
 #   sudo grappa remote           attach an IEx remote shell to the running node
 #   sudo grappa version          print the release version
@@ -16,6 +17,7 @@
 #
 # `migrate` is sugar for `eval 'Grappa.Release.migrate()'` — the same
 # Ecto.Migrator the other deploy paths call, reachable WITHOUT mix.
+# `seed-themes` is its twin over `Grappa.Release.seed_themes()`.
 
 set -euo pipefail
 
@@ -40,6 +42,13 @@ fi
 # `migrate` → eval the release migrator.
 if [ "$cmd" = "migrate" ]; then
 	set -- eval 'Grappa.Release.migrate()'
+fi
+
+# `seed-themes` → eval the release theme seeder (#1167). Not sugar alone: the
+# install scriptlets call this verb, so it is the packaged host's ONLY door to
+# the built-in gallery, and the one an operator re-runs to heal a failed seed.
+if [ "$cmd" = "seed-themes" ]; then
+	set -- eval 'Grappa.Release.seed_themes()'
 fi
 
 [ -r "$ENV_FILE" ] || die "env file $ENV_FILE not readable (run as root, or join the grappa group)"

--- a/infra/packaging/scripts/postinstall.sh
+++ b/infra/packaging/scripts/postinstall.sh
@@ -48,6 +48,23 @@ abort-*)
 		exit 1
 	fi
 
+	# ── Built-in theme gallery ─────────────────────────────────────────
+	# The curated palettes ship COMPILED into the release and their
+	# wallpapers ship in the cic bundle, but the gallery reads the DB — so
+	# without this step the package installs a bouncer with an empty theme
+	# section (#1167). Idempotent upsert (system owner + name), which is
+	# also how an upgrade picks up built-ins added since.
+	# NON-FATAL, unlike migrate: the gallery is cosmetic and the upsert
+	# converges, so failing a package transaction over it would cost the
+	# operator a working install for a missing colour scheme. Loud, never
+	# silent — same posture deploy_common holds on every substrate (#440).
+	if ! /usr/bin/grappa seed-themes; then
+		echo "grappa: built-in theme seeding FAILED (see error above)." >&2
+		echo "        The install is complete and the schema is applied;" >&2
+		echo "        the theme gallery may be empty or stale." >&2
+		echo "        Retry with: sudo grappa seed-themes" >&2
+	fi
+
 	# ── systemd: enable, do NOT start ──────────────────────────────────
 	# The operator must set a real PHX_HOST in /etc/grappa/grappa.env
 	# before the service can boot, so we enable-on-boot but leave the

--- a/test/infra/packaging_seed_themes_test.bats
+++ b/test/infra/packaging_seed_themes_test.bats
@@ -1,0 +1,288 @@
+#!/usr/bin/env bats
+#
+# The PACKAGED install doors and the built-in theme gallery (#1167).
+#
+# #435 taught the orchestrated deploy paths to seed the curated built-in
+# themes; the packaged doors were never wired. A `.deb`/`.rpm` or AUR install
+# ran the migrator and stopped, so the operator got a working bouncer with an
+# EMPTY theme gallery — the palettes ship compiled into the release, but the
+# gallery reads the DB and nothing ever turned the compiled data into rows.
+# The wallpapers were never the missing part: the package simply did not
+# finish installing itself.
+#
+# Scope: the three packaged doors' DECISION — that each one reaches the
+# seeder, in the only order that helps (schema before data), and what it does
+# when the seed fails. The release is a recorder stub that logs every
+# invocation, so the assertions read what the RELEASE would actually have
+# seen, not what the source text looks like.
+#
+# The scriptlets address the host by ABSOLUTE path (/usr/bin/grappa,
+# /etc/grappa, /var/lib/grappa), so each is copied into a sandbox with those
+# prefixes re-rooted. `assert_rerooted` then proves the rewrite was TOTAL: a
+# leaked absolute path would either abort the run as non-root or, worse, touch
+# the real host — and a harness that half-runs the script would let every
+# assertion below hold for the wrong reason.
+#
+# The fatal/non-fatal split is the property that most wants pinning:
+#   * a failed MIGRATE aborts the package transaction (a half-applied schema
+#     is a correctness defect);
+#   * a failed SEED is LOUD but non-fatal, carrying its retry command — the
+#     posture deploy_common has held for every substrate since #440
+#     (docs/OPERATIONS.md: "A seed failure WARNS and continues"). Inverting
+#     it would let a cosmetic gallery failure fail an install.
+
+load ../bats_helpers
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+    PKG_SRC="$REPO_SRC/infra/packaging"
+
+    ROOT="$BATS_TEST_TMPDIR/root"
+    mkdir -p "$ROOT/usr/bin" "$ROOT/usr/share/grappa" "$ROOT/usr/lib/grappa/bin" \
+        "$ROOT/usr/lib/sysusers.d" "$ROOT/usr/lib/tmpfiles.d" "$ROOT/etc"
+
+    CALL_LOG="$BATS_TEST_TMPDIR/calls.log"
+    export CALL_LOG
+    : > "$CALL_LOG"
+
+    # Failure injection, per verb: the two must be independently faultable or
+    # the fatal/non-fatal split cannot be observed at all.
+    export MIGRATE_RC=0
+    export SEED_RC=0
+
+    # /usr/bin/grappa — the packaged operator CLI, recorded.
+    cat > "$ROOT/usr/bin/grappa" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALL_LOG"
+case "${1:-}" in
+    migrate)
+        if [ "${MIGRATE_RC:-0}" -ne 0 ]; then
+            echo "** (Exqlite.Error) some migration blew up" >&2
+            exit "$MIGRATE_RC"
+        fi
+        ;;
+    seed-themes)
+        if [ "${SEED_RC:-0}" -ne 0 ]; then
+            echo "** (Ecto.ConstraintError) seeding blew up" >&2
+            exit "$SEED_RC"
+        fi
+        ;;
+esac
+EOF
+    chmod 0755 "$ROOT/usr/bin/grappa"
+
+    # /usr/lib/grappa/bin/grappa — the mix-release boot script the wrapper
+    # execs, recorded with the same log so ORDER stays observable.
+    cat > "$ROOT/usr/lib/grappa/bin/grappa" <<'EOF'
+#!/usr/bin/env bash
+printf 'release: %s\n' "$*" >> "$CALL_LOG"
+EOF
+    chmod 0755 "$ROOT/usr/lib/grappa/bin/grappa"
+
+    printf '#!/bin/sh\nprintf "gen-secrets\\n" >> "$CALL_LOG"\n' \
+        > "$ROOT/usr/share/grappa/gen-secrets.sh"
+    chmod 0755 "$ROOT/usr/share/grappa/gen-secrets.sh"
+    cp "$PKG_SRC/grappa.env.example" "$ROOT/usr/share/grappa/grappa.env.example"
+
+    # ---- PATH stubs: the host mutations the suite must not perform --------
+    # chown needs root and the suite has none; systemctl/systemd-* would talk
+    # to the developer's own init. chmod is deliberately NOT stubbed.
+    STUB="$BATS_TEST_TMPDIR/stub"
+    mkdir -p "$STUB"
+    for noop in chown systemctl systemd-sysusers systemd-tmpfiles; do
+        printf '#!/bin/sh\nexit 0\n' > "$STUB/$noop"
+        chmod 0755 "$STUB/$noop"
+    done
+
+    # `install -o root -g grappa` fails for an unprivileged user, and the
+    # ownership is not what this suite is about — drop the owner flags and
+    # perform the real copy/mkdir so the file-existence assertions stay real.
+    cat > "$STUB/install" <<'EOF'
+#!/bin/sh
+mode=''
+dir=0
+set -- "$@"
+operands=''
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -d) dir=1; shift ;;
+        -o|-g) shift 2 ;;
+        -m) mode="$2"; shift 2 ;;
+        *) operands="$operands $1"; shift ;;
+    esac
+done
+# shellcheck disable=SC2086
+set -- $operands
+if [ "$dir" = 1 ]; then
+    mkdir -p "$@"
+    if [ -n "$mode" ]; then chmod "$mode" "$@"; fi
+else
+    cp "$1" "$2"
+    if [ -n "$mode" ]; then chmod "$mode" "$2"; fi
+fi
+EOF
+    chmod 0755 "$STUB/install"
+    PATH="$STUB:$PATH"
+}
+
+# Copy a packaging script into the sandbox with every host-absolute grappa
+# path re-rooted under $ROOT.
+reroot() {
+    sed -e "s#/usr/bin/grappa#$ROOT/usr/bin/grappa#g" \
+        -e "s#/usr/lib/grappa#$ROOT/usr/lib/grappa#g" \
+        -e "s#/usr/lib/sysusers.d#$ROOT/usr/lib/sysusers.d#g" \
+        -e "s#/usr/lib/tmpfiles.d#$ROOT/usr/lib/tmpfiles.d#g" \
+        -e "s#/usr/share/grappa#$ROOT/usr/share/grappa#g" \
+        -e "s#/usr/share/doc/grappa#$ROOT/usr/share/doc/grappa#g" \
+        -e "s#/etc/grappa#$ROOT/etc/grappa#g" \
+        -e "s#/var/lib/grappa#$ROOT/var/lib/grappa#g" \
+        "$1" > "$2"
+    assert_rerooted "$2"
+}
+
+# Every re-rooted path reads `<tmpdir>/root/usr/...`, so the character before
+# the prefix is alphanumeric; a LEAKED one is preceded by whitespace, a quote
+# or the start of a line. Anything found here means the sandbox is porous and
+# the run below would not be measuring the script we shipped.
+assert_rerooted() {
+    local leaked
+    leaked="$(grep -nE '(^|[^/[:alnum:]_.-])/(usr|etc|var)/[[:alnum:]/._-]*grappa' "$1")" || return 0
+    printf 'absolute host paths survived the re-root:\n%s\n' "$leaked" >&2
+    return 1
+}
+
+postinstall() {
+    reroot "$PKG_SRC/scripts/postinstall.sh" "$BATS_TEST_TMPDIR/postinstall.sh"
+    sh "$BATS_TEST_TMPDIR/postinstall.sh" "$@"
+}
+
+# pacman sources the scriptlet and calls one hook; there is no shebang.
+arch_hook() {
+    reroot "$PKG_SRC/aur/grappa.install" "$BATS_TEST_TMPDIR/grappa.install"
+    bash -c ". '$BATS_TEST_TMPDIR/grappa.install'; $1"
+}
+
+wrapper() {
+    reroot "$PKG_SRC/grappa-wrapper.sh" "$BATS_TEST_TMPDIR/grappa"
+    chmod 0755 "$BATS_TEST_TMPDIR/grappa"
+    mkdir -p "$ROOT/etc/grappa"
+    printf 'DATABASE_PATH=%s/db\n' "$ROOT" > "$ROOT/etc/grappa/grappa.env"
+    "$BATS_TEST_TMPDIR/grappa" "$@"
+}
+
+calls() {
+    cat "$CALL_LOG"
+}
+
+# ── The deb/rpm door ────────────────────────────────────────────────────────
+
+@test "the deb/rpm postinstall seeds the gallery, after applying the schema" {
+    run postinstall configure
+    [ "$status" -eq 0 ]
+
+    # The migrate call is the harness's own sanity token: without it, an
+    # absent seed would be indistinguishable from a scriptlet that never ran.
+    grep -qx 'migrate' "$CALL_LOG"
+    grep -qx 'seed-themes' "$CALL_LOG"
+
+    # Schema before data. A seed against an unmigrated DB has no themes table.
+    local order
+    order="$(grep -nxE 'migrate|seed-themes' "$CALL_LOG" | cut -d: -f2 | tr '\n' ' ')"
+    [ "$order" = "migrate seed-themes " ]
+}
+
+@test "an rpm's numeric \$1 seeds too — the door is not dpkg-only" {
+    # rpm passes 1/2, never "configure"; a seed gated on the dpkg spelling
+    # would leave every RHEL-family install with an empty gallery.
+    run postinstall 1
+    [ "$status" -eq 0 ]
+    grep -qx 'seed-themes' "$CALL_LOG"
+}
+
+@test "a dpkg rollback neither migrates nor seeds" {
+    run postinstall abort-upgrade
+    [ "$status" -eq 0 ]
+    refute grep -qx 'seed-themes' "$CALL_LOG"
+    refute grep -qx 'migrate' "$CALL_LOG"
+}
+
+@test "a failed seed does NOT fail the package — but says so, with the retry" {
+    # The #440 posture: the gallery is cosmetic and the upsert converges, so
+    # aborting a package transaction over it costs the operator a working
+    # install for a missing colour scheme. Loud, not fatal, and never silent.
+    export SEED_RC=1
+    run postinstall configure
+
+    [ "$status" -eq 0 ]
+    grep -qx 'seed-themes' "$CALL_LOG"
+    [[ "$output" == *"grappa seed-themes"* ]]
+}
+
+@test "a failed migrate still aborts, and never reaches the seed" {
+    # The other half of the split. Seeding data into a half-applied schema is
+    # not a recovery, and the transaction must still fail.
+    export MIGRATE_RC=1
+    run postinstall configure
+
+    [ "$status" -ne 0 ]
+    refute grep -qx 'seed-themes' "$CALL_LOG"
+    [[ "$output" == *"migration FAILED"* ]]
+}
+
+# ── The AUR door ────────────────────────────────────────────────────────────
+
+@test "the Arch scriptlet seeds on first install, after the schema" {
+    run arch_hook post_install
+    [ "$status" -eq 0 ]
+
+    grep -qx 'migrate' "$CALL_LOG"
+    grep -qx 'seed-themes' "$CALL_LOG"
+
+    local order
+    order="$(grep -nxE 'migrate|seed-themes' "$CALL_LOG" | cut -d: -f2 | tr '\n' ' ')"
+    [ "$order" = "migrate seed-themes " ]
+}
+
+@test "the Arch scriptlet re-seeds on upgrade — new built-ins reach old boxes" {
+    # The seed set is versioned CODE: a gallery materialised once at install
+    # would never gain a theme added in a later release. That is the whole
+    # reason #440 made the deploy hook run on every deploy.
+    run arch_hook post_upgrade
+    [ "$status" -eq 0 ]
+    grep -qx 'seed-themes' "$CALL_LOG"
+}
+
+@test "a failed Arch seed leaves the transaction green, loudly" {
+    export SEED_RC=1
+    run arch_hook post_install
+
+    [ "$status" -eq 0 ]
+    grep -qx 'seed-themes' "$CALL_LOG"
+    [[ "$output" == *"grappa seed-themes"* ]]
+}
+
+@test "a failed Arch migrate aborts the transaction before the seed" {
+    export MIGRATE_RC=1
+    run arch_hook post_install
+
+    [ "$status" -ne 0 ]
+    refute grep -qx 'seed-themes' "$CALL_LOG"
+}
+
+# ── The operator CLI ────────────────────────────────────────────────────────
+
+@test "grappa seed-themes reaches Grappa.Release.seed_themes()" {
+    # The verb the two scriptlets above call, and the documented manual
+    # recovery path. Without it they invoke nothing at all.
+    run wrapper seed-themes
+    [ "$status" -eq 0 ]
+    [ "$(calls)" = "release: eval Grappa.Release.seed_themes()" ]
+}
+
+@test "grappa migrate still reaches Grappa.Release.migrate()" {
+    # The sibling verb, pinned in the same file: the seed verb is added by
+    # extending the same dispatch, and a botched extension would eat it.
+    run wrapper migrate
+    [ "$status" -eq 0 ]
+    [ "$(calls)" = "release: eval Grappa.Release.migrate()" ]
+}

--- a/test/infra/release_entrypoint_migrate_test.bats
+++ b/test/infra/release_entrypoint_migrate_test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 #
 # Bats suite for infra/docker/release-entrypoint.sh BOOT-TIME MIGRATION
-# (#867).
+# (#867) and the built-in theme seed that rides the same decision (#1167).
 #
 # With #862's secrets in place, `docker run <image> start` on a fresh volume
 # got one step further and died on `no such table: admin_events` — the image
@@ -54,15 +54,30 @@ setup() {
     : > "$CALL_LOG"
 
     # MIGRATE_RC injects a failing migrator (a broken migration, a locked DB,
-    # a read-only volume — all the same shape from out here).
+    # a read-only volume — all the same shape from out here). SEED_RC is its
+    # sibling for the theme seed: the two must be independently faultable, or
+    # the fatal/non-fatal split between them cannot be observed.
     export MIGRATE_RC=0
+    export SEED_RC=0
     cat > "$APP/bin/grappa" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$CALL_LOG"
 env > "$ENV_DIR/$1"
-if [ "$1" = eval ] && [ "${MIGRATE_RC:-0}" -ne 0 ]; then
-    echo "** (Exqlite.Error) some migration blew up" >&2
-    exit "$MIGRATE_RC"
+if [ "$1" = eval ]; then
+    case "$2" in
+        *migrate*)
+            if [ "${MIGRATE_RC:-0}" -ne 0 ]; then
+                echo "** (Exqlite.Error) some migration blew up" >&2
+                exit "$MIGRATE_RC"
+            fi
+            ;;
+        *seed_themes*)
+            if [ "${SEED_RC:-0}" -ne 0 ]; then
+                echo "** (Ecto.ConstraintError) seeding blew up" >&2
+                exit "$SEED_RC"
+            fi
+            ;;
+    esac
 fi
 EOF
     chmod 0755 "$APP/bin/grappa"
@@ -88,6 +103,7 @@ calls() {
 }
 
 MIGRATE_CALL="eval Grappa.Release.migrate()"
+SEED_CALL="eval Grappa.Release.seed_themes()"
 
 @test "a bare start migrates, and does it BEFORE the release boots" {
     run entrypoint start
@@ -202,6 +218,68 @@ MIGRATE_CALL="eval Grappa.Release.migrate()"
     GRAPPA_AUTO_MIGRATE='' run entrypoint start
     [ "$status" -eq 0 ]
     grep -qF "$MIGRATE_CALL" "$CALL_LOG"
+}
+
+# ── Built-in theme seeding (#1167) ──────────────────────────────────────────
+#
+# Same door, same argument as #867: a bare `docker run` has no other way to
+# reach the seeder, so the image landed with an empty theme gallery. The seed
+# rides GRAPPA_AUTO_MIGRATE rather than getting a knob of its own — an
+# operator who turns the flag off did so to keep boot from writing to the DB,
+# and the seed is a write.
+
+@test "a bare start seeds the built-in themes, after the schema is applied" {
+    run entrypoint start
+    [ "$status" -eq 0 ]
+
+    grep -qF "$SEED_CALL" "$CALL_LOG"
+    # Schema before data: an upsert against an unmigrated DB has no table.
+    [ "$(head -n1 "$CALL_LOG")" = "$MIGRATE_CALL" ]
+    [ "$(sed -n 2p "$CALL_LOG")" = "$SEED_CALL" ]
+    [ "$(tail -n1 "$CALL_LOG")" = "start" ]
+}
+
+@test "GRAPPA_AUTO_MIGRATE=0 boots without seeding either" {
+    # The ruling, pinned: one knob, not two. A seed that ignored the flag
+    # would write to the DB of an operator who asked for no boot-time writes.
+    export GRAPPA_AUTO_MIGRATE=0
+    run entrypoint start
+    [ "$status" -eq 0 ]
+
+    refute grep -qF "$SEED_CALL" "$CALL_LOG"
+    [ "$(calls)" = "start" ]
+}
+
+@test "a failed seed still boots — the gallery is cosmetic, the schema is not" {
+    # deploy_common has held this posture on every substrate since #440: the
+    # seed WARNS and continues, because the upsert converges and the next
+    # boot heals it. Refusing to start would trade a working bouncer for a
+    # missing colour scheme.
+    export SEED_RC=1
+    run entrypoint start
+
+    [ "$status" -eq 0 ]
+    grep -qF "$SEED_CALL" "$CALL_LOG"
+    [ "$(tail -n1 "$CALL_LOG")" = "start" ]
+    # Not a silent swallow: the operator gets the failure and the retry.
+    [[ "$output" == *"seed_themes"* ]]
+}
+
+@test "a failed migration never reaches the seed" {
+    export MIGRATE_RC=1
+    run entrypoint start
+
+    [ "$status" -ne 0 ]
+    refute grep -qF "$SEED_CALL" "$CALL_LOG"
+}
+
+@test "non-boot verbs never seed" {
+    for verb in rpc remote stop version pid; do
+        : > "$CALL_LOG"
+        run entrypoint "$verb"
+        [ "$status" -eq 0 ]
+        refute grep -qF "$SEED_CALL" "$CALL_LOG"
+    done
 }
 
 @test "the secret bootstrap and the resource caps still ride through" {


### PR DESCRIPTION
The curated built-in themes are compiled into the release and their wallpapers
ride the cic bundle, but the gallery reads the DB — so every door that migrates
and stops leaves the operator with an empty theme section. `.deb`/`.rpm`, the
AUR package and a bare `docker run` all did exactly that. #435 recurring
through the doors #435 did not cover.

## What changed

- `infra/packaging/scripts/postinstall.sh` and `infra/packaging/aur/grappa.install`
  seed right after their existing migrate.
- `infra/docker/release-entrypoint.sh` seeds inside the existing auto-migrate
  guard.
- `infra/packaging/grappa-wrapper.sh` gains the `seed-themes` verb the two
  scriptlets invoke — the packaged host's only door to the seeder, and the
  operator's recovery command.

## Two calls worth reviewing

**The container seed rides `GRAPPA_AUTO_MIGRATE`; no `GRAPPA_AUTO_SEED`.** An
operator who sets that flag to 0 did so to keep boot from writing to the
database, and seeding is a write — one switch over the same intent, not two.

**Seeding is NON-FATAL where migrating is fatal, which reverses what the issue
suggested.** The issue asked for fail-loud "in the same style" as migrate;
`docs/OPERATIONS.md` already records the opposite posture for this exact
operation, held on every substrate since #440 — a seed failure warns, carries
its retry command, and continues, because the upsert converges. The split
tracks what a failure costs: a half-applied schema is a correctness defect, an
empty gallery is cosmetic. Fail-loud would let a missing colour scheme abort a
pacman transaction or refuse a container boot.

## Evidence

Three scriptlets that had **no automated gate of any kind** now execute under
bats. Each is copied into a sandbox with its host-absolute paths re-rooted (the
rewrite is proven total before anything runs) and driven against a recorder
stub of the packaged CLI; the migrate call doubles as a sanity token, so "no
seed recorded" cannot be confused with "the script never ran".

- Read RED first: **9 of 27 failed** before the fix.
- **Ten single-point mutants, ten killed, zero survivors** — removing the seed
  from each door, dropping or mis-pointing the wrapper verb, hoisting the
  container seed out of the flag guard, making either seed fatal, seeding
  before migrating, and gating the postinstall seed on the dpkg spelling.
- **Four arms have no killer and are labelled regression guards, not
  coverage**: the dpkg-rollback arm, the Arch failed-migrate ordering arm, the
  container failed-migrate arm, and the sibling `grappa migrate` arm.
- Full `scripts/bats.sh`: 418 passed, 0 failed. `scripts/shellcheck.sh`
  (pinned container, 71 derived scripts): clean.

The issue's diagnosis re-measured true, but its line numbers are stale — it
measured at `3383abf6` and `install.sh` has since lost 67 lines, moving its
seed from `:299` to `:232`.

**Not measured:** no real `.deb`/`.rpm` install, no pacman transaction, no
`docker run` of the release image. What is proven is the scriptlets' decision
logic against a recorder, plus `Grappa.Release.seed_themes/0` being the same
entry point four substrates already call in production.

Rationale in `docs/DESIGN_NOTES.md` (2026-08-10, #1167).