### PR TITLE
#348 — per-user auto-away debounce: a delay, an off switch, and visitors too

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -65,6 +65,9 @@ const PRIVMSG_TIMEOUT_MS = 15_000;
 const OPER_TIMEOUT_MS = 5_000;
 const NICKSERV_TIMEOUT_MS = 5_000;
 const AWAY_TIMEOUT_MS = 5_000;
+// #348 — see `whoisAway` for why this sits at the TOPIC/PRIVMSG fake-lag
+// ceiling rather than at `waitForLine`'s 8s default.
+const WHOIS_TIMEOUT_MS = 15_000;
 
 export class IrcPeer {
   private readonly client: Client;
@@ -348,6 +351,77 @@ export class IrcPeer {
     this.client.raw(["WHOIS", nick]);
   }
 
+  // #348 — "is `nick` away RIGHT NOW", as one correlated round-trip.
+  //
+  // WHOIS is request/response and always ends in 318 RPL_ENDOFWHOIS, so a
+  // reply that arrives WITHOUT a 301 is a POSITIVE statement of "present".
+  // Watching the line stream for a 301 instead (the `whois` + `waitForLine`
+  // shape above) cannot say that: it only ever reports "I heard nothing",
+  // which is equally what a throttled, dead or never-registered peer
+  // produces. A spec asserting "still not away" over a window is satisfied
+  // by silence, so silence must not be a verdict — hence this returns a
+  // boolean ONLY when the server actually answered.
+  //
+  // Both failure modes REJECT rather than resolving false, because "not
+  // away" is exactly the wrong thing to tell a caller here:
+  //   * no 318 inside the budget — the peer asked and nobody answered;
+  //   * 401 ERR_NOSUCHNICK — the nick is not on the network at all (e.g.
+  //     the bouncer registered a suffixed nick after a collision), so the
+  //     question was never about the session under test.
+  //
+  // Budget matches TOPIC/PRIVMSG above rather than `waitForLine`'s 8s
+  // default: a WHOIS is a reply to our OWN command and so sits behind the
+  // same bahamut fake-lag bank, whose overshoot is bounded by the ~10s cap.
+  // It is a condition-wait — it resolves the instant 318 lands.
+  async whoisAway(nick: string, timeoutMs = WHOIS_TIMEOUT_MS): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      let sawAway = false;
+
+      const settle = (finish: () => void) => {
+        clearTimeout(timer);
+        this.client.removeListener("raw", handler);
+        finish();
+      };
+
+      const timer = setTimeout(() => {
+        settle(() =>
+          reject(
+            new Error(
+              `IrcPeer: no 318 RPL_ENDOFWHOIS for ${nick} within ${timeoutMs}ms — ` +
+                `the WHOIS went unanswered, so "away" is unknown, not false`,
+            ),
+          ),
+        );
+      }, timeoutMs);
+
+      const handler = (event: { line: string; from_server: boolean }) => {
+        if (!event.from_server) return;
+        switch (whoisNumericFor(event.line, nick)) {
+          case "301":
+            sawAway = true;
+            return;
+          case "401":
+            settle(() =>
+              reject(
+                new Error(
+                  `IrcPeer: 401 ERR_NOSUCHNICK for ${nick} — nobody by that nick is on ` +
+                    `the network, so this WHOIS says nothing about the session under test`,
+                ),
+              ),
+            );
+            return;
+          case "318":
+            settle(() => resolve(sawAway));
+            return;
+          default:
+        }
+      };
+
+      this.client.on("raw", handler);
+      this.client.raw(["WHOIS", nick]);
+    });
+  }
+
   async part(channel: string, reason: string): Promise<void> {
     const parted = onceMatching(
       this.client,
@@ -543,6 +617,22 @@ export class IrcPeer {
       this.client.quit(reason);
     });
   }
+}
+
+// #348 — the numeric of a WHOIS reply line that is ABOUT `nick`, or null.
+//
+// Server numerics are `:<prefix> <numeric> <requester> <subject> …`, so the
+// subject is read off field 3 rather than regex-matched anywhere in the line:
+// a 301's away message is free text and can contain a nick, a numeric, or
+// both. Nick comparison is exact `===`, the convention every other predicate
+// in this file already uses (`event.nick === this.nick`) — bahamut is
+// CASEMAPPING=ascii and echoes the nick as it holds it, and a spelling that
+// somehow differed would surface as a LOUD unanswered-WHOIS rather than as a
+// quiet wrong answer.
+function whoisNumericFor(line: string, nick: string): string | null {
+  const parts = line.split(" ");
+  if (parts.length < 4) return null;
+  return parts[3] === nick ? parts[1] : null;
 }
 
 // #806 — every wait below detaches its handler on the TIMEOUT branch too,

--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -16,6 +16,7 @@
 
 import { Client, type IrcEventMap, type IrcEventName } from "irc-framework";
 import { awaitPrivmsg } from "./privmsgWait";
+import { awaitWhoisAway } from "./whoisWait";
 
 const HOST = process.env.E2E_IRC_HOST ?? "bahamut-test";
 const PORT = Number(process.env.E2E_IRC_PORT ?? "6667");
@@ -351,75 +352,17 @@ export class IrcPeer {
     this.client.raw(["WHOIS", nick]);
   }
 
-  // #348 — "is `nick` away RIGHT NOW", as one correlated round-trip.
+  // #348 — "is `nick` away RIGHT NOW", as one correlated round-trip, rather
+  // than the `whois` + `waitForLine` shape above which can only report that
+  // it heard nothing. Rationale, failure modes and the parsing all live in
+  // `whoisWait.ts`, where they are unit-tested without a testnet.
   //
-  // WHOIS is request/response and always ends in 318 RPL_ENDOFWHOIS, so a
-  // reply that arrives WITHOUT a 301 is a POSITIVE statement of "present".
-  // Watching the line stream for a 301 instead (the `whois` + `waitForLine`
-  // shape above) cannot say that: it only ever reports "I heard nothing",
-  // which is equally what a throttled, dead or never-registered peer
-  // produces. A spec asserting "still not away" over a window is satisfied
-  // by silence, so silence must not be a verdict — hence this returns a
-  // boolean ONLY when the server actually answered.
-  //
-  // Both failure modes REJECT rather than resolving false, because "not
-  // away" is exactly the wrong thing to tell a caller here:
-  //   * no 318 inside the budget — the peer asked and nobody answered;
-  //   * 401 ERR_NOSUCHNICK — the nick is not on the network at all (e.g.
-  //     the bouncer registered a suffixed nick after a collision), so the
-  //     question was never about the session under test.
-  //
-  // Budget matches TOPIC/PRIVMSG above rather than `waitForLine`'s 8s
+  // The budget matches TOPIC/PRIVMSG above rather than `waitForLine`'s 8s
   // default: a WHOIS is a reply to our OWN command and so sits behind the
   // same bahamut fake-lag bank, whose overshoot is bounded by the ~10s cap.
-  // It is a condition-wait — it resolves the instant 318 lands.
-  async whoisAway(nick: string, timeoutMs = WHOIS_TIMEOUT_MS): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      let sawAway = false;
-
-      const settle = (finish: () => void) => {
-        clearTimeout(timer);
-        this.client.removeListener("raw", handler);
-        finish();
-      };
-
-      const timer = setTimeout(() => {
-        settle(() =>
-          reject(
-            new Error(
-              `IrcPeer: no 318 RPL_ENDOFWHOIS for ${nick} within ${timeoutMs}ms — ` +
-                `the WHOIS went unanswered, so "away" is unknown, not false`,
-            ),
-          ),
-        );
-      }, timeoutMs);
-
-      const handler = (event: { line: string; from_server: boolean }) => {
-        if (!event.from_server) return;
-        switch (whoisNumericFor(event.line, nick)) {
-          case "301":
-            sawAway = true;
-            return;
-          case "401":
-            settle(() =>
-              reject(
-                new Error(
-                  `IrcPeer: 401 ERR_NOSUCHNICK for ${nick} — nobody by that nick is on ` +
-                    `the network, so this WHOIS says nothing about the session under test`,
-                ),
-              ),
-            );
-            return;
-          case "318":
-            settle(() => resolve(sawAway));
-            return;
-          default:
-        }
-      };
-
-      this.client.on("raw", handler);
-      this.client.raw(["WHOIS", nick]);
-    });
+  // It is a condition-wait — it resolves the instant the 318 lands.
+  whoisAway(nick: string, timeoutMs = WHOIS_TIMEOUT_MS): Promise<boolean> {
+    return awaitWhoisAway(this.client, { nick, timeoutMs });
   }
 
   async part(channel: string, reason: string): Promise<void> {
@@ -617,22 +560,6 @@ export class IrcPeer {
       this.client.quit(reason);
     });
   }
-}
-
-// #348 — the numeric of a WHOIS reply line that is ABOUT `nick`, or null.
-//
-// Server numerics are `:<prefix> <numeric> <requester> <subject> …`, so the
-// subject is read off field 3 rather than regex-matched anywhere in the line:
-// a 301's away message is free text and can contain a nick, a numeric, or
-// both. Nick comparison is exact `===`, the convention every other predicate
-// in this file already uses (`event.nick === this.nick`) — bahamut is
-// CASEMAPPING=ascii and echoes the nick as it holds it, and a spelling that
-// somehow differed would surface as a LOUD unanswered-WHOIS rather than as a
-// quiet wrong answer.
-function whoisNumericFor(line: string, nick: string): string | null {
-  const parts = line.split(" ");
-  if (parts.length < 4) return null;
-  return parts[3] === nick ? parts[1] : null;
 }
 
 // #806 — every wait below detaches its handler on the TIMEOUT branch too,

--- a/cicchetto/e2e/fixtures/whoisWait.test.ts
+++ b/cicchetto/e2e/fixtures/whoisWait.test.ts
@@ -111,11 +111,17 @@ describe("awaitWhoisAway", () => {
     await expect(wait).resolves.toBe(false);
   });
 
-  it("ignores a numeric that only appears in the away message's free text", async () => {
+  // The sharp case, and the reason the subject is read off field 3 rather
+  // than looked for anywhere in the line: this IS a 301, and our nick IS in
+  // it — in somebody else's away text, where a person may well put it.
+  // Matching on "the line mentions the nick" reports away for a user who is
+  // present, which is the one wrong answer the negative assertions cannot
+  // survive.
+  it("ignores a 301 about somebody else whose away text names our nick", async () => {
     const source = fakeSource();
     const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
     source.server(
-      `:leaf4.azzurra.chat 311 i348-away-watcher ${NICK} u h * :gone, ask 301 about ${NICK}`,
+      `:leaf4.azzurra.chat 301 i348-away-watcher someone-else :back later, ask ${NICK}`,
     );
     source.server(END);
     await expect(wait).resolves.toBe(false);

--- a/cicchetto/e2e/fixtures/whoisWait.test.ts
+++ b/cicchetto/e2e/fixtures/whoisWait.test.ts
@@ -1,0 +1,149 @@
+// #348 — the away oracle is the instrument three negative assertions are
+// judged by, so it has to be evidence rather than a shrug. These run under
+// the cic vitest project (see vitest.config.ts) because the wait is
+// deliberately free of the e2e-only `irc-framework` dependency — same
+// reason, same shape as `privmsgWait.test.ts`.
+//
+// The cases that matter are the ones where the OLD stream-watching oracle
+// answered "not away" for the wrong reason: nobody answered at all, the
+// nick is not on the network, or the 301 belonged to somebody else.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { awaitWhoisAway, type RawLineEvent, type WhoisSource } from "./whoisWait";
+
+type FakeSource = WhoisSource & {
+  server: (line: string) => void;
+  own: (line: string) => void;
+  attached: () => number;
+  sent: () => string[][];
+};
+
+function fakeSource(): FakeSource {
+  const handlers = new Set<(event: RawLineEvent) => void>();
+  const sent: string[][] = [];
+  return {
+    on: (_event, handler) => {
+      handlers.add(handler);
+    },
+    removeListener: (_event, handler) => {
+      handlers.delete(handler);
+    },
+    raw: (parts) => {
+      sent.push(parts);
+    },
+    server: (line) => {
+      for (const handler of [...handlers]) handler({ line, from_server: true });
+    },
+    own: (line) => {
+      for (const handler of [...handlers]) handler({ line, from_server: false });
+    },
+    attached: () => handlers.size,
+    sent: () => sent,
+  };
+}
+
+async function failureOf(wait: Promise<boolean>): Promise<string> {
+  try {
+    await wait;
+  } catch (err) {
+    return (err as Error).message;
+  }
+  throw new Error("expected the round-trip to reject, but it resolved");
+}
+
+const NICK = "s1a2b3c4";
+const END = `:leaf4.azzurra.chat 318 i348-away-watcher ${NICK} :End of /WHOIS list.`;
+const AWAY = `:leaf4.azzurra.chat 301 i348-away-watcher ${NICK} :auto-away`;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("awaitWhoisAway", () => {
+  it("asks: it puts the WHOIS on the wire, or nothing would ever answer", () => {
+    const source = fakeSource();
+    void awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 }).catch(() => {});
+    expect(source.sent()).toEqual([["WHOIS", NICK]]);
+  });
+
+  it("is away when a 301 precedes the 318", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    source.server(AWAY);
+    source.server(END);
+    await expect(wait).resolves.toBe(true);
+  });
+
+  it("is present when the round-trip completes with no 301 — an answer, not a silence", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    source.server(`:leaf4.azzurra.chat 311 i348-away-watcher ${NICK} u h * :real name`);
+    source.server(END);
+    await expect(wait).resolves.toBe(false);
+  });
+
+  it("rejects when nobody answers: silence is not a verdict of present", async () => {
+    const source = fakeSource();
+    // The rejection handler is attached BEFORE the clock is advanced: a
+    // rejection that lands with nothing listening is an unhandled rejection,
+    // which vitest fails the RUN over while every test still reports green.
+    const failure = failureOf(awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 }));
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(await failure).toContain("no 318 RPL_ENDOFWHOIS");
+  });
+
+  it("rejects on 401: a nick that is not on the network says nothing about the session", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    source.server(`:leaf4.azzurra.chat 401 i348-away-watcher ${NICK} :No such nick/channel`);
+    expect(await failureOf(wait)).toContain("401 ERR_NOSUCHNICK");
+  });
+
+  it("ignores a 301 about somebody else", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    source.server(":leaf4.azzurra.chat 301 i348-away-watcher someone-else :away");
+    source.server(END);
+    await expect(wait).resolves.toBe(false);
+  });
+
+  it("ignores a numeric that only appears in the away message's free text", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    source.server(
+      `:leaf4.azzurra.chat 311 i348-away-watcher ${NICK} u h * :gone, ask 301 about ${NICK}`,
+    );
+    source.server(END);
+    await expect(wait).resolves.toBe(false);
+  });
+
+  it("ignores our own outbound frames", async () => {
+    const source = fakeSource();
+    const wait = awaitWhoisAway(source, { nick: NICK, timeoutMs: 1_000 });
+    // `raw` fires for both directions; a 301-shaped line we SENT is not the
+    // network telling us anything.
+    source.own(AWAY);
+    source.server(END);
+    await expect(wait).resolves.toBe(false);
+  });
+
+  it("detaches its listener on every branch, so a peer does not accumulate handlers", async () => {
+    const answered = fakeSource();
+    const wait = awaitWhoisAway(answered, { nick: NICK, timeoutMs: 1_000 });
+    expect(answered.attached()).toBe(1);
+    answered.server(END);
+    await wait;
+    expect(answered.attached()).toBe(0);
+
+    const silent = fakeSource();
+    const timedOut = failureOf(awaitWhoisAway(silent, { nick: NICK, timeoutMs: 1_000 }));
+    expect(silent.attached()).toBe(1);
+    await vi.advanceTimersByTimeAsync(1_001);
+    await timedOut;
+    expect(silent.attached()).toBe(0);
+  });
+});

