### PR TITLE
cic(#1226): let the ircd's echo say you are away, in the seam

### DIFF
--- a/cicchetto/e2e/tests/issue1226-away-seam-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue1226-away-seam-feedback.spec.ts
@@ -1,0 +1,77 @@
+// #1226 — /away and its un-away twin were silent in the client. compose.ts's
+// "away" case returns `{ok: true}` (a SILENT success, ComposeBox.tsx:515), so
+// the only cue was the 💤 sidebar badge — a STATE indicator, and off-screen on
+// a phone with the sidebar collapsed. This spec pins the acknowledgement the
+// operator actually looks at: a line in the feedback seam under the compose
+// box, on BOTH transitions.
+//
+// Drives the real round-trip, exactly as #276 does for the badge: `/away
+// :reason` over the user-level Phoenix Channel → GrappaChannel.handle_in
+// ("away") → Session.set_explicit_away → `AWAY :reason` upstream → bahamut
+// replies 306 RPL_NOWAWAY → EventRouter's typed `away_confirmed` effect →
+// broadcast on Topic.user → cic's awayStatus store → the seam. Bare `/away`
+// unsets → 305 RPL_UNAWAY → away_confirmed(present) → the second line.
+//
+// The trigger is the SERVER echo, not the local push resolving (vjt's ruling,
+// 2026-08-11), which is why the assertion below is worth its fake-lag wait: a
+// seam fed by the local ack would light up even when the ircd never confirmed.
+//
+// Severity is the GREEN notice register (#356): class `compose-box-notice`,
+// `role=status`. The red `compose-box-error` MUST NOT appear — an away
+// acknowledgement is not a failure. Copy is state-ONLY (no reason echoed, no
+// tally — the #1108 precedent), pinned here against ComposeBox.tsx's
+// AWAY_SET_NOTICE / AWAY_UNSET_NOTICE.
+//
+// CLEANUP: afterEach clears away iff the badge is still up (failure path), so
+// a mid-run failure does not leave the seeded session away for the next spec.
+
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// ComposeBox.tsx AWAY_SET_NOTICE / AWAY_UNSET_NOTICE.
+const AWAY_SET_LINE = "away: you are marked as away";
+const AWAY_UNSET_LINE = "away: you are no longer away";
+
+// 60s — login + channel seed + two AWAY round-trips against the real bahamut
+// testnet (fake-lag on both echoes), with load headroom.
+test.setTimeout(60_000);
+
+test.afterEach(async ({ page }) => {
+  const badge = page.locator(".sidebar-away-badge");
+  if ((await badge.count().catch(() => 0)) > 0) {
+    await composeSend(page, "/away").catch(() => {});
+  }
+});
+
+test("#1226 — /away and un-away each render a green line in the compose seam", async ({ page }) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: specNick() });
+
+  const notice = page.locator(".compose-box-notice");
+  const error = page.locator(".compose-box-error");
+
+  // Baseline: nothing in the seam before either transition.
+  await expect(notice).toHaveCount(0);
+
+  // GOING AWAY. One assertion, not a count-then-text pair: the notice
+  // auto-dismisses after ~3s (#356), so a second poll on the same element
+  // could legitimately find it gone. `toHaveText` resolves the instant the
+  // 306 echo lands and never waits on the dismissal.
+  await composeSend(page, "/away :testing #1226 seam feedback");
+  await expect(notice).toHaveText(AWAY_SET_LINE, { timeout: 15_000 });
+  await expect(notice).toHaveAttribute("role", "status");
+  await expect(error).toHaveCount(0);
+  // The reason is NOT echoed back: state only.
+  await expect(notice).not.toContainText("testing #1226");
+
+  // COMING BACK. composeSend's own submit clears the first line on the way in
+  // (ComposeBox clears feedback at submit start), so this text can only come
+  // from the 305 echo.
+  await composeSend(page, "/away");
+  await expect(notice).toHaveText(AWAY_UNSET_LINE, { timeout: 15_000 });
+  await expect(notice).toHaveAttribute("role", "status");
+  await expect(error).toHaveCount(0);
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -1,5 +1,14 @@
-import { type Component, createMemo, createSignal, onCleanup, Show } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  Show,
+  untrack,
+} from "solid-js";
 import { isDiagEnabled } from "./DiagFloat";
