### PR TITLE
#1158 item 4: an inactive session is an event, not a preserved identity

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -453,6 +453,26 @@ export async function terminateSession(adminToken: string, sessionId: string): P
   }
 }
 
+// #1158 item 4 — the lifecycle log collapsed to one entry per session.
+// A spec uses this as a PRECONDITION barrier, never as the property under
+// test: the log is a bounded global ring written from an async cast, so a
+// spec that wants to drive the "subject deleted, event survives" surface
+// must first establish that the event actually landed.
+export async function listSessionLogSessions(
+  adminToken: string,
+): Promise<Array<{ session_id: string; event: string; nick: string | null }>> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/session_log/sessions`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.listSessionLogSessions: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as {
+    session_log_sessions: Array<{ session_id: string; event: string; nick: string | null }>;
+  };
+  return body.session_log_sessions;
+}
+
 // M-cluster M-8 — operator-side delete via admin bearer. Mirrors
 // `Grappa.Operator.delete_visitor/1`. Used by e2e tests that mint
 // a visitor and need teardown cleanup on early-assertion-failure

--- a/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
+++ b/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
@@ -1,0 +1,116 @@
+// #1158 item 4 — an operator must be able to see a session that is over,
+// including one whose subject no longer exists.
+//
+// vjt ruled the retention fork on 2026-08-11 ("tutto giusto conserviamo
+// solo l'evento"): visitor retention is UNCHANGED — an anon visitor is
+// still purged at logout and reaped at TTL, and the co-terminal identity
+// contract stands. What survives is the EVENT: `session_log_events` (#215)
+// carries no FK to the subject, so the CASCADE that destroys the visitor
+// leaves the lifecycle rows behind. Those rows are keyed on the same
+// `<kind>:<id>:<network>` composite the admin session rows are, which is
+// what makes the unified Sessions view able to list them.
+//
+// What this spec pins is the SURFACE contract, in the one direction the
+// product actually promises:
+//
+//     given the log remembers a session, and no subject row does,
+//     the Sessions view lists it, marks it deleted, and offers no verb.
+//
+// It deliberately does NOT assert the converse. The log is a bounded
+// global ring written from an async telemetry cast on a path that
+// includes `terminate/2`, so a MISSING entry is forgetfulness, not
+// evidence a session never ran. That is why the log entry is established
+// as a PRECONDITION (polled off the API before the delete) rather than
+// assumed after it: the barrier failing means the sink did not record,
+// which is a different fact from the surface being wrong, and the spec
+// says which one it hit.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT — only
+// the admin class reaches the console, and reachability for the other
+// two is covered by `m7-admin-gate-settings-drawer.spec.ts`.
+
+import { openAdminSessionDetail, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+test("#1158 item 4 a deleted visitor's session survives as a log-only row with no verbs", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitorNick = `i1158-ghost-${Date.now()}`;
+  const visitor = await mintVisitor(visitorNick);
+  let deleted = false;
+
+  try {
+    // PRECONDITION, not the property: wait until the sink has actually
+    // written this session's lifecycle row. Everything below is about
+    // what the surface does GIVEN that row exists.
+    const sessionIdPrefix = `visitor:${visitor.id}:`;
+    await expect
+      .poll(
+        async () => {
+          const entries = await listSessionLogSessions(admin.token);
+          return entries.filter((e) => e.session_id.startsWith(sessionIdPrefix)).length;
+        },
+        {
+          timeout: 20_000,
+          message: `precondition: session_log never recorded ${sessionIdPrefix}* — the sink did not write, so the surface under test cannot be driven`,
+        },
+      )
+      .toBeGreaterThan(0);
+
+    const [logged] = (await listSessionLogSessions(admin.token)).filter((e) =>
+      e.session_id.startsWith(sessionIdPrefix),
+    );
+    if (logged === undefined) throw new Error("precondition vanished between poll and read");
+    const key = logged.session_id;
+
+    // Destroy the identity through the operator verb the ruling leaves
+    // untouched. After this there is no visitor row, no credential and
+    // no pid — only the event.
+    await reapVisitors(admin.token, visitor.id);
+    deleted = true;
+
+    await page.addInitScript(
+      ([token, subjectJson]) => {
+        localStorage.setItem("grappa-token", token);
+        localStorage.setItem("grappa-subject", subjectJson);
+        localStorage.setItem("cic.installChoice", "browser");
+      },
+      [admin.token, admin.subjectJson] as const,
+    );
+    await page.goto("/");
+    await openAdminSessionsTab(page);
+
+    // THE property. Without the log join this row cannot exist at all:
+    // both row-backed endpoints lost the subject with the CASCADE.
+    const row = page.getByTestId(`admin-session-row-${key}`);
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row).toContainText(visitorNick);
+
+    // Marked, so it does not read as a live session that merely looks
+    // broken — the operator must be able to tell "gone" from "down".
+    await expect(page.getByTestId(`admin-session-gone-${key}`)).toBeVisible();
+
+    // No credential to park, no pid to stop: every verb would resolve to
+    // a subject that is gone, so none is offered. Asserting all three
+    // matters — a single surviving button is a guaranteed failed request.
+    await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-session-reconnect-${key}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-session-delete-${key}`)).toHaveCount(0);
+
+    // The dictated shape: the row stays a summary, the record lives in
+    // the drill-in ("nei dettagli mostrare tutte le info", vjt 2026-08-11).
+    // Not `logged.event`: terminating the session can append a newer
+    // lifecycle row between the barrier and the render, so the stable
+    // claim is that the panel names the log as the record, and carries a
+    // last-event fact at all.
+    const detail = await openAdminSessionDetail(page, key);
+    await expect(detail).toContainText("session log only");
+    await expect(detail).toContainText("last event");
+  } finally {
+    if (!deleted) await reapVisitors(admin.token, visitor.id);
+  }
+});

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -32,7 +32,6 @@
 
 import {
   adminSessionRowKey,
-  adminSessionRows,
   openAdminSessionDetail,
   openAdminSessionsTab,
 } from "../fixtures/cicchettoPage";