--- a/cicchetto/e2e/fixtures/whoisWait.ts
+++ b/cicchetto/e2e/fixtures/whoisWait.ts
@@ -1,0 +1,103 @@
+// #348 — "is <nick> away RIGHT NOW", as one correlated WHOIS round-trip.
+//
+// WHOIS is request/response and always ends in `318 RPL_ENDOFWHOIS`, so a
+// reply that completes WITHOUT a `301 RPL_AWAY` is a POSITIVE statement of
+// "present". Watching the line stream for a 301 instead cannot say that: it
+// only ever reports "I heard nothing", which is equally what a peer killed
+// by bahamut's per-IP limits, a reply stuck behind the fake-lag bank, and a
+// nick that never registered all produce. A spec asserting "still not away"
+// over a window is otherwise satisfied by silence — so silence must not be
+// able to be a verdict.
+//
+// Both failure modes REJECT rather than resolving false, because "not away"
+// is precisely the wrong thing to tell a caller here:
+//   * no 318 inside the budget — the peer asked and nobody answered;
+//   * `401 ERR_NOSUCHNICK` — nobody by that nick is on the network (e.g. the
+//     bouncer registered a suffixed nick after a collision), so the reply
+//     says nothing about the session under test.
+//
+// Lives in its own module, free of the e2e-only `irc-framework` dependency
+// and reached through a structural source, for the reason `privmsgWait.ts`
+// gives: the instrument a claim is judged by has to be provable itself, and
+// that means unit-testable under the cic vitest project without a testnet.
+
+export type RawLineEvent = { line: string; from_server: boolean };
+
+export type WhoisSource = {
+  on(event: "raw", handler: (event: RawLineEvent) => void): unknown;
+  removeListener(event: "raw", handler: (event: RawLineEvent) => void): unknown;
+  raw(parts: string[]): void;
+};
+
+export type WhoisAwayOptions = {
+  nick: string;
+  timeoutMs: number;
+};
+
+// The numeric of a WHOIS reply line that is ABOUT `nick`, or null.
+//
+// Server numerics are `:<prefix> <numeric> <requester> <subject> …`, so the
+// subject is read off field 3 rather than regex-matched anywhere in the line:
+// a 301's away message is FREE TEXT and can hold a nick, a numeric, or both,
+// and a spec whose oracle can be flipped by what somebody typed after `/away`
+// is not an oracle. Nick comparison is exact `===`, the convention every
+// other predicate in `ircClient.ts` already uses (`event.nick === this.nick`)
+// — bahamut is CASEMAPPING=ascii and echoes the nick as it holds it, and a
+// spelling that somehow differed surfaces as a LOUD unanswered-WHOIS rather
+// than as a quiet wrong answer.
+export function whoisNumericFor(line: string, nick: string): string | null {
+  const parts = line.split(" ");
+  if (parts.length < 4) return null;
+  return parts[3] === nick ? parts[1] : null;
+}
+
+export function awaitWhoisAway(source: WhoisSource, opts: WhoisAwayOptions): Promise<boolean> {
+  const { nick, timeoutMs } = opts;
+
+  return new Promise((resolve, reject) => {
+    let sawAway = false;
+
+    const settle = (finish: () => void) => {
+      clearTimeout(timer);
+      source.removeListener("raw", handler);
+      finish();
+    };
+
+    const timer = setTimeout(() => {
+      settle(() =>
+        reject(
+          new Error(
+            `whoisAway: no 318 RPL_ENDOFWHOIS for ${nick} within ${timeoutMs}ms — ` +
+              `the WHOIS went unanswered, so "away" is unknown, not false`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+
+    const handler = (event: RawLineEvent) => {
+      if (!event.from_server) return;
+      switch (whoisNumericFor(event.line, nick)) {
+        case "301":
+          sawAway = true;
+          return;
+        case "401":
+          settle(() =>
+            reject(
+              new Error(
+                `whoisAway: 401 ERR_NOSUCHNICK for ${nick} — nobody by that nick is on ` +
+                  `the network, so this WHOIS says nothing about the session under test`,
+              ),
+            ),
+          );
+          return;
+        case "318":
+          settle(() => resolve(sawAway));
+          return;
+        default:
+      }
+    };
+
+    source.on("raw", handler);
+    source.raw(["WHOIS", nick]);
+  });
+}

--- a/cicchetto/e2e/tests/issue348-auto-away-knob.spec.ts
+++ b/cicchetto/e2e/tests/issue348-auto-away-knob.spec.ts
@@ -1,0 +1,155 @@
+// #348 — the auto-away debounce is a per-user knob, and turning it has
+// to change what other people see.
+//
+// Until this, the grace period between "every device of mine is hidden"
+// and the upstream `AWAY` was one compile-time constant for the whole
+// deployment. The ask was a per-user setting with an off state, and the
+// two claims worth an e2e are the ones no unit test can make:
+//
+//   1. the bouncer waits the value the user PICKED IN THE UI, not the
+//      deployment's own default;
+//   2. changing it reaches a session that is already running — no
+//      reconnect, no restart.
+//
+// Both are asserted the way a human would notice them: through a peer's
+// WHOIS, which shows `301 RPL_AWAY` exactly when the network thinks the
+// user is away. The knob is driven through the settings control, not
+// through the REST endpoint — the control is half of what #348 shipped.
+//
+// The integration env sets the deployment default SHORT
+// (`config/dev.exs`, `auto_away_debounce_ms: 2_000`) so the #671 spec
+// need not wait ten minutes. That number is what makes this spec's
+// oracle sharp: a CUSTOM value well above it can be told apart from the
+// default, because "still not away" long after 2s can only mean the
+// preference is in force.
+//
+// Per `feedback_ux_e2e_mandatory`: server behaviour a client observes,
+// so it ships with a Playwright e2e via scripts/integration.sh.
+
+import { loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { setPageVisibility } from "../fixtures/push";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const PEER_NICK = "i348-away-watcher";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The custom delay this spec configures. Chosen far above the
+// integration default (2s) so "not away yet" is evidence the preference
+// won, and low enough that the whole spec stays under a minute.
+const CUSTOM_DEBOUNCE_SECONDS = 12;
+
+// Long enough past the 2s deployment default that an AWAY here would
+// mean the preference was ignored; far enough below the 12s preference
+// that it cannot be the preference firing early.
+const PAST_DEFAULT_MS = 6_000;
+
+// The budget for the preference itself to fire, measured from the hide.
+const PREFERENCE_BUDGET_MS = 20_000;
+
+// How long "never" gets to prove itself. Four times the deployment
+// default, on a run that has already shown this harness CAN see an AWAY.
+const OFF_WINDOW_MS = 8_000;
+
+const rplAway = (nick: string) => new RegExp(` 301 .* ${nick} `);
+
+// A peer's read of "is this nick away right now". Polls WHOIS because
+// the away flag is state, not an event: asking once races the bouncer's
+// round-trip.
+async function awayWithin(peer: IrcPeer, nick: string, budgetMs: number): Promise<boolean> {
+  const seen = peer.waitForLine(rplAway(nick), `RPL_AWAY for ${nick}`, budgetMs);
+  peer.whois(nick);
+  const poll = setInterval(() => peer.whois(nick), 2_000);
+  try {
+    await seen;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearInterval(poll);
+  }
+}
+
+test("#348 — the bouncer waits the delay the user picked, and honours a change made live", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const vjt = specUser();
+  const nick = specNick();
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: nick });
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+
+  const saveViaControl = async (act: () => Promise<void>) => {
+    const saved = page.waitForResponse(
+      (res) =>
+        res.url().includes("/me/settings/auto-away-debounce-seconds") &&
+        res.request().method() === "PUT",
+      { timeout: 10_000 },
+    );
+    await act();
+    const res = await saved;
+    expect(res.status()).toBe(200);
+  };
+
+  try {
+    // ---- the user picks a custom delay, in the UI -----------------------
+    await openSettingsDrawer(page);
+    await page.getByTestId("general-settings-entry").click();
+
+    const select = page.getByTestId("auto-away-select");
+    await expect(select).toBeVisible({ timeout: 5_000 });
+    await select.selectOption("custom");
+
+    await saveViaControl(async () => {
+      await page.getByTestId("auto-away-custom-input").fill(String(CUSTOM_DEBOUNCE_SECONDS));
+      await page.getByTestId("auto-away-custom-save").click();
+    });
+
+    // Close the drawer so the page is a normal session again before the
+    // visibility flip (an open drawer is not what a backgrounded phone
+    // looks like, and the flip is the thing under test).
+    await page.keyboard.press("Escape");
+
+    // ---- hiding starts the clock the USER set ---------------------------
+    await setPageVisibility(page, false);
+
+    // Pre-state: past the deployment's own 2s default and still present.
+    // If the preference were ignored, the AWAY would already be up — so
+    // this is the assertion that the knob, not the default, is in force.
+    expect(await awayWithin(peer, nick, PAST_DEFAULT_MS)).toBe(false);
+
+    // ...and the preference does fire. Without this the check above would
+    // be satisfied by an auto-away that is simply broken.
+    expect(await awayWithin(peer, nick, PREFERENCE_BUDGET_MS)).toBe(true);
+
+    // ---- coming back clears it ------------------------------------------
+    await setPageVisibility(page, true);
+    await expect
+      .poll(async () => await awayWithin(peer, nick, 3_000), { timeout: 20_000 })
+      .toBe(false);
+
+    // ---- switching OFF reaches the RUNNING session ----------------------
+    // No reload, no reconnect: the same page, the same upstream session
+    // that just demonstrated it can go away.
+    await openSettingsDrawer(page);
+    await page.getByTestId("general-settings-entry").click();
+    await saveViaControl(async () => {
+      await page.getByTestId("auto-away-select").selectOption("off");
+    });
+    await page.keyboard.press("Escape");
+
+    await setPageVisibility(page, false);
+
+    // With auto-away off the bouncer arms nothing at all, so this window
+    // — four times the deployment default, on a session that went away
+    // in this very test — stays clear.
+    expect(await awayWithin(peer, nick, OFF_WINDOW_MS)).toBe(false);
+  } finally {
+    await peer.disconnect("#348 spec done");
+  }
+});

--- a/cicchetto/e2e/tests/issue348-auto-away-knob.spec.ts
+++ b/cicchetto/e2e/tests/issue348-auto-away-knob.spec.ts
@@ -16,12 +16,20 @@
 // user is away. The knob is driven through the settings control, not
 // through the REST endpoint — the control is half of what #348 shipped.
 //
+// Three of the four assertions here are NEGATIVE ("not away yet", "away
+// cleared", "off means never"), and a negative read off a line stream is
+// worthless: no-301-heard is also what a dead peer, a throttled reply and
+// a nick that never registered all look like. So every question is a
+// complete WHOIS round-trip ending in `318 RPL_ENDOFWHOIS`
+// (`IrcPeer.whoisAway`) — the peer asked, the network answered, and the
+// answer did or did not carry a 301. Silence is an error, never a verdict.
+//
 // The integration env sets the deployment default SHORT
 // (`config/dev.exs`, `auto_away_debounce_ms: 2_000`) so the #671 spec
 // need not wait ten minutes. That number is what makes this spec's
 // oracle sharp: a CUSTOM value well above it can be told apart from the
-// default, because "still not away" long after 2s can only mean the
-// preference is in force.
+// default, because an answered "still present" long after 2s can only
+// mean the preference is in force.
 //
 // Per `feedback_ux_e2e_mandatory`: server behaviour a client observes,
 // so it ships with a Playwright e2e via scripts/integration.sh.
@@ -45,29 +53,45 @@ const CUSTOM_DEBOUNCE_SECONDS = 12;
 // that it cannot be the preference firing early.
 const PAST_DEFAULT_MS = 6_000;
 
-// The budget for the preference itself to fire, measured from the hide.
+// The budget for the preference itself to fire, clocked from the END of
+// the window above rather than from the hide — the two run back to back,
+// so the preference has already spent PAST_DEFAULT_MS of its 12s by the
+// time this one opens. Sized as a generous ceiling on a condition-wait,
+// not as a second measurement of the delay: the claim "longer than the
+// deployment default" is made by the window above, and pinning an upper
+// bound on the delay too would only add a way to go red on a slow host.
 const PREFERENCE_BUDGET_MS = 20_000;
 
 // How long "never" gets to prove itself. Four times the deployment
 // default, on a run that has already shown this harness CAN see an AWAY.
 const OFF_WINDOW_MS = 8_000;
 
-const rplAway = (nick: string) => new RegExp(` 301 .* ${nick} `);
+// Cadence of the round-trips inside a window. Unchanged from the WHOIS
+// poll this replaced, so the command load on bahamut's per-connection
+// fake-lag bank is the same as before.
+const WHOIS_POLL_MS = 2_000;
 
-// A peer's read of "is this nick away right now". Polls WHOIS because
-// the away flag is state, not an event: asking once races the bouncer's
-// round-trip.
+// "Was the bouncer away at any point inside this window?"
+//
+// Every answer is a COMPLETED WHOIS round-trip (`IrcPeer.whoisAway`), so a
+// `false` here means the network was asked and answered "present" — not
+// that nothing was heard. That distinction is what makes the three
+// negative assertions below worth anything: watching the line stream for
+// a 301 reports the same silence whether auto-away correctly held off,
+// or the peer died, or bahamut throttled the reply. Three of this spec's
+// four assertions want `false`, so silence must never be able to produce
+// it — a peer that stops answering now throws.
+//
+// The final probe is taken AT the end of the window, so a `false` verdict
+// speaks about the window's closing instant and not some earlier moment
+// inside it.
 async function awayWithin(peer: IrcPeer, nick: string, budgetMs: number): Promise<boolean> {
-  const seen = peer.waitForLine(rplAway(nick), `RPL_AWAY for ${nick}`, budgetMs);
-  peer.whois(nick);
-  const poll = setInterval(() => peer.whois(nick), 2_000);
-  try {
-    await seen;
-    return true;
-  } catch {
-    return false;
-  } finally {
-    clearInterval(poll);
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    if (await peer.whoisAway(nick)) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(WHOIS_POLL_MS, remaining)));
   }
 }
 
@@ -128,10 +152,11 @@ test("#348 — the bouncer waits the delay the user picked, and honours a change
     expect(await awayWithin(peer, nick, PREFERENCE_BUDGET_MS)).toBe(true);
 
     // ---- coming back clears it ------------------------------------------
+    // Not decoration: "present again, upstream" is the durable pre-state
+    // the OFF phase needs, and it is established by a round-trip the
+    // network answered rather than assumed from the visibility flip.
     await setPageVisibility(page, true);
-    await expect
-      .poll(async () => await awayWithin(peer, nick, 3_000), { timeout: 20_000 })
-      .toBe(false);
+    await expect.poll(() => peer.whoisAway(nick), { timeout: 20_000 }).toBe(false);
 
     // ---- switching OFF reaches the RUNNING session ----------------------
     // No reload, no reconnect: the same page, the same upstream session

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -14,6 +14,7 @@ import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, token } from "./lib/auth";
+import { autoAwayDebounceValue, loadAutoAwayDebounce, saveAutoAwayDebounce } from "./lib/autoAway";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import {
   windowMuteKey,
@@ -95,6 +96,19 @@ export type Props = {
   onClose: () => void;
 };
 
+// #348 — the auto-away ladder the control offers. Deliberately coarse:
+// these are the answers to "how long before my friends see me as away",
+// and anything between the rungs is what the custom entry is for. The
+// site-default entry carries NO number — cic does not know the server's
+// constant and a copy here would go stale the day it moves.
+const AUTO_AWAY_PRESETS = [
+  { seconds: 60, label: "1 minute" },
+  { seconds: 300, label: "5 minutes" },
+  { seconds: 600, label: "10 minutes" },
+  { seconds: 1800, label: "30 minutes" },
+  { seconds: 3600, label: "1 hour" },
+];
+
 const SettingsDrawer: Component<Props> = (props) => {
   const [size, setSize] = createSignal<FontSizeKey>(getFontSize());
   const [timeFmt, setTimeFmt] = createSignal<TimeFormatKey>(getTimeFormat());
@@ -117,6 +131,14 @@ const SettingsDrawer: Component<Props> = (props) => {
   // cache on drawer mount, saveUploadTtlSeconds round-trips on
   // change. `null` = "use the active host's defaultTtl".
   const [uploadTtlSavingError, setUploadTtlSavingError] = createSignal<string | null>(null);
+  // #348 — auto-away debounce. The server owns the behaviour AND the
+  // accepted range; these three only drive the control. `customMode`
+  // is a MODE the user can enter without having written anything yet,
+  // which is why it is a signal and not derived from the stored value
+  // alone.
+  const [autoAwaySavingError, setAutoAwaySavingError] = createSignal<string | null>(null);
+  const [autoAwayCustomMode, setAutoAwayCustomMode] = createSignal(false);
+  const [autoAwayCustomDraft, setAutoAwayCustomDraft] = createSignal("");
   // #228, #251 — source-bind (vhost) selection. Server owns the allow-set +
   // current selection (no admin pin — #251). `null` view = not-yet-loaded
   // (the widget stays hidden until the first GET lands).
@@ -420,6 +442,9 @@ const SettingsDrawer: Component<Props> = (props) => {
       // fieldset's `<select>` reflects the server value before the
       // first user interaction.
       void loadUploadTtlSeconds(t);
+      // #348 — same reason: the auto-away control must show what the
+      // server stored, not a client-side guess.
+      void loadAutoAwayDebounce(t);
       // #228, #251 — load the source-bind (vhost) view so the widget
       // reflects the server's allow-set + current selection.
       void loadVhostSettings(t);
@@ -628,6 +653,72 @@ const SettingsDrawer: Component<Props> = (props) => {
     } catch {
       /* swallowed — UI will refresh on next drawer open */
     }
+  };
+
+  // #348 — which entry the auto-away `<select>` is showing.
+  //
+  // A stored value that matches no preset renders as "custom" with the
+  // input filled, rather than collapsing onto the nearest rung: the
+  // number decides when the bouncer says you are away, so showing a
+  // different one would misreport the setting.
+  const autoAwaySelectValue = (): string => {
+    if (autoAwayCustomMode()) return "custom";
+    const seconds = autoAwayDebounceValue();
+    if (seconds === null) return "";
+    if (seconds === 0) return "off";
+    return AUTO_AWAY_PRESETS.some((p) => p.seconds === seconds) ? String(seconds) : "custom";
+  };
+
+  const autoAwayCustomValue = (): string => {
+    if (autoAwayCustomMode()) return autoAwayCustomDraft();
+    const seconds = autoAwayDebounceValue();
+    return seconds === null || seconds === 0 ? "" : String(seconds);
+  };
+
+  // #348 — persist a new auto-away preference. `null` clears it, `0`
+  // switches auto-away off; the accepted range for anything else is the
+  // server's to enforce, so a refusal is surfaced verbatim rather than
+  // pre-empted by a second copy of the bounds here.
+  const saveAutoAway = async (seconds: number | null) => {
+    const t = token();
+    if (t === null) return;
+    setAutoAwaySavingError(null);
+    try {
+      await saveAutoAwayDebounce(t, seconds);
+    } catch (err) {
+      setAutoAwaySavingError(err instanceof Error ? err.message : "save_failed");
+    }
+  };
+
+  // Selecting "custom" only opens the input — it is a mode, not a value.
+  // Writing here would persist whatever the input was seeded with.
+  const onAutoAwayChange = async (e: Event) => {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+
+    if (value === "custom") {
+      setAutoAwayCustomDraft(autoAwayCustomValue());
+      setAutoAwayCustomMode(true);
+      return;
+    }
+
+    setAutoAwayCustomMode(false);
+
+    if (value === "") return await saveAutoAway(null);
+    if (value === "off") return await saveAutoAway(0);
+    return await saveAutoAway(Number(value));
+  };
+
+  const onAutoAwayCustomSave = async () => {
+    // An empty box is not a zero: `Number("")` is 0, which is the OFF
+    // sentinel, so committing a blank input would silently switch
+    // auto-away off instead of asking for a number.
+    const raw = autoAwayCustomDraft().trim();
+    const seconds = Number(raw);
+    if (raw === "" || !Number.isInteger(seconds)) {
+      setAutoAwaySavingError("enter a whole number of seconds");
+      return;
+    }
+    await saveAutoAway(seconds);
   };
 
   // UX-4 bucket M (2026-05-19) — upload-TTL `<select>` change handler.
@@ -1295,6 +1386,65 @@ const SettingsDrawer: Component<Props> = (props) => {
                 </Show>
               </fieldset>
             </Show>
+
+            {/* #348 — how long after your last device goes away the bouncer
+                tells the network you are away. The delay and the off switch
+                are ONE control (vjt's ruling): they answer one question, and
+                two widgets could contradict each other. Outside the
+                host-gated Show above — this has nothing to do with uploads —
+                and shown to visitors too, whose sessions auto-away like
+                everyone else's. */}
+            <fieldset class="auto-away-fieldset">
+              <legend>auto-away</legend>
+              <label>
+                mark me away after:
+                <select
+                  data-testid="auto-away-select"
+                  value={autoAwaySelectValue()}
+                  onChange={(e) => {
+                    void onAutoAwayChange(e);
+                  }}
+                >
+                  <option value="">use site default</option>
+                  <option value="off">never — stay online</option>
+                  <For each={AUTO_AWAY_PRESETS}>
+                    {(preset) => <option value={String(preset.seconds)}>{preset.label}</option>}
+                  </For>
+                  <option value="custom">custom…</option>
+                </select>
+              </label>
+              <Show when={autoAwaySelectValue() === "custom"}>
+                <label>
+                  seconds:
+                  <input
+                    type="number"
+                    inputmode="numeric"
+                    data-testid="auto-away-custom-input"
+                    value={autoAwayCustomValue()}
+                    onInput={(e) => setAutoAwayCustomDraft(e.currentTarget.value)}
+                  />
+                  <button
+                    type="button"
+                    data-testid="auto-away-custom-save"
+                    onClick={() => {
+                      void onAutoAwayCustomSave();
+                    }}
+                  >
+                    save
+                  </button>
+                </label>
+              </Show>
+              <p class="settings-section-blurb" data-testid="auto-away-hint">
+                When every device of yours is closed or in the background, the bouncer waits this
+                long and then tells the network you are away. It stays connected either way — this
+                only changes what other people see. Pick "never" to keep the away flag off entirely.
+              </p>
+              <Show when={autoAwaySavingError() !== null}>
+                <p class="auto-away-error" role="alert" data-testid="auto-away-error">
+                  {autoAwaySavingError()}
+                </p>
+              </Show>
+            </fieldset>
           </section>
         </Show>
 

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -246,6 +246,22 @@ vi.mock("../lib/uploadOrchestrator", () => ({
 // signal via openShareModal(); mock it so the click is observable here
 // without mounting the modal (its own behaviour lives in
 // ShareSessionModal.test.tsx).
+// #348 — the auto-away knob reads and writes through `lib/autoAway`.
+// The store's own behaviour (load / save / wire mirror) is exercised in
+// its module test; here the public surface is mocked so these cases stay
+// about the CONTROL: what it offers, what it sends, and what it shows
+// when the server refuses.
+const autoAwayHolder = vi.hoisted(() => ({ current: null as number | null }));
+vi.mock("../lib/autoAway", () => ({
+  loadAutoAwayDebounce: vi.fn(async () => {
+    /* no-op; the drawer test asserts on the call only */
+  }),
+  saveAutoAwayDebounce: vi.fn(async (_t: string, seconds: number | null) => {
+    autoAwayHolder.current = seconds;
+  }),
+  autoAwayDebounceValue: () => autoAwayHolder.current,
+}));
+
 const shareModalHolder = { opened: 0 };
 // #462 — spread the REAL module so `SHARE_SESSION_LABEL` comes from the one
 // place that declares it: a hand-written copy in the factory would be a
@@ -290,6 +306,7 @@ beforeEach(() => {
   // state where me() returns null. Admin entry MUST be hidden.
   meHolder.current = null;
   uploadTtlHolder.current = null;
+  autoAwayHolder.current = null;
   subjectHolder.current = null;
   selectedChannelHolder.current = null;
   windowCandidatesHolder.current = [];
@@ -1765,5 +1782,148 @@ describe("SettingsDrawer (#476/#478 — per-network identity, both subjects)", (
     const stub = screen.getByTestId("delete-account-modal-stub");
     expect(stub).toHaveTextContent("nick-b");
     expect(stub).not.toHaveTextContent("nick-a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #348 — auto-away debounce control (General)
+// ---------------------------------------------------------------------------
+//
+// One control, three states, per vjt's ruling: a preset ladder, an
+// explicit "never", and a custom entry for a value no ladder can guess.
+// The interesting cases are the seams between them — picking "custom"
+// must not write anything on its own, and a stored value that matches no
+// preset must still be visible rather than silently rendering as the
+// nearest option.
+
+describe("SettingsDrawer — auto-away debounce (#348)", () => {
+  it("offers the presets, an off entry and a custom entry", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const select = screen.getByTestId("auto-away-select") as HTMLSelectElement;
+    const opts = Array.from(select.querySelectorAll("option")).map((o) => o.value);
+
+    expect(opts).toContain(""); // use site default
+    expect(opts).toContain("off");
+    expect(opts).toContain("custom");
+    expect(opts).toContain("600");
+  });
+
+  // cic does NOT know the server's default — it is a server constant, and
+  // a copy here would print a stale number the day it changes.
+  it("names no number on the site-default option", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const select = screen.getByTestId("auto-away-select") as HTMLSelectElement;
+    const dflt = Array.from(select.querySelectorAll("option")).find((o) => o.value === "");
+
+    expect(dflt?.textContent).toMatch(/default/i);
+    expect(dflt?.textContent).not.toMatch(/\d/);
+  });
+
+  it("loads the stored preference on mount", async () => {
+    const store = await import("../lib/autoAway");
+    wrap(true);
+    await waitFor(() => {
+      expect(store.loadAutoAwayDebounce).toHaveBeenCalledWith("test-bearer");
+    });
+  });
+
+  it("reflects a stored preset in the select", () => {
+    autoAwayHolder.current = 300;
+    wrap(true);
+    openSub("general-settings-entry");
+    expect((screen.getByTestId("auto-away-select") as HTMLSelectElement).value).toBe("300");
+  });
+
+  it("shows OFF as its own entry, not as the default one", () => {
+    autoAwayHolder.current = 0;
+    wrap(true);
+    openSub("general-settings-entry");
+    expect((screen.getByTestId("auto-away-select") as HTMLSelectElement).value).toBe("off");
+  });
+
+  it("picking a preset saves those seconds", async () => {
+    const store = await import("../lib/autoAway");
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "1800" } });
+    await waitFor(() => {
+      expect(store.saveAutoAwayDebounce).toHaveBeenCalledWith("test-bearer", 1800);
+    });
+  });
+
+  it("picking never saves 0, the off sentinel", async () => {
+    const store = await import("../lib/autoAway");
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "off" } });
+    await waitFor(() => {
+      expect(store.saveAutoAwayDebounce).toHaveBeenCalledWith("test-bearer", 0);
+    });
+  });
+
+  it("picking the site default clears the preference", async () => {
+    const store = await import("../lib/autoAway");
+    autoAwayHolder.current = 300;
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "" } });
+    await waitFor(() => {
+      expect(store.saveAutoAwayDebounce).toHaveBeenCalledWith("test-bearer", null);
+    });
+  });
+
+  // "custom" is a MODE, not a value: it reveals the input and waits. A
+  // write here would persist whatever the input happened to be seeded
+  // with, which is not something the user asked for.
+  it("picking custom reveals the input and writes nothing yet", async () => {
+    const store = await import("../lib/autoAway");
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "custom" } });
+
+    expect(screen.getByTestId("auto-away-custom-input")).toBeInTheDocument();
+    expect(store.saveAutoAwayDebounce).not.toHaveBeenCalled();
+  });
+
+  it("committing a custom value saves that number", async () => {
+    const store = await import("../lib/autoAway");
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "custom" } });
+
+    const input = screen.getByTestId("auto-away-custom-input") as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "45" } });
+    fireEvent.click(screen.getByTestId("auto-away-custom-save"));
+
+    await waitFor(() => {
+      expect(store.saveAutoAwayDebounce).toHaveBeenCalledWith("test-bearer", 45);
+    });
+  });
+
+  // A value stored from another client (or a future, wider ladder) has to
+  // remain visible and editable — collapsing it onto the nearest preset
+  // would misreport what the bouncer is actually waiting.
+  it("shows a stored non-preset value in the custom input", () => {
+    autoAwayHolder.current = 47;
+    wrap(true);
+    openSub("general-settings-entry");
+
+    expect((screen.getByTestId("auto-away-select") as HTMLSelectElement).value).toBe("custom");
+    expect((screen.getByTestId("auto-away-custom-input") as HTMLInputElement).value).toBe("47");
+  });
+
+  it("surfaces the server's refusal instead of pretending it saved", async () => {
+    const store = await import("../lib/autoAway");
+    vi.mocked(store.saveAutoAwayDebounce).mockRejectedValueOnce(new Error("out_of_range"));
+
+    wrap(true);
+    openSub("general-settings-entry");
+    fireEvent.change(screen.getByTestId("auto-away-select"), { target: { value: "1800" } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auto-away-error")).toHaveTextContent("out_of_range");
+    });
   });
 });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1188,6 +1188,11 @@ export type WireUserEvent =
       // (malformed / absent → []), threaded into applyServerSettings.
       http_host_aliases: string[];
     }
