### PR TITLE
cic(#431): /ame and /amsg, paced against the door that decides

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -4291,13 +4291,18 @@ describe("compose /ame + /amsg fan-out (#431)", () => {
 // mode this describe exists to keep out.
 describe("compose /ame + /amsg pacing against the send door (#431)", () => {
   const k = channelKey("freenode", "#a");
-  const TEN = ["#c01", "#c02", "#c03", "#c04", "#c05", "#c06", "#c07", "#c08", "#c09", "#c10"];
+  // SEVEN, not ten: enough to outrun the bucket's five-token burst, few enough
+  // to stay clear of the confirm gate. At ten this arm sat exactly on the
+  // threshold and died to a mutant that moved it — a coupling in the test, not
+  // in the product, which made "the pacing broke" and "the gate moved" report
+  // as the same failure.
+  const SEVEN = ["#c01", "#c02", "#c03", "#c04", "#c05", "#c06", "#c07"];
 
   it("waits the door's own retry-after and retries the refused channel — no drop, no dup", async () => {
     vi.useFakeTimers();
     try {
       localStorage.setItem("grappa-token", "tok");
-      await setWindows(joinedOn("freenode", TEN));
+      await setWindows(joinedOn("freenode", SEVEN));
       const sb = await import("../lib/scrollback");
       const api = await import("../lib/api");
       const compose = await import("../lib/compose");
@@ -4322,7 +4327,7 @@ describe("compose /ame + /amsg pacing against the send door (#431)", () => {
 
       // Paused on the refusal: five delivered, the sixth refused, and the door
       // has NOT been hit again. A fan-out that swallowed the 429 would already
-      // be at ten here — and would have dropped #c06 on the way.
+      // be at seven here — and would have dropped #c06 on the way.
       await vi.advanceTimersByTimeAsync(0);
       expect(targetsOf(sb)).toEqual(["#c01", "#c02", "#c03", "#c04", "#c05", "#c06"]);
 
@@ -4344,11 +4349,8 @@ describe("compose /ame + /amsg pacing against the send door (#431)", () => {
         "#c06",
         "#c06",
         "#c07",
-        "#c08",
-        "#c09",
-        "#c10",
       ]);
-      expect(await done).toEqual({ ok: `/amsg: sent to ${TEN.join(", ")}` });
+      expect(await done).toEqual({ ok: `/amsg: sent to ${SEVEN.join(", ")}` });
     } finally {
       vi.useRealTimers();
     }

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
-import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
 import { BLANK_BODY_ERROR, serverAcceptsBody } from "./serverBodyPredicate";
 
 vi.mock("../lib/api", () => {
@@ -4129,5 +4129,295 @@ describe("compose submit — $server slash-only gate (CP13 S9)", () => {
     expect(result).not.toEqual({
       error: "Server window accepts only slash-commands. Try /raw <line>",
     });
+  });
+});
+
+// #431 — /ame + /amsg: one message per JOINED channel of the CURRENT network.
+//
+// The fan-out list is derived from the server-owned `windowStateByChannel`
+// projection, the same one #30's channel tab-completion reads — no parallel
+// client-side channel list to drift. Three things are load-bearing here and
+// each has its own arm below: WHICH windows are targets (only `joined`), the
+// confirm gate above 10 channels, and the pacing against the send door.
+type ScrollbackModule = typeof import("../lib/scrollback");
+
+// The window-state map compose reads its fan-out list from. Seeded per test so
+// each arm states exactly which windows exist and in which state.
+const setWindows = async (states: Record<string, string>): Promise<void> => {
+  const ws = await import("../lib/windowState");
+  vi.mocked(ws.windowStateByChannel).mockReturnValue(
+    states as unknown as ReturnType<typeof ws.windowStateByChannel>,
+  );
+};
+
+const joinedOn = (slug: string, names: string[]): Record<string, string> =>
+  Object.fromEntries(names.map((n) => [channelKey(slug, n), "joined"]));
+
+// The wire log: who each PRIVMSG was addressed to, and what went out. Read off
+// the send stub in call order, so a drop shows as a missing entry and a
+// duplicate as a repeated one.
+const targetsOf = (sb: ScrollbackModule): string[] =>
+  vi.mocked(sb.sendMessage).mock.calls.map((c) => c[1]);
+
+const bodiesOf = (sb: ScrollbackModule): string[] =>
+  vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2]);
+
+describe("compose /ame + /amsg fan-out (#431)", () => {
+  const k = channelKey("freenode", "#a");
+
+  it("fans out to every joined channel of THIS network, and no other network's", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows({
+      ...joinedOn("freenode", ["#a", "#b"]),
+      ...joinedOn("libera", ["#z"]),
+    });
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg back in ten");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(targetsOf(sb).sort()).toEqual(["#a", "#b"]);
+    expect(bodiesOf(sb)).toEqual(["back in ten", "back in ten"]);
+  });
+
+  // THE exclusion arm. vjt's constraint 1 names queries / $server / the invite
+  // window; of those only the invite window can be a key in this map at all
+  // (queries live in `queryWindows`, $server is never joined — verified at the
+  // feeders: subscribe.ts's "joined" arm and userTopic.ts's, both channel-keyed
+  // by construction). What DOES the excluding is the `joined` predicate, and it
+  // covers the invite window along with every other not-actually-in-it state.
+  // Widening it to "present in the map" kills this.
+  it("targets only JOINED windows — never invited/pending/failed/kicked/parked", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows({
+      [channelKey("freenode", "#a")]: "joined",
+      [channelKey("freenode", "#invited")]: "invited",
+      [channelKey("freenode", "#pending")]: "pending",
+      [channelKey("freenode", "#failed")]: "failed",
+      [channelKey("freenode", "#kicked")]: "kicked",
+      [channelKey("freenode", "#parked")]: "parked",
+    });
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(targetsOf(sb)).toEqual(["#a"]);
+  });
+
+  it("/ame frames every copy as a CTCP ACTION", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows(joinedOn("freenode", ["#a", "#b"]));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/ame waves");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(bodiesOf(sb)).toEqual(["\x01ACTION waves\x01", "\x01ACTION waves\x01"]);
+  });
+
+  it("/amsg sends plain text — no ACTION framing", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows(joinedOn("freenode", ["#a", "#b"]));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg waves");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(bodiesOf(sb)).toEqual(["waves", "waves"]);
+  });
+
+  it("the reply echoes the target list", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows(joinedOn("freenode", ["#b", "#a"]));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    expect(await compose.submit(k, "freenode", "#a")).toEqual({
+      ok: "/amsg: sent to #a, #b",
+    });
+  });
+
+  it("no joined channel on this network is an error, and the draft survives it", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows(joinedOn("libera", ["#z"]));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    const r = await compose.submit(k, "freenode", "#a");
+
+    expect(r).toEqual({ error: "/amsg: no joined channel on freenode" });
+    expect(vi.mocked(sb.sendMessage)).not.toHaveBeenCalled();
+    expect(compose.getDraft(k)).toBe("/amsg hi");
+  });
+
+  // The fan-out is per-NETWORK, not per-window: typing it in the $server window
+  // (which has no IRC target of its own) still reaches the network's channels.
+  it("fans out from the $server window too — the source window is not the target", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setWindows(joinedOn("freenode", ["#a", "#b"]));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+
+    const serverKey = channelKey("freenode", SERVER_WINDOW_NAME);
+    compose.setDraft(serverKey, "/amsg hi");
+    await compose.submit(serverKey, "freenode", SERVER_WINDOW_NAME);
+
+    expect(targetsOf(sb).sort()).toEqual(["#a", "#b"]);
+  });
+});
+
+// #431 constraint 2 — PACING, and this is the part that can do real harm.
+//
+// The send door is the #340 per-(subject, network) token bucket: capacity 5,
+// refill 0.5/s, and it is deliberately tuned to refuse BEFORE the ircd's flood
+// protection kills the connection (messages_controller `take_send_token`). So
+// honouring ITS retry-after IS the pacing — the same #666 verb a multi-line
+// paste already drains through, over channels instead of lines. A fan-out that
+// treats the 429 as fatal, or that ignores the server's hint, is the failure
+// mode this describe exists to keep out.
+describe("compose /ame + /amsg pacing against the send door (#431)", () => {
+  const k = channelKey("freenode", "#a");
+  const TEN = ["#c01", "#c02", "#c03", "#c04", "#c05", "#c06", "#c07", "#c08", "#c09", "#c10"];
+
+  it("waits the door's own retry-after and retries the refused channel — no drop, no dup", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      await setWindows(joinedOn("freenode", TEN));
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+
+      // The bucket admits its 5-token burst, then refuses the 6th ONCE with a
+      // retry_after of 3s — deliberately NOT the 2s client-side default, so an
+      // implementation that ignores the server's hint is a distinct mutant from
+      // one that has no pacing at all.
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 6 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 3 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "/amsg back in ten");
+      const done = compose.submit(k, "freenode", "#a");
+
+      // Paused on the refusal: five delivered, the sixth refused, and the door
+      // has NOT been hit again. A fan-out that swallowed the 429 would already
+      // be at ten here — and would have dropped #c06 on the way.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(targetsOf(sb)).toEqual(["#c01", "#c02", "#c03", "#c04", "#c05", "#c06"]);
+
+      // Still waiting at the client-side default. The server said three.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(targetsOf(sb)).toHaveLength(6);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // #c06 appears twice on the CALL log — refused, then delivered — and
+      // every other channel exactly once. Advancing past a refusal would drop
+      // it; restarting the fan-out would duplicate the five before it.
+      expect(targetsOf(sb)).toEqual([
+        "#c01",
+        "#c02",
+        "#c03",
+        "#c04",
+        "#c05",
+        "#c06",
+        "#c06",
+        "#c07",
+        "#c08",
+        "#c09",
+        "#c10",
+      ]);
+      expect(await done).toEqual({ ok: `/amsg: sent to ${TEN.join(", ")}` });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// #431 constraint 3 — the blast-radius gate. One keystroke that writes to N
+// channels is a spam vector, so above TEN channels the fan-out asks first and
+// the question names every target. Ten is a DECIDED number (vjt, 2026-08-09):
+// the pair of arms below pins it from both sides, so moving the threshold one
+// step in either direction kills exactly one of them.
+describe("compose /ame + /amsg confirmation above ten channels (#431)", () => {
+  const k = channelKey("freenode", "#a");
+  const chans = (n: number): string[] =>
+    Array.from({ length: n }, (_, i) => `#c${String(i + 1).padStart(2, "0")}`);
+
+  const setJoined = (names: string[]): Promise<void> => setWindows(joinedOn("freenode", names));
+
+  it("ten channels go out without asking", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setJoined(chans(10));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const dialog = await import("../lib/confirmDialog");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(targetsOf(sb)).toEqual(chans(10));
+    expect(dialog.confirmRequest()).toBeNull();
+  });
+
+  it("eleven channels send NOTHING until the operator confirms, and the question names them all", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setJoined(chans(11));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const dialog = await import("../lib/confirmDialog");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(sb.sendMessage)).not.toHaveBeenCalled();
+    const req = dialog.confirmRequest();
+    expect(req).not.toBeNull();
+    // The blast radius is the point of the dialog: it states the count AND
+    // spells out every channel, so "11" is never the only thing on screen.
+    expect(req?.body).toContain("11 channels");
+    for (const c of chans(11)) expect(req?.body).toContain(c);
+
+    dialog.acceptConfirm();
+    await vi.waitFor(() => expect(targetsOf(sb)).toEqual(chans(11)));
+  });
+
+  it("dismissing the question sends nothing at all", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    await setJoined(chans(11));
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const dialog = await import("../lib/confirmDialog");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "/amsg hi");
+    await compose.submit(k, "freenode", "#a");
+    dialog.dismissConfirm();
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(vi.mocked(sb.sendMessage)).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1546,3 +1546,46 @@ describe("parseSlash — /ping (#591)", () => {
     expect(parseSlash("/ping bob junk here")).toEqual({ kind: "ping", target: "bob" });
   });
 });
