### PR TITLE
#1205: stand the horizontal swipe claim down while a selection is live

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -295,7 +295,18 @@ const ComposeBox: Component<Props> = (props) => {
       // hand off the instant it does. A vertical drag WITH room returns null →
       // we stay hands-off so pan-y scrolls the draft.
       const boundary = textareaEl ? scrollBoundary(textareaEl) : { atTop: true, atBottom: true };
-      claimedAxis = claimAxis(swipeStart, { x: t.clientX, y: t.clientY }, boundary);
+      // #1205 — the DOM half of the selection gate: a non-collapsed selection
+      // means this horizontal drag is a handle drag, and claiming it would
+      // preventDefault the very thing the user is doing. Live like the
+      // boundary, and unreadable counts as collapsed (the pre-#1205 claim).
+      const selectionActive =
+        textareaEl !== undefined && textareaEl.selectionStart !== textareaEl.selectionEnd;
+      claimedAxis = claimAxis(
+        swipeStart,
+        { x: t.clientX, y: t.clientY },
+        boundary,
+        selectionActive,
+      );
       if (claimedAxis === null) return;
       if (diagOn) {
         const st = textareaEl ? textareaEl.scrollTop : -1;

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireTouch } from "./helpers/touchEvents";
 
 // #904 — the send queue lives in the store, keyed on the window, and
 // ComposeBox is a VIEW over it: the spinner, the readOnly refusal and the
@@ -664,6 +665,57 @@ describe("ComposeBox", () => {
       } finally {
         vi.mocked(compose.getDraft).mockReturnValue("");
       }
+    });
+  });
+
+  // #1205 — the call site of the #1205 gate: the DOM read that tells the pure
+  // `claimAxis` whether a selection is live. The reported symptom is Android
+  // selection handles that will not drag, and the mechanism is this listener's
+  // unconditional `preventDefault` once the horizontal claim lands. What is
+  // measured here is the CLAIM SIGNAL — `defaultPrevented` on the touchmove —
+  // plus its product consequence (tab-complete). jsdom has no selection
+  // handles and no native drag-to-select, so this proves the wiring and the
+  // decision, NOT that a real handle moves; that half is device-only.
+  describe("#1205 — a live selection hands the horizontal drag to the OS", () => {
+    const dragRight = (ta: HTMLTextAreaElement): Event => {
+      fireTouch(ta, "touchstart", { clientX: 100, clientY: 300 });
+      const move = fireTouch(ta, "touchmove", { clientX: 160, clientY: 302 });
+      fireTouch(ta, "touchend", { clientX: 160, clientY: 302 });
+      return move;
+    };
+
+    const composerWith = async (draft: string): Promise<HTMLTextAreaElement> => {
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.getDraft).mockReturnValue(draft);
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      return screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+    };
+
+    afterEach(async () => {
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.getDraft).mockReturnValue("");
+    });
+
+    it("a horizontal drag over a SELECTED word is not claimed", async () => {
+      const compose = await import("../lib/compose");
+      const ta = await composerWith("hello world");
+      ta.setSelectionRange(0, 5);
+      // The pre-state the whole case rests on: an EMPTY textarea clamps any
+      // range to 0,0 and the assertion below would pass for the wrong reason.
+      expect(ta.selectionStart).not.toBe(ta.selectionEnd);
+      const move = dragRight(ta);
+      expect(move.defaultPrevented).toBe(false);
+      expect(compose.tabComplete).not.toHaveBeenCalled();
+    });
+
+    it("the same drag with a COLLAPSED caret is still claimed for tab-complete", async () => {
+      const compose = await import("../lib/compose");
+      const ta = await composerWith("hello world");
+      ta.setSelectionRange(5, 5);
+      expect(ta.selectionStart).toBe(ta.selectionEnd);
+      const move = dragRight(ta);
+      expect(move.defaultPrevented).toBe(true);
+      expect(compose.tabComplete).toHaveBeenCalled();
     });
   });
 