+  // #348 — the subject's auto-away debounce changed, on this device or
+  // another one. ONE scalar, three states: null = no preference (the
+  // server's own default applies), 0 = off, N = seconds. Mirrors
+  // `Grappa.UserSettings.Wire.auto_away_debounce_changed/1`.
+  | { kind: "auto_away_debounce_changed"; auto_away_debounce_seconds: number | null }
   | { kind: "archive_changed"; network_slug: string }
   // UX-7-B (2026-05-22) — `archive_purged` push after a destructive
   // archive-entry delete (operator dropped scrollback for the target).

--- a/cicchetto/src/lib/autoAway.ts
+++ b/cicchetto/src/lib/autoAway.ts
@@ -1,0 +1,60 @@
+/**
+ * #348 — the auto-away debounce preference, cached client-side.
+ *
+ * The server owns the behaviour: it is the thing that waits and then
+ * sends `AWAY` upstream. cic only reads the stored preference so the
+ * settings control can render it, writes it when the user changes it,
+ * and mirrors the server's push so a change made on the phone shows up
+ * on the laptop without a reload.
+ *
+ * Three states in one value, matching the wire: `null` = no preference
+ * (the server's own default applies — a number cic deliberately does
+ * not know), `0` = off, `N` = seconds.
+ */
+
+import { createSignal } from "solid-js";
+import { getAutoAwayDebounceSeconds, putAutoAwayDebounceSeconds } from "./userSettings";
+
+const [autoAwayDebounce, setAutoAwayDebounceSignal] = createSignal<number | null>(null);
+
+/** The cached preference: `null` (server default), `0` (off) or seconds. */
+export function autoAwayDebounceValue(): number | null {
+  return autoAwayDebounce();
+}
+
+/**
+ * Load the stored preference into the cache. Errors are swallowed: the
+ * cache stays at `null`, which renders as "use site default" — the same
+ * thing the server does for a subject with no preference, so a failed
+ * read shows the truth rather than a wrong number.
+ */
+export async function loadAutoAwayDebounce(token: string): Promise<void> {
+  try {
+    setAutoAwayDebounceSignal(await getAutoAwayDebounceSeconds(token));
+  } catch {
+    /* swallowed — the control falls back to "use site default" */
+  }
+}
+
+/**
+ * Persist a new preference and mirror what the server echoed back — not
+ * what we sent. Throws `ApiError` on 4xx/5xx so the caller can surface
+ * the server's message (which is where the accepted range is spelled).
+ */
+export async function saveAutoAwayDebounce(token: string, seconds: number | null): Promise<void> {
+  setAutoAwayDebounceSignal(await putAutoAwayDebounceSeconds(token, seconds));
+}
+
+/**
+ * Adopt a change the SERVER announced (the `auto_away_debounce_changed`
+ * push, fired for every write including ones from another device). cic
+ * never originates this state — it only mirrors it.
+ */
+export function applyAutoAwayDebounceFromWire(seconds: number | null): void {
+  setAutoAwayDebounceSignal(seconds);
+}
+
+/** Test-only: drop the cache back to "no preference". */
+export function resetAutoAwayDebounceForTests(): void {
+  setAutoAwayDebounceSignal(null);
+}

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -91,6 +91,56 @@ export async function putNotificationPrefs(
 }
 
 // ---------------------------------------------------------------------------
