### PR TITLE
docs(grappa-live): make the agents chatty, not milestone-only

### DIFF
--- a/.claude/skills/grappa-live/SKILL.md
+++ b/.claude/skills/grappa-live/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: grappa-live
-description: Report progress to the #grappa-live IRC channel from a coding agent (w1, w2, orch). Use when a task starts, ships, breaks, or blocks — never for narration. Posting goes through tools/grappa-post.py over the grappa REST API; the agent holds no IRC socket.
+description: Report progress to the #grappa-live IRC channel from a coding agent (w1, w2, orch). Use while working — say what you are doing now, what you found, what you shipped, what blocks you. Posting goes through tools/grappa-post.py over the grappa REST API; the agent holds no IRC socket.
 ---
 
 # grappa-live — progress reporting into IRC
 
 `#grappa-live` is a **human-facing observability channel**. A person watching it
-should be able to tell, at a glance, what the fleet is doing and whether anything
-needs them. It is not a log sink and it is not an inter-agent bus: nothing reads
-your messages back to you, so anything you post that nobody would act on is pure
-noise.
+should be able to follow, line by line, what the fleet is doing without opening a
+terminal. **vjt's standing order (2026-08-11): be chatty — keep him updated on
+what you are working on**, not only on the milestones. It is still not a log sink
+and not an inter-agent bus: nothing reads your messages back to you, so a line
+nobody could follow is noise, but silence while you work is now the worse failure.
 
 ## How to post
 
@@ -28,7 +29,7 @@ work is not. Log it and move on.
 
 ## When to post
 
-Post on **state changes a human would want to know about**:
+Post on **state changes**, always:
 
 - a task is picked up (issue number + one clause on what it is)
 - a PR is opened, and again when it merges
@@ -36,19 +37,33 @@ Post on **state changes a human would want to know about**:
 - you are **blocked on a ruling** — say what you need decided, not the whole analysis
 - a task is abandoned or handed back
 
-Do **not** post: file-by-file progress, "starting work", "thinking about it",
-test-by-test output, anything you would only say to fill silence.
+And post **while you work**, so the channel reads as a running commentary:
+
+- what you are on right now, when you switch to something else
+- what you found that changed your plan — a wrong assumption, a second bug, a
+  file that turned out to be the real culprit
+- the shape of the fix you settled on, before you spend an hour writing it
+- a long-running step you are waiting on (a full test run, a build, a deploy)
+  and the verdict when it lands
+
+Rough cadence: **a line every few minutes of real work**, and one whenever
+something you'd tell a colleague over your shoulder happens. If nothing changed
+since your last line, say nothing — repeating yourself is the one kind of chatty
+that helps nobody.
+
+Do **not** post: file-by-file diffs, test-by-test output, your reasoning at
+length, or the same state twice.
 
 ## How to write it
 
 - **One line. Max 40 words.** Links do not count toward the 40.
 - Lead with the issue or PR number — it is the only handle the reader has.
-- State the fact, not the journey. `#1208 merged, /part reason wired` beats a
-  paragraph on how the parser was wrong.
+- State the fact, not the journey. `#1208 parser was fine, the router drops the
+  reason — fixing there` beats a paragraph on how you got there.
 - No blasphemy, no jokes: this channel is read by people who are not in on them.
 - English or Italian, match the thread; do not switch mid-task.
-- One message per event. If you have three things to say, you have one thing to
-  say and two to drop.
+- One message per event, and one event per message. Three things to say means
+  three lines spread over the work, not one paragraph now.
 
 ## What never goes in the channel
 


### PR DESCRIPTION
vjt's order tonight (2026-08-11, DM): *"voglio che siano chatty"* — *"e che mi aggiornino su cosa fanno"*.

The skill shipped in #1213 said the opposite: `never for narration`, `do not post "starting work"`, post only on state changes. An agent following it goes silent for the entire middle of a task — the exact stretch a human watching `#grappa-live` wants to see.

**What changes**

- New *post while you work* section: what you're on now, what changed your plan, the shape of the fix before writing it, long waits and their verdict.
- Rough cadence stated: a line every few minutes of real work; nothing when nothing moved.
- Frontmatter description and the channel intro rewritten around running commentary.

**What does not change**

One line, max 40 words, issue/PR number first, no secrets, no blasphemy, one event per message. Repeating an unchanged state is still noise.
