### PR TITLE
cic(#1199): let the dismissable scrollback cards close on Escape

### DIFF
--- a/cicchetto/src/LusersCard.tsx
+++ b/cicchetto/src/LusersCard.tsx
@@ -1,5 +1,6 @@
 import { type Component, Show } from "solid-js";
 import { dismissLusersCard, lusersBundleByNetwork } from "./lib/lusersBundle";
+import { createOverlayEscape } from "./lib/overlayScrollLock";
 
 // P-0d — LUSERS card. Renders a structured snapshot of network state
 // (clients, operators, channels, servers, local/global counts) folded
@@ -27,6 +28,14 @@ const fmt = (n: number | null): string => (n === null ? "—" : n.toLocaleString
 
 const LusersCard: Component<Props> = (props) => {
   const snapshot = () => lusersBundleByNetwork()[props.networkSlug];
+  // #1199 — Escape dismisses through the shared ordered ESC stack (the same
+  // door every modal uses), invoking the SAME verb the × does, so a modal
+  // opened over the card still closes first. Escape-only, no scroll-lock
+  // refcount: the card sits IN the scrollback flow, not over it.
+  createOverlayEscape(
+    () => snapshot() !== undefined,
+    () => dismissLusersCard(props.networkSlug),
+  );
 
   return (
     <Show when={snapshot()} keyed>

--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -1,6 +1,7 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoisBundle } from "./lib/api";
 import { formatDuration } from "./lib/duration";
+import { createOverlayEscape } from "./lib/overlayScrollLock";
 import { whoisBundleHasFields } from "./lib/whoisBundle";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
@@ -80,6 +81,17 @@ const collectTags = (b: WhoisBundle): TagChip[] => {
 
 const WhoisCard: Component<Props> = (props) => {
   const bundle = () => props.bundle;
+  // #1199 — Escape closes the card through the shared ordered ESC stack, the
+  // same door every modal uses, so a modal opened over the card still closes
+  // first. Gated on `onDismiss`: it is the dismissability of the mount site,
+  // and the rail card (which omits it) must NOT be closable — a persistent
+  // per-window surface Escape can close is one the operator cannot bring back.
+  // Escape-only, no scroll-lock refcount: the card sits IN the scrollback flow,
+  // not over it.
+  createOverlayEscape(
+    () => bundle() !== undefined && props.onDismiss !== undefined,
+    () => props.onDismiss?.(),
+  );
   const hasFields = (): boolean => {
     const b = bundle();
     return b !== undefined && whoisBundleHasFields(b);

--- a/cicchetto/src/WhowasCard.tsx
+++ b/cicchetto/src/WhowasCard.tsx
@@ -1,4 +1,5 @@
 import { type Component, Show } from "solid-js";
+import { createOverlayEscape } from "./lib/overlayScrollLock";
 import { dismissWhowasCard, whowasCardBySlug } from "./lib/whowasCard";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
@@ -27,6 +28,14 @@ export type Props = {
 
 const WhowasCard: Component<Props> = (props) => {
   const bundle = () => whowasCardBySlug()[props.networkSlug];
+  // #1199 — Escape dismisses through the shared ordered ESC stack (the same
+  // door every modal uses), invoking the SAME verb the × does, so a modal
+  // opened over the card still closes first. Escape-only, no scroll-lock
+  // refcount: the card sits IN the scrollback flow, not over it.
+  createOverlayEscape(
+    () => bundle() !== undefined,
+    () => dismissWhowasCard(props.networkSlug),
+  );
 
   return (
     <Show when={bundle()}>

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ConfirmModal from "../ConfirmModal";
+import LusersCard from "../LusersCard";
+import type { ConnectionInfo, Network, WhoisBundle } from "../lib/api";
+import { type ConfirmRequest, confirmRequest, requestConfirm } from "../lib/confirmDialog";
+import { install, type KeybindingHandlers, registerHandlers, uninstall } from "../lib/keybindings";
+import { applyLusersBundle, markLusersRequested } from "../lib/lusersBundle";
+import { __resetForTest, overlayCount, overlayEscapeDepth } from "../lib/overlayScrollLock";
+import { setWhowasBundle } from "../lib/whowasCard";
+import ServerInfoCard from "../ServerInfoCard";
+import WhoisCard from "../WhoisCard";
+import WhowasCard from "../WhowasCard";
+
+// #1199 — the scrollback cards' Escape contract, in one place because it is
+// one contract across four components (three that enrol, one that must not).
+//
+// Escape reaches the cards through the SAME door every modal uses: the single
+// window keydown listener in `lib/keybindings` → `runTopmostOverlayEscape` →
+// the LIFO overlay ESC stack. These tests drive that real door — install()
+// plus a KeyboardEvent bubbling up from an in-document target — never the
+// stack verb directly, because a card that registered on a private `document`
+// listener instead would satisfy "Esc dismisses the card" and betray itself
+// only on the ordering arm (`MediaViewerModal.tsx` records the same warning).
+//
+// The cards are inline scrollback content, NOT covering overlays, so they
+// join the ESC stack WITHOUT the scroll-lock refcount: `overlayCount()` must
+// stay 0 while a card is up. A refcount held for the life of a card would
+// freeze the scrollback snapshot behind it and add the iOS `overlay-open`
+// touch lock — the hazard `RailActions.tsx:74-77` already records for the
+// permanent rail column.
+
+// Dispatched on a real in-document target and left to BUBBLE, exactly as a
+// browser delivers a keypress. Not on `window` directly: an event whose target
+// IS window never reaches a `document` listener, so a window-dispatch would
+// make the shared stack and a private document listener indistinguishable —
+// and telling those two apart is the whole point of the ordering arm.
+const dispatchEscape = (): void => {
+  document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+};
+
+// createOverlayLock defers its Esc registration a microtask; a signal write
+// also schedules the Solid effect. One macrotask turn flushes both.
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+const WHOIS_BUNDLE: WhoisBundle = {
+  network: "azzurra",
+  target: "alice",
+  source: "user",
+  user: "alice_u",
+  host: "alice.host",
+  realname: "Alice Liddell",
+  server: "irc.azzurra.org",
+  server_info: "Azzurra Hub",
+  is_operator: false,
+  oper_text: null,
+  idle_seconds: null,
+  signon: null,
+  channels: null,
+  using_ssl: false,
+  is_registered: false,
+  is_admin: false,
+  is_services_admin: false,
+  is_helper: false,
+  is_chanop: false,
+  is_agent: false,
+  is_java: false,
+  umodes: null,
+  away_message: null,
+  actually_host: null,
+  actually_ip: null,
+  account: null,
+  secure: false,
+  secure_cipher: null,
+  certfp: null,
+  extra_lines: null,
+};
+
+const WHOWAS_BUNDLE = {
+  network: "azzurra",
+  target: "Alice",
+  user: "alice_u",
+  host: "alice.host",
+  realname: "Alice Liddell",
+  server: "irc.azzurra.org",
+  logoff_time: "Mon May 13 12:34:56 2026",
+  not_found: false,
+};
+
+const LUSERS_SNAPSHOT = {
+  total_users: 1234,
+  invisible: 56,
+  servers: 3,
+  operators: 7,
+  unknown_connections: 2,
+  channels_formed: 89,
+  local_clients: 100,
+  local_servers: 1,
+  current_local: 100,
+  max_local: 200,
+  current_global: 1234,
+  max_global: 5000,
+};
+
+const SERVER_NOW = Date.parse("2026-07-31T12:00:00.000Z");
+
+const SERVER_CONN: ConnectionInfo = {
+  server: "89.31.72.10",
+  port: 6697,
+  tls: true,
+  registered: true,
+  connected_at: new Date(SERVER_NOW - 3600 * 1000).toISOString(),
+};
+
+const SERVER_NET: Network = {
+  kind: "user",
+  id: 7,
+  slug: "libera",
+  services_flavor: "atheme",
+  nick: "vjt",
+  ident: "vjt",
+  realname: "VJT",
+  connection_state: "connected",
+  connection_state_reason: null,
+  connection_state_changed_at: new Date(SERVER_NOW - 86400 * 1000).toISOString(),
+  connection: SERVER_CONN,
+  inserted_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+const leaveChannelRequest = (onConfirm: () => void): ConfirmRequest => ({
+  title: "Leave channel",
+  body: "Do you want to leave #italia?",
+  confirmLabel: "Yes",
+  onConfirm,
+  alternative: null,
+});
+
+let handlers: KeybindingHandlers;
+
+beforeEach(() => {
+  handlers = {
+    selectChannelByIndex: vi.fn(),
+    nextUnread: vi.fn(),
+    prevUnread: vi.fn(),
+    insertIntoCompose: vi.fn(),
+    closeDrawer: vi.fn(),
+    cycleNickComplete: vi.fn(),
+  };
+  registerHandlers(handlers);
+  install();
+  __resetForTest();
+});
+
+afterEach(() => {
+  uninstall();
+  __resetForTest();
+});
+
+describe("#1199 scrollback cards close on Escape", () => {
+  it("Escape dismisses the user-issued WHOIS card through the shared stack", async () => {
+    const onDismiss = vi.fn();
+    render(() => <WhoisCard bundle={WHOIS_BUNDLE} onDismiss={onDismiss} />);
+    await flush();
+
+    dispatchEscape();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    // The card did NOT reach the drawer fallback — the stack claimed the key.
+    expect(handlers.closeDrawer).not.toHaveBeenCalled();
+  });
+
+  it("Escape dismisses the WHOWAS card", async () => {
+    setWhowasBundle("net-esc-whowas", WHOWAS_BUNDLE);
+    render(() => <WhowasCard networkSlug="net-esc-whowas" />);
+    await flush();
+    expect(screen.queryByTestId("whowas-card")).not.toBeNull();
+
+    dispatchEscape();
+
+    expect(screen.queryByTestId("whowas-card")).toBeNull();
+  });
+
+  it("Escape dismisses the LUSERS card", async () => {
+    markLusersRequested("net-esc-lusers");
+    applyLusersBundle("net-esc-lusers", LUSERS_SNAPSHOT);
+    render(() => <LusersCard networkSlug="net-esc-lusers" />);
+    await flush();
+    expect(screen.queryByTestId("lusers-card")).not.toBeNull();
+
+    dispatchEscape();
+
+    expect(screen.queryByTestId("lusers-card")).toBeNull();
+  });
+
+  it("a card holds no scroll-lock refcount while it is up", async () => {
+    setWhowasBundle("net-esc-refcount", WHOWAS_BUNDLE);
+    render(() => <WhowasCard networkSlug="net-esc-refcount" />);
+    await flush();
+
+    expect(overlayEscapeDepth()).toBe(1);
+    expect(overlayCount()).toBe(0);
+    expect(document.documentElement.classList.contains("overlay-open")).toBe(false);
+  });
+});
+
+describe("#1199 cards that must NOT close on Escape", () => {
+  it("the query-rail WHOIS card (no onDismiss) never joins the ESC stack", async () => {
+    render(() => <WhoisCard bundle={WHOIS_BUNDLE} />);
+    await flush();
+
+    expect(overlayEscapeDepth()).toBe(0);
+
+    dispatchEscape();
+
+    // Nothing claimed the key, so it fell through to the drawer fallback.
+    expect(handlers.closeDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("the persistent server-info rail card never joins the ESC stack", async () => {
+    render(() => <ServerInfoCard network={SERVER_NET} now={SERVER_NOW} />);
+    await flush();
+
+    expect(overlayEscapeDepth()).toBe(0);
+
+    dispatchEscape();
+
+    expect(handlers.closeDrawer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("#1199 Escape ordering: a modal over a card", () => {
+  // Split from the behavioural arm below deliberately. This one pins the
+  // PREMISE — card and modal share ONE stack, modal on top — and the next one
+  // pins the ORDER that premise buys, with no depth assertion in it, so a card
+  // that left the stack for a private listener is caught by the out-of-order
+  // dismissal itself rather than by a precondition tripping first.
+  it("the card and the modal occupy one stack, modal on top", async () => {
+    render(() => (
+      <>
+        <WhoisCard bundle={WHOIS_BUNDLE} onDismiss={vi.fn()} />
+        <ConfirmModal />
+      </>
+    ));
+    await flush();
+    expect(overlayEscapeDepth()).toBe(1);
+
+    requestConfirm(leaveChannelRequest(vi.fn()));
+    await flush();
+
+    expect(overlayEscapeDepth()).toBe(2);
+  });
+
+  it("closes the modal on the first Escape and the card on the second", async () => {
+    const onDismiss = vi.fn();
+    const onConfirm = vi.fn();
+    render(() => (
+      <>
+        <WhoisCard bundle={WHOIS_BUNDLE} onDismiss={onDismiss} />
+        <ConfirmModal />
+      </>
+    ));
+    await flush();
+    requestConfirm(leaveChannelRequest(onConfirm));
+    await flush();
+    expect(confirmRequest()).not.toBeNull();
+
+    dispatchEscape();
+    await flush();
+
+    expect(onDismiss).not.toHaveBeenCalled(); // the card did NOT jump the queue
+    expect(confirmRequest()).toBeNull(); // the modal went first
+    expect(onConfirm).not.toHaveBeenCalled(); // and it CANCELLED, never confirmed
+
+    dispatchEscape();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(handlers.closeDrawer).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/overlayScrollLock.test.ts
+++ b/cicchetto/src/__tests__/overlayScrollLock.test.ts
@@ -21,6 +21,7 @@ import { createMemo, createRoot, createSignal } from "solid-js";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   __resetForTest,
+  createOverlayEscape,
   createOverlayLock,
   handleTouchmove,
   isListenerAttached,
@@ -235,6 +236,81 @@ describe("overlay escape stack (#232)", () => {
       expect(overlayEscapeDepth()).toBe(0);
       expect(onEscape).not.toHaveBeenCalled(); // store-close never invokes onEscape
       expect(runTopmostOverlayEscape()).toBe(false);
+      dispose();
+    });
+  });
+});
+
+// #1199 — `createOverlayEscape` is the ESC half of `createOverlayLock` on its
+// own: the SAME LIFO stack and the same lifecycle edges, minus the scroll-lock
+// refcount. It exists because the scrollback cards (whois/whowas/lusers) are
+// inline content, not covering overlays — enrolling them through
+// createOverlayLock would hold a refcount for the life of the card, freezing
+// the scrollback snapshot behind it and adding the iOS `overlay-open` touch
+// lock (`RailActions.tsx:74-77` records the same hazard for the rail column).
+describe("overlay escape-only registration (#1199)", () => {
+  test("joins the Esc stack without touching the scroll-lock refcount", async () => {
+    await createRoot(async (dispose) => {
+      const [open, setOpen] = createSignal(false);
+      createOverlayEscape(open, () => setOpen(false));
+
+      setOpen(true);
+      await flush();
+      expect(overlayEscapeDepth()).toBe(1);
+      expect(overlayCount()).toBe(0);
+      expect(document.documentElement.classList.contains(CLASS)).toBe(false);
+      expect(isListenerAttached()).toBe(false);
+
+      expect(runTopmostOverlayEscape()).toBe(true);
+      await flush();
+      expect(open()).toBe(false);
+      expect(overlayEscapeDepth()).toBe(0);
+      dispose();
+    });
+  });
+
+  test("closing via its own store unregisters it, and unmount drains it", async () => {
+    await createRoot(async (dispose) => {
+      const [open, setOpen] = createSignal(true);
+      const onEscape = vi.fn();
+      createOverlayEscape(open, onEscape);
+      await flush();
+      expect(overlayEscapeDepth()).toBe(1);
+
+      setOpen(false); // closed by the × path
+      await flush();
+      expect(overlayEscapeDepth()).toBe(0);
+      expect(onEscape).not.toHaveBeenCalled();
+
+      setOpen(true); // re-opened, then torn down while still open
+      await flush();
+      expect(overlayEscapeDepth()).toBe(1);
+      dispose();
+      expect(overlayEscapeDepth()).toBe(0);
+    });
+  });
+
+  test("a lock registered after an escape-only entry is the one Esc closes first", async () => {
+    await createRoot(async (dispose) => {
+      const [cardOpen, setCardOpen] = createSignal(false);
+      const [modalOpen, setModalOpen] = createSignal(false);
+      createOverlayEscape(cardOpen, () => setCardOpen(false));
+      createOverlayLock(modalOpen, ".x-over-card", () => setModalOpen(false));
+
+      setCardOpen(true);
+      await flush();
+      setModalOpen(true); // the modal opens OVER the card
+      await flush();
+      expect(overlayEscapeDepth()).toBe(2);
+
+      expect(runTopmostOverlayEscape()).toBe(true);
+      await flush();
+      expect(modalOpen()).toBe(false); // modal first
+      expect(cardOpen()).toBe(true); // card untouched
+
+      expect(runTopmostOverlayEscape()).toBe(true);
+      await flush();
+      expect(cardOpen()).toBe(false); // card second
       dispose();
     });
   });

--- a/cicchetto/src/lib/overlayScrollLock.ts
+++ b/cicchetto/src/lib/overlayScrollLock.ts
@@ -290,3 +290,47 @@ export function createOverlayLock(
     release();
   });
 }
+
+/**
+ * #1199 — the ESC half of `createOverlayLock` on its own: the SAME ordered
+ * stack and the same open/close/unmount edges, WITHOUT the scroll-lock
+ * refcount. Call from a component body:
+ *
+ *   createOverlayEscape(() => myBundle() !== undefined, dismissMyCard);
+ *
+ * For a surface that is dismissable but covers nothing — the inline scrollback
+ * cards (whois / whowas / lusers), which render in the message flow rather than
+ * over it. Going through `createOverlayLock` would ALSO hold a refcount for the
+ * whole life of the card, which freezes the scrollback snapshot behind it
+ * (`ScrollbackPane`'s `isOverlayFrozen`) and adds the iOS `overlay-open` touch
+ * lock: the hazard `RailActions.tsx` already records for the permanent rail
+ * column. A surface that DOES cover the pane still wants `createOverlayLock`.
+ *
+ * Membership of the one shared stack is the point, not an implementation
+ * detail: it is what makes a modal opened over a card close FIRST. A private
+ * `document` keydown listener on the card would close the card instead, and
+ * would be the second global ESC listener this stack exists to prevent.
+ *
+ * No deferred microtask, unlike `createOverlayLock`: that deferral exists only
+ * so Solid can commit the render before `querySelector` looks for the lock
+ * element, and there is no element to look for here.
+ */
+export function createOverlayEscape(isOpen: () => boolean, onEscape: () => void): void {
+  const escapeToken = {};
+  let registered = false;
+  const release = (): void => {
+    if (!registered) return;
+    unregisterEscape(escapeToken);
+    registered = false;
+  };
+  createEffect(() => {
+    if (!isOpen()) {
+      release();
+      return;
+    }
+    if (registered) return;
+    registerEscape(escapeToken, onEscape);
+    registered = true;
+  });
+  onCleanup(release);
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37359,3 +37359,81 @@ two-line `FROM ghcr.io/vjt/grappa:latest`.
 door or real `PHX_HOST`, and no `update` verb — only `install` plus a
 bare-run restart. A missing image fails the job and never skips it: a smoke
 test that quietly passes having tested nothing is worse than not having one.
+
+---
+
+## 2026-08-10 — #1199: the cards were never enrolled, and only three of them can be
+
+A self-hoster reported on IRC that a scrollback card opened with `/whois` will
+not close on Escape — the `×` is the only way out. The premise the issue offers
+is that this is enrolment into a mechanism that already exists, and that part
+holds: `createOverlayLock` + `runTopmostOverlayEscape` have carried every modal
+since #232, and `WhoisCard` / `WhowasCard` / `LusersCard` simply never
+registered.
+
+**The set of cards is not the set the issue names.** It names WHOIS, WHOWAS and
+server-info. `ServerInfoCard` has no dismiss verb at all — no `×`, no
+`onDismiss`, and its own moduledoc says why: it is the rail's persistent
+per-kind surface, present for as long as the server window is focused. Giving
+Escape a card with nothing to close is not an enrolment, it is inventing a
+dismissal, and it lands squarely on the constraint the issue itself states —
+a permanent surface Escape can close is one the operator cannot bring back.
+It stays out. `LusersCard`, which the issue omits, IS in the family: same
+ephemeral per-network snapshot, same `×`, same store verb. Leaving it out
+would half-migrate the family and leave the next reader two patterns to copy.
+
+**`createOverlayLock` is the wrong door, and the reason is already written
+down.** That verb does two things at once: it registers the ESC entry AND
+pushes the scroll-lock refcount. The second is wrong for a card. A card renders
+INSIDE the scrollback flow, not over it, so a refcount held for the card's
+whole life would freeze the scrollback snapshot behind it (`ScrollbackPane`'s
+`isOverlayFrozen`, whose trigger IS `overlayCount() > 0`) and add the iOS
+`overlay-open` touch-lock chain. `RailActions` records that exact hazard for
+the permanent rail column, and #608 is where it was paid for.
+
+So the ESC half is split out as `createOverlayEscape`: the SAME LIFO stack, the
+same open/close/unmount edges, no refcount. Reuse the verbs, not the nouns —
+the shared execution framework is the ordered stack, and the 20% that does not
+fit is the scroll lock. Sharing that stack is the whole point rather than an
+implementation detail: it is what makes a modal opened over a card close first,
+and it keeps the app to the one global keydown listener the stack exists to
+guarantee. A private `document` listener on the card would satisfy "Escape
+closes the card" and get the ordering wrong, which is the failure mode the
+`MediaViewerModal` comment warns about.
+
+`createOverlayEscape` does NOT defer a microtask, unlike its sibling. That
+deferral exists solely so Solid can commit the render before `querySelector`
+looks for the lock element, and there is no element to look for here.
+
+**The gate is the presence of `onDismiss`, because `WhoisCard` is mounted
+twice.** `ScrollbackPane` passes the dismiss handler; `RailContext` (#606)
+deliberately omits it, and that omission IS the statement that the rail card is
+not user-dismissable. Reading dismissability off the prop keeps one fact in one
+place instead of teaching the component a second flag. `WhowasCard` and
+`LusersCard` are unconditionally dismissable, so they enrol whenever their
+bundle is up.
+
+**Displacement.** Four mutants, applied one at a time to the committed tree by
+exact one-shot replacement, each re-running the two #1199 files. Dropping the
+`onDismiss` gate kills exactly one arm — the query-rail card, which then joins
+the stack. Replacing the enrolment with a private `document` keydown listener
+kills three, and the one that matters is the ordering arm's
+`expect(onDismiss).not.toHaveBeenCalled()`: the card jumps the queue and closes
+on the same Escape as the modal above it. Enrolling `WhowasCard` through
+`createOverlayLock` instead kills exactly the refcount arm. Removing
+`onCleanup(release)` kills exactly the unmount arm.
+
+The ordering test is deliberately a PAIR. One arm pins the premise (card and
+modal in one stack, modal on top) and the other pins the order with no depth
+assertion in it at all — otherwise the private-listener mutant dies on a
+precondition and never gets to demonstrate the out-of-order dismissal. For the
+same reason the Escape event is dispatched on an in-document target and left to
+bubble: an event whose target IS `window` never reaches a `document` listener,
+so a window-dispatch would make the two mechanisms indistinguishable and the
+ordering arms vacuous.
+
+**Not measured.** No browser run and no e2e spec: this is jsdom plus the real
+keybindings listener. The claim is the wiring and the ordering, not the pixels.
+The server-info arm has no unique killer among the four mutants — nothing in
+this change can make a card with no dismiss verb enrol — and is carried as a
+regression guard against a later over-enrolment, not as coverage.


### PR DESCRIPTION
Follow-up to #232. A keyboard user who opens a card with `/whois` had to reach
for the pointer: the `×` was the only way out. The ordered ESC stack that has
carried every modal since #232 was already there; the cards were simply never
enrolled.

## What changed

`createOverlayEscape` — the ESC half of `createOverlayLock` on its own: the
SAME LIFO stack, the same open/close/unmount edges, **no scroll-lock refcount**.
`WhoisCard`, `WhowasCard` and `LusersCard` enrol through it.

## Two departures from the issue text, both deliberate

**`ServerInfoCard` stays out.** The issue names it, but that card has no
dismiss verb at all — no `×`, no `onDismiss`. Its own moduledoc says why: it is
the rail's persistent per-kind surface. Giving Escape a card with nothing to
close is inventing a dismissal, and it lands on the constraint the issue itself
states — a permanent surface Escape can close is one the operator cannot bring
back. A regression guard pins it out of the stack.

**`LusersCard` comes in.** The issue omits it; it is the same ephemeral
per-network family as WHOWAS — same `×`, same store verb. Leaving it out would
half-migrate the family.

## Why not `createOverlayLock`

That verb bundles the ESC entry AND the scroll-lock refcount. A card renders
*inside* the scrollback flow, not over it, so a refcount held for the card's
whole life would freeze the scrollback snapshot behind it (`ScrollbackPane`'s
`isOverlayFrozen`, whose trigger is `overlayCount() > 0`) and add the iOS
`overlay-open` touch lock. `RailActions` already records that exact hazard for
the permanent rail column.

## Gate

`onDismiss` presence. `WhoisCard` is mounted twice and only the `/whois` mount
passes it; the query-rail mount (#606) deliberately omits it, and that omission
IS the statement that the rail card is not user-dismissable.

## Measurement

Written test-first and read red. Four mutants, one at a time against the
committed tree, exact one-shot replacement, both #1199 files re-run each time:

| mutant | arms killed |
| --- | --- |
| drop the `onDismiss` gate | 1 — the query-rail card joins the stack |
| private `document` keydown listener instead of the stack | 3 — incl. the ordering arm's `expect(onDismiss).not.toHaveBeenCalled()`: the card jumps the queue |
| enrol WHOWAS via `createOverlayLock` | 1 — the refcount arm |
| remove `onCleanup(release)` | 1 — the unmount arm |

The ordering test is a **pair** on purpose: one arm pins the premise (card and
modal in one stack, modal on top), the other pins the order with no depth
assertion in it, otherwise the private-listener mutant dies on a precondition
and never demonstrates the out-of-order dismissal. Escape is dispatched on an
in-document target and left to bubble — an event whose target IS `window` never
reaches a `document` listener, so a window-dispatch would make the two
mechanisms indistinguishable and the ordering arms vacuous.

## Gates

- `bun run check` — rc=0
- `bun run test` — rc=0, 274 files / 5048 tests, run after the rebase onto
  `origin/main` on a clean tree

## Not measured

No browser run, no e2e spec: jsdom plus the real keybindings listener. The
claim is the wiring and the ordering, not the pixels. The `ServerInfoCard` arm
has no unique killer among the four mutants — nothing here can make a card with
no dismiss verb enrol — and is carried as a regression guard, not as coverage.