### PR TITLE
#1208: /part <reason> — the sigil decides the target, and the reason reaches the wire

### DIFF
--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -440,7 +440,9 @@ describe("Sidebar", () => {
     expect(apiMod.postPart).not.toHaveBeenCalled();
     // Confirming fires the PART.
     acceptConfirm();
-    expect(apiMod.postPart).toHaveBeenCalledWith("tok", "freenode", "#italia");
+    // #1208 — the × carries no reason: the trailing `null` pins the bare
+    // `PART #italia` frame this door has always produced.
+    expect(apiMod.postPart).toHaveBeenCalledWith("tok", "freenode", "#italia", null);
   });
 
   // #473 — the per-network Archive `<details>` section was REMOVED from the

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -672,6 +672,56 @@ describe("tagNetwork (bucket F H4)", () => {
   });
 });
 
+// #1208 — the PART reason travels as a `?reason=` query param rather than a
+// DELETE body: the reason is public by construction (it ships to a channel
+// full of people), and a query param needs no assumption about intermediaries
+// forwarding a body on DELETE. These pin the URL the server contract reads.
+describe("postPart reason (#1208)", () => {
+  function urlOf(fetchMock: ReturnType<typeof vi.fn>): string {
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error("fetch not called");
+    return (call as [string, RequestInit])[0];
+  }
+
+  it("omits the query param entirely when the reason is null", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.postPart("tok", "freenode", "#sniffo", null);
+
+    expect(urlOf(fetchMock)).toBe("/networks/freenode/channels/%23sniffo");
+  });
+
+  it("omits the query param when the reason is an empty string", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.postPart("tok", "freenode", "#sniffo", "");
+
+    expect(urlOf(fetchMock)).toBe("/networks/freenode/channels/%23sniffo");
+  });
+
+  it("appends a percent-encoded reason when one is given", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.postPart("tok", "freenode", "#sniffo", "non trovo utili le bestemmie");
+
+    expect(urlOf(fetchMock)).toBe(
+      "/networks/freenode/channels/%23sniffo?reason=non%20trovo%20utili%20le%20bestemmie",
+    );
+  });
+
+  it("encodes a reason carrying & and = so it cannot forge a second param", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.postPart("tok", "freenode", "#sniffo", "a&b=c");
+
+    expect(urlOf(fetchMock)).toBe("/networks/freenode/channels/%23sniffo?reason=a%26b%3Dc");
+  });
+});
+
 describe("deleteArchiveEntry (UX-1)", () => {
   it("DELETE /networks/:slug/archive/:target with bearer + percent-encoded target", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2003,7 +2003,43 @@ describe("compose submit — slash command dispatch", () => {
     compose.setDraft(k, "/part");
     const result = await compose.submit(k, "freenode", "#a");
 
-    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#a");
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#a", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // #1208 — a sigil-less /part keeps the current-window fallback for the
+  // TARGET and forwards the whole rest as the REASON. Both halves matter:
+  // asserting only the reason would pass with the target regressed to "non".
+  it("/part with a sigil-less reason parts the current channel with that reason", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/part non trovo utili le bestemmie");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith(
+      "tok",
+      "freenode",
+      "#a",
+      "non trovo utili le bestemmie",
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("/part with an explicit channel forwards both the target and the reason", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/part #altro ci vediamo");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#altro", "ci vediamo");
     expect(result).toEqual({ ok: true });
   });
 

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -207,6 +207,40 @@ describe("parseSlash — /part", () => {
       reason: "byebye",
     });
   });
+
+  // #1208 — the reported defect. Without a sigil test the first word of a
+  // bare reason was taken as the target, so the user got "The request was
+  // malformed." about a channel called "non" that they never typed. Every
+  // IRC client resolves this ambiguity by sigil: no sigil ⇒ it is the reason.
+  it("/part with a sigil-less first token is all reason, not a target (#1208)", () => {
+    expect(parseSlash("/part non trovo utili le bestemmie")).toEqual({
+      kind: "part",
+      channel: null,
+      reason: "non trovo utili le bestemmie",
+    });
+  });
+
+  it("/part with a single sigil-less word is a reason, not a channel (#1208)", () => {
+    expect(parseSlash("/part ciao")).toEqual({
+      kind: "part",
+      channel: null,
+      reason: "ciao",
+    });
+  });
+
+  // Unlike /join, /part must NOT auto-prepend `#` to a bare name: doing so
+  // is what created the phantom target. The three non-`#` RFC sigils still
+  // name a channel, so they keep the target arm.
+  it.each(["&local", "+modeless", "!safe"])(
+    "/part %s is a target, not a reason (#1208)",
+    (chan) => {
+      expect(parseSlash(`/part ${chan} ciao`)).toEqual({
+        kind: "part",
+        channel: chan,
+        reason: "ciao",
+      });
+    },
+  );
 });
 
 describe("parseSlash — /topic (context-aware, #23)", () => {

--- a/cicchetto/src/__tests__/windowClose.test.ts
+++ b/cicchetto/src/__tests__/windowClose.test.ts
@@ -112,7 +112,7 @@ describe("closeChannelWindow — channel close clears local windowState", () => 
 
     // Server side: PART (no-op upstream for a never-joined channel) +
     // de-autojoin via the DELETE.
-    expect(api.postPart).toHaveBeenCalledWith("utok", "bahamut-test", "#k38");
+    expect(api.postPart).toHaveBeenCalledWith("utok", "bahamut-test", "#k38", null);
     // Local side: clear the windowState pseudo-projection so the row
     // can't re-emerge as an orphaned greyed pseudo-row once
     // channelsBySlug drops the name.
@@ -255,7 +255,7 @@ describe("dismissPseudoWindow — drops a pseudo-row; the landing is bucket E's"
     auth.setToken("utok");
     const { dismissPseudoWindow } = await import("../lib/windowClose");
     dismissPseudoWindow("freenode", "#inv");
-    expect(api.postPart).toHaveBeenCalledWith("utok", "freenode", "#inv");
+    expect(api.postPart).toHaveBeenCalledWith("utok", "freenode", "#inv", null);
   });
 
   it("clears the windowState entry via forceParted (token-gated user close)", async () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2363,13 +2363,23 @@ export async function postJoin(
 // Mirror of `GrappaWeb.ChannelsController.delete/2`. DELETE the channel
 // to forward a PART upstream. Server emits a `:part` scrollback row +
 // the EventRouter Map.deletes the channel key from state.members.
+//
+// #1208 — the optional PART reason rides as a `?reason=` query param, not a
+// DELETE body: the reason is public by construction (it is broadcast to every
+// member of the channel), so there is nothing to keep out of a URL, and a
+// query param assumes nothing about intermediaries forwarding a body on
+// DELETE. An absent or empty reason omits the param entirely, so the request
+// line is byte-identical to the pre-#1208 one — that is what keeps the three
+// non-/part doors (sidebar ×, window close, autojoin drop) unchanged.
 export async function postPart(
   token: string,
   networkSlug: string,
   channelName: string,
+  reason: string | null,
 ): Promise<void> {
+  const query = reason === null || reason === "" ? "" : `?reason=${encodeURIComponent(reason)}`;
   const res = await fetch(
-    `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}`,
+    `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}${query}`,
     {
       method: "DELETE",
       headers: buildHeaders(token),

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1102,7 +1102,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         case "part": {
           const target = cmd.channel ?? channelName;
-          await postPart(t, networkSlug, target);
+          await postPart(t, networkSlug, target, cmd.reason);
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -410,10 +410,27 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   },
 
   part: (_verb, rest) => {
+    // #1208 — `/part <reason>` is the common form and it MUST NOT eat its
+    // first word as a target. Pre-fix the first token was the channel
+    // unconditionally, so `/part non trovo utili le bestemmie` issued a
+    // DELETE against a channel named "non" and the operator was told "The
+    // request was malformed." about a name they never typed.
+    //
+    // The sigil resolves the ambiguity, as it does in every other IRC
+    // client: a first token matching [#&+!] is the target, anything else is
+    // the start of the reason and the target falls back to the current
+    // window (in compose.ts).
+    //
+    // Deliberately NOT symmetric with `join` above: /join auto-prepends `#`
+    // to a bare name because a JOIN has no second meaning for its first
+    // token. /part does, so the same sugar here is precisely what
+    // manufactures the phantom channel.
     if (rest === "") return { kind: "part", channel: null, reason: null };
     const sp = rest.search(/\s/);
-    if (sp === -1) return { kind: "part", channel: rest, reason: null };
-    return { kind: "part", channel: rest.slice(0, sp), reason: rest.slice(sp + 1).trim() };
+    const first = sp === -1 ? rest : rest.slice(0, sp);
+    if (!/^[#&+!]/.test(first)) return { kind: "part", channel: null, reason: rest };
+    if (sp === -1) return { kind: "part", channel: first, reason: null };
+    return { kind: "part", channel: first, reason: rest.slice(sp + 1).trim() };
   },
 
   topic: (_verb, rest) => {

--- a/cicchetto/src/lib/windowClose.ts
+++ b/cicchetto/src/lib/windowClose.ts
@@ -62,7 +62,10 @@ import { forceParted } from "./windowState";
 function partAndForget(networkSlug: string, name: string): void {
   const t = token();
   if (!t) return;
-  void postPart(t, networkSlug, name);
+  // #1208 — a window close carries no reason: closing a tab is not a
+  // statement to the channel. Explicit `null` keeps the wire frame the bare
+  // `PART #chan` it has always been.
+  void postPart(t, networkSlug, name, null);
   forceParted(channelKey(networkSlug, name));
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38085,3 +38085,78 @@ module's own header already says the gesture is dogfood-only. What is proven
 is that we stop calling `preventDefault` on that drag, which is the mechanism
 the report points at; that this is sufficient on a real Android is vjt's
 observation to make, not ours.
+
+---
+
+## 2026-08-10 — #1208: `/part <reason>` — the sigil decides the target, and the reason had no plumbing at all
+
+Reported on #grappa by strk-oli: `/part non trovo utili le bestemmie` from
+`irc.sindro.me` surfaced **"The request was malformed."** Two defects stacked,
+and only the first one was visible.
+
+**The parser had no sigil test, so the first word was always the target.** The
+handler took `rest` up to the first space as the channel, unconditionally. So
+that command issued `DELETE /networks/:slug/channels/non`, the server refused
+the sigil-less name, and the operator was told a channel they never typed was
+malformed. The fix is the same test `join` already runs — a first token matching
+`[#&+!]` is the target, anything else starts the reason — which is how every
+other IRC client resolves this ambiguity.
+
+**`/part` deliberately does NOT inherit `/join`'s bare-name sugar.** `/join`
+auto-prepends `#` so `/join sniffo` works. Copying that into `/part` is
+precisely what manufactures the phantom channel: a JOIN's first token has no
+second meaning, a PART's does. The two verbs look symmetric and are not, and
+the next person to "make them consistent" will reintroduce this bug.
+
+**The reason was parsed and then read by nobody.** Even spelled correctly,
+`/part #chan bye` left silently: `compose.ts` dropped `cmd.reason`, `postPart`
+was a bare DELETE, and `Session.send_part/3` had no parameter for it. So the
+second half of the fix is plumbing, not logic — compose → `?reason=` →
+controller → `Session.send_part/4` → the `:send_part` cast →
+`Client.send_part/3` → `PART <chan> :<reason>`.
+
+**Query param, not a DELETE body.** The reason is public by construction: it is
+broadcast to every member of the channel. There is nothing to keep out of a URL,
+and a query param assumes nothing about intermediaries forwarding a body on
+DELETE. The `/quit` reason travels in a JSON body only because PATCH already had
+one.
+
+**Absent or empty is the ABSENCE of a reason, byte for byte.** Not `PART #chan
+:`. This is the load-bearing constraint and it is not about `/part` at all:
+three other doors reach the same code — the sidebar ×, the window close, and
+the autojoin drop — and none of them is making a statement to the channel. Each
+passes `null` explicitly; no default argument hides the choice. `""` collapses
+to the bare form at the framing layer, mirroring `send_join/3`'s empty-key arm.
+
+**Each check sits at the boundary that owns it.** The controller refuses a
+non-binary param (a repeated key reaches Plug as a list) and CR/LF/NUL, up
+front — `delete/2` strips the channel from autojoin BEFORE it casts the PART,
+so a reason refused any later leaves a rejected request with the leave already
+half-applied. That ordering is the bug the first draft of this change shipped
+and a test caught. CR/LF earns `:invalid_line`, not `:bad_request`: free text
+whose only fault is smuggling a second command behind the trailing `:` is
+exactly the distinction `FallbackController` keeps that tag for. The byte cap is
+`BodyLimit`'s — the existing SSOT for user text bound for the wire, `byte_size`
+not graphemes — not a new number. `Session.send_part/4` re-checks CR/LF/NUL at
+the domain boundary as `send_join/4` does for its key: the controller is one
+door into PART, not the only one.
+
+**No 512-byte rejection, and that is deliberate.** `send_join/3`'s list clause
+rejects an over-512 framed line because ircd truncation there silently drops
+tail channels and strands their `:pending` windows forever. A truncated PART
+reason strands nothing — it is a shortened goodbye. `send_quit/2` and
+`send_topic/3`, the two closest siblings (user text, trailing param), do not cap
+either. Capping PART would be the inconsistent choice, not the safe one.
+
+**Measured: `/quit` is NOT the same class, contrary to the issue text.** The
+issue closes with "same class as the `/quit` reason path — worth checking that
+one while in there." It was checked, with a throwaway probe driving the real
+door: `PATCH /networks/:slug {connection_state: "parked", reason: "…"}` puts
+`QUIT :non trovo utili le bestemmie\r\n` on the wire, user text intact.
+`quitAll` → `patchNetwork` → `parse_reason` → `Networks.disconnect/2` →
+`best_effort_quit` → `Session.send_quit/3` has been plumbed since T32. Nothing
+to fix; the scope was not widened. The one real gap is evidentiary, not
+behavioural: no test pins a USER-SUPPLIED reason on the QUIT wire —
+`connection_state_test.exs` asserts the frame from the context function with a
+hardcoded string, and no controller test sends `reason` at all. Left as-is
+rather than widened on a worker's own initiative.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -449,17 +449,32 @@ defmodule Grappa.IRC.Client do
   end
 
   @doc """
-  Sends `PART <channel>\\r\\n`. Rejects CR/LF/NUL AND a malformed
-  channel name (missing `#`/`&`/`+`/`!` prefix, embedded whitespace
-  /comma/BELL, or length > 50) with `{:error, :invalid_line}`. Same
-  irc/S2 rationale as `send_join/3`.
+  Sends `PART <channel>\\r\\n`, or `PART <channel> :<reason>\\r\\n` when
+  `reason` is a non-empty binary (#1208). Rejects CR/LF/NUL in EITHER field
+  AND a malformed channel name (missing `#`/`&`/`+`/`!` prefix, embedded
+  whitespace/comma/BELL, or length > 50) with `{:error, :invalid_line}`.
+  Same irc/S2 rationale as `send_join/3`.
+
+  `nil` and `""` are both "no reason" and frame the bare form — mirroring
+  `send_join/3`'s empty-key clause, and keeping every non-`/part` door
+  (sidebar ×, window close, autojoin drop) byte-identical to pre-#1208.
   """
-  @spec send_part(pid(), String.t()) :: send_result()
-  def send_part(client, channel) do
-    if Identifier.safe_line_token?(channel) and Identifier.valid_channel?(channel),
-      do: send_line(client, "PART #{channel}\r\n"),
+  @spec send_part(pid(), String.t(), String.t() | nil) :: send_result()
+  def send_part(client, channel, reason) do
+    if joinable_channel?(channel) and safe_part_reason?(reason),
+      do: send_line(client, part_frame(channel, reason)),
       else: reject_invalid_line(:part)
   end
+
+  # The reason is the TRAILING param, so it may hold spaces — only CR/LF/NUL
+  # would break the frame. Absent reason is trivially safe.
+  defp safe_part_reason?(nil), do: true
+  defp safe_part_reason?(reason) when is_binary(reason), do: Identifier.safe_line_token?(reason)
+  defp safe_part_reason?(_), do: false
+
+  defp part_frame(channel, nil), do: "PART #{channel}\r\n"
+  defp part_frame(channel, ""), do: "PART #{channel}\r\n"
+  defp part_frame(channel, reason), do: "PART #{channel} :#{reason}\r\n"
 
   @doc """
   Sends `TOPIC <channel> :<body>\\r\\n`. The colon prefix marks the body

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -805,17 +805,28 @@ defmodule Grappa.Session do
   @doc """
   Queues a PART upstream through the session. Cast (see `send_join/4`
   for the rationale). `{:error, :no_session}` if not registered.
+
+  `reason` (#1208) is the optional PART message. `nil` — and the empty
+  string, which is the same thing — frames the bare `PART <channel>` this
+  call has always sent. Rejected with `{:error, :invalid_line}` when it
+  carries CR/LF/NUL: the reason is the trailing param, so an embedded CRLF
+  would end the PART line early and let the tail parse as its own command.
   """
-  @spec send_part(subject(), integer(), String.t()) ::
+  @spec send_part(subject(), integer(), String.t(), String.t() | nil) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_part(subject, network_id, channel)
-      when is_subject(subject) and is_integer(network_id) and is_binary(channel) do
-    if Identifier.safe_line_token?(channel) and Identifier.valid_channel?(channel) do
-      cast_session(subject, network_id, {:send_part, channel})
+  def send_part(subject, network_id, channel, reason)
+      when is_subject(subject) and is_integer(network_id) and is_binary(channel) and
+             (is_nil(reason) or is_binary(reason)) do
+    if Identifier.safe_line_token?(channel) and Identifier.valid_channel?(channel) and
+         safe_part_reason?(reason) do
+      cast_session(subject, network_id, {:send_part, channel, reason})
     else
       {:error, :invalid_line}
     end
   end
+
+  defp safe_part_reason?(nil), do: true
+  defp safe_part_reason?(reason), do: Identifier.safe_line_token?(reason)
 
   @doc """
   Declines the inbound invite held on `channel` (#976) — drops the `:invited`

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -74,7 +74,7 @@ defmodule Grappa.Session.Server do
   per-channel PubSub topic, AND sends the PRIVMSG upstream — atomic
   from the caller's view, single source for the row + wire event.
   `{:send_join, [ch, …], key}` (a canonical-folded channel LIST — #382)
-  / `{:send_part, ch}` are upstream-only (channel-membership tracking
+  / `{:send_part, ch, reason}` are upstream-only (channel-membership tracking
   lands in Phase 5 alongside JOIN/PART persistence).
   """
   use GenServer, restart: :transient
@@ -2678,7 +2678,8 @@ defmodule Grappa.Session.Server do
   end
 
   @impl GenServer
-  def handle_cast({:send_part, channel}, state) when is_binary(channel) do
+  def handle_cast({:send_part, channel, reason}, state)
+      when is_binary(channel) and (is_nil(reason) or is_binary(reason)) do
     # UX-4 bucket H — eager local-state cleanup regardless of upstream
     # PART outcome. Pre-fix the operator's window stayed in the sidebar
     # forever if upstream rejected PART (442 ERR_NOTONCHANNEL on PART
@@ -2747,7 +2748,7 @@ defmodule Grappa.Session.Server do
     # rejoined the parted channel on the next reconnect.
     maybe_persist_last_joined(prev, state)
 
-    case Client.send_part(state.client, channel) do
+    case Client.send_part(state.client, channel, reason) do
       :ok ->
         {:noreply, state}
 

--- a/lib/grappa_web/controllers/channels_controller.ex
+++ b/lib/grappa_web/controllers/channels_controller.ex
@@ -177,6 +177,39 @@ defmodule GrappaWeb.ChannelsController do
        else: {:error, :bad_request}
   end
 
+  # #1208 — the optional `?reason=` query param for DELETE (PART). Validated
+  # UP FRONT, like `validate_channel_name/1` and `validate_optional_key/1` are
+  # for their fields: `delete/2` removes the channel from autojoin BEFORE it
+  # casts the PART, so a reason refused any later would leave a rejected
+  # request with the leave already half-applied.
+  #
+  # Non-binary is `:bad_request` — a repeated key (`?reason[]=a&reason[]=b`)
+  # reaches Plug as a list, and a list must not fall through to a binary
+  # guard. CR/LF/NUL is `:invalid_line`, not `:bad_request`: the reason is
+  # otherwise free text, so smuggling a second IRC command behind the trailing
+  # `:` is the ONLY thing wrong with it, which is exactly the distinction
+  # `FallbackController` keeps that tag for. `BodyLimit` owns the byte cap,
+  # like it does for every other user-text field bound for the wire.
+  #
+  # `Session.send_part/4` re-checks CR/LF/NUL at the domain boundary, as
+  # `send_join/4` does for its key: this controller is one door into PART,
+  # not the only one.
+  #
+  # An absent param is `{:ok, nil}`, which frames the bare PART — the
+  # pre-#1208 behaviour for every caller that never learns this param exists.
+  @spec part_reason(map()) ::
+          {:ok, String.t() | nil} | {:error, :bad_request | :invalid_line | :body_too_large}
+  defp part_reason(%{"reason" => reason}) when is_binary(reason) do
+    with :ok <- BodyLimit.check(reason) do
+      if Grappa.IRC.Identifier.safe_line_token?(reason),
+        do: {:ok, reason},
+        else: {:error, :invalid_line}
+    end
+  end
+
+  defp part_reason(%{"reason" => _}), do: {:error, :bad_request}
+  defp part_reason(_), do: {:ok, nil}
+
   @doc """
   `DELETE /networks/:network_id/channels/:channel_id` — casts
   `PART <channel_id>` upstream AND removes the channel from the
@@ -186,10 +219,15 @@ defmodule GrappaWeb.ChannelsController do
   not in autojoin (e.g. a manually-joined `source: :joined` channel),
   and the autojoin removal is a no-op when the channel is not in the
   list. Returns 202 + `{"ok": true}`.
+
+  Optional `?reason=<text>` (#1208) becomes the PART message
+  (`PART <channel> :<reason>`). Absent or empty leaves the wire frame
+  byte-identical to the pre-#1208 bare form.
   """
   @spec delete(Plug.Conn.t(), map()) ::
-          Plug.Conn.t() | {:error, :bad_request | :no_session | :invalid_line}
-  def delete(conn, %{"channel_id" => channel}) do
+          Plug.Conn.t()
+          | {:error, :bad_request | :no_session | :invalid_line | :body_too_large}
+  def delete(conn, %{"channel_id" => channel} = params) do
     subject = Subject.to_session(conn.assigns.current_subject)
     network = conn.assigns.network
 
@@ -203,9 +241,13 @@ defmodule GrappaWeb.ChannelsController do
     # Pre-fix race window was ~5ms (DB write latency); under load it
     # widened. e2e suite saw it as the cp15-b6/r6/bughunt-1-b/m9
     # rotating-victim cascade. (E2E-ROBUSTNESS bucket D follow-up.)
-    with :ok <- validate_channel_name(channel),
+    # #1208 — `part_reason/1` is FIRST in the chain on purpose: a refused
+    # reason must not leave the autojoin UPDATE below already applied, or a
+    # 400 would still have half-performed the leave.
+    with {:ok, reason} <- part_reason(params),
+         :ok <- validate_channel_name(channel),
          :ok <- remove_from_autojoin(conn.assigns.current_subject, network, channel),
-         :ok <- Session.send_part(subject, network.id, channel) do
+         :ok <- Session.send_part(subject, network.id, channel, reason) do
       # #459 — archive_changed is broadcast by the SESSION when `send_part`
       # applies the PART (drops the channel from the active set), NOT here.
       # This action used to fire it optimistically right after the async cast,

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -286,6 +286,55 @@ defmodule Grappa.IRC.ClientTest do
                IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
     end
 
+    # #1208 — the PART reason. `nil` MUST frame byte-for-byte the pre-#1208
+    # bare form: every non-/part door into PART (the sidebar ×, the window
+    # close, an autojoin drop) passes `nil`, so a stray `PART #chan :` there
+    # would be a visible regression on the wire for every one of them.
+    test "send_part/3 with a nil reason emits the bare PART form" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_part(client, "#sniffo", nil)
+
+      assert {:ok, "PART #sniffo\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+    end
+
+    test "send_part/3 emits PART #chan :reason when a reason is given" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_part(client, "#sniffo", "non trovo utili le bestemmie")
+
+      assert {:ok, "PART #sniffo :non trovo utili le bestemmie\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+    end
+
+    # Mirrors `send_join/3`'s empty-key clause: an empty reason is the
+    # ABSENCE of a reason, not `PART #chan :`.
+    test "send_part/3 with an empty reason emits the bare PART form" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_part(client, "#sniffo", "")
+
+      assert {:ok, "PART #sniffo\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+    end
+
+    # The reason is trailing, so spaces survive verbatim behind the `:` —
+    # this is the whole point of the colon and the exact case (#1208) that
+    # the sigil-less parser used to shred into a phantom channel.
+    test "send_part/3 keeps spaces in the reason verbatim behind the colon" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_part(client, "#sniffo", "a  b   c")
+
+      assert {:ok, "PART #sniffo :a  b   c\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+    end
+
     test "send_topic/3 emits TOPIC #chan :body framing" do
       {server, port} = start_server()
       client = start_client(port)
@@ -1432,8 +1481,19 @@ defmodule Grappa.IRC.ClientTest do
       assert {:error, :invalid_line} = Client.send_join(client, "#chan\r\nQUIT", nil)
     end
 
-    test "send_part/2 rejects \\r\\n in channel", %{client: client} do
-      assert {:error, :invalid_line} = Client.send_part(client, "#chan\r\nQUIT")
+    test "send_part/3 rejects \\r\\n in channel", %{client: client} do
+      assert {:error, :invalid_line} = Client.send_part(client, "#chan\r\nQUIT", nil)
+    end
+
+    # #1208 — the reason rides behind `:` as the trailing param, so CRLF in
+    # it would terminate the PART line early and let the tail parse as its
+    # own command. Same boundary as the channel, same verdict.
+    test "send_part/3 rejects \\r\\n in reason", %{client: client} do
+      assert {:error, :invalid_line} = Client.send_part(client, "#chan", "bye\r\nQUIT :pwn")
+    end
+
+    test "send_part/3 rejects NUL byte in reason", %{client: client} do
+      assert {:error, :invalid_line} = Client.send_part(client, "#chan", "bye\x00pwn")
     end
 
     # UX-4 bucket F: key field also runs through safe_line_token? — CRLF
@@ -1496,12 +1556,12 @@ defmodule Grappa.IRC.ClientTest do
       assert {:error, :invalid_line} = Client.send_join(client, channels, nil)
     end
 
-    test "send_part/2 rejects malformed channel (missing #/&/+/!) (irc/S2)", %{client: client} do
-      assert {:error, :invalid_line} = Client.send_part(client, "no-hash")
+    test "send_part/3 rejects malformed channel (missing #/&/+/!) (irc/S2)", %{client: client} do
+      assert {:error, :invalid_line} = Client.send_part(client, "no-hash", nil)
     end
 
-    test "send_part/2 rejects empty channel (irc/S2)", %{client: client} do
-      assert {:error, :invalid_line} = Client.send_part(client, "")
+    test "send_part/3 rejects empty channel (irc/S2)", %{client: client} do
+      assert {:error, :invalid_line} = Client.send_part(client, "", nil)
     end
 
     # Codebase review 2026-05-12 irc/S3: an empty target makes the wire

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -6279,7 +6279,7 @@ defmodule Grappa.Session.ServerTest do
                      1_000
 
       slug = network.slug
-      :ok = Grappa.Session.send_part({:user, user.id}, network.id, "#existing")
+      :ok = Grappa.Session.send_part({:user, user.id}, network.id, "#existing", nil)
 
       assert_receive %Phoenix.Socket.Broadcast{
                        event: "event",

--- a/test/grappa/session_test.exs
+++ b/test/grappa/session_test.exs
@@ -4,7 +4,7 @@ defmodule Grappa.SessionTest do
   cover guards that fire BEFORE the registry lookup / GenServer
   call/cast — so they need no live `Session.Server` and no DB.
 
-  The CRLF guard for `send_privmsg/4 | send_join/4 | send_part/3` is
+  The CRLF guard for `send_privmsg/4 | send_join/4 | send_part/4` is
   the canonical case (S29 C1): CRLF in the body or target would
   smuggle a second IRC command onto the wire if it ever reached the
   Client. The Session facade rejects with `{:error, :invalid_line}`
@@ -117,25 +117,43 @@ defmodule Grappa.SessionTest do
     end
   end
 
-  describe "send_part/3 CRLF guard" do
+  describe "send_part/4 CRLF guard" do
     test "rejects \\r\\n in channel before whereis lookup" do
       assert {:error, :invalid_line} =
-               Session.send_part({:user, @user_id}, @network_id, "#chan\r\nQUIT")
+               Session.send_part({:user, @user_id}, @network_id, "#chan\r\nQUIT", nil)
     end
 
     test "rejects malformed channel (missing prefix) before whereis lookup (CRIT-1)" do
       assert {:error, :invalid_line} =
-               Session.send_part({:user, @user_id}, @network_id, "no-hash")
+               Session.send_part({:user, @user_id}, @network_id, "no-hash", nil)
     end
 
     test "rejects empty channel before whereis lookup (CRIT-1)" do
       assert {:error, :invalid_line} =
-               Session.send_part({:user, @user_id}, @network_id, "")
+               Session.send_part({:user, @user_id}, @network_id, "", nil)
     end
 
     test "valid input falls through to :no_session for unknown session" do
       assert {:error, :no_session} =
-               Session.send_part({:user, @user_id}, @network_id, "#chan")
+               Session.send_part({:user, @user_id}, @network_id, "#chan", nil)
+    end
+
+    # #1208 — the PART reason is user text from the compose box, so it runs
+    # through the same pre-dispatch CRLF gate the channel does. Without it a
+    # reason could smuggle a second command onto the wire behind the `:`.
+    test "rejects \\r\\n in reason before whereis lookup" do
+      assert {:error, :invalid_line} =
+               Session.send_part({:user, @user_id}, @network_id, "#chan", "bye\r\nQUIT :pwn")
+    end
+
+    test "rejects a NUL byte in reason before whereis lookup" do
+      assert {:error, :invalid_line} =
+               Session.send_part({:user, @user_id}, @network_id, "#chan", "bye\x00pwn")
+    end
+
+    test "a valid reason falls through to :no_session for unknown session" do
+      assert {:error, :no_session} =
+               Session.send_part({:user, @user_id}, @network_id, "#chan", "ciao raga")
     end
   end
 

--- a/test/grappa_web/controllers/channels_controller_test.exs
+++ b/test/grappa_web/controllers/channels_controller_test.exs
@@ -376,6 +376,106 @@ defmodule GrappaWeb.ChannelsControllerTest do
       assert json_response(conn, 400)["error"] == "bad_request"
     end
 
+    # #1208 — end to end: the `?reason=` query param has to survive the whole
+    # chain (controller → `Session.send_part/4` → the `:send_part` cast →
+    # `Client.send_part/3`) and land as the PART trailing param. Asserting the
+    # literal wire line is the only oracle that proves it: a test stopping at
+    # the 202 would pass with the reason silently dropped, which is exactly
+    # the defect this closes.
+    test "reason query param lands on the wire as the PART trailing param",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      conn =
+        delete(
+          conn,
+          "/networks/#{network.slug}/channels/%23sniffo?reason=non+trovo+utili+le+bestemmie"
+        )
+
+      assert json_response(conn, 202) == %{"ok" => true}
+
+      assert {:ok, "PART #sniffo :non trovo utili le bestemmie\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # An empty `?reason=` is the ABSENCE of a reason — byte-identical to the
+    # no-param call above, not `PART #sniffo :`.
+    test "empty reason query param emits the bare PART form", %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=")
+
+      assert json_response(conn, 202) == %{"ok" => true}
+
+      assert {:ok, "PART #sniffo\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # S29 C1 for the new field: CRLF in the reason would smuggle a second
+    # command behind the trailing `:`. Rejected AHEAD of the autojoin UPDATE,
+    # so a refused request leaves no half-applied leave behind.
+    test "reason with URL-encoded CRLF returns 400 and does not touch autojoin",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      {network, _} = network_with_server(port: port, slug: "az-1208-crlf-#{u()}")
+      _ = credential_fixture(vjt, network, %{autojoin_channels: ["#sniffo", "#other"]})
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      conn =
+        delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=bye%0AQUIT+%3Apwn")
+
+      assert json_response(conn, 400)["error"] == "invalid_line"
+
+      reloaded = Credentials.get_credential!(vjt, network)
+      assert reloaded.autojoin_channels == ["#sniffo", "#other"]
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The reason is user text headed for the IRC wire, so it goes through the
+    # SAME `BodyLimit` byte cap every other such field does — bytes, not
+    # graphemes. Above the cap it is refused at the door rather than handed to
+    # a framing layer that would silently truncate it.
+    test "over-cap reason returns 413 and sends nothing upstream", %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      oversize = String.duplicate("a", GrappaWeb.BodyLimit.max_body_bytes() + 1)
+
+      conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=#{oversize}")
+
+      assert json_response(conn, 413)["error"] == "body_too_large"
+
+      assert {:error, :timeout} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PART"), 200)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # A repeated key (`?reason=a&reason[]=b`) reaches Plug as a non-binary.
+    # Reject the SHAPE at the door rather than let it reach a guard that
+    # would `function_clause` inside the request.
+    test "non-string reason param returns 400 bad_request", %{conn: conn, vjt: vjt} do
+      _ = ensure_azzurra_credential(vjt)
+
+      conn = delete(conn, "/networks/azzurra/channels/%23sniffo?reason[]=a&reason[]=b")
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
     # BUG5a: DELETE also removes the channel from autojoin_channels so that
     # GET /channels returns it as absent (not as joined: false). Without this
     # fix, cicchetto's channels_changed refetch would return the channel with


### PR DESCRIPTION
Fixes the two stacked defects behind strk-oli's report: `/part non trovo utili
le bestemmie` answered **"The request was malformed."** about a channel named
`non` that he never typed, and even the correct spelling left without a message.

## The two defects

**1 — the parser had no sigil test.** `slashCommands.ts` took `rest` up to the
first space as the channel, unconditionally, so every bare reason was read as a
target. Now a first token matching `[#&+!]` is the target and anything else
starts the reason, with the current-window fallback intact — how every other IRC
client resolves the ambiguity.

`/part` deliberately does **not** inherit `/join`'s bare-name sugar. A JOIN's
first token has no second meaning; a PART's does, and auto-prepending `#` is
precisely what manufactures the phantom channel. The two verbs look symmetric
and are not.

**2 — the reason was parsed and read by nobody.** `compose.ts` discarded
`cmd.reason`, `postPart` was a bare DELETE, and `Session.send_part/3` had no
parameter for it. Plumbed end to end: compose → `?reason=` → controller →
`Session.send_part/4` → the `:send_part` cast → `Client.send_part/3` →
`PART <chan> :<reason>`.

## Decisions worth reviewing

- **Query param, not a DELETE body.** The reason is public by construction (it
  is broadcast to every member of the channel), so nothing needs keeping out of
  a URL, and a query param assumes nothing about intermediaries forwarding a
  body on DELETE.
- **Absent or empty is the ABSENCE of a reason, byte for byte** — not
  `PART #chan :`. Load-bearing beyond `/part`: the sidebar ×, the window close
  and the autojoin drop share this code and none of them is making a statement
  to the channel. Each passes `null` explicitly; no default argument hides it.
- **Validation ordering.** `part_reason/1` runs FIRST in `delete/2`'s `with`,
  because the autojoin UPDATE precedes the PART cast — a reason refused later
  would leave a rejected request with the leave half-applied. The first draft
  got this wrong and a test caught it.
- **CR/LF earns `:invalid_line`, not `:bad_request`.** Free text whose only
  fault is smuggling a second command behind the trailing `:` is exactly the
  distinction `FallbackController` keeps that tag for.
- **The byte cap is `BodyLimit`'s**, the existing SSOT for user text bound for
  the wire (`byte_size`, not graphemes) — not a new number.
- **No 512-byte rejection, deliberately.** `send_join/3`'s list clause rejects
  over-512 lines because truncation there silently drops tail channels and
  strands `:pending` windows. A truncated PART reason strands nothing;
  `send_quit/2` and `send_topic/3`, the closest siblings, do not cap either.

## `/quit` measured — NOT the same class

The issue closes with "same class as the `/quit` reason path". It is not, and
this was measured rather than read: a throwaway probe driving the real door
(`PATCH /networks/:slug {connection_state: "parked", reason: "…"}`) put
`QUIT :non trovo utili le bestemmie\r\n` on the wire with the text intact.
Plumbed since T32. Scope not widened.

One gap is worth recording: it is evidentiary, not behavioural. No test pins a
**user-supplied** reason on the QUIT wire — `connection_state_test.exs` asserts
the frame from the context function with a hardcoded string, and no controller
test sends `reason` at all. Left alone rather than widened unasked.

## Evidence

**Displacement — 18 mutants, 18 killed, 0 skipped.** Baseline green first; each
mutant applied to a clean tree by a one-shot exact-string injector that refuses
to run unless its pattern occurs exactly once, and each checked for BUILD
success before its verdict was read (a mutant that does not compile is a false
zero-kill, not a survivor). Arms covered: the client's reason/empty/bare framing
arms and its CRLF guard; the session facade's reason pass-through and CRLF
guard; the server cast's pass-through; the controller's param read, non-binary
refusal, CRLF gate, byte cap and check-ordering; the cic parser's sigil test and
sigil set; the api layer's presence, empty-collapse and percent-encoding; and
compose's forwarding plus windowClose's explicit `null`.

Two pairs share a single killer and therefore **detect without localising**: M4
(session nils the reason) and M6 (server cast nils it) are both caught only by
the end-to-end wire test, and M9/M11 (controller CRLF gate dropped vs. checked
after the autojoin UPDATE) are both caught only by the CRLF-plus-autojoin test.
Serial links in one chain; the oracle proves the chain, not which link broke.

**cic gates green:** `bun run check` rc=0, `bun run test` 275 files / 5129 tests
passed, both re-run AFTER the rebase onto `main` (which brought #445's changes
to `windowClose.ts`, `windowClose.test.ts` and `Sidebar.test.tsx` — all files
this branch also touches, so the automerge needed re-proving).

## What is NOT proven — read before merging

- 🔴 **No Elixir gate was run against this HEAD.** Docker died host-wide
  mid-session and cannot be restarted over ssh (`open -a Docker` → error -54;
  Docker Desktop is stuck on a GUI error dialog), so `scripts/check.sh` is
  unavailable. The last full run, one commit earlier, was 8 doctests / 58
  properties / 5757 tests with exactly **one** failure — a `send_part/3` call
  site in `session/server_test.exs` outside the scoped files, now fixed and
  folded into the plumbing commit. That fix has never been re-gated. **CI is
  the gate here.**
- The cic gates above ran with **host bun** (`bun --bun run`,
  `bun install --frozen-lockfile`) rather than the container, for the same
  reason. `bun.lock` and `package.json` are byte-identical before and after
  (sha1 `e7f640a9…` / `01eb69ef…`).
- No e2e and no `scripts/integration.sh` — that lane belongs to another worker
  and Docker is down regardless.
- The 413 test proves the **controller** refuses an over-cap reason; it does not
  prove the transport. In production an enormous URL may take a 414 from Bandit
  first. Both refuse; the tag differs.
- No browser verification of the cic UX.