+// auto_away_debounce_seconds — #348.
+//
+// How long the bouncer waits, after the subject's last device goes
+// hidden, before telling the network they are away. ONE scalar carries
+// three states, because the delay and the off switch are one control:
+//
+//   null  no preference — the server's own default applies. cic does NOT
+//         know that number and must not print one: it is a server
+//         constant, and a copy here would drift the day it changes.
+//   0     off. The bouncer arms no timer at all.
+//   N     seconds.
+//
+// The accepted range lives on the server, deliberately un-mirrored here
+// for the same reason: an out-of-range value comes back as a 422 whose
+// message names the bounds, which is one source of truth instead of two.
+// ---------------------------------------------------------------------------
+
+export type AutoAwayDebounceResponse = {
+  auto_away_debounce_seconds: number | null;
+};
+
+export async function getAutoAwayDebounceSeconds(token: string): Promise<number | null> {
+  const res = await fetch("/me/settings/auto-away-debounce-seconds", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, res.statusText || "auto_away_debounce_get_failed");
+  }
+  const body = (await res.json()) as AutoAwayDebounceResponse;
+  return body.auto_away_debounce_seconds;
+}
+
+export async function putAutoAwayDebounceSeconds(
+  token: string,
+  seconds: number | null,
+): Promise<number | null> {
+  const res = await fetch("/me/settings/auto-away-debounce-seconds", {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ auto_away_debounce_seconds: seconds }),
+  });
+  if (!res.ok) throw await readError(res);
+  const body = (await res.json()) as AutoAwayDebounceResponse;
+  return body.auto_away_debounce_seconds;
+}
+
+// ---------------------------------------------------------------------------
 // upload_ttl_seconds — UX-4 bucket M (2026-05-19).
 //
 // Server stores the operator's upload-TTL preference as an integer of

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -14,6 +14,7 @@ import {
 } from "./api";
 import { loadArchive } from "./archive";
 import { clearLocalAuth, socketUserName, token } from "./auth";
+import { applyAutoAwayDebounceFromWire } from "./autoAway";
 import { setAwayState } from "./awayStatus";
 import { setBanlistBundle } from "./banlistCard";
 import { setServerBundleHash, setServerBundleVersion } from "./bundleHash";
@@ -898,6 +899,17 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // call-site switch below (different store keys per topic boundary
       // → "reuses the verb, not the noun").
       return narrowWindowStateEvent(r);
+    case "auto_away_debounce_changed":
+      // #348 — the auto-away preference moved. `null` (no preference)
+      // is a MEANINGFUL value here, not a missing field, so the
+      // narrower admits it explicitly and rejects anything that is
+      // neither null nor a number.
+      if (r.auto_away_debounce_seconds !== null && typeof r.auto_away_debounce_seconds !== "number")
+        return null;
+      return {
+        kind: "auto_away_debounce_changed",
+        auto_away_debounce_seconds: r.auto_away_debounce_seconds,
+      };
     case "archive_changed":
       // UX-1 (2026-05-17) — server broadcasts after a successful PART
       // (channel moves into archive list). Single-field envelope: cic
