### PR TITLE
cic(#445): pseudo-row dismiss lands on MRU, not $server

### DIFF
--- a/cicchetto/e2e/tests/issue445-pseudo-dismiss-lands-mru.spec.ts
+++ b/cicchetto/e2e/tests/issue445-pseudo-dismiss-lands-mru.spec.ts
@@ -1,0 +1,126 @@
+// #445 — where focus lands when a greyed pseudo-row is dismissed with ×.
+//
+// #71 INC-3 unified the pseudo-row × behind one verb (`dismissPseudoWindow`)
+// and, to keep the desktop behaviour byte-identical, kept the Sidebar's
+// explicit redirect to the network `$server` window. It recorded the target
+// itself as an open product question, because every OTHER window close in
+// the app — /part, a server-side kick, the /disconnect cascade, a query
+// close — lands on the most-recently-viewed window via selection.ts's
+// bucket-E close-watcher. vjt ruled MRU (issue #445, 2026-08-07).
+//
+// MRU is not a different redirect, it is one fewer: the verb stops
+// pre-empting the watcher that already owns every other close target.
+//
+// WHY AN E2E, AND WHY THIS FILE EXISTS AT ALL: the landing is a
+// COMPOSITION of three parties that no unit can hold at once — the ×
+// dropping the windowState key, the server's PART cleanup, and the
+// watcher's live-window scan across channelsBySlug + queryWindowsByNetwork
+// + windowStateByChannel. jsdom sees the first and the third with the
+// second mocked. #902 deleted `issue71-inc3-bottombar-invite.spec.ts`, the
+// only e2e that had ever pinned a pseudo-row dismiss LANDING, and recorded
+// the deletion as a real coverage loss in its commit message; this file
+// takes that coverage back at the `:failed` shape, which — unlike the
+// `:invited` one #902 retired — still exists.
+//
+// The pre-state assertion is load-bearing: `/join` focuses the channel it
+// joins (compose.ts), so the rejected join leaves the greyed row FOCUSED.
+// Without asserting that first, "focus is on the seed channel afterwards"
+// is equally true of a run where focus never left the seed channel.
+//
+// Scope: desktop chromium. The rule is surface-independent by
+// construction — one verb, and since #902 the mobile BottomBar renders no
+// pseudo-rows at all, so there is no second surface left to diverge.
+//
+// CHANNEL CLEANUP: random per-run suffixes; afterEach has the peer quit.
+
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+const KEYED_A = `#i445-a-${crypto.randomUUID().slice(0, 8)}`;
+const KEYED_B = `#i445-b-${crypto.randomUUID().slice(0, 8)}`;
+const CHANNEL_KEY = "porco-dio";
+
+let peer: IrcPeer | null = null;
+
+test.afterEach(async () => {
+  if (peer) {
+    await peer.disconnect("e2e cleanup").catch(() => {});
+    peer = null;
+  }
+});
+
+test("#445 — dismissing a pseudo-row lands on the most-recently-viewed window, never $server", async ({
+  page,
+}) => {
+  // Peer founds two +k channels (auto-opped on the testnet bahamut; see
+  // cp15-b6-pending-to-failed-invite-only.spec.ts for the
+  // NO_CHANOPS_WHEN_SPLIT rationale). Joining either without the key
+  // earns a 475 → `{:join_failed, …}` → a `:failed` greyed pseudo-row.
+  peer = await IrcPeer.connect({ nick: `i445-${crypto.randomUUID().slice(0, 6)}` });
+  for (const ch of [KEYED_A, KEYED_B]) {
+    await peer.join(ch);
+    await peer.mode(ch, "+k", CHANNEL_KEY);
+  }
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+
+  // The seed channel is the MRU entry the dismissal must return to. Only
+  // channel/query focus enters MRU (selection.ts bucket E), so viewing it
+  // is what arms this whole spec.
+  await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: specNick() });
+  await expect(sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL)).toHaveClass(/selected/, {
+    timeout: 10_000,
+  });
+
+  const serverWindow = sidebarWindow(page, NETWORK_SLUG, NETWORK_SLUG);
+
+  // ─── Arm 1: the dismissed row IS the focused window ───
+  await composeSend(page, `/join ${KEYED_A}`);
+
+  const rowA = sidebarWindow(page, NETWORK_SLUG, KEYED_A);
+  // Gate on the typed `join_failed` having landed — `data-window-state`
+  // is the discrete seam (`.sidebar-window-greyed` is shared by every
+  // non-joined state, so it cannot tell `pending` from `failed`).
+  await expect(rowA).toHaveAttribute("data-window-state", "failed", { timeout: 15_000 });
+  // PRE-STATE: `/join` moved focus onto the row that just failed. This is
+  // the exact case INC-3 sent to `$server`.
+  await expect(rowA).toHaveClass(/selected/, { timeout: 10_000 });
+
+  await rowA.locator(".sidebar-close").click();
+
+  await expect(rowA).toHaveCount(0, { timeout: 10_000 });
+  // The ruling: MRU. Pre-#445 this is `$server`, so both halves are said
+  // out loud — the positive alone would also pass if focus went nowhere
+  // and the seed row had merely stayed selected, and the negative alone
+  // would pass on a landing at home.
+  await expect(sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL)).toHaveClass(/selected/, {
+    timeout: 10_000,
+  });
+  await expect(serverWindow).not.toHaveClass(/selected/);
+
+  // ─── Arm 2: the dismissed row is NOT the focused window ───
+  // A × on a row the operator is not looking at is housekeeping, not
+  // navigation: focus must not move at all.
+  await composeSend(page, `/join ${KEYED_B}`);
+
+  const rowB = sidebarWindow(page, NETWORK_SLUG, KEYED_B);
+  await expect(rowB).toHaveAttribute("data-window-state", "failed", { timeout: 15_000 });
+  await expect(rowB).toHaveClass(/selected/, { timeout: 10_000 });
+
+  // Navigate away; the greyed row stays in the sidebar, unfocused.
+  await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: specNick() });
+  await expect(sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL)).toHaveClass(/selected/, {
+    timeout: 10_000,
+  });
+  await expect(rowB).not.toHaveClass(/selected/);
+
+  await rowB.locator(".sidebar-close").click();
+
+  await expect(rowB).toHaveCount(0, { timeout: 10_000 });
+  await expect(sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL)).toHaveClass(/selected/);
+  await expect(serverWindow).not.toHaveClass(/selected/);
+});

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -721,8 +721,9 @@ describe("Sidebar", () => {
   // in archive (one window, two surfaces — vjt dogfood bug).
   // Post-BK: × fires forceParted (drops windowStateByChannel key) →
   // row vanishes; visibleArchiveForNetwork's pseudo-name filter releases
-  // and the archive section shows the row. If the closed pseudo-row WAS
-  // the selected window, selection redirects to $server.
+  // and the archive section shows the row. #445 — the × no longer steers
+  // focus at all; the close-watcher in selection.ts picks the next window
+  // (MRU), the same way it does for every other window close.
   describe("UX-5 bucket BK — pseudo-row × button", () => {
     it("renders an aria-labeled × button on a failed pseudo-row", () => {
       mockWindowState = { "freenode #it-opers": "failed" };
@@ -753,31 +754,24 @@ describe("Sidebar", () => {
       expect(forcePartedMock).toHaveBeenCalledWith("freenode #it-opers");
     });
 
-    it("clicking × on the selected pseudo-row redirects selection to $server", () => {
+    // #445 — the × steers no focus, not even when it closes the window
+    // the operator is looking at. That is the hard case: it is exactly
+    // when INC-3 redirected to `$server`. Where focus goes INSTEAD is not
+    // this component's business and is deliberately not asserted here —
+    // selection.ts's bucket-E close-watcher owns it, and selection.test.ts's
+    // two "#445" arms hold the landing (MRU when focused, unmoved when not).
+    //
+    // The former "clicking × on a non-selected pseudo-row does NOT
+    // redirect selection" sibling was deleted along with the redirect it
+    // guarded: with no focus branch left anywhere on this path, it
+    // differed from this arm only in a `selectedChannel` mock value that
+    // nothing downstream reads. Keeping both would have counted one
+    // behaviour twice.
+    it("clicking × on the SELECTED pseudo-row steers no focus (#445)", () => {
       mockWindowState = { "freenode #it-opers": "failed" };
       vi.spyOn(selMod, "selectedChannel").mockReturnValue({
         networkSlug: "freenode",
         channelName: "#it-opers",
-        kind: "channel",
-      });
-      render(() => <Sidebar />);
-      const closeBtn = screen.getByLabelText("Close #it-opers");
-      fireEvent.click(closeBtn);
-      expect(selMod.setSelectedChannel).toHaveBeenCalledWith({
-        networkSlug: "freenode",
-        channelName: "$server",
-        kind: "server",
-      });
-      expect(forcePartedMock).toHaveBeenCalledWith("freenode #it-opers");
-    });
-
-    it("clicking × on a non-selected pseudo-row does NOT redirect selection", () => {
-      mockWindowState = { "freenode #it-opers": "failed" };
-      // Default selectedChannel mock returns null. Re-mock to a DIFFERENT
-      // selection so we can assert setSelectedChannel is NOT called.
-      vi.spyOn(selMod, "selectedChannel").mockReturnValue({
-        networkSlug: "freenode",
-        channelName: "#italia",
         kind: "channel",
       });
       render(() => <Sidebar />);

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -15,6 +15,11 @@ vi.mock(import("../lib/api"), async (importOriginal) => {
     listChannels: vi.fn().mockResolvedValue([]),
     listMessages: vi.fn(),
     sendMessage: vi.fn(),
+    // #445 — the bucket-E arms below drive the REAL `dismissPseudoWindow`
+    // (lib/windowClose) rather than poking windowState directly, so the
+    // whole dismiss composition is under test. That verb DELETEs upstream;
+    // stub it or the unmocked `fetch` errors on jsdom's relative URL.
+    postPart: vi.fn().mockResolvedValue(undefined),
     // UX-4 bucket D — selection.ts now imports `networks` from
     // `lib/networks` to drive the parked-network → home redirect.
     // networks.ts's `createResource` chain fires `me()` on every token
@@ -1299,6 +1304,113 @@ describe("selection store", () => {
       await new Promise((r) => setTimeout(r, 20));
 
       // The re-joined selection SURVIVES — no focus theft to $server.
+      expect(sel.selectedChannel()?.channelName).toBe("#bofh");
+      expect(sel.selectedChannel()?.kind).toBe("channel");
+      expect(sel.selectedChannel()?.networkSlug).toBe("freenode");
+    });
+
+    // #445 — the × on a greyed pseudo-row (invited/failed/kicked/parked)
+    // lands focus on the MOST-RECENTLY-VIEWED window, exactly like every
+    // other window close. Until #445 `dismissPseudoWindow` pre-empted this
+    // picker with an explicit `$server` redirect (#71 INC-3's unification
+    // target), so a dismissal was the ONE close in the app that ignored
+    // MRU. Deleting that redirect leaves one owner of the close target —
+    // this watcher — per CLAUDE.md "don't duplicate state, derive it".
+    //
+    // These two arms drive the REAL `dismissPseudoWindow` rather than
+    // calling `forceParted` directly: the thing #445 changes is the
+    // COMPOSITION (verb drops the key → this watcher picks the target),
+    // and a test that skips the verb cannot see a redirect put back.
+    it("#445: dismissing the FOCUSED pseudo-row lands on MRU, not $server", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([userNet("freenode", 1, "connected")]);
+      vi.mocked(api.listChannels)
+        .mockResolvedValueOnce([
+          { name: "#bofh", joined: true, source: "autojoin" },
+          { name: "#new", joined: true, source: "joined" },
+        ])
+        .mockResolvedValue([{ name: "#bofh", joined: true, source: "autojoin" }]);
+      const auth = await import("../lib/auth");
+      const sel = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      const windowState = await import("../lib/windowState");
+      const { channelKey } = await import("../lib/channelKey");
+      const { dismissPseudoWindow } = await import("../lib/windowClose");
+      auth.setToken("tokE-445-focused");
+      await vi.waitFor(() => {
+        expect(networks.channelsBySlug()?.freenode?.length).toBe(2);
+      });
+
+      // MRU := [#new, #bofh] — #bofh viewed first, then #new.
+      sel.setSelectedChannel({ networkSlug: "freenode", channelName: "#bofh", kind: "channel" });
+      sel.setSelectedChannel({ networkSlug: "freenode", channelName: "#new", kind: "channel" });
+
+      // Peer KICK turns #new into a greyed pseudo-row: gone from cbs,
+      // still in windowStateByChannel. UX-7-E keeps focus on it (the
+      // operator must see the kick reason) — assert that PRE-STATE, or a
+      // post-dismiss "focus is #bofh" could just mean focus was never on
+      // #new to begin with.
+      windowState.setKicked(channelKey("freenode", "#new"), "operator", "spam");
+      networks.refetchChannels();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(sel.selectedChannel()?.channelName).toBe("#new");
+
+      // The × — the real verb, the whole composition.
+      dismissPseudoWindow("freenode", "#new");
+
+      await vi.waitFor(() => {
+        expect(sel.selectedChannel()?.channelName).toBe("#bofh");
+      });
+      expect(sel.selectedChannel()?.kind).toBe("channel");
+      // Named explicitly: `$server` is the pre-#445 landing, and it is
+      // reachable from here (the network IS connected, so it is this
+      // picker's own step-2 fallback). Only the MRU hit distinguishes.
+      expect(sel.selectedChannel()?.channelName).not.toBe("$server");
+    });
+
+    it("#445: dismissing a NON-focused pseudo-row does not move focus at all", async () => {
+      // The other half of the target rule: a × on a row the operator is
+      // not looking at is housekeeping, not navigation. Green before #445
+      // too (the deleted redirect was already focus-gated) — it is here to
+      // pin the gate that survives the rewrite. Its killer is the
+      // plausible wrong fix: calling the fallback picker from
+      // `dismissPseudoWindow` unconditionally instead of deriving it.
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([userNet("freenode", 1, "connected")]);
+      vi.mocked(api.listChannels)
+        .mockResolvedValueOnce([
+          { name: "#bofh", joined: true, source: "autojoin" },
+          { name: "#new", joined: true, source: "joined" },
+        ])
+        .mockResolvedValue([{ name: "#bofh", joined: true, source: "autojoin" }]);
+      const auth = await import("../lib/auth");
+      const sel = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      const windowState = await import("../lib/windowState");
+      const { channelKey } = await import("../lib/channelKey");
+      const { dismissPseudoWindow } = await import("../lib/windowClose");
+      auth.setToken("tokE-445-unfocused");
+      await vi.waitFor(() => {
+        expect(networks.channelsBySlug()?.freenode?.length).toBe(2);
+      });
+
+      sel.setSelectedChannel({ networkSlug: "freenode", channelName: "#new", kind: "channel" });
+      windowState.setKicked(channelKey("freenode", "#new"), "operator", "spam");
+      networks.refetchChannels();
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Focus AWAY from the pseudo-row; it stays in the sidebar, greyed.
+      sel.setSelectedChannel({ networkSlug: "freenode", channelName: "#bofh", kind: "channel" });
+      await new Promise((r) => setTimeout(r, 20));
+      expect(sel.selectedChannel()?.channelName).toBe("#bofh");
+
+      dismissPseudoWindow("freenode", "#new");
+
+      await new Promise((r) => setTimeout(r, 20));
       expect(sel.selectedChannel()?.channelName).toBe("#bofh");
       expect(sel.selectedChannel()?.kind).toBe("channel");
       expect(sel.selectedChannel()?.networkSlug).toBe("freenode");

--- a/cicchetto/src/__tests__/windowClose.test.ts
+++ b/cicchetto/src/__tests__/windowClose.test.ts
@@ -69,10 +69,13 @@ vi.mock("../lib/windowState", () => ({
   forceParted: vi.fn(),
 }));
 
-// dismissPseudoWindow (#71 INC-3) imports selection to redirect focus off a
-// dismissed, currently-focused pseudo-row. Mock it as controllable spies —
-// same "boundary spy, don't pull the reactive chain" rationale as the
-// windowState mock above.
+// #445 — windowClose no longer imports selection AT ALL: the pseudo-row ×
+// stopped steering focus and left the target to selection.ts's bucket-E
+// close-watcher. These spies stay as the tripwire for putting a redirect
+// back — mocking the module means ANY future import of it from this unit
+// routes through them, so a re-added `setSelectedChannel` call is visible
+// here even though the green run never touches them. Where focus actually
+// LANDS is selection.test.ts's business (the two #445 bucket-E arms).
 const selectedChannelMock = vi.hoisted(() => vi.fn<() => unknown>());
 const setSelectedChannelMock = vi.hoisted(() => vi.fn());
 vi.mock("../lib/selection", () => ({
@@ -209,16 +212,18 @@ describe("disconnectNetwork — registered-user branch", () => {
   });
 });
 
-// #71 INC-3 — dismissPseudoWindow is THE shared verb behind the × on a
-// non-joined pseudo-row (invited/failed/kicked/parked): drop its
-// windowState key AND, if the row was the FOCUSED window, redirect to the
-// network's $server window BEFORE dropping it. Both the desktop Sidebar
-// and the mobile BottomBar route their pseudo-row × through this — one
-// implementation, one navigation outcome on both surfaces (the divergence
-// the INC-3 review caught: BottomBar previously did a raw setParted and
-// let the bucket-E watcher pick MRU). The $server-vs-MRU destination is a
-// deferred product choice (DESIGN_NOTES 2026-07-26 + follow-up issue).
-describe("dismissPseudoWindow — drops a pseudo-row, redirects if it was focused", () => {
+// #71 INC-3 / #445 — dismissPseudoWindow is THE shared verb behind the ×
+// on a non-joined pseudo-row (failed/kicked/parked): drop its windowState
+// key, forward the PART, and NOTHING ELSE. INC-3 unified the two surfaces
+// on the Sidebar's explicit `$server` redirect and deferred whether that
+// was the right destination; #445 answered MRU, which is not a different
+// redirect but ONE FEWER — the bucket-E close-watcher already picks MRU
+// for every other close, so the verb stops pre-empting it.
+//
+// Consequently this file no longer pins a destination: it pins the two
+// side effects the verb still owns, plus the negative (it steers no
+// focus). The destination lives with its owner, in selection.test.ts.
+describe("dismissPseudoWindow — drops a pseudo-row; the landing is bucket E's", () => {
   // #511 — a × on an :invited pseudo-row USED to be client-only
   // (forceParted only), so the server kept `window_states[ch] = :invited`
   // and #482's cold-subscribe backfill re-emitted `window_invited` on the
@@ -262,10 +267,27 @@ describe("dismissPseudoWindow — drops a pseudo-row, redirects if it was focuse
     const { dismissPseudoWindow } = await import("../lib/windowClose");
     dismissPseudoWindow("freenode", "#inv");
     expect(windowState.forceParted).toHaveBeenCalledWith(channelKey("freenode", "#inv"));
-    expect(setSelectedChannelMock).not.toHaveBeenCalled();
   });
 
-  it("redirects focus to the network $server window when the dismissed pseudo-row IS the focused one", async () => {
+  // #445 — the hardest case for the deleted redirect: the dismissed row IS
+  // the focused one, which is precisely when INC-3 steered to `$server`.
+  // The verb must now steer nowhere and let the drop speak for itself.
+  //
+  // Stated plainly: on green this asserts a mock that is never reached,
+  // because the module under test no longer imports selection. That is
+  // what makes it a tripwire rather than coverage — it kills exactly one
+  // mutant (put the redirect back) and measures no behaviour of its own.
+  // The behaviour — where focus goes instead — is selection.test.ts's
+  // "#445: dismissing the FOCUSED pseudo-row lands on MRU, not $server".
+  //
+  // The former "does NOT redirect when a DIFFERENT window is focused"
+  // sibling was DELETED with the redirect it guarded: with no focus
+  // branch left in the verb, it differed from this arm only in a mock
+  // return value neither test's subject reads. Its real content — a ×
+  // on an unfocused row must not steal focus — now lives in
+  // selection.test.ts's "#445: ... NON-focused ..." arm, against the
+  // watcher that genuinely branches on the selection.
+  it("steers NO focus, even when the dismissed pseudo-row is the focused window (#445)", async () => {
     selectedChannelMock.mockReturnValue({
       networkSlug: "freenode",
       channelName: "#inv",
@@ -273,30 +295,11 @@ describe("dismissPseudoWindow — drops a pseudo-row, redirects if it was focuse
     });
     const auth = await import("../lib/auth");
     auth.setToken("utok");
-    const { SERVER_WINDOW_NAME } = await import("../lib/windowKinds");
     const windowState = await import("../lib/windowState");
     const { channelKey } = await import("../lib/channelKey");
     const { dismissPseudoWindow } = await import("../lib/windowClose");
     dismissPseudoWindow("freenode", "#inv");
-    // Redirect fires BEFORE the drop (pre-empts the bucket-E MRU pick).
-    expect(setSelectedChannelMock).toHaveBeenCalledWith({
-      networkSlug: "freenode",
-      channelName: SERVER_WINDOW_NAME,
-      kind: "server",
-    });
-    expect(windowState.forceParted).toHaveBeenCalledWith(channelKey("freenode", "#inv"));
-  });
-
-  it("does NOT redirect when a DIFFERENT window is focused (no focus steal)", async () => {
-    selectedChannelMock.mockReturnValue({
-      networkSlug: "freenode",
-      channelName: "#other",
-      kind: "channel",
-    });
-    const auth = await import("../lib/auth");
-    auth.setToken("utok");
-    const { dismissPseudoWindow } = await import("../lib/windowClose");
-    dismissPseudoWindow("freenode", "#inv");
     expect(setSelectedChannelMock).not.toHaveBeenCalled();
+    expect(windowState.forceParted).toHaveBeenCalledWith(channelKey("freenode", "#inv"));
   });
 });

--- a/cicchetto/src/lib/windowClose.ts
+++ b/cicchetto/src/lib/windowClose.ts
@@ -3,8 +3,6 @@ import { getSubject, token } from "./auth";
 import { channelKey } from "./channelKey";
 import { requestConfirm } from "./confirmDialog";
 import { closeQueryWindowState } from "./queryWindows";
-import { selectedChannel, setSelectedChannel } from "./selection";
-import { SERVER_WINDOW_NAME } from "./windowKinds";
 import { forceParted } from "./windowState";
 
 // Shared close-window helpers. Two call sites today: Sidebar × on
@@ -78,13 +76,16 @@ export function closeQueryWindow(networkId: number, targetNick: string): void {
 
 // #71 INC-3 — THE shared verb for dismissing a non-joined pseudo-row
 // (pending/failed/kicked/parked) via its ×. Was previously inline in
-// Sidebar.handleClosePseudo; the mobile bar's raw setParted let the
-// bucket-E close-watcher pick MRU, a per-surface divergence the INC-3
-// review caught. #902 left the desktop Sidebar its only caller — the mobile
-// BottomBar's sole pseudo-row was the `:invited` tab, and that is a banner
-// now — but the verb stays HERE rather than moving back inline: it is a
-// window-lifecycle verb, and the file it lives in is the one that owns the
-// PART.
+// Sidebar.handleClosePseudo, where a per-surface divergence had grown:
+// the mobile bar's raw setParted deferred to the bucket-E close-watcher
+// while the Sidebar redirected to $server — same action, two navigations.
+// INC-3 unified on the Sidebar's spelling to keep the change behaviour-
+// free; #445 has since settled the target the other way (see below), so
+// the surviving unification is the VERB, not the destination. #902 left
+// the desktop Sidebar its only caller — the mobile BottomBar's sole
+// pseudo-row was the `:invited` tab, and that is a banner now — but the
+// verb stays HERE rather than moving back inline: it is a window-lifecycle
+// verb, and the file it lives in is the one that owns the PART.
 //
 // #511 — the dismissal goes through the SAME `partAndForget` DELETE path
 // `closeChannelWindow` uses, not a client-only `forceParted`. Pre-fix this
@@ -97,20 +98,24 @@ export function closeQueryWindow(networkId: number, targetNick: string): void {
 // banner takes its own DELETE door instead (#902 removed the row, #976 gave
 // the refusal its own verb).
 //
-// If the dismissed row IS the focused window, redirect to the network's
-// $server window FIRST, pre-empting the bucket-E watcher (which would
-// otherwise pick the most-recently-viewed window). $server-vs-MRU is a
-// deferred product choice — see DESIGN_NOTES 2026-07-26 #71 INC-3 + the
-// follow-up issue; today both surfaces land on $server. The redirect runs
-// before `partAndForget`, so in the (unreachable in-UI) no-token case focus
-// still moves to $server while the row stays put — harmless because a
-// pseudo-row is never rendered without a token; revisit only if some
-// token-expiry edge ever makes this path reachable.
+// #445 — this verb steers NO focus. INC-3 shipped an explicit "if the
+// dismissed row is the focused window, go to $server" redirect here and
+// deferred whether $server was the right destination; vjt ruled MRU. That
+// ruling deletes code rather than replacing it: selection.ts's bucket-E
+// close-watcher ALREADY resolves MRU → $server → home for every other
+// close in the app (/part, a server-side kick, the /disconnect cascade, a
+// query close), and it fires here too the moment `forceParted` drops the
+// key — a pseudo-row is live to that watcher precisely because
+// `windowIsPresent` says so (UX-7-E). The old redirect's only effect was
+// to PRE-EMPT it, making the dismissal the one close that ignored MRU.
+// Removing it leaves one owner of the close target, per CLAUDE.md "don't
+// duplicate state — derive it".
+//
+// Do not re-add a redirect here, not even "to MRU": calling the picker
+// from this side would duplicate the derivation AND fire for an unfocused
+// row, stealing focus from a window the operator is looking at. The
+// watcher is focus-gated by construction; this verb must not be.
 export function dismissPseudoWindow(networkSlug: string, name: string): void {
-  const sel = selectedChannel();
-  if (sel !== null && sel.networkSlug === networkSlug && sel.channelName === name) {
-    setSelectedChannel({ networkSlug, channelName: SERVER_WINDOW_NAME, kind: "server" });
-  }
   partAndForget(networkSlug, name);
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37868,3 +37868,71 @@ surface. `/ame` is a builtin in the only sense #427 leaves available: it is in
 that comment exists to prevent. The alias engine still cannot express iteration,
 so none of this is user-scriptable today, and nothing here is pre-built for a
 future iteration primitive.
+
+---
+
+## 2026-08-10 — #445: the pseudo-row dismiss target is MRU, which means one redirect fewer
+
+vjt ruled MRU on the question #71 INC-3 deferred: where focus lands when the ×
+on a greyed pseudo-row (`:failed` / `:kicked` / `:parked`) closes the window
+the operator is looking at. INC-3 had unified the two surfaces on the
+Sidebar's explicit redirect to the network `$server` window — deliberately the
+zero-behaviour-change spelling — and recorded the destination itself as an
+open product question, because every OTHER close in the app lands on the
+most-recently-viewed window.
+
+**The ruling deletes code; it does not replace it.** selection.ts's bucket-E
+close-watcher already resolves MRU → `$server` → home for /part, a
+server-side kick, the /disconnect cascade and a query close, and it already
+fires on this path: a pseudo-row is live to that watcher precisely because
+`windowIsPresent` says so (UX-7-E), so `forceParted` dropping the key IS the
+vanish transition it arms on. The redirect's only effect was to pre-empt it,
+which is what made a dismissal the one close that ignored MRU. Removing it
+leaves one owner of the close target, and `windowClose` stops importing
+`selection` altogether.
+
+**An explicit MRU redirect from the verb was rejected**, not merely unneeded.
+It would duplicate the derivation — the failure mode CLAUDE.md's
+"derive, don't duplicate" names — and it would fire for an UNFOCUSED row,
+stealing focus from a window the operator is looking at. The watcher is
+focus-gated by construction; the verb must not be gated at all. That is
+written into the verb as a "do not re-add this" note, because the wrong fix
+here looks like the right one.
+
+**The brief's cross-reference was falsified, and the falsification is the
+result.** It said to update "the INC-3 e2e assert pinning the landing on
+`$server`". No such assert exists: #902 deleted
+`issue71-inc3-bottombar-invite.spec.ts` outright — its subject, the
+`:invited` slice in the mobile BottomBar, no longer exists in any form — and
+that commit says so in as many words, recording the pseudo-row dismiss path
+as left with no e2e at all, "a real coverage loss". #445 takes the coverage
+back rather than editing an assert that was already gone, at the `:failed`
+shape, which unlike `:invited` is still a pseudo-row.
+
+A THIRD site pinned `$server` that no one had listed: `Sidebar.test.tsx`'s
+"clicking × on the selected pseudo-row redirects selection to $server". It
+surfaced by running the suite, not by grepping the brief's file list. Both it
+and its windowClose sibling are now negatives — the verb steers no focus even
+in the case INC-3 sent to `$server` — and both are labelled IN PLACE as
+tripwires for re-adding a redirect rather than as coverage of where focus
+lands, since on green neither reaches the mock it asserts against. Their two
+"non-selected row does not redirect" siblings were deleted with the branch
+they guarded: with no focus branch left, each differed from its partner only
+in a mock value nothing downstream reads.
+
+**Measured.** The e2e read red before the fix with the seed row's class as
+`""` while focus sat on `$server`; the unit landing arm read
+`expected '$server' to be '#bofh'`. Two mutants in the verb: restoring the
+gated redirect kills the focused-landing arm plus both tripwires and leaves
+the unfocused arm passing (so deleting the redirect is load-bearing);
+INVERTING the gate kills exactly one assertion, the unfocused arm (so that
+arm is coverage, not a regression guard).
+
+**Not proven: that the rule holds across surfaces.** The brief asked for a
+mutant where a Sidebar/BottomBar divergence breaks an arm. There is no second
+surface to diverge: since #902 `navPseudoChannelsForNetwork` returns `[]` on
+mobile and the BottomBar renders no pseudo-row at all, leaving
+`dismissPseudoWindow` exactly one caller. The claim is true by construction
+and untestable by mutation; it would become testable again only if a mobile
+pseudo-row came back, and inventing one to test it would have been inventing
+product.


### PR DESCRIPTION
Ruling from #445 (vjt, 2026-08-07): the × on a greyed pseudo-row
(`:failed` / `:kicked` / `:parked`) should land focus on the
most-recently-viewed window, not the network `$server` window that #71
INC-3 had unified both surfaces on.

## What changed

MRU is **one redirect fewer, not a different one**. selection.ts's bucket-E
close-watcher already resolves MRU → `$server` → home for every other close
(`/part`, a server-side kick, the `/disconnect` cascade, a query close), and
it already fires on this path — a pseudo-row is live to it precisely because
`windowIsPresent` says so (UX-7-E), so `forceParted` dropping the key is the
vanish transition it arms on. `dismissPseudoWindow`'s explicit redirect only
pre-empted it. Deleting it leaves one owner of the close target;
`windowClose` no longer imports `selection` at all.

An explicit *MRU* redirect from the verb was rejected, not merely unneeded:
it duplicates the derivation, and it would fire for an **unfocused** row,
stealing focus from a window the operator is looking at. The watcher is
focus-gated by construction; the verb must not be gated at all. That is
written into the verb as a "do not re-add this" note.

## Two corrections to the map

* **The INC-3 e2e assert this was supposed to update does not exist.** #902
  deleted `issue71-inc3-bottombar-invite.spec.ts` outright and recorded the
  pseudo-row dismiss path as left with no e2e — "a real coverage loss and is
  recorded as such". So this adds a new spec at the `:failed` shape instead
  of editing an assert that was already gone.
* **A third site pinned `$server`** that was not on anyone's list:
  `Sidebar.test.tsx`. It surfaced by running the suite, not by grepping.

## Evidence

* **Red read, not deduced.** e2e pre-fix: the seed row's class was `""` while
  focus sat on `$server`. Unit pre-fix: `expected '$server' to be '#bofh'`.
* **Mutant A** — restore the gated redirect: kills the focused-landing arm
  plus both tripwires; the unfocused arm keeps passing. Deleting the redirect
  is load-bearing.
* **Mutant C** — invert the focus gate: kills **exactly one** assertion, the
  unfocused arm. That arm is coverage, not a regression guard.
* The two remaining `$server`-era negatives (windowClose, Sidebar) are
  labelled in place as **tripwires**, not coverage: on green neither reaches
  the mock it asserts against. Their "non-selected row does not redirect"
  siblings were deleted with the branch they guarded.
* Gates on the rebased tree (base `cd6e73cb`): `bun run check` rc=0 (biome +
  tsc src + tsc e2e), vitest 275 files / 5118 tests green, working tree clean
  before and after. `docs/DESIGN_NOTES.md` contributes 68/0 lines — measured
  by `--numstat` after each of two rebases, both of which silently ate the
  `---` separator and both times had it amended back into the docs commit.

## e2e attribution

Three full-suite runs and one iso: two on this branch, one on a detached
baseline at the branch's then-base (one variable — this change — removed).

| spec | baseline | branch run 1 | branch run 2 | verdict |
|---|---|---|---|---|
| `issue168-scroll-authority` (paged UP → send) | ✘ | ✘ | ✘ | pre-existing, recurring |
| `p0b-peer-away` | ✘ | ✘ | ✓ | pre-existing, flaky |
| `ux-2-mobile-archive` @webkit | ✓ | ✘ | ✓ | one sample only, did not recur |
| `ux-z-cluster-journey` @webkit | ✓ | ✘ | ✓ | one sample only, did not recur |
| `slash-commands-bundle` `/q` closes the window | ✓ | ✓ | ✘ | **open**, see below |

The `#445` spec itself is green in every run it appears in, and all four
originally-failing specs pass in an iso re-run.

## Open, and not to be waved through

`slash-commands-bundle › /q on a query window closes that window (bucket B)`
failed once, on run 2 only: the peer's sidebar `li` did not reach count 0.
That is the close-window neighbourhood, so it does not get a "looks
unrelated" pass on inspection alone — but this diff touches neither
`closeQueryWindow` nor `closeQueryWindowState` nor the sidebar's query row,
and one sample attributes nothing either way. It needs one iso re-run before
merge; the e2e lane is currently held elsewhere.

## Not proven

The rule holding **across surfaces** cannot be mutated: since #902
`navPseudoChannelsForNetwork` returns `[]` on mobile and the BottomBar renders
no pseudo-row, so `dismissPseudoWindow` has exactly one caller. True by
construction, untestable — and inventing a mobile pseudo-row to test it would
have been inventing product.