+
+// #431 — /ame and /amsg: the mIRC "say it in every channel" pair. The parser's
+// whole job is the body; WHICH channels, the confirm gate and the pacing all
+// live in compose.ts (this module stays pure — no store reads).
+describe("parseSlash — /ame + /amsg fan-out (#431)", () => {
+  it("/ame <text> parses to {kind:'ame', body}", () => {
+    expect(parseSlash("/ame waves at everyone")).toEqual({
+      kind: "ame",
+      body: "waves at everyone",
+    });
+  });
+
+  it("/amsg <text> parses to {kind:'amsg', body}", () => {
+    expect(parseSlash("/amsg back in ten")).toEqual({ kind: "amsg", body: "back in ten" });
+  });
+
+  // Unlike /me (whose empty body is a legal, if pointless, one-window ACTION),
+  // an empty fan-out is N empty frames the send door refuses one at a time.
+  it("bare /ame → error (a body is required)", () => {
+    expect(parseSlash("/ame")).toEqual({
+      kind: "error",
+      verb: "ame",
+      message: "/ame requires a message",
+    });
+  });
+
+  it("bare /amsg → error (a body is required)", () => {
+    expect(parseSlash("/amsg")).toEqual({
+      kind: "error",
+      verb: "amsg",
+      message: "/amsg requires a message",
+    });
+  });
+
+  // #431 constraint 4 as MEASURED, not as the issue text spells it: the issue
+  // says builtins are "never shadowed by a user alias (#427)", but #427 ruled
+  // the opposite — an alias shadows ANY builtin except the fixed two-name
+  // repair surface (/alias, /unalias). /ame is a builtin, so it inherits the
+  // rule that actually exists. Adding "ame" to NON_SHADOWABLE_VERBS kills this.
+  it("a user alias shadows /ame like any other builtin — #427", () => {
+    expect(parseSlash("/ame hello", { ame: "me" })).toEqual({ kind: "me", body: "hello" });
+  });
+});

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -15,6 +15,7 @@ import { openBanlistModal } from "./banlistModal";
 import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