@@ -1442,6 +1454,14 @@ moduleRoot(() => {
           // F1 — see `joined` arm above. Same shape + setter as
           // `subscribe.ts` per-channel kicked arm.
           setKicked(channelKey(payload.network, payload.channel), payload.by, payload.reason);
+          return;
+
+        case "auto_away_debounce_changed":
+          // #348 — mirror the server's own announcement so the settings
+          // control converges across the subject's devices. cic never
+          // originates this state; it only reflects what the server
+          // stored, including for the write this device just made.
+          applyAutoAwayDebounceFromWire(payload.auto_away_debounce_seconds);
           return;
 
         case "archive_changed":

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1335,6 +1335,11 @@ export const S_ThemesWireT = {
   },
 } as const;
 
+// Grappa.UserSettings.Wire.auto_away_debounce_changed_payload/0
+export const S_UserSettingsWireAutoAwayDebounceChangedPayload = {
+  o: { kind: { l: "auto_away_debounce_changed" }, auto_away_debounce_seconds: { u: ["i", "z"] } },
+} as const;
+
 // Grappa.Vhosts.AdminWire.grant_json/0
 export const S_VhostsAdminWireGrantJson = {
   o: {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1360,6 +1360,13 @@ export type ThemesWireT = {
   inserted_at: string;
 };
 
+// === Grappa.UserSettings.Wire ===
+
+export type UserSettingsWireAutoAwayDebounceChangedPayload = {
+  kind: "auto_away_debounce_changed";
+  auto_away_debounce_seconds: number | null;
+};
+
 // === Grappa.Vhosts.AdminWire ===
 
 export type VhostsAdminWireVhostJson = {

--- a/cicchetto/src/lib/wireTypesAssert.ts
+++ b/cicchetto/src/lib/wireTypesAssert.ts
@@ -107,6 +107,7 @@ import type {
   SessionWireWindowInviteDeclinedPayload,
   SessionWireWindowInvitedPayload,
   SessionWireWindowPendingPayload,
+  UserSettingsWireAutoAwayDebounceChangedPayload,
   WindowCountsWireEvent,
 } from "./wireTypes";
 
@@ -241,6 +242,12 @@ export type _Assert_ArchiveChanged = Assert<
 >;
 export type _Assert_ArchivePurged = Assert<
   Equal<Extract<WireUserEvent, { kind: "archive_purged" }>, ScrollbackWireArchivePurgedPayload>
+>;
+export type _Assert_AutoAwayDebounceChanged = Assert<
+  Equal<
+    Extract<WireUserEvent, { kind: "auto_away_debounce_changed" }>,
+    UserSettingsWireAutoAwayDebounceChangedPayload
+  >
 >;
 export type _Assert_ServerSettingsChanged = Assert<
   Equal<

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38243,3 +38243,76 @@ testnet only: that the WHOIS/301 collision the gate now closes ever bit a
 real operator — the reasoning that a 20-100 ms RTT would lose the race
 every time is inference, and the delay measured here is the ircd
 deferring the parse, not the network.
+
+---
+
+## 2026-08-11 — #348: one knob for the auto-away delay, its off switch, and everyone
+
+The grace period between "every device of this subject went hidden" and the
+upstream `AWAY` was one compile-time constant for the whole deployment
+(`Session.Server.@auto_away_debounce_ms`, 600_000 since the 2026-07-19 bump
+away from a twitchy 30s). #671 had already built the injection seam — boot →
+`:persistent_term` → the spawn boundary — so what was missing was a per-user
+value, a way to switch the behaviour off, and a way for either to reach a
+session that is already running.
+
+**One scalar, three states.** vjt ruled that the delay and the off switch are
+ONE control, so the store keeps one key: absent = no preference (the
+deployment default applies), `0` = off, N = seconds. The context speaks
+`:disabled` because a closed set deserves an atom; JSON has no atoms, so `0`
+is the sentinel on the wire, translated at exactly two places (the controller
+decoding a body, the JSON view rendering a response) and nowhere else. `0` is
+therefore NOT an accepted delay: passing it as one is a 422, because a
+zero-second debounce and "no debounce at all" would otherwise be the same
+number meaning opposite things. No migration — `user_settings` is a single
+JSON `data` map and the schema is deliberately key-agnostic.
+
+**Off means no timer, not a long one.** `arm_auto_away_debounce/1` is now the
+single arm site and refuses to arm on `:disabled`. A very large window would
+still flap the user AWAY eventually, which is the thing the switch exists to
+prevent. Switching off also cancels a timer already in flight: a switch that
+lets one last AWAY through, up to a window later, is the same surprise wearing
+a delay.
+
+**A second bridge topic, not a second channel.** A settings write announces on
+two surfaces because it has two audiences with incompatible payloads. Live
+`Session.Server` processes need a raw Elixir term, and the user topic cannot
+carry one — a non-JSON-encodable payload crashes Phoenix's fastlane during
+fan-out. So `Topic.user_settings/1` joins `Topic.ws_presence/1` as an internal
+write-edge-to-session fan-out, excluded from `parse/1`/`valid?/1` so no WS
+client can join it, while the subject's other devices get the
+`auto_away_debounce_changed` wire event on `Topic.user/1`. Both leave from the
+context, so no door can persist a value without announcing it. The subject
+label is a parameter (the `Notify.add/4` precedent) rather than a hidden
+lookup: routing is the caller's knowledge, and deriving it here would make
+every write pay for a second query.
+
+**A retune re-arms.** We never recorded when the hide happened, so the honest
+options were "restart the window now" or "ignore this until the next hide".
+vjt ruled restart: a knob that visibly does nothing until you background the
+tab again is the worse surprise.
+
+**Visitors auto-away too — the old policy was reversed.** The presence-bridge
+subscription used to be gated to `{:user, _}` subjects, reasoning that a
+visitor's disconnect is a bouncer disconnect so auto-away was moot. That is
+true of the DISCONNECT case and misses the one auto-away exists for: a device
+that BACKGROUNDS while its socket lives. A visitor who locked their phone
+stayed visibly present upstream for as long as the socket held. Storage was
+never the obstacle (`user_settings` has been subject-scoped, XOR
+user_id/visitor_id, since 2026-05-15), and vjt set the default: visitors
+resolve the same deployment default users do, overridable through their own
+settings row. Nothing in the session is visitor-specific any more.
+
+**Two numbers cic deliberately does not know.** The settings control (General:
+a preset ladder plus a custom seconds entry, both per vjt's ruling) does not
+print the deployment default on its "use site default" option, and does not
+bound the custom input with a copy of the accepted range. Both are server
+constants; a client-side copy goes stale the day one moves. An out-of-range
+value comes back as a 422 whose message names the bounds, and cic surfaces it
+verbatim. The accepted range itself is ONE constant in `Grappa.UserSettings`,
+with the type and both accessors derived from it.
+
+**Unproven here:** the e2e (`issue348-auto-away-knob.spec.ts`) is written but
+has not been run — the integration stack belonged to another worker for the
+duration of this work. Everything else is measured: the full Elixir gate and
+both cic gates are green.

--- a/lib/grappa/pubsub/topic.ex
+++ b/lib/grappa/pubsub/topic.ex
@@ -227,6 +227,32 @@ defmodule Grappa.PubSub.Topic do
   end
 
   @doc """
+  Builds the settings-change bridge topic (#348).
+
+  Second instance of the `ws_presence/1` shape and subscribed by the
+  same processes: an internal grappa-side fan-out from a settings write
+  to the subject's live `Grappa.Session.Server` processes, so a knob a
+  session reads (today the auto-away debounce) takes effect without a
+  session restart.
+
+  Distinct from `user/1` in the same three ways: direction (write edge →
+  session), audience (per-session subscribers, NOT browsers), and
+  payload (raw Elixir terms, where `user/1` carries only JSON-encodable
+  wire maps and would crash the WS fastlane on anything else). A
+  settings write announces on BOTH — this one for the sessions, `user/1`
+  for the subject's other devices.
+
+  Excluded from `parse/1` and `valid?/1` on purpose, like
+  `ws_presence/1`: those validate the public topic grammar enforced at
+  `GrappaWeb.GrappaChannel`'s `join/3`, and this bridge must never be
+  subscribable by an external WS client.
+  """
+  @spec user_settings(String.t()) :: t()
+  def user_settings(subject_label) when is_binary(subject_label) and subject_label != "" do
+    "grappa:user_settings:" <> subject_label
+  end
+
+  @doc """
   Decodes a topic string back into its tagged-tuple form.
 
   Returns `{:ok, parsed}` for any of the three documented shapes,

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -252,15 +252,20 @@ defmodule Grappa.Session do
       when is_subject(subject) and is_integer(network_id) and is_map(opts) do
     ^subject = Map.fetch!(opts, :subject)
 
-    # #671 — inject the boot-resolved auto-away debounce at the single
-    # spawn choke point (the CLAUDE.md start_link-opts pattern for a
-    # dynamically-spawned GenServer: boot reads env → persistent_term →
-    # the spawn boundary injects). `put_new` so a caller/test that already
-    # set the key (a substituted short window) wins.
+    # #671 — inject the auto-away debounce at the single spawn choke
+    # point (the CLAUDE.md start_link-opts pattern for a dynamically-
+    # spawned GenServer: boot reads env → persistent_term → the spawn
+    # boundary injects). `put_new` so a caller/test that already set the
+    # key (a substituted short window) wins.
+    #
+    # #348 — the value is now the SUBJECT's preference resolved over that
+    # boot default (and `:disabled` when they switched auto-away off), so
+    # a session starts on the window its user chose. A subject with no
+    # preference resolves to the same boot default as before.
     full_opts =
       opts
       |> Map.put(:network_id, network_id)
-      |> Map.put_new(:auto_away_debounce_ms, Server.auto_away_debounce_ms())
+      |> Map.put_new(:auto_away_debounce_ms, Server.auto_away_debounce_for(subject))
 
     DynamicSupervisor.start_child(
       Grappa.SessionSupervisor,

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -265,7 +265,9 @@ defmodule Grappa.Session do
     full_opts =
       opts
       |> Map.put(:network_id, network_id)
-      |> Map.put_new(:auto_away_debounce_ms, Server.auto_away_debounce_for(subject))
+      |> Map.put_new_lazy(:auto_away_debounce_ms, fn ->
+        Server.auto_away_debounce_for(subject)
+      end)
 
     DynamicSupervisor.start_child(
       Grappa.SessionSupervisor,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -539,9 +539,11 @@ defmodule Grappa.Session.Server do
           # omits it and inherits `@autojoin_defer_ms`.
           optional(:autojoin_defer_ms) => pos_integer(),
           # #671 auto-away debounce window. Normally injected by
-          # `Grappa.Session.start_session/3` from the boot-resolved default;
-          # a test / integration env may substitute a short window.
-          optional(:auto_away_debounce_ms) => non_neg_integer(),
+          # `Grappa.Session.start_session/3`, which resolves the subject's
+          # #348 preference over the boot-resolved default; a test /
+          # integration env may substitute a short window. `:disabled` is
+          # the #348 OFF state — no debounce timer is ever armed.
+          optional(:auto_away_debounce_ms) => non_neg_integer() | :disabled,
           # GH #189 — on-connect perform list + its `$oper_pass` secret,
           # decrypted plaintext from the credential (nil when unset). Run at 001
           # before the built-in identify and before autojoin. The `$nickserv_pass`
@@ -673,8 +675,11 @@ defmodule Grappa.Session.Server do
           away_state: AwayState.t(),
           auto_away_timer: reference() | nil,
           # #671 — the auto-away debounce window (ms), injected from
-          # `start_session/3` (boot-resolved default; opts override in tests).
-          auto_away_debounce_ms: non_neg_integer(),
+          # `start_session/3` (the subject's #348 preference over the
+          # boot-resolved default; opts override in tests). `:disabled`
+          # (#348) means auto-away is off for this subject: the arm site
+          # arms nothing rather than arming a very long timer.
+          auto_away_debounce_ms: non_neg_integer() | :disabled,
           # S4.2: IRCv3 caps confirmed active by upstream CAP ACK. Keys are
           # lowercase cap names (e.g. "labeled-response"). Empty until the
           # upstream ACKs at least one cap. Caps added on ACK; never removed
@@ -966,6 +971,39 @@ defmodule Grappa.Session.Server do
   @spec auto_away_debounce_ms() :: non_neg_integer()
   def auto_away_debounce_ms do
     :persistent_term.get(@auto_away_debounce_key, @auto_away_debounce_ms)
+  end
+
+  @doc """
+  Turns a stored #348 preference into the window this session waits.
+
+  `nil` (no preference) resolves to the boot-resolved default, so a
+  subject who never touched the knob is byte-identical to pre-#348;
+  `:disabled` passes through as the OFF state the arm site refuses to
+  arm on; a seconds integer becomes milliseconds.
+
+  The single resolver for both entry points — the spawn boundary, which
+  reads the stored preference, and the live refresh, which is handed the
+  new one by the settings broadcast.
+  """
+  @spec resolve_auto_away_debounce(UserSettings.auto_away_debounce()) ::
+          non_neg_integer() | :disabled
+  def resolve_auto_away_debounce(nil), do: auto_away_debounce_ms()
+  def resolve_auto_away_debounce(:disabled), do: :disabled
+
+  def resolve_auto_away_debounce(seconds) when is_integer(seconds) and seconds > 0,
+    do: seconds * 1_000
+
+  @doc """
+  The auto-away window for `subject`: their #348 preference resolved
+  over the boot default. Read at the spawn boundary
+  (`Grappa.Session.start_session/3`) so a session starts on the value
+  the user chose, not only on the one they choose next.
+  """
+  @spec auto_away_debounce_for(Grappa.Subject.t()) :: non_neg_integer() | :disabled
+  def auto_away_debounce_for({_, _} = subject) do
+    subject
+    |> UserSettings.get_auto_away_debounce_seconds()
+    |> resolve_auto_away_debounce()
   end
 
   @doc """
@@ -1307,6 +1345,16 @@ defmodule Grappa.Session.Server do
         Phoenix.PubSub.subscribe(
           Grappa.PubSub,
           Topic.ws_presence(opts.subject_label)
+        )
+
+      # #348 — and to the settings bridge, so retuning (or switching off)
+      # the auto-away debounce takes effect on a live session instead of
+      # waiting for its next restart. Same subject gate as above: only
+      # user sessions run auto-away, so only they care.
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.user_settings(opts.subject_label)
         )
     end
 
@@ -2858,8 +2906,7 @@ defmodule Grappa.Session.Server do
     # (lifecycle review HIGH S3).
     :ok = cancel_and_drain(state.auto_away_timer, :auto_away_debounce_fire)
 
-    timer = Process.send_after(self(), :auto_away_debounce_fire, state.auto_away_debounce_ms)
-    {:noreply, %{state | auto_away_timer: timer}}
+    {:noreply, arm_auto_away_debounce(%{state | auto_away_timer: nil})}
   end
 
   # S3.2 — Auto-away debounce fired. If still `:away_explicit`, skip (user
@@ -2872,6 +2919,15 @@ defmodule Grappa.Session.Server do
   def handle_info(:auto_away_debounce_fire, state) do
     next_state = set_auto_away_internal(%{state | auto_away_timer: nil})
     {:noreply, next_state}
+  end
+
+  # #348 — the subject retuned the auto-away debounce, or switched it
+  # off, from any of their devices. `Grappa.UserSettings` announces the
+  # new preference on the settings bridge topic and every live session
+  # of that subject hears it, on every network — the point being that a
+  # knob turned now applies now, not at the session's next restart.
+  def handle_info({:auto_away_debounce_changed, preference}, state) do
+    {:noreply, apply_auto_away_debounce(state, resolve_auto_away_debounce(preference))}
   end
 
   # Linked Client crashed abnormally. Record a backoff failure (so the
@@ -6341,6 +6397,40 @@ defmodule Grappa.Session.Server do
   # messages; the single-shot drain would leak one. Constant overhead
   # in the steady state (queue empty), zero correctness obligation on
   # call sites.
+  # #348 — the ONE place a debounce timer is armed. `:disabled` arms
+  # nothing: the ruling is that off means no timer exists, not that the
+  # timer is very long, and a long timer would still flap the user AWAY
+  # eventually. The caller cancels-and-drains first either way, so a
+  # timer armed before the switch cannot outlive it.
+  @spec arm_auto_away_debounce(t()) :: t()
+  defp arm_auto_away_debounce(%{auto_away_debounce_ms: :disabled} = state), do: state
+
+  defp arm_auto_away_debounce(state) do
+    timer = Process.send_after(self(), :auto_away_debounce_fire, state.auto_away_debounce_ms)
+    %{state | auto_away_timer: timer}
+  end
+
+  # #348 — adopt a new debounce window on a LIVE session.
+  #
+  # Switching off also cancels whatever is in flight: a switch that let
+  # one last timer fire, up to a full window later, would produce
+  # exactly the surprise AWAY it exists to prevent.
+  #
+  # Any other change deliberately leaves an armed timer alone, so a
+  # retune applies from the NEXT hide. Whether it should instead restart
+  # the window the session is currently inside of is #348's open
+  # question (we do not record when the hide happened, so "restart" is
+  # the only alternative we could implement honestly) — it is confined
+  # to this function so the ruling is a one-clause change.
+  @spec apply_auto_away_debounce(t(), non_neg_integer() | :disabled) :: t()
+  defp apply_auto_away_debounce(state, :disabled) do
+    :ok = cancel_and_drain(state.auto_away_timer, :auto_away_debounce_fire)
+    %{state | auto_away_debounce_ms: :disabled, auto_away_timer: nil}
+  end
+
+  defp apply_auto_away_debounce(state, debounce_ms) when is_integer(debounce_ms),
+    do: %{state | auto_away_debounce_ms: debounce_ms}
+
   @spec cancel_and_drain(reference() | nil, atom()) :: :ok
   def cancel_and_drain(nil, _), do: :ok
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1333,30 +1333,34 @@ defmodule Grappa.Session.Server do
       managed_source_alias: Map.get(opts, :managed_source_alias)
     }
 
-    # S3.1 / S3.2 / #182: subscribe to the WSPresence PubSub topic for this
-    # user so auto-away debounce and cancel fire on `:ws_visible` /
-    # `:ws_all_hidden` (device-foreground) transitions. Only user sessions
-    # (not visitor sessions) participate in auto-away; visitor disconnect =
-    # bouncer disconnect (ephemeral credential). Visitors still report
-    # visibility to WSPresence for the push-suppression gate, but their
-    # Session.Server doesn't subscribe here.
-    if match?({:user, _}, opts.subject) do
-      :ok =
-        Phoenix.PubSub.subscribe(
-          Grappa.PubSub,
-          Topic.ws_presence(opts.subject_label)
-        )
+    # S3.1 / S3.2 / #182: subscribe to the WSPresence PubSub topic for
+    # this subject so the auto-away debounce arms and cancels on the
+    # `:ws_visible` / `:ws_all_hidden` (device-foreground) transitions.
+    #
+    # #348 — BOTH subject kinds subscribe. This used to be gated to
+    # `{:user, _}` on the reasoning that a visitor's disconnect is a
+    # bouncer disconnect (ephemeral credential), so auto-away was moot;
+    # what that missed is the case auto-away exists for — a device that
+    # BACKGROUNDS without disconnecting. A visitor who locked their
+    # phone therefore stayed visibly present upstream for as long as the
+    # socket held. Their preference has a home already (`user_settings`
+    # is subject-scoped, XOR user_id/visitor_id) and they resolve the
+    # same server-wide default as users, so nothing here is
+    # visitor-specific any more.
+    :ok =
+      Phoenix.PubSub.subscribe(
+        Grappa.PubSub,
+        Topic.ws_presence(opts.subject_label)
+      )
 
-      # #348 — and to the settings bridge, so retuning (or switching off)
-      # the auto-away debounce takes effect on a live session instead of
-      # waiting for its next restart. Same subject gate as above: only
-      # user sessions run auto-away, so only they care.
-      :ok =
-        Phoenix.PubSub.subscribe(
-          Grappa.PubSub,
-          Topic.user_settings(opts.subject_label)
-        )
-    end
+    # #348 — and to the settings bridge, so retuning (or switching off)
+    # the auto-away debounce takes effect on a live session instead of
+    # waiting for its next restart.
+    :ok =
+      Phoenix.PubSub.subscribe(
+        Grappa.PubSub,
+        Topic.user_settings(opts.subject_label)
+      )
 
     emit_lifecycle(:spawned, state)
 
@@ -6412,24 +6416,30 @@ defmodule Grappa.Session.Server do
 
   # #348 — adopt a new debounce window on a LIVE session.
   #
-  # Switching off also cancels whatever is in flight: a switch that let
-  # one last timer fire, up to a full window later, would produce
-  # exactly the surprise AWAY it exists to prevent.
+  # Switching off cancels whatever is in flight and arms nothing: a
+  # switch that let one last timer fire, up to a full window later,
+  # would produce exactly the surprise AWAY it exists to prevent.
   #
-  # Any other change deliberately leaves an armed timer alone, so a
-  # retune applies from the NEXT hide. Whether it should instead restart
-  # the window the session is currently inside of is #348's open
-  # question (we do not record when the hide happened, so "restart" is
-  # the only alternative we could implement honestly) — it is confined
-  # to this function so the ruling is a one-clause change.
+  # A retune while a timer is in flight RE-ARMS at the new window (vjt's
+  # ruling). We do not record when the hide happened, so the honest
+  # alternatives were "restart the window" or "ignore the change until
+  # the next hide", and a knob that visibly does nothing until you hide
+  # again is the worse surprise. The window therefore restarts from the
+  # moment of the change.
   @spec apply_auto_away_debounce(t(), non_neg_integer() | :disabled) :: t()
   defp apply_auto_away_debounce(state, :disabled) do
     :ok = cancel_and_drain(state.auto_away_timer, :auto_away_debounce_fire)
     %{state | auto_away_debounce_ms: :disabled, auto_away_timer: nil}
   end
 
-  defp apply_auto_away_debounce(state, debounce_ms) when is_integer(debounce_ms),
-    do: %{state | auto_away_debounce_ms: debounce_ms}
+  defp apply_auto_away_debounce(%{auto_away_timer: nil} = state, debounce_ms)
+       when is_integer(debounce_ms),
+       do: %{state | auto_away_debounce_ms: debounce_ms}
+
+  defp apply_auto_away_debounce(state, debounce_ms) when is_integer(debounce_ms) do
+    :ok = cancel_and_drain(state.auto_away_timer, :auto_away_debounce_fire)
+    arm_auto_away_debounce(%{state | auto_away_debounce_ms: debounce_ms, auto_away_timer: nil})
+  end
 
   @spec cancel_and_drain(reference() | nil, atom()) :: :ok
   def cancel_and_drain(nil, _), do: :ok

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -65,6 +65,9 @@ defmodule Grappa.UserSettings do
   | `"last_client_prefix64"`| `String.t() \\| nil`  | `get_last_client_prefix64/1`,   |
   |                        | (opaque base16)        | `put_last_client_prefix64/2`    |
   |                        |                        | (#543)                          |
+  | `"auto_away_debounce_seconds"` | `auto_away_debounce()` | `get_auto_away_debounce_seconds/1`, |
+  |                        | (`0` on the JSON side  | `put_auto_away_debounce_seconds/2`  |
+  |                        | = `:disabled`)         | (#348)                          |
 
   ## Boundary
 
@@ -167,6 +170,22 @@ defmodule Grappa.UserSettings do
           presence_filter: %{String.t() => String.t()}
         }
 
+  @typedoc """
+  #348 — the stored auto-away debounce preference for one subject.
+
+  Three states, deliberately one value:
+
+    * `nil` — nothing stored; the session keeps the server-wide default.
+    * `:disabled` — auto-away is OFF: no debounce timer is ever armed.
+    * `pos_integer()` — seconds to wait after the last visible device hides.
+
+  `:disabled` is an atom here and the integer `0` in `data` / on the wire
+  (CLAUDE.md: atoms for closed sets, JSON scalars at the boundary). The
+  distinction is not cosmetic — a zero-second debounce and "no debounce
+  at all" share a wire number but mean opposite things.
+  """
+  @type auto_away_debounce :: pos_integer() | :disabled | nil
+
   @notification_prefs_key "notification_prefs"
   @upload_ttl_seconds_key "upload_ttl_seconds"
   @vhost_selection_key "vhost_selection"
@@ -222,6 +241,24 @@ defmodule Grappa.UserSettings do
   # for a transient screenshot. A bound this loose accepts whatever ladder
   # cic surfaces today while making "100-year TTL DOS body" return 422.
   @upload_ttl_seconds_max 31_536_000
+
+  # #348 — the grace period between "every device of this subject went
+  # hidden" and the upstream `AWAY`. ONE key, THREE states, because the
+  # delay and the off switch are ONE control: absent = the server-wide
+  # default (`Grappa.Session.Server.auto_away_debounce_ms/0`), the `0`
+  # sentinel = OFF (no timer is armed at all — never a very large one),
+  # any other in-range integer = seconds.
+  @auto_away_debounce_seconds_key "auto_away_debounce_seconds"
+
+  # The accepted window, as ONE constant: which ladder cic offers and how
+  # wide the API opens are still vjt's call on #348, so both bounds move
+  # in a single line. 1s is a floor an e2e can drive without a
+  # minute-long wait rather than a recommendation; 24h is a ceiling for
+  # the same reason `@upload_ttl_seconds_max` has one — a user-writable
+  # number needs a bound — and sits far past any real delay.
+  @auto_away_debounce_seconds_range 1..86_400
+  @auto_away_debounce_seconds_min @auto_away_debounce_seconds_range.first
+  @auto_away_debounce_seconds_max @auto_away_debounce_seconds_range.last
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -547,6 +584,110 @@ defmodule Grappa.UserSettings do
       |> Ecto.Changeset.add_error(
         :upload_ttl_seconds,
         "must be a positive integer up to #{@upload_ttl_seconds_max} seconds, or null"
+      )
+
+    {:error, cs}
+  end
+
+  # ---------------------------------------------------------------------------
+  # auto_away_debounce_seconds accessors (#348)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Smallest debounce, in seconds, this boundary accepts.
+
+  Exposed so callers and tests read the bound from the one constant that
+  defines it instead of restating the number.
+  """
+  @spec auto_away_debounce_seconds_min() :: pos_integer()
+  def auto_away_debounce_seconds_min, do: @auto_away_debounce_seconds_min
+
+  @doc """
+  Largest debounce, in seconds, this boundary accepts. See
+  `auto_away_debounce_seconds_min/0`.
+  """
+  @spec auto_away_debounce_seconds_max() :: pos_integer()
+  def auto_away_debounce_seconds_max, do: @auto_away_debounce_seconds_max
+
+  @doc """
+  Returns the stored auto-away debounce preference for `subject`.
+
+  `nil` means "no preference" — the caller keeps the server-wide default.
+  A stored value that is malformed or out of the accepted range reads
+  back as `nil` too: a corrupted row degrades to the default rather than
+  to an arbitrary delay, mirroring `get_upload_ttl_seconds/1`.
+  """
+  @spec get_auto_away_debounce_seconds(Subject.t()) :: auto_away_debounce()
+  def get_auto_away_debounce_seconds({_, _} = subject) do
+    case fetch_existing_or_nil(subject) do
+      nil ->
+        nil
+
+      %Settings{data: data} ->
+        decode_auto_away_debounce(data[@auto_away_debounce_seconds_key])
+    end
+  end
+
+  @doc """
+  Sets the auto-away debounce preference for `subject`.
+
+  Accepts `nil` (clear — back to the server default), `:disabled` (OFF —
+  stored as the `0` sentinel) or an integer in
+  `#{@auto_away_debounce_seconds_min}..#{@auto_away_debounce_seconds_max}`
+  seconds. Anything else, the integer `0` included, is a changeset error
+  on `:auto_away_debounce_seconds`: `0` is the OFF *sentinel*, not a
+  zero-second delay a caller may ask for.
+
+  Preserves other keys in `data` (merge semantics, mirror of
+  `put_upload_ttl_seconds/2`).
+  """
+  @spec put_auto_away_debounce_seconds(Subject.t(), auto_away_debounce()) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def put_auto_away_debounce_seconds({_, _} = subject, value) do
+    with :ok <- validate_auto_away_debounce_seconds(value, subject),
+         {:ok, settings} <- get_or_init(subject) do
+      merged_data =
+        case value do
+          nil -> Map.delete(settings.data, @auto_away_debounce_seconds_key)
+          :disabled -> Map.put(settings.data, @auto_away_debounce_seconds_key, 0)
+          n -> Map.put(settings.data, @auto_away_debounce_seconds_key, n)
+        end
+
+      cs = Settings.changeset(settings, %{data: merged_data})
+      persist(cs)
+    end
+  end
+
+  @spec decode_auto_away_debounce(term()) :: auto_away_debounce()
+  defp decode_auto_away_debounce(0), do: :disabled
+
+  defp decode_auto_away_debounce(n)
+       when is_integer(n) and n >= @auto_away_debounce_seconds_min and
+              n <= @auto_away_debounce_seconds_max,
+       do: n
+
+  defp decode_auto_away_debounce(_), do: nil
+
+  @spec validate_auto_away_debounce_seconds(term(), Subject.t()) ::
+          :ok | {:error, Ecto.Changeset.t()}
+  defp validate_auto_away_debounce_seconds(nil, _), do: :ok
+  defp validate_auto_away_debounce_seconds(:disabled, _), do: :ok
+
+  defp validate_auto_away_debounce_seconds(n, _)
+       when is_integer(n) and n >= @auto_away_debounce_seconds_min and
+              n <= @auto_away_debounce_seconds_max,
+       do: :ok
+
+  defp validate_auto_away_debounce_seconds(_, subject) do
+    attrs = Subject.put_subject_id(%{data: %{}}, subject)
+
+    cs =
+      %Settings{}
+      |> Settings.changeset(attrs)
+      |> Ecto.Changeset.add_error(
+        :auto_away_debounce_seconds,
+        "must be an integer between #{@auto_away_debounce_seconds_min} and " <>
+          "#{@auto_away_debounce_seconds_max} seconds, 0 to disable, or null"
       )
 
     {:error, cs}

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -182,22 +182,6 @@ defmodule Grappa.UserSettings do
           presence_filter: %{String.t() => String.t()}
         }
 
-  @typedoc """
-  #348 — the stored auto-away debounce preference for one subject.
-
-  Three states, deliberately one value:
-
-    * `nil` — nothing stored; the session keeps the server-wide default.
-    * `:disabled` — auto-away is OFF: no debounce timer is ever armed.
-    * `pos_integer()` — seconds to wait after the last visible device hides.
-
-  `:disabled` is an atom here and the integer `0` in `data` / on the wire
-  (CLAUDE.md: atoms for closed sets, JSON scalars at the boundary). The
-  distinction is not cosmetic — a zero-second debounce and "no debounce
-  at all" share a wire number but mean opposite things.
-  """
-  @type auto_away_debounce :: pos_integer() | :disabled | nil
-
   @notification_prefs_key "notification_prefs"
   @upload_ttl_seconds_key "upload_ttl_seconds"
   @vhost_selection_key "vhost_selection"
@@ -271,6 +255,25 @@ defmodule Grappa.UserSettings do
   @auto_away_debounce_seconds_range 1..86_400
   @auto_away_debounce_seconds_min @auto_away_debounce_seconds_range.first
   @auto_away_debounce_seconds_max @auto_away_debounce_seconds_range.last
+
+  @typedoc """
+  #348 — the stored auto-away debounce preference for one subject.
+
+  Three states, deliberately one value:
+
+    * `nil` — nothing stored; the session keeps the server-wide default.
+    * `:disabled` — auto-away is OFF: no debounce timer is ever armed.
+    * `pos_integer()` — seconds to wait after the last visible device hides.
+
+  `:disabled` is an atom here and the integer `0` in `data` / on the wire
+  (CLAUDE.md: atoms for closed sets, JSON scalars at the boundary). The
+  distinction is not cosmetic — a zero-second debounce and "no debounce
+  at all" share a wire number but mean opposite things.
+  """
+  @type auto_away_debounce ::
+          unquote(@auto_away_debounce_seconds_min)..unquote(@auto_away_debounce_seconds_max)
+          | :disabled
+          | nil
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -611,14 +614,14 @@ defmodule Grappa.UserSettings do
   Exposed so callers and tests read the bound from the one constant that
   defines it instead of restating the number.
   """
-  @spec auto_away_debounce_seconds_min() :: pos_integer()
+  @spec auto_away_debounce_seconds_min() :: unquote(@auto_away_debounce_seconds_min)
   def auto_away_debounce_seconds_min, do: @auto_away_debounce_seconds_min
 
   @doc """
   Largest debounce, in seconds, this boundary accepts. See
   `auto_away_debounce_seconds_min/0`.
   """
-  @spec auto_away_debounce_seconds_max() :: pos_integer()
+  @spec auto_away_debounce_seconds_max() :: unquote(@auto_away_debounce_seconds_max)
   def auto_away_debounce_seconds_max, do: @auto_away_debounce_seconds_max
 
   @doc """

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -84,12 +84,24 @@ defmodule Grappa.UserSettings do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
+    deps: [
+      Grappa.Accounts,
+      Grappa.IRC,
+      Grappa.PubSub,
+      Grappa.Repo,
+      Grappa.Subject,
+      Grappa.UserSettings.Wire,
+      Grappa.Visitors.Visitor
+    ],
     exports: [Settings]
 
   import Ecto.Query
 
+  alias Grappa.PubSub.Topic
+
   alias Grappa.{Accounts.User, IRC.Identifier, Repo, Subject, UserSettings.Settings, Visitors.Visitor}
+
+  alias Grappa.UserSettings.Wire
 
   @typedoc """
   Per-conversation notification mutes (#866) — the one DENY-list in
@@ -629,7 +641,7 @@ defmodule Grappa.UserSettings do
   end
 
   @doc """
-  Sets the auto-away debounce preference for `subject`.
+  Sets the auto-away debounce preference for `subject` and announces it.
 
   Accepts `nil` (clear — back to the server default), `:disabled` (OFF —
   stored as the `0` sentinel) or an integer in
@@ -638,12 +650,24 @@ defmodule Grappa.UserSettings do
   on `:auto_away_debounce_seconds`: `0` is the OFF *sentinel*, not a
   zero-second delay a caller may ask for.
 
+  `subject_label` is the user-rooted PubSub topic root
+  (`Grappa.Subject.label/1`), taken as an argument rather than looked up
+  here for the same reason `Grappa.Notify.add/4` takes it: routing is
+  the caller's knowledge, and a hidden second query to recover it would
+  make every write pay for it.
+
+  On success the change goes out on BOTH surfaces (see
+  `broadcast_auto_away_debounce/2`) — a value nobody hears about would
+  leave live sessions waiting on the old delay until they restart.
+  Nothing is announced when the write is rejected or the DB is down.
+
   Preserves other keys in `data` (merge semantics, mirror of
   `put_upload_ttl_seconds/2`).
   """
-  @spec put_auto_away_debounce_seconds(Subject.t(), auto_away_debounce()) ::
+  @spec put_auto_away_debounce_seconds(Subject.t(), auto_away_debounce(), String.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  def put_auto_away_debounce_seconds({_, _} = subject, value) do
+  def put_auto_away_debounce_seconds({_, _} = subject, value, subject_label)
+      when is_binary(subject_label) do
     with :ok <- validate_auto_away_debounce_seconds(value, subject),
          {:ok, settings} <- get_or_init(subject) do
       merged_data =
@@ -654,8 +678,40 @@ defmodule Grappa.UserSettings do
         end
 
       cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+
+      with {:ok, saved} <- persist(cs) do
+        :ok = broadcast_auto_away_debounce(value, subject_label)
+        {:ok, saved}
+      end
     end
+  end
+
+  # Two audiences, two shapes, one write.
+  #
+  #   * the bridge topic — a raw term for the subject's live
+  #     `Session.Server` processes, which need the atom to tell OFF from
+  #     a delay and must not have to parse a wire map;
+  #   * the user topic — the JSON-encodable wire event for the subject's
+  #     other devices, so a knob turned on the phone shows up on the
+  #     laptop.
+  #
+  # A wire map on the bridge would be a lie about the audience; a raw
+  # term on the user topic would crash Phoenix's fastlane during fan-out
+  # (the CLAUDE.md PubSub invariant).
+  @spec broadcast_auto_away_debounce(auto_away_debounce(), String.t()) :: :ok
+  defp broadcast_auto_away_debounce(value, subject_label) do
+    :ok =
+      Phoenix.PubSub.broadcast(
+        Grappa.PubSub,
+        Topic.user_settings(subject_label),
+        {:auto_away_debounce_changed, value}
+      )
+
+    :ok =
+      Grappa.PubSub.broadcast_event(
+        Topic.user(subject_label),
+        Wire.auto_away_debounce_changed(value)
+      )
   end
 
   @spec decode_auto_away_debounce(term()) :: auto_away_debounce()

--- a/lib/grappa/user_settings/settings.ex
+++ b/lib/grappa/user_settings/settings.ex
@@ -38,6 +38,7 @@ defmodule Grappa.UserSettings.Settings do
   | `"upload_ttl_seconds"` | `pos_integer() \\| nil`           | `Grappa.UserSettings` (UX-4 M) |
   | `"vhost_selection"`    | `list(String.t())`                  | `Grappa.Vhosts` (#228)       |
   | `"display_prefs"`      | `Grappa.UserSettings.display_prefs()` | `Grappa.UserSettings` (#449) |
+  | `"auto_away_debounce_seconds"` | `pos_integer() \\| 0` (`0` = OFF) | `Grappa.UserSettings` (#348) |
 
   ## String-key invariant (IMPORTANT)
 

--- a/lib/grappa/user_settings/wire.ex
+++ b/lib/grappa/user_settings/wire.ex
@@ -1,0 +1,62 @@
+defmodule Grappa.UserSettings.Wire do
+  @moduledoc """
+  Single source of truth for the public JSON wire shape of the per-user
+  settings pushes (#348).
+
+  One door emits this contract today: `Grappa.UserSettings`, after a
+  successful write, broadcasts on `Grappa.PubSub.Topic.user/1` so the
+  subject's OTHER devices mirror a change made on one of them. The REST
+  response of the same write carries the identical scalar — one shape,
+  two doors, per the CLAUDE.md "one feature, one code path, every door"
+  rule.
+
+  ## One event per setting, not one `settings_changed` for all
+
+  A generic "your settings changed" push would either carry the whole
+  settings blob (leaking every other key on every write) or carry
+  nothing and force a re-fetch. A narrow, additive event per setting
+  keeps each payload honest about what actually moved; the wire contract
+  is additive-only (#447), so a second setting is a second `kind`, never
+  a repurposed field.
+
+  ## The `0` sentinel
+
+  `Grappa.UserSettings.auto_away_debounce/0` is `nil | :disabled |
+  pos_integer()`. JSON has no atoms, so `:disabled` travels as `0` —
+  the same encoding `GrappaWeb.UserSettingsJSON` renders on the REST
+  side. `null` stays "no preference, the server default applies".
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  alias Grappa.UserSettings
+
+  @typedoc """
+  Wire shape of the `auto_away_debounce_changed` push (#348).
+
+  `auto_away_debounce_seconds`: `null` = no preference, `0` = auto-away
+  off, any other integer = seconds.
+  """
+  @type auto_away_debounce_changed_payload :: %{
+          kind: :auto_away_debounce_changed,
+          auto_away_debounce_seconds: non_neg_integer() | nil
+        }
+
+  @doc """
+  Builds the `auto_away_debounce_changed` push payload from the stored
+  preference.
+
+  The atom `kind` is passed through unchanged: `Jason.encode!/1`
+  stringifies it at the JSON edge while `mix grappa.gen_wire_types`
+  emits the literal string union cic asserts against (the
+  `Grappa.ServerSettings.Wire` precedent).
+  """
+  @spec auto_away_debounce_changed(UserSettings.auto_away_debounce()) ::
+          auto_away_debounce_changed_payload()
+  def auto_away_debounce_changed(:disabled),
+    do: %{kind: :auto_away_debounce_changed, auto_away_debounce_seconds: 0}
+
+  def auto_away_debounce_changed(seconds)
+      when is_nil(seconds) or is_integer(seconds),
+      do: %{kind: :auto_away_debounce_changed, auto_away_debounce_seconds: seconds}
+end

--- a/lib/grappa_web/controllers/user_settings_controller.ex
+++ b/lib/grappa_web/controllers/user_settings_controller.ex
@@ -130,10 +130,8 @@ defmodule GrappaWeb.UserSettingsController do
   @spec show_auto_away_debounce_seconds(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show_auto_away_debounce_seconds(conn, _) do
     subject = Subject.from_assigns(conn.assigns)
-
-    render(conn, :auto_away_debounce_seconds,
-      debounce: UserSettings.get_auto_away_debounce_seconds(subject)
-    )
+    debounce = UserSettings.get_auto_away_debounce_seconds(subject)
+    render(conn, :auto_away_debounce_seconds, debounce: debounce)
   end
 
   @doc """
@@ -159,9 +157,8 @@ defmodule GrappaWeb.UserSettingsController do
              decode_auto_away_debounce(seconds),
              subject_label
            ) do
-      render(conn, :auto_away_debounce_seconds,
-        debounce: UserSettings.get_auto_away_debounce_seconds(subject)
-      )
+      debounce = UserSettings.get_auto_away_debounce_seconds(subject)
+      render(conn, :auto_away_debounce_seconds, debounce: debounce)
     end
   end
 

--- a/lib/grappa_web/controllers/user_settings_controller.ex
+++ b/lib/grappa_web/controllers/user_settings_controller.ex
@@ -121,6 +121,56 @@ defmodule GrappaWeb.UserSettingsController do
   def update_upload_ttl_seconds(_, _), do: {:error, :bad_request}
 
   @doc """
+  `GET /me/settings/auto-away-debounce-seconds` — the subject's
+  auto-away grace period (#348).
+
+  `null` = no preference, so the session keeps the server-wide default;
+  `0` = auto-away is OFF for this subject; any other integer = seconds.
+  """
+  @spec show_auto_away_debounce_seconds(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show_auto_away_debounce_seconds(conn, _) do
+    subject = Subject.from_assigns(conn.assigns)
+
+    render(conn, :auto_away_debounce_seconds,
+      debounce: UserSettings.get_auto_away_debounce_seconds(subject)
+    )
+  end
+
+  @doc """
+  `PUT /me/settings/auto-away-debounce-seconds` — persists the subject's
+  auto-away grace period. Body: `{"auto_away_debounce_seconds": N}` with
+  `N` an integer in the accepted range, `0` to switch auto-away off, or
+  `null` to clear the preference.
+
+  Validation in `Grappa.UserSettings.put_auto_away_debounce_seconds/2`.
+  422 + `field_errors.auto_away_debounce_seconds` on rejection; a
+  non-integer, non-null body is a 400.
+  """
+  @spec update_auto_away_debounce_seconds(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :bad_request | Ecto.Changeset.t() | :db_unavailable}
+  def update_auto_away_debounce_seconds(conn, %{"auto_away_debounce_seconds" => seconds})
+      when is_integer(seconds) or is_nil(seconds) do
+    subject = Subject.from_assigns(conn.assigns)
+
+    with {:ok, _} <-
+           UserSettings.put_auto_away_debounce_seconds(subject, decode_auto_away_debounce(seconds)) do
+      render(conn, :auto_away_debounce_seconds,
+        debounce: UserSettings.get_auto_away_debounce_seconds(subject)
+      )
+    end
+  end
+
+  def update_auto_away_debounce_seconds(_, _), do: {:error, :bad_request}
+
+  # `0` is the OFF sentinel on the wire (JSON has no atoms); the context
+  # speaks `:disabled`. Every other integer travels untouched so the
+  # range verdict — including a negative one — stays the context's to
+  # give, as a 422 rather than a silent reinterpretation here.
+  @spec decode_auto_away_debounce(integer() | nil) :: UserSettings.auto_away_debounce()
+  defp decode_auto_away_debounce(0), do: :disabled
+  defp decode_auto_away_debounce(seconds), do: seconds
+
+  @doc """
   `GET /me/settings/vhost` — the subject's vhost self-service view
   (#228, #251): the allowed set, each option marked `in_pool` + `granted`,
   plus the current selection. The allowed set is mode-dependent (#596):

--- a/lib/grappa_web/controllers/user_settings_controller.ex
+++ b/lib/grappa_web/controllers/user_settings_controller.ex
@@ -151,9 +151,14 @@ defmodule GrappaWeb.UserSettingsController do
   def update_auto_away_debounce_seconds(conn, %{"auto_away_debounce_seconds" => seconds})
       when is_integer(seconds) or is_nil(seconds) do
     subject = Subject.from_assigns(conn.assigns)
+    subject_label = GrappaWeb.Subject.topic_label(conn.assigns.current_subject)
 
     with {:ok, _} <-
-           UserSettings.put_auto_away_debounce_seconds(subject, decode_auto_away_debounce(seconds)) do
+           UserSettings.put_auto_away_debounce_seconds(
+             subject,
+             decode_auto_away_debounce(seconds),
+             subject_label
+           ) do
       render(conn, :auto_away_debounce_seconds,
         debounce: UserSettings.get_auto_away_debounce_seconds(subject)
       )

--- a/lib/grappa_web/controllers/user_settings_json.ex
+++ b/lib/grappa_web/controllers/user_settings_json.ex
@@ -22,6 +22,16 @@ defmodule GrappaWeb.UserSettingsJSON do
         }
 
   @typedoc """
+  Wire shape for the auto_away_debounce_seconds envelope (#348).
+
+  `null` = no preference (the server default applies), `0` = auto-away
+  OFF, any other integer = seconds.
+  """
+  @type auto_away_debounce_seconds_response :: %{
+          auto_away_debounce_seconds: non_neg_integer() | nil
+        }
+
+  @typedoc """
   One allowed vhost in the self-service view (#228, #251, #252).
 
   `name` is the address's reverse-DNS (cloak) string — the human label
@@ -77,6 +87,20 @@ defmodule GrappaWeb.UserSettingsJSON do
   def upload_ttl_seconds(%{seconds: seconds}) do
     %{upload_ttl_seconds: seconds}
   end
+
+  @doc """
+  Renders the `:auto_away_debounce_seconds` action — GET/PUT 200 shape (#348).
+
+  The context's `:disabled` atom becomes the `0` sentinel here, the one
+  place that translation is allowed to happen on the way out; `nil`
+  stays JSON `null` and means "no preference, use the server default".
+  """
+  @spec auto_away_debounce_seconds(%{debounce: UserSettings.auto_away_debounce()}) ::
+          auto_away_debounce_seconds_response()
+  def auto_away_debounce_seconds(%{debounce: :disabled}), do: %{auto_away_debounce_seconds: 0}
+
+  def auto_away_debounce_seconds(%{debounce: seconds}),
+    do: %{auto_away_debounce_seconds: seconds}
 
   @doc "Renders the `:vhost` action — GET/PUT 200 response shape (#228, #251)."
   @spec vhost(%{available: [vhost_option()], selection: [String.t()]}) ::

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -361,6 +361,19 @@ defmodule GrappaWeb.Router do
     get "/me/settings/upload-ttl-seconds", UserSettingsController, :show_upload_ttl_seconds
     put "/me/settings/upload-ttl-seconds", UserSettingsController, :update_upload_ttl_seconds
 
+    # #348 — the WS-disconnect -> upstream AWAY grace period, per subject.
+    # ONE scalar carries three states: `null` = no preference (the
+    # server-wide default applies), `0` = OFF (no timer is ever armed),
+    # N = seconds. The `0` sentinel is translated to/from the context's
+    # `:disabled` atom at this boundary and nowhere else.
+    get "/me/settings/auto-away-debounce-seconds",
+        UserSettingsController,
+        :show_auto_away_debounce_seconds
+
+    put "/me/settings/auto-away-debounce-seconds",
+        UserSettingsController,
+        :update_auto_away_debounce_seconds
+
     # #228 — per-subject vhost (source-bind) self-selection. GET returns
     # the allowed set (generally-available ∪ granted) + current selection
     # + pin; PUT persists a selection authz-clamped to the allowed set.

--- a/test/grappa/pubsub/topic_test.exs
+++ b/test/grappa/pubsub/topic_test.exs
@@ -131,6 +131,35 @@ defmodule Grappa.PubSub.TopicTest do
     end
   end
 
+  describe "user_settings/1 (#348)" do
+    test "builds the settings-change bridge topic" do
+      assert Topic.user_settings("vjt") == "grappa:user_settings:vjt"
+    end
+
+    test "preserves identifiers verbatim" do
+      assert Topic.user_settings("alice-2") == "grappa:user_settings:alice-2"
+    end
+
+    test "raises on empty subject_label" do
+      assert_raise FunctionClauseError, fn -> Topic.user_settings("") end
+    end
+
+    test "raises on non-binary subject_label" do
+      assert_raise FunctionClauseError, fn -> Topic.user_settings(nil) end
+    end
+
+    # The bridge carries raw Elixir terms to server processes, so a WS
+    # client must never be able to join it — same posture as
+    # `ws_presence/1`, and the reason both stay outside the public
+    # topic grammar `GrappaChannel.join/3` validates against.
+    test "is not part of the public topic grammar" do
+      topic = Topic.user_settings("vjt")
+
+      assert Topic.parse(topic) == :error
+      refute Topic.valid?(topic)
+    end
+  end
+
   describe "socket/2 (#1088)" do
     test "builds the per-connection addressed-delivery topic" do
       assert Topic.socket("vjt", "ref-1") == "grappa:user:vjt/socket:ref-1"

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9057,6 +9057,25 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #348 — the two halves of the visibility signal the auto-away tests
+  # drive, as named steps: a device that is present and foregrounded, and
+  # the moment it backgrounds. Registering + foregrounding is the
+  # PRE-STATE (WSPresence must have something visible to lose), so a test
+  # that skipped it would assert against a transition that never fired.
+  defp visible_device(user) do
+    :ok = WSPresence.reset_for_test()
+    device = spawn(fn -> Process.sleep(:infinity) end)
+    :ok = WSPresence.register(user.name, device)
+    :ok = WSPresence.set_visibility(user.name, device, true)
+    device
+  end
+
+  defp background(user, device), do: :ok = WSPresence.set_visibility(user.name, device, false)
+
+  # The subject's PubSub topic root, from the production builder — the
+  # same string the web edge hands the context on a settings PUT.
+  defp topic_label(user), do: Grappa.Subject.label({:user, user.name})
+
   describe "away_state transitions (S3.2)" do
     # All tests in this describe block use a real IRCServer so we can verify
     # the AWAY lines sent upstream. The handler accepts the handshake and
@@ -9392,6 +9411,131 @@ defmodule Grappa.Session.ServerTest do
       assert String.starts_with?(away_line, "AWAY :auto-away")
       state = SessionStateHelpers.fetch(pid)
       assert AwayState.state_of(SessionStateHelpers.away_state(state)) == :away_auto
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #348 — the debounce is a per-user preference now. What a user (or
+    # their peer) can observe is only ever the upstream AWAY: sooner,
+    # later, or never. These four drive the real chain — context write →
+    # PubSub → Session.Server — and assert the line, using the armed
+    # timer only where "nothing happened" needs a witness.
+
+    test "the session waits the per-user delay, not the server default (#348)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+
+      # Stored BEFORE the spawn: the value has to be read at the spawn
+      # boundary, not only by the live-refresh path.
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          Grappa.UserSettings.auto_away_debounce_seconds_min(),
+          topic_label(user)
+        )
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      device = visible_device(user)
+      :ok = background(user, device)
+
+      # The server-wide default is 600s. This line inside 3s can only be
+      # the 1s preference — nothing else shortens the wait.
+      assert {:ok, away_line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 3_000)
+
+      assert String.starts_with?(away_line, "AWAY :auto-away")
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "OFF arms no timer at all and never goes away (#348)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          :disabled,
+          topic_label(user)
+        )
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      device = visible_device(user)
+      :ok = background(user, device)
+
+      # Silence alone would also be what a 10-minute timer looks like, so
+      # the state is the discriminator: disabled means NO armed timer,
+      # never a very large one.
+      assert {:error, :timeout} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 200)
+
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) == nil
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "switching OFF kills a timer armed before the switch (#348)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      device = visible_device(user)
+      :ok = background(user, device)
+
+      # Pre-state: with no preference stored the default debounce is
+      # armed and in flight. Without this the assertion below would pass
+      # against a timer that was never there.
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) != nil
+
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          :disabled,
+          topic_label(user)
+        )
+
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) == nil
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a new delay takes effect on a live session, no restart (#348)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      # The session booted with the 600s default; the user retunes it
+      # from another device while the session keeps running.
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          Grappa.UserSettings.auto_away_debounce_seconds_min(),
+          topic_label(user)
+        )
+
+      device = visible_device(user)
+      :ok = background(user, device)
+
+      assert {:ok, away_line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 3_000)
+
+      assert String.starts_with?(away_line, "AWAY :auto-away")
 
       Process.exit(device, :kill)
       :ok = GenServer.stop(pid, :normal, 1_000)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9541,6 +9541,73 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "retuning re-arms the timer already in flight (#348)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      device = visible_device(user)
+      :ok = background(user, device)
+
+      # Pre-state: the 600s default is armed and in flight. The retune
+      # below happens INSIDE that window and there is no second hide, so
+      # only a re-arm can produce an AWAY here.
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) != nil
+
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          Grappa.UserSettings.auto_away_debounce_seconds_min(),
+          topic_label(user)
+        )
+
+      assert {:ok, away_line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 3_000)
+
+      assert String.starts_with?(away_line, "AWAY :auto-away")
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #348 — visitors auto-away too. Until this, `Session.Server` only
+    # subscribed to the presence bridge for `{:user, _}` subjects, so a
+    # visitor who backgrounded their tab stayed visibly present upstream
+    # forever. The knob and its storage are subject-scoped already, so
+    # the only thing in the way was the subscribe gate.
+    test "a visitor session goes auto-away when its last device hides (#348)" do
+      {server, port} = start_server_with_001()
+      {visitor, network} = visitor_with_network(port)
+      label = Grappa.Subject.label({:visitor, visitor.id})
+
+      {:ok, _} =
+        Grappa.UserSettings.put_auto_away_debounce_seconds(
+          {:visitor, visitor.id},
+          Grappa.UserSettings.auto_away_debounce_seconds_min(),
+          label
+        )
+
+      pid = start_visitor_session_for(visitor, network)
+      :ok = await_handshake(server)
+
+      :ok = WSPresence.reset_for_test()
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(label, device)
+      :ok = WSPresence.set_visibility(label, device, true)
+      :ok = WSPresence.set_visibility(label, device, false)
+
+      assert {:ok, away_line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 3_000)
+
+      assert String.starts_with?(away_line, "AWAY :auto-away")
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "set_auto_away when :away_explicit is a no-op (explicit takes precedence)" do
       {server, port} = start_server_with_001()
       {user, network, _} = setup_user_and_network(port)

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -33,6 +33,12 @@ defmodule Grappa.UserSettingsTest do
     user
   end
 
+  # The PubSub topic root a settings write broadcasts on, built by the
+  # same production function the web edge uses — never spelled out here.
+  defp label(%Grappa.Accounts.User{name: name}), do: Grappa.Subject.label({:user, name})
+
+  defp label(%Grappa.Visitors.Visitor{id: id}), do: Grappa.Subject.label({:visitor, id})
+
   # ---------------------------------------------------------------------------
   # get_or_init/1
   # ---------------------------------------------------------------------------
@@ -1157,7 +1163,7 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
 
       assert {:ok, %Settings{}} =
-               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label(user))
 
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == 120
     end
@@ -1166,17 +1172,17 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
 
       assert {:ok, %Settings{}} =
-               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled)
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled, label(user))
 
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == :disabled
     end
 
     test "nil clears the preference (back to the server default)" do
       user = user_fixture()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label(user))
 
       assert {:ok, %Settings{}} =