--- a/cicchetto/src/__tests__/swipe.test.ts
+++ b/cicchetto/src/__tests__/swipe.test.ts
@@ -138,47 +138,76 @@ describe("claimAxis (#123 nested-scroll handoff — boundary claim, NOT velocity
   it("claims a horizontal drag regardless of boundary (native pan-x is blocked)", () => {
     // Rightward past slop, mid-scroll: still claimed — a horizontal drag can
     // only select text otherwise, so we own it for tab-complete.
-    expect(claimAxis({ x: 0, y: 0 }, { x: 20, y: 2 }, MID)).toBe("horizontal");
-    expect(claimAxis({ x: 50, y: 0 }, { x: 30, y: 2 }, AT_TOP)).toBe("horizontal");
+    expect(claimAxis({ x: 0, y: 0 }, { x: 20, y: 2 }, MID, false)).toBe("horizontal");
+    expect(claimAxis({ x: 50, y: 0 }, { x: 30, y: 2 }, AT_TOP, false)).toBe("horizontal");
   });
 
   it("claims an up-drag only when the textarea is AT the bottom edge", () => {
     // Finger-up scrolls the content up (scrollTop → max). At the bottom edge
     // there is no room left → the up-drag hands off to the history-recall
     // gesture. AT_TOP has room to scroll (does NOT claim; see below).
-    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_BOTTOM)).toBe("vertical");
-    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_BOTH)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_BOTTOM, false)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_BOTH, false)).toBe("vertical");
   });
 
   it("does NOT claim an up-drag with scroll room below — native scroll owns it", () => {
     // Mid-scroll, or at the TOP with the whole draft still below: a finger-up
     // drag scrolls the draft. Returning null leaves it to native pan-y (the
     // #123 handoff — the gesture arms only once scrollTop hits the bottom).
-    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, MID)).toBeNull();
-    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_TOP)).toBeNull();
+    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, MID, false)).toBeNull();
+    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_TOP, false)).toBeNull();
   });
 
   it("claims a down-drag only when the textarea is AT the top edge", () => {
     // Finger-down scrolls the content down (scrollTop → 0). At the top edge
     // there is no room left → the down-drag hands off to recall-next.
-    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_TOP)).toBe("vertical");
-    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_BOTH)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_TOP, false)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_BOTH, false)).toBe("vertical");
   });
 
   it("does NOT claim a down-drag with scroll room above", () => {
-    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, MID)).toBeNull();
-    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_BOTTOM)).toBeNull();
+    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, MID, false)).toBeNull();
+    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_BOTTOM, false)).toBeNull();
   });
 
   it("is null before the drag clears the slop (still undecided)", () => {
     // Under 8px on both axes → no axis committed yet, even at a boundary.
-    expect(claimAxis({ x: 0, y: 0 }, { x: 5, y: 3 }, AT_BOTH)).toBeNull();
+    expect(claimAxis({ x: 0, y: 0 }, { x: 5, y: 3 }, AT_BOTH, false)).toBeNull();
   });
 
   it("is velocity-BLIND: a slow-starting flick at the bottom still claims", () => {
     // No elapsed/velocity input at all — the signature proves the claim can't
     // abandon a genuine flick just because its first slop-crossing is slow.
-    expect(claimAxis({ x: 0, y: 100 }, { x: 0, y: 50 }, AT_BOTTOM)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 100 }, { x: 0, y: 50 }, AT_BOTTOM, false)).toBe("vertical");
+  });
+});
+
+describe("claimAxis (#1205 — a live selection is the OS's drag, not ours)", () => {
+  // Dragging a native selection handle IS a horizontal drag on the textarea,
+  // so the blanket horizontal claim suppressed it along with the stray
+  // drag-to-select it was written for. With a NON-collapsed selection the user
+  // is adjusting that selection; the claim stands down so the OS handles move.
+  // The flag is an ARGUMENT — the call site does the DOM read (selectionStart
+  // vs selectionEnd), this function stays pure.
+
+  it("does NOT claim a horizontal drag while a selection is live", () => {
+    // Same two drags the blanket-claim case above asserts, with a selection on:
+    // both hand back to the OS, whatever the scroll boundary says.
+    expect(claimAxis({ x: 0, y: 0 }, { x: 20, y: 2 }, MID, true)).toBeNull();
+    expect(claimAxis({ x: 50, y: 0 }, { x: 30, y: 2 }, AT_TOP, true)).toBeNull();
+  });
+
+  it("still claims a horizontal drag with a collapsed caret (tab-complete intact)", () => {
+    // The affordance the claim exists for. A caret is not a selection, so the
+    // gate must not fire on the ordinary compose case.
+    expect(claimAxis({ x: 0, y: 0 }, { x: 20, y: 2 }, MID, false)).toBe("horizontal");
+  });
+
+  it("leaves the VERTICAL claim alone — a selection does not block history recall", () => {
+    // Handle drags are horizontal; gating the whole claim would kill the
+    // recall gesture for anyone who left a word selected in the draft.
+    expect(claimAxis({ x: 0, y: 60 }, { x: 0, y: 40 }, AT_BOTTOM, true)).toBe("vertical");
+    expect(claimAxis({ x: 0, y: 0 }, { x: 0, y: 20 }, AT_TOP, true)).toBe("vertical");
   });
 });
 

