### PR TITLE
docs: drop the `:disconnected` connection_state that never existed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,12 @@ not the surrounding code.**
   state; `Grappa.Session.whereis/2` is the live-pid truth. They can
   disagree: a `:connected` credential whose `Session.Server` crashed
   mid-restart; a `:parked` credential whose pid is in respawn backoff;
-  a row marked `:disconnected` whose process is in `terminate/2`.
+  a row STILL reading `:connected` whose process is already in
+  `terminate/2`, because `Networks.disconnect/2` and `mark_failed/2`
+  both stop the session BEFORE writing the transition. The closed set
+  is `[:connected, :parked, :failed]` — there is no `:disconnected`
+  state (the `:disconnected` in `session_log_events` is a lifecycle
+  EVENT, a different axis).
   `AdminSessionsTab` surfaces BOTH columns and shows an explicit
   `null` when the live pid is gone — diagnostic value beats false
   uniformity. When adding a new admin listing, return both


### PR DESCRIPTION
## What

One sentence in `CLAUDE.md` claimed a `connection_state` that does not exist:

> a row marked `:disconnected` whose process is in `terminate/2`

The closed set is `[:connected, :parked, :failed]` — `lib/grappa/networks/credential.ex:86`, repeated as the `@type` at `:133` and as the `Ecto.Enum` at `:251`. `cicchetto/src/lib/connectionStateEmoji.ts:13` already states there is no `:disconnected` at the DB level.

Every session reads `CLAUDE.md` at startup, so this was a falsehood in the rulebook rather than a stale comment in a corner. It contaminated a measurement on #1158 earlier today.

## What changed

Only the state named in the example. The lesson it illustrates — DB intent and live pid are separate sources of truth and can disagree — is correct and is kept.

The replacement is measured, not guessed: `Networks.disconnect/2` (`lib/grappa/networks.ex:745-747`) and `Networks.mark_failed/2` (`:789-791`) both call `Session.stop_session/2` BEFORE `transition!/3`. So during `terminate/2` the row genuinely still reads `:connected`, and a concurrent admin read observes exactly that divergence. Same teaching, true instance.

The sentence also now names the other, legitimate use of the word, so a future grep does not "fix" it into a bug: `:disconnected` IS a real lifecycle event in `session_log_events` (#215, `lib/grappa/session_log/event.ex`) — a different axis from a credential's connection state. `docs/DESIGN_NOTES.md` uses it in that sense and is deliberately untouched.

## Scope

Docs only, one file, six lines. No code, no schema, no reordering of the surrounding section.

## Test plan

- [x] `grep -rn ":disconnected" CLAUDE.md docs/` — one hit in `CLAUDE.md` (fixed here), one in `docs/DESIGN_NOTES.md` which is the `session_log` event and correctly left alone.
- [x] Closed set verified at all three declarations in `lib/grappa/networks/credential.ex`.
- [x] Write-before-stop ordering verified in `lib/grappa/networks.ex` for both transition verbs.