+import { awayByNetwork } from "./lib/awayStatus";
 import { channelKey } from "./lib/channelKey";
 import {
   draftFramePreview,
@@ -117,6 +126,13 @@ const NOTICE_DISMISS_MS = 3_000;
 //                strings built in compose.ts, previously computed + discarded).
 type Feedback = { text: string; severity: "error" | "notice" };
 
+// #1226 — the away seam copy. State ONLY: no reason echoed back, no tally
+// (the #1108 precedent — extra detail in the seam distracts from the one
+// thing the line is there to say). Same lowercase-topic register as the
+// other notices ("notify: watching gigi").
+const AWAY_SET_NOTICE = "away: you are marked as away";
+const AWAY_UNSET_NOTICE = "away: you are no longer away";
+
 // #925 — did the pointer come up inside the box it went down on? The one
 // piece of geometry in the send button's pointer-driven activation, kept
 // pure so the abort-by-sliding-off case is decidable without touch physics.
@@ -177,6 +193,41 @@ const ComposeBox: Component<Props> = (props) => {
     }, NOTICE_DISMISS_MS);
   };
   onCleanup(clearNoticeTimer);
+
+  // #1226 — /away and its un-away twin were silent here: compose.ts's "away"
+  // case returns `{ok: true}`, a silent success, so the 💤 sidebar badge was
+  // the only cue — and on a phone, sidebar collapsed, there was none at all.
+  //
+  // The trigger is the SERVER echo, not the local push resolving: the store
+  // below is fed by `away_confirmed`, which grappa emits only on the upstream
+  // 305 RPL_UNAWAY / 306 RPL_NOWAWAY numerics. That is the ircd's truth rather
+  // than our optimism, at the cost of the fake-lag latency (vjt's ruling,
+  // 2026-08-11). It also makes this ONE path for every transition — typed
+  // /away, auto-away on a WS drop, a toggle from another device — because all
+  // three reach the client as the same event. No second branch to tell them
+  // apart, which is exactly why the automatic ones are in scope too.
+  //
+  // Fires on the FLIP only. `prevAway` remembers the slug alongside the value,
+  // so mounting into an already-away network and switching the window between
+  // an away network and a present one are both silent: the state is not news,
+  // only a change to it is.
+  let prevAway: { slug: string; away: boolean } | null = null;
+  createEffect(() => {
+    const slug = props.networkSlug;
+    const away = awayByNetwork()[slug] === true;
+    const prev = prevAway;
+    prevAway = { slug, away };
+    if (prev === null || prev.slug !== slug || prev.away === away) return;
+    // A sticky red error is NOT displaced. It is up because the operator must
+    // read it, and it got there from something THEY did; an away echo can
+    // arrive on its own, so overwriting would make a must-read error vanish
+    // while the user is doing nothing. Deliberate loss, not an oversight: an
+    // away change that lands while an error is showing is seen by nobody here
+    // — the 💤 sidebar badge remains the state surface.
+    if (untrack(feedback)?.severity === "error") return;
+    showNotice(away ? AWAY_SET_NOTICE : AWAY_UNSET_NOTICE);
+  });
+
   let pickerInput: HTMLInputElement | undefined;
   let textareaEl: HTMLTextAreaElement | undefined;
   let swipeStart: Point | null = null;

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -102,6 +102,9 @@ vi.mock("../lib/networks", () => ({
 }));
 
 import ComposeBox from "../ComposeBox";
+// #1226 — the REAL away store, not a mock: it is the production feed for the
+// seam (userTopic's `away_confirmed` arm calls exactly this setter).
+import { setAwayState } from "../lib/awayStatus";
 // Static handle on the mocked module (vi.mock is hoisted, so this IS the
 // mock). The older cases reach for it via `await import` case-by-case; the
 // #925 block asserts on `submit` in every one of its tests.
@@ -824,6 +827,74 @@ describe("ComposeBox", () => {
       await new Promise((r) => setTimeout(r, 0));
       expect(screen.queryByRole("status")).toBeNull();
       expect(screen.queryByRole("alert")).toBeNull();
+    });
+  });
+
+  // #1226 — the away seam. `/away` and its un-away twin were silent: the
+  // "away" case in compose.ts returns `{ok: true}`, a SILENT success, so the
+  // 💤 sidebar badge was the only cue — and it is off-screen on a phone.
+  //
+  // These tests drive the REAL `awayStatus` store and never go through
+  // `submit()`, because that IS the production path: the seam is fed by the
+  // server echo (`away_confirmed` → `setAwayState`, emitted only on the
+  // upstream 305/306 numerics), so an auto-away on WS drop and a toggle from
+  // another device arrive by exactly this route, with no compose action
+  // behind them. Distinct network slugs per test: the store is a module
+  // singleton and this file does not reset modules between cases.
+  describe("#1226 — away / un-away feedback seam", () => {
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+
+    it("a flip to AWAY renders a green notice, with no submit involved", async () => {
+      render(() => <ComposeBox networkSlug="net1226a" channelName="#a" />);
+      await flush();
+      expect(screen.queryByRole("status")).toBeNull();
+      setAwayState("net1226a", true);
+      const notice = await screen.findByText(/you are marked as away/i);
+      expect(notice).toHaveClass("compose-box-notice");
+      expect(notice.getAttribute("role")).toBe("status");
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(vi.mocked(compose_.submit)).not.toHaveBeenCalled();
+    });
+
+    it("a flip back to PRESENT renders the un-away notice", async () => {
+      setAwayState("net1226b", true);
+      render(() => <ComposeBox networkSlug="net1226b" channelName="#a" />);
+      await flush();
+      setAwayState("net1226b", false);
+      const notice = await screen.findByText(/you are no longer away/i);
+      expect(notice).toHaveClass("compose-box-notice");
+      expect(notice.getAttribute("role")).toBe("status");
+    });
+
+    it("mounting into an ALREADY-away network is silent — state is not news", async () => {
+      setAwayState("net1226c", true);
+      render(() => <ComposeBox networkSlug="net1226c" channelName="#a" />);
+      await flush();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("switching the window to an away network is silent — no flip on it", async () => {
+      setAwayState("net1226e", true);
+      const [slug, setSlug] = createSignal("net1226d");
+      render(() => <ComposeBox networkSlug={slug()} channelName="#a" />);
+      await flush();
+      setSlug("net1226e");
+      await flush();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("a sticky error is NOT displaced by an away flip", async () => {
+      vi.mocked(compose_.submit).mockResolvedValue({ error: "/notify: network not found" });
+      render(() => <ComposeBox networkSlug="net1226f" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      fireEvent.keyDown(ta, { key: "Enter" });
+      await screen.findByRole("alert");
+      setAwayState("net1226f", true);
+      await flush();
+      // The error the operator must read survives; the away change is lost
+      // here on purpose (the 💤 badge stays the state surface).
+      expect(screen.getByRole("alert")).toHaveTextContent(/network not found/i);
+      expect(screen.queryByText(/you are marked as away/i)).toBeNull();
     });
   });
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39359,3 +39359,55 @@ device, and it carries three anti-hollow-green preconditions: the long
 option is in the select, both device rows rendered, and all five named
 controls laid out. Red before the CSS change (`scrollWidth` 393 vs
 `clientWidth` 263), green after.
+
+---
+
+## 2026-08-11 — #1226: the away seam is driven by the ircd's echo, not our ack
+
+`/away` and its un-away twin were silent in cicchetto. The `"away"` case
+in `compose.ts` returns `{ok: true}`, which `ComposeBox` documents as
+*silent success — no seam*, so the only cue was the 💤 badge on the
+sidebar network-header row. That badge is a STATE indicator, not an
+acknowledgement, and on a phone with the sidebar collapsed there was no
+cue at all.
+
+**The trigger is the server echo.** vjt's ruling (#grappa, 2026-08-11)
+picked `away_confirmed` over the local push resolving. grappa emits that
+event only on the upstream **305 RPL_UNAWAY / 306 RPL_NOWAWAY**
+numerics, so the line the operator reads is the ircd's truth rather than
+our optimism; the cost is the fake-lag latency between typing and
+seeing, accepted deliberately. A local ack would render a confirmation
+for a command the upstream may never have confirmed — the one thing an
+acknowledgement must not do.
+
+**One path, so the un-typed transitions come for free.** Auto-away on a
+WS drop (#348) and a toggle from another device produce the same
+`away_confirmed` with no compose action behind them. Because the seam
+reads the store rather than a command result, all three transitions
+arrive by the identical route: no branch tells them apart, and the
+ruling's "fire on those too if it is simpler" is satisfied by not
+writing the branch at all. The seam fires on the FLIP only — the
+remembered value is per network slug, so mounting into an already-away
+network and switching windows between an away network and a present one
+stay silent. State is not news; a change to it is.
+
+**A sticky red error is not displaced.** An error is up because the
+operator must read it and it arrived from something they did; an away
+echo can arrive on its own. Overwriting would make a must-read error
+vanish while the user is doing nothing, so the notice yields. The
+consequence is stated rather than left implicit: an away change landing
+while an error is showing is seen by nobody in the seam, and the 💤
+badge remains the state surface for it.
+
+**Copy is state only** — no reason echoed back, no tally, per the #1108
+precedent that detail in the seam distracts from the one thing the line
+exists to say. Severity is the green notice register of #356, which
+already auto-dismisses; nothing new was added to the seam's vocabulary.
+
+**Architecturally**, this is the first thing to write `feedback()` from
+outside `doSubmit()`. The seam had rendered only synchronous command
+results, though the SURFACE was already fed by reactive state (the amber
+`SplitWarningLine` derives from the draft). Driving it from a store
+subscription is therefore an extension of what the line already does —
+notably NOT a synthesised command result, which would have put a lie
+about provenance into the one place built to be honest about it.


### PR DESCRIPTION
Refs #1226.

`/away` and its un-away twin were silent in the client: `compose.ts`'s
`"away"` case returns `{ok: true}`, which `ComposeBox` treats as a silent
success, so the 💤 sidebar badge was the only cue — a *state* indicator, and
off-screen on a phone with the sidebar collapsed.

## The four decisions, as ruled

vjt's ruling (2026-08-11) answered all four design questions on the issue, and
this implements them without reopening any:

1. **Trigger — the server echo.** The seam reads the `awayStatus` store, fed by
   `away_confirmed`, which grappa emits only on the upstream **305 RPL_UNAWAY /
   306 RPL_NOWAWAY** numerics. The line is the ircd's truth, not our optimism;
   the fake-lag latency is the accepted cost.
2. **Severity — green.** The `#356` notice register (`compose-box-notice`,
   `role=status`, auto-dismissing). Nothing new in the seam's vocabulary.
3. **Copy — state only.** `away: you are marked as away` /
   `away: you are no longer away`. No reason echoed, no tally (`#1108`).
4. **Non-typed transitions — yes, via the simpler path.** Because the seam reads
   the store rather than a command result, auto-away on a WS drop and a toggle
   from another device arrive by the identical route. There is no branch telling
   them apart, because no branch was needed.

## Shape

One `createEffect` in `ComposeBox` calling the existing `showNotice`. It fires
on the **flip** only — the remembered value is per network slug, so mounting
into an already-away network, and switching windows between an away network and
a present one, are both silent: state is not news, a change to it is.

A **sticky red error is not displaced.** An error is up because the operator
must read it and it came from something they did; an away echo can arrive on its
own, so overwriting would make a must-read error vanish while the user is doing
nothing. The consequence is written into the code rather than left implicit: an
away change that lands while an error shows is seen by nobody in the seam, and
the 💤 badge remains the state surface for it.

Architecturally this is the first writer of `feedback()` outside `doSubmit()`.
The seam had rendered only synchronous command results — though the surface was
already fed by reactive state (the amber `SplitWarningLine` derives from the
draft). It is a store subscription, deliberately **not** a synthesised command
result, which would have put a lie about provenance into the one line built to
be honest about it.

Scope held: cicchetto only, no wire and no server change.

## Test plan

- [x] `issue1226-away-seam-feedback.spec.ts` — real `/away :reason` + bare
      `/away` against the bahamut testnet, asserting the visible line on **both**
      transitions, `role=status`, no `compose-box-error`, and that the reason is
      not echoed. **Proven by displacement:** against the pre-fix bundle it fails
      with `element(s) not found` on the first seam line (`1 failed`); with the
      effect in place, `1 passed`. Both runs were full fresh stacks, so each
      served a bundle rebuilt from its own source.
- [x] `ComposeBox.test.tsx` — five cases: the two flips (red before the fix, `2
      failed | 107 passed`; green after), plus three guards that mount-while-away,
      window-switch and sticky-error-precedence stay silent.
- [x] `bun run check` (biome + tsc over `src` and `e2e`) — rc 0, warnings
      pre-existing in `default.css`, untouched here.
- [x] Full `bun run test` — 279 files, 5235 tests, rc 0.

Note for the merge: the `DESIGN_NOTES.md` entry appends at EOF, as does #1231's
— whichever lands second will want a trivial EOF resolution keeping both.