--- a/cicchetto/src/lib/swipe.ts
+++ b/cicchetto/src/lib/swipe.ts
@@ -99,7 +99,8 @@ export const dragAxis = (
 // native scroll + drag-to-select) or leave it to the textarea's native `pan-y`
 // scroll? Claim ONLY a drag native scroll can no longer consume:
 //   * horizontal — `touch-action: pan-y` already blocks native pan-x, so a
-//     horizontal drag would otherwise select text; we own it (→ tab-complete);
+//     horizontal drag would otherwise select text; we own it (→ tab-complete)
+//     UNLESS a selection is already live (#1205, see below);
 //   * vertical once the textarea has NO scroll room LEFT in the drag direction.
 //     Screen y grows downward, so a finger-UP drag (dy < 0) scrolls the content
 //     up — scrollTop INCREASES — until the BOTTOM edge; a finger-DOWN drag
@@ -114,15 +115,29 @@ export const dragAxis = (
 // touchstart-snapshot design was the "double-swipe" #123 bug). Velocity plays
 // NO part here — see `isFastSwipe`; the flick test is deferred to touchend over
 // the whole gesture.
+//
+// #1205 — `selectionActive` (the textarea's selection is NOT collapsed) stands
+// the HORIZONTAL claim down. Dragging a native selection handle is a horizontal
+// drag on the textarea, so the blanket claim's `preventDefault` suppressed the
+// deliberate handle drag along with the stray drag-to-select it was written
+// for: the reported symptom is Android handles that will not move. A live
+// selection means the user is adjusting THAT, not asking for nick completion,
+// so the whole touch goes back to the OS. Read LIVE like `boundary`, not
+// snapshotted at touchstart: an engine that collapses the selection on the
+// touch that starts the next gesture would otherwise cost a real swipe. The
+// VERTICAL arm is untouched — handle drags are horizontal, and gating recall
+// on a stale selection would break the affordance for a different reason. The
+// flag is an ARGUMENT: the DOM read belongs to the call site, this stays pure.
 export const claimAxis = (
   start: Point,
   current: Point,
   boundary: ScrollBoundary,
+  selectionActive: boolean,
   slopPx: number = DRAG_SLOP_PX,
 ): DragAxis | null => {
   const axis = dragAxis(start, current, slopPx);
   if (axis === null) return null; // under the slop — still undecided
-  if (axis === "horizontal") return "horizontal";
+  if (axis === "horizontal") return selectionActive ? null : "horizontal";
   // Vertical: claim only when native scroll has hit its wall in this direction.
   const movingUp = current.y - start.y < 0;
   if (movingUp) return boundary.atBottom ? "vertical" : null;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38029,3 +38029,59 @@ claim, per-row) and are declared as such rather than counted.
 events drive no pixel scroll, chromium is not iOS Safari, and whether a
 presence row that no longer moves reads as deliberate or as broken is a device
 call — vjt's dogfood, like the rest of #1067.
+
+---
+
+## 2026-08-10 — #1205: a live selection is the OS's drag, not the composer's
+
+Android reported selection handles in the compose textarea that would not
+drag: long-press selects a word, the Cut/Copy/Paste bar opens, and then
+neither handle moves. Keyboard open or closed, which is what tells it apart
+from the closed #79 (there the selection never *starts*).
+
+The mechanism is the #123 gesture claim. `ComposeBox` binds a non-passive
+element-level `touchmove` and, once `claimAxis` claims an axis,
+`preventDefault`s the rest of the touch. The horizontal arm claimed
+unconditionally, and the source said why: `touch-action: pan-y` already
+blocks native pan-x, so a horizontal drag could only stray-select text, and
+we own it for tab-complete. Dragging a selection HANDLE is also a horizontal
+drag on that textarea, so the suppression written for accidental selection
+also killed the deliberate one. The comment on the handlers had already named
+the coupling — "suppress native scroll + drag-to-select once we own the
+gesture" — without allowing for drag-to-select being the point.
+
+**The gate is on the claim, not the binder.** `claimAxis` gains a
+`selectionActive` argument and returns `null` for a horizontal drag while the
+selection is non-collapsed; the listener and its `preventDefault` are
+untouched. That keeps ONE authority for "do we own this touch" — the same
+posture #1156 took on the presence rows — instead of a second, listener-level
+veto that would have to be kept in agreement with the first.
+
+**The flag is an argument; the DOM read is the call site's.** `boundary` is
+already shaped that way, so `swipe.ts` stays pure and DOM-free and the whole
+decision remains unit-testable without touch physics. It is read LIVE on each
+move, like the boundary, rather than snapshotted at touchstart: the claim is
+only ever asked while unclaimed, and an engine that collapses the selection
+on the very touch that begins the next gesture would make a snapshot cost a
+real swipe.
+
+**The vertical arm is deliberately untouched.** Handle drags are horizontal.
+Standing the whole claim down on a live selection would break history recall
+for anyone who left a word selected in their draft — a different affordance,
+broken for no reason. A mutant that gates the whole claim is what pins this.
+
+**Measured.** Red first, at both levels: the pure claim (`selection on →
+null`) and the call site, where the touchmove's `defaultPrevented` and
+`tabComplete` measure what the DOM read actually decided. Four mutants, each
+compiled before its result was read: dropping the gate kills one assertion
+per level; gating the whole claim kills exactly the vertical guard; pinning
+the call site's read to `false` kills only the selected-word case; pinning it
+to `true` kills only the collapsed-caret case. The pure "still claims with a
+collapsed caret" case has no unique killer — it is a tripwire, not coverage.
+
+**Not proven: that a handle now moves.** jsdom has no selection handles and
+no native drag-to-select, and Playwright's webkit is not iOS touch — the
+module's own header already says the gesture is dogfood-only. What is proven
+is that we stop calling `preventDefault` on that drag, which is the mechanism
+the report points at; that this is sufficient on a real Android is vjt's
+observation to make, not ours.


### PR DESCRIPTION
## What

The compose textarea's gesture claim (`claimAxis`) owned **every** horizontal
drag past the 8px slop, and `ComposeBox`'s non-passive `touchmove` listener
`preventDefault`s the rest of the touch once an axis is claimed. Dragging a
native selection handle IS a horizontal drag on that textarea, so the
suppression written for accidental drag-to-select also suppressed the
deliberate one — the reported symptom (#1205) is Android handles that will not
move, keyboard open or closed.

The horizontal arm now stands down while the selection is non-collapsed.

## How

- `claimAxis` takes `selectionActive: boolean` and returns `null` for a
  horizontal drag while it is set. **The gate is on the claim, not the
  binder** — one authority for "do we own this touch", no second
  listener-level veto to keep in agreement.
- The flag is an **argument**, the way `boundary` already is: the DOM read
  (`selectionStart !== selectionEnd`) belongs to the call site, and `swipe.ts`
  stays pure and DOM-free.
- Read **live** on each move rather than snapshotted at touchstart — the claim
  is only asked while unclaimed, and an engine that collapses the selection on
  the touch that begins the next gesture would make a snapshot cost a real
  swipe.
- The **vertical** arm (history recall) is untouched: handle drags are
  horizontal, and gating the whole claim would break a different affordance
  for anyone who left a word selected in the draft.

## Acceptance, against the issue

1. Non-collapsed selection → horizontal drag not claimed, `preventDefault` not
   called. Measured at the call site as `defaultPrevented === false`.
2. Collapsed caret → swipe-right still reaches `tabComplete`. Measured in the
   same pair.
3. `swipe.test.ts` covers both halves of `claimAxis`, which had no
   active-selection case at all.

## Evidence

Red first, both levels; the two discriminating assertions failed and the three
regression guards passed. Green after: `bun run test` **5123 passed / 275
files, rc 0**; `bun run check` rc 0; working tree clean before and after.

Four mutants, one at a time, **each compiled (`tsc --noEmit` rc 0) before its
result was read**:

| mutant | kills |
| --- | --- |
| drop the gate (`return "horizontal"`) | the pure selection-live case **and** the call-site selected-word case — one per level |
| gate the WHOLE claim (`if (selectionActive) return null` before the axis switch) | exactly the vertical guard |
| call site pinned `selectionActive = false` | only the call-site selected-word case |
| call site pinned `selectionActive = true` | only the call-site collapsed-caret case |

The pure "still claims with a collapsed caret" case has **no unique killer** —
declared as a tripwire, not coverage.

## What this does NOT prove

**That a handle now moves on a device.** jsdom has no selection handles and no
native drag-to-select; Playwright's webkit is not iOS/Android touch (the
module header already records the gesture as dogfood-only). What is proven is
that we stop calling `preventDefault` on that drag — the mechanism the report
points at. No e2e is proposed for that reason; if one is wanted anyway, it
needs a lane.

**Tooling note:** Docker Desktop is down on this host, so the cic gates ran
under host `bun 1.3.13` with `bun --bun run …` (bun runtime, matching
`oven/bun:1`) and `bun install --frozen-lockfile`, instead of
`scripts/bun.sh`. Lockfiles unchanged; CI is the authoritative re-run.