### PR TITLE
#1196: a per-client token, scoped strictly less than the account

### DIFF
--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -456,6 +456,20 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // token the server can emit and the switch is exhaustive by
       // construction. Copy stays operator-shaped, not reassuring.
       return "The server needs a full restart to apply a database change.";
+    case "client_token_scope":
+      // #1196 — 403 for a per-client token on a credential-management
+      // route. cic authenticates with a browser session, so this arm is
+      // unreachable from here in practice; it exists because the union is
+      // generated from every REST token the server can emit. Copy is
+      // written for whoever does see it: a client author reading a
+      // grappa error body, who needs "use the browser", not "log in
+      // again".
+      return "That can only be done from a browser session, not with a client token.";
+    case "client_token_cap_reached":
+      // #1196 — 422, the account is holding its maximum number of live
+      // client tokens. A bounded list, so the remedy is to make room
+      // rather than to wait.
+      return "You already have the maximum number of client tokens. Revoke one first.";
 
     default:
       // Cic M2 reviewer fix: exhaustiveness assertion. Adding a token

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1477,6 +1477,8 @@ export const S_ErrorTokensRestErrorToken = {
     { l: "image_reencode_failed" },
     { l: "not_connected" },
     { l: "forbidden_vhost" },
+    { l: "client_token_scope" },
+    { l: "client_token_cap_reached" },
     { l: "invalid_credentials" },
     { l: "invalid_two_factor" },
     { l: "two_factor_challenge_expired" },

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -45,6 +45,18 @@ export const S_AccountsAdminWireT = {
   },
 } as const;
 
+// Grappa.Accounts.Wire.client_token_json/0
+export const S_AccountsWireClientTokenJson = {
+  o: {
+    handle: "s",
+    label: "s",
+    created_at: "s",
+    last_seen_at: "s",
+    ip: { u: ["s", "z"] },
+    user_agent: { u: ["s", "z"] },
+  },
+} as const;
+
 // Grappa.Accounts.Wire.credential_json/0
 export const S_AccountsWireCredentialJson = { o: { id: "s", name: "s" } } as const;
 

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1467,6 +1467,8 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "image_reencode_failed",
   "not_connected",
   "forbidden_vhost",
+  "client_token_scope",
+  "client_token_cap_reached",
   "invalid_credentials",
   "invalid_two_factor",
   "two_factor_challenge_expired",

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -99,6 +99,15 @@ export type AccountsWireCredentialJson = {
   name: string;
 };
 
