### PR TITLE
cic(#1192): CTCP submenu on the nick context menu

### DIFF
--- a/cicchetto/e2e/tests/issue1192-ctcp-submenu.spec.ts
+++ b/cicchetto/e2e/tests/issue1192-ctcp-submenu.spec.ts
@@ -1,0 +1,102 @@
+// #1192 — the nick context menu's CTCP submenu.
+//
+// The machinery has been shipped since #591: `/ctcp` works typed, the server
+// classifies the reply, the echo renders. What #1192 added is the way IN, so
+// what has to be proven here is exactly the part jsdom cannot see — that a real
+// right-click in a real browser reaches a real IRC peer.
+//
+// Three arms, each of which can fail on its own:
+//
+//   1. The drill-down. Clicking the group row replaces the item list with the
+//      six verbs instead of invoking anything; the top level is gone and the
+//      back row brings it back. The unit tests pin the mechanism against stubbed
+//      rects — this pins that it survives the portal, the backdrop and the #487
+//      measured placement in a browser that actually paints.
+//   2. The wire. The peer itself witnesses `\x01VERSION\x01`. This is the arm
+//      that makes the spec more than a DOM tour: a menu that opened beautifully
+//      and dispatched nothing would pass every other assertion here.
+//   3. The #640 shape. The echo lands in the SOURCE window and no query tab is
+//      minted for the peer — a CTCP probe is a control surface, not the start
+//      of a conversation.
+//
+// Untagged (chromium), like the #487 spec it shares a menu with: this is a
+// right-click affordance, and the mobile long-press door onto the SAME shell is
+// covered by #1067's spec.
+
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLine, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The six verbs the menu offers. Not imported from src: this is the CONTRACT
+// the operator sees, and a spec that read the same constant the component reads
+// would agree with it no matter what either one said.
+const VERBS = ["VERSION", "TIME", "PING", "CLIENTINFO", "USERINFO", "SOURCE"];
+
+const menuItem = (page: Page, label: string) =>
+  page.locator(".context-menu .context-menu-item", { hasText: label });
+
+test("#1192 — the CTCP submenu drills down and puts a real VERSION probe on the wire", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  // Per-run unique nick: the test network persists across runs and a fixed nick
+  // is a 433/ghost time bomb under CI rerun (mirrors #591/#637/#641).
+  const peer = await IrcPeer.connect({ nick: `m1192-${crypto.randomUUID().slice(0, 5)}` });
+
+  try {
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+    await peer.join(CHANNEL);
+    const memberRow = page.locator(".members-pane .member-name", { hasText: peer.nick });
+    await expect(memberRow).toBeVisible({ timeout: 15_000 });
+
+    await memberRow.click({ button: "right" });
+    await expect(page.locator(".context-menu")).toBeVisible({ timeout: 5_000 });
+
+    // ARM 1 — the group row NAVIGATES. Asserting WHOIS is gone is the half that
+    // makes this non-trivial: a submenu appended to the existing list would show
+    // the verbs too, and only the disappearance of the top level proves the list
+    // was replaced rather than extended.
+    await expect(menuItem(page, "CTCP ▸")).toBeVisible();
+    await menuItem(page, "CTCP ▸").click();
+    for (const verb of VERBS) {
+      await expect(menuItem(page, verb)).toBeVisible();
+    }
+    await expect(menuItem(page, "WHOIS")).toHaveCount(0);
+
+    // …and the back row is a real way out, not decoration.
+    await menuItem(page, "‹ CTCP").click();
+    await expect(menuItem(page, "WHOIS")).toBeVisible();
+    await menuItem(page, "CTCP ▸").click();
+
+    // ARM 2 — arm the peer-side wire witness BEFORE the click, so the listener
+    // cannot miss a frame that arrives faster than the assertion is attached.
+    const sawCtcp = peer.waitForLine(
+      new RegExp(`PRIVMSG ${peer.nick} :\x01VERSION\x01`),
+      "CTCP VERSION frame at the peer",
+      15_000,
+    );
+    await menuItem(page, "VERSION").click();
+    await sawCtcp;
+
+    // The menu closes on an ACTION, unlike on the group row.
+    await expect(page.locator(".context-menu")).toHaveCount(0);
+
+    // ARM 3 — the echo renders in the SOURCE window (the channel we are looking
+    // at), naming the recipient, with no \x01 anywhere near the DOM.
+    const echo = scrollbackLine(page, "privmsg", `→ CTCP VERSION to ${peer.nick}`);
+    await expect(echo).toBeVisible({ timeout: 15_000 });
+    expect(await echo.textContent()).not.toContain("\x01");
+
+    // #640 — and NO query tab for the peer. A probe that minted a conversation
+    // window is the regression this shape exists to prevent.
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
+  } finally {
+    await peer.disconnect("#1192 done");
+  }
+});