-               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, nil)
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, nil, label(user))
 
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
     end
@@ -1186,10 +1192,10 @@ defmodule Grappa.UserSettingsTest do
       min = UserSettings.auto_away_debounce_seconds_min()
       max = UserSettings.auto_away_debounce_seconds_max()
 
-      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, min)
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, min, label(user))
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == min
 
-      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, max)
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, max, label(user))
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == max
     end
 
@@ -1200,7 +1206,7 @@ defmodule Grappa.UserSettingsTest do
 
       for bogus <- [0, -1, min - 1, max + 1, "120", 1.5, :off] do
         assert {:error, %Ecto.Changeset{} = cs} =
-                 UserSettings.put_auto_away_debounce_seconds({:user, user.id}, bogus)
+                 UserSettings.put_auto_away_debounce_seconds({:user, user.id}, bogus, label(user))
 
         assert Keyword.has_key?(cs.errors, :auto_away_debounce_seconds)
       end
@@ -1210,7 +1216,7 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
       {:ok, _} = UserSettings.set_highlight_patterns({:user, user.id}, ["foo", "bar"])
 
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300)
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300, label(user))
 
       assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
       assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == 300
@@ -1219,8 +1225,88 @@ defmodule Grappa.UserSettingsTest do
     test "works for visitor subjects (visitor-parity at the store layer)" do
       visitor = visitor_fixture()
 