+import { requestConfirm } from "./confirmDialog";
 import { scrubCtcpDelimiters } from "./ctcpAction";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
@@ -247,14 +248,20 @@ const DEFAULT_RETRY_AFTER_MS = 2_000;
 // waits, this bounds their DURATION).
 const MAX_RETRY_AFTER_MS = 60_000;
 
-// Safety valve: how many times ONE line is re-paced against a persistent 429
+// Safety valve: how many times ONE send is re-paced against a persistent 429
 // before the fan-out gives up and surfaces the throttle. An honest send door
 // admits on the FIRST retry once a token has refilled (we waited its own
 // retry-after), so the cap is only reached by a door that refuses PAST its own
 // hint (a misbehaving/severed server, or a proxy 429) — the guard that keeps
 // the composer from hanging on an unbounded retry loop. Generous enough to
 // absorb timer jitter around the refill boundary.
-const MAX_PACED_RETRIES_PER_LINE = 5;
+const MAX_PACED_RETRIES_PER_SEND = 5;
+
+// #431 — above this many channels an /ame|/amsg asks before it writes anything.
+// A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
+// writes to N channels is a spam vector, and ten is where a fan-out stops
+// reading as "the rooms I am in" and starts reading as a broadcast.
+const FANOUT_CONFIRM_THRESHOLD = 10;
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -275,59 +282,73 @@ const retryAfterMs = (e: ApiError): number => {
   return Math.min(ms, MAX_RETRY_AFTER_MS);
 };
 