--- a/cicchetto/e2e/tests/issue487-context-menu-viewport-clamp.spec.ts
+++ b/cicchetto/e2e/tests/issue487-context-menu-viewport-clamp.spec.ts
@@ -91,7 +91,11 @@ test.describe("#487 context menu viewport clamp", () => {
 
     // Precondition (anti-hollow-green): at the raw click the menu WOULD have
     // overflowed BOTH edges, so the flip math was genuinely exercised.
-    expect(g.itemCount).toBe(8);
+    // #1192 added the CTCP group between WHOIS and Query, so the nick menu is
+    // nine rows. Kept as an exact count, not a `>=`: this number is the
+    // precondition that the menu really is tall enough to overflow, and a
+    // loosened assertion would stop noticing if the menu ever shrank.
+    expect(g.itemCount).toBe(9);
     expect(g.height).toBeGreaterThan(0);
     expect(vp.height - 4 + g.height).toBeGreaterThan(g.innerHeight);
     expect(vp.width - 4 + g.width).toBeGreaterThan(g.innerWidth);
@@ -101,7 +105,10 @@ test.describe("#487 context menu viewport clamp", () => {
     expect(g.left).toBeGreaterThanOrEqual(0);
     expect(g.bottom).toBeLessThanOrEqual(g.innerHeight);
     expect(g.right).toBeLessThanOrEqual(g.innerWidth);
-    // The last item (Query) sits inside the fold → clickable.
+    // The last item (Query) sits inside the fold → clickable. Still Query after
+    // #1192: the CTCP group went in ABOVE it, deliberately, so this proof stays
+    // a proof — a drill-down row would swap the list instead of closing, and
+    // the click below would assert nothing.
     expect(g.lastItemBottom).toBeLessThanOrEqual(g.innerHeight);
 
     // Actionability proof: the last item is hit-testable (not covered / off

--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { type Component, createEffect, createSignal, For, onCleanup } from "solid-js";
+import { type Component, createEffect, createSignal, For, on, onCleanup, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { computeMenuPosition } from "./lib/menuPosition";
 
@@ -36,11 +36,24 @@ import { computeMenuPosition } from "./lib/menuPosition";
 // all four insets from one measurement, which is what the X axis (landscape
 // notch) and the bottom edge (home indicator) need.
 
-export type ContextMenuItem = {
+// An item either DOES something or OPENS something, never both — so the two
+// are separate shapes rather than one shape with an optional field, and
+// `"submenu" in item` narrows exhaustively.
+//
+// #1192 — a submenu holds ACTIONS ONLY, so nesting is impossible by
+// construction. That is not a limitation to lift later: the drill state below
+// is a single index into `props.items`, which is what keeps it from going stale
+// when the caller re-renders the list. Depth would need a path, and nothing
+// wants depth.
+export type ContextMenuAction = {
   label: string;
   enabled: boolean;
   action: () => void;
 };
+
+export type ContextMenuItem =
+  | ContextMenuAction
+  | { label: string; enabled: boolean; submenu: ContextMenuAction[] };
 
 export type Props = {
   items: ContextMenuItem[];
@@ -58,8 +71,48 @@ const ContextMenu: Component<Props> = (props) => {
     onCleanup(() => document.removeEventListener("keydown", onKeyDown));
   });
 
-  const handleItemClick = (item: ContextMenuItem): void => {
+  // #1192 — the drill-down level, held as an INDEX into `props.items` rather
+  // than as the submenu object itself. The caller rebuilds its item array on
+  // every access (a JSX prop is a getter, and `UserContextMenu` calls `items()`
+  // inline), so a captured object would go stale the moment anything upstream
+  // re-rendered; an index is re-resolved against the current props every read.
+  const [drilledIndex, setDrilledIndex] = createSignal<number | null>(null);
+
+  const drilled = (): ContextMenuAction[] | null => {
+    const index = drilledIndex();
+    if (index === null) return null;
+    const item = props.items[index];
+    return item !== undefined && "submenu" in item ? item.submenu : null;
+  };
+
+  const visibleItems = (): ContextMenuItem[] => drilled() ?? props.items;
+
+  // The parent's own label, shown on the back row so the drilled level says
+  // where it is as well as how to leave.
+  const drilledLabel = (): string => {
+    const index = drilledIndex();
+    return index === null ? "" : (props.items[index]?.label ?? "");
+  };
+
+  // A second open can reuse this component instance: both call sites gate on a
+  // `<Show>` whose signal goes value→value when the operator right-clicks a
+  // different nick while the menu is up, so nothing unmounts. The placement
+  // effect already has to re-run for that case; the drill level has to RESET for
+  // it, or the second nick opens straight into the first one's submenu.
+  createEffect(
+    on(
+      () => [props.position.x, props.position.y],
+      () => setDrilledIndex(null),
+      { defer: true },
+    ),
+  );
+
+  const handleItemClick = (item: ContextMenuItem, index: number): void => {
     if (!item.enabled) return;
+    if ("submenu" in item) {
+      setDrilledIndex(index);
+      return;
+    }
     item.action();
     props.onClose();
   };
@@ -78,6 +131,12 @@ const ContextMenu: Component<Props> = (props) => {
     // signal), so `onMount` alone would strand the menu at the first coords.
     const clickX = props.position.x;
     const clickY = props.position.y;
+    // #1192 — and track the drill level for the same reason: entering or
+    // leaving a submenu swaps the item list, so the box changes HEIGHT. Without
+    // this read the menu keeps the placement measured for the previous level,
+    // and a submenu opened near the bottom edge hangs off the fold — the exact
+    // #487 defect, re-entered through a door #487 could not have known about.
+    drilledIndex();
     if (!menuRef || !safeAreaRef) return;
     const rect = menuRef.getBoundingClientRect();
     const safe = safeAreaRef.getBoundingClientRect();
@@ -137,16 +196,34 @@ const ContextMenu: Component<Props> = (props) => {
         }}
         role="menu"
       >
-        <For each={props.items}>
-          {(item) => (
+        {/* #1192 — the way back UP a drill-down. Deliberately a peer of the
+            items (same `.context-menu-item` class, so it inherits the hit
+            target and the e2e's locator) rather than a floating chrome
+            affordance: on a long-press menu there is nowhere to put chrome, and
+            a row is the one thing a thumb already knows how to hit. Escape is
+            left alone — it still closes the whole menu, the behaviour every
+            existing caller of this shell already has. */}
+        <Show when={drilled()}>
+          <button
+            type="button"
+            class="context-menu-item context-menu-back"
+            onClick={() => setDrilledIndex(null)}
+          >
+            ‹ {drilledLabel()}
+          </button>
+        </Show>
+        <For each={visibleItems()}>
+          {(item, index) => (
             <button
               type="button"
               class="context-menu-item"
               classList={{ "context-menu-item-disabled": !item.enabled }}
               disabled={!item.enabled}
-              onClick={() => handleItemClick(item)}
+              onClick={() => handleItemClick(item, index())}
             >
-              {item.label}
+              {/* The ▸ is the shell's job, not the caller's: the caller names
+                  the group, the shell says it opens. */}
+              {"submenu" in item ? `${item.label} ▸` : item.label}
             </button>
           )}
         </For>

--- a/cicchetto/src/UserContextMenu.tsx
+++ b/cicchetto/src/UserContextMenu.tsx
@@ -1,5 +1,6 @@
 import type { Component } from "solid-js";
-import ContextMenu, { type ContextMenuItem } from "./ContextMenu";
+import ContextMenu, { type ContextMenuAction, type ContextMenuItem } from "./ContextMenu";
+import { sendCtcpQuery } from "./lib/ctcpQuery";
 import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { setSelectedChannel } from "./lib/selection";
 import {
@@ -25,6 +26,19 @@ import {
 // The chrome (portal, backdrop, Escape, the #487 measured viewport clamp) lives
 // in `ContextMenu`, shared since #1067 added the long-press message menu. This
 // module is now only the item list.
+//
+// #1192 added a ninth entry: a CTCP group that drills down rather than six more
+// rows on a menu that already has eight.
+
+// #1192 — the verbs worth a menu row. Small and closed on purpose: `/ctcp` is
+// still there for anything else, and every entry here costs a row on a menu
+// that a thumb has to hit.
+//
+// Neither VERSION nor CLIENTINFO is verifiable — both are strings the remote
+// client picks for itself (CLIENTINFO is the verbs it claims to answer, which
+// is capability discovery, not identity). They are worth asking; they are not
+// worth believing.
+const CTCP_VERBS = ["VERSION", "TIME", "PING", "CLIENTINFO", "USERINFO", "SOURCE"] as const;
 
 export type Props = {
   networkSlug: string;
@@ -38,6 +52,36 @@ export type Props = {
 
 const UserContextMenu: Component<Props> = (props) => {
   const isOp = (): boolean => props.ownModes.includes("@");
+
+  // Every verb dispatches identically — the seam owns the #640 source-window
+  // echo and the #600 register-before-send ordering, so there is nothing here
+  // for PING to special-case. Args are empty: a menu row has no place to type
+  // one, and a BARE ping is what correlates through the #637 token-less
+  // fallback without the seam inventing wire bytes.
+  //
+  // Detached, because a menu item's action is synchronous and this menu has no
+  // inline error channel the way the composer does. Never bare, though: an
+  // unhandled rejection is how a throttled or WS-down probe becomes a row that
+  // simply never appears. Same shape as compose.ts's detached fan-out — a
+  // grep key and the reason it stopped.
+  const ctcpItems = (): ContextMenuAction[] =>
+    CTCP_VERBS.map((verb) => ({
+      label: verb,
+      enabled: true,
+      action: (): void => {
+        void sendCtcpQuery({
+          networkSlug: props.networkSlug,
+          networkId: props.networkId,
+          sourceChannel: props.channelName,
+          targetNick: props.targetNick,
+          verb,
+          args: "",
+          sentAtMs: Date.now(),
+        }).catch((err: unknown) => {
+          console.warn(`[ctcp-menu] ${verb} to ${props.targetNick} never left:`, err);
+        });
+      },
+    }));
 
   const items = (): ContextMenuItem[] => [
     {
@@ -77,6 +121,15 @@ const UserContextMenu: Component<Props> = (props) => {
       // Always enabled — no perm required.
       enabled: true,
       action: () => pushWhois(props.networkId, props.targetNick, null),
+    },
+    {
+      // #1192 — sits between WHOIS and Query because it belongs with WHOIS:
+      // both interrogate the person, while Query talks to them. Always enabled,
+      // like its neighbours — asking a peer for its VERSION needs no channel
+      // privilege.
+      label: "CTCP",
+      enabled: true,
+      submenu: ctcpItems(),
     },
     {
       label: "Query",

--- a/cicchetto/src/__tests__/ContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/ContextMenu.test.tsx
@@ -1,7 +1,7 @@
-import { render } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
-import ContextMenu from "../ContextMenu";
+import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
 
 // #949 — the WIRING half of the safe-area clamp. The arithmetic is pinned as a
 // pure fn (lib/menuPosition.test.ts) and the stylesheet rules at source level
@@ -17,6 +17,23 @@ import ContextMenu from "../ContextMenu";
 
 const ITEMS = [
   { label: "whois", enabled: true, action: vi.fn() },
+  { label: "query", enabled: true, action: vi.fn() },
+];
+
+// #1192 — a top level with one drillable group in the MIDDLE. Middle on
+// purpose: the drill state is an index into this array, so a group at index 0
+// would let an off-by-one read as correct.
+const VERSION_ACTION = vi.fn();
+const NESTED: ContextMenuItem[] = [
+  { label: "whois", enabled: true, action: vi.fn() },
+  {
+    label: "ctcp",
+    enabled: true,
+    submenu: [
+      { label: "VERSION", enabled: true, action: (): void => VERSION_ACTION() },
+      { label: "TIME", enabled: true, action: vi.fn() },
+    ],
+  },
   { label: "query", enabled: true, action: vi.fn() },
 ];
 
@@ -83,6 +100,36 @@ describe("ContextMenu safe-area placement (#949)", () => {
     expect(menuEl.style.left).toBe("59px");
   });
 
+  // #1192 — a submenu changes the box HEIGHT, which is exactly the input the
+  // #487 placement math takes. If the effect does not re-run on the drill, the
+  // menu keeps the placement measured for the previous level and a submenu
+  // opened low on the screen hangs off the fold — #487's defect, re-entered
+  // through a door #487 could not have known about.
+  it("re-measures the placement when drilling changes the box height", () => {
+    const [position, setPosition] = createSignal({ x: 1, y: 1 });
+    render(() => <ContextMenu items={NESTED} position={position()} onClose={vi.fn()} />);
+    stubRect(".context-menu-safe-area", { top: 0, right: 1024, bottom: 768, left: 0 });
+
+    // A rect that GROWS on the drill, the way a 2-item top level growing into a
+    // 6-verb submenu does. jsdom paints nothing, so the height is the one thing
+    // the test has to supply itself.
+    let height = 100;
+    const menuEl = document.querySelector(".context-menu");
+    if (!(menuEl instanceof HTMLElement)) throw new Error(".context-menu did not render");
+    menuEl.getBoundingClientRect = (): DOMRect =>
+      ({ top: 0, left: 0, right: 200, bottom: height, width: 200, height }) as DOMRect;
+
+    // Press low: 700 + 100 overflows 768, so the placement flips to 600.
+    setPosition({ x: 100, y: 700 });
+    expect(menuEl.style.top).toBe("600px");
+
+    // Now the taller level. 700 + 400 overflows too, and the flip lands at 300 —
+    // a value only a RE-measurement can produce.
+    height = 400;
+    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    expect(menuEl.style.top).toBe("300px");
+  });
+
   it("honours the press coordinates when there is no inset to dodge", () => {
     // The no-notch case — every desktop browser and every engine in the e2e
     // suite, where env(safe-area-inset-*) resolves to 0. The fix must be a
@@ -94,5 +141,71 @@ describe("ContextMenu safe-area placement (#949)", () => {
     );
     expect(menuEl.style.left).toBe("100px");
     expect(menuEl.style.top).toBe("400px");
+  });
+});
+
+// #1192 — the drill-down itself. A submenu keeps the nick menu from growing by
+// six items; the shell owns the mechanism so both menus that mount it inherit
+// it, and the CTCP verb list stays a plain data structure at the call site.
+describe("ContextMenu drill-down (#1192)", () => {
+  const labels = (): string[] =>
+    [...document.querySelectorAll(".context-menu-item")].map((b) => b.textContent ?? "");
+
+  it("marks a drillable group with ▸ and leaves plain items unmarked", () => {
+    render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    // The caller names the group; the shell says it opens. A caller that had to
+    // spell the ▸ itself would eventually spell it two ways.
+    expect(labels()).toEqual(["whois", "ctcp ▸", "query"]);
+  });
+
+  it("swaps the list for the submenu instead of closing the menu", () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+
+    // The group row is a NAVIGATION, not an invocation: closing here would make
+    // the six verbs unreachable.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(labels()).toEqual(["‹ ctcp", "VERSION", "TIME"]);
+  });
+
+  it("invokes a submenu action and closes", () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^version$/i }));
+
+    expect(VERSION_ACTION).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to the top level from the back row, without acting", () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^‹ ctcp$/i }));
+
+    expect(labels()).toEqual(["whois", "ctcp ▸", "query"]);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("resets to the top level when the menu re-opens at new coordinates", () => {
+    // Both call sites keep this component mounted across a value→value change
+    // of their `<Show>` signal: right-clicking a second nick while the menu is
+    // up re-positions it without unmounting. Without the reset that second nick
+    // opens straight into the first one's submenu — and the actions in it are
+    // bound to the FIRST nick.
+    const [position, setPosition] = createSignal({ x: 10, y: 10 });
+    render(() => <ContextMenu items={NESTED} position={position()} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    expect(labels()).toEqual(["‹ ctcp", "VERSION", "TIME"]);
+
+    setPosition({ x: 400, y: 400 });
+
+    expect(labels()).toEqual(["whois", "ctcp ▸", "query"]);
   });
 });

--- a/cicchetto/src/__tests__/UserContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/UserContextMenu.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // C5.1 — UserContextMenu: right-click submenu on member nick.
 //
 // Tests assert:
-//   1. All 8 items render (op/deop/voice/devoice/kick/ban/WHOIS/query).
+//   1. All 9 items render (op/deop/voice/devoice/kick/ban/WHOIS/CTCP/query).
 //   2. When own nick has @-mode, op-gated items are enabled.
 //   3. When own nick lacks @-mode, op-gated items are disabled (not hidden).
 //   4. WHOIS + Query are always enabled regardless of modes.
@@ -21,6 +21,7 @@ const mockPushChannelBan = vi.fn();
 const mockPushWhois = vi.fn();
 const mockOpenQueryWindowState = vi.fn();
 const mockSetSelectedChannel = vi.fn();
+const mockSendCtcpQuery = vi.fn();
 
 vi.mock("../lib/socket", () => ({
   pushChannelOp: (...args: unknown[]) => mockPushChannelOp(...args),
@@ -30,6 +31,15 @@ vi.mock("../lib/socket", () => ({
   pushChannelKick: (...args: unknown[]) => mockPushChannelKick(...args),
   pushChannelBan: (...args: unknown[]) => mockPushChannelBan(...args),
   pushWhois: (...args: unknown[]) => mockPushWhois(...args),
+}));
+
+// #1192 — the CTCP submenu dispatches through the shared seam; its own
+// contract (the #640 source-window echo, the #600 ordering) is pinned in
+// ctcpQuery.test.ts, so here it is a boundary spy. Resolves, because the
+// production action attaches a `.catch` and an unhandled rejection from a
+// bare `vi.fn()` would fail the run for the wrong reason.
+vi.mock("../lib/ctcpQuery", () => ({
+  sendCtcpQuery: (...args: unknown[]) => mockSendCtcpQuery(...args),
 }));
 
 vi.mock("../lib/networks", () => ({
@@ -65,11 +75,12 @@ const baseProps = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSendCtcpQuery.mockResolvedValue(undefined);
 });
 
 describe("UserContextMenu", () => {
-  describe("renders all 8 items", () => {
-    it("shows Op, Deop, Voice, Devoice, Kick, Ban, WHOIS, Query", () => {
+  describe("renders all 9 items", () => {
+    it("shows Op, Deop, Voice, Devoice, Kick, Ban, WHOIS, CTCP, Query", () => {
       render(() => <UserContextMenu {...baseProps} />);
       expect(screen.getByRole("button", { name: /^op$/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^deop$/i })).toBeInTheDocument();
@@ -78,6 +89,8 @@ describe("UserContextMenu", () => {
       expect(screen.getByRole("button", { name: /^kick$/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^ban$/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^whois$/i })).toBeInTheDocument();
+      // #1192 — the shell appends the ▸, so the accessible name carries it.
+      expect(screen.getByRole("button", { name: /^ctcp ▸$/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^query$/i })).toBeInTheDocument();
     });
   });
@@ -166,6 +179,63 @@ describe("UserContextMenu", () => {
         channelName: "alice",
         kind: "query",
       });
+    });
+
+    it("CTCP drills into the six verbs instead of acting", async () => {
+      render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
+      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+
+      // The whole point of the group: six verbs behind ONE row, so the nick
+      // menu does not grow to fourteen.
+      for (const verb of ["VERSION", "TIME", "PING", "CLIENTINFO", "USERINFO", "SOURCE"]) {
+        expect(
+          screen.getByRole("button", { name: new RegExp(`^${verb}$`, "i") }),
+        ).not.toBeDisabled();
+      }
+      expect(mockSendCtcpQuery).not.toHaveBeenCalled();
+    });
+
+    it("a CTCP verb dispatches against the SOURCE window, with no invented args", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1706743200000);
+      render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
+      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^version$/i }));
+
+      // `sourceChannel` is the window the operator is looking at (#640) and the
+      // recipient travels separately — the probe must not mint a query tab.
+      // `args: ""` because a menu row has nowhere to type one, and because a
+      // BARE ping is what the #637 token-less fallback correlates.
+      expect(mockSendCtcpQuery).toHaveBeenCalledWith({
+        networkSlug: "freenode",
+        networkId: 42,
+        sourceChannel: "#grappa",
+        targetNick: "alice",
+        verb: "VERSION",
+        args: "",
+        sentAtMs: 1706743200000,
+      });
+      vi.mocked(Date.now).mockRestore();
+    });
+
+    it("PING goes through the same door as every other verb", async () => {
+      // No special case at the call site is the point: the seam decides what
+      // correlates, off the VERB. A menu that hand-rolled PING here is exactly
+      // the drift #1192 moved the ordering into the seam to prevent.
+      vi.spyOn(Date, "now").mockReturnValue(1706743200000);
+      render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
+      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^ping$/i }));
+
+      expect(mockSendCtcpQuery).toHaveBeenCalledWith({
+        networkSlug: "freenode",
+        networkId: 42,
+        sourceChannel: "#grappa",
+        targetNick: "alice",
+        verb: "PING",
+        args: "",
+        sentAtMs: 1706743200000,
+      });
+      vi.mocked(Date.now).mockRestore();
     });
 
     it("WHOIS button calls pushWhois with networkId and nick (server null)", async () => {

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1189,6 +1189,38 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  // #1192 — a deliberate behaviour change, pinned so it cannot regress by
+  // accident in either direction.
+  //
+  // `/ctcp bob PING` was always a ping; only `/ping` knew to correlate one. Its
+  // reply therefore fell out in `$server` as an uncorrelated "← CTCP PING reply
+  // from bob" row. Routing both verbs through the one seam means the VERB
+  // decides, not which command spelled it, so the RTT now lands in the source
+  // window either way.
+  //
+  // The WIRE is untouched, and that is the half worth guarding: the seam mints
+  // no token, so a bare `/ctcp bob PING` still frames `\x01PING\x01` — the raw
+  // escape hatch keeps sending exactly the operator's bytes, and the empty
+  // token rides the #637 token-less fallback home.
+  it("/ctcp <target> PING correlates without inventing a token (#1192)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    vi.spyOn(Date, "now").mockReturnValue(1706743200000);
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ctcp bob ping");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", "bob");
+    expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "", k, "#a", 1706743200000);
+    expect(result).toEqual({ ok: true });
+
+    vi.mocked(Date.now).mockRestore();
+  });
+
   // #640 — ACTION is the exception: it IS conversation (/me to an explicit
   // target), so it rides the normal send path INTO the target window (3 args,
   // no ctcpTarget), exactly as before #640. The parser upper-cases the verb.

--- a/cicchetto/src/__tests__/ctcpQuery.test.ts
+++ b/cicchetto/src/__tests__/ctcpQuery.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+
+// Boundary stubs. The seam's whole job is WHICH two calls it makes and in WHAT
+// ORDER, so both collaborators are spies: the send door (scrollback.sendMessage,
+// whose own REST plumbing is pinned in scrollback.test.ts) and the correlation
+// store (pingCorrelation.registerPing, whose RTT arithmetic is pinned in
+// pingCorrelation.test.ts).
+vi.mock("../lib/scrollback", () => ({
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("../lib/pingCorrelation", () => ({
+  registerPing: vi.fn(),
+  resolvePing: vi.fn(),
+}));
+
+// The invariant fields of a dispatch. `verb` / `args` are supplied per test —
+// they are the axis under test.
+const QUERY = {
+  networkSlug: "freenode",
+  networkId: 1,
+  sourceChannel: "#a",
+  targetNick: "bob",
+  sentAtMs: 1706743200000,
+};
+
+describe("sendCtcpQuery — #1192", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The shape every verb shares: the frame is echoed in the SOURCE window (the
+  // one the operator is looking at) with the wire recipient in the 4th
+  // `ctcpTarget` arg — the #640 contract that keeps a control-surface probe from
+  // minting a query window for the peer.
+  it("frames a non-PING verb into the SOURCE window with the recipient in ctcpTarget", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", "bob");
+  });
+
+  // Verb-agnostic means verb-agnostic: PING is the ONLY verb the seam correlates,
+  // and every other one is fire-and-forget. A seam that registered for everything
+  // would leak a pending entry per menu click that can never resolve.
+  it("registers no correlation for a non-PING verb", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
+
+    expect(pc.registerPing).not.toHaveBeenCalled();
+  });
+
+  // Args are the caller's bytes, passed through untouched — the seam is not a
+  // parser. `\x01VERB args\x01`, one space, no re-quoting.
+  it("carries args into the frame verbatim", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "CLIENTINFO", args: "PING TIME" });
+
+    expect(sb.sendMessage).toHaveBeenCalledWith(
+      "freenode",
+      "#a",
+      "\x01CLIENTINFO PING TIME\x01",
+      "bob",
+    );
+  });
+
+  // PING correlates. The token is the caller's `args` — opaque to this seam and
+  // to the store — and the pending entry is keyed on the SOURCE window so the
+  // RTT line lands where the operator asked the question.
+  it("registers a PING against the source window, keyed on the caller's token", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    // A token that is deliberately NOT the timestamp. `/ping` happens to mint
+    // `String(Date.now())`, and asserting against that value here would let a
+    // seam that ignored the caller and re-read the clock pass anyway.
+    await sendCtcpQuery({ ...QUERY, verb: "PING", args: "tok-591" });
+
+    expect(pc.registerPing).toHaveBeenCalledWith(
+      1,
+      "bob",
+      "tok-591",
+      channelKey("freenode", "#a"),
+      "#a",
+      1706743200000,
+    );
+  });
+
+  // A BARE ping — what a menu item sends, and what `/ctcp bob PING` has always
+  // put on the wire. The seam must NOT mint a token to make correlation easier
+  // for itself: `/ctcp` is the raw escape hatch and has to send the bytes the
+  // operator asked for. Correlation still works, through the #637 token-less
+  // fallback (the peer echoes a bare `\x01PING\x01`, which resolves the empty
+  // token).
+  it("sends a bare PING unframed by an invented token, and still registers it", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "PING", args: "" });
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", "bob");
+    expect(pc.registerPing).toHaveBeenCalledWith(
+      1,
+      "bob",
+      "",
+      channelKey("freenode", "#a"),
+      "#a",
+      1706743200000,
+    );
+  });
+
+  // The verb reaches this seam from two directions — a parser that upper-cases
+  // (slashCommands) and a menu that passes a literal. Fold before the comparison
+  // so a lower-cased PING is still a PING; the alternative is a silently
+  // uncorrelated ping whose reply falls out in $server.
+  it("correlates a lower-cased ping verb", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "ping", args: "tok" });
+
+    expect(pc.registerPing).toHaveBeenCalled();
+  });
+
+  // #600 — the ordering this seam exists to make unloseable.
+  //
+  // `sendMessage` is a REST POST. Its ack can resolve AFTER the peer's CTCP PING
+  // reply has already been processed on the separate, already-open WS. If the
+  // registration waited on the send, `maybeConsumePingReply → resolvePing` would
+  // find no pending entry and drop the RTT — the deterministic CI timeout #600
+  // diagnosed, invisible on a fast local box. compose.ts got this right by hand;
+  // a second caller (the #1192 nick menu) is exactly how a hand-held invariant
+  // drifts, which is why the ordering now lives HERE and not at the call sites.
+  //
+  // Modelled with a send that never settles: if registration is behind the
+  // await, these assertions run against zero calls.
+  it("registers the pending BEFORE the send resolves", async () => {
+    const sb = await import("../lib/scrollback");
+    const pc = await import("../lib/pingCorrelation");
+    let releaseSend!: () => void;
+    vi.mocked(sb.sendMessage).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      }),
+    );
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    const inFlight = sendCtcpQuery({ ...QUERY, verb: "PING", args: "tok" });
+    // Flush microtasks so the seam reaches — and blocks on — the send await.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sb.sendMessage).toHaveBeenCalled();
+    expect(pc.registerPing).toHaveBeenCalled();
+
+    releaseSend();
+    await inFlight;
+  });
+});

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -16,7 +16,7 @@ import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { requestConfirm } from "./confirmDialog";
-import { scrubCtcpDelimiters } from "./ctcpAction";
+import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -205,14 +205,6 @@ const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
   if (keys.length === 0) sessionStorage.removeItem(DRAFTS_KEY);
   else sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(drafts));
 };
-
-// #591 — the single CTCP frame builder: `\x01VERB\x01` (no args) or
-// `\x01VERB args\x01`. This is the ONE place that wraps a body in CTCP `\x01`
-// framing — shared by /me (verb ACTION, one frame per line) and /ctcp
-// (arbitrary verb, single frame). Empty args yield NO trailing space, so a
-// bare `/ctcp bob version` frames as `\x01VERSION\x01`, not `\x01VERSION \x01`.
-export const ctcpFrame = (verb: string, args: string): string =>
-  args === "" ? `\x01${verb}\x01` : `\x01${verb} ${args}\x01`;
 
 // The lines a free-text body fans out to — one PRIVMSG each, after the exit
 // scrub. Shared by the send path and #1108's pre-send preview so the count

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -17,6 +17,7 @@ import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
+import { sendCtcpQuery } from "./ctcpQuery";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -29,7 +30,6 @@ import { splitMessageLines } from "./messageLines";
 import { openModeModal } from "./modeModal";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
 import { asciiFold, nickEquals } from "./nickEquals";
-import { registerPing } from "./pingCorrelation";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 import { quitAll } from "./quit";
@@ -983,64 +983,66 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         // #591 — /ctcp <target> <VERB> [args]: a single CTCP frame to an
-        // EXPLICIT target (not the current window), built via the shared
-        // `ctcpFrame` seam. Non-ACTION CTCP is single-line by convention
-        // (Grappa.IRC.LineSplit) so there is no multiline fan-out. AWAIT the
-        // send: a CTCP verb MUST NOT silently no-op when the WS is down.
+        // EXPLICIT target (not the current window). Non-ACTION CTCP is
+        // single-line by convention (Grappa.IRC.LineSplit) so there is no
+        // multiline fan-out. AWAIT the send: a CTCP verb MUST NOT silently
+        // no-op when the WS is down.
         case "ctcp": {
-          // #640 — a CTCP QUERY (VERSION/PING/TIME/…) is a control-surface
-          // probe, not a conversation: its self-echo renders in the SOURCE
-          // window (`channelName`, where the operator typed it), NEVER a query
-          // window for the recipient. Send to the source window with the wire
-          // recipient in `ctcpTarget`; the server keys the echo to the source,
-          // carries the recipient in `meta.ctcp_target`, and never auto-opens a
-          // window for it.
-          //
-          // ACTION is the exception — it IS conversation (`/me` to an explicit
-          // target), so it belongs in the TARGET window and rides the normal
-          // send path unchanged (the server also rejects an ACTION via the CTCP
-          // route — `Session.send_ctcp`'s non-ACTION gate). The parser
-          // upper-cases the verb; guard case-insensitively regardless.
-          const frame = ctcpFrame(cmd.verb, cmd.args);
+          // ACTION is the exception this door keeps for itself: it IS
+          // conversation (`/me` to an explicit target), so it belongs in the
+          // TARGET window and rides the normal send path (the server also
+          // rejects an ACTION through the CTCP route — `Session.send_ctcp`'s
+          // non-ACTION gate). The parser upper-cases the verb; guard
+          // case-insensitively regardless.
           if (cmd.verb.toUpperCase() === "ACTION") {
-            await sendPrivmsg(networkSlug, cmd.target, frame);
-          } else {
-            await sendPrivmsg(networkSlug, channelName, frame, cmd.target);
+            await sendPrivmsg(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
+            result = { ok: true };
+            break;
           }
+          const ctcpNetworkId = networkIdBySlug(networkSlug);
+          if (ctcpNetworkId === undefined) return { error: "/ctcp: network not found" };
+          // Everything else is a control-surface probe and goes through the
+          // #1192 seam, which owns the #640 source-window echo and the #600
+          // register-before-send ordering.
+          //
+          // Consequence worth naming: `/ctcp <t> PING` now CORRELATES, where it
+          // used to drop its reply into `$server` as an uncorrelated
+          // "← CTCP PING reply from …" row. The verb was always a ping; only
+          // the sugar knew to correlate it. Nothing changes on the WIRE — the
+          // seam mints no token, so a bare `/ctcp bob PING` still frames
+          // `\x01PING\x01` and rides the #637 token-less fallback home.
+          await sendCtcpQuery({
+            networkSlug,
+            networkId: ctcpNetworkId,
+            sourceChannel: channelName,
+            targetNick: cmd.target,
+            verb: cmd.verb,
+            args: cmd.args,
+            sentAtMs: Date.now(),
+          });
           result = { ok: true };
           break;
         }
-        // #591 — /ping <target>: CTCP PING sugar. The token is a client
-        // timestamp; it travels in the frame, comes back verbatim in the
-        // reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`.
-        // Keyed on the SOURCE window so the RTT line lands where /ping was typed
-        // (irssi behavior; synthesized in subscribe.ts).
-        //
-        // #600 — register the pending entry BEFORE the send, NOT after. The
-        // earlier "register after a successful send — the reply cannot precede
-        // the send" ordering held only for the WIRE: `sendPrivmsg` is a REST
-        // POST, and on a slow/loaded runner its ack resolves AFTER the peer's
-        // CTCP PING reply has already been processed on the (separate,
-        // already-open) WS. With registration behind the `await`,
-        // `maybeConsumePingReply → resolvePing` found no pending entry and
-        // dropped the reply — the RTT line never rendered → the 15s CI timeout
-        // (deterministic on the CI runner, invisible on a fast local box).
-        // Registering first makes the pending present for any reply; if the send
-        // below throws, the orphaned entry is inert (one-shot, identity-scoped
-        // clear, never resolves without a matching reply).
+        // #591 — /ping <target>: CTCP PING sugar over the same seam. The token
+        // is a client timestamp; it travels in the frame, comes back verbatim in
+        // the reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`
+        // (synthesized in subscribe.ts, irssi behavior). Minting the token is
+        // ALL this sugar adds — the correlation bookkeeping and its ordering
+        // belong to the seam, and did not survive being held by hand once a
+        // third caller appeared.
         case "ping": {
-          const networkId = networkIdBySlug(networkSlug);
-          if (networkId === undefined) return { error: "/ping: network not found" };
+          const pingNetworkId = networkIdBySlug(networkSlug);
+          if (pingNetworkId === undefined) return { error: "/ping: network not found" };
           const sentAtMs = Date.now();
-          const token = String(sentAtMs);
-          // registerPing keys the RTT correlation on the SOURCE window
-          // (`key`/`channelName`) so the reply's RTT line lands where /ping was
-          // typed — the SAME window the #640 echo now renders in (the two halves
-          // finally converge).
-          registerPing(networkId, cmd.target, token, key, channelName, sentAtMs);
-          // #640 — echo to the SOURCE window (`channelName`) with the wire
-          // recipient in `ctcpTarget`; never opens a query window for the peer.
-          await sendPrivmsg(networkSlug, channelName, ctcpFrame("PING", token), cmd.target);
+          await sendCtcpQuery({
+            networkSlug,
+            networkId: pingNetworkId,
+            sourceChannel: channelName,
+            targetNick: cmd.target,
+            verb: "PING",
+            args: String(sentAtMs),
+            sentAtMs,
+          });
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/ctcpAction.ts
+++ b/cicchetto/src/lib/ctcpAction.ts
@@ -13,6 +13,22 @@
 export const CTCP_DELIMITER = "\x01";
 const CTCP_ACTION_PREFIX = `${CTCP_DELIMITER}ACTION `;
 
+// #591 — the single CTCP frame builder: `\x01VERB\x01` (no args) or
+// `\x01VERB args\x01`. This is the ONE place that wraps a body in CTCP `\x01`
+// framing — shared by /me (verb ACTION, one frame per line), /ctcp (arbitrary
+// verb, single frame) and the #1192 nick-menu CTCP submenu. Empty args yield NO
+// trailing space, so a bare `/ctcp bob version` frames as `\x01VERSION\x01`,
+// not `\x01VERSION \x01`.
+//
+// #1192 moved it here from `compose.ts`. It always belonged next to the
+// envelope it builds — the note below already had to point across a module
+// boundary to name it — and the move is what lets `ctcpQuery.ts` frame a menu
+// dispatch without importing `compose`, which imports `ctcpQuery` back.
+export const ctcpFrame = (verb: string, args: string): string =>
+  args === ""
+    ? `${CTCP_DELIMITER}${verb}${CTCP_DELIMITER}`
+    : `${CTCP_DELIMITER}${verb} ${args}${CTCP_DELIMITER}`;
+
 // The inner text of an action body, or the body unchanged when the envelope
 // isn't there. Defensive on purpose: a future server-side pre-strip, or a row
 // persisted before the wire form was stored, must still render.
@@ -26,7 +42,7 @@ export const stripCtcpAction = (body: string | null): string => {
 // Scrub every CTCP delimiter out of operator-typed free text.
 //
 // `\x01` is framing, and cic has exactly ONE sanctioned producer of it
-// (`ctcpFrame` in compose.ts). A delimiter arriving in free text is either a
+// (`ctcpFrame`, above). A delimiter arriving in free text is either a
 // paste or a bug upstream; either way it is not framing the operator chose, so
 // it must not survive to the wire. Scrub rather than reject — the byte is
 // invisible, so refusing the whole message would be an unexplainable failure,

--- a/cicchetto/src/lib/ctcpQuery.ts
+++ b/cicchetto/src/lib/ctcpQuery.ts
@@ -1,0 +1,79 @@
+import { channelKey } from "./channelKey";
+import { ctcpFrame } from "./ctcpAction";
+import { registerPing } from "./pingCorrelation";
+import { sendMessage } from "./scrollback";
+
+// #1192 — the ONE door an outbound CTCP query goes through.
+//
+// A CTCP query is a control-surface probe, not conversation, and it has two
+// halves that must stay welded together:
+//
+//   1. #640 — the self-echo belongs in the SOURCE window (the one the operator
+//      is looking at), with the wire recipient travelling in `ctcpTarget`. Send
+//      it to the recipient's window instead and a probe mints a phantom query
+//      tab for somebody the operator never talked to.
+//   2. #600 — a PING's pending correlation entry MUST be registered BEFORE the
+//      send is awaited. `sendMessage` is a REST POST; on a loaded runner its ack
+//      resolves AFTER the peer's reply has already been processed on the
+//      separate, already-open WS. Register behind the await and
+//      `maybeConsumePingReply → resolvePing` finds nothing, the RTT line never
+//      renders, and the failure is deterministic on CI and invisible locally.
+//
+// compose.ts held both by hand while `/ping` and `/ctcp` were the only callers.
+// #1192 adds a second, independent caller — the nick context menu's CTCP
+// submenu — and a hand-held invariant with two callers is an invariant with a
+// drift date. So the ordering lives here, and the callers lose the ability to
+// get it wrong.
+//
+// Deliberately NOT here:
+//
+//   * ACTION. `/me` and `/ctcp <t> ACTION …` ARE conversation, so they belong in
+//     the TARGET window and ride the ordinary send path; the server rejects an
+//     ACTION through the CTCP route anyway (`Session.send_ctcp`'s non-ACTION
+//     gate). compose.ts keeps that branch above this call.
+//   * Token minting. `args` is the caller's bytes, framed verbatim. `/ping` is
+//     sugar that mints a timestamp token; `/ctcp` is the raw escape hatch and
+//     must put exactly what the operator typed on the wire. A seam that invented
+//     a token to make its own correlation tidier would silently rewrite the
+//     escape hatch. A BARE ping still correlates — through the #637 token-less
+//     fallback, since the peer echoes a bare `\x01PING\x01` back.
+//   * The clock. `sentAtMs` is passed in, keeping the whole correlation chain
+//     wall-clock-free the way `pingCorrelation` is, so the RTT origin is a value
+//     the caller can pin and this module's ordering can be asserted without
+//     mocking time.
+type CtcpQuery = {
+  networkSlug: string;
+  networkId: number;
+  // The window the operator asked from — where the echo, and a PING's RTT, land.
+  sourceChannel: string;
+  // The wire recipient. NOT the window: see #640 above.
+  targetNick: string;
+  verb: string;
+  args: string;
+  sentAtMs: number;
+};
+
+export const sendCtcpQuery = async (query: CtcpQuery): Promise<void> => {
+  // PING is the one verb whose reply cic can attribute back to the question, so
+  // it is the one verb that registers. Everything else is fire-and-forget: its
+  // reply is an asynchronous NOTICE the server routes to `$server`, and a
+  // pending entry for it could only ever leak. Folded because the verb reaches
+  // here from a parser that upper-cases AND from a menu that passes a literal.
+  if (query.verb.toUpperCase() === "PING") {
+    registerPing(
+      query.networkId,
+      query.targetNick,
+      query.args,
+      channelKey(query.networkSlug, query.sourceChannel),
+      query.sourceChannel,
+      query.sentAtMs,
+    );
+  }
+
+  await sendMessage(
+    query.networkSlug,
+    query.sourceChannel,
+    ctcpFrame(query.verb, query.args),
+    query.targetNick,
+  );
+};

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6660,6 +6660,13 @@ html.resize-dragging * {
   cursor: not-allowed;
 }
 
+/* #1192 — the drill-down's back row. Muted and ruled off so the level it
+   leaves reads as a header rather than as one more thing to invoke. */
+.context-menu-back {
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+
 /* Mobile drawer mode (≤768px) */
 
 @media (max-width: 768px) {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -38316,3 +38316,82 @@ with the type and both accessors derived from it.
 has not been run — the integration stack belonged to another worker for the
 duration of this work. Everything else is measured: the full Elixir gate and
 both cic gates are green.
+
+---
+
+## 2026-08-11 — #1192: a CTCP submenu, and where the answer is not
+
+The verbs already worked. `/ctcp bob version` has framed, sent, echoed and
+rendered since #591; what #1192 added is the way in — the same shape as the
+WHOWAS request, machinery shipped with no entry point.
+
+vjt ruled four questions at once, all as proposed.
+
+**The submenu drills down in place rather than flying out beside the parent.**
+A flyout is a mouse affordance, and this shell also backs the long-press
+message menu on a phone; a second floating box would need its own copy of the
+#487 viewport clamp and the #949 safe-area math — the hardest code in
+`ContextMenu.tsx` — duplicated to serve the input device cic is least used on.
+Two details in the implementation are load-bearing and were not obvious. The
+drill level is an INDEX into `props.items`, not the submenu object: a JSX prop
+is a getter and `UserContextMenu` calls `items()` inline, so a captured object
+goes stale as soon as anything upstream re-renders. And it resets when the
+press coordinates move, because both call sites gate on a `<Show>` whose signal
+goes value→value when the operator right-clicks a second nick while the menu is
+up — nothing unmounts, so without the reset the second nick opens into the
+first one's submenu with the first one's actions bound to it. The placement
+effect also had to start reading the level: swapping the list changes the box
+HEIGHT, which is an input to the #487 math, so a submenu opened near the bottom
+edge would hang off the fold — #487's own defect, re-entered through a door
+#487 could not have known about.
+
+**Six verbs: VERSION, TIME, PING, CLIENTINFO, USERINFO, SOURCE.** Small and
+closed; `/ctcp` remains for anything else. Neither VERSION nor CLIENTINFO is
+verifiable — both are strings the remote client picks for itself, and
+CLIENTINFO is capability discovery, not identity. Worth asking, not worth
+believing.
+
+**PING is in, and the register-before-send ordering moved into a seam.** #600
+established that the pending correlation entry must be registered BEFORE the
+send is awaited: `sendMessage` is a REST POST whose ack can resolve after the
+peer's reply has already crossed the separate, already-open WS, and registering
+behind the await drops the RTT deterministically on a loaded runner and never
+locally. `compose.ts` held that by hand while `/ping` and `/ctcp` were the only
+callers. A menu item is a third caller, and a hand-held invariant with three
+callers has a drift date rather than a guarantee — so `lib/ctcpQuery.ts` now
+owns both halves (the ordering, and #640's source-window echo with the
+recipient in `ctcpTarget`), and the callers lost the ability to get it wrong.
+
+Three things stayed out of that seam deliberately. ACTION, because `/me` to an
+explicit target is conversation and belongs in the target's window. The clock,
+which the caller passes in, keeping the correlation chain wall-clock-free the
+way `pingCorrelation` already is. And token minting: `args` is framed verbatim,
+so a bare PING stays `\x01PING\x01` on the wire and correlates through the
+#637 token-less fallback. That last one is what let the seam absorb `/ctcp`
+without moving a single byte on the wire.
+
+One behaviour did change on purpose. `/ctcp <t> PING` now correlates and
+renders an RTT, where before its reply fell out in `$server` as an
+uncorrelated "← CTCP PING reply from …" row. It was always a ping; only the
+sugar knew to correlate one. With the VERB deciding instead of the spelling of
+the command, both spellings behave the same.
+
+**The reply stays in `$server`, and that is the interesting half.** CTCP
+replies come back as asynchronous NOTICEs, outside the WHOIS numeric burst,
+and `route_non_channel_notice/3` sends every CTCP-framed NOTICE to `$server` —
+protocol is not conversation, whether or not a query window is open. So the
+operator clicks VERSION on bob in `#chan`, reads `→ CTCP VERSION to bob` in
+`#chan`, and the answer appears in `$server`. That split predates this issue
+(typed `/ctcp` has always had it) but the menu makes it discoverable, so the
+surprise gets louder. It was left alone on purpose: moving it means reopening
+#546's NOTICE-routing ruling server-side, which is a separate decision, not a
+side effect of adding a menu row. PING is the one verb whose answer lands where
+it was asked, and only because the correlation table already existed to earn
+it.
+
+Consequently there is no spinner and no pending state anywhere in this menu.
+Clients that suppress CTCP never answer at all, so any affordance built on the
+promise of a reply would have to degrade to empty rather than spin — the
+cheapest way to satisfy that is to promise nothing. Escape also still closes
+the whole menu rather than stepping up one level; the back row is the way up.
+That is a judgement call, not a ruling, and it is one line if it should change.


### PR DESCRIPTION
Issue #1192 — a CTCP submenu on the nick context menu.

The verbs already worked. `/ctcp bob version` has framed, sent, echoed and rendered since #591; what was missing was the way in — the same shape as the WHOWAS request, machinery shipped with no entry point.

vjt ruled four questions at once, all as proposed: the submenu drills down **in place**, six verbs, **PING included** with the #600 register-before-send ordering, and **the reply stays in `$server`** (`route_non_channel_notice/3` untouched, #546 not reopened). Scope is cic-only.

## The seven commits

| | |
|---|---|
| `5639b84` | move the CTCP frame builder next to the envelope it builds |
| `52ee958` | give the outbound CTCP query one door that owns the ordering |
| `325b3eb` | route `/ctcp` and `/ping` through it |
| `b5bd36c` | teach the context-menu shell to drill down one level |
| `e973376` | put the CTCP verbs on the nick menu, behind one row |
| `15b7078` | the e2e, against a real peer |
| `c91f3f1` | DESIGN_NOTES |

The ordering moved into `lib/ctcpQuery.ts` because `compose.ts` was holding it by hand and the menu is a **third** caller. #600 established that a PING's pending correlation entry must be registered BEFORE the send is awaited — `sendMessage` is a REST POST whose ack can resolve after the peer's reply has already crossed the separate, already-open WS. A hand-held invariant with three callers has a drift date, not a guarantee.

**One behaviour changes on purpose:** `/ctcp <t> PING` now correlates and renders an RTT, where its reply used to fall out in `$server` uncorrelated. It was always a ping; only the sugar knew to correlate one. **The wire does not move** — the seam mints no token, so a bare `/ctcp bob PING` still frames `\x01PING\x01` and rides the #637 token-less fallback home.

## Gates

| Gate | Result |
|---|---|
| `bun run check` (biome + tsc src + tsc e2e) | rc=0 |
| vitest | 276 files, 5150 tests, rc=0 |
| e2e `#1192` | green |
| integration suite, **this branch** | 695 passed / 2 failed |
| integration suite, **base `305e2df8`** | 693 passed / 3 failed |

Working tree porcelain was identical before and after every gate.

### What clears the branch

Four distinct failures across the two runs, **one** shared:

* branch: `cp15-b6-part-archive-rejoin`, `p0b-peer-away`
* base: `issue168-scroll-authority`, `issue269-visitor-reconnect-toggle`, `p0b-peer-away`

The only overlap is `p0b-peer-away`, which is the already-filed #944 ghost-nick flake. The rest are disjoint across the two runs, and **the base is redder than the branch**. All eleven specs this diff could plausibly touch are green on the branch: `issue487` (its item-count pin moved 8 → 9 here), the three message-menu specs sharing the shell, the three CTCP specs, `c5-member-leftclick`, and the two rail-menu specs.

### Mutation testing — 11 mutants, all compiled, all killed, none survived

* **7 on the seam.** The one that matters is the #600 mutant: the same two calls in the wrong order, which kills the ordering test and only that one.
* **1 on `compose`.** Restoring the pre-seam `sendPrivmsg` call kills the new `/ctcp … PING` pin and only that one, while the `/ctcp bob version` pin stays green — that is the evidence the wire really did not move.
* **3 on the e2e**, one per arm, attributed by line: E1 → line 68 (the verbs never appear), E2 → the peer-side wire witness times out, E3 → line 93 (the source-window echo). E3 got **past** the wire await, so arm 2 survived it: the arms are genuinely independent.
* **The compile gate was proven to bite.** A sloppy mutant (delete the call, keep the import) gives `tsc` rc=1 `TS6133`. Without that check, "all eleven compiled" would have been an unfalsifiable zero-kill.

## What is NOT proven

* **The base is not green on this host.** The honest claim is that this branch does not worsen an already-red base, with the reds disjoint apart from #944 — not that the integration suite is green.
* **`cp15-b6` is not diagnosed, only attributed.** One green and one red is one sample per side; it is not shown to be a flake, and it is not shown to be this branch's doing. Both stay open, and neither justifies widening its 5 s budget.
* **No real client was observed answering any of the six verbs.** The e2e proves the frame leaves and the echo renders; the reply was not asserted for any verb.
* **No device dogfood.** The drill-down is proven in chromium and in jsdom, not on a phone.

## Judgement calls that were mine, not vjt's

* **Escape still closes the whole menu** rather than stepping up one level. The back row is the way up. One line if it should change.
* **The detached send carries a `.catch` with a grep key**; the neighbouring WHOIS item still floats its promise bare. Two patterns in one file, deliberately not widened.