-      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:visitor, visitor.id}, 60)
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:visitor, visitor.id}, 60, label(visitor))
       assert UserSettings.get_auto_away_debounce_seconds({:visitor, visitor.id}) == 60
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # put_auto_away_debounce_seconds/3 — the two announcements (#348)
+  # ---------------------------------------------------------------------------
+  #
+  # A write has two audiences and they need different shapes: live
+  # `Session.Server` processes, which want a raw term on a bridge topic no
+  # WS client can join, and the subject's other devices, which want the
+  # JSON-encodable wire event on the public user topic. Both leave from
+  # the context, so no door can persist the value without announcing it.
+
+  describe "put_auto_away_debounce_seconds/3 broadcasts" do
+    setup do
+      user = user_fixture()
+      label = label(user)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user(label))
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user_settings(label))
+
+      {:ok, user: user, label: label}
+    end
+
+    test "a delay reaches sessions as a term and devices as a wire event", %{
+      user: user,
+      label: label
+    } do
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label)
+
+      assert_receive {:auto_away_debounce_changed, 120}
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        payload: %{kind: :auto_away_debounce_changed, auto_away_debounce_seconds: 120}
+      }
+    end
+
+    test "OFF stays an atom for sessions and becomes 0 for devices", %{user: user, label: label} do
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled, label)
+
+      assert_receive {:auto_away_debounce_changed, :disabled}
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        payload: %{kind: :auto_away_debounce_changed, auto_away_debounce_seconds: 0}
+      }
+    end
+
+    test "clearing the preference is announced too, as nil/null", %{user: user, label: label} do
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label)
+      assert_receive {:auto_away_debounce_changed, 120}
+
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, nil, label)
+
+      assert_receive {:auto_away_debounce_changed, nil}
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        payload: %{kind: :auto_away_debounce_changed, auto_away_debounce_seconds: nil}
+      }
+    end
+
+    test "a rejected value announces nothing", %{user: user, label: label} do
+      over = UserSettings.auto_away_debounce_seconds_max() + 1
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, over, label)
+
+      refute_receive {:auto_away_debounce_changed, _}, 100
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :auto_away_debounce_changed}}, 100
+    end
+
+    test "another subject's topics stay silent", %{user: user, label: label} do
+      other = user_fixture()
+      other_label = label(other)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user_settings(other_label))
+
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label)
+
+      assert_receive {:auto_away_debounce_changed, 120}
+      refute_receive {:auto_away_debounce_changed, _}, 100
     end
   end
 end

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -21,6 +21,7 @@ defmodule Grappa.UserSettingsTest do
   import Grappa.AuthFixtures, only: [visitor_fixture: 0]
 
   alias Grappa.{Accounts, Repo, UserSettings}
