### PR TITLE
cic(#1227, #1228): settings drawer at phone width — drop a redundant label, let a fieldset shrink

### DIFF
--- a/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
@@ -1,0 +1,217 @@
+// #1228 — on a phone the settings drawer's notifications sub-page renders
+// past the drawer's own right border: the master-toggle label, both text
+// inputs, the mute select and the devices rows' `remove` buttons are all
+// sliced by the screen edge.
+//
+// MEASURED cause (none of this was established when the issue was filed —
+// the issue was written from a screenshot and listed four candidates, three
+// of which the measurement refutes):
+//
+//   * The `mute:` <select> is the only box in the sub-page whose width
+//     depends on the USER'S DATA — a <select> takes its intrinsic width from
+//     its longest OPTION, and the options are `"<conversation> — <network>"`.
+//     With short names it needs 173px; with one long conversation name it
+//     needs 367px, against 239px of available drawer width.
+//   * A <fieldset> defaults to `min-inline-size: min-content` and, unlike
+//     other boxes, will not shrink below it. So the select's 367px becomes
+//     the fieldset's 381px floor, and EVERY control inside is then laid out
+//     against a box 142px wider than the drawer. That is why the whole
+//     sub-page is cut and not one control — and why the drawer HEADER, which
+//     lives outside the fieldset, is not.
+//   * Refuted by the same measurement: the two text inputs (intrinsic 156px
+//     and 155px — their `size` attribute is not the driver), the devices
+//     rows (163px), the master toggle (116px). Adding `min-width: 0` to the
+//     labels' flex children changes nothing; removing the fieldset's
+//     `min-inline-size` removes the overflow and restoring it brings it
+//     back.
+//
+// jsdom has no layout engine, so vitest is structurally blind to this class
+// of defect — the only oracle is a real engine at a real phone width, hence
+// @webkit (iPhone 15). The reported device was wider (~440 CSS px, read off
+// the screenshot), but the drawer is `width: 22rem` and so is 263px wide on
+// both: the available width this spec measures against is identical.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: a subject-shape-
+// agnostic CSS layout contract — registered vjt suffices.
+
+import type { Page } from "@playwright/test";
+import {
+  composeSend,
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { pushCatcherEndpoint, resetPushSubscriptions } from "../fixtures/push";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// A real iPhone Safari UA so the devices row renders the shape the operator
+// sees (`📱 Safari on iOS`), not a placeholder.
+const DEVICE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+// The smallest text size — the one the report came from. `--font-size` drives
+// the root font size, so S is where the 22rem drawer is NARROWEST (263px) and
+// the squeeze is worst.
+const FONT_SIZE = "S";
+
+// 32 chars, bahamut's CHANNELLEN. The long name is the whole point: it is what
+// makes the mute select's intrinsic width exceed the drawer, and it is the
+// difference between a seeded account and vjt's.
+const LONG_CHANNEL = `#${"z".repeat(31)}`;
+
+// Seed a push subscription straight over REST. The devices list only renders
+// when there is at least one row, and both of its `remove` buttons are named
+// on the issue — but going through the real SW/PushManager stub would buy
+// nothing: the row's GEOMETRY is what is under test, and the server takes the
+// same row either way.
+async function seedOneDevice(token: string, id: string): Promise<void> {
+  const res = await fetch("http://grappa-test:4000/push/subscriptions", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": DEVICE_UA,
+    },
+    body: JSON.stringify({
+      endpoint: pushCatcherEndpoint(id),
+      keys: { p256dh: "BJ1228p256dhkeymaterialplaceholder", auth: "auth1228placeholder" },
+    }),
+  });
+  if (!res.ok) throw new Error(`seedOneDevice: ${res.status} ${await res.text()}`);
+}
+
+type Offender = {
+  tag: string;
+  cls: string;
+  testid: string | null;
+  text: string;
+  width: number;
+  right: number;
+  overflow: number;
+};
+
+// The five boxes the issue names as sliced by the screen edge. They are the
+// probe's own non-vacuity check: if the sub-page did not render, or the
+// devices list came up empty, the offender list would be trivially empty and
+// this spec would pass on the broken build.
+const WITNESSES = {
+  masterToggle: ".notifications-fieldset .master-toggle",
+  channelsInput: '[data-testid="pref-channels-only"]',
+  nicksInput: '[data-testid="pref-nicks-only"]',
+  mutePicker: '[data-testid="pref-mute-picker"]',
+  deviceRemove: ".devices-list .device-remove",
+} as const;
+
+type Witness = { found: boolean; width: number; right: number };
+
+type Measurement = {
+  viewportWidth: number;
+  rootFontSize: string;
+  drawerLeft: number;
+  drawerRight: number;
+  drawerClientWidth: number;
+  drawerScrollWidth: number;
+  witnesses: Record<string, Witness>;
+  // Every box ranked by right edge, overflowing or not — so a failure report
+  // names the widest box even when the list of offenders is long.
+  widest: Offender[];
+  offenders: Offender[];
+};
+
+async function measure(page: Page): Promise<Measurement> {
+  return await page.locator(".settings-drawer.open").evaluate((drawer, witnessSelectors) => {
+    const style = getComputedStyle(drawer);
+    const box = drawer.getBoundingClientRect();
+    const contentRight =
+      box.right - Number.parseFloat(style.paddingRight) - Number.parseFloat(style.borderRightWidth);
+
+    const witnesses: Record<string, Witness> = {};
+    for (const [name, selector] of Object.entries(witnessSelectors)) {
+      const el = drawer.querySelector(selector);
+      const r = el === null ? null : el.getBoundingClientRect();
+      witnesses[name] =
+        r === null
+          ? { found: false, width: 0, right: 0 }
+          : {
+              found: true,
+              width: Math.round(r.width * 10) / 10,
+              right: Math.round(r.right * 10) / 10,
+            };
+    }
+
+    const boxes: Offender[] = [];
+    for (const el of Array.from(drawer.querySelectorAll("*"))) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) continue;
+      boxes.push({
+        tag: el.tagName.toLowerCase(),
+        cls: el.getAttribute("class") ?? "",
+        testid: el.getAttribute("data-testid"),
+        text: (el.textContent ?? "").trim().slice(0, 40),
+        width: Math.round(r.width * 10) / 10,
+        right: Math.round(r.right * 10) / 10,
+        overflow: Math.round((r.right - contentRight) * 10) / 10,
+      });
+    }
+    boxes.sort((a, b) => b.right - a.right);
+
+    return {
+      viewportWidth: window.innerWidth,
+      rootFontSize: getComputedStyle(document.documentElement).fontSize,
+      drawerLeft: Math.round(box.left * 10) / 10,
+      drawerRight: Math.round(box.right * 10) / 10,
+      drawerClientWidth: drawer.clientWidth,
+      drawerScrollWidth: drawer.scrollWidth,
+      witnesses,
+      widest: boxes.slice(0, 5),
+      offenders: boxes.filter((b) => b.overflow > 0.5),
+    };
+  }, WITNESSES);
+}
+
+test("@webkit #1228 — a long conversation name does not push the notifications sub-page off the drawer", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await resetPushSubscriptions(vjt.token);
+  // Two devices, as in the report — both `remove` buttons were sliced there.
+  await seedOneDevice(vjt.token, "1228-a");
+  await seedOneDevice(vjt.token, "1228-b");
+
+  await page.addInitScript((s) => localStorage.setItem("cicchetto.fontSize", s), FONT_SIZE);
+  await loginAs(page, vjt);
+
+  // The long name has to reach the mute picker's OPTIONS, which are built
+  // from the open windows.
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+  await composeSend(page, `/join ${LONG_CHANNEL}`);
+
+  await openSettingsSection(page, "push");
+  await expect(page.getByTestId("devices-list").locator("li")).toHaveCount(2);
+  // PRECONDITION (anti-hollow-green): the long option is actually IN the
+  // select. Without it the drawer has nothing wide to lay out and every
+  // assertion below passes on the broken build too.
+  await expect(page.getByTestId("pref-mute-picker")).toContainText(LONG_CHANNEL);
+
+  const m = await measure(page);
+  console.log(
+    `#1228 vw=${m.viewportWidth} root=${m.rootFontSize} drawer=${m.drawerLeft}..${m.drawerRight} client=${m.drawerClientWidth} scroll=${m.drawerScrollWidth} widest=${JSON.stringify(m.widest[0])}`,
+  );
+
+  // PRECONDITION: this is the phone geometry the issue is about — the drawer
+  // pinned to the screen's right edge, at its narrowest text size.
+  expect(m.viewportWidth).toBeLessThanOrEqual(440);
+  expect(m.drawerRight).toBeCloseTo(m.viewportWidth, 0);
+
+  // PRECONDITION: the five boxes the issue names were rendered AND laid out.
+  for (const [name, w] of Object.entries(m.witnesses)) {
+    expect(w, `witness ${name} must be present`).toMatchObject({ found: true });
+    expect(w.width, `witness ${name} must have been laid out`).toBeGreaterThan(0);
+  }
+
+  // The drawer's own scroller is the second half of the same fact: content
+  // wider than the box is exactly what the operator sees cut by the screen.
+  expect(m.drawerScrollWidth).toBe(m.drawerClientWidth);
+  expect(m.offenders).toEqual([]);
+});

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1384,9 +1384,16 @@ const SettingsDrawer: Component<Props> = (props) => {
             <Show when={activeHost().ttlOptions.length > 0}>
               <fieldset class="upload-ttl-fieldset">
                 <legend>upload retention</legend>
+                {/* #1227 — the visible "upload duration:" text was a second
+                    name for the control the legend already names, and on a
+                    phone it ate the width the select needed (the option text
+                    was cut off mid-word). The <label> stays as the row's flex
+                    box; the accessible name moves onto the select itself,
+                    because a <legend> names the GROUP and would leave the
+                    control nameless for a screen reader. */}
                 <label>
-                  upload duration:
                   <select
+                    aria-label="upload duration"
                     data-testid="upload-ttl-select"
                     value={uploadTtlSelectValue()}
                     onChange={(e) => {

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -898,6 +898,21 @@ describe("SettingsDrawer (bucket M — upload-TTL fieldset)", () => {
     expect(legend.closest("fieldset")).toHaveClass("upload-ttl-fieldset");
   });
 
+  // #1227 — the visible "upload duration:" text was a second name for a
+  // control the legend already names, and on a phone it squeezed the select
+  // off the drawer's right edge. It is the accessible name that has to
+  // survive the visual cleanup: a <legend> names the GROUP, not the control,
+  // so dropping the text without a replacement would leave the select
+  // nameless for a screen reader. Both halves are asserted here because
+  // nothing guarded either before.
+  it("drops the visible 'upload duration:' text but keeps the select's accessible name", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const select = screen.getByTestId("upload-ttl-select");
+    expect(select).toHaveAccessibleName("upload duration");
+    expect(screen.queryByText(/upload duration:/)).toBeNull();
+  });
+
   it("loads the server preference on mount", async () => {
     const orch = await import("../lib/uploadOrchestrator");
     wrap(true);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4242,10 +4242,29 @@ html.resize-dragging * {
   margin: 0;
 }
 
+/* #1228 — `min-inline-size: 0` is the load-bearing line, not decoration. A
+   <fieldset> defaults to `min-inline-size: min-content` and, unlike every
+   other box here, will NOT shrink below it. So one wide child sets a floor
+   the whole fieldset is laid out against, and every control inside — not
+   just the wide one — is rendered past the drawer's right border and cut by
+   the screen.
+   Measured on the notifications sub-page at phone width: the `mute:` <select>
+   takes its intrinsic width from its longest OPTION ("<conversation> —
+   <network>"), so one long conversation name moved it from 173px to 367px
+   against 239px of available drawer width; the fieldset's floor became 381px
+   and the sub-page spilled 142px. Proven by displacement — dropping this
+   constraint removes the overflow, restoring it brings it back, while
+   `min-width: 0` on the labels' flex children changes nothing.
+   Deliberately on the SHARED selector, not on `.notifications-fieldset`: all
+   seven drawer fieldsets carry the identical default, and none of them has a
+   reason to grow past the drawer. The other two selects are fed by constants
+   (auto-away presets) and host config (upload TTL labels) — the same bomb
+   with a longer fuse. */
 .settings-drawer fieldset {
   border: 1px solid var(--border);
   padding: 0.5rem;
   margin: 0;
+  min-inline-size: 0;
 }
 
 .settings-drawer legend {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39291,3 +39291,71 @@ drill-in (the `session_id` index exists and is still unused by any
 query), and any retention change whatsoever. If a future surface needs
 the identity rather than the event, that reopens vjt's fork; it is not
 a mechanical extension of this.
+
+---
+
+## 2026-08-11 — #1228: a drawer fieldset that will not shrink, and the control whose width is the user's data
+
+The notifications sub-page rendered past the settings drawer's right
+border on a phone — every control cut by the screen edge, not one. The
+issue was written from a screenshot and listed four candidate causes.
+Three of them are wrong, and the measurement says so: the two text
+inputs need 156px and 155px of intrinsic width (their `size` attribute
+is not the driver), the devices rows need 163px, the master toggle
+116px — against 239px of available drawer width. All of them fit.
+
+**The one box in the sub-page whose width is the USER'S DATA is the
+`mute:` `<select>`.** A `<select>` takes its intrinsic width from its
+longest OPTION, and the options are `"<conversation> — <network>"`. With
+short names it needs 173px. With one long conversation name it needs
+367px. That is the whole difference between a seeded test account and a
+real one, and it is why the defect did not reproduce until the data was
+reproduced: at default text size in a 393px viewport the sub-page has
+zero overflow and 12px of headroom, and it stays that way across every
+text size on the ladder.
+
+**The mechanism that turns one wide control into a wholly cut page is
+the `<fieldset>`.** A fieldset defaults to `min-inline-size: min-content`
+and, unlike every other box in the drawer, will not shrink below it. So
+the select's 367px became the fieldset's 381px floor, and EVERY child —
+including the ones that fit comfortably — was laid out against a box
+142px wider than the drawer. It also explains the shape of the
+screenshot: the drawer HEADER, which lives outside the fieldset, is not
+cut.
+
+Proven by displacement rather than by plausibility: dropping
+`min-inline-size` removes the overflow (`scrollWidth` 393 → 263, 25
+offending boxes → 0), restoring it brings the overflow back, and
+`min-width: 0` on the labels' flex children — the other candidate that
+survived reading the stylesheet — changes nothing in either direction.
+
+**The cure goes on the shared `.settings-drawer fieldset` rule, not on
+`.notifications-fieldset`.** A census of the drawer found seven
+fieldsets carrying the identical default; three contain a `<select>`.
+Only the mute picker is fed by user data today, but the upload-TTL
+picker is fed by host config and the auto-away picker by compile-time
+presets — the same bomb with a longer fuse, one long label away. No
+drawer fieldset has a reason to grow past the drawer, so the constraint
+is wrong for all seven, not just the one that bit. The identity
+`Network` select is the pre-existing counter-example that proves the
+shape: it is also fed by user data, and it is safe precisely because
+`.settings-identity :where(input, select)` pins it to `width: 100%`.
+
+**Known, measured, NOT fixed here.** The muted-conversations list in the
+same fieldset is a second data-driven width: `.watchlists-keyword` is
+`flex: 1` with no `min-width: 0`, so its automatic minimum size shoves
+the network badge and the unmute `×` past the drawer edge (60.8px and
+78.8px with a 32-character conversation muted). The fieldset fix cannot
+reach it — a flex item's automatic minimum is a different mechanism —
+and the reported screenshot does not show it, since that mute list was
+empty. Recorded rather than folded in: it is a different box, a
+different constraint, and not the defect that was reported.
+
+Guard: `issue1228-settings-drawer-phone-overflow.spec.ts`, on the
+@webkit iPhone project because jsdom has no layout engine and vitest is
+structurally blind to rendered geometry. It reproduces the DATA (joins a
+32-character channel so the option exists) rather than the reporter's
+device, and it carries three anti-hollow-green preconditions: the long
+option is in the select, both device rows rendered, and all five named
+controls laid out. Red before the CSS change (`scrollWidth` 393 vs
+`clientWidth` 263), green after.


### PR DESCRIPTION
Two issues from vjt's iPhone dogfood of staging, same family (the settings
drawer squeezed at phone width), one PR because they touch the same files and
stacking two would only fight in rebase. One commit each.

## #1227 — the legend already names it

The upload-retention row carried a visible `upload duration:` label beside a
fieldset whose legend already said `upload retention`. Two names for one
widget, and the redundant one ate the width the select needed — the option
text was cut mid-word.

Dropping the text alone would have been a regression for anyone not looking at
the screen: that `<label>` was what gave the select its accessible name, and a
`<legend>` names the GROUP, not the control. The name moves onto the select as
`aria-label`.

Two assertions, because neither half was guarded before: the accessible name
is exactly `upload duration`, and the visible text is gone. The red run named
the old value literally (`upload duration:`) — that is the proof the label,
not the legend, was carrying it.

The `auto-away` fieldset below has the identical shape and is deliberately
untouched, per the issue's own "not in scope".

## #1228 — measured, and the issue's candidates are mostly wrong

The issue was filed from a screenshot and says plainly that the cause was not
established. It listed four candidates. Three are refuted by measurement at
phone width, where the drawer gives 239px of usable width:

| box | intrinsic width needed |
| --- | --- |
| `only in channels` input | 156px |
| `only from nicks` input | 155px |
| devices rows | 163px |
| master toggle | 116px |
| **`mute:` select, short names** | **173px** |
| **`mute:` select, one long name** | **367px** |

The `mute:` `<select>` is the only box in the sub-page whose width comes from
the USER'S DATA — a `<select>` takes its intrinsic width from its longest
OPTION, and the options are `"<conversation> — <network>"`. That is why a
seeded account never reproduced it: the trigger is the data, not the device.
At default text size the sub-page has 12px of headroom and zero overflow, and
it stays that way across every text size on the ladder.

What turns one wide control into a wholly cut page is the `<fieldset>`: it
defaults to `min-inline-size: min-content` and will not shrink below it. The
select's 367px becomes the fieldset's 381px floor, and every child — including
the ones that fit — is laid out against a box 142px wider than the drawer. It
also explains the screenshot's shape: the drawer header, which lives outside
the fieldset, is not cut.

**Proven by displacement, not plausibility.** Dropping the constraint takes
`scrollWidth` 393 → 263 and 25 offending boxes → 0; restoring it brings them
back; `min-width: 0` on the labels' flex children — the other candidate the
stylesheet suggests — moves nothing in either direction.

**The cure is one line on the shared `.settings-drawer fieldset` rule**, not
on `.notifications-fieldset`. A census found **seven** drawer fieldsets
carrying the identical default, three of them holding a `<select>`; the cure
covers all seven. Only the mute picker is data-fed today, but the upload-TTL
picker (host config) and the auto-away picker (compile-time presets) are one
long label away from the same floor, and no drawer fieldset has a reason to
outgrow the drawer. The identity `Network` select is the pre-existing
counter-example that proves the shape — also data-fed, and safe only because
`.settings-identity :where(input, select)` already pins it to `width: 100%`.

### Measured and deliberately NOT fixed here

The muted-conversations list in the same fieldset is a **second** data-driven
width: `.watchlists-keyword` is `flex: 1` with no `min-width: 0`, so with a
32-character conversation muted its automatic minimum shoves the network badge
60.8px and the unmute `×` 78.8px past the drawer edge. The fieldset fix cannot
reach it — a flex item's automatic minimum is a different mechanism — and the
reported screenshot does not show it, because that mute list was empty.
Recorded in DESIGN_NOTES rather than folded in: different box, different
constraint, not the reported defect.

## Test plan

- [x] `bun run check` (biome + tsc + e2e tsc) green
- [x] `bun run test` — 5231 vitest tests green, including the new #1227 pair
- [x] New e2e guard RED before the CSS change (`scrollWidth` 393 vs
      `clientWidth` 263, widest box the fieldset at 380.8px overflowing by
      141.8px) and GREEN after (`scrollWidth` 263 = `clientWidth`)
- [ ] Full `scripts/integration.sh` — orchestrator's call

The guard lives on the @webkit iPhone project because jsdom has no layout
engine and vitest is structurally blind to rendered geometry. It reproduces
the DATA (joins a 32-character channel so the long option exists) rather than
the reporter's device, and it refuses to pass vacuously: the long option must
be in the select, both device rows present, and all five controls the issue
names must be laid out before any verdict is read.

Refs #1227, #1228.