@@ -89,9 +88,26 @@ test("M-8 admin deletes a minted visitor from the unified Sessions view (inline 
 
     // Identity-wide: the assertion is on EVERY row of this visitor, not
     // the one the panel hung off. A delete that reaped only the clicked
-    // (visitor, network) pair would leave the siblings on screen, and
-    // `toHaveCount(0)` over the prefix is what catches that.
-    await expect(adminSessionRows(page, "visitor", visitor.id)).toHaveCount(0, { timeout: 10_000 });
+    // (visitor, network) pair would leave the siblings behind.
+    //
+    // #1158 item 4 changed what that looks like on screen, not what the
+    // verb does. The identity is still destroyed — but `session_log_events`
+    // has no FK to the subject, so a row can SURVIVE the CASCADE as the
+    // log-only class: badged "deleted", no DB state, no verbs. Counting
+    // rows would now assert the pre-item-4 world.
+    //
+    // So the identity-wide property moves onto the verbs. `rowActions`
+    // gives a credential-backed visitor row exactly one of Disconnect /
+    // Reconnect, on every network it is bound to; zero of either across
+    // the whole `visitor:<id>:` prefix is "no credential of this visitor
+    // survives anywhere" — the same claim, and it holds whether or not
+    // the log happened to remember the session (bounded ring, best-effort
+    // write: this spec must not depend on it).
+    const survivingVerbs = page.locator(
+      `[data-testid^="admin-session-disconnect-visitor:${visitor.id}:"],` +
+        `[data-testid^="admin-session-reconnect-visitor:${visitor.id}:"]`,
+    );
+    await expect(survivingVerbs).toHaveCount(0, { timeout: 10_000 });
     await expect(page.getByTestId("admin-sessions-error")).toHaveCount(0);
   } finally {
     // Idempotent — 404 if test already deleted it; safety net for

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -18,12 +18,14 @@ import {
   type AdminCredential,
   type AdminNetwork,
   type AdminSession,
+  type AdminSessionLogEntry,
   type AdminVisitor,
   ApiError,
   adminDeleteVisitor,
   adminDisconnectSession,
   adminListCredentials,
   adminListNetworks,
+  adminListSessionLogSessions,
   adminListSessions,
   adminListVisitors,
   adminReconnectSession,
@@ -54,6 +56,18 @@ import { token } from "./lib/auth";
 // (subject, network) pair, so a visitor on two networks yields two rows
 // whose Delete buttons would each nuke both. Behind the disclosure, and
 // labelled with what it actually destroys, it stops being a footgun.
+//
+// #1158 item 4 — a fifth source, `/admin/session_log/sessions`. vjt ruled
+// the retention fork "keep only the event" (2026-08-11): an anon visitor
+// is still purged at logout and reaped at TTL, so for a session that is
+// over the lifecycle log is the ONLY record left — it carries no FK to
+// the subject and outlives the CASCADE. It joins on `session_id`, which
+// is the row key, so it both fills in "what did this session last do"
+// and supplies rows for subjects that no longer exist.
+//
+// The log is a bounded ring, so those rows are RECENT history, not an
+// archive, and the card subtitle says so rather than letting the table
+// imply completeness.
 //
 // Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
 
@@ -90,12 +104,14 @@ const AdminSessionsTab: Component = () => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
   const [sessions, setSessions] = createSignal<AdminSession[] | null>(null);
   const [networks, setNetworks] = createSignal<AdminNetwork[] | null>(null);
+  const [logSessions, setLogSessions] = createSignal<AdminSessionLogEntry[] | null>(null);
   const [confirmingKey, setConfirmingKey] = createSignal<string | null>(null);
   const [detailKey, setDetailKey] = createSignal<string | null>(null);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
 
-  const loaded = (): boolean => visitors() !== null && credentials() !== null;
+  const loaded = (): boolean =>
+    visitors() !== null && credentials() !== null && logSessions() !== null;
 
   const rows = createMemo<AdminSubjectRow[]>(() =>
     loaded()
@@ -104,6 +120,7 @@ const AdminSessionsTab: Component = () => {
           credentials: credentials() ?? [],
           sessions: sessions() ?? [],
           networks: networks() ?? [],
+          logSessions: logSessions() ?? [],
         })
       : [],
   );
@@ -115,27 +132,35 @@ const AdminSessionsTab: Component = () => {
     setError(null);
     setConfirmingKey(null);
     try {
-      // Four endpoints, one table. The two row-backed ones supply the
+      // Five endpoints, one table. The two row-backed ones supply the
       // rows, /admin/sessions supplies the live join, /admin/networks
-      // supplies the capacity summary + the slug for an orphan row.
+      // supplies the capacity summary + the slug for an orphan row, and
+      // /admin/session_log/sessions supplies the history join plus the
+      // rows of subjects that no longer exist (#1158 item 4).
       // Failure of ANY collapses the whole render to the banner: a
       // half-built merge is worse than no table, because the operator
-      // cannot tell which half is missing.
-      const [nextVisitors, nextCredentials, nextSessions, nextNetworks] = await Promise.all([
-        adminListVisitors(t),
-        adminListCredentials(t),
-        adminListSessions(t),
-        adminListNetworks(t),
-      ]);
+      // cannot tell which half is missing. That holds hardest for the
+      // log: a silently dropped fetch would remove exactly the rows the
+      // operator came for, and leave a table that looks complete.
+      const [nextVisitors, nextCredentials, nextSessions, nextNetworks, nextLogSessions] =
+        await Promise.all([
+          adminListVisitors(t),
+          adminListCredentials(t),
+          adminListSessions(t),
+          adminListNetworks(t),
+          adminListSessionLogSessions(t),
+        ]);
       setVisitors(nextVisitors);
       setCredentials(nextCredentials);
       setSessions(nextSessions);
       setNetworks(nextNetworks);
+      setLogSessions(nextLogSessions);
     } catch (e) {
       setVisitors(null);
       setCredentials(null);
       setSessions(null);
       setNetworks(null);
+      setLogSessions(null);
       const code = e instanceof ApiError ? e.code : "fetch_failed";
       setError(code);
     } finally {
@@ -267,7 +292,7 @@ const AdminSessionsTab: Component = () => {
           <AdminCard
             hostsRefresh
             title="Sessions"
-            subtitle="row-backed — parked and failed subjects are listed too, with live state joined on"
+            subtitle="row-backed — parked and failed subjects are listed too, with live state joined on; rows marked deleted come from the lifecycle log, which keeps recent history only"
             data-testid="admin-sessions-table-card"
           >
             <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
@@ -316,6 +341,21 @@ const AdminSessionsTab: Component = () => {
                                   {row.subject_kind}
                                 </AdminBadge>
                                 <span class="admin-session-nick">{renderLabel(row)}</span>
+                                {/* #1158 item 4 — this row exists only
+                                    because the lifecycle log outlived the
+                                    subject. Say so on the row itself: it
+                                    has no state to read and no verb to
+                                    press, and without the marker it reads
+                                    as a session that merely looks broken. */}
+                                <Show when={row.origin === "session_log"}>
+                                  <AdminBadge
+                                    tone="warn"
+                                    ariaLabel="subject deleted, session log only"
+                                    testId={`admin-session-gone-${row.key}`}
+                                  >
+                                    deleted
+                                  </AdminBadge>
+                                </Show>
                               </span>
                               <span class="admin-session-network">
                                 {row.network_slug ?? `network ${row.network_id}`}
@@ -351,6 +391,9 @@ const AdminSessionsTab: Component = () => {
                               />
                             )}
                           </For>
+                          {/* An empty cell reads as a rendering bug. The
+                              dash says the absence is the answer. */}
+                          <Show when={rowActions(row).length === 0}>—</Show>
                         </td>
                       </tr>
                       <Show when={detailKey() === row.key}>
@@ -398,9 +441,12 @@ const AdminSessionsTab: Component = () => {
 };
 
 function renderLabel(row: AdminSubjectRow): string {
-  // `null` only on an orphan pid whose DB row is gone. Say so rather
-  // than rendering a blank — it is the divergence, not a missing value.
-  return row.label ?? `${row.subject_id.slice(0, 8)} (no DB row)`;
+  if (row.label !== null) return row.label;
+  // `null` on an orphan pid whose DB row is gone, or on a log entry the
+  // server wrote before the session had a nick. Say which rather than
+  // rendering a blank — it is the divergence, not a missing value.
+  const why = row.origin === "session_log" ? "no nick logged" : "no DB row";
+  return `${row.subject_id.slice(0, 8)} (${why})`;
 }
 
 function renderWho(row: AdminSubjectRow): string {
@@ -451,6 +497,34 @@ function renderExpires(row: AdminSubjectRow): string {
   return days <= 0 ? "expired" : `in ${days}d`;
 }
 
+// Human duration for a session that has ended. Raw milliseconds are
+// unreadable at the scale a bouncer session actually runs for.
+function renderDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return h < 24 ? `${h}h${m % 60}m` : `${Math.floor(h / 24)}d${h % 24}h`;
+}
+
+// The last thing the lifecycle log saw this session do. `null` is NOT
+// "this session never ran": the log is a bounded global ring written
+// from an async cast, so it forgets, and saying so is the honest render.
+function renderLastEvent(row: AdminSubjectRow): string {
+  const e = row.last_event;
+  if (e === null) return "nothing logged (bounded ring — not proof it never ran)";
+  return `${e.event} · ${e.at}`;
+}
+
+// Only meaningful on a disconnect: reason / cleanliness / how long it
+// had been up. Each part is dropped when the row does not carry it.
+function renderEnded(e: AdminSessionLogEntry): string {
+  const clean = e.clean === null ? "" : e.clean ? " (clean)" : " (unclean)";
+  const lasted = e.duration_ms === null ? "" : `, lasted ${renderDuration(e.duration_ms)}`;
+  return `${e.reason ?? "no reason recorded"}${clean}${lasted}`;
+}
+
 function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
   const facts: { label: string; value: string }[] = [
     // DB intent and live pid are separate sources of truth and both
@@ -461,7 +535,21 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     { label: "live", value: renderLive(row) },
     { label: "network", value: row.network_slug ?? `id ${row.network_id}` },
     { label: "upstream", value: renderUpstream(row) },
+    // #1158 item 4 — the third source, and the only one that says
+    // anything at all about a session that is over.
+    { label: "last event", value: renderLastEvent(row) },
   ];
+
+  if (row.last_event?.event === "disconnected") {
+    facts.push({ label: "ended", value: renderEnded(row.last_event) });
+  }
+
+  if (row.origin === "session_log") {
+    facts.push({
+      label: "record",
+      value: "session log only — the subject was deleted, the event outlived it",
+    });
+  }
 
   if (row.live !== null) {
     facts.push(

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AdminCredential, AdminNetwork, AdminSession, AdminVisitor } from "../lib/api";
+import type {
+  AdminCredential,
+  AdminNetwork,
+  AdminSession,
+  AdminSessionLogEntry,
+  AdminVisitor,
+} from "../lib/api";
 
 vi.mock("../lib/auth", () => ({
   token: () => "test-bearer",
@@ -14,6 +20,7 @@ vi.mock("../lib/api", async () => {
     adminListCredentials: vi.fn(),
     adminListSessions: vi.fn(),
     adminListNetworks: vi.fn(),
+    adminListSessionLogSessions: vi.fn(),
     adminDisconnectSession: vi.fn(),
     adminReconnectSession: vi.fn(),
     adminTerminateSession: vi.fn(),
@@ -114,16 +121,40 @@ const userSession = (): AdminSession =>
 const VISITOR_KEY = `visitor:${VISITOR_ID}:1`;
 const USER_KEY = `user:${USER_ID}:1`;
 
+const GONE_VISITOR_ID = "33333333-3333-3333-3333-333333333333";
+const GONE_KEY = `visitor:${GONE_VISITOR_ID}:1`;
+
+const logEntry = (over: Partial<AdminSessionLogEntry> = {}): AdminSessionLogEntry =>
+  ({
+    id: 7,
+    session_id: GONE_KEY,
+    event: "disconnected",
+    subject_kind: "visitor",
+    network_id: 1,
+    network_slug: "azzurra",
+    nick: "guest9",
+    old_nick: null,
+    reason: ":tcp_closed",
+    clean: false,
+    duration_ms: 3_600_000,
+    delay_ms: null,
+    attempt: null,
+    at: "2026-08-10T10:00:00Z",
+    ...over,
+  }) as AdminSessionLogEntry;
+
 async function mountWith(over: {
   visitors?: AdminVisitor[];
   credentials?: AdminCredential[];
   sessions?: AdminSession[];
+  logSessions?: AdminSessionLogEntry[];
 }) {
   const api = await import("../lib/api");
   vi.mocked(api.adminListVisitors).mockResolvedValue(over.visitors ?? []);
   vi.mocked(api.adminListCredentials).mockResolvedValue(over.credentials ?? []);
   vi.mocked(api.adminListSessions).mockResolvedValue(over.sessions ?? []);
   vi.mocked(api.adminListNetworks).mockResolvedValue([NETWORK]);
+  vi.mocked(api.adminListSessionLogSessions).mockResolvedValue(over.logSessions ?? []);
   render(() => <AdminSessionsTab />);
   return api;
 }
@@ -381,6 +412,76 @@ describe("AdminSessionsTab — the drill-down keeps both sources of truth", () =
   });
 });
 
+// #1158 item 4 — vjt ruled "keep only the event" (2026-08-11): visitor
+// retention is unchanged, so an anon visitor is still purged at logout,
+// and the lifecycle log — which carries no FK to the subject — is the
+// only thing left. These tests assert the operator can still SEE that
+// session, and that the surface never pretends the subject is still there.
+describe("AdminSessionsTab — a session whose subject was deleted", () => {
+  it("lists a session that only the log remembers", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
+    expect(row.textContent).toContain("guest9");
+  });
+
+  it("marks the row as deleted rather than letting it read as merely broken", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    expect(await screen.findByTestId(`admin-session-gone-${GONE_KEY}`)).toBeTruthy();
+  });
+
+  // No credential to park, no pid to stop: every verb would resolve to a
+  // subject that is gone, so the cell offers none.
+  it("offers no verb on the row", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
+    expect(screen.queryByTestId(`admin-session-disconnect-${GONE_KEY}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-session-reconnect-${GONE_KEY}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-session-terminate-${GONE_KEY}`)).toBeNull();
+  });
+
+  it("puts why it ended in the drill-down, not in the table", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
+    expect(row.textContent).not.toContain(":tcp_closed");
+
+    fireEvent.click(screen.getByTestId(`admin-session-details-${GONE_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${GONE_KEY}`);
+    expect(panel).toHaveTextContent(":tcp_closed");
+    expect(panel).toHaveTextContent("unclean");
+    expect(panel).toHaveTextContent("1h0m");
+  });
+
+  it("joins the last event onto a subject that still exists", async () => {
+    await mountWith({
+      credentials: [userCredential()],
+      logSessions: [logEntry({ session_id: USER_KEY, subject_kind: "user", event: "connected" })],
+    });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${USER_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+    expect(panel).toHaveTextContent("connected");
+    expect(panel).toHaveTextContent("2026-08-10T10:00:00Z");
+  });
+
+  // The ring is global, bounded and written from an async cast. An empty
+  // log is forgetfulness, not proof — and the panel must not imply it is.
+  it("does not claim a session never ran when the log has nothing", async () => {
+    await mountWith({ credentials: [userCredential()], logSessions: [] });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${USER_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+    expect(panel).toHaveTextContent("nothing logged");
+    expect(panel).toHaveTextContent("not proof it never ran");
+  });
+});
+
 describe("AdminSessionsTab — load and failure", () => {
   it("renders the empty state when every source is empty", async () => {
     await mountWith({});
@@ -394,12 +495,31 @@ describe("AdminSessionsTab — load and failure", () => {
     vi.mocked(api.adminListCredentials).mockRejectedValue(new Error("boom"));
     vi.mocked(api.adminListSessions).mockResolvedValue([]);
     vi.mocked(api.adminListNetworks).mockResolvedValue([NETWORK]);
+    vi.mocked(api.adminListSessionLogSessions).mockResolvedValue([]);
 
     render(() => <AdminSessionsTab />);
 
     await screen.findByTestId("admin-sessions-error");
     // A half-built merge is worse than no table: the operator cannot
     // tell which half is missing.
+    expect(screen.queryByTestId("admin-sessions-table")).toBeNull();
+  });
+
+  // Deliberate, and the rule's hardest case: a dropped session-log fetch
+  // would remove exactly the deleted-subject rows and leave a table that
+  // looks complete. A missing ENTRY is forgetfulness; a missing FETCH is
+  // a failure, and the two must not render the same.
+  it("collapses the table when the session-log fetch fails, rather than hiding rows", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminListVisitors).mockResolvedValue([parkedVisitor()]);
+    vi.mocked(api.adminListCredentials).mockResolvedValue([]);
+    vi.mocked(api.adminListSessions).mockResolvedValue([]);
+    vi.mocked(api.adminListNetworks).mockResolvedValue([NETWORK]);
+    vi.mocked(api.adminListSessionLogSessions).mockRejectedValue(new Error("boom"));
+
+    render(() => <AdminSessionsTab />);
+
+    await screen.findByTestId("admin-sessions-error");
     expect(screen.queryByTestId("admin-sessions-table")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -6,7 +6,13 @@ import {
   rowActions,
   rowKey,
 } from "../lib/adminSubjectRows";
-import type { AdminCredential, AdminNetwork, AdminSession, AdminVisitor } from "../lib/api";
+import type {
+  AdminCredential,
+  AdminNetwork,
+  AdminSession,
+  AdminSessionLogEntry,
+  AdminVisitor,
+} from "../lib/api";
 
 // #1157 — the merge behind the unified admin sessions view.
 //
@@ -92,12 +98,32 @@ const session = (over: Partial<AdminSession> = {}): AdminSession =>
 const network = (over: Partial<AdminNetwork> = {}): AdminNetwork =>
   ({ id: 42, slug: "azzurra", ...over }) as AdminNetwork;
 
+const logEntry = (over: Partial<AdminSessionLogEntry> = {}): AdminSessionLogEntry =>
+  ({
+    id: 1,
+    session_id: `visitor:${VISITOR_ID}:42`,
+    event: "disconnected",
+    subject_kind: "visitor",
+    network_id: 42,
+    network_slug: "azzurra",
+    nick: "guest1",
+    old_nick: null,
+    reason: ":quit",
+    clean: true,
+    duration_ms: 900,
+    delay_ms: null,
+    attempt: null,
+    at: "2026-08-10T12:00:00Z",
+    ...over,
+  }) as AdminSessionLogEntry;
+
 const build = (over: Partial<Parameters<typeof buildSubjectRows>[0]> = {}): AdminSubjectRow[] =>
   buildSubjectRows({
     visitors: [],
     credentials: [],
     sessions: [],
     networks: [network()],
+    logSessions: [],
     ...over,
   });
 
@@ -236,6 +262,88 @@ describe("buildSubjectRows — the /admin/sessions left join", () => {
   });
 });
 
+// #1158 item 4 — a session whose subject row was destroyed. vjt's ruling
+// (2026-08-11) is "keep only the event": visitor retention is unchanged,
+// so an anon visitor is still purged at logout and reaped at TTL, and the
+// ONLY trace left is `session_log_events` — which has no FK to the
+// subject and therefore survives the CASCADE. The log is keyed on the
+// same `<kind>:<id>:<network>` composite the rows are, so it both joins
+// onto live rows and supplies rows nothing else can.
+describe("buildSubjectRows — the session-log join", () => {
+  it("joins the newest logged event onto a row that still exists", () => {
+    const rows = build({ visitors: [visitor()], logSessions: [logEntry()] });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.last_event?.event).toBe("disconnected");
+    expect(rows[0]?.last_event?.duration_ms).toBe(900);
+    // The row is still credential-backed: the log adds history, it does
+    // not reclassify a subject that is very much on record.
+    expect(rows[0]?.origin).toBe("credential");
+  });
+
+  it("leaves last_event null when the log remembers nothing — absence is not an error", () => {
+    const rows = build({ credentials: [credential()], logSessions: [] });
+
+    expect(rows[0]?.last_event).toBeNull();
+  });
+
+  // THE test for item 4. Without this row the operator has no way to see
+  // that a purged visitor ever held a session.
+  it("appends a session the log remembers but no subject row does", () => {
+    const rows = build({ credentials: [credential()], logSessions: [logEntry()] });
+
+    expect(rows).toHaveLength(2);
+    const ghost = rows[rows.length - 1];
+    expect(ghost?.origin).toBe("session_log");
+    expect(ghost?.key).toBe(`visitor:${VISITOR_ID}:42`);
+    expect(ghost?.subject_kind).toBe("visitor");
+    expect(ghost?.label).toBe("guest1");
+    expect(ghost?.network_slug).toBe("azzurra");
+    // Neither source of truth has anything to say: no credential to hold
+    // an intent, no pid to be alive. Both null, neither defaulted.
+    expect(ghost?.connection_state).toBeNull();
+    expect(ghost?.live).toBeNull();
+  });
+
+  it("does not duplicate a row the log matched", () => {
+    const rows = build({ visitors: [visitor()], logSessions: [logEntry()] });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("does not swallow an orphan pid that the log also remembers", () => {
+    const orphan = session({ subject_id: "deadbeef-0000-0000-0000-000000000000" });
+    const rows = build({
+      sessions: [orphan],
+      logSessions: [logEntry({ session_id: "visitor:deadbeef-0000-0000-0000-000000000000:42" })],
+    });
+
+    // One row, and it keeps the live pid — the log enriches it rather
+    // than shadowing it with a historical duplicate.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.origin).toBe("orphan_pid");
+    expect(rows[0]?.live).not.toBeNull();
+    expect(rows[0]?.last_event?.event).toBe("disconnected");
+  });
+
+  it("ignores a log entry whose session_id is not the row composite", () => {
+    const rows = build({ logSessions: [logEntry({ session_id: "nonsense" })] });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("carries a log-only row for a deleted USER too, not just visitors", () => {
+    const rows = build({
+      logSessions: [
+        logEntry({ session_id: `user:${USER_ID}:42`, subject_kind: "user", nick: "vjt" }),
+      ],
+    });
+
+    expect(rows[0]?.subject_kind).toBe("user");
+    expect(rows[0]?.origin).toBe("session_log");
+  });
+});
+
 describe("channelCount — an unknown count is not zero", () => {
   const rowWith = (l: AdminSubjectRow["live"]): AdminSubjectRow =>
     ({ ...build({ credentials: [credential()] })[0], live: l }) as AdminSubjectRow;
@@ -283,6 +391,14 @@ describe("rowActions — reconnect is visitor-only, and chosen on LIVE truth", (
 
     expect(rowActions(row)).not.toContain("reconnect");
     expect(rowActions(row)).toEqual(["disconnect", "terminate"]);
+  });
+
+  // A log-only row has no credential and no pid, so every verb would
+  // resolve to nothing. Offering one would guarantee a failed request.
+  it("offers no verb at all on a log-only row", () => {
+    const ghost = build({ logSessions: [logEntry()] })[0] as AdminSubjectRow;
+
+    expect(rowActions(ghost)).toEqual([]);
   });
 
   it("offers the same user verbs whether or not the pid is live", () => {

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -2,6 +2,7 @@ import type {
   AdminCredential,
   AdminNetwork,
   AdminSession,
+  AdminSessionLogEntry,
   AdminVisitor,
   AdminVisitorNetwork,
 } from "./api";
@@ -34,6 +35,24 @@ import type {
 // The join key is the composite `<kind>:<subject_id>:<network_id>` the
 // `/admin/sessions/:id/*` verbs already parse, so the row that renders a
 // button is keyed by the very string that button will POST.
+//
+// #1158 item 4 — a fourth source: `/admin/session_log/sessions`, the
+// lifecycle log collapsed to each session's newest event. Its
+// `session_id` is that same composite, which is what makes this a join
+// and not a new data model.
+//
+// It earns its place because of a retention asymmetry vjt ruled on
+// (2026-08-11, "keep only the event"): an anon/incognito visitor is
+// destroyed at logout and again by the TTL reap, and that stays true —
+// but `session_log_events` carries NO FK to the subject, so it outlives
+// the CASCADE. So the log both enriches rows that exist (what did this
+// session last do, and why did it stop) and supplies the ONLY row a
+// destroyed subject can ever have.
+//
+// It is best-effort BY CONSTRUCTION — a bounded global ring, written
+// from an async cast on a path that includes `terminate/2`. A session
+// missing from it is not evidence it never ran, and nothing here may
+// treat absence as a fact.
 
 /** The live-state core the three endpoints agree on. `/admin/sessions`
  * carries a superset (the peer triple); the row-backed pair do not. */
@@ -49,6 +68,15 @@ export type VisitorIdentity = {
   ip: string | null;
   identified: boolean;
 };
+
+/**
+ * Which source put this row on the table. Explicit rather than inferred
+ * from a pattern of nulls: `credential` and `orphan_pid` were already
+ * distinguishable only by `connection_state === null`, and the log-only
+ * class shares that null with the orphans while meaning the opposite
+ * thing (no pid at all, versus nothing BUT a pid).
+ */
+export type RowOrigin = "credential" | "orphan_pid" | "session_log";
 
 export type AdminSubjectRow = {
   /** `<kind>:<subject_id>:<network_id>` — the id the admin verbs parse. */
@@ -73,6 +101,11 @@ export type AdminSubjectRow = {
   last_seen_at: string | null;
   /** Present iff `subject_kind === "visitor"`. */
   visitor: VisitorIdentity | null;
+  origin: RowOrigin;
+  /** The newest lifecycle event the session log remembers for this
+   * session. `null` means the log has nothing — which is NOT a claim
+   * that the session never ran (bounded ring, best-effort write). */
+  last_event: AdminSessionLogEntry | null;
 };
 
 export function rowKey(kind: "user" | "visitor", subjectId: string, networkId: number): string {
@@ -98,8 +131,12 @@ export function channelCount(row: AdminSubjectRow): number | null {
  * truth, never on `connection_state`: a credential still marked
  * `:connected` whose pid died must offer Reconnect, and that divergence
  * is the whole reason both columns exist.
+ *
+ * A log-only row offers nothing: there is no credential to park and no
+ * pid to stop, so every verb would resolve to a subject that is gone.
  */
 export function rowActions(row: AdminSubjectRow): ("disconnect" | "reconnect" | "terminate")[] {
+  if (row.origin === "session_log") return [];
   if (row.subject_kind === "visitor") {
     return row.live === null ? ["reconnect"] : ["disconnect"];
   }
@@ -111,24 +148,50 @@ function slugOf(networks: AdminNetwork[], networkId: number): string | null {
 }
 
 /**
+ * Split a log entry's `session_id` back into the triple the row key is
+ * built from. Returns `null` for anything that is not that composite —
+ * the log is a free-text-ish store the server writes, and a row keyed on
+ * a string we cannot parse would be a row no admin verb could ever act
+ * on. Dropping it is honest; guessing is not.
+ */
+function parseSessionId(
+  sessionId: string,
+): { kind: "user" | "visitor"; subjectId: string; networkId: number } | null {
+  const parts = sessionId.split(":");
+  if (parts.length !== 3) return null;
+  const [kind, subjectId, rawNetwork] = parts;
+  if (kind !== "user" && kind !== "visitor") return null;
+  if (subjectId === undefined || subjectId === "") return null;
+  if (rawNetwork === undefined || !/^\d+$/.test(rawNetwork)) return null;
+  return { kind, subjectId, networkId: Number(rawNetwork) };
+}
+
+/**
  * Build the unified row set.
  *
  * Ordering is stable and meaningful rather than incidental: visitors,
- * then users, then the orphan-pid rows last — the operator scans the
- * populations they came for, and anything that should not exist sits at
- * the bottom where it stands out.
+ * then users, then the two rows-without-a-credential classes at the
+ * bottom — orphan pids (a pid with no DB row), then log-only rows
+ * (neither, just an event). The operator scans the populations they came
+ * for first, and the divergences sit where they stand out.
  */
 export function buildSubjectRows(input: {
   visitors: AdminVisitor[];
   credentials: AdminCredential[];
   sessions: AdminSession[];
   networks: AdminNetwork[];
+  logSessions: AdminSessionLogEntry[];
 }): AdminSubjectRow[] {
-  const { visitors, credentials, sessions, networks } = input;
+  const { visitors, credentials, sessions, networks, logSessions } = input;
 
   const sessionByKey = new Map<string, AdminSession>();
   for (const s of sessions) {
     sessionByKey.set(rowKey(s.subject_kind, s.subject_id, s.network_id), s);
+  }
+
+  const logByKey = new Map<string, AdminSessionLogEntry>();
+  for (const e of logSessions) {
+    logByKey.set(e.session_id, e);
   }
 
   const rows: AdminSubjectRow[] = [];
@@ -158,6 +221,8 @@ export function buildSubjectRows(input: {
         upstream: sessionByKey.get(key)?.live_state ?? null,
         last_seen_at: v.last_seen_at,
         visitor: identity,
+        origin: "credential",
+        last_event: logByKey.get(key) ?? null,
       });
     }
   }
@@ -177,6 +242,8 @@ export function buildSubjectRows(input: {
       upstream: sessionByKey.get(key)?.live_state ?? null,
       last_seen_at: c.last_seen_at,
       visitor: null,
+      origin: "credential",
+      last_event: logByKey.get(key) ?? null,
     });
   }
 
@@ -186,6 +253,10 @@ export function buildSubjectRows(input: {
   for (const s of sessions) {
     const key = rowKey(s.subject_kind, s.subject_id, s.network_id);
     if (claimed.has(key)) continue;
+    // Claim it: the log pass below is keyed on the same composite, and
+    // an orphan pid the log also remembers must stay ONE row that keeps
+    // the live truth, not two.
+    claimed.add(key);
     rows.push({
       key,
       subject_kind: s.subject_kind,
@@ -198,6 +269,39 @@ export function buildSubjectRows(input: {
       upstream: s.live_state,
       last_seen_at: s.last_seen_at,
       visitor: null,
+      origin: "orphan_pid",
+      last_event: logByKey.get(key) ?? null,
+    });
+  }
+
+  // The log-only class: the subject row is gone (a purged visitor, an
+  // unbound credential) and no pid is left either, so the lifecycle log
+  // is the only place this session still exists. It runs LAST so it can
+  // never shadow a row that has live truth behind it — an orphan pid the
+  // log also remembers stays an orphan-pid row, enriched, not duplicated.
+  for (const e of logSessions) {
+    if (claimed.has(e.session_id)) continue;
+    const parsed = parseSessionId(e.session_id);
+    if (parsed === null) continue;
+    claimed.add(e.session_id);
+    rows.push({
+      key: e.session_id,
+      subject_kind: parsed.kind,
+      subject_id: parsed.subjectId,
+      label: e.nick,
+      network_id: parsed.networkId,
+      // The log stores the slug it saw at emit time; fall back to the
+      // live network list, then to null (the caller renders the raw id).
+      network_slug: e.network_slug ?? slugOf(networks, parsed.networkId),
+      connection_state: null,
+      live: null,
+      upstream: null,
+      // NOT `e.at`: this column is when a BROWSER last touched the
+      // bouncer, and there is no browser session left to have touched it.
+      last_seen_at: null,
+      visitor: null,
+      origin: "session_log",
+      last_event: e,
     });
   }
 

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -54,6 +54,7 @@ import type {
   ScrollbackWireT,
   ServerSettingsWireUploadView,
   SessionLogWireListResult,
+  SessionLogWireSessionsResult,
   SessionLogWireT,
   SessionWireBanlistBundlePayload,
   SessionWireBanlistEntry,
@@ -1850,6 +1851,27 @@ export async function adminListSessionLog(
   if (!res.ok) throw await readError(res);
   const body = (await res.json()) as SessionLogWireListResult;
   return body.session_log;
+}
+
+// #1158 item 4 — the same log collapsed to one entry per session_id (that
+// session's newest event), mirror of
+// `Grappa.SessionLog.Wire.sessions_result/0`. Feeds the admin Sessions
+// view: `session_id` is `(subject, network)`-grained, i.e. the same key
+// the rows are built on, so this joins straight onto them AND supplies a
+// row for a session whose subject was deleted. Best-effort by
+// construction — an absent entry is not evidence the session never ran.
+export async function adminListSessionLogSessions(
+  token: string,
+  limit?: number,
+): Promise<SessionLogWireT[]> {
+  const url =
+    limit === undefined
+      ? "/admin/session_log/sessions"
+      : `/admin/session_log/sessions?limit=${limit}`;
+  const res = await fetch(url, { headers: buildHeaders(token) });
+  if (!res.ok) throw await readError(res);
+  const body = (await res.json()) as SessionLogWireSessionsResult;
+  return body.session_log_sessions;
 }
 
 // M-cluster M-10 — admin Networks tab wire types + fetch wrappers.

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1324,6 +1324,11 @@ export const S_SessionLogWireEvent = {
 // Grappa.SessionLog.Wire.list_result/0
 export const S_SessionLogWireListResult = { o: { session_log: { a: S_SessionLogWireT } } } as const;
 
+// Grappa.SessionLog.Wire.sessions_result/0
+export const S_SessionLogWireSessionsResult = {
+  o: { session_log_sessions: { a: S_SessionLogWireT } },
+} as const;
+
 // Grappa.SubjectSearch.AdminWire.result_json/0
 export const S_SubjectSearchAdminWireResultJson = {
   o: { type: { e: ["user", "visitor"] }, id: "s", network: { u: ["s", "z"] }, nick: "s" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1345,6 +1345,10 @@ export type SessionLogWireListResult = {
   session_log: SessionLogWireT[];
 };
 
+export type SessionLogWireSessionsResult = {
+  session_log_sessions: SessionLogWireT[];
+};
+
 // === Grappa.SubjectSearch.AdminWire ===
 
 export type SubjectSearchAdminWireResultJson = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39199,3 +39199,95 @@ clauses, so SQL does the comparing. The class is wider than `sort_by` — a bare
 **Not claimed.** The `network_id` tie-break is NOT pinned: no fixture ties two
 rows belonging to the same user. And nothing here was measured against
 production or against a real CI runner — the numbers are all the local suite.
+
+---
+
+## 2026-08-11 — #1158 item 4: an inactive session is an EVENT, not a preserved identity
+
+vjt's ruling on the retention fork raised by the item-4 measurement:
+*"tutto giusto conserviamo solo l'evento"*. Two products were on the
+table — preserve the anon/incognito visitor identity past logout, or
+preserve only the fact that the session existed — and the second won.
+So visitor retention is **unchanged**: the anon visitor is still purged
+at logout and reaped by the TTL, and the co-terminal identity contract
+stands exactly as designed. Nothing here extends a TTL, defers a purge,
+or adds an FK-bearing row that outlives its subject.
+
+**The measurement that made this cheap: the log is already at the right
+grain.** `session_log_events.session_id` is
+`"<kind>:<uuid>:<network_id>"` — byte-identical in shape to the admin
+row key `adminSubjectRows.rowKey/3` builds, and to the string the
+`/admin/sessions/:id/*` verbs parse. That single fact is why item 4 is
+a JOIN rather than a new data model: no new identifier, no new
+vocabulary, no "session vs credential" split to adjudicate. The
+conflation the measurement flagged dissolves once you notice the log
+was keyed on `(subject, network)` all along.
+
+**The asymmetry between the two halves is the whole design.** For a
+user, nothing new was needed: the credential is durable, nothing GCs
+it, and it already renders regardless of `connection_state` — listing
+an inactive user session is a join, not a retention change. For an
+anon visitor the row is deliberately destroyed on two clocks, so there
+is nothing to list; but `session_log_events` carries **no FK to the
+subject** (plain `:string` / `:integer` columns,
+`20260715120000_create_session_log_events.exs`), so it survives the
+CASCADE. The event is the only survivor, and the ruling says the event
+is enough.
+
+**What shipped.** `SessionLog.list_latest_per_session/1` collapses the
+ring to each session's newest event, bounded in SESSIONS rather than
+rows (a chatty session must not crowd out three quiet ones), behind
+`GET /admin/session_log/sessions`. `buildSubjectRows` takes it as a
+fifth source: it joins onto every existing row (so a parked credential
+can finally say *when* it dropped and *why*), and appends a row for
+every session no other source claims. Those rows carry an explicit
+`origin: "session_log"`, a "deleted" badge, and **no verbs at all** —
+there is no credential to park and no pid to stop, so every button
+would resolve to a subject that is gone.
+
+**`origin` replaced an inference.** The row type previously
+distinguished credential-backed from orphan-pid rows only by
+`connection_state === null`. The log-only class shares that null while
+meaning the opposite thing — nothing but a pid, versus no pid at all —
+so the discriminator had to become explicit rather than a pattern of
+nulls three call sites re-derived.
+
+**A latent bug fell out, and the test caught it before the code did.**
+The orphan-pid loop checked `claimed` but never ADDED to it. Harmless
+while it was the last pass; the moment a fourth pass keyed on the same
+composite ran after it, an orphan pid the log also remembered rendered
+TWICE — once with live truth, once as a historical ghost. The test that
+found it was written first and failed for exactly that reason.
+
+**Best-effort is a property of the record, so it is a property of every
+claim about it.** The ring is global (5000 rows), pruned on write, and
+fed by an async telemetry cast from a path that includes `terminate/2`.
+Therefore: a missing entry is forgetfulness, never evidence a session
+never ran, and the detail panel says so in those terms instead of
+rendering a blank. The e2e spec asserts ONE direction — *given* the log
+remembers a session and no subject row does, the view lists it, marks
+it, and offers no verb — and establishes the log entry as a polled
+PRECONDITION before the delete, so a sink that failed to write reports
+itself as a failed precondition rather than as a broken surface.
+
+**A green spec was asserting the pre-ruling world.**
+`m8-admin-visitors-delete` ended on `toHaveCount(0)` over every row of
+the deleted visitor. Under the ruling a row MAY survive — badged,
+verbless — so that count now encodes the old product. It was rewritten,
+not weakened: the identity-wide property moved onto the verbs
+(`rowActions` gives a credential-backed visitor row exactly one of
+Disconnect / Reconnect on every network it is bound to, so zero of
+either across the `visitor:<id>:` prefix is "no credential survives
+anywhere"). The rewrite is also *stronger* against the ring: it holds
+whether or not the log happened to remember.
+
+**The bound is stated, not hidden.** At most ~200 sessions come back
+from the endpoint, so the deleted rows are recent history and not an
+archive. The card subtitle says that on screen — a table that silently
+truncates reads as complete.
+
+**Deliberately not built.** A per-session event timeline in the
+drill-in (the `session_id` index exists and is still unused by any
+query), and any retention change whatsoever. If a future surface needs
+the identity rather than the event, that reopens vjt's fork; it is not
+a mechanical extension of this.

--- a/lib/grappa/session_log.ex
+++ b/lib/grappa/session_log.ex
@@ -186,6 +186,38 @@ defmodule Grappa.SessionLog do
     |> Repo.all()
   end
 
+  @doc """
+  Returns the NEWEST event of each distinct `session_id`, newest-first,
+  bounded to `limit` **sessions** (not rows — a session with a long
+  history still costs one).
+
+  `session_id` is `(subject, network)`-grained, so this collapses the
+  event stream to the same grain the admin session rows already use, and
+  the row it yields is the last thing that session did: a `:disconnected`
+  carries `reason` / `clean` / `duration_ms`, a still-live one carries
+  whatever it last transitioned through.
+
+  This is the ONLY record of a session whose subject row is gone (#1158
+  item 4): `session_log_events` has no FK to `users` / `visitors`, so it
+  survives the visitor purge + reap CASCADE. Best-effort by construction
+  — the ring is global and bounded, and the disconnect write is an async
+  cast — so a MISSING session is not an error, and no caller may treat
+  the absence of a row as evidence a session never existed.
+  """
+  @spec list_latest_per_session(pos_integer()) :: [Event.t()]
+  def list_latest_per_session(limit) when is_integer(limit) and limit > 0 do
+    newest_per_session =
+      Event
+      |> group_by([e], e.session_id)
+      |> select([e], max(e.id))
+
+    Event
+    |> where([e], e.id in subquery(newest_per_session))
+    |> order_by([e], desc: e.id)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
   @impl GenServer
   def init(opts) do
     if Keyword.get(opts, :attach_telemetry, true) do

--- a/lib/grappa/session_log/wire.ex
+++ b/lib/grappa/session_log/wire.ex
@@ -37,6 +37,13 @@ defmodule Grappa.SessionLog.Wire do
   @typedoc "REST list envelope — `GET /admin/session_log`."
   @type list_result :: %{session_log: [t()]}
 
+  @typedoc """
+  REST envelope for the per-session collapse — `GET
+  /admin/session_log/sessions` (#1158 item 4). Same entry shape as the
+  tail; one entry per `session_id`, carrying that session's newest event.
+  """
+  @type sessions_result :: %{session_log_sessions: [t()]}
+
   @doc "Renders one persisted `Event` to its public wire shape."
   @spec to_json(Event.t()) :: t()
   def to_json(%Event{} = e) do
@@ -66,4 +73,9 @@ defmodule Grappa.SessionLog.Wire do
   @spec list_payload([Event.t()]) :: list_result()
   def list_payload(events) when is_list(events),
     do: %{session_log: Enum.map(events, &to_json/1)}
+
+  @doc "Wraps the per-session collapse as the `%{session_log_sessions: [...]}` envelope."
+  @spec sessions_payload([Event.t()]) :: sessions_result()
+  def sessions_payload(events) when is_list(events),
+    do: %{session_log_sessions: Enum.map(events, &to_json/1)}
 end

--- a/lib/grappa_web/controllers/admin/session_log_controller.ex
+++ b/lib/grappa_web/controllers/admin/session_log_controller.ex
@@ -17,6 +17,19 @@ defmodule GrappaWeb.Admin.SessionLogController do
   The snapshot door (cic fetches on tab mount); live updates arrive via
   the admin Channel's `session_log_event` push. One feature, three doors —
   context (`Grappa.SessionLog`) → controller (here) → channel.
+
+  ## GET /admin/session_log/sessions
+
+  The same entries collapsed to one per `session_id` — each session's
+  NEWEST event — newest-first, bounded by `?limit` in SESSIONS. Wire
+  shape `%{session_log_sessions: [...]}` (`Grappa.SessionLog.Wire`).
+
+  This is what lets the admin Sessions view list a session whose subject
+  row is gone (#1158 item 4): `session_id` is `(subject, network)`-grained
+  — the very key the session rows are built on — and the log carries no
+  FK to the subject, so it outlives the visitor purge. Best-effort by
+  construction: a session missing from this list is not evidence it never
+  existed.
   """
   use GrappaWeb, :controller
 
@@ -31,6 +44,13 @@ defmodule GrappaWeb.Admin.SessionLogController do
   def index(conn, params) do
     entries = SessionLog.list(parse_limit(params))
     json(conn, Wire.list_payload(entries))
+  end
+
+  @doc false
+  @spec sessions(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def sessions(conn, params) do
+    entries = SessionLog.list_latest_per_session(parse_limit(params))
+    json(conn, Wire.sessions_payload(entries))
   end
 
   # `?limit` is a defensive clamp — a malformed / out-of-range value falls

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -202,6 +202,11 @@ defmodule GrappaWeb.Router do
 
     # #215 — persisted IRC session-lifecycle log (read-only tail).
     get "/session_log", SessionLogController, :index
+    # #1158 item 4 — the same log collapsed to one entry per session_id.
+    # Backs the admin Sessions view's inactive rows: the log has no FK to
+    # the subject, so it is the only trace of a session whose visitor was
+    # purged. Literal segment, so it cannot shadow the tail route above.
+    get "/session_log/sessions", SessionLogController, :sessions
 
     # #318 — live WS presence + per-pid visibility freshness snapshot.
     # Read-only diagnostic for the iOS stale-`:visible` push bug.

--- a/test/grappa/session_log_persistence_test.exs
+++ b/test/grappa/session_log_persistence_test.exs
@@ -128,6 +128,7 @@ defmodule Grappa.SessionLogPersistenceTest do
       # Six rows on disk, three sessions. A row-bounded query would answer
       # ONE session here — the newest two rows both belong to u3.
       assert Repo.aggregate(Event, :count) == 6
+
       assert Enum.map(SessionLog.list_latest_per_session(2), & &1.session_id) ==
                ["user:u3:7", "user:u2:7"]
     end

--- a/test/grappa/session_log_persistence_test.exs
+++ b/test/grappa/session_log_persistence_test.exs
@@ -87,6 +87,52 @@ defmodule Grappa.SessionLogPersistenceTest do
     assert Enum.map(SessionLog.list(10), & &1.session_id) == ["user:u6:7", "user:u5:7", "user:u4:7"]
   end
 
+  describe "list_latest_per_session/1 (#1158 item 4)" do
+    test "collapses a session's history to its newest event" do
+      SessionLog.emit(:connected, state({:visitor, "v1"}), [])
+
+      SessionLog.emit(:disconnected, state({:visitor, "v1"}),
+        reason: ":quit",
+        clean: true,
+        duration_ms: 900
+      )
+
+      drain()
+
+      assert [%Event{} = row] = SessionLog.list_latest_per_session(10)
+      assert row.session_id == "visitor:v1:7"
+      assert row.event == :disconnected
+      assert row.reason == ":quit"
+      assert row.duration_ms == 900
+    end
+
+    test "returns one row per session, newest-first" do
+      for n <- 1..3, do: SessionLog.emit(:connected, state({:user, "u#{n}"}), [])
+      SessionLog.emit(:disconnected, state({:user, "u1"}), reason: ":tcp_closed", clean: false)
+      drain()
+
+      rows = SessionLog.list_latest_per_session(10)
+
+      assert Enum.map(rows, & &1.session_id) == ["user:u1:7", "user:u3:7", "user:u2:7"]
+      assert Enum.map(rows, & &1.event) == [:disconnected, :connected, :connected]
+    end
+
+    test "the limit bounds SESSIONS, not the raw rows behind them" do
+      for n <- 1..3 do
+        SessionLog.emit(:connected, state({:user, "u#{n}"}), [])
+        SessionLog.emit(:identified, state({:user, "u#{n}"}), [])
+      end
+
+      drain()
+
+      # Six rows on disk, three sessions. A row-bounded query would answer
+      # ONE session here — the newest two rows both belong to u3.
+      assert Repo.aggregate(Event, :count) == 6
+      assert Enum.map(SessionLog.list_latest_per_session(2), & &1.session_id) ==
+               ["user:u3:7", "user:u2:7"]
+    end
+  end
+
   test "persist broadcasts the wire event on Topic.session_log/0" do
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.session_log())
 

--- a/test/grappa_web/controllers/admin/session_log_controller_test.exs
+++ b/test/grappa_web/controllers/admin/session_log_controller_test.exs
@@ -98,4 +98,76 @@ defmodule GrappaWeb.Admin.SessionLogControllerTest do
       assert body == %{"session_log" => []}
     end
   end
+
+  describe "GET /admin/session_log/sessions (#1158 item 4)" do
+    test "no bearer returns 401", %{conn: conn} do
+      assert conn |> get("/admin/session_log/sessions") |> json_response(401) ==
+               %{"error" => "unauthorized"}
+    end
+
+    test "non-admin user returns 403", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      assert conn
+             |> put_bearer(session.id)
+             |> get("/admin/session_log/sessions")
+             |> json_response(403) == %{"error" => "forbidden"}
+    end
+
+    test "200 returns the newest event of each session, one row per session", %{conn: conn} do
+      insert_event(%{session_id: "visitor:v1:7", subject_kind: :visitor, event: :connected})
+      insert_event(%{session_id: "user:a:7", event: :connected})
+
+      insert_event(%{
+        session_id: "visitor:v1:7",
+        subject_kind: :visitor,
+        event: :disconnected,
+        reason: ":quit",
+        clean: true,
+        duration_ms: 900
+      })
+
+      session = admin_session()
+
+      body =
+        conn
+        |> put_bearer(session.id)
+        |> get("/admin/session_log/sessions")
+        |> json_response(200)
+
+      assert %{"session_log_sessions" => [first, second]} = body
+      assert first["session_id"] == "visitor:v1:7"
+      assert first["event"] == "disconnected"
+      assert first["reason"] == ":quit"
+      assert first["duration_ms"] == 900
+      assert second["session_id"] == "user:a:7"
+      assert second["event"] == "connected"
+    end
+
+    test "?limit caps the number of sessions", %{conn: conn} do
+      for n <- 1..5, do: insert_event(%{session_id: "user:u#{n}:7"})
+
+      session = admin_session()
+
+      body =
+        conn
+        |> put_bearer(session.id)
+        |> get("/admin/session_log/sessions?limit=2")
+        |> json_response(200)
+
+      assert length(body["session_log_sessions"]) == 2
+    end
+
+    test "empty log returns an empty list", %{conn: conn} do
+      session = admin_session()
+
+      body =
+        conn
+        |> put_bearer(session.id)
+        |> get("/admin/session_log/sessions")
+        |> json_response(200)
+
+      assert body == %{"session_log_sessions" => []}
+    end
+  end
 end


### PR DESCRIPTION
Builds item 4 of #1158 on vjt's ruling of 2026-08-11 (`#1158#issuecomment-5251047449`, clarified by `#issuecomment-5250500189`): *"tutto giusto conserviamo solo l'evento"*.

## What the ruling settles, and what this does NOT change

**Visitor retention is untouched.** The anon/incognito visitor is still purged at logout and still reaped by the TTL; the co-terminal identity contract stands. No TTL is extended, no purge deferred, no FK-bearing row outlives its subject. What is preserved is the EVENT, not the identity.

## The measurement that made it a join

`session_log_events.session_id` is already `"<kind>:<uuid>:<network_id>"` — the same composite the admin session rows are keyed on and the `/admin/sessions/:id/*` verbs parse. So no new identifier and no new vocabulary were needed. And because that table carries **no FK to `users` / `visitors`**, it survives the CASCADE that destroys a visitor: for a session that is over, it is the only record left.

## The two halves cost differently, and that is the design

- **User half — nothing new.** The credential is durable, nothing GCs it, and it already renders regardless of `connection_state`. Listing an inactive user session is a join.
- **Visitor half — the event only.** The row is deliberately destroyed on two clocks, so there is nothing to list; the log is what remains.

## Changes

**Server.** `SessionLog.list_latest_per_session/1` collapses the ring to each session's newest event, behind `GET /admin/session_log/sessions`. The limit bounds **sessions**, not rows — a chatty session must not crowd three quiet ones out of the answer, which a row-bounded tail would let it do.

**cic.** `buildSubjectRows` takes the log as a fifth source. It joins onto every existing row (a parked credential can finally say *when* it dropped and *why*) and appends a row for every session no other source claims. Those rows carry `origin: "session_log"`, a "deleted" badge, and **no verbs** — no credential to park, no pid to stop, so every button would resolve to a subject that is gone. Full record in the drill-in, per the dictated surface.

`origin` replaces an inference: credential-backed and orphan-pid rows were distinguishable only by `connection_state === null`, and the log-only class shares that null while meaning the opposite thing.

**A latent bug the new test found before the code did.** The orphan-pid pass checked `claimed` but never added to it. Harmless while it was last; the moment a fourth pass keyed on the same composite ran after it, an orphan pid the log also remembered rendered twice — once with live truth, once as a ghost.

## Best-effort is a property of the record, so it constrains every claim

The ring is global (5000), pruned on write, fed by an async cast from a path including `terminate/2`. So a missing entry is forgetfulness, never evidence a session never ran — the detail panel says exactly that instead of rendering a blank, and the card subtitle states that the deleted rows are recent history, not an archive.

The e2e spec asserts **one direction only**: given the log remembers a session and no subject row does, the view lists it, marks it, offers no verb. The log entry is established as a polled **precondition** before the delete, so a sink that failed to write reports itself as a failed precondition rather than as a broken surface.

## A green spec was asserting the pre-ruling world

`m8-admin-visitors-delete` ended on `toHaveCount(0)` over every row of the deleted visitor. Under the ruling a row MAY survive — badged, verbless. Rewritten, not weakened or deleted: the identity-wide property moves onto the verbs (`rowActions` gives a credential-backed visitor row exactly one of Disconnect / Reconnect on every network it is bound to, so zero of either across the `visitor:<id>:` prefix is "no credential survives anywhere"). The rewrite is also stronger against the ring — it holds whether or not the log remembered.

## Evidence

- `scripts/check.sh` rc=0, clean tree before **and** after: `8 doctests, 59 properties, 5895 tests, 0 failures`; Dialyzer `Total errors: 0`; Credo `5627 mods/funs, found no issues.`; `wireTypes.ts` + `wireSchema.ts` `is in sync.`; 428 bats. Sobelow's gate passes — it is not silent: two pre-existing `Traversal.FileModule` **Low Confidence** findings on `lib/grappa/cic/bundle.ex:157,170`, untouched here and below the Medium threshold.
- cic: `bun run check` rc=0, `bun run test` 5211 passed / 278 files.
- e2e, **local green on the admin family only** (not the full suite, which stays CI's gate): 51 passed / 0 failed across 22 specs — the `admin-*` family plus every other consumer of the shared `buildSubjectRows` path (`m8`, `m9b`, `m-z`, `issue589`, `ux-6-g`, `issue1073`) and `issue269-visitor-reconnect-toggle`, which has no "admin" in its name but drives the very Disconnect/Reconnect verbs this changes.
- **The new spec was proven capable of failing.** With the log-only append mutated off, it dies on the row's `toBeVisible` — the intended assertion, not an incidental one.

## Not built

A per-session event timeline in the drill-in (the `session_id` index exists and is still unused by any query), and any retention change. A future surface that wants the identity rather than the event reopens vjt's fork; it is not a mechanical extension of this.