+export type AccountsWireClientTokenJson = {
+  handle: string;
+  label: string;
+  created_at: string;
+  last_seen_at: string;
+  ip: string | null;
+  user_agent: string | null;
+};
+
 // === Grappa.AdminEvents.Wire ===
 
 export const ADMIN_EVENTS_WIRE_EVENT_KIND = [

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -241,5 +241,57 @@ safely (the 429 status / the socket close remain unambiguous).
 
 ---
 
+## 7. Per-client tokens (#1196)
+
+If the account you connect as has a second factor armed — TOTP or a
+passkey — `POST /auth/login` with the account password answers **202
+`two_factor_required`**, and there is nothing an unattended client can
+do with that: a TOTP code rotates every thirty seconds, WebAuthn needs
+an authenticator and an origin, and a recovery code is single-use.
+
+A **per-client token** is the credential to use instead. Its owner mints
+it from a browser session and pastes it into your config; **you send it
+in the `password` field of `POST /auth/login`, exactly where the account
+password would go.** Nothing else about your login changes:
+
+```
+POST /auth/login  { "identifier": "vjt", "password": "<the token>" }
+200               { "token": "<the same token>", "subject": {...} }
+```
+
+Three properties worth designing around:
+
+- **The reply is the token you sent.** The token IS the bearer, so a
+  reconnect does not mint a new session; store it once and reuse it. You
+  may also skip `/auth/login` entirely and present it directly as
+  `Authorization: Bearer <token>` / the WS bearer subprotocol (§3a).
+- **It does not expire while idle.** A browser session dies after seven
+  days of silence; a client token does not. Revocation by its owner is
+  the only thing that ends it — expect a `401`, and surface it as "this
+  token was revoked", not as a transient network error.
+- **It is scoped.** A client token can read and send as the account, and
+  that is all. The account's own credential surfaces — `/admin/*`,
+  `/me/totp*`, `/me/passkeys*`, `DELETE /me`, and the token routes
+  themselves — answer **403 `client_token_scope`**. That is not a
+  credential problem and retrying will not help: the operation needs a
+  browser session. Do not treat it like a `401`.
+
+A wrong token is indistinguishable from a wrong password: same `401
+invalid_credentials`, same login throttle (`429 too_many_attempts` after
+ten failures from one address in fifteen minutes). Back off accordingly.
+
+Minting, listing and revoking are the account owner's job, from a
+browser session, and are documented here only so a client author knows
+what to tell them: `POST /me/client-tokens {label, password}` returns
+`token` **once**; `GET /me/client-tokens` lists `{handle, label,
+created_at, last_seen_at, ip, user_agent}` and never the secret again;
+`DELETE /me/client-tokens/:handle` revokes one.
+
+Source: `lib/grappa_web/controllers/auth_controller.ex`
+(`account_login/3`), `lib/grappa_web/plugs/require_full_session.ex`,
+`lib/grappa_web/controllers/client_token_controller.ex`.
+
+---
+
 *This document tracks a live contract. When it disagrees with the code,
 the code is right — start from the `file:line` anchors above.*

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37656,3 +37656,125 @@ always-on bouncer long after the 005 burst ever uses — had no isupport arm at
 all. `subscribe.test.ts` now asserts the budget lands in the REAL store
 (`frameBudgetBaseForNetwork`), not on a `seedIsupport` spy, so the shared fold
 has one killer per door and the door itself has its first guard.
+
+---
+
+## 2026-08-10 — #1196: a credential a headless client can hold
+
+Arming TOTP or a passkey locked out every client that logs in with a name and
+a password. `/auth/login` is the only door and it has no non-interactive path:
+the account answers 202 `two_factor_required`, and an unattended client has
+nowhere to put a code that rotates every thirty seconds, no channel to be
+prompted on at reconnect, and a recovery code it would burn on the first one.
+The shape of that in practice is a hard either/or — a second factor, or an
+always-on client — on exactly the account most worth protecting.
+
+**The primitive already existed and the issue said so; the work was checking
+that it did.** `Grappa.Accounts.Session` is a bearer-token row whose `:id` IS
+the token, already carrying `client_id`, `last_seen_at` and `revoked_at`. What
+a client token needs on top is a different lifecycle, a label, and a smaller
+scope — three behaviours, not a second domain. A separate `client_tokens`
+table would have duplicated the bearer lookup, the revoke, the revocation
+broadcast, the WS auth and the admin listing, and forced `/auth/login` to try
+two tables; the 20% that does not fit is behaviour, so it rides `kind` on the
+one table.
+
+**`kind` is a column and not a derived `label != nil`.** Deriving it is
+tempting — a client token is, today, exactly the row that has a label — and
+CLAUDE.md's own design discipline says derive rather than duplicate. It is
+wrong here because the field would be load-bearing for a *security* boundary
+while looking like presentation: a later "name your browser session" feature
+would flip the scope gate and the idle exemption by accident, in a commit that
+appears to touch only a display string. The discriminator has to mean
+"restricted, non-expiring".
+
+**The token IS the bearer, so login answers with what it was given.** The
+alternative — mint a fresh session row per token login — needs a parent FK, a
+cascade revoke, and grows a row on every reconnect of a client that reconnects
+unattended forever. Returning the same row instead makes revocation one UPDATE
+and makes `last_seen_at` the device list's honesty signal for free.
+
+**The consequence is that the id can never be listed back**, and that is what
+decided how a token is addressed. `Session.handle/1` — the truncated SHA-256
+the operator log (S9) already used for the same row — was promoted out of
+`Accounts` into the schema, so the log line and the wire cannot drift into two
+names for one thing. `DELETE /me/client-tokens/:handle` revokes without ever
+re-presenting the secret, and the match runs in Elixir over the caller's own
+tokens because the digest is derived, never stored: there is no column to
+compare against and nothing that can fall out of sync with the id. The label
+was the other candidate for the key and lost — it would have needed a
+uniqueness constraint and a URL-safe charset, and it correlates with nothing
+in the logs.
+
+**The scope is not a follow-up to the feature, it is the feature.** A token
+that can administer, re-credential, or mint another token IS the account, and
+then the second factor on the account is decorative. The refusal
+(`RequireFullSession`, 403 `client_token_scope`) is mounted on pipelines
+rather than on routes: `:admin_authn` gains it so the whole console inherits
+it the way it inherits `is_admin`, and a new `:full_session` pipeline carries
+the second factors, self-service deletion, and the token routes. Grouping is
+the point — the hazard is not the route we wrote today, it is the credential
+route someone adds next year without thinking about tokens at all.
+
+`GrappaWeb.RouterScopeTest` is the backstop for that: it walks the compiled
+route table, DRIVES every credential-management path with a token bearer, and
+demands the scope refusal from each. Exercising rather than introspecting
+`pipe_through` was forced by Phoenix (`__routes__/0` does not expose the
+pipelines) and turned out better — it survives a plug moving between pipelines
+and fails on the response rather than on a spelling. The bearer belongs to an
+ADMIN account deliberately: a non-admin would be turned away by
+`Admin.AuthPlug` first and every `/admin` arm would pass for the wrong reason.
+Its sibling arm asserts the filter still matches something, because a
+path-prefix filter that matches nothing passes vacuously forever.
+
+**The console's live feed is a second door, so `AdminChannel` carries the same
+refusal.** Admin-ness is necessary and no longer sufficient; both conditions
+sit in one clause so neither can be satisfied alone.
+
+**Deliberately NOT special-cased: the revoke sweeps.** Every credential change
+that already evicts an account's other sessions —
+`revoke_other_sessions_for_user!/2` from TOTP enrolment and disable,
+`revoke_sessions_for_user/1` from the operator resets — evicts its client
+tokens with them. Fail-closed, zero branches, and arming or resetting a factor
+is exactly the moment a re-issue is wanted. An arm asserts it so the absence
+of a branch cannot quietly become one.
+
+**Two departures the issue asked for and one it did not.** The idle window
+does not apply (both at `check_idle/1` and at the reaper — the GC and the auth
+gate have to agree on which rows the window governs, not merely on how wide it
+is), the label is required, and — not in the issue — minting is
+password-gated, mirroring `TotpController.start_enrollment`: a borrowed
+browser bearer alone must not issue a credential that outlives it. That
+inherits the sibling's known limitation, that an account in passkey
+`passwordless` mode whose owner no longer knows the password cannot mint. A
+per-account cap of 20 live tokens is likewise ours, not the issue's: an
+unbounded self-service writer is a hole in a security feature, and the bound
+is what keeps `handle/1`'s 48 bits collision-free by orders of magnitude.
+
+**Where it is accepted: the `password` field, and the argument for it is about
+other people's code.** A header or a dedicated endpoint is cleaner in the
+abstract and obliges every client that speaks to grappa to learn a second
+authentication mode for no gain. In the `password` field, nothing changes
+client-side. The cost is that the login door now has two credentials behind
+one input, so it must not become two oracles: a wrong token returns the same
+`401 invalid_credentials`, and the throttle is charged exactly once per
+attempt (at the Argon2 branch, never at the token miss). An arm spends five of
+the ten-per-window budget on UUID-shaped wrong passwords, succeeds mid-way to
+show the budget was not exhausted, spends the rest, and requires the eleventh
+attempt to be 429 — the count is what proves the two doors share one charge.
+
+**Sixteen single-point mutants, one at a time, each killed.** The kill sets are
+disjoint and named in the PR. The arms with NO unique killer are labelled
+regression guards rather than counted as coverage: the inverse-direction guard
+that a web session still expires and is still swept, the sweep-takes-tokens
+arm above, the 404s for an unknown and for another account's handle, the 400
+for an absent password, the visitor 403, the router test's anti-vacuity arm,
+and the browser-session controls that pair each refusal. Honest ordering, too:
+the production code was written before the arms, so the red for each guard
+came from displacement rather than chronologically.
+
+**Deploy: expand-only, so `Grappa.Deploy.Preflight` classifies the migration
+HOT** — Ecto selects named columns, so a node still running the old `Session`
+module cannot see the two new ones, and reload brings schema and column into
+agreement in either order. The first commit's message says COLD; the
+classifier disagrees and it is right.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4339,6 +4339,20 @@ not accept the account password or TOTP, and shottino cannot complete WebAuthn.
 If a user loses both passkey and recovery codes, restore password login from the
 instance host:
 
+**A headless client uses a per-client token instead (#1196).** Arming TOTP or a
+passkey does not have to lock shottino, weechat, or any other unattended client
+out any more: the account holder mints a token from a browser session (`POST
+/me/client-tokens`, label plus the account password) and the client sends it in
+the `password` field of the ordinary login. Nothing on the client side changes.
+The token does not age out, is revocable one at a time, and cannot reach
+`/admin/*`, the account password, the second factors, or the token surface
+itself — a leaked one reads and sends as the account, and nothing more. The
+account's own device list is `GET /me/client-tokens`, which shows a `handle`,
+the label, `last_seen_at` and the last source IP, and never the secret again.
+
+The two reset verbs below revoke client tokens along with everything else, so
+a user whose factors you reset has to mint a new one for each client.
+
 ```sh
 bin/grappa reset-passkeys ACCOUNT_NAME
 ```

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -8,6 +8,9 @@ defmodule Grappa.Accounts do
       `get_user/1`, `get_user_by_name!/1`, `get_user_by_name/1`,
       `list_all_users/0`, `update_admin_flags/2`
     * sessions: `create_session/4`, `authenticate/1`, `revoke_session/1`
+    * client tokens (#1196): `create_client_token/5`,
+      `list_client_tokens/1`, `revoke_client_token/2`,
+      `authenticate_client_token/5`
 
   Both `User` and `Session` schemas are exported so downstream callers
   (controllers, channels, plugs) can pattern-match on the structs —
@@ -43,6 +46,29 @@ defmodule Grappa.Accounts do
   call returns `{:error, :expired}`. To keep the per-request DB-write
   cost negligible, `last_seen_at` is bumped at most once every 60 s
   (`@last_seen_bump_threshold_seconds`).
+
+  ## Client tokens (GH #1196)
+
+  A `:client`-kind session is the credential a headless client presents
+  in place of the account password, so that arming TOTP or a passkey no
+  longer locks that client out. It is the same row primitive with two
+  deliberate departures, both keyed on `Session.kind`:
+
+    * the sliding idle window does NOT apply (`check_idle/1` and
+      `delete_expired_sessions/0` both exempt it) — a client that was
+      offline a fortnight must come back to a working token, and
+      revocation is the intended kill switch;
+    * it carries a restricted scope, enforced at the web edge by
+      `GrappaWeb.Plugs.RequireFullSession`, so it can read and send but
+      cannot administer, re-credential, or re-mint.
+
+  What is deliberately NOT special-cased: the revoke sweeps. Every
+  credential-material change that already evicts an account's other
+  sessions (`revoke_other_sessions_for_user!/2`, reached from TOTP
+  enrolment / disable; `revoke_sessions_for_user/1`, reached from the
+  operator resets) evicts its client tokens along with them. That is the
+  fail-closed direction and it costs no branch: arming or resetting a
+  second factor is exactly the moment a re-issue is wanted.
   """
   use Boundary,
     top_level?: true,
@@ -447,6 +473,162 @@ defmodule Grappa.Accounts do
     end
   end
 
+  # A device list a person reads, and a bound on a self-service writer.
+  # Neither number is load-bearing on the security boundary; the cap is
+  # here so an authenticated caller cannot grow the table without limit,
+  # and so `Session.handle/1`'s 48 bits stay collision-free by orders of
+  # magnitude within one account's live set.
+  @max_client_tokens 20
+
+  @doc """
+  Mints a per-client token for `user` (GH #1196) — a `:client`-kind
+  session row whose `:id` is the secret the client will present.
+
+  The caller is responsible for the door: a client token may only be
+  minted from a session that has already cleared the account's second
+  factor, which `GrappaWeb.Plugs.RequireFullSession` enforces by
+  refusing the minting route to a `:client` bearer. Any `:web` session
+  reached its bearer through the full `/auth/login` ladder, so
+  "already cleared the second factor" and "is not itself a client
+  token" are the same statement.
+
+  `label` is the human name of the device; it is validated (trimmed,
+  1..64 chars, no control characters) at the changeset boundary.
+  Refuses with `{:error, :client_token_cap_reached}` once the account
+  holds `#{@max_client_tokens}` live tokens.
+
+  The returned `Session.t().id` is the token, and this is the ONLY
+  moment it is knowable — `list_client_tokens/1` renders
+  `Session.handle/1` instead, so a later read cannot recover it.
+  """
+  @spec create_client_token(User.t(), String.t(), String.t() | nil, String.t() | nil, keyword()) ::
+          {:ok, Session.t()}
+          | {:error, Ecto.Changeset.t() | :client_token_cap_reached | :db_unavailable}
+  def create_client_token(%User{id: user_id}, label, ip, user_agent, opts)
+      when is_binary(user_id) and is_binary(label) do
+    if Repo.aggregate(live_client_tokens_query(user_id), :count, :id) >= @max_client_tokens do
+      {:error, :client_token_cap_reached}
+    else
+      do_create_session(
+        %{user_id: user_id, ip: ip, user_agent: user_agent, kind: :client, label: label},
+        opts
+      )
+    end
+  end
+
+  @doc """
+  The account's live per-client tokens, oldest first.
+
+  Returns the rows themselves so the caller keeps a domain type; the
+  wire shape (`Grappa.Accounts.Wire.client_token_to_json/1`) is what
+  drops the secret `:id` in favour of `Session.handle/1`.
+  """
+  @spec list_client_tokens(User.t()) :: [Session.t()]
+  def list_client_tokens(%User{id: user_id}) when is_binary(user_id) do
+    user_id
+    |> live_client_tokens_query()
+    |> order_by([s], asc: s.created_at)
+    |> Repo.all()
+  end
+
+  @doc """
+  Revokes the caller's client token named by its public `handle`
+  (`Session.handle/1`), the one-way digest the device list publishes.
+
+  Addressing the row by handle rather than by id is what lets a token be
+  revoked without ever re-presenting the secret — and it is why the
+  match runs in Elixir over the account's own live tokens (at most
+  #{@max_client_tokens} rows) instead of as a SQL predicate: the digest
+  is derived, never stored, so there is no column to compare against and
+  nothing to drift out of sync with the id.
+
+  Scoped to `user`'s own rows, so a handle belonging to another account
+  is `{:error, :not_found}` and not a cross-account kill switch.
+  """
+  @spec revoke_client_token(User.t(), String.t()) ::
+          :ok | {:error, :not_found | :db_unavailable}
+  def revoke_client_token(%User{} = user, handle) when is_binary(handle) do
+    case Enum.find(list_client_tokens(user), &(Session.handle(&1) == handle)) do
+      nil -> {:error, :not_found}
+      %Session{id: id} -> revoke_session(id)
+    end
+  end
+
+  @doc """
+  Resolves a per-client token presented in place of `name`'s password.
+
+  Succeeds only for a live `:client`-kind row that belongs to the
+  account named `name` — a `:web` bearer, a revoked token, and a token
+  belonging to a different account all return `{:error, :no_match}`, so
+  the caller falls through to the ordinary password ladder (and charges
+  its throttle) exactly as if the value had been a wrong password.
+
+  The account name is compared the ACCOUNT way — byte-equal, as
+  `get_user_by_name/1` looks it up — not the ASCII nick fold: the login
+  door already treats the account namespace as case-sensitive, and
+  folding here would fork what "the account named X" means.
+
+  On a match the row's `ip`, `user_agent`, `client_id` and
+  `last_seen_at` are refreshed so the device list shows where the token
+  was last used. That refresh is best-effort: it is audit, and a
+  saturated writer must not deny a client whose credential is valid
+  (the same posture, and the same log line, as `touch_session/2`).
+  """
+  @spec authenticate_client_token(
+          String.t(),
+          String.t(),
+          String.t() | nil,
+          String.t() | nil,
+          keyword()
+        ) :: {:ok, {User.t(), Session.t()}} | {:error, :no_match}
+  def authenticate_client_token(name, token, ip, user_agent, opts)
+      when is_binary(name) and is_binary(token) do
+    with {:ok, _} <- Ecto.UUID.cast(token),
+         %Session{kind: :client, revoked_at: nil, user_id: user_id} = session
+         when is_binary(user_id) <- Repo.get(Session, token),
+         %User{name: ^name} = user <- Repo.get(User, user_id) do
+      {:ok, {user, record_client_token_use(session, ip, user_agent, opts)}}
+    else
+      _ -> {:error, :no_match}
+    end
+  end
+
+  @spec live_client_tokens_query(Ecto.UUID.t()) :: Ecto.Query.t()
+  defp live_client_tokens_query(user_id) do
+    from(s in Session,
+      where: s.user_id == ^user_id and s.kind == :client and is_nil(s.revoked_at)
+    )
+  end
+
+  # The audit refresh behind `authenticate_client_token/5`. Rides the
+  # monotonic guard in `Session.touch_changeset/2` for the same reason
+  # `touch_session/2` does, and degrades the same way: the contract
+  # returns a `Session.t()`, so a rejected write logs and the caller
+  # continues with the row it already read.
+  @spec record_client_token_use(Session.t(), String.t() | nil, String.t() | nil, keyword()) ::
+          Session.t()
+  defp record_client_token_use(%Session{} = session, ip, user_agent, opts) do
+    changes = [ip: ip, user_agent: user_agent, client_id: Keyword.get(opts, :client_id)]
+
+    changeset =
+      session
+      |> Session.touch_changeset(DateTime.utc_now())
+      |> Ecto.Changeset.change(changes)
+
+    case Repo.update(changeset) do
+      {:ok, updated} ->
+        updated
+
+      {:error, _} ->
+        Logger.warning("client token use not recorded; serving the token anyway",
+          session_ref: Session.handle(session),
+          reason: :touch_rejected
+        )
+
+        session
+    end
+  end
+
   @doc """
   Verifies a bearer token and returns the live `Session` on success.
 
@@ -458,6 +640,8 @@ defmodule Grappa.Accounts do
     * `:revoked`      — row exists but `revoked_at` is set.
     * `:expired`      — `last_seen_at` is older than the 7-day idle
       window. The row is left in place (audit + housekeeping cron).
+      A `:client`-kind row (#1196) is never `:expired`: the idle window
+      does not govern a per-client token, revocation does.
 
   On success, `last_seen_at` is bumped to `now` if the previous bump
   was more than 60 s ago — otherwise the row is returned untouched
@@ -530,7 +714,7 @@ defmodule Grappa.Accounts do
            {:ok, {subject, Repo.update_all(session_by_id_query(id), set: [revoked_at: DateTime.utc_now()])}}
          end) do
       {:ok, {subject, {affected, _}}} ->
-        Logger.info("session revoked", session_ref: session_handle(id), affected: affected)
+        Logger.info("session revoked", session_ref: Session.handle(id), affected: affected)
         if subject, do: Revocations.announce(subject)
         :ok
 
@@ -921,6 +1105,13 @@ defmodule Grappa.Accounts do
   on every use, cadence-capped at 60s). Any use would refresh it out of
   the window, so a stale timestamp is proof-of-non-use.
 
+  Scoped to `kind == :web` for the same drift-proofing reason it reuses
+  `@idle_timeout_seconds`: `authenticate/1` exempts a `:client` row from
+  the idle window (#1196), so sweeping one here would delete a
+  credential that is still perfectly able to authenticate — the GC and
+  the auth gate must agree on which rows the window governs, not just on
+  how wide it is.
+
   Scoped to `user_id IS NOT NULL` on purpose. Visitor sessions are NOT
   swept here — a visitor's `sessions` rows are removed by
   `Grappa.Visitors.Reaper` via the `sessions.visitor_id ON DELETE
@@ -938,7 +1129,7 @@ defmodule Grappa.Accounts do
 
     query =
       from(s in Session,
-        where: not is_nil(s.user_id) and s.last_seen_at < ^cutoff
+        where: not is_nil(s.user_id) and s.kind == :web and s.last_seen_at < ^cutoff
       )
 
     # #590 — this is a BACKGROUND writer (the #223 idle-session reaper is the
@@ -986,6 +1177,23 @@ defmodule Grappa.Accounts do
     |> Repo.all()
   end
 
+  # #1196 — a client token does not age out. The whole failure this
+  # feature exists to remove is an unattended client coming back after a
+  # long silence to a credential that died while it was away, so the
+  # idle window is not merely lengthened here, it does not apply. The
+  # `last_seen_at` bump still runs: it is what makes the device list
+  # honest about which tokens are actually in use, and it is the signal
+  # an operator reads before revoking one.
+  defp check_idle(%Session{kind: :client} = session) do
+    now = DateTime.utc_now()
+
+    if DateTime.diff(now, session.last_seen_at, :second) > @last_seen_bump_threshold_seconds do
+      {:ok, touch_session(session, now)}
+    else
+      {:ok, session}
+    end
+  end
+
   defp check_idle(session) do
     now = DateTime.utc_now()
     idle = DateTime.diff(now, session.last_seen_at, :second)
@@ -1018,25 +1226,11 @@ defmodule Grappa.Accounts do
 
       {:error, _} ->
         Logger.warning("touch_session backward-clock detected; ignoring",
-          session_ref: session_handle(session.id),
+          session_ref: Session.handle(session),
           reason: :backward_clock
         )
 
         session
     end
-  end
-
-  # S9: the bearer token IS the session-id (accounts/session.ex), so
-  # logging the raw id emits a live credential into the log stream —
-  # log-read access is broader than DB access, and this path fires for an
-  # ACTIVE, non-revoked session (the backward-clock warning). A truncated
-  # SHA-256 hex digest is a stable, non-reversible handle: it correlates
-  # log lines for one session without ever exposing a usable token. 12
-  # hex chars (48 bits) disambiguates concurrent sessions in a grep;
-  # reversing it would mean brute-forcing the 122-bit UUID space.
-  @spec session_handle(String.t()) :: String.t()
-  defp session_handle(id) when is_binary(id) do
-    digest = :crypto.hash(:sha256, id)
-    binary_part(Base.encode16(digest, case: :lower), 0, 12)
   end
 end

--- a/lib/grappa/accounts/session.ex
+++ b/lib/grappa/accounts/session.ex
@@ -31,6 +31,35 @@ defmodule Grappa.Accounts.Session do
       only way to invalidate a session before its 7-day idle window
       elapses. Revoked sessions are kept (not deleted) so audit /
       housekeeping can see them; the Phase 5 cron does the actual GC.
+
+  ## Two kinds (GH #1196)
+
+  `kind` splits the table into the browser bearer (`:web`, the default
+  and everything that existed before) and the per-client token
+  (`:client`). A client token is the same primitive — a row whose `:id`
+  is the bearer — with three differences, and `kind` is what each of
+  them reads:
+
+    * **No idle expiry.** `Accounts.authenticate/1` never ages a
+      `:client` row out, and `Accounts.delete_expired_sessions/0` never
+      sweeps one. A headless client that was offline a fortnight comes
+      back to a working token; revocation is the intended kill switch.
+    * **A restricted scope.** `GrappaWeb.Plugs.RequireFullSession`
+      refuses the account's own credential-management surfaces to a
+      `:client` bearer, so a leaked token can read and send messages
+      but cannot become the account.
+    * **A label**, so the device list is readable. Required on a
+      `:client` row, refused on a `:web` one.
+
+  `kind` is a column rather than `label != nil` on purpose: the scope
+  and lifecycle rules must key off a field that MEANS "restricted,
+  non-expiring". Deriving them from the nullness of a display string
+  would let a later "name your browser session" feature flip the
+  security boundary by accident.
+
+  The `:id` of a client token is still the secret, so it must never be
+  listed back — `handle/1` is the public, one-way name a device list
+  and an operator log line use instead.
   """
   use Ecto.Schema
 
@@ -38,6 +67,13 @@ defmodule Grappa.Accounts.Session do
 
   alias Grappa.Accounts.User
   alias Grappa.Visitors.Visitor
+
+  @typedoc """
+  Which door minted the row, and therefore which lifecycle + scope it
+  obeys. `:web` is the browser bearer; `:client` is the #1196 per-client
+  token.
+  """
+  @type kind :: :web | :client
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t() | nil,
@@ -50,7 +86,9 @@ defmodule Grappa.Accounts.Session do
           revoked_at: DateTime.t() | nil,
           user_agent: String.t() | nil,
           ip: String.t() | nil,
-          client_id: Grappa.ClientId.t() | nil
+          client_id: Grappa.ClientId.t() | nil,
+          kind: kind() | nil,
+          label: String.t() | nil
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -64,10 +102,27 @@ defmodule Grappa.Accounts.Session do
     field :user_agent, :string
     field :ip, :string
     field :client_id, Grappa.ClientId
+    field :kind, Ecto.Enum, values: [:web, :client], default: :web
+    field :label, :string
   end
 
-  @cast_fields [:user_id, :visitor_id, :created_at, :last_seen_at, :ip, :user_agent, :client_id]
+  @cast_fields [
+    :user_id,
+    :visitor_id,
+    :created_at,
+    :last_seen_at,
+    :ip,
+    :user_agent,
+    :client_id,
+    :kind,
+    :label
+  ]
   @required_fields [:created_at, :last_seen_at]
+
+  @label_max_length 64
+  # A label is rendered in a device list and in an operator's terminal.
+  # C0 / DEL / C1 are never legitimate there and would corrupt both.
+  @label_printable ~r/\A[^\x{0000}-\x{001F}\x{007F}-\x{009F}]+\z/u
 
   @doc """
   Changeset for inserting a new session row.
@@ -100,8 +155,57 @@ defmodule Grappa.Accounts.Session do
     |> cast(attrs, @cast_fields)
     |> validate_required(@required_fields)
     |> validate_subject_xor()
+    |> validate_label_matches_kind()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
+  end
+
+  @doc """
+  The public, one-way name of a session row (GH #1196).
+
+  The bearer token IS `:id`, so `:id` may never be listed back to the
+  caller or written to a log. This truncated SHA-256 digest is the
+  stable handle that stands in for it: it correlates an operator log
+  line (`session_ref:`) with a row in the caller's own device list, and
+  it is what `DELETE /me/client-tokens/:handle` addresses — so revoking
+  a token never requires re-presenting the secret.
+
+  12 hex chars (48 bits) disambiguates every session an account will
+  ever hold concurrently; reversing it would mean brute-forcing the
+  122-bit UUID space. S9 introduced this digest for the log line; #1196
+  promoted it to the schema so the log and the wire cannot drift into
+  two different names for one row.
+  """
+  @spec handle(t() | Ecto.UUID.t()) :: String.t()
+  def handle(%__MODULE__{id: id}) when is_binary(id), do: handle(id)
+
+  def handle(id) when is_binary(id) do
+    digest = :crypto.hash(:sha256, id)
+    binary_part(Base.encode16(digest, case: :lower), 0, 12)
+  end
+
+  # A label is the readable name of a client token, so a `:client` row
+  # without one is an unreadable device list. A `:web` row with one is
+  # the inverse hazard: `kind` (not label-nullness) is the security
+  # discriminator precisely BECAUSE the two must not be confusable, and
+  # letting a browser session carry a label starts the confusion.
+  @spec validate_label_matches_kind(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp validate_label_matches_kind(changeset) do
+    case get_field(changeset, :kind) do
+      :client ->
+        changeset
+        |> update_change(:label, &String.trim/1)
+        |> validate_required([:label])
+        |> validate_length(:label, max: @label_max_length)
+        |> validate_format(:label, @label_printable, message: "must not contain control characters")
+
+      _ ->
+        if get_field(changeset, :label) do
+          add_error(changeset, :label, "is only valid on a client token")
+        else
+          changeset
+        end
+    end
   end
 
   @doc """

--- a/lib/grappa/accounts/wire.ex
+++ b/lib/grappa/accounts/wire.ex
@@ -15,7 +15,11 @@ defmodule Grappa.Accounts.Wire do
   exposure that `Grappa.Networks.Wire` defends against — but it is
   still credential material that must never appear on the wire.)
 
-  Two output shapes today:
+  The same hazard, sharper, on `Grappa.Accounts.Session`: that schema's
+  `:id` is not a hash of the credential, it IS the credential. #1196's
+  `client_token_to_json/1` is the allowlist that keeps it off the wire.
+
+  Three output shapes today:
 
     * `user_to_json/1` — full profile shape `{id, name, is_admin,
       inserted_at}`. Used by `GrappaWeb.MeJSON.show/1` for `GET /me`
@@ -29,6 +33,9 @@ defmodule Grappa.Accounts.Wire do
       gratuitous (login is a credential-exchange surface, not a
       profile lookup; clients call `GET /me` after login when they
       need the full profile).
+    * `client_token_to_json/1` — the #1196 device-list shape
+      `{handle, label, created_at, last_seen_at, ip, user_agent}` for
+      `GET /me/client-tokens`. Deliberately id-less.
 
   Adding a field to either wire shape = one edit here. Removing a
   field = a breaking change visible at this single site.
@@ -37,7 +44,7 @@ defmodule Grappa.Accounts.Wire do
   same pattern on credential and scrollback rows respectively.
   """
 
-  alias Grappa.Accounts.User
+  alias Grappa.Accounts.{Session, User}
 
   @type user_json :: %{
           id: Ecto.UUID.t(),
@@ -49,6 +56,19 @@ defmodule Grappa.Accounts.Wire do
   @type credential_json :: %{
           id: Ecto.UUID.t(),
           name: String.t()
+        }
+
+  @typedoc """
+  A per-client token as the account's own device list sees it (#1196).
+  Carries no `id`: the id is the secret.
+  """
+  @type client_token_json :: %{
+          handle: String.t(),
+          label: String.t(),
+          created_at: DateTime.t(),
+          last_seen_at: DateTime.t(),
+          ip: String.t() | nil,
+          user_agent: String.t() | nil
         }
 
   @doc """
@@ -70,5 +90,32 @@ defmodule Grappa.Accounts.Wire do
   @spec user_to_credential_json(User.t()) :: credential_json()
   def user_to_credential_json(%User{} = user) do
     %{id: user.id, name: user.name}
+  end
+
+  @doc """
+  Renders a per-client token (`Grappa.Accounts.Session` of kind
+  `:client`, GH #1196) to its public JSON shape.
+
+  The omission IS the feature. A session row's `:id` is the bearer
+  token, so this shape publishes `Session.handle/1` — the one-way
+  digest — and never the id. That is what makes "shown once at
+  creation, never retrievable again" true of every read path at once,
+  rather than a property each new controller has to remember: the
+  minting response is the one place that renders the secret, and it
+  does so explicitly and separately.
+
+  `last_seen_at` and `ip` are the two fields that make an unexpected
+  token visible to its owner, which is the point of the list.
+  """
+  @spec client_token_to_json(Session.t()) :: client_token_json()
+  def client_token_to_json(%Session{kind: :client} = session) do
+    %{
+      handle: Session.handle(session),
+      label: session.label,
+      created_at: session.created_at,
+      last_seen_at: session.last_seen_at,
+      ip: session.ip,
+      user_agent: session.user_agent
+    }
   end
 end

--- a/lib/grappa_web/channels/admin_channel.ex
+++ b/lib/grappa_web/channels/admin_channel.ex
@@ -124,6 +124,13 @@ defmodule GrappaWeb.AdminChannel do
   end
 
   @spec authorize(Phoenix.Socket.t()) :: :ok | {:error, :forbidden}
-  defp authorize(%{assigns: %{is_admin: true}}), do: :ok
+  # #1196 — admin-ness is necessary but no longer sufficient: a
+  # per-client token minted by an admin is still a scoped credential, and
+  # the operator console is the first surface it must not reach. The REST
+  # side refuses via `GrappaWeb.Plugs.RequireFullSession`; this is the
+  # same refusal on the door the console's live feed actually comes
+  # through. Both conditions in ONE clause so neither can be satisfied
+  # alone.
+  defp authorize(%{assigns: %{is_admin: true, current_session_kind: :web}}), do: :ok
   defp authorize(_), do: {:error, :forbidden}
 end

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -254,6 +254,11 @@ defmodule GrappaWeb.UserSocket do
       socket =
         socket
         |> assign(:current_session_id, session.id)
+        # #1196 — the WS twin of the `Plugs.Authn` assign. `AdminChannel`
+        # reads it to keep the operator console off a per-client token:
+        # the REST admin gate would otherwise be the only one, and the
+        # console's live feed rides this socket, not REST.
+        |> assign(:current_session_kind, session.kind)
         # #1088 — the per-CONNECTION discriminator. Minted here, at the one
         # boundary where "a WebSocket" is created, so every channel process
         # of this socket shares it and it dies with the transport.

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -416,28 +416,35 @@ defmodule GrappaWeb.AuthController do
       case Accounts.authenticate_client_token(name, password, ip, user_agent(conn),
              client_id: conn.assigns[:current_client_id]
            ) do
-        {:ok, {user, session}} ->
-          # #1196 — a per-client token in the `password` field. The row IS
-          # the bearer, so the answer is the token the client already
-          # holds, in the ordinary login envelope: nothing on the client
-          # side has to learn a second authentication mode, and a
-          # reconnecting client does not accrete a session row per
-          # reconnect.
-          #
-          # It does not descend the ladder below, and that is the whole
-          # point rather than a shortcut: the second factor was cleared
-          # once already, interactively, at the moment this token was
-          # issued. Asking a headless client to clear it again is the
-          # lockout #1196 exists to remove.
-          conn
-          |> put_status(:ok)
-          |> render(:login, token: session.id, subject: {:user, user})
-
-        {:error, :no_match} ->
-          with {:ok, user} <- authenticate_mode1(name, password, ip) do
-            second_factor_ladder(conn, user)
-          end
+        {:ok, {user, session}} -> client_token_login(conn, user, session)
+        {:error, :no_match} -> password_login(conn, name, password, ip)
       end
+    end
+  end
+
+  # #1196 — a per-client token was presented in the `password` field. The
+  # row IS the bearer, so the answer is the token the client already
+  # holds, in the ordinary login envelope: nothing on the client side has
+  # to learn a second authentication mode, and a reconnecting client does
+  # not accrete a session row per reconnect.
+  #
+  # It does not descend the second-factor ladder, and that is the point
+  # rather than a shortcut: the factor was cleared once already,
+  # interactively, at the moment this token was issued. Asking a headless
+  # client to clear it again is the lockout #1196 exists to remove.
+  @spec client_token_login(Plug.Conn.t(), Accounts.User.t(), Accounts.Session.t()) ::
+          Plug.Conn.t()
+  defp client_token_login(conn, user, session) do
+    conn
+    |> put_status(:ok)
+    |> render(:login, token: session.id, subject: {:user, user})
+  end
+
+  @spec password_login(Plug.Conn.t(), String.t(), String.t(), String.t() | nil) ::
+          Plug.Conn.t() | {:error, term()}
+  defp password_login(conn, name, password, ip) do
+    with {:ok, user} <- authenticate_mode1(name, password, ip) do
+      second_factor_ladder(conn, user)
     end
   end
 

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -20,6 +20,23 @@ defmodule GrappaWeb.AuthController do
     * `DELETE /auth/logout` — revokes the session bound to the bearer
       token via the `:authn` pipeline. Idempotent.
 
+  ## Per-client tokens (GH #1196)
+
+  The `password` field of `/auth/login` also accepts a per-client token
+  (`Grappa.Accounts.authenticate_client_token/5`), checked before the
+  Argon2 ladder. On a match the account's second factor is not asked
+  for: it was cleared interactively when the token was issued, and a
+  headless client has nowhere to put a rotating code.
+
+  It is accepted in the `password` field rather than behind a header or
+  a dedicated endpoint because that is the shape every client that
+  speaks to grappa today already sends — the alternative is cleaner in
+  the abstract and obliges every one of them to learn a second
+  authentication mode for no gain. A wrong token is indistinguishable
+  from a wrong password on the wire, in the log, and in the throttle:
+  the fall-through charges `@mode1_bucket` exactly once, at the Argon2
+  branch, so the token door adds no free guesses.
+
   Login records the requesting `ip` + `user-agent` on the session row
   for audit (`Accounts.create_session/4`). The IP is read from
   `conn.remote_ip` AFTER the `GrappaWeb.Plugs.RemoteIpFromProxy` plug
@@ -395,23 +412,54 @@ defmodule GrappaWeb.AuthController do
   defp account_login(conn, name, password) when is_binary(password) do
     ip = format_ip(conn)
 
-    with :ok <- check_mode1_throttle(ip),
-         {:ok, user} <- authenticate_mode1(name, password, ip) do
-      cond do
-        user.passkey_mode == :passwordless ->
-          {:error, :invalid_credentials}
-
-        user.passkey_mode == :second_factor ->
-          passkey_second_factor(conn, user)
-
-        TOTP.enabled?(user) ->
+    with :ok <- check_mode1_throttle(ip) do
+      case Accounts.authenticate_client_token(name, password, ip, user_agent(conn),
+             client_id: conn.assigns[:current_client_id]
+           ) do
+        {:ok, {user, session}} ->
+          # #1196 — a per-client token in the `password` field. The row IS
+          # the bearer, so the answer is the token the client already
+          # holds, in the ordinary login envelope: nothing on the client
+          # side has to learn a second authentication mode, and a
+          # reconnecting client does not accrete a session row per
+          # reconnect.
+          #
+          # It does not descend the ladder below, and that is the whole
+          # point rather than a shortcut: the second factor was cleared
+          # once already, interactively, at the moment this token was
+          # issued. Asking a headless client to clear it again is the
+          # lockout #1196 exists to remove.
           conn
-          |> put_status(:accepted)
-          |> json(%{two_factor_required: true, challenge_token: sign_challenge(user, conn)})
+          |> put_status(:ok)
+          |> render(:login, token: session.id, subject: {:user, user})
 
-        true ->
-          mint_user_session(conn, user)
+        {:error, :no_match} ->
+          with {:ok, user} <- authenticate_mode1(name, password, ip) do
+            second_factor_ladder(conn, user)
+          end
       end
+    end
+  end
+
+  # The post-password ladder: which door (if any) the account still has
+  # to walk through before a bearer is minted.
+  @spec second_factor_ladder(Plug.Conn.t(), Accounts.User.t()) ::
+          Plug.Conn.t() | {:error, term()}
+  defp second_factor_ladder(conn, user) do
+    cond do
+      user.passkey_mode == :passwordless ->
+        {:error, :invalid_credentials}
+
+      user.passkey_mode == :second_factor ->
+        passkey_second_factor(conn, user)
+
+      TOTP.enabled?(user) ->
+        conn
+        |> put_status(:accepted)
+        |> json(%{two_factor_required: true, challenge_token: sign_challenge(user, conn)})
+
+      true ->
+        mint_user_session(conn, user)
     end
   end
 

--- a/lib/grappa_web/controllers/client_token_controller.ex
+++ b/lib/grappa_web/controllers/client_token_controller.ex
@@ -1,0 +1,96 @@
+defmodule GrappaWeb.ClientTokenController do
+  @moduledoc """
+  The account's own per-client tokens (GH #1196).
+
+  A per-client token is what a headless client presents in place of the
+  account password, so that arming TOTP or a passkey stops being a
+  choice between a second factor and an always-on client. These three
+  verbs are how one is issued, seen, and killed:
+
+    * `POST /me/client-tokens` — mint. Returns the secret ONCE.
+    * `GET /me/client-tokens` — the device list. Never returns a secret.
+    * `DELETE /me/client-tokens/:handle` — revoke a single token.
+
+  All three sit behind `GrappaWeb.Plugs.RequireFullSession`, so a client
+  token cannot reach them: a token that could mint tokens would make one
+  leak permanent, and a token that could list them would break the
+  shown-once contract.
+
+  Minting is additionally password-gated, the same way
+  `GrappaWeb.TotpController` gates enrolment and for the same reason: a
+  borrowed browser bearer alone must not be able to issue a credential
+  that outlives it. Combined with the scope gate, "issued only from a
+  session that has already cleared the second factor" holds by
+  construction — a `:web` bearer reached its token through whatever
+  factors the account has armed, and now re-proves the password on top.
+
+  Visitors have no account, no password and no second factor, so the
+  whole surface is `:forbidden` for them.
+  """
+  use GrappaWeb, :controller
+
+  alias Grappa.Accounts
+  alias GrappaWeb.RemoteIP
+
+  @doc "Lists the caller's live client tokens. Secrets are not included."
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :forbidden}
+  def index(%{assigns: %{current_subject: {:user, user}}} = conn, _) do
+    render(conn, :index, tokens: Accounts.list_client_tokens(user))
+  end
+
+  def index(_, _), do: {:error, :forbidden}
+
+  @doc """
+  Mints a client token and returns it once.
+
+  Requires the account password alongside the label — see the moduledoc
+  for why a valid bearer is not sufficient on its own.
+  """
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom() | Ecto.Changeset.t()}
+  def create(
+        %{assigns: %{current_subject: {:user, user}}} = conn,
+        %{"label" => label, "password" => password}
+      )
+      when is_binary(label) and is_binary(password) do
+    with :ok <- Accounts.verify_password(user, password),
+         {:ok, session} <-
+           Accounts.create_client_token(user, label, RemoteIP.format(conn), user_agent(conn),
+             client_id: conn.assigns[:current_client_id]
+           ) do
+      conn
+      |> put_status(:created)
+      |> render(:create, token: session)
+    end
+  end
+
+  def create(%{assigns: %{current_subject: {:user, _}}}, _), do: {:error, :bad_request}
+
+  def create(_, _), do: {:error, :forbidden}
+
+  @doc """
+  Revokes one of the caller's client tokens by its public handle.
+
+  Scoped to the caller's own tokens, so a handle belonging to another
+  account is a 404 and not a cross-account kill switch. Unlike minting
+  this is NOT password-gated: revocation is the safe direction, and a
+  kill switch that is hard to reach is a kill switch nobody pulls.
+  """
+  @spec delete(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :forbidden | :not_found | :db_unavailable}
+  def delete(%{assigns: %{current_subject: {:user, user}}} = conn, %{"handle" => handle})
+      when is_binary(handle) do
+    with :ok <- Accounts.revoke_client_token(user, handle) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  def delete(_, _), do: {:error, :forbidden}
+
+  @spec user_agent(Plug.Conn.t()) :: String.t() | nil
+  defp user_agent(conn) do
+    case get_req_header(conn, "user-agent") do
+      [ua | _] -> ua
+      [] -> nil
+    end
+  end
+end

--- a/lib/grappa_web/controllers/client_token_json.ex
+++ b/lib/grappa_web/controllers/client_token_json.ex
@@ -1,0 +1,32 @@
+defmodule GrappaWeb.ClientTokenJSON do
+  @moduledoc """
+  Phoenix view layer for `GrappaWeb.ClientTokenController` (GH #1196).
+
+  Both shapes delegate to `Grappa.Accounts.Wire.client_token_to_json/1`,
+  which is deliberately id-less — a session row's `:id` IS the bearer
+  token. `create/1` is the ONE place in the codebase that puts it on the
+  wire, and it does so by adding an explicit `:token` key on top of the
+  id-less shape rather than by relaxing the allowlist. That is what
+  keeps "shown once at creation, never retrievable again" a property of
+  the serializer rather than a rule each new read path has to remember.
+  """
+  alias Grappa.Accounts.{Session, Wire}
+
+  @doc "Renders the device list — `{tokens: [...]}`, no secrets."
+  @spec index(%{tokens: [Session.t()]}) :: %{tokens: [Wire.client_token_json()]}
+  def index(%{tokens: tokens}) when is_list(tokens) do
+    %{tokens: Enum.map(tokens, &Wire.client_token_to_json/1)}
+  end
+
+  @doc """
+  Renders a freshly minted token — the device-list shape PLUS `token`,
+  the secret the client stores in its config. This response is the only
+  time it is knowable.
+  """
+  @spec create(%{token: Session.t()}) :: map()
+  def create(%{token: %Session{id: id} = session}) when is_binary(id) do
+    session
+    |> Wire.client_token_to_json()
+    |> Map.put(:token, id)
+  end
+end

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -41,6 +41,8 @@ defmodule GrappaWeb.FallbackController do
            :bad_request
            | :forbidden
            | :forbidden_vhost
+           | :client_token_scope
+           | :client_token_cap_reached
            | :not_found
            | :no_session
            | :not_invited
@@ -369,6 +371,27 @@ defmodule GrappaWeb.FallbackController do
     conn
     |> put_status(:forbidden)
     |> json(%{error: "forbidden"})
+  end
+
+  # #1196 — the bearer is a per-client token and the route is one of the
+  # account's credential-management surfaces. Distinct 403 tag so a
+  # client author reads "this credential is scoped, use the browser" and
+  # not "log in again" — the token is perfectly valid, it is simply not
+  # the account. `GrappaWeb.Plugs.RequireFullSession` is the only caller.
+  def call(conn, {:error, :client_token_scope}) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "client_token_scope"})
+  end
+
+  # #1196 — the account already holds the maximum number of live client
+  # tokens. 422 like `:list_full`: the request is well-formed and the
+  # resource is a bounded list, not a rate, so "revoke one first" is the
+  # remedy rather than "retry later".
+  def call(conn, {:error, :client_token_cap_reached}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "client_token_cap_reached"})
   end
 
   # #228 — a vhost selection outside the subject's allowed set. Distinct

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -105,6 +105,8 @@ defmodule GrappaWeb.ErrorTokens do
           | :image_reencode_failed
           | :not_connected
           | :forbidden_vhost
+          | :client_token_scope
+          | :client_token_cap_reached
           | :invalid_credentials
           | :invalid_two_factor
           | :two_factor_challenge_expired

--- a/lib/grappa_web/plugs/authn.ex
+++ b/lib/grappa_web/plugs/authn.ex
@@ -31,6 +31,13 @@ defmodule GrappaWeb.Plugs.Authn do
   the admission gates and `AuthController` for per-client session
   tracking.
 
+  `:current_session_kind` (#1196) carries the authenticated row's
+  `Session.kind` — `:web` for a browser bearer, `:client` for a
+  per-client token. It is assigned HERE, from the row this plug already
+  loaded, so the downstream scope gate
+  (`GrappaWeb.Plugs.RequireFullSession`) never re-reads the credential
+  to decide what it is allowed to do.
+
   Loading the subject here costs one DB round-trip per authenticated
   request but eliminates the `Accounts.get_user!/1` re-fetch each
   user-aware controller used to perform. The session FK is
@@ -67,7 +74,9 @@ defmodule GrappaWeb.Plugs.Authn do
     with {:ok, token} <- get_token(conn),
          {:ok, session} <- Accounts.authenticate(token),
          {:ok, conn} <- assign_subject(conn, session) do
-      assign(conn, :current_session_id, session.id)
+      conn
+      |> assign(:current_session_id, session.id)
+      |> assign(:current_session_kind, session.kind)
     else
       {:error, reason} ->
         # Reason stays in operator logs (greppable) but never reaches

--- a/lib/grappa_web/plugs/require_full_session.ex
+++ b/lib/grappa_web/plugs/require_full_session.ex
@@ -1,0 +1,57 @@
+defmodule GrappaWeb.Plugs.RequireFullSession do
+  @moduledoc """
+  Scope gate for the per-client token (GH #1196).
+
+  A client token exists so that arming a second factor no longer locks a
+  headless client out of the account. That is only a hardening — rather
+  than a way around the second factor — if the token is strictly less
+  than the account. This plug is where "strictly less" is spelled: it
+  refuses, with a 403 tagged `client_token_scope`, every route it is
+  mounted on when the authenticated bearer is a `:client` session.
+
+  What it is mounted on, and why those:
+
+    * the `:admin_authn` pipeline — the whole operator console;
+    * `/me/totp*`, `/me/passkeys*` — the account's second factors. A
+      credential that could disarm the factors it was issued under would
+      make those factors decorative;
+    * `DELETE /me` — self-service account deletion. Not named in #1196's
+      list, but strictly worse than everything on it;
+    * `/me/client-tokens*` — a token cannot mint, list, or revoke
+      tokens. Without this, one leaked token is every future token.
+
+  The account password lives on `PUT /admin/users/:id/password`, so the
+  admin gate above already covers "cannot change the account password";
+  there is no self-service password route to gate separately today. A
+  future one MUST be mounted here — `GrappaWeb.RouterScopeTest` fails if
+  a route whose path looks like credential management is reachable
+  without this plug.
+
+  What is deliberately NOT gated: reading and sending messages, the
+  network verbs, settings, uploads, themes. Those are what a client is
+  FOR, and the worst case of a leaked token is bounded to exactly them
+  — bad, but revocable, and visible in the owner's own device list.
+
+  Mount downstream of `GrappaWeb.Plugs.Authn`, which is what assigns
+  `:current_session_kind`. An unauthenticated conn never reaches here;
+  if a pipeline regression ever let one through, the missing assign
+  falls to the refusing clause (fail-closed).
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias GrappaWeb.FallbackController
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(%Plug.Conn{assigns: %{current_session_kind: :web}} = conn, _), do: conn
+
+  def call(conn, _) do
+    conn
+    |> FallbackController.call({:error, :client_token_scope})
+    |> halt()
+  end
+end

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -81,6 +81,20 @@ defmodule GrappaWeb.Router do
   # signal. M-cluster M-2.
   pipeline :admin_authn do
     plug GrappaWeb.Admin.AuthPlug
+    # GH #1196 — the operator console is the first thing a per-client
+    # token must not reach. Mounted inside the admin pipeline rather
+    # than repeated per route so a new `/admin` route inherits the scope
+    # gate the same way it inherits the `is_admin` gate.
+    plug GrappaWeb.Plugs.RequireFullSession
+  end
+
+  # GH #1196 — the account's own credential-management surfaces. A
+  # per-client token authenticates fine and is refused here with a 403
+  # `client_token_scope`: it may read and send as the account, but it may
+  # not administer it, re-credential it, or mint another token. Mounted
+  # downstream of `:authn`, which assigns `:current_session_kind`.
+  pipeline :full_session do
+    plug GrappaWeb.Plugs.RequireFullSession
   end
 
   # GH #630 — coarse per-subject inbound request budget on the REST door.
@@ -266,6 +280,49 @@ defmodule GrappaWeb.Router do
     get "/config", ConfigController, :show
   end
 
+  # GH #1196 — the account's credential-management surfaces, grouped so
+  # the `:full_session` scope gate applies to all of them at once and a
+  # sibling added later inherits it. Everything here can change what the
+  # account IS; everything in the scope below only uses it.
+  #
+  # `GrappaWeb.RouterScopeTest` asserts the membership of this scope
+  # against the router table, so a credential route added to the wrong
+  # block fails the suite rather than shipping ungated.
+  scope "/", GrappaWeb do
+    # `:full_session` ahead of `:request_budget`: a scope refusal is
+    # cheaper than metering the call that is about to be refused.
+    pipe_through [:api, :authn, :full_session, :request_budget]
+
+    get "/me/totp", TotpController, :show
+    post "/me/totp/enrollment", TotpController, :start_enrollment
+    post "/me/totp/enrollment/confirm", TotpController, :confirm_enrollment
+    delete "/me/totp", TotpController, :delete
+    get "/me/passkeys", PasskeyController, :index
+    post "/me/passkeys/registration/options", PasskeyController, :registration_options
+    post "/me/passkeys/registration", PasskeyController, :register
+    post "/me/passkeys/mode/options", PasskeyController, :mode_options
+    post "/me/passkeys/passwordless/recovery", PasskeyController, :prepare_passwordless
+    post "/me/passkeys/passwordless/options", PasskeyController, :passwordless_options
+    post "/me/passkeys/mode", PasskeyController, :set_mode
+    delete "/me/passkeys/:id", PasskeyController, :delete
+
+    # #157 — self-service account deletion: an explicit, IRREVERSIBLE
+    # total wipe of the caller's OWN account + all state. Subject-routed
+    # (user / visitor) in `Grappa.AccountDeletion`; admins + anon visitors
+    # 403 (not offered self-delete). `/me` already rides the nginx
+    # allowlist + the SW navigation denylist, so no proxy/SW change.
+    # #1196 moved it into the gated block: it is strictly worse than the
+    # password change the token is already refused.
+    delete "/me", MeController, :delete
+
+    # #1196 — the token surface itself. A token that could mint tokens
+    # would make one leak permanent; a token that could list them would
+    # break the shown-once contract. Both refusals come from the pipeline.
+    get "/me/client-tokens", ClientTokenController, :index
+    post "/me/client-tokens", ClientTokenController, :create
+    delete "/me/client-tokens/:handle", ClientTokenController, :delete
+  end
+
   scope "/", GrappaWeb do
     pipe_through [:api, :authn, :request_budget]
 
@@ -286,25 +343,6 @@ defmodule GrappaWeb.Router do
     post "/session/networks", SessionController, :add_network
 
     get "/me", MeController, :show
-    get "/me/totp", TotpController, :show
-    post "/me/totp/enrollment", TotpController, :start_enrollment
-    post "/me/totp/enrollment/confirm", TotpController, :confirm_enrollment
-    delete "/me/totp", TotpController, :delete
-    get "/me/passkeys", PasskeyController, :index
-    post "/me/passkeys/registration/options", PasskeyController, :registration_options
-    post "/me/passkeys/registration", PasskeyController, :register
-    post "/me/passkeys/mode/options", PasskeyController, :mode_options
-    post "/me/passkeys/passwordless/recovery", PasskeyController, :prepare_passwordless
-    post "/me/passkeys/passwordless/options", PasskeyController, :passwordless_options
-    post "/me/passkeys/mode", PasskeyController, :set_mode
-    delete "/me/passkeys/:id", PasskeyController, :delete
-
-    # #157 — self-service account deletion: an explicit, IRREVERSIBLE
-    # total wipe of the caller's OWN account + all state. Subject-routed
-    # (user / visitor) in `Grappa.AccountDeletion`; admins + anon visitors
-    # 403 (not offered self-delete). `/me` already rides the nginx
-    # allowlist + the SW navigation denylist, so no proxy/SW change.
-    delete "/me", MeController, :delete
 
     # Per-user settings — push notifications cluster B3 (2026-05-14).
     # Visitor-parity V4 (2026-05-15) lifted the user-only gate; both

--- a/priv/repo/migrations/20260810120000_add_client_tokens_to_sessions.exs
+++ b/priv/repo/migrations/20260810120000_add_client_tokens_to_sessions.exs
@@ -1,0 +1,29 @@
+defmodule Grappa.Repo.Migrations.AddClientTokensToSessions do
+  use Ecto.Migration
+
+  # GH #1196 — a per-client token is a `sessions` row with a different
+  # lifecycle (no idle expiry) and a restricted authorization scope. Two
+  # columns carry that difference.
+  #
+  # `kind` is the discriminator and is deliberately NOT derived from
+  # `label IS NOT NULL`: the scope + lifecycle rules must hang off a field
+  # that MEANS "restricted, non-expiring", not off the nullness of a
+  # display string. A later feature that labels web sessions ("Chrome on
+  # Mac") would otherwise flip the security boundary silently.
+  #
+  # Default `"web"` backfills every existing row to today's behaviour, so
+  # the deploy needs no data migration — but it DOES need a restart: the
+  # schema change is a COLD deploy.
+  def change do
+    alter table(:sessions) do
+      add :kind, :string, null: false, default: "web"
+      add :label, :string, null: true
+    end
+
+    # The device list is `WHERE user_id = ? AND kind = 'client'`. The
+    # existing `[:user_id]` index already narrows to a handful of rows,
+    # but the composite keeps the list a pure index read as a long-lived
+    # account accumulates web sessions around its few client tokens.
+    create index(:sessions, [:user_id, :kind])
+  end
+end

--- a/priv/repo/migrations/20260810120000_add_client_tokens_to_sessions.exs
+++ b/priv/repo/migrations/20260810120000_add_client_tokens_to_sessions.exs
@@ -12,8 +12,11 @@ defmodule Grappa.Repo.Migrations.AddClientTokensToSessions do
   # Mac") would otherwise flip the security boundary silently.
   #
   # Default `"web"` backfills every existing row to today's behaviour, so
-  # the deploy needs no data migration — but it DOES need a restart: the
-  # schema change is a COLD deploy.
+  # there is no data migration. Expand-only, which is why
+  # `Grappa.Deploy.Preflight` classifies it HOT: Ecto selects named
+  # columns, so a node still running the old `Session` module cannot see
+  # the two new ones, and the reload brings the schema and the column
+  # into agreement in either order.
   def change do
     alter table(:sessions) do
       add :kind, :string, null: false, default: "web"

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -1,0 +1,212 @@
+defmodule Grappa.Accounts.ClientTokenTest do
+  @moduledoc """
+  GH #1196 — the per-client token at the context boundary: what it is,
+  how long it lives, and who it answers to.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.{Session, Wire}
+  alias Grappa.Repo
+
+  @thirty_days 30 * 24 * 3600
+
+  defp idle_for(%Session{} = session, seconds) do
+    session
+    |> Ecto.Changeset.change(last_seen_at: DateTime.add(DateTime.utc_now(), -seconds, :second))
+    |> Repo.update!()
+  end
+
+  defp client_token(user, label) do
+    {:ok, session} = Accounts.create_client_token(user, label, "203.0.113.9", "weechat", [])
+    session
+  end
+
+  describe "create_client_token/5" do
+    test "mints a :client row whose id is the bearer and stores the label" do
+      user = user_fixture()
+
+      session = client_token(user, "laptop weechat")
+
+      assert session.kind == :client
+      assert session.label == "laptop weechat"
+      assert {:ok, %Session{id: id}} = Accounts.authenticate(session.id)
+      assert id == session.id
+    end
+
+    test "trims the label and refuses a blank or control-character one" do
+      user = user_fixture()
+
+      assert {:ok, %Session{label: "phone"}} =
+               Accounts.create_client_token(user, "  phone  ", nil, nil, [])
+
+      assert {:error, %Ecto.Changeset{} = blank} =
+               Accounts.create_client_token(user, "   ", nil, nil, [])
+
+      assert %{label: ["can't be blank"]} = errors_on(blank)
+
+      assert {:error, %Ecto.Changeset{} = control} =
+               Accounts.create_client_token(user, "we" <> <<0x07>> <> "chat", nil, nil, [])
+
+      assert %{label: ["must not contain control characters"]} = errors_on(control)
+    end
+
+    test "refuses to mint past the per-account cap" do
+      user = user_fixture()
+
+      for n <- 1..20, do: client_token(user, "client #{n}")
+
+      assert {:error, :client_token_cap_reached} =
+               Accounts.create_client_token(user, "one too many", nil, nil, [])
+
+      # The cap counts LIVE tokens, so revoking one makes room again —
+      # otherwise an account that cycles devices would wedge permanently.
+      :ok = Accounts.revoke_client_token(user, Session.handle(hd(Accounts.list_client_tokens(user))))
+
+      assert {:ok, %Session{}} = Accounts.create_client_token(user, "replacement", nil, nil, [])
+    end
+
+    test "a web session may not carry a label" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               %Session{}
+               |> Session.changeset(%{
+                 user_id: user.id,
+                 created_at: DateTime.utc_now(),
+                 last_seen_at: DateTime.utc_now(),
+                 label: "pretending to be a client"
+               })
+               |> Repo.insert()
+
+      assert %{label: ["is only valid on a client token"]} = errors_on(cs)
+    end
+  end
+
+  describe "lifecycle" do
+    test "a client token idle for a month still authenticates" do
+      user = user_fixture()
+      token = user |> client_token("fortnight away") |> idle_for(@thirty_days)
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+    end
+
+    test "a web session idle for a month does not — the exemption did not widen" do
+      user = user_fixture()
+      web = user |> session_fixture() |> idle_for(@thirty_days)
+
+      assert {:error, :expired} = Accounts.authenticate(web.id)
+    end
+
+    test "the idle reaper sweeps the web session and spares the client token" do
+      user = user_fixture()
+      token = user |> client_token("survivor") |> idle_for(@thirty_days)
+      web = user |> session_fixture() |> idle_for(@thirty_days)
+
+      assert {:ok, 1} = Accounts.delete_expired_sessions()
+
+      assert Repo.get(Session, token.id)
+      refute Repo.get(Session, web.id)
+    end
+
+    test "revoking kills it" do
+      user = user_fixture()
+      token = client_token(user, "compromised")
+
+      :ok = Accounts.revoke_client_token(user, Session.handle(token))
+
+      assert {:error, :revoked} = Accounts.authenticate(token.id)
+      assert Accounts.list_client_tokens(user) == []
+    end
+
+    test "a credential-material sweep takes the client tokens with it" do
+      # Not a special case in the code, and this arm is what keeps it from
+      # becoming one: arming or resetting a second factor evicts an
+      # account's other sessions, and a client token is one of them.
+      user = user_fixture()
+      token = client_token(user, "issued before the reset")
+
+      :ok = Accounts.revoke_sessions_for_user(user)
+
+      assert {:error, :revoked} = Accounts.authenticate(token.id)
+    end
+  end
+
+  describe "authenticate_client_token/5" do
+    test "resolves the account's own live token and records where it was used" do
+      user = user_fixture(name: "vjt-tok")
+      token = client_token(user, "irssi")
+
+      assert {:ok, {resolved_user, session}} =
+               Accounts.authenticate_client_token(
+                 "vjt-tok",
+                 token.id,
+                 "198.51.100.7",
+                 "irssi/1.4",
+                 client_id: nil
+               )
+
+      assert resolved_user.id == user.id
+      assert session.ip == "198.51.100.7"
+      assert session.user_agent == "irssi/1.4"
+    end
+
+    test "refuses a web bearer presented as a token" do
+      user = user_fixture(name: "vjt-web")
+      web = session_fixture(user)
+
+      assert {:error, :no_match} =
+               Accounts.authenticate_client_token("vjt-web", web.id, nil, nil, [])
+    end
+
+    test "refuses another account's token" do
+      owner = user_fixture(name: "owner")
+      other = user_fixture(name: "other")
+      token = client_token(owner, "owner's laptop")
+
+      assert {:error, :no_match} =
+               Accounts.authenticate_client_token(other.name, token.id, nil, nil, [])
+    end
+
+    test "refuses a revoked token, and anything that is not a token at all" do
+      user = user_fixture(name: "vjt-rev")
+      token = client_token(user, "gone")
+      :ok = Accounts.revoke_client_token(user, Session.handle(token))
+
+      assert {:error, :no_match} =
+               Accounts.authenticate_client_token("vjt-rev", token.id, nil, nil, [])
+
+      assert {:error, :no_match} =
+               Accounts.authenticate_client_token("vjt-rev", "not-a-uuid", nil, nil, [])
+
+      assert {:error, :no_match} =
+               Accounts.authenticate_client_token("vjt-rev", Ecto.UUID.generate(), nil, nil, [])
+    end
+  end
+
+  describe "handle addressing" do
+    test "the wire shape publishes the handle and never the secret" do
+      user = user_fixture()
+      token = client_token(user, "phone")
+
+      json = Wire.client_token_to_json(token)
+
+      refute Map.has_key?(json, :id)
+      refute json |> Map.values() |> Enum.member?(token.id)
+      assert json.handle == Session.handle(token)
+      assert json.label == "phone"
+      assert json.ip == "203.0.113.9"
+    end
+
+    test "revoking by another account's handle is a miss, not a kill switch" do
+      owner = user_fixture()
+      other = user_fixture()
+      token = client_token(owner, "owner's")
+
+      assert {:error, :not_found} = Accounts.revoke_client_token(other, Session.handle(token))
+      assert {:ok, %Session{}} = Accounts.authenticate(token.id)
+    end
+  end
+end

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -7,9 +7,8 @@ defmodule Grappa.Accounts.ClientTokenTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Accounts
+  alias Grappa.{Accounts, Repo}
   alias Grappa.Accounts.{Session, Wire}
-  alias Grappa.Repo
 
   @thirty_days 30 * 24 * 3600
 

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -1208,6 +1208,7 @@ defmodule Grappa.Deploy.PreflightTest do
       20260728120000_add_nickserv_pass_to_network_credentials
       20260802190000_add_user_totp
       20260805100000_add_old_nick_to_session_log_events
+      20260810120000_add_client_tokens_to_sessions
     )
 
     test "every migration on disk classifies, and the HOT set is exactly the pinned one" do

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -51,7 +51,10 @@ defmodule GrappaWeb.AdminChannelTest do
     socket(UserSocket, "user_socket:test", %{
       user_name: user_name,
       current_subject: subject,
-      is_admin: is_admin
+      is_admin: is_admin,
+      # #1196 — `UserSocket.connect/3` assigns the authenticated row's
+      # kind; `:web` is what an ordinary browser handshake produces.
+      current_session_kind: Keyword.get(opts, :session_kind, :web)
     })
   end
 
@@ -66,6 +69,20 @@ defmodule GrappaWeb.AdminChannelTest do
     test "non-admin user rejected forbidden" do
       user = user_fixture(is_admin: false)
       socket = build_socket(user.name, {:user, user.id}, is_admin: false)
+
+      assert {:error, %{error: "forbidden"}} =
+               subscribe_and_join(socket, "grappa:admin:events", %{})
+    end
+
+    test "an admin's per-client token rejected forbidden" do
+      # #1196 — the console's live feed comes through this socket, not
+      # through REST, so the scope gate has to exist on both doors. An
+      # admin holding a client token is admin AND scoped: the token is
+      # for reading and sending, never for operating the bouncer.
+      admin = user_fixture(is_admin: true)
+
+      socket =
+        build_socket(admin.name, {:user, admin.id}, is_admin: true, session_kind: :client)
 
       assert {:error, %{error: "forbidden"}} =
                subscribe_and_join(socket, "grappa:admin:events", %{})

--- a/test/grappa_web/client_token_scope_test.exs
+++ b/test/grappa_web/client_token_scope_test.exs
@@ -1,0 +1,138 @@
+defmodule GrappaWeb.ClientTokenScopeTest do
+  @moduledoc """
+  GH #1196 — the scope boundary IS the feature.
+
+  A per-client token exists so that arming a second factor stops locking
+  a headless client out. That is a hardening only while the token is
+  strictly less than the account: if it can administer, re-credential,
+  or re-mint, then the token is the account and the second factor on the
+  account is decorative.
+
+  Every arm below is one edge of that boundary, and each is paired with
+  a control — the same route reached by an ordinary browser session —
+  so a refusal cannot be mistaken for a route that simply does not work.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+
+  setup do
+    admin = user_fixture(is_admin: true)
+    {:ok, token} = Accounts.create_client_token(admin, "headless client", nil, nil, [])
+    web = session_fixture(admin)
+
+    %{admin: admin, token: token, web: web}
+  end
+
+  defp as_token(conn, %{token: token}), do: put_bearer(conn, token.id)
+  defp as_web(conn, %{web: web}), do: put_bearer(conn, web.id)
+
+  defp assert_scope_refusal(conn) do
+    assert json_response(conn, 403) == %{"error" => "client_token_scope"}
+  end
+
+  describe "a client token cannot reach the operator console" do
+    test "GET /admin/me", %{conn: conn} = ctx do
+      conn |> as_token(ctx) |> get("/admin/me") |> assert_scope_refusal()
+    end
+
+    test "and the same admin's browser session can", %{conn: conn} = ctx do
+      assert %{"name" => _} = conn |> as_web(ctx) |> get("/admin/me") |> json_response(200)
+    end
+  end
+
+  describe "a client token cannot change the account password" do
+    # The account password lives on the admin surface, so this is both
+    # the password boundary of #1196 and a second witness that the admin
+    # gate covers mutating routes and not merely the console's reads.
+    test "PUT /admin/users/:id/password", %{conn: conn, admin: admin} = ctx do
+      conn
+      |> as_token(ctx)
+      |> put("/admin/users/#{admin.id}/password", %{"password" => "a-brand-new-password"})
+      |> assert_scope_refusal()
+    end
+
+    test "and the same admin's browser session can", %{conn: conn, admin: admin} = ctx do
+      conn = conn |> as_web(ctx) |> put("/admin/users/#{admin.id}/password", %{"password" => "a-brand-new-password"})
+
+      refute conn.status == 403
+    end
+  end
+
+  describe "a client token cannot touch the account's second factors" do
+    test "GET /me/totp", %{conn: conn} = ctx do
+      conn |> as_token(ctx) |> get("/me/totp") |> assert_scope_refusal()
+    end
+
+    test "DELETE /me/totp", %{conn: conn} = ctx do
+      conn
+      |> as_token(ctx)
+      |> delete("/me/totp", %{"password" => "irrelevant"})
+      |> assert_scope_refusal()
+    end
+
+    test "GET /me/passkeys", %{conn: conn} = ctx do
+      conn |> as_token(ctx) |> get("/me/passkeys") |> assert_scope_refusal()
+    end
+
+    test "POST /me/passkeys/registration/options", %{conn: conn} = ctx do
+      conn
+      |> as_token(ctx)
+      |> post("/me/passkeys/registration/options", %{})
+      |> assert_scope_refusal()
+    end
+
+    test "and the browser session reaches them", %{conn: conn} = ctx do
+      assert %{"enabled" => false} = conn |> as_web(ctx) |> get("/me/totp") |> json_response(200)
+      assert %{"passkeys" => _} = conn |> as_web(ctx) |> get("/me/passkeys") |> json_response(200)
+    end
+  end
+
+  describe "a client token cannot mint, list, or revoke tokens" do
+    test "POST /me/client-tokens", %{conn: conn} = ctx do
+      conn
+      |> as_token(ctx)
+      |> post("/me/client-tokens", %{"label" => "a second one", "password" => "x"})
+      |> assert_scope_refusal()
+    end
+
+    test "GET /me/client-tokens", %{conn: conn} = ctx do
+      conn |> as_token(ctx) |> get("/me/client-tokens") |> assert_scope_refusal()
+    end
+
+    test "DELETE /me/client-tokens/:handle", %{conn: conn, token: token} = ctx do
+      handle = Grappa.Accounts.Session.handle(token)
+
+      conn |> as_token(ctx) |> delete("/me/client-tokens/#{handle}") |> assert_scope_refusal()
+    end
+
+    test "and the browser session reaches the list", %{conn: conn} = ctx do
+      assert %{"tokens" => [_]} =
+               conn |> as_web(ctx) |> get("/me/client-tokens") |> json_response(200)
+    end
+  end
+
+  describe "a client token cannot delete the account" do
+    test "DELETE /me", %{conn: conn} = ctx do
+      conn |> as_token(ctx) |> delete("/me") |> assert_scope_refusal()
+    end
+  end
+
+  describe "what a client token is FOR still works" do
+    # Without this the arms above would be satisfied by a token that can
+    # do nothing at all, which is not a feature.
+    test "GET /me", %{conn: conn, admin: admin} = ctx do
+      assert %{"name" => name} = conn |> as_token(ctx) |> get("/me") |> json_response(200)
+      assert name == admin.name
+    end
+
+    test "GET /networks", %{conn: conn} = ctx do
+      # The account holds no credential, so the honest answer is the
+      # empty list — what matters is that it is a 200 from the resource
+      # surface and not the scope refusal the arms above assert.
+      assert conn |> as_token(ctx) |> get("/networks") |> json_response(200) == []
+    end
+  end
+end

--- a/test/grappa_web/controllers/auth_controller_client_token_test.exs
+++ b/test/grappa_web/controllers/auth_controller_client_token_test.exs
@@ -1,0 +1,135 @@
+defmodule GrappaWeb.AuthControllerClientTokenTest do
+  @moduledoc """
+  GH #1196 — `POST /auth/login` accepting a per-client token in the
+  `password` field.
+
+  The lockout this removes is concrete: with TOTP armed, an account's
+  password login answers 202 `two_factor_required` and a headless client
+  has nowhere to put a code that rotates every thirty seconds. The first
+  describe is that lockout and its way out, measured on one account.
+
+  `async: false` — the login throttle is a global ETS singleton keyed by
+  source IP, exactly as in `GrappaWeb.AuthControllerTest`.
+  """
+  use GrappaWeb.ConnCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.TOTP
+  alias Grappa.RateLimit.FailureWindow
+
+  @rfc_secret "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+  setup do
+    :ets.delete_all_objects(FailureWindow.table_name())
+    :ok
+  end
+
+  defp with_ip(conn, d), do: %{conn | remote_ip: {10, 77, 0, d}}
+
+  defp login(conn, name, password) do
+    post(conn, "/auth/login", %{"identifier" => name, "password" => password})
+  end
+
+  defp arm_totp(user) do
+    now = System.system_time(:second)
+    {:ok, code} = TOTP.code_at(@rfc_secret, now)
+    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    :ok
+  end
+
+  describe "an account with TOTP armed" do
+    setup do
+      {user, password} = user_fixture_with_password()
+      :ok = arm_totp(user)
+      {:ok, token} = Accounts.create_client_token(user, "weechat on the vps", nil, nil, [])
+
+      %{user: user, password: password, token: token}
+    end
+
+    test "still asks a password login for the second factor", %{
+      conn: conn,
+      user: user,
+      password: password
+    } do
+      body = conn |> with_ip(1) |> login(user.name, password) |> json_response(202)
+
+      assert body["two_factor_required"] == true
+    end
+
+    test "admits the client token straight through, and answers with that same token", %{
+      conn: conn,
+      user: user,
+      token: token
+    } do
+      body = conn |> with_ip(1) |> login(user.name, token.id) |> json_response(200)
+
+      # The row IS the bearer, so a reconnect does not accrete a second
+      # session row — the client gets back what it already had.
+      assert body["token"] == token.id
+      refute body["two_factor_required"]
+      assert body["subject"]["name"] == user.name
+    end
+  end
+
+  describe "what the password field will not accept" do
+    setup do
+      {user, password} = user_fixture_with_password()
+      {:ok, token} = Accounts.create_client_token(user, "laptop", nil, nil, [])
+
+      %{user: user, password: password, token: token}
+    end
+
+    test "a browser bearer for the same account", %{conn: conn, user: user} do
+      web = session_fixture(user)
+
+      body = conn |> with_ip(2) |> login(user.name, web.id) |> json_response(401)
+
+      assert body == %{"error" => "invalid_credentials"}
+    end
+
+    test "another account's client token", %{conn: conn, token: token} do
+      {stranger, _} = user_fixture_with_password()
+
+      body = conn |> with_ip(3) |> login(stranger.name, token.id) |> json_response(401)
+
+      assert body == %{"error" => "invalid_credentials"}
+    end
+
+    test "a revoked token", %{conn: conn, user: user, token: token} do
+      :ok = Accounts.revoke_client_token(user, Grappa.Accounts.Session.handle(token))
+
+      body = conn |> with_ip(4) |> login(user.name, token.id) |> json_response(401)
+
+      assert body == %{"error" => "invalid_credentials"}
+    end
+  end
+
+  describe "the token door buys no extra guesses" do
+    # A UUID-shaped wrong password takes the token lookup AND the Argon2
+    # ladder. If the extra door charged its own failure, the account's
+    # ten-per-window budget would be spent in five attempts — so the
+    # count is what proves the two doors share one charge.
+    test "a wrong UUID-shaped password charges the window exactly once per attempt", %{
+      conn: conn
+    } do
+      {user, password} = user_fixture_with_password()
+      wrong = Ecto.UUID.generate()
+
+      for _ <- 1..5 do
+        assert conn |> with_ip(5) |> login(user.name, wrong) |> json_response(401)
+      end
+
+      # Half the budget spent, not all of it.
+      assert conn |> with_ip(5) |> login(user.name, password) |> json_response(200)
+
+      for _ <- 1..5 do
+        assert conn |> with_ip(5) |> login(user.name, wrong) |> json_response(401)
+      end
+
+      assert conn |> with_ip(5) |> login(user.name, password) |> json_response(429) ==
+               %{"error" => "too_many_attempts"}
+    end
+  end
+end

--- a/test/grappa_web/controllers/auth_controller_client_token_test.exs
+++ b/test/grappa_web/controllers/auth_controller_client_token_test.exs
@@ -35,7 +35,7 @@ defmodule GrappaWeb.AuthControllerClientTokenTest do
   defp arm_totp(user) do
     now = System.system_time(:second)
     {:ok, code} = TOTP.code_at(@rfc_secret, now)
-    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    {:ok, _} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
     :ok
   end
 

--- a/test/grappa_web/controllers/client_token_controller_test.exs
+++ b/test/grappa_web/controllers/client_token_controller_test.exs
@@ -112,7 +112,7 @@ defmodule GrappaWeb.ClientTokenControllerTest do
 
   describe "visitors" do
     test "have no account to issue a token for", %{conn: conn} do
-      {_visitor, session} = visitor_and_session()
+      {_, session} = visitor_and_session()
 
       conn = conn |> recycle() |> put_bearer(session.id)
 

--- a/test/grappa_web/controllers/client_token_controller_test.exs
+++ b/test/grappa_web/controllers/client_token_controller_test.exs
@@ -1,0 +1,122 @@
+defmodule GrappaWeb.ClientTokenControllerTest do
+  @moduledoc """
+  GH #1196 — the three verbs an account uses to issue, see, and kill a
+  per-client token.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.Session
+
+  setup %{conn: conn} do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    %{conn: put_bearer(conn, session.id), user: user, password: password}
+  end
+
+  describe "POST /me/client-tokens" do
+    test "mints a usable token and shows it once", %{conn: conn, user: user, password: password} do
+      body =
+        conn
+        |> post("/me/client-tokens", %{"label" => "weechat", "password" => password})
+        |> json_response(201)
+
+      assert body["label"] == "weechat"
+      assert %{"token" => token, "handle" => handle} = body
+
+      # The secret works as a bearer straight away, and the handle it
+      # was announced under is the one the list will publish.
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token)
+      assert handle == Session.handle(token)
+      assert [%Session{}] = Accounts.list_client_tokens(user)
+    end
+
+    test "the list never gives the secret back", %{conn: conn, password: password} do
+      minted =
+        conn
+        |> post("/me/client-tokens", %{"label" => "irssi", "password" => password})
+        |> json_response(201)
+
+      %{"tokens" => [listed]} = conn |> get("/me/client-tokens") |> json_response(200)
+
+      assert listed["handle"] == minted["handle"]
+      refute Map.has_key?(listed, "token")
+      refute listed |> Map.values() |> Enum.member?(minted["token"])
+    end
+
+    test "refuses without the account password", %{conn: conn} do
+      body =
+        conn
+        |> post("/me/client-tokens", %{"label" => "borrowed", "password" => "not-the-password"})
+        |> json_response(401)
+
+      assert body == %{"error" => "invalid_credentials"}
+    end
+
+    test "refuses when the password is absent entirely", %{conn: conn} do
+      assert conn
+             |> post("/me/client-tokens", %{"label" => "no password"})
+             |> json_response(400) == %{"error" => "bad_request"}
+    end
+
+    test "surfaces the per-account cap as a distinct 422", %{
+      conn: conn,
+      user: user,
+      password: password
+    } do
+      for n <- 1..20, do: Accounts.create_client_token(user, "client #{n}", nil, nil, [])
+
+      assert conn
+             |> post("/me/client-tokens", %{"label" => "one too many", "password" => password})
+             |> json_response(422) == %{"error" => "client_token_cap_reached"}
+    end
+  end
+
+  describe "DELETE /me/client-tokens/:handle" do
+    test "revokes by handle without ever re-presenting the secret", %{
+      conn: conn,
+      user: user,
+      password: password
+    } do
+      %{"token" => token, "handle" => handle} =
+        conn
+        |> post("/me/client-tokens", %{"label" => "compromised", "password" => password})
+        |> json_response(201)
+
+      assert conn |> delete("/me/client-tokens/#{handle}") |> response(204)
+
+      assert {:error, :revoked} = Accounts.authenticate(token)
+      assert Accounts.list_client_tokens(user) == []
+    end
+
+    test "an unknown handle is a 404", %{conn: conn} do
+      assert conn
+             |> delete("/me/client-tokens/deadbeefcafe")
+             |> json_response(404) == %{"error" => "not_found"}
+    end
+
+    test "another account's handle is a 404, and their token survives", %{conn: conn} do
+      stranger = user_fixture()
+      {:ok, theirs} = Accounts.create_client_token(stranger, "theirs", nil, nil, [])
+
+      assert conn
+             |> delete("/me/client-tokens/#{Session.handle(theirs)}")
+             |> json_response(404) == %{"error" => "not_found"}
+
+      assert {:ok, %Session{}} = Accounts.authenticate(theirs.id)
+    end
+  end
+
+  describe "visitors" do
+    test "have no account to issue a token for", %{conn: conn} do
+      {_visitor, session} = visitor_and_session()
+
+      conn = conn |> recycle() |> put_bearer(session.id)
+
+      assert conn |> get("/me/client-tokens") |> json_response(403) == %{"error" => "forbidden"}
+    end
+  end
+end

--- a/test/grappa_web/router_scope_test.exs
+++ b/test/grappa_web/router_scope_test.exs
@@ -52,9 +52,10 @@ defmodule GrappaWeb.RouterScopeTest do
   end
 
   defp credential_routes do
-    GrappaWeb.Router.__routes__()
-    |> Enum.filter(&credential_management?/1)
-    |> Enum.reject(&(&1.plug == @loopback_plug))
+    Enum.filter(
+      GrappaWeb.Router.__routes__(),
+      &(credential_management?(&1) and &1.plug != @loopback_plug)
+    )
   end
 
   # `:id` / `:handle` / `:network_id` only have to be routable; the scope

--- a/test/grappa_web/router_scope_test.exs
+++ b/test/grappa_web/router_scope_test.exs
@@ -1,0 +1,123 @@
+defmodule GrappaWeb.RouterScopeTest do
+  @moduledoc """
+  GH #1196 — a router-table invariant, not a route test.
+
+  The scope gate is mounted per pipeline, so a credential-management
+  route declared inside the right block inherits it automatically. The
+  hazard is the route declared in the WRONG block: it authenticates, it
+  works, and it is silently reachable by a per-client token. Nothing
+  about it looks wrong at the call site.
+
+  So this enumerates the compiled route table and actually DRIVES every
+  credential-management route with a client-token bearer, asserting the
+  scope refusal each time. Exercising beats introspecting the pipelines:
+  it survives a plug being moved between pipelines, and it fails on the
+  thing that matters — the response — rather than on a spelling.
+
+  The bearer belongs to an ADMIN account on purpose. A non-admin would
+  be refused by `GrappaWeb.Admin.AuthPlug` first, and every `/admin` arm
+  would pass for the wrong reason; requiring the body to be exactly
+  `client_token_scope` is what keeps the admin arms honest.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+
+  # Paths that can change what the account IS, as opposed to using it.
+  # Prefix-matched, so `/me/totp/enrollment/confirm` is covered by
+  # `/me/totp` and a new sibling needs no edit here.
+  @credential_prefixes ["/admin", "/me/totp", "/me/passkeys", "/me/client-tokens"]
+
+  # Exact `{method, path}` pairs that are credential management without
+  # looking like it from the prefix alone.
+  @credential_routes [{"DELETE", "/me"}]
+
+  # The loopback `/admin` scope (`POST /admin/reload`,
+  # `/admin/cic-bundle-changed`) carries no bearer at all: it is gated on
+  # the transport peer by `GrappaWeb.Plugs.LoopbackOnly`, so there is no
+  # session whose kind could be checked, and driving it here would run a
+  # real code reload. Identified by its controller — the loopback scope
+  # routes to `GrappaWeb.AdminController`, the operator console to
+  # `GrappaWeb.Admin.*` — so a console route can never fall into the
+  # exclusion by being named `/admin/something`.
+  @loopback_plug GrappaWeb.AdminController
+
+  defp method(%{verb: verb}), do: verb |> Atom.to_string() |> String.upcase()
+
+  defp credential_management?(%{path: path} = route) do
+    Enum.any?(@credential_prefixes, &String.starts_with?(path, &1)) or
+      {method(route), path} in @credential_routes
+  end
+
+  defp credential_routes do
+    GrappaWeb.Router.__routes__()
+    |> Enum.filter(&credential_management?/1)
+    |> Enum.reject(&(&1.plug == @loopback_plug))
+  end
+
+  # `:id` / `:handle` / `:network_id` only have to be routable; the scope
+  # gate runs in the pipeline, upstream of any controller that would
+  # care what they contain.
+  defp concrete_path(%{path: path}) do
+    path
+    |> String.split("/")
+    |> Enum.map_join("/", fn
+      ":" <> _ -> "placeholder"
+      "*" <> _ -> "placeholder"
+      segment -> segment
+    end)
+  end
+
+  defp drive(conn, route) do
+    path = concrete_path(route)
+
+    case route.verb do
+      :get -> get(conn, path)
+      :post -> post(conn, path, %{})
+      :put -> put(conn, path, %{})
+      :patch -> patch(conn, path, %{})
+      :delete -> delete(conn, path)
+    end
+  end
+
+  test "no credential-management route answers a per-client token" do
+    admin = user_fixture(is_admin: true)
+    {:ok, token} = Accounts.create_client_token(admin, "headless", nil, nil, [])
+
+    for route <- credential_routes() do
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> put_bearer(token.id)
+        |> drive(route)
+
+      assert json_response(conn, 403) == %{"error" => "client_token_scope"},
+             """
+             #{method(route)} #{route.path} is reachable by a per-client token.
+
+             Mount it on the `:full_session` scope (or `:admin_authn`) in
+             GrappaWeb.Router — see GH #1196.
+             """
+    end
+  end
+
+  test "the invariant has something to check" do
+    # A filter that matches nothing passes vacuously forever. This is the
+    # arm that notices when a router refactor renames the paths out from
+    # under the prefixes above.
+    matched = credential_routes()
+
+    assert length(matched) > 20
+
+    for prefix <- @credential_prefixes do
+      assert Enum.any?(matched, &String.starts_with?(&1.path, prefix)),
+             "no route matches the credential prefix #{prefix} any more"
+    end
+
+    for {verb, path} <- @credential_routes do
+      assert Enum.any?(matched, &(&1.path == path and method(&1) == verb)),
+             "no route matches #{verb} #{path} any more"
+    end
+  end
+end


### PR DESCRIPTION
## The lockout

Arming TOTP or a passkey on an account today locks out every client that
authenticates with a name and a password. `/auth/login` is the only door and
it has no non-interactive path: the account answers `202 two_factor_required`,
and an unattended client has nowhere to put a code that rotates every thirty
seconds, no channel to be prompted on at reconnect, and a recovery code it
would burn on the first one. The practical shape is a hard either/or — a
second factor, or an always-on client — on exactly the account most worth
protecting.

## What ships

A **per-client token**: a credential the account holder mints from a browser
session and pastes into a client's config, accepted in place of the password.
It is the app-password / personal-access-token model — not a way around the
second factor, but a separate credential whose issuance required it.

The primitive already existed, as #1196 said it did. `Grappa.Accounts.Session`
is a bearer-token row whose `:id` IS the token, already carrying `client_id`,
`last_seen_at` and `revoked_at`. A `:client`-kind row is that row with a
different lifecycle, a label, and a smaller scope. A separate table would have
duplicated the bearer lookup, the revoke, the revocation broadcast, the WS
auth and the admin listing, and forced `/auth/login` to try two of them.

`kind` is a column rather than a derived `label != nil`, deliberately: the
scope and lifecycle rules must key off a field that MEANS "restricted,
non-expiring". Deriving them from the nullness of a display string would let a
later "name your browser session" feature flip a security boundary by
accident, in a commit that appears to touch only presentation.

## The scope boundary

This is the part that decides whether the feature is a hardening or a hole, so
it is the part with the most arms. A client token can read and send as the
account. It cannot:

| boundary | refusal |
|---|---|
| `/admin/*` — the whole operator console | 403 `client_token_scope` |
| the account password (`PUT /admin/users/:id/password`) | 403 `client_token_scope` |
| `/me/totp*`, `/me/passkeys*` — the second factors | 403 `client_token_scope` |
| `/me/client-tokens*` — mint, list, revoke | 403 `client_token_scope` |
| `DELETE /me` — not in #1196's list, strictly worse than what is | 403 `client_token_scope` |
| `grappa:admin:events` — the console's live feed, over the socket | join `forbidden` |

`GrappaWeb.Plugs.RequireFullSession` draws the line once and the pipelines
apply it: `:admin_authn` gains it, so the console inherits the refusal the way
it inherits `is_admin`, and a new `:full_session` pipeline carries the account's
own credential surfaces. Grouping rather than per-route checks is the point —
the hazard is not the route written today, it is the credential route added
next year by someone not thinking about tokens.

`GrappaWeb.RouterScopeTest` is the backstop: it walks the compiled route table,
drives every credential-management path with a token bearer, and demands the
scope refusal from each. It exercises rather than introspects `pipe_through`
(Phoenix does not expose it), which also means it survives a plug moving
between pipelines. The bearer belongs to an admin account on purpose — a
non-admin would be turned away by `Admin.AuthPlug` first and every `/admin`
arm would pass for the wrong reason.

With that boundary the worst case of a leaked token is reading and sending as
the account: bad, bounded, revocable, and visible in the owner's device list.

## Where it is accepted

In the `password` field of `POST /auth/login`, checked before the Argon2
ladder and instead of it. Cleaner alternatives exist in the abstract — a
header, a dedicated endpoint — and all of them oblige every client that speaks
to grappa to learn a second authentication mode for no gain. **No client-side
change is required.**

The token IS the bearer, so login answers with the token it was given: a
client that reconnects unattended forever accretes no rows, and revocation
stays one UPDATE.

Two doors behind one input must not become two oracles. A wrong token returns
the same `401 invalid_credentials` as a wrong password, and the login throttle
is charged exactly once per attempt (at the Argon2 branch, never at the token
miss). The arm spends five of the ten-per-window budget on UUID-shaped wrong
passwords, succeeds mid-way to show the budget was not exhausted, spends the
rest, and requires the eleventh attempt to be `429` — the count is what proves
the two doors share one charge.

## Lifecycle

- **No idle expiry.** The sliding seven-day window does not apply, at both
  sites that enforce it: `authenticate/1` and the reaper. A client offline for
  a fortnight comes back to a working credential; revocation is the kill
  switch. The GC and the auth gate have to agree on which rows the window
  governs, not merely on how wide it is.
- **Shown once.** The id is the secret, so `Wire.client_token_to_json/1` is
  id-less by construction and the minting response is the single site that
  renders it. Addressing is by `Session.handle/1` — the truncated SHA-256 the
  operator log already used for the same row, promoted into the schema so the
  log line and the wire cannot drift into two names for one thing.
  `DELETE /me/client-tokens/:handle` therefore revokes without re-presenting
  the secret.
- **Swept with the account's other sessions.** Deliberately NOT special-cased:
  every credential change that already evicts an account's sessions evicts its
  client tokens too. Fail-closed, zero branches, and arming or resetting a
  factor is exactly when a re-issue is wanted. An arm asserts it, so the
  absence of a branch cannot quietly become one.
- **Minting is password-gated**, mirroring `TotpController.start_enrollment`:
  a borrowed browser bearer alone must not issue a credential that outlives
  it. That inherits the sibling's known limitation — an account in passkey
  `passwordless` mode whose owner no longer knows the password cannot mint.
- **Capped at 20 live tokens per account.** Not in #1196; an unbounded
  self-service writer is a hole in a security feature, and the bound keeps
  `handle/1`'s 48 bits collision-free by orders of magnitude. Refused as
  `422 client_token_cap_reached`; revoking one makes room.

## Evidence

`scripts/check.sh` rc=0 — `8 doctests, 57 properties, 5724 tests, 0 failures`,
418 bats. cic `bun run check` rc=0, `bun run test` 5037/273 green,
`gen_wire_types --check` in sync twice.

**Sixteen single-point mutants, one guard at a time removed from production.
All sixteen killed, kill sets disjoint:**

| mutant | dies |
|---|---|
| `:admin_authn` loses the scope gate | 3 (both console arms + router table) |
| the credential scope loses `:full_session` | 9 (`/me` arms + router table) |
| `AdminChannel` drops the session-kind conjunct | 1 |
| `check_idle` loses the `:client` exemption | 1 |
| the reaper loses its `:web` scoping | 1 |
| token lookup stops requiring `kind: :client` | 2 (context + login door) |
| token lookup stops requiring `revoked_at: nil` | 2 |
| token lookup stops pinning the account name | 2 |
| the token query stops scoping to its owner | 2 |
| the wire shape leaks the id | 2 |
| minting drops the password gate | 1 |
| the changeset drops the label validation | 2 |
| the mint cap is raised out of reach | 2 |
| the login door never matches a token | 1 |
| a failed account login charges the window twice | 1 |
| `create_client_token` mints a `:web` row | 39 (blast radius — proves nothing is vacuous) |

**Arms with no unique killer, labelled regression guards rather than counted
as coverage:** the inverse-direction guard that a web session still expires
and is still swept; the sweep-takes-tokens arm; the 404 for an unknown handle
and for another account's; the 400 for an absent password; the visitor 403;
the router test's anti-vacuity arm; and the browser-session controls that pair
each refusal.

**Ordering, stated honestly:** the production code was written before the
arms, so the red for each guard came from displacement rather than
chronologically. Displacement is the stronger measurement, but it is not
test-first and this PR does not claim it was.

## Deploy

**HOT.** The migration is expand-only, and `Grappa.Deploy.Preflight` classifies
it so: Ecto selects named columns, so a node still running the old `Session`
module cannot see the two new ones, and the reload brings schema and column
into agreement in either order. Commit 27bd8d86's message says COLD; 766d650a
corrects it, with the pinned HOT set in `PreflightTest` as the witness.

## Not measured

No integration / e2e run — the stack lane is held elsewhere, so the PR's CI is
the gate for it. cic's static e2e gate (`bun run check`) is green. No browser
UI ships here: minting and the device list are REST verbs, with no cic screen
yet.
