### PR TITLE
#1098: the credential-order flake is Erlang term order on %DateTime{}

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39144,3 +39144,58 @@ The #410 auth-method LOCK moved to the new page's suite instead of dying
 with the file it happened to live in: it pins the dropdown to the
 codegen-emitted closed set in array order, which is not a property of
 where the dropdown sits.
+
+---
+
+## 2026-08-11 — #1098: the query was right, and Erlang term order sorted the ORACLE
+
+The flake read as a credential-ordering bug, and the issue body named two
+causes. Both are false, measured:
+
+- *"the sort runs across every credential in the DB"* — `DataCase` opens a
+  sandbox owner per test (`data_case.ex:24`), so no test sees another's rows.
+- *"the tie-break is missing"* — `credentials.ex:1254` already orders by
+  `[asc: c.inserted_at, asc: c.user_id, asc: c.network_id]`.
+
+The query was correct. The defect was in the test's ORACLE, which rebuilt the
+expected list out of the query result with `Enum.sort_by/2` — that is Erlang
+term order. `inserted_at` is `:utc_datetime_usec`, so the values are
+`%DateTime{}` structs, and term order on a map compares the values in KEY
+order, and atoms compare alphabetically: `:microsecond` before `:minute`,
+`:month`, `:second`, and `:year` dead last. Two timestamps straddling a second
+boundary therefore come out reversed. Deterministic repro, timestamps forced:
+
+- chronological, what the query returns: …41.999969 → …42.000012 → …42.000030
+- term order, what the oracle expected: …42.000012 → …42.000030 → …41.999969
+
+The cure changes no production code. The test forces its timestamps (one at
+the end of a second, two tied inside the next) and names the expected rows
+outright instead of re-deriving them. An oracle that never sorts cannot
+mis-sort.
+
+**The mutant that made the test honest, including the round it survived.**
+Deleting `asc: c.user_id` from the query SURVIVED the first layout: the two
+tied rows differed in `user_id` and `network_id` in the same direction, so
+`network_id` alone still ordered them — a defect in the test, not a property
+of the code. Crossing the keys (the low `user_id` on the high `network_id`)
+makes that same mutant kill exactly that one test. The pre-fix test from
+`origin/main` under the same mutant reports `98 tests, 0 failures`, which is
+the evidence that the new oracle is STRONGER and not merely different: the old
+one was blind to the tie-break it claimed to cover. The same `order_by` string
+also appears at `credentials.ex:1284`, so that mutant has to be injected by
+line, never by string.
+
+**Census, so the next reader does not repeat it.** Term order on `%DateTime{}`
+/ `Date` / `Time` has exactly one occurrence in this repo, and it was this
+test. All 32 `Enum.sort*` / `min*` / `max*` sites under `lib/` were read and
+none is temporal. `scrollback.ex:952` sorts on `last_activity`, which looks
+temporal and is not: it is `max(m.server_time)`, and `server_time` is an
+`:integer` of epoch milliseconds. The `<` / `>` comparisons on `expires_at`
+and `last_seen_at` (visitors, accounts, uploads) all sit inside Ecto `where:`
+clauses, so SQL does the comparing. The class is wider than `sort_by` — a bare
+`dt1 < dt2` between two structs falls in the same hole. The rule is
+`DateTime.compare/2`, or a scalar sort key, or let the database order it.
+
+**Not claimed.** The `network_id` tie-break is NOT pinned: no fixture ties two
+rows belonging to the same user. And nothing here was measured against
+production or against a real CI runner — the numbers are all the local suite.

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -727,29 +727,82 @@ defmodule Grappa.NetworksTest do
       assert {u2.id, net_a.id} in pairs
     end
 
-    test "orders by inserted_at ascending so Bootstrap output is deterministic" do
-      u1 = user_fixture("alice-#{System.unique_integer([:positive])}")
-      u2 = user_fixture("bob-#{System.unique_integer([:positive])}")
+    test "orders by (inserted_at, user_id, network_id) so Bootstrap is deterministic" do
+      # The tie-break is `user_id` ASC, so the test has to know which UUID
+      # sorts first — they are random per run. The rows are then inserted in
+      # the OPPOSITE order, so insertion order alone cannot produce the
+      # expected list and a query that dropped the tie-break would show it.
+      [lo_user, hi_user] =
+        Enum.sort_by(
+          [
+            user_fixture("alice-#{System.unique_integer([:positive])}"),
+            user_fixture("bob-#{System.unique_integer([:positive])}")
+          ],
+          & &1.id
+        )
+
       net_a = network_fixture("net-a-#{System.unique_integer([:positive])}")
       net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
 