-// Split a free-text body into one PRIVMSG per line (see messageLines.ts for
-// the wire-framing why) and send each, in order. `action` wraps every line in
-// CTCP ACTION framing for /me (via the shared `ctcpFrame` builder). Sequential
-// await preserves wire order; a single-line body loops exactly once (the
-// common path). Shared by the privmsg, me, and msg send sites — the only
-// free-text paths whose body can contain an operator-typed newline.
+// One outbound PRIVMSG: which target, which line of the body. The line is held
+// UNFRAMED (the CTCP wrap happens at the door) so the residue callback can hand
+// the operator back what they typed rather than what went on the wire.
+type PacedSend = { target: string; line: string };
+
+// Expand a body into the ordered send plan for `targets`, TARGET-MAJOR: every
+// line of the body for the first target, then every line for the second, and so
+// on. One target is the #666 single-window case (a paste = one PRIVMSG per
+// line, see messageLines.ts for the wire-framing why); N targets is the #431
+// /ame|/amsg fan-out. Building ONE flat plan rather than nesting a per-target
+// drain inside a per-line one is what keeps the retry safe: a paced retry
+// re-sends exactly one (target, line), never a target whose earlier lines
+// already landed.
 //
-// #666 — a send-door 429 retries the SAME line after the server's retry-after
-// (never advancing `sent` past a refusal → never a drop, never a dup); any
-// other error stops and propagates. `onProgress` (optional) fires after every
-// acked line AND before every pace/stop, with the count sent so far and the
-// unsent remainder joined back into a body — compose `submit` mirrors that
-// remainder into the draft so it holds ONLY what has not gone out. External
-// callers (ServiceModal, RegistrationWizardModal) pass no callback and simply
-// inherit the never-drop + pacing behaviour.
-export const sendBodyLines = async (
-  slug: string,
-  target: string,
-  body: string,
-  action: boolean,
-  onProgress?: (sent: number, total: number, residue: string) => void,
-): Promise<void> => {
-  // #1126 — the exit guard. This is the ONE free-text outbound door, and
-  // `ctcpFrame` (applied below, AFTER the scrub) is the ONE sanctioned producer
-  // of \x01. Anything the operator typed, pasted, or had written into their
-  // compose box by another verb is text, never framing. Scrubbing here rather
-  // than at each writer means the next path that learns to fill the compose box
-  // inherits the guarantee instead of having to remember it.
+// The lines come from `draftLines`, which owns the #1126 exit scrub, and each
+// one is framed at the door by `wireBody` — so a plan holds what the operator
+// typed and the drain turns it into wire bytes.
+const planSends = (targets: readonly string[], body: string): PacedSend[] => {
   const lines = draftLines(body);
-  const total = lines.length;
+  return targets.flatMap((target) => lines.map((line) => ({ target, line })));
+};
+
+// #666/#431 — THE paced drain, shared by both fan-outs that can burst the send
+// door. Sends `plan` in order, sequential await so wire order is preserved.
+// `action` wraps every line in CTCP ACTION framing (via the shared `ctcpFrame`
+// builder) for /me and /ame.
+//
+// A send-door 429 is a PAUSE, not a failure: wait the server's own retry-after,
+// then retry THE SAME entry — `sent` never advances past a refusal, so the
+// drain neither drops an entry nor duplicates a delivered one. Any other error
+// (WS down, invalid_line, a severed-session 401) stops it and propagates.
+// Pacing engages only for a plan of MORE than one send: a lone throttled send
+// surfaces immediately, preserving #342's throttle-copy affordance.
+//
+// #431 — why honouring the server's hint IS the pacing an /ame fan-out needs,
+// rather than a guessed inter-message sleep. The door is the #340
+// per-(subject, network) token bucket (capacity 5, refill 0.5/s), and it is
+// deliberately tuned to refuse BEFORE the ircd's flood protection kills the
+// connection (`messages_controller.take_send_token`, whose moduledoc says so).
+// The retry-after it hands back is that bucket's own refill interval, so
+// waiting it paces against the thing that actually decides. A constant here
+// would be a second, unmeasured opinion about the same limit, free to drift
+// from it the moment the bucket is retuned.
+//
+// `onProgress` fires after every acked send AND before every pace/stop, with
+// the count acked so far.
+const drainPaced = async (
+  plan: readonly PacedSend[],
+  slug: string,
+  action: boolean,
+  onProgress: (sent: number) => void,
+): Promise<void> => {
+  const total = plan.length;
   let sent = 0;
-  // Consecutive paced retries of the CURRENT line; reset when `sent` advances.
+  // Consecutive paced retries of the CURRENT entry; reset when `sent` advances.
   let retries = 0;
   while (sent < total) {
-    // `?? ""` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
-    const line = lines[sent] ?? "";
+    // `??` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
+    const { target, line } = plan[sent] ?? { target: "", line: "" };
     try {
       await sendPrivmsg(slug, target, wireBody(line, action));
       sent += 1;
       retries = 0;
-      onProgress?.(sent, total, lines.slice(sent).join("\n"));
+      onProgress(sent);
     } catch (e) {
-      // The residue always starts at `sent` — the first line NOT yet acked.
-      // On a 429 that is the refused line (retry it after pacing); on a fatal
-      // error it is the line that failed (kept, not dropped). Either way the
-      // caller's draft must hold exactly lines[sent..].
-      onProgress?.(sent, total, lines.slice(sent).join("\n"));
-      // Auto-pace ONLY a multi-line paste (the #666 domain): a SINGLE throttled
-      // send surfaces immediately, preserving #342's throttle-copy affordance.
-      // `retries` caps the wait against a door that refuses past its own
-      // retry-after (misbehaving/severed server) so the composer never hangs —
-      // an honest throttle admits on the first retry once a token has refilled.
-      if (isSendThrottled(e) && total > 1 && retries < MAX_PACED_RETRIES_PER_LINE) {
+      onProgress(sent);
+      if (isSendThrottled(e) && total > 1 && retries < MAX_PACED_RETRIES_PER_SEND) {
         retries += 1;
         await sleep(retryAfterMs(e));
         // loop retries the same `sent` index — never advanced past a refusal.
@@ -367,6 +388,57 @@ export const draftFramePreview = (
     draftLines(cmd.body).map((line) => wireBody(line, action)),
     budget,
   );
+};
+
+// Send a free-text body to ONE target, one PRIVMSG per line, paced. Shared by
+// the privmsg, me, and msg send sites — the only free-text paths whose body can
+// contain an operator-typed newline. External callers (ServiceModal,
+// RegistrationWizardModal) pass no callback and simply inherit the never-drop +
+// pacing behaviour.
+//
+// `onProgress` reports the count sent so far and the unsent remainder joined
+// back into a body — compose `submit` mirrors that remainder into the draft so
+// it holds ONLY what has not gone out. The residue always starts at `sent`, the
+// first line NOT yet acked: on a 429 that is the refused line (about to be
+// retried), on a fatal error the line that failed (kept, not dropped).
+export const sendBodyLines = async (
+  slug: string,
+  target: string,
+  body: string,
+  action: boolean,
+  onProgress?: (sent: number, total: number, residue: string) => void,
+): Promise<void> => {
+  const plan = planSends([target], body);
+  await drainPaced(plan, slug, action, (sent) =>
+    onProgress?.(
+      sent,
+      plan.length,
+      plan
+        .slice(sent)
+        .map((p) => p.line)
+        .join("\n"),
+    ),
+  );
+};
+
+// #431 — /ame + /amsg: one copy of the body to EVERY target, through the same
+// paced door. `onProgress` reports completed CHANNELS rather than sends, so a
+// fatal stop can tell the operator how far the fan-out actually got — the count
+// they need to decide whether to retype it.
+const sendFanOut = async (
+  slug: string,
+  targets: readonly string[],
+  body: string,
+  action: boolean,
+  onProgress: (channelsDone: number) => void,
+): Promise<void> => {
+  const plan = planSends(targets, body);
+  // Target-major and every target carries the same lines, so the plan divides
+  // evenly and a completed channel is a whole run of `perTarget` acks. Never a
+  // division by zero: an empty plan means the loop below never runs, so
+  // `onProgress` is never called.
+  const perTarget = plan.length / targets.length;
+  await drainPaced(plan, slug, action, (sent) => onProgress(Math.floor(sent / perTarget)));
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {
@@ -852,6 +924,70 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           );
           if ("error" in r) return r;
           result = r;
+          break;
+        }
+        // #431 — /ame + /amsg: the same body to EVERY joined channel of THIS
+        // network. Deliberately not addressed to the active window: the fan-out
+        // is per-NETWORK (vjt 2026-08-09 — cross-network is out of scope, and
+        // no flag for it), so it works from the $server window just as well as
+        // from a channel, and it includes the window it was typed in.
+        case "ame":
+        case "amsg": {
+          const action = cmd.kind === "ame";
+          // The joined-channel projection #30's channel tab-completion already
+          // reads: server-owned, so `invited` (the window an unsolicited INVITE
+          // opens), `pending`, `failed`, `kicked` and `parked` are all excluded
+          // by the same `joined` predicate, and there is no parallel
+          // client-side channel list to drift from it. Queries and $server
+          // cannot appear at all — `window_states` is channel-keyed by
+          // construction on the server, a DM lives in `queryWindows`.
+          const targets = joinedChannelsOnNetwork(key).sort();
+          if (targets.length === 0) {
+            return { error: `/${cmd.kind}: no joined channel on ${networkSlug}` };
+          }
+          // Channels the fan-out has finished, for the "how far did it get"
+          // half of a failure — the number that tells the operator whether
+          // retyping the line would double-send it.
+          let done = 0;
+          const run = (): Promise<void> =>
+            sendFanOut(networkSlug, targets, cmd.body, action, (n) => {
+              done = n;
+            });
+          if (targets.length > FANOUT_CONFIRM_THRESHOLD) {
+            // The question names every target, not just the count: the blast
+            // radius IS the thing being consented to, so "11 channels" alone
+            // would be consent without disclosure.
+            requestConfirm({
+              title: action ? "Send action to every channel" : "Send message to every channel",
+              body: `Send to ${targets.length} channels on ${networkSlug}? ${targets.join(", ")}`,
+              confirmLabel: "Send",
+              // Detached: `requestConfirm` resolves nothing, so the send cannot
+              // be awaited here and its failure cannot surface inline the way
+              // the un-gated path's does below. Logged with a grep key instead,
+              // mirroring `windowClose.disconnectNetwork` — the same shape of
+              // destructive-action-behind-a-confirm. Never bare: an unhandled
+              // rejection here would be a fan-out that stopped in silence.
+              onConfirm: () => {
+                void run().catch((err) => {
+                  console.warn(
+                    `[/${cmd.kind}] fan-out stopped after ${done} of ${targets.length} channels on ${networkSlug}:`,
+                    err,
+                  );
+                });
+              },
+              alternative: null,
+            });
+            result = { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
+            break;
+          }
+          try {
+            await run();
+          } catch (e) {
+            return {
+              error: `${friendlyError(e)} — sent to ${done} of ${targets.length} channels`,
+            };
+          }
+          result = { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
           break;
         }
         // #591 — /ctcp <target> <VERB> [args]: a single CTCP frame to an

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -99,6 +99,13 @@ export type SlashCommand =
   | { kind: "empty" }
   | { kind: "privmsg"; body: string }
   | { kind: "me"; body: string }
+  // #431 — /ame + /amsg, the mIRC "say it everywhere" pair. Same body grammar
+  // as /me, but the target is NOT the active window: compose.ts fans one copy
+  // out per JOINED channel of the current network. The parser stays pure — it
+  // knows nothing about which channels exist, the confirm gate above ten of
+  // them, or the pacing against the send door.
+  | { kind: "ame"; body: string }
+  | { kind: "amsg"; body: string }
   | { kind: "join"; channels: string[]; key: string | null }
   | { kind: "part"; channel: string | null; reason: string | null }
   | { kind: "topic-show"; channel: string | null }
@@ -314,6 +321,23 @@ function parseCtcp(rest: string): SlashCommand {
   return { kind: "ctcp", target, verb, args };
 }
 
+// #431 — shared grammar for the two fan-out verbs: the trimmed remainder is the
+// message, whole. `kind` is the discriminated-union literal (as `parseNicksVerb`
+// and `parseNickReason` do) so the loose `verb` string is never re-cast back to
+// the narrow set; `verb` supplies the error copy so it names what was typed.
+//
+// An EMPTY body is refused, where /me tolerates one. The asymmetry is the point:
+// /me's empty ACTION is one pointless frame to one window, whereas an empty
+// fan-out is one refused frame per joined channel, each burning a send token
+// against the #340 bucket on the way to delivering nothing.
+type FanOutKind = "ame" | "amsg";
+
+function parseFanOut(kind: FanOutKind, verb: string, rest: string): SlashCommand {
+  const body = rest.trim();
+  if (body === "") return err(verb, `/${verb} requires a message`);
+  return { kind, body };
+}
+
 // #591 — /ping <target>. Only the target survives the parser; compose.ts owns
 // the timestamp token + reply correlation. Trailing tokens are ignored (a nick
 // is a single word), mirroring /whois <server> <nick> <junk>.
@@ -329,6 +353,17 @@ type Handler = (verb: string, rest: string) => SlashCommand;
 
 const DISPATCH: Readonly<Record<string, Handler>> = {
   me: (_verb, rest) => ({ kind: "me", body: rest }),
+
+  // #431 — the fan-out pair. Registered as BUILTINS, which is the whole of what
+  // "builtin" buys them under #427: a same-named user alias shadows them like
+  // it shadows /join or /quit, because the non-shadowable set is the fixed
+  // two-name repair surface (/alias, /unalias) and nothing else. Issue #431's
+  // body claims the opposite ("builtins are never shadowed by aliases") — it
+  // predates #427, which reversed exactly that. The alias engine (#385) cannot
+  // express iteration, so this is not scriptable today; nothing here is
+  // pre-built for a future iteration primitive.
+  ame: (verb, rest) => parseFanOut("ame", verb, rest),
+  amsg: (verb, rest) => parseFanOut("amsg", verb, rest),
 
   // #591 — CTCP send verbs. /ctcp is the general form; /ping is the RTT sugar.
   ctcp: (_verb, rest) => parseCtcp(rest),

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -37778,3 +37778,93 @@ HOT** — Ecto selects named columns, so a node still running the old `Session`
 module cannot see the two new ones, and reload brings schema and column into
 agreement in either order. The first commit's message says COLD; the
 classifier disagrees and it is right.
+
+---
+
+## 2026-08-10 — #431: `/ame` + `/amsg` — the exclusions were already there, and the pacing belonged to #666
+
+mIRC's "say it in every channel" pair, asked for by a long-time mIRC user who
+moved to cicchetto. vjt's ruling (2026-08-09) settled the one open question in
+the issue body: the fan-out is the joined-channel set of the **current network
+only**. Cross-network is out of scope and gets no flag — a multi-network client
+that sprays an action across every network at once is a different, worse
+feature wearing the same name.
+
+**The target list is not new, and that is the point.** `joinedChannelsOnNetwork`
+already existed in `compose.ts` for #30's channel tab-completion, reading the
+server-owned `windowStateByChannel` projection. The fan-out reads the same
+function, so it inherits the exclusions rather than restating them.
+
+That matters for the three exclusions the issue asks for, because only one of
+them is a filter. The `:invited` window — the greyed not-joined tab an
+unsolicited INVITE opens — IS a key in that map, and what keeps it (along with
+`pending`, `failed`, `kicked` and `parked`) out of the fan-out is the `joined`
+predicate. Queries and `$server` are a different case: they cannot be in the map
+at all. The server keys `window_states` by channel, a DM lives in
+`queryWindows`, and `$server` is never joined — verified at the feeders
+(`subscribe.ts`'s `joined` arm, `userTopic.ts`'s `joined`/`window_pending`
+arms), all channel-keyed by construction. So no sigil guard was added. One was
+written for #30, measured against the suite at zero failing tests, and deleted;
+re-adding it here would reinstate dead code and buy an arm that can only be
+killed by injecting a state production cannot produce.
+
+Stated plainly because it is easy to misread as a dropped constraint: the
+exclusion vjt asked for is enforced, and the mutant that removes it kills an
+arm. It is just that the arm it kills is shared with #30's, because there is one
+predicate serving both callers. The fan-out's own arm is therefore a regression
+guard on that reuse, not independent coverage of the predicate.
+
+**Pacing is #666's verb, generalised — not a new sleep.** The two hazards are
+one hazard: N PRIVMSGs in a burst against the `#340` per-`(subject, network)`
+token bucket. One PRIVMSG per line of a paste and one per channel of a fan-out
+differ only in what the list is made of. So `sendBodyLines`' loop became
+`drainPaced`, over a flat `(target, line)` plan that `planSends` builds
+target-major; the single-target case is the old behaviour byte for byte.
+
+**Flat, not nested,** and this is the part worth remembering. The obvious shape
+— call `sendBodyLines` once per channel — nests one paced retry inside another.
+A multi-line body whose third line is refused would throw out of the inner
+drain with two lines already delivered, and the outer drain would pace and
+retry *that whole channel*, re-sending the two. A flat plan makes a retry
+re-send exactly one `(target, line)`, so the never-drop / never-dup property
+#666 established survives the second dimension.
+
+**Why the server's `retry-after` and not a constant.** The bucket is capacity 5,
+refill 0.5/s, and `messages_controller.take_send_token` says out loud what it is
+for: it is tuned at or below the upstream flood allowance so grappa's 429 always
+trips before bahamut k-lines the connection. The `retry-after` it hands back IS
+that bucket's refill interval. Waiting it paces against the thing that actually
+decides; a hardcoded inter-message delay would be a second, unmeasured opinion
+about the same limit, free to drift the moment the bucket is retuned. The test
+proves the difference by having the stub answer `retry_after: 3` — deliberately
+not the 2s client-side fallback — so "ignores the hint" is a distinct mutant
+from "has no pacing", and it is: it kills exactly one arm, and only that one.
+
+**Ten channels, and the question names them.** Above ten the fan-out asks first.
+Ten is decided, not tuned. The dialog spells out every target rather than only
+the count, because the blast radius is the thing being consented to and "11
+channels?" is consent without disclosure.
+
+**What the confirm costs, honestly.** `requestConfirm` resolves nothing — it
+carries a `() => void` — so the gated send cannot be awaited by `submit`, and
+unlike the un-gated path its failure cannot surface inline. It is logged with a
+`[/ame]` grep key instead, mirroring `windowClose.disconnectNetwork`, which is
+the same shape of destructive-action-behind-a-confirm. Making the confirm
+awaitable was considered and refused: the store is last-write-wins, so a second
+request replacing a pending one would strand a promise that never settles, and
+`submit` holds the window's outbox while it waits — a composer dead until
+reload, which is worse than the log line. The other cost is that the arm returns
+`ok`, so the pump clears the draft when the dialog opens; a cancel loses the
+typed line from the box but not from the composer history, because `takeDraft`
+pushes to history before it clears.
+
+**The issue text contradicted the codebase on shadowing, and the codebase won.**
+#431's body says builtins are "never shadowed by a user alias (#427)". #427 ruled
+the exact opposite — it reversed #385's decision #3 — leaving a deliberately
+fixed two-name deny list, `/alias` and `/unalias`, the command-side repair
+surface. `/ame` is a builtin in the only sense #427 leaves available: it is in
+`DISPATCH`, and a same-named user alias shadows it exactly as one shadows
+`/join`. Widening the deny list for a convenience verb would start the drift
+that comment exists to prevent. The alias engine still cannot express iteration,
+so none of this is user-scriptable today, and nothing here is pre-built for a
+future iteration primitive.


### PR DESCRIPTION
mIRC's "say it in every channel" pair (issue #431). The fan-out is the
joined-channel set of the **current network only** — vjt's ruling,
2026-08-09. Cross-network is out of scope and carries no flag.

cic-only: no Elixir, no e2e spec touched.

## Where the constraints landed

Two of the issue's constraints were already satisfied by code, and one is
contradicted by a later ruling. Per the standing instruction that measured
code beats the issue text, the code won in all three cases.

**Target list — reused, not rebuilt.** `joinedChannelsOnNetwork` already
existed for #30's channel tab-completion, over the server-owned
`windowStateByChannel` projection. The fan-out reads the same function.
That makes the `:invited` window (and `pending`/`failed`/`kicked`/`parked`)
excluded by the `joined` predicate, and makes queries and `$server`
excluded *structurally*: the server keys `window_states` by channel, a DM
lives in `queryWindows`, and `$server` is never joined — checked at the
feeders (`subscribe.ts`'s `joined` arm, `userTopic.ts`'s
`joined`/`window_pending` arms). No sigil guard was added: one was written
for #30, measured at zero failing tests, and deleted.

**Pacing — #666's verb, generalised.** One PRIVMSG per line of a paste and
one per channel of a fan-out are the same hazard against the same #340
token bucket, so `sendBodyLines`' loop became `drainPaced` over a flat
`(target, line)` plan. Flat, not a per-channel drain wrapping a per-line
one: nesting them lets a retry re-send a channel whose earlier lines
already landed. The bucket (capacity 5, refill 0.5/s) is tuned to refuse
before the ircd's flood protection kills the sender, so waiting the
`retry-after` it hands back paces against the thing that actually decides;
a constant would be a second, unmeasured opinion about the same limit.

**Shadowing — #431's body cites #427 backwards.** It says builtins are
never shadowed by a user alias; #427 ruled the opposite, leaving a
deliberately fixed two-name deny list (`/alias`, `/unalias`). `/ame` is a
builtin in the only sense #427 leaves: it is in `DISPATCH`, and an alias
shadows it as one shadows `/join`.

**Confirm gate.** Above ten channels the fan-out asks first, and the
question spells out every target rather than only the count.

## Displacement

Seven mutants, one at a time on the product, each run against both suites.
Full log in the PR discussion below.

| Mutant | Dead arms |
|---|---|
| M1 `joined`-only → any window state | 2 — the fan-out arm **and** #30's, shared predicate |
| M2 threshold 10 → 11 | 2 — both confirm-gate arms |
| M3 threshold 10 → 9 | 1 |
| M4 pacing removed (429 fatal) | 9 — the fan-out arm **and** 8 pre-existing #666/#737/#907, shared drain |
| M5 ignore server `retry-after` | 1 |
| M6 `/ame` drops ACTION framing | 1 |
| M7 `/ame` made non-shadowable | 1 |

Declared, not counted: the exclusion arm has no killer unique to it, because
there is one predicate and #30 already pins it — it is a regression guard on
the fan-out's reuse. Same for the pacing arm under M4; its unique killer is
M5.

## What is not proven

No browser and no e2e. This is unit-level only: the send door is a stub, so
"the operator does not get flood-killed" is an argument from the bucket's
configuration, not a measurement against a real ircd.

## Gates

`bun run check` rc=0, `bun run test` rc=0 — 275 files, 5118 tests, run on
the rebased tree after resolving the #1108 conflict in `compose.ts`.