### PR TITLE
cic(#1223): give the phone admin card back its width

### DIFF
--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -1,0 +1,189 @@
+// #1223 items 2 and 3 — what an admin row card does on a phone, once
+// #1157 turned rows into cards.
+//
+// vjt, dogfooding staging on an iPhone: *"abbiamo tap target solo sul testo
+// quando invece dovrebbe esser tutta l'area, parlo ad es dei nomi visitor"*.
+// Two separate defects behind that reading, both of them layout, both
+// therefore invisible to jsdom (`feedback_cicchetto_browser_smoke`) and to
+// every vitest suite that mounts these components:
+//
+//   2. `.adm-row-expand` puts the 44px `--tap-min` floor on HEIGHT only and
+//      sizes its box with `inline-flex`, so the door to the row's detail is
+//      the caret + badge + nick run and the rest of the card's heading is
+//      dead space that looks tappable. Asserted by TAPPING that dead space
+//      and requiring the panel to open — the visible outcome, not the
+//      declarations that produce it.
+//
+//   3. `.adm-facts` sizes its label track from the LONGEST label, so on a
+//      393px screen the value track keeps well under half the width and
+//      wraps timestamps over several lines. Asserted as the value track
+//      taking the panel's full width, with the label above it.
+//
+// Item 1 of the same issue (the detail panel repeating fields the card
+// already shows) is NOT in scope here: it needs a product call between
+// dropping the columns for real and dropping the panel on mobile, and it is
+// the only one of the three that changes what is on screen rather than where
+// it is.
+//
+// The desktop test is the counter-claim, and it is why item 3's fix is a
+// `@container` rule rather than a blanket single column: at a width where two
+// columns fit, two columns are what the operator gets. Without it, collapsing
+// unconditionally would pass.
+//
+// Sessions is the tab under test because its disclosure is `alwaysOpenable`
+// (#1157), so the SAME control can be measured at both widths. The button is
+// `AdminRowName`, which every tab routes identity through.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated, the EXEMPT shape.
+
+import type { Locator, Page } from "@playwright/test";
+import { adminSessionRowKey, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// admin-vjt has no network bind, so `loginAs`'s network-section shell-ready
+// selector would time out. Same shape as #1073 / m7-admin-gate / m11-events.
+async function adminLogin(page: Page): Promise<void> {
+  const seed = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+async function openSessionsTab(page: Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-sessions").click();
+  await expect(page.getByTestId("admin-sessions-table")).toBeVisible({ timeout: 10_000 });
+}
+
+type Box = { x: number; y: number; width: number; height: number };
+
+async function boxOf(locator: Locator, what: string): Promise<Box> {
+  const box = await locator.boundingBox();
+  if (box === null)
+    throw new Error(`${what} has no layout box — the markup or the classes drifted`);
+  return box;
+}
+
+test("#1223 @webkit on a phone the whole card heading opens the row, not just the nick", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`tap1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    const row = page.getByTestId(`admin-session-row-${key}`);
+    await row.scrollIntoViewIfNeeded();
+    await expect(row).toBeVisible();
+
+    // Pre-state, asserted rather than assumed: the panel is CLOSED, so the
+    // tap below is what opens it and not a coincidence of a panel already on
+    // screen from a previous step.
+    const panel = page.getByTestId(`admin-session-detail-${key}`);
+    await expect(panel).toHaveCount(0);
+
+    const heading = row.locator("td.adm-cell-title");
+    const glyphs = row.locator(".admin-session-lines");
+    const headingBox = await boxOf(heading, "the card heading cell");
+    const glyphBox = await boxOf(glyphs, "the identity's glyph run");
+
+    // The probe point: the heading's right end, past everything that is
+    // drawn. If the glyph run happens to fill the heading there is no dead
+    // space to aim at and the tap would prove nothing — fail loudly rather
+    // than pass vacuously.
+    const tapX = headingBox.x + headingBox.width - 6;
+    const tapY = headingBox.y + headingBox.height / 2;
+    const deadSpace = tapX - (glyphBox.x + glyphBox.width);
+    expect(
+      deadSpace,
+      "the probe must land beyond the drawn identity — otherwise it is not testing the dead space",
+    ).toBeGreaterThan(8);
+
+    await page.touchscreen.tap(tapX, tapY);
+
+    await expect(
+      panel,
+      "tapping the card heading beside the nick must open the row's detail",
+    ).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});
+
+test("#1223 @webkit on a phone a detail fact gives its value the panel's full width", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`facts1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    await page.getByTestId(`admin-session-details-${key}`).tap();
+    const panel = page.getByTestId(`admin-session-detail-${key}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    const facts = panel.locator(".adm-facts");
+    const factsBox = await boxOf(facts, "the facts list");
+    const dtBox = await boxOf(facts.locator("dt").first(), "the first fact's label");
+    const ddBox = await boxOf(facts.locator("dd").first(), "the first fact's value");
+
+    // The label is a caption ABOVE its value, not a track beside it.
+    expect(
+      ddBox.y,
+      `the value must sit under its label on a narrow panel (facts list ${Math.round(factsBox.width)}px wide)`,
+    ).toBeGreaterThanOrEqual(dtBox.y + dtBox.height - 0.5);
+
+    // And the point of moving it: the value gets the width the label track
+    // and its gap were taking. Separate from the assertion above because a
+    // collapse that left a fixed label column would satisfy that one.
+    expect(
+      ddBox.width,
+      "the value track must take essentially the whole panel width",
+    ).toBeGreaterThanOrEqual(factsBox.width * 0.9);
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});
+
+test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`wide1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    await page.getByTestId(`admin-session-details-${key}`).click();
+    const panel = page.getByTestId(`admin-session-detail-${key}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    const facts = panel.locator(".adm-facts");
+    const dtBox = await boxOf(facts.locator("dt").first(), "the first fact's label");
+    const ddBox = await boxOf(facts.locator("dd").first(), "the first fact's value");
+
+    // Beside, not under: the phone fix is a container query, so a panel with
+    // room keeps the label column that makes a list of facts scannable.
+    expect(
+      ddBox.x,
+      "with room for two columns the value must sit beside its label",
+    ).toBeGreaterThanOrEqual(dtBox.x + dtBox.width);
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5439,6 +5439,32 @@ html.resize-dragging * {
   overflow-wrap: anywhere;
 }
 
+/* #1223 — two columns stop paying when the panel is narrow. The label
+   track is `auto`, so the LONGEST label sizes it (`CONNECTION`, `LAST
+   EVENT`, uppercase with 0.1em tracking); add the 16px column gap and
+   the panel's own chrome and the value track is left with well under
+   half a phone screen, which wrapped an `addr:port` upstream over three
+   lines and an ISO-8601 timestamp over five on a 393px-class viewport.
+
+   Container, not viewport: `.adm-detail-body` already declares
+   `container-type: inline-size`, and it is the box that actually
+   constrains this list — nested in a card, in a tab body, beside a
+   220px rail on desktop. A viewport breakpoint would be measuring the
+   wrong box, the same mistake `@container (max-width: 56rem)` above
+   exists to avoid (a 1180x820 tablet got it wrong).
+
+   30rem, i.e. the width below which the value track can no longer hold
+   one line of what this list actually renders: 6rem of label track plus
+   the 1rem gap is chrome, and the panel's values are timestamps and
+   `host:port` pairs of ~20 mono characters. Below that the pair reads
+   better stacked — the label is a caption for the value, and a caption
+   above costs one line and buys the value the whole width. */
+@container (max-width: 30rem) {
+  .adm-facts {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Networks used to freeze its slug column at the left edge while the
    rest panned — the mitigation for being the one tab `ux-6-g` pinned as
    deliberately wider than a phone. #1074 removed the reason: its six
@@ -5741,6 +5767,30 @@ html.resize-dragging * {
 
   .adm-table td.adm-cell-title::before {
     content: none;
+  }
+
+  /* #1223 — the disclosure is the CARD's door, so the card's heading is
+     the door, not the glyph run inside it. `.adm-row-expand` puts the
+     44px `--tap-min` floor on HEIGHT only, and `inline-flex` sizes the
+     box to caret + badge + nick: on a phone that leaves most of the
+     heading's width as dead space that looks tappable and is not (vjt,
+     iPhone dogfood: "tap target solo sul testo ... dovrebbe esser tutta
+     l'area"). Filling the cell turns the 44px floor into a 44px-by-full-
+     width target.
+
+     Specificity, not preference: `.admin-session-who .adm-row-expand`
+     (0,2,0) re-declares `inline-flex` for the Sessions identity cell, so
+     a bare `.adm-row-expand` here would lose on exactly the tab vjt
+     named. `.adm-table td .adm-row-expand` is (0,2,1) and covers every
+     tab, which is the point — all of them route identity through
+     `AdminRowName`.
+
+     Scoped to the stacked regime deliberately: above 899px the cell is a
+     table cell in a row of its own siblings rather than a card heading,
+     and the complaint is a touch one. */
+  .adm-table td .adm-row-expand {
+    display: flex;
+    width: 100%;
   }
 
   /* Nothing is wide, so nothing may claim it is: the desktop slack


### PR DESCRIPTION
## Scope

**#1223 items 2 and 3 only.** Item 1 — the detail panel repeating fields the
card already shows — is NOT in this PR. The issue defers it to vjt's call
between the two ways out (drop the secondary columns for real below 900px, or
drop the panel on mobile), and it stays open awaiting that decision. Nothing
here touches `.adm-col-detail` or the `.adm-table td` stacking rule.

## Item 2 — the whole card heading is the door, not the glyph run

`.adm-row-expand` opens a row's detail panel and puts the 44px `--tap-min`
floor on **height only**; `inline-flex` sizes its box to caret + badge + nick.
Below 900px a row is a card and the identity cell is its heading, so most of
that heading is dead space that looks tappable and is not.

The button now fills its cell. Written `.adm-table td .adm-row-expand`
(specificity `(0,2,1)`) rather than `.adm-row-expand`, because
`.admin-session-who .adm-row-expand` `(0,2,0)` re-declares `inline-flex` for
the Sessions identity cell — a bare class selector would have lost on exactly
the tab the report names. It applies to every tab: they all route identity
through `AdminRowName`.

Scoped to the stacked regime (`max-width: 899px`). Above it the cell is a
table cell among siblings and the complaint is a touch one; the desktop
pointer case is untouched.

## Item 3 — a narrow facts panel stacks label over value

`.adm-facts` sizes its label track from the **longest** label (`CONNECTION`,
`LAST EVENT`, uppercase with `0.1em` tracking). With the 16px column gap and
the panel's own chrome the value track keeps well under half a phone screen.

It collapses to a single column via `@container`, not a viewport breakpoint:
`.adm-detail-body` already declares `container-type: inline-size` and is the
box that actually constrains the list. Same reasoning as the
`@container (max-width: 56rem)` rule above it, which exists because a viewport
breakpoint got a 1180x820 tablet wrong.

The `30rem` threshold also makes the phone case unconditional: a container is
never wider than the viewport, so every screen under 480px collapses however
deeply the panel is nested, while a desktop panel (~860px at 1180px of screen)
keeps two columns.

## Test

Both defects are layout, so jsdom is blind to them and no vitest suite can
guard either. `e2e/tests/issue1223-admin-card-affordances.spec.ts` asserts the
visible outcome, not the declarations:

- `@webkit` — **taps the dead space** at the right end of the card heading,
  past the drawn identity, and requires the detail panel to open. The closed
  panel is asserted as the pre-state, and the probe refuses to run if the glyph
  run happens to fill the heading (a vacuous pass).
- `@webkit` — requires the first fact's value to sit **under** its label and to
  take ≥90% of the list's width. Two assertions because a collapse that left a
  fixed label column would satisfy the first alone.
- chromium — the counter-claim at desktop width: the value stays **beside** its
  label. Without it, collapsing unconditionally would pass.

## Gates

- `bun run check` (biome + tsc over `src` and `e2e`) — rc 0. Biome on
  `default.css` alone reports 25 warnings, all pre-existing; none names the new
  selectors.
- `bun run test` — rc 0, 279 files / 5230 tests.
- The Playwright spec has **not been executed**: the e2e lane was not available
  to this branch. It needs a run before merge, on a rebuilt cic bundle.