-      {:ok, c1} =
-        Credentials.bind_credential(u1, net_a, %{nick: "a", auth_method: :none, autojoin_channels: []})
+      {:ok, straddler} =
+        Credentials.bind_credential(hi_user, net_a, %{
+          nick: "a",
+          auth_method: :none,
+          autojoin_channels: []
+        })
 
-      {:ok, c2} =
-        Credentials.bind_credential(u2, net_a, %{nick: "b", auth_method: :none, autojoin_channels: []})
+      {:ok, tied_hi} =
+        Credentials.bind_credential(hi_user, net_b, %{
+          nick: "a",
+          auth_method: :none,
+          autojoin_channels: []
+        })
 
-      {:ok, c3} =
-        Credentials.bind_credential(u1, net_b, %{nick: "a", auth_method: :none, autojoin_channels: []})
+      {:ok, tied_lo} =
+        Credentials.bind_credential(lo_user, net_a, %{
+          nick: "b",
+          auth_method: :none,
+          autojoin_channels: []
+        })
+
+      # #1098 — the shape of the recorded red, forced rather than waited for:
+      # one row at the very end of a second, two in the next one, tied with
+      # each other. In a real run the clock decides whether this ever occurs,
+      # which is why the flake surfaced once and vanished on rerun.
+      straddler = stamp(straddler, ~U[2026-08-09 02:29:41.999969Z])
+      tied_hi = stamp(tied_hi, ~U[2026-08-09 02:29:42.000012Z])
+      tied_lo = stamp(tied_lo, ~U[2026-08-09 02:29:42.000012Z])
 
       ts =
         Enum.map(Credentials.list_credentials_for_all_users(), &{&1.user_id, &1.network_id, &1.inserted_at})
 
-      # Strictly non-decreasing inserted_at — ties broken by composite key.
-      assert ts == Enum.sort_by(ts, fn {u, n, t} -> {t, u, n} end)
-      assert {c1.user_id, c1.network_id, c1.inserted_at} in ts
-      assert {c2.user_id, c2.network_id, c2.inserted_at} in ts
-      assert {c3.user_id, c3.network_id, c3.inserted_at} in ts
+      # Stated outright, never re-derived with `Enum.sort_by/2`: that sorts by
+      # Erlang TERM order, and term order on a `%DateTime{}` compares the
+      # struct's map values in alphabetical KEY order — weighing `:microsecond`
+      # BEFORE `:minute` and `:second`. It ranks `…41.999969Z` AFTER
+      # `…42.000012Z`, so it disagrees with SQL exactly when two rows straddle
+      # a second boundary. The query is chronological and right; the oracle
+      # that re-sorted the query's own output was the wrong one (#1098).
+      assert ts == [
+               {straddler.user_id, straddler.network_id, straddler.inserted_at},
+               {tied_lo.user_id, tied_lo.network_id, tied_lo.inserted_at},
+               {tied_hi.user_id, tied_hi.network_id, tied_hi.inserted_at}
+             ]
+    end
+
+    # #1098 — pins a credential's `inserted_at` and hands the row back as it
+    # now reads, so the assertions above compare stored values rather than
+    # the pre-update struct.
+    defp stamp(%Credential{} = cred, %DateTime{} = at) do
+      {1, _} =
+        Repo.update_all(
+          from(c in Credential,
+            where: c.user_id == ^cred.user_id and c.network_id == ^cred.network_id
+          ),
+          set: [inserted_at: at]
+        )
+
+      %{cred | inserted_at: at}
     end
   end
 

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -748,21 +748,21 @@ defmodule Grappa.NetworksTest do
       net_a = network_fixture("net-a-#{System.unique_integer([:positive])}")
       net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
 
-      {:ok, straddler} =
+      {:ok, _} =
         Credentials.bind_credential(hi_user, net_b, %{
           nick: "a",
           auth_method: :none,
           autojoin_channels: []
         })
 
-      {:ok, tied_hi} =
+      {:ok, _} =
         Credentials.bind_credential(hi_user, net_a, %{
           nick: "a",
           auth_method: :none,
           autojoin_channels: []
         })
 
-      {:ok, tied_lo} =
+      {:ok, _} =
         Credentials.bind_credential(lo_user, net_b, %{
           nick: "b",
           auth_method: :none,
@@ -773,9 +773,12 @@ defmodule Grappa.NetworksTest do
       # one row at the very end of a second, two in the next one, tied with
       # each other. In a real run the clock decides whether this ever occurs,
       # which is why the flake surfaced once and vanished on rerun.
-      straddler = stamp(straddler, ~U[2026-08-09 02:29:41.999969Z])
-      tied_hi = stamp(tied_hi, ~U[2026-08-09 02:29:42.000012Z])
-      tied_lo = stamp(tied_lo, ~U[2026-08-09 02:29:42.000012Z])
+      boundary = ~U[2026-08-09 02:29:41.999969Z]
+      next_second = ~U[2026-08-09 02:29:42.000012Z]
+
+      stamp(hi_user, net_b, boundary)
+      stamp(hi_user, net_a, next_second)
+      stamp(lo_user, net_b, next_second)
 
       ts =
         Enum.map(Credentials.list_credentials_for_all_users(), &{&1.user_id, &1.network_id, &1.inserted_at})
@@ -788,25 +791,21 @@ defmodule Grappa.NetworksTest do
       # a second boundary. The query is chronological and right; the oracle
       # that re-sorted the query's own output was the wrong one (#1098).
       assert ts == [
-               {straddler.user_id, straddler.network_id, straddler.inserted_at},
-               {tied_lo.user_id, tied_lo.network_id, tied_lo.inserted_at},
-               {tied_hi.user_id, tied_hi.network_id, tied_hi.inserted_at}
+               {hi_user.id, net_b.id, boundary},
+               {lo_user.id, net_b.id, next_second},
+               {hi_user.id, net_a.id, next_second}
              ]
     end
 
-    # #1098 — pins a credential's `inserted_at` and hands the row back as it
-    # now reads, so the assertions above compare stored values rather than
-    # the pre-update struct.
-    defp stamp(%Credential{} = cred, %DateTime{} = at) do
+    # #1098 — pins one credential's `inserted_at`, so the ordering case under
+    # test is produced on purpose instead of waited for from the clock.
+    defp stamp(%Accounts.User{} = user, %Network{} = network, %DateTime{} = at) do
       {1, _} =
-        Repo.update_all(
-          from(c in Credential,
-            where: c.user_id == ^cred.user_id and c.network_id == ^cred.network_id
-          ),
-          set: [inserted_at: at]
-        )
+        Credential
+        |> where([c], c.user_id == ^user.id and c.network_id == ^network.id)
+        |> Repo.update_all(set: [inserted_at: at])
 
-      %{cred | inserted_at: at}
+      :ok
     end
   end
 

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -729,9 +729,13 @@ defmodule Grappa.NetworksTest do
 
     test "orders by (inserted_at, user_id, network_id) so Bootstrap is deterministic" do
       # The tie-break is `user_id` ASC, so the test has to know which UUID
-      # sorts first — they are random per run. The rows are then inserted in
-      # the OPPOSITE order, so insertion order alone cannot produce the
-      # expected list and a query that dropped the tie-break would show it.
+      # sorts first — they are random per run. The two tied rows below then
+      # cross the two keys deliberately: the lower `user_id` sits on the
+      # HIGHER `network_id`, so `network_id` alone would order them the other
+      # way round, and they are inserted in the opposite order again, so
+      # insertion order cannot produce the expected list either. Measured:
+      # without the crossing, dropping `asc: c.user_id` from the query still
+      # passes, because `network_id` happens to agree.
       [lo_user, hi_user] =
         Enum.sort_by(
           [
@@ -745,21 +749,21 @@ defmodule Grappa.NetworksTest do
       net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
 
       {:ok, straddler} =
-        Credentials.bind_credential(hi_user, net_a, %{
-          nick: "a",
-          auth_method: :none,
-          autojoin_channels: []
-        })
-
-      {:ok, tied_hi} =
         Credentials.bind_credential(hi_user, net_b, %{
           nick: "a",
           auth_method: :none,
           autojoin_channels: []
         })
 
+      {:ok, tied_hi} =
+        Credentials.bind_credential(hi_user, net_a, %{
+          nick: "a",
+          auth_method: :none,
+          autojoin_channels: []
+        })
+
       {:ok, tied_lo} =
-        Credentials.bind_credential(lo_user, net_a, %{
+        Credentials.bind_credential(lo_user, net_b, %{
           nick: "b",
           auth_method: :none,
           autojoin_channels: []


### PR DESCRIPTION
## What the flake actually was

`networks_test.exs` — *"orders by inserted_at ascending so Bootstrap output is deterministic"* —
went red once on `main` and green on a same-content rerun. The issue read it structurally as an
assertion over a shared, polluted table. **Both halves of that reading are wrong, and the code
says so:**

- **The test does not see other tests' rows.** `DataCase` checks out a sandbox owner per test
  (`test/support/data_case.ex:24`); the neighbouring test asserting
  `list_credentials_for_all_users() == []` only holds because of it.
- **The query already has the tie-break.** `credentials.ex:1254` orders by
  `[asc: c.inserted_at, asc: c.user_id, asc: c.network_id]`.

**The query is correct. The oracle was not.** `inserted_at` is `:utc_datetime_usec`, so it is a
`%DateTime{}` struct, and the test rebuilt its expectation from the query's own output with
`Enum.sort_by/2` — whose default sorter is Erlang **term order**. Term order on a map compares
values in *alphabetical key order*, which puts `:microsecond` ahead of `:minute` and `:second`
(and `:day` ahead of `:month` and `:year`). It is not chronological.

The two agree right up until two rows straddle a second boundary. Then the query says
`…41.999969Z` comes first and term order says it comes last, because it is comparing `999969`
against `12`. The recorded CI failure carries exactly that timestamp — `…02:29:41.999969Z` — the
last microseconds of a second. That is also why the rerun was green: the clock decided, not the
tree.

## Reproduced deterministically, before any fix

Forcing the three rows onto that boundary instead of waiting for it:

```
left  (query, chronological): …41.999969 → …42.000012 → …42.000030
right (term order):           …42.000012 → …42.000030 → …41.999969
```

`98 tests, 1 failure`, on demand, every time.

## The cure

No production change. The rows now carry the boundary on purpose — one at the end of a second,
two tied in the next — and the expected list is **stated outright** instead of re-derived by
sorting the query's own output. There is no sort left in the oracle, so it cannot be wrong in
this way again, and naming the timestamps directly also pins the storage round-trip: a column
that quietly dropped microseconds would now fail here rather than agree with itself.

## Evidence, including a measurement that went against me

| Mutation | Result |
|---|---|
| Drop `asc: c.user_id` from the query, **first layout of the cure** | **Survived.** The two tied rows differed in `user_id` and `network_id` in the *same* direction, so `network_id` alone reproduced the expected order. My test claimed to pin the tie-break and did not. |
| Same mutation, after crossing the keys (lower `user_id` on the higher `network_id`) | Kills **exactly** this test (98 tests, 1 failure) |
| Same mutation against the **pre-fix test** from `origin/main` | **98 tests, 0 failures** — the old test was blind to it |

The last row is the one worth reading: the tie-break the old comment described had never been
exercised, because clock-generated timestamps are essentially always distinct. So this is
strictly more pinned than before, not merely different.

## The trap is not local to this test — a survey, not a change

`Enum.sort_by/2` on a `%DateTime{}` (or `Date`, or `Time`) is unsound anywhere, and so is a bare
`dt1 < dt2` between structs, for the same reason. Surveyed rather than assumed — all 32
`Enum.sort*/min*/max*` sites in `lib/` read with context:

- **Production is clean: zero instances.**
- `scrollback.ex:952`, `Enum.sort_by(& &1.last_activity, :desc)`, looked like the twin and is
  **not**: `last_activity` is `max(m.server_time)` and `server_time` is `:integer` (epoch
  milliseconds), where term order is correct.
- The `<` / `>` comparisons on `expires_at` / `last_seen_at` in `visitors.ex`, `accounts.ex` and
  `uploads.ex` are inside Ecto `where:` clauses — SQL comparisons, not term order.
- In the test tree, the only other temporal sort is on `server_time`, an integer.

Nothing else to fix, so nothing else is touched here.

## Gates

`scripts/check.sh` → **RC=0**: Credo strict *found no issues*, 8 doctests / 59 properties /
**5887 tests, 0 failures**, Dialyzer **Total errors: 0**, bats `1..428` with zero `not ok`.
Branch is on `origin/main` at `175ecf1c`.

## What I am not claiming

- **The `network_id` tie-break is still not pinned.** The two tied rows differ in user *and*
  network, so `asc: c.network_id` has no witness of its own; adding one needs a second pair
  tied at the same timestamp under the same user. Left out deliberately rather than implied.
- **Nothing was measured against CI or production** — the reproduction, the cure and all three
  mutants are local suite runs. The single historical red in the issue is the only field
  observation, and I did not reproduce it in CI.
- **I did not establish an incidence rate.** The mechanism explains a rare, rerun-green failure,
  and the timestamp in the recorded red matches it, but "how often" was never measured and this
  does not measure it either — it removes the dependency on the clock instead.
