### PR TITLE
#944: the away banner was late, not lost — and a 301 needs its own 311

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38160,3 +38160,86 @@ behavioural: no test pins a USER-SUPPLIED reason on the QUIT wire —
 `connection_state_test.exs` asserts the frame from the context function with a
 hardcoded string, and no controller test sends `reason` at all. Left as-is
 rather than widened on a worker's own initiative.
+
+---
+
+## 2026-08-10 — #944: the away banner was LATE, not lost — and a pending WHOIS is not a claim on the next 301
+
+`p0b-peer-away` and `issue270-peer-away-overlap` had been flaking for a
+night. The issue body said the spec addressed the peer by the requested
+nick instead of the granted one; that was already fixed (`6e811706`) and
+was not the cause. Two DIFFERENT defects were, and only one of them is
+the flake.
+
+**The flake is a latency bill, and the rail's speculative WHOIS pays it
+first.** Measured on the live testnet with a temporary probe on
+`Session.Server`'s route path (20 iterations of `p0b`, 2 red): the server
+emitted `peer_away` **20 times out of 20** — including both reds. The
+event is never dropped; it arrives too late for the spec's 5 s budget.
+The numbers, per iteration:
+
+    21:28:37.515  command=WHOIS    headroom_s=-1.61   (cic rail, auto)
+    21:28:37.524  command=PRIVMSG  headroom_s=-3.60   (the operator's /msg)
+    21:28:39.578  311 / 301 / 318                     (+2.05 s, the WHOIS)
+    21:28:42.569  301 → peer_away                     (+5.05 s)  RED
+
+The operator's own message is sent 9-65 ms AFTER the rail's WHOIS — cic's
+WS push beats its own REST POST — so the WHOIS takes the cheaper slot and
+the operator's reply pays for both. The delay of the standalone 301 then
+tracks `|headroom_s|`: ~3.0 s in the greens, 5.05 s in the red, against a
+5 s assert. `#270` carries a 10 s budget and cedes far more rarely, which
+is the same fact seen from the other end.
+
+**Displaced, with the prediction written first.** Suppressing the rail's
+auto-WHOIS (cic-side, experiment only) was predicted to move the PRIVMSG
+headroom from ~-3.5 s to ~-1.5 s, the reply from ~3 s to ~1.5 s, and the
+red to zero. Measured: `command=WHOIS` count 0 (the instrument checks
+itself), headroom **-1.5 s**, reply **2.0 s** (twice: 1 ms, bank fully
+drained), and **0 red in 60 iterations** against **6 red in 40** with it.
+The suite also ran 30% faster. So the rail's one extra command is not the
+whole 2 s base delay — the session's own login/join/reset traffic is —
+but it is what pushes the operator's reply across the budget.
+
+This is the first MEASUREMENT of the mechanism `lib/railWhois.ts` has
+been describing as inferred-from-source since #800 ("the ircd-side
+mechanism is still unconfirmed"): bahamut's `since - now < 10` recvQ gate
+(`s_bsd.c`) stops PARSING a socket that is over its bank, so the cost of
+a speculative command lands on the NEXT thing the operator does. The
+remedy is a design question and is deliberately NOT decided here: only
+the server can see the bank (`Grappa.IRC.FakeLag` already computes
+`headroom_s`), so deferring non-user-initiated upstream commands while
+headroom is negative is the shape to consider. Filed, not built.
+
+**The second defect is real and is what this change fixes.** The 301 arm
+was dual-purpose, gated on the mere PRESENCE of a `whois_pending` entry:
+pending → fold into the bundle, absent → emit `:peer_away`. A pending
+entry only says we ASKED. Between the ask and the reply, a standalone 301
+— bahamut's answer to our own PRIVMSG — was folded into a bundle it does
+not belong to and the banner was lost for good, not merely delayed.
+Observed in the wild once in 20 iterations (`21:28:31.102`, a standalone
+301 with a primed-but-unopened bundle).
+
+The discriminator is the bundle's OWN 311, and it was verified on the
+wire rather than read off the source. Two clients on the testnet leaf:
+
+    WHOIS   → 311 → 312 → 301 → 317 → 318
+    PRIVMSG → 301                       (bare, no 311)
+
+311 RPL_WHOISUSER opens every WHOIS reply and is the only numeric that
+folds `:user`, so its presence in the accumulator IS the "bundle open"
+fact — derived, not tracked in a parallel flag. Before it, a 301 can only
+be the standalone reply. `whois_bundle_open?/2` is that predicate.
+
+**Deliberately left alone: the `:delegated` numeric catch-all** shares the
+shape (it folds ANY unmatched numeric into a pending bundle) but the
+311-first order is only MEASURED for 301 on bahamut. Widening an
+unmeasured gate to every numeric and every ircd is the error this entry
+is about, in the other direction.
+
+**Not proven.** That the four nightly reds all had the lateness signature:
+their artifacts are gone and only w1's `#270` red and the two reproduced
+here were examined. Also unproven, and explicitly a claim about the
+testnet only: that the WHOIS/301 collision the gate now closes ever bit a
+real operator — the reasoning that a 20-100 ms RTT would lose the race
+every time is inference, and the delay measured here is the ircd
+deferring the parse, not the network.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1265,15 +1265,31 @@ defmodule Grappa.Session.EventRouter do
 
   # 301 RPL_AWAY: `:server 301 own_nick target :away message`. Dual-purpose:
   #
-  #   * WHOIS-bundle case (whois_pending entry exists for target) — fold
+  #   * WHOIS-bundle case (the target's bundle is OPEN — see below) — fold
   #     `away_message` into the bundle accumulator. Bundle emits at 318.
   #
-  #   * Standalone case (no whois_pending entry) — operator just /msg'd an
-  #     away peer and upstream replied with the away note. Emit a typed
+  #   * Standalone case — operator just /msg'd an away peer and upstream
+  #     replied with the away note. Emit a typed
   #     `{:peer_away, target, msg}` effect; `Server.apply_effects` broadcasts
   #     a `peer_away` wire event on the user-level topic, cic dm-listener
   #     renders an inline ephemeral row in the peer's DM window. cic owns
   #     localization (no human-readable string baked into the wire payload).
+  #
+  # #944 — which case applies is decided by the bundle's OWN 311, not by the
+  # mere existence of a pending entry. A pending WHOIS says we asked; the 311
+  # says the answer has started arriving, and only from then on can a 301
+  # belong to it. Measured on the testnet leaf: a WHOIS answers
+  # `311 → 312 → 301 → 317 → 318`, a PRIVMSG to an away peer answers with a
+  # BARE 301.
+  #
+  # Gating on the entry alone made the two indistinguishable whenever both
+  # were in flight, which is the normal case and not an exotic one: cic's rail
+  # auto-WHOISes the peer as soon as the DM card is on screen, 6 ms after the
+  # operator's own `/msg` (measured). Any upstream round trip slower than that
+  # window — i.e. any real network — lost the away reply into the bundle, and
+  # the banner the operator was owed never mounted. The e2e specs
+  # (p0b-peer-away, issue270-peer-away-overlap) only passed because the
+  # testnet's RTT is ~1 ms, and flaked whenever it wasn't.
   defp do_route(
          %Message{command: {:numeric, 301}, params: [_, target | rest]},
          state
@@ -1283,7 +1299,7 @@ defmodule Grappa.Session.EventRouter do
     pending = Map.get(state, :whois_pending, %{})
     msg = whois_trailing(rest)
 
-    case Map.has_key?(pending, nick_key) do
+    case whois_bundle_open?(pending, nick_key) do
       true ->
         {:cont, whois_fold(state, target, %{away_message: msg}), []}
 
@@ -3654,6 +3670,20 @@ defmodule Grappa.Session.EventRouter do
   # special-case appends to the existing `:channels` list rather than
   # overwriting (319 may chunk over multiple lines).
   @spec whois_fold(state(), String.t(), map()) :: state()
+  # #944 — has the pending bundle for `nick_key` started ARRIVING? Derived from
+  # the 311 fold rather than tracked separately: 311 RPL_WHOISUSER is the first
+  # numeric of every WHOIS reply and the only one that folds `:user`, so its
+  # presence in the accumulator IS the "bundle open" fact. A primed-but-unopened
+  # entry means we asked and upstream has not answered yet, which is exactly
+  # when a 301 must be read as the standalone reply to our own PRIVMSG.
+  @spec whois_bundle_open?(map(), String.t()) :: boolean()
+  defp whois_bundle_open?(pending, nick_key) do
+    case Map.fetch(pending, nick_key) do
+      {:ok, accum} -> Map.has_key?(accum, :user)
+      :error -> false
+    end
+  end
+
   defp whois_fold(state, target, fold) when is_binary(target) and is_map(fold) do
     pending = Map.get(state, :whois_pending, %{})
     nick_key = normalize_nick(target, casemapping(state))

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -3934,7 +3934,18 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "301 RPL_AWAY folds away_message into bundle when whois_pending entry exists" do
-      state = whois_pending_state("alice")
+      # The 311 comes FIRST on the wire and is what opens the bundle — observed
+      # on the testnet leaf: `311 → 312 → 301 → 317 → 318`. Routing it here is
+      # not scaffolding, it is the reply order the fold is allowed to assume.
+      {:cont, state, []} =
+        EventRouter.route(
+          msg(
+            {:numeric, 311},
+            ["vjt", "alice", "alice_u", "alice.host", "*", "Alice Realname"],
+            {:server, "irc.test.org"}
+          ),
+          whois_pending_state("alice")
+        )
 
       m =
         msg(
@@ -3945,6 +3956,32 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
       assert new_state.whois_pending["alice"][:away_message] == "Gone fishing"
+    end
+
+    # #944 — a pending WHOIS is NOT enough to claim a 301. Bahamut answers a
+    # WHOIS with `311 → 312 → 301 → 317 → 318` and answers a PRIVMSG to an away
+    # peer with a BARE 301 (both observed on the testnet leaf), so the 311 is
+    # what marks the bundle as open; before it, a 301 can only be the standalone
+    # reply to our own message.
+    #
+    # The race this closes: cic's rail auto-WHOISes the peer the moment the DM
+    # card comes on screen — measured 6 ms after the operator's `/msg` — so any
+    # upstream round trip slower than that window lost the away reply into the
+    # bundle and the DM banner never mounted. Gating on the entry alone made
+    # `peer_away` a coin flip on RTT; p0b-peer-away / issue270-peer-away-overlap
+    # were the specs that kept paying for it.
+    test "301 arriving before the bundle's own 311 is standalone (#944)" do
+      state = whois_pending_state("alice")
+
+      m =
+        msg(
+          {:numeric, 301},
+          ["vjt", "alice", "Gone fishing"],
+          {:server, "irc.test.org"}
+        )
+
+      {:cont, new_state, [{:peer_away, "alice", "Gone fishing"}]} = EventRouter.route(m, state)
+      refute Map.has_key?(new_state.whois_pending["alice"], :away_message)
     end
 
     test "301 with no whois_pending entry emits :peer_away typed effect (P-0b standalone)" do


### PR DESCRIPTION
## What this changes

One small correctness fix in `EventRouter`'s 301 arm, plus the decision
log. **It is deliberately not a fix for the `p0b-peer-away` flake** —
that turned out to be a different defect, measured and filed rather than
built.

### The fix: a pending WHOIS is not a claim on the next 301

The 301 arm was dual-purpose, gated on the mere PRESENCE of a
`whois_pending` entry: pending → fold into the WHOIS bundle, absent →
emit `:peer_away`. A pending entry only says we *asked*. Between the ask
and the reply, bahamut's answer to our own PRIVMSG — a bare 301 — was
folded into a bundle it does not belong to, and the peer-away banner was
lost for good.

Not exotic: cic's rail auto-WHOISes the DM peer within milliseconds of
the operator's `/msg`, so both are routinely in flight. Observed once in
20 live iterations.

The discriminator is the bundle's own 311, **verified on the wire**, not
read off the ircd source:

```
WHOIS   → 311 → 312 → 301 → 317 → 318
PRIVMSG → 301                        (bare, no 311)
```

311 opens every WHOIS reply and is the only numeric that folds `:user`,
so its presence in the accumulator *is* the "bundle open" fact —
derived, not a parallel flag to keep in sync.

## What the flake actually is (measured, not fixed here)

With a temporary probe on the route path, 20 iterations of `p0b`, 2 red:
the server emitted `peer_away` **20 times out of 20, both reds
included**. The event is never dropped — it arrives too late for the
spec's 5 s budget.

```
21:28:37.515  command=WHOIS    headroom_s=-1.61   (cic rail, automatic)
21:28:37.524  command=PRIVMSG  headroom_s=-3.60   (the operator's /msg)
21:28:39.578  311 / 301 / 318                     (+2.05 s)
21:28:42.569  301 → peer_away                     (+5.05 s)   RED
```

The rail's WHOIS goes out *before* the operator's own message (the WS
push beats the REST POST) and spends ~2 s of bahamut's fake-lag bank, so
the operator's reply pays for both. The 301's delay tracks
`|headroom_s|`: ~3.0 s green, 5.05 s red, against a 5 s assert. `#270`
budgets 10 s and cedes far more rarely — the same fact from the other
end.

**Displacement, prediction written first.** Suppressing the rail's
auto-WHOIS was predicted to move headroom to ~-1.5 s, the reply to
~1.5 s, and the red to zero. Measured: `command=WHOIS` count 0 (the
instrument checks itself), headroom **-1.5 s**, reply **2.0 s**, and
**0 red in 60 iterations** against **6 red in 40** with it. The suite
also ran 30 % faster.

This is the first measurement of the mechanism `railWhois.ts` has
carried as inferred-from-source since #800. The remedy is a design
question — only the server can see the bank — so it is filed, not built.

## Not proven

- That all four nightly reds had the lateness signature: their artifacts
  are gone; only w1's `#270` red and the two reproduced here were read.
- That the WHOIS/301 collision this gate closes ever bit a real
  operator. The RTT argument is inference; the delay measured here is
  the ircd deferring its parse, not the network.

## Gates

- `scripts/check.sh` — rc=0 (full static + unit + bats).
- `scripts/test.sh test/grappa/session/event_router_test.exs` — 354
  tests, 0 failures; the new test is red before the fix (`MatchError`,
  the 301 folded silently) and green after.
- e2e: the away family was run 116 times across the investigation. The
  residual `p0b` flake is the latency bill above and is untouched by
  this change — the full integration suite has NOT been run on this
  branch.