+  alias Grappa.PubSub.Topic
   alias Grappa.UserSettings.Settings
 
   # ---------------------------------------------------------------------------
@@ -1136,9 +1137,7 @@ defmodule Grappa.UserSettingsTest do
       {:ok, settings} = UserSettings.get_or_init({:user, user.id})
 
       for bogus <- ["600", -1, 1.5, %{"seconds" => 600}] do
-        Repo.update!(
-          Settings.changeset(settings, %{data: %{"auto_away_debounce_seconds" => bogus}})
-        )
+        Repo.update!(Settings.changeset(settings, %{data: %{"auto_away_debounce_seconds" => bogus}}))
 
         assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
       end
@@ -1245,8 +1244,8 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
       label = label(user)
 
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user(label))
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user_settings(label))
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user_settings(label))
 
       {:ok, user: user, label: label}
     end
@@ -1301,7 +1300,7 @@ defmodule Grappa.UserSettingsTest do
       other = user_fixture()
       other_label = label(other)
 
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.user_settings(other_label))
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user_settings(other_label))
 
       {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, label)
 

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -1087,4 +1087,140 @@ defmodule Grappa.UserSettingsTest do
       assert UserSettings.get_last_client_prefix64({:visitor, visitor.id}) == hex
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # auto_away_debounce_seconds accessors (#348)
+  # ---------------------------------------------------------------------------
+  #
+  # THREE states, one scalar — the setting is one control per vjt's ruling
+  # (a delay AND an off switch), so it is one key and never a value plus a
+  # sibling boolean:
+  #
+  #   nil         no preference — the session keeps the server-wide default
+  #   :disabled   auto-away OFF for this subject: no timer is ever armed
+  #   n           seconds to wait after the last visible device hides
+  #
+  # `:disabled` is an ATOM in the context API (CLAUDE.md: atoms for closed
+  # sets) and the integer `0` on the JSON side of the boundary. The integer
+  # `0` is therefore NOT a valid seconds value here — passing it in is a
+  # 422, exactly like -1.
+
+  describe "get_auto_away_debounce_seconds/1" do
+    test "returns nil when no settings row exists" do
+      fake_id = Ecto.UUID.generate()
+      assert UserSettings.get_auto_away_debounce_seconds({:user, fake_id}) == nil
+    end
+
+    test "returns nil when the row exists but has no auto_away_debounce_seconds key" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.get_or_init({:user, user.id})
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+    end
+
+    test "decodes the stored 0 sentinel as :disabled" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+      Repo.update!(Settings.changeset(settings, %{data: %{"auto_away_debounce_seconds" => 0}}))
+
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == :disabled
+    end
+
+    test "returns nil for malformed stored values (never crashes, falls back to default)" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      for bogus <- ["600", -1, 1.5, %{"seconds" => 600}] do
+        Repo.update!(
+          Settings.changeset(settings, %{data: %{"auto_away_debounce_seconds" => bogus}})
+        )
+
+        assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+      end
+    end
+
+    test "returns nil for a stored value above the accepted range" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      Repo.update!(
+        Settings.changeset(settings, %{
+          data: %{"auto_away_debounce_seconds" => UserSettings.auto_away_debounce_seconds_max() + 1}
+        })
+      )
+
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+    end
+  end
+
+  describe "put_auto_away_debounce_seconds/2" do
+    test "persists a positive integer and reads back identically" do
+      user = user_fixture()
+
+      assert {:ok, %Settings{}} =
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == 120
+    end
+
+    test "persists :disabled and reads it back as :disabled" do
+      user = user_fixture()
+
+      assert {:ok, %Settings{}} =
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled)
+
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == :disabled
+    end
+
+    test "nil clears the preference (back to the server default)" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+
+      assert {:ok, %Settings{}} =
+               UserSettings.put_auto_away_debounce_seconds({:user, user.id}, nil)
+
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+    end
+
+    test "accepts both ends of the range exactly" do
+      user = user_fixture()
+      min = UserSettings.auto_away_debounce_seconds_min()
+      max = UserSettings.auto_away_debounce_seconds_max()
+
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, min)
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == min
+
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, max)
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == max
+    end
+
+    test "rejects out-of-range, zero and non-integer values at the boundary" do
+      user = user_fixture()
+      min = UserSettings.auto_away_debounce_seconds_min()
+      max = UserSettings.auto_away_debounce_seconds_max()
+
+      for bogus <- [0, -1, min - 1, max + 1, "120", 1.5, :off] do
+        assert {:error, %Ecto.Changeset{} = cs} =
+                 UserSettings.put_auto_away_debounce_seconds({:user, user.id}, bogus)
+
+        assert Keyword.has_key?(cs.errors, :auto_away_debounce_seconds)
+      end
+    end
+
+    test "preserves other data keys (merge semantics, not replace)" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.set_highlight_patterns({:user, user.id}, ["foo", "bar"])
+
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300)
+
+      assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == 300
+    end
+
+    test "works for visitor subjects (visitor-parity at the store layer)" do
+      visitor = visitor_fixture()
+
+      assert {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:visitor, visitor.id}, 60)
+      assert UserSettings.get_auto_away_debounce_seconds({:visitor, visitor.id}) == 60
+    end
+  end
 end

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -697,4 +697,172 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # auto_away_debounce_seconds — #348
+  # ---------------------------------------------------------------------------
+  #
+  # The wire carries the three states as ONE scalar: `null` = no
+  # preference, `0` = OFF, N = seconds. The atom lives on the context side
+  # of the boundary only, so these tests are also the pin that the
+  # `0 <-> :disabled` translation happens HERE and nowhere else.
+
+  describe "GET /me/settings/auto-away-debounce-seconds" do
+    test "401 without bearer", %{conn: conn} do
+      conn = get(conn, "/me/settings/auto-away-debounce-seconds")
+      assert json_response(conn, 401) == %{"error" => "unauthorized"}
+    end
+
+    test "returns null when never persisted", %{conn: conn} do
+      {_user, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> get("/me/settings/auto-away-debounce-seconds")
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => nil}
+    end
+
+    test "renders a stored delay", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> get("/me/settings/auto-away-debounce-seconds")
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => 120}
+    end
+
+    test "renders the OFF state as 0, not as null", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> get("/me/settings/auto-away-debounce-seconds")
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => 0}
+    end
+  end
+
+  describe "PUT /me/settings/auto-away-debounce-seconds" do
+    test "401 without bearer", %{conn: conn} do
+      conn =
+        put(conn, "/me/settings/auto-away-debounce-seconds", %{
+          "auto_away_debounce_seconds" => 120
+        })
+
+      assert json_response(conn, 401) == %{"error" => "unauthorized"}
+    end
+
+    test "200 + persisted for an in-range delay", %{conn: conn} do
+      {user, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{
+          "auto_away_debounce_seconds" => 300
+        })
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => 300}
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == 300
+    end
+
+    test "0 disables — stored as :disabled, echoed as 0", %{conn: conn} do
+      {user, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{"auto_away_debounce_seconds" => 0})
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => 0}
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == :disabled
+    end
+
+    test "null clears back to the server default", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{"auto_away_debounce_seconds" => nil})
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => nil}
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+    end
+
+    test "422 + field_errors above the accepted range", %{conn: conn} do
+      {user, session} = user_and_session()
+      over = UserSettings.auto_away_debounce_seconds_max() + 1
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{
+          "auto_away_debounce_seconds" => over
+        })
+
+      assert %{"error" => "validation_failed", "field_errors" => fe} = json_response(conn, 422)
+      assert Map.has_key?(fe, "auto_away_debounce_seconds")
+      assert UserSettings.get_auto_away_debounce_seconds({:user, user.id}) == nil
+    end
+
+    test "422 below the accepted range (negative is not the OFF sentinel)", %{conn: conn} do
+      {_user, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{"auto_away_debounce_seconds" => -1})
+
+      assert %{"error" => "validation_failed"} = json_response(conn, 422)
+    end
+
+    test "400 when the body carries a non-integer", %{conn: conn} do
+      {_user, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{
+          "auto_away_debounce_seconds" => "120"
+        })
+
+      assert json_response(conn, 400)
+    end
+
+    test "200 + persisted for a visitor (visitor-parity at the API)", %{conn: conn} do
+      {visitor, session} = visitor_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{"auto_away_debounce_seconds" => 60})
+
+      assert json_response(conn, 200) == %{"auto_away_debounce_seconds" => 60}
+      assert UserSettings.get_auto_away_debounce_seconds({:visitor, visitor.id}) == 60
+    end
+
+    test "highlight_patterns survives an auto-away PUT", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, _} = UserSettings.set_highlight_patterns({:user, user.id}, ["foo", "bar"])
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/auto-away-debounce-seconds", %{
+          "auto_away_debounce_seconds" => 120
+        })
+
+      assert json_response(conn, 200)
+      assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
+    end
+  end
 end

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -714,7 +714,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
     end
 
     test "returns null when never persisted", %{conn: conn} do
-      {_user, session} = user_and_session()
+      {_, session} = user_and_session()
 
       conn =
         conn
@@ -726,7 +726,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "renders a stored delay", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, Grappa.Subject.label({:user, user.name}))
+
+      {:ok, _} =
+        UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, Grappa.Subject.label({:user, user.name}))
 
       conn =
         conn
@@ -738,7 +740,13 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "renders the OFF state as 0, not as null", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled, Grappa.Subject.label({:user, user.name}))
+
+      {:ok, _} =
+        UserSettings.put_auto_away_debounce_seconds(
+          {:user, user.id},
+          :disabled,
+          Grappa.Subject.label({:user, user.name})
+        )
 
       conn =
         conn
@@ -787,7 +795,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "null clears back to the server default", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300, Grappa.Subject.label({:user, user.name}))
+
+      {:ok, _} =
+        UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300, Grappa.Subject.label({:user, user.name}))
 
       conn =
         conn
@@ -815,7 +825,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
     end
 
     test "422 below the accepted range (negative is not the OFF sentinel)", %{conn: conn} do
-      {_user, session} = user_and_session()
+      {_, session} = user_and_session()
 
       conn =
         conn
@@ -826,7 +836,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
     end
 
     test "400 when the body carries a non-integer", %{conn: conn} do
-      {_user, session} = user_and_session()
+      {_, session} = user_and_session()
 
       conn =
         conn

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -726,7 +726,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "renders a stored delay", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120)
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 120, Grappa.Subject.label({:user, user.name}))
 
       conn =
         conn
@@ -738,7 +738,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "renders the OFF state as 0, not as null", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled)
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, :disabled, Grappa.Subject.label({:user, user.name}))
 
       conn =
         conn
@@ -787,7 +787,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
     test "null clears back to the server default", %{conn: conn} do
       {user, session} = user_and_session()
-      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300)
+      {:ok, _} = UserSettings.put_auto_away_debounce_seconds({:user, user.id}, 300, Grappa.Subject.label({:user, user.name}))
 
       conn =
         conn


### PR DESCRIPTION
Makes the WS-disconnect → upstream `AWAY` grace period a per-user setting
with an off state, reaching sessions that are already running.

Refs #348.

## What changed

- **Store** — one `user_settings` key, three states: absent = no preference
  (deployment default applies), `0` = off, N = seconds. No migration: the
  settings row is a single JSON map. The accepted range is ONE constant, with
  the type and both bounds accessors derived from it.
- **REST** — `GET`/`PUT /me/settings/auto-away-debounce-seconds`. The
  `0 ↔ :disabled` translation happens at this boundary and nowhere else; an
  out-of-range integer is a 422, a non-integer body a 400.
- **Live refresh** — a write announces on two surfaces: a raw term on a new
  internal bridge topic (`Topic.user_settings/1`, the `ws_presence/1` shape,
  unjoinable by a WS client) for live `Session.Server`s, and the
  `auto_away_debounce_changed` wire event on the user topic for the subject's
  other devices. Both leave from the context, so no door can persist without
  announcing.
- **OFF is a real off** — the single arm site refuses to arm on `:disabled`,
  and switching off cancels a timer already in flight.
- **Retune re-arms** — per ruling: the window restarts at the new value rather
  than waiting for the next hide.
- **Visitors** — the presence-bridge subscription is no longer gated to
  `{:user, _}`. A visitor who backgrounds their tab now goes away like anyone
  else, resolving the same default; the comment stating the old policy was
  rewritten rather than left to contradict the code.
- **cic** — a control in General: preset ladder + a custom seconds entry, with
  the server's push mirrored so a change on one device shows on another.

## Assumptions, named

- The accepted range (1s–24h) is a judgement call behind one constant, so
  moving it is a one-line change.
- cic prints neither the deployment default nor the range: both are server
  constants and a client copy would drift. Refusals are surfaced verbatim.
- Visitor default = the same one users get (vjt), no visitor-specific branch.

## Test plan

- [x] Full Elixir gate: 5784 tests / 0 failures, Dialyzer 0 errors, Credo,
      Sobelow, 428 infra bats — `scripts/check.sh` exit 0, working tree
      verified unchanged before and after.
- [x] cic gates: `bun run check` exit 0, `bun run test` 5140 tests / 0
      failures.
- [x] The four session-behaviour tests were each killed by a targeted mutant
      (arm-despite-disabled, global-instead-of-per-user, no-bridge-subscribe,
      no-cancel-on-off), so none of them passes vacuously.
- [ ] **`e2e/tests/issue348-auto-away-knob.spec.ts` is UNRUN.** The
      integration stack belonged to another worker for the duration; the spec
      needs a lane before this is shippable.