### PR TITLE
test: release BOTH `:totp_login` rows, not just the per-account one

### DIFF
--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -70,6 +70,16 @@ defmodule GrappaWeb.AuthControllerTest do
   defp stop_visitor_session(visitor_id, network_id),
     do: :ok = Grappa.Session.stop_session({:visitor, visitor_id}, network_id)
 
+  # The door charges TWO rows, so the teardown must release two. Clearing
+  # only `{ip, user_id}` leaves ten failures on the per-ADDRESS ceiling,
+  # which is a process-global ETS row every test in the run shares: three
+  # tests spending ten each reach `@totp_ip_max_failures` and the next
+  # request from 127.0.0.1 is refused 429 whatever it was asking for.
+  defp clear_totp_window(user_id) do
+    :ok = FailureWindow.clear(:totp_login, {"127.0.0.1", user_id})
+    :ok = FailureWindow.clear(:totp_login, "127.0.0.1")
+  end
+
   defp arm_totp(user) do
     enrollment = TOTP.new_enrollment(user, "Grappa test")
     previous_step = System.system_time(:second) - 30
@@ -350,6 +360,7 @@ defmodule GrappaWeb.AuthControllerTest do
   describe "POST /auth/totp/verify throttle (:totp_login)" do
     test "the 11th attempt is 429 too_many_attempts even with the correct code", %{conn: conn} do
       {user, password} = user_fixture_with_password()
+      on_exit(fn -> clear_totp_window(user.id) end)
       secret = arm_totp(user)
       wrong = wrong_totp_code(secret, System.system_time(:second))
 
@@ -381,6 +392,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
     test "a fresh account is unaffected by another's exhausted window", %{conn: conn} do
       {spent, spent_password} = user_fixture_with_password()
+      on_exit(fn -> clear_totp_window(spent.id) end)
       spent_secret = arm_totp(spent)
       wrong = wrong_totp_code(spent_secret, System.system_time(:second))
 

--- a/test/grappa_web/recovery_code_doors_test.exs
+++ b/test/grappa_web/recovery_code_doors_test.exs
@@ -52,7 +52,12 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
   # refused even when the code handed over is genuine.
   test "the second_factor-without-TOTP door is inside the same failure window", %{conn: conn} do
     %{user: user, password: password, code: code} = arm(:second_factor_without_totp)
-    on_exit(fn -> FailureWindow.clear(:totp_login, {"127.0.0.1", user.id}) end)
+    # The door charges TWO rows, so the teardown must release two. Clearing
+    # only `{ip, user_id}` leaves ten failures on the per-ADDRESS ceiling,
+    # which is a process-global ETS row every test in the run shares: three
+    # tests spending ten each reach `@totp_ip_max_failures` and the next
+    # request from 127.0.0.1 is refused 429 whatever it was asking for.
+    on_exit(fn -> clear_totp_window(user.id) end)
 
     live = session_count(user)
     challenge = challenge_token(conn, user, password)
@@ -198,6 +203,11 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
         name: "phone"
       })
     )
+  end
+
+  defp clear_totp_window(user_id) do
+    :ok = FailureWindow.clear(:totp_login, {"127.0.0.1", user_id})
+    :ok = FailureWindow.clear(:totp_login, "127.0.0.1")
   end
 
   defp reload(user), do: Repo.get!(User, user.id)


### PR DESCRIPTION
## The symptom

`GrappaWeb.RecoveryCodeDoorsTest` fails intermittently with `429 too_many_attempts` where it expects `200` or `401` — `recovery_code_doors_test.exs:37` and `:53`.

## What I measured

I sampled the `Grappa.RateLimit.FailureWindow` ETS row for `{:totp_login, "127.0.0.1"}` throughout a run (probe in `test_helper.exs`, not committed) and swept seeds.

| run | peak per-address count | result |
|---|---|---|
| the two files alone, 25 seeds | 10–12 typical, 20 twice, 30 once | 0 failures |
| **full suite, `--seed 184178`** | **30** | **2 failures** — `:37` and `:53` |
| full suite, `--seed 184178`, rerun | 30 | same 2 failures, identical |
| full suite, `--seed 184178`, with this fix | **10** | 0 failures |

`config :ex_unit, max_cases: 1`, so ordering is a pure function of the seed and these runs are reproductions, not coin flips. Reproduced on current `main` (`4d22ab84`), which is why the "one red does not make a truth" bar is met: two identical reds at one seed, then green at the same seed with the teardown paired.

## The mechanism

`check_totp_throttle/2` (`lib/grappa_web/controllers/auth_controller.ex:550-551`) gates on TWO keys:

- `{ip, user_id}` — `@totp_max_failures 10`
- the bare `ip` — `@totp_ip_max_failures 30`, 15-minute window

`verify_second_factor/3` charges both on failure (`:574`, `:578`) and clears only the per-account row on success (`:561`) — deliberately, and the comment says why: one account an attacker can satisfy must not reset the ceiling for every other account they are guessing.

`FailureWindow` is a single process-global ETS table for the whole run, and every conn test knocks from `127.0.0.1`. Three tests spend ten failures each on that address:

- `auth_controller_test.exs` — "the 11th attempt is 429 …"
- `auth_controller_test.exs` — "a fresh account is unaffected by another's exhausted window"
- `recovery_code_doors_test.exs` — "the second_factor-without-TOTP door is inside the same failure window"

All three cleared only their own `{ip, user_id}` key. 10 + 10 + 10 = 30 is exactly the ceiling, so the next door request from `127.0.0.1` is refused whatever it was asking for. The only thing that ever reset it was the `:ets.delete_all_objects` in the per-IP aggregate describe's `setup` — incidental, not designed — which is why the failure appeared and vanished with the seed's ordering.

## The fix

Each of the three tests now clears BOTH rows on exit, via a small `clear_totp_window/1` helper per file that states the pairing. The tests leave the address as they found it.

No constant widened, no assertion weakened, no timeout raised, and no production code touched — the limits and the tests' claims are exactly as they were.

## What I did NOT measure, and refuse to claim

- I did not establish how often this fires in CI. One historical red (#1206's run) plus my two reproductions is what I have; I make no frequency claim.
- I did not sweep the full suite across many seeds — only the reported seed, three times (red, red, green-with-fix). Other seeds may reach 30 by a different ordering; the fix removes the accumulation rather than one ordering, but I have not enumerated orderings.
- I did not audit the other `FailureWindow` buckets (`:mode1_login`, `:passkey_recovery`, `:visitor_login`) for the same half-teardown shape. It looks like the same class and it is out of this change's scope; worth its own pass.
- The `:ets.delete_all_objects` wipe in the aggregate describe is left alone. It is a global side effect that erases every bucket, and it is now the *only* thing standing between an unrelated test and someone else's leftovers — but changing it is not needed to fix this and would widen the diff.

## Test plan

- [x] `scripts/test.sh --seed 184178` — red before (2 failures), twice; green after.
- [x] `scripts/check.sh` — Credo `found no issues`, Sobelow, `5887 tests, 0 failures`, Dialyzer `Total errors: 0`, `done (passed successfully)`.
- [x] Working tree carries only the two test files; the measurement probe was reverted before the commit.