### PR TITLE
cic(#1223 p1, #1224): make the phone column drop real, and move ended sessions to their own sub-page

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1025,6 +1025,27 @@ export async function openAdminSessionsTab(page: Page): Promise<Locator> {
   return table;
 }
 
+// #1224 — the ended-sessions sub-page, reached the only way an operator can:
+// through the Sessions tab's card header. Deliberately NOT routed through
+// `openAdminSessionsTab`: that one waits on `admin-sessions-table`, which does
+// not render when the live list is empty, and an empty live list is exactly
+// when a spec is most likely to be looking for a session that is over. The
+// door itself is the barrier — it renders as soon as the tab's data loads.
+// Idempotent about how it got there: a spec that already opened the Sessions
+// tab must not be sent back through the rail launcher, which is a TOGGLE and
+// would close the pane it is standing in.
+export async function openAdminEndedSessions(page: Page): Promise<Locator> {
+  const door = page.getByTestId("admin-sessions-ended-open");
+  if ((await door.count()) === 0) {
+    await openAdminConsole(page);
+    await page.getByTestId("admin-tab-sessions").click();
+  }
+  await door.click({ timeout: 15_000 });
+  const subpage = page.getByTestId("admin-ended-sessions-page");
+  await expect(subpage).toBeVisible({ timeout: 10_000 });
+  return subpage;
+}
+
 // A row's testid suffix is the composite `<kind>:<subject_id>:<network_id>` —
 // the same string the `/admin/sessions/:id/*` verbs parse. A spec knows the
 // subject id (a minted visitor id, a seeded user id) but not the network's

--- a/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
+++ b/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
@@ -107,11 +107,19 @@ test("#1158 item 4 a deleted visitor's session survives on the ended-sessions pa
     // claim is that the page names the event it is showing.
     await expect(page.getByTestId(`admin-ended-session-event-${key}`)).not.toBeEmpty();
 
+    // PROVENANCE. Before #1224 the drill-in carried `record: session log
+    // only — the subject was deleted, the event outlived it`, and the
+    // assert on it is the one claim the move did not relocate by itself:
+    // the sub-page states it as its premise instead of per-row, but a
+    // premise nobody asserts is not covered. So it is asserted here, on a
+    // POPULATED page — the empty-state wording is pinned in the unit
+    // twin, and an empty screen cannot witness this.
+    const card = page.getByTestId("admin-ended-sessions-card");
+    await expect(card).toContainText("From the lifecycle log");
+
     // The caveat survived the move — a page named after a population
     // implies it holds all of it, and a bounded ring does not.
-    await expect(page.getByTestId("admin-ended-sessions-card")).toContainText(
-      "not evidence the session never ran",
-    );
+    await expect(card).toContainText("not evidence the session never ran");
 
     // No credential to park, no pid to stop: every verb would resolve to
     // a subject that is gone, so none is offered on either screen.

--- a/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
+++ b/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
@@ -10,11 +10,16 @@
 // `<kind>:<id>:<network>` composite the admin session rows are, which is
 // what makes the unified Sessions view able to list them.
 //
-// What this spec pins is the SURFACE contract, in the one direction the
-// product actually promises:
+// #1224 moved the SURFACE, not the property. Those rows used to sit inline
+// in the live list with a `deleted` badge and three em-dashes — `last
+// seen`, `channels` and `actions` are live-process facts, and there is
+// neither a process nor a row. vjt (2026-08-11): a sub-page of Sessions
+// with the record's own columns, no badge, and the live list strictly
+// live. So what this spec pins is now:
 //
 //     given the log remembers a session, and no subject row does,
-//     the Sessions view lists it, marks it deleted, and offers no verb.
+//     the ENDED-SESSIONS page lists it, the live list does not, and
+//     nothing anywhere offers a verb against it.
 //
 // It deliberately does NOT assert the converse. The log is a bounded
 // global ring written from an async telemetry cast on a path that
@@ -29,12 +34,12 @@
 // the admin class reaches the console, and reachability for the other
 // two is covered by `m7-admin-gate-settings-drawer.spec.ts`.
 
-import { openAdminSessionDetail, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { openAdminEndedSessions, openAdminSessionsTab } from "../fixtures/cicchettoPage";
 import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-test("#1158 item 4 a deleted visitor's session survives as a log-only row with no verbs", async ({
+test("#1158 item 4 a deleted visitor's session survives on the ended-sessions page", async ({
   page,
 }) => {
   const admin = getSeededAdmin();
@@ -81,35 +86,41 @@ test("#1158 item 4 a deleted visitor's session survives as a log-only row with n
       [admin.token, admin.subjectJson] as const,
     );
     await page.goto("/");
+
+    // #1224's half: the live list is strictly live. The table itself is
+    // the barrier — asserting absence against a tab that has not rendered
+    // would pass on an empty screen.
     await openAdminSessionsTab(page);
+    await expect(page.getByTestId(`admin-session-row-${key}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-session-gone-${key}`)).toHaveCount(0);
 
     // THE property. Without the log join this row cannot exist at all:
     // both row-backed endpoints lost the subject with the CASCADE.
-    const row = page.getByTestId(`admin-session-row-${key}`);
+    const subpage = await openAdminEndedSessions(page);
+    const row = subpage.getByTestId(`admin-ended-session-row-${key}`);
     await expect(row).toBeVisible({ timeout: 15_000 });
     await expect(row).toContainText(visitorNick);
 
-    // Marked, so it does not read as a live session that merely looks
-    // broken — the operator must be able to tell "gone" from "down".
-    await expect(page.getByTestId(`admin-session-gone-${key}`)).toBeVisible();
+    // The record's own columns, which is what the move was for. Not
+    // `logged.event`: terminating the session can append a newer
+    // lifecycle row between the barrier and the render, so the stable
+    // claim is that the page names the event it is showing.
+    await expect(page.getByTestId(`admin-ended-session-event-${key}`)).not.toBeEmpty();
+
+    // The caveat survived the move — a page named after a population
+    // implies it holds all of it, and a bounded ring does not.
+    await expect(page.getByTestId("admin-ended-sessions-card")).toContainText(
+      "not evidence the session never ran",
+    );
 
     // No credential to park, no pid to stop: every verb would resolve to
-    // a subject that is gone, so none is offered. Asserting all three
-    // matters — a single surviving button is a guaranteed failed request.
+    // a subject that is gone, so none is offered on either screen.
+    // Asserting all four matters — a single surviving button is a
+    // guaranteed failed request.
     await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-reconnect-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-delete-${key}`)).toHaveCount(0);
-
-    // The dictated shape: the row stays a summary, the record lives in
-    // the drill-in ("nei dettagli mostrare tutte le info", vjt 2026-08-11).
-    // Not `logged.event`: terminating the session can append a newer
-    // lifecycle row between the barrier and the render, so the stable
-    // claim is that the panel names the log as the record, and carries a
-    // last-event fact at all.
-    const detail = await openAdminSessionDetail(page, key);
-    await expect(detail).toContainText("session log only");
-    await expect(detail).toContainText("last event");
   } finally {
     if (!deleted) await reapVisitors(admin.token, visitor.id);
   }

--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -1,11 +1,12 @@
-// #1223 items 2 and 3 — what an admin row card does on a phone, once
-// #1157 turned rows into cards.
+// #1223 — what an admin row card does on a phone, once #1157 turned rows
+// into cards.
 //
 // vjt, dogfooding staging on an iPhone: *"abbiamo tap target solo sul testo
-// quando invece dovrebbe esser tutta l'area, parlo ad es dei nomi visitor"*.
-// Two separate defects behind that reading, both of them layout, both
-// therefore invisible to jsdom (`feedback_cicchetto_browser_smoke`) and to
-// every vitest suite that mounts these components:
+// quando invece dovrebbe esser tutta l'area, parlo ad es dei nomi visitor"*
+// and *"poi abbiamo quest'idiozia di mostrare colonne già mostrate"*.
+// Separate defects behind those readings, all of them layout, all therefore
+// invisible to jsdom (`feedback_cicchetto_browser_smoke`) and to every
+// vitest suite that mounts these components:
 //
 //   2. `.adm-row-expand` puts the 44px `--tap-min` floor on HEIGHT only and
 //      sizes its box with `inline-flex`, so the door to the row's detail is
@@ -19,11 +20,24 @@
 //      wraps timestamps over several lines. Asserted as the value track
 //      taking the panel's full width, with the label above it.
 //
-// Item 1 of the same issue (the detail panel repeating fields the card
-// already shows) is NOT in scope here: it needs a product call between
-// dropping the columns for real and dropping the panel on mobile, and it is
-// the only one of the three that changes what is on screen rather than where
-// it is.
+//   1. the detail panel repeats fields the card already shows. vjt ruled the
+//      fork on 2026-08-11 — *"1223 punto 1: direi drop no?"* — so the columns
+//      really leave the card and the panel stays the only place they live.
+//
+//      Two defects share that symptom, and only ONE of them is in this file.
+//      The `.adm-col-detail` specificity failure (Users, Credentials) is a
+//      question about what is PAINTED, invisible to jsdom, so it is asserted
+//      here. The Sessions repeat is JSX — `detailFacts` carried a `network`
+//      fact while the identity cell printed the slug at every width, desktop
+//      included — which vitest sees perfectly well and
+//      `AdminSessionsTab.test.tsx` pins. Bringing it here too would buy a
+//      slower copy of a test that already exists.
+//
+//      Also asserted here: the 769-899 BAND. The console's card regime starts
+//      at 900px and `isMobile()` is 768px, so a fix that only raised the CSS
+//      selector would have made that band strictly worse — columns gone,
+//      `AdminRowName` still a plain span, no door to the panel they went
+//      into. That is a real-browser claim as much as the drop is.
 //
 // The desktop test is the counter-claim, and it is why item 3's fix is a
 // `@container` rule rather than a blanket single column: at a width where two
@@ -62,6 +76,25 @@ async function openSessionsTab(page: Page): Promise<void> {
   await openAdminConsole(page);
   await page.getByTestId("admin-tab-sessions").click();
   await expect(page.getByTestId("admin-sessions-table")).toBeVisible({ timeout: 10_000 });
+}
+
+async function openUsersTab(page: Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-users").click();
+  await expect(page.getByTestId("admin-users-table")).toBeVisible({ timeout: 10_000 });
+}
+
+// The card's cells that are actually PAINTED. `getClientRects()` rather than
+// a computed-style read: a `display: none` cell has no boxes, which is the
+// property under test, and it costs nothing on WebKit (where reading computed
+// style has bitten this suite before).
+async function paintedCellTexts(row: Locator): Promise<string[]> {
+  return row.locator("td").evaluateAll((tds) =>
+    tds
+      .filter((td) => td.getClientRects().length > 0)
+      .map((td) => (td.textContent ?? "").trim())
+      .filter((text) => text !== ""),
+  );
 }
 
 type Box = { x: number; y: number; width: number; height: number };
@@ -186,4 +219,84 @@ test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
   } finally {
     await reapVisitors(admin.token, visitor.id);
   }
+});
+
+// Item 1, the half only a browser can see. The panel's subtitle promises
+// "the columns the table drops on a phone", and until #1223 it was the one
+// thing on screen that was false: `.adm-col-detail { display: none }` is
+// (0,1,0) and lost to the `.adm-table td` stacking rule (0,1,1), so every
+// dropped column came back as a labelled line of the card and the panel
+// underneath said it a second time.
+//
+// The oracle is the report itself — no value may be on the card AND in the
+// panel — rather than a check that a particular selector is hidden: that is
+// the property vjt read off the screen, and it survives the next tab growing
+// a column.
+test("#1223 @webkit on a phone no field is on the card and in the panel at once", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
+
+  await adminLogin(page);
+  await openUsersTab(page);
+
+  const row = page.getByTestId(`admin-user-row-${adminId}`);
+  await row.scrollIntoViewIfNeeded();
+  await expect(row).toBeVisible();
+
+  const panel = page.getByTestId(`admin-user-detail-${adminId}`);
+  await expect(panel).toHaveCount(0);
+  await page.getByTestId(`admin-user-details-${adminId}`).tap();
+  await expect(panel).toBeVisible({ timeout: 5_000 });
+
+  const cardValues = await paintedCellTexts(row);
+  const factValues = (await panel.locator("dd").allTextContents())
+    .map((t) => t.trim())
+    .filter((t) => t !== "");
+
+  // Non-vacuity, both sides: an empty card or an empty panel would make the
+  // intersection trivially empty and the test a mirror.
+  expect(cardValues.length, "the row card must still show something").toBeGreaterThan(0);
+  expect(factValues.length, "the panel must carry the dropped columns").toBeGreaterThan(0);
+
+  expect(
+    factValues.filter((value) => cardValues.includes(value)),
+    `values printed twice — card ${JSON.stringify(cardValues)}, panel ${JSON.stringify(factValues)}`,
+  ).toEqual([]);
+});
+
+// The band the console's two breakpoints leave between them. 820px is a
+// portrait iPad: the CSS has already turned the table into cards and taken
+// the secondary columns away, and `isMobile()` — 768px — says desktop.
+test.describe("#1223 the 769-899 band", () => {
+  test.use({ viewport: { width: 820, height: 1180 } });
+
+  test("#1223 the columns leave and the door to their panel is there", async ({ page }) => {
+    const admin = getSeededAdmin();
+    const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
+
+    await adminLogin(page);
+    await openUsersTab(page);
+
+    const row = page.getByTestId(`admin-user-row-${adminId}`);
+    await expect(row).toBeVisible();
+
+    // Gone from the card: this is the width at which the drop applies.
+    const dropped = row.locator("td.adm-col-detail");
+    expect(await dropped.count(), "the secondary cells must still be in the DOM").toBeGreaterThan(
+      0,
+    );
+    for (let i = 0; i < (await dropped.count()); i++) {
+      await expect(dropped.nth(i)).toBeHidden();
+    }
+
+    // And reachable: the disclosure has to exist wherever the columns leave,
+    // or this band is where the record becomes unreadable.
+    await page.getByTestId(`admin-user-details-${adminId}`).click();
+    const panel = page.getByTestId(`admin-user-detail-${adminId}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    await expect(panel).toContainText("live sessions");
+    await expect(panel).toContainText("inserted");
+  });
 });

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -92,9 +92,11 @@ test("M-8 admin deletes a minted visitor from the unified Sessions view (inline 
     //
     // #1158 item 4 changed what that looks like on screen, not what the
     // verb does. The identity is still destroyed — but `session_log_events`
-    // has no FK to the subject, so a row can SURVIVE the CASCADE as the
-    // log-only class: badged "deleted", no DB state, no verbs. Counting
-    // rows would now assert the pre-item-4 world.
+    // has no FK to the subject, so the session can SURVIVE the CASCADE as
+    // the log-only class: no DB state, no pid, no verbs. (#1224 then moved
+    // that class off this list onto the ended-sessions sub-page, which is
+    // one more reason not to count rows here: the count now depends on a
+    // screen this spec is not looking at.)
     //
     // So the identity-wide property moves onto the verbs. `rowActions`
     // gives a credential-backed visitor row exactly one of Disconnect /

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -23,7 +23,8 @@
 // not exist any more.
 //
 // The replacement is a claim no relocation of the scroller can satisfy: at
-// 393px, on EVERY tab, no scroll container inside the admin pane may have
+// 393px, on EVERY surface (#1224 — tabs AND the sub-pages that open from
+// inside one), no scroll container inside the admin pane may have
 // `scrollWidth > clientWidth`. Moving `overflow-x` one level in or out —
 // the exact trap the deleted CSS comment documented, and the thing #1074
 // did — fails it, because the offender is reported wherever it lands.
@@ -52,16 +53,14 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 
-// Every tab AdminPane mounts (`TABS` in AdminPane.tsx). The pan is a
-// property of the pane, not of the three tabs that happened to have tables
-// when this spec was written, so the oracle visits all of them.
+// Every tab AdminPane mounts (`TABS` in AdminPane.tsx).
 const ADMIN_TABS = [
   "sessions",
   "events",
@@ -78,10 +77,89 @@ const ADMIN_TABS = [
   "debug",
 ] as const;
 
+// #1224 — the width oracle enumerates SURFACES, not tabs.
+//
+// This comment used to say "the pan is a property of the pane, not of the
+// three tabs that happened to have tables" and then loop the tab list. Both
+// halves were true when written and the second stopped being true: a tab is
+// not the only thing the pane shows. `AdminUsersTab` has opened
+// `AdminUserPage` from inside the Users panel since #1158 (which is where
+// the Credentials tab went), and #1224 added the ended-sessions page behind
+// the Sessions card header. Two full-pane surfaces with tables, at 393px,
+// that a loop over `ADMIN_TABS` structurally cannot reach — the guard had
+// quietly become a list of the places that existed when it was written.
+//
+// So the list of TABS stays (it is what the touch-action tests below are
+// about — `#admin-tab-<key>` is a real element with a real CSS contract),
+// and the width claim moves onto this list of surfaces instead.
+//
+// 🔴 Why the sub-page half is still hand-written, and what would fix it.
+// A surface is discoverable once you are ON it — both sub-pages render
+// `.adm-subpage-head`. A DOOR is not: `admin-sessions-ended-open` is a
+// static testid on a card-header button, `admin-user-networks-<id>` is a
+// per-row button in an actions cell, they share no convention, and the
+// cells they sit in also hold Delete. There is nothing a crawl could press
+// safely and nothing a selector could match honestly. Giving every door one
+// marker attribute would make this list derive itself; until then the
+// completeness assertion below covers the TAB half automatically, and a new
+// sub-page needs a line here. That is a real gap, stated rather than
+// papered over — a comment that claims coverage it does not have is exactly
+// how this one went stale.
+type Surface = {
+  name: string;
+  open: (page: Page) => Promise<void>;
+};
+
+async function openTab(page: Page, tab: string): Promise<void> {
+  await page.getByTestId(`admin-tab-${tab}`).tap();
+  await expect(page.locator(`#admin-tab-${tab}`)).toBeVisible({ timeout: 10_000 });
+}
+
+// Takes the subject's id because the user page is per-user and only one
+// user will do: its networks TABLE renders under `mine().length > 0`, and
+// the seeded `admin-vjt` — which `.first()` reaches, being row one — has no
+// IRC bind, so it shows the empty state and the surface would be measured
+// with nothing on it. `vjt` has the bind. Measured, not assumed: `.first()`
+// is what the first run of this extension did, and the barrier caught it.
+function adminSurfaces(vjtUserId: string): Surface[] {
+  return [
+    ...ADMIN_TABS.map((tab) => ({
+      name: `tab:${tab}`,
+      open: (page: Page) => openTab(page, tab),
+    })),
+    {
+      name: "subpage:ended-sessions",
+      open: async (page: Page) => {
+        await openTab(page, "sessions");
+        await page.getByTestId("admin-sessions-ended-open").tap();
+        await expect(page.getByTestId("admin-ended-sessions-page")).toBeVisible({
+          timeout: 10_000,
+        });
+        // Anti-hollow-green: measure a POPULATED page or fail here. An
+        // empty-state card cannot overflow and would pass on nothing.
+        await expect(page.getByTestId("admin-ended-sessions-table")).toBeVisible({
+          timeout: 10_000,
+        });
+      },
+    },
+    {
+      name: "subpage:user-page",
+      open: async (page: Page) => {
+        await openTab(page, "users");
+        await page.getByTestId(`admin-user-networks-${vjtUserId}`).tap();
+        await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
+        await expect(page.getByTestId("admin-user-networks-table")).toBeVisible({
+          timeout: 10_000,
+        });
+      },
+    },
+  ];
+}
+
 test.setTimeout(180_000);
 
 type Offender = {
-  tab: string;
+  surface: string;
   tag: string;
   testId: string | null;
   cls: string;
@@ -145,6 +223,28 @@ async function createSeedVhost(adminToken: string): Promise<number | null> {
   return ((await res.json()) as { id: number }).id;
 }
 
+// A row on the ended-sessions sub-page. The only thing that puts one there
+// is a session the lifecycle log remembers whose subject no longer exists
+// (#1158 item 4), so this mints a visitor, waits for the sink to write its
+// row, then destroys the identity — the same arrange `issue1158-item4` uses.
+// No teardown: the subject is already gone, and the log row is the point.
+async function seedEndedSession(adminToken: string): Promise<void> {
+  const visitor = await mintVisitor(`ux6g-ended-${Date.now()}`);
+  const prefix = `visitor:${visitor.id}:`;
+  await expect
+    .poll(
+      async () =>
+        (await listSessionLogSessions(adminToken)).filter((e) => e.session_id.startsWith(prefix))
+          .length,
+      {
+        timeout: 20_000,
+        message: `precondition: session_log never recorded ${prefix}* — the ended-sessions surface cannot be populated, so measuring it would prove nothing`,
+      },
+    )
+    .toBeGreaterThan(0);
+  await reapVisitors(adminToken, visitor.id);
+}
+
 async function deleteSeedVhost(adminToken: string, id: number | null): Promise<void> {
   if (id === null) return;
   await fetch(`${GRAPPA_BASE_URL}/admin/vhosts/${id}`, {
@@ -185,26 +285,38 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
   }
 
-  test("@webkit admin on mobile — no tab can be panned sideways", async ({ page }) => {
+  test("@webkit admin on mobile — no surface can be panned sideways", async ({ page }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`ux6g-${Date.now()}`);
     let vhostId: number | null = null;
 
     try {
       vhostId = await createSeedVhost(admin.token);
+      // A row on the ended-sessions sub-page, by the only route that makes
+      // one: a session the log remembers whose subject is gone. Without it
+      // that surface renders an empty-state card and measuring it would be
+      // the very "an empty tab cannot overflow" pass this spec was rewritten
+      // to stop doing.
+      await seedEndedSession(admin.token);
       await openAdminPane(page);
+
+      // The TAB half of the surface list maintains itself: a tab added to
+      // `TABS` without a line here fails on the count rather than going
+      // unmeasured. The sub-page half cannot (see the note on `Surface`).
+      await expect(
+        page.getByTestId("admin-pane").locator("[role='tab']"),
+        "a tab exists that the surface list does not name — add it to ADMIN_TABS",
+      ).toHaveCount(ADMIN_TABS.length);
 
       const offenders: Offender[] = [];
 
-      for (const tab of ADMIN_TABS) {
-        await page.getByTestId(`admin-tab-${tab}`).tap();
-        const panel = page.locator(`#admin-tab-${tab}`);
-        await expect(panel).toBeVisible({ timeout: 10_000 });
+      for (const surface of adminSurfaces(vjtUserId)) {
+        await surface.open(page);
 
         // The pane, not just the panel: the pre-#1157 arrangement made the
         // PANEL the scroller, and a future one could push it further out.
         const found = await page.getByTestId("admin-pane").evaluate((root) => {
-          const out: Omit<Offender, "tab">[] = [];
+          const out: Omit<Offender, "surface">[] = [];
           const consider = (el: Element): void => {
             // NAMED EXEMPTION, not a filter that makes the red go away.
             // `.adm-nav` is the tab strip: nine chips, `overflow-x: auto`
@@ -232,12 +344,12 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
           return out;
         });
 
-        offenders.push(...found.map((o) => ({ ...o, tab })));
+        offenders.push(...found.map((o) => ({ ...o, surface: surface.name })));
       }
 
       expect(
         offenders,
-        `nothing in the admin pane may be pannable at 393px, on any tab — ` +
+        `nothing in the admin pane may be pannable at 393px, on any surface — ` +
           `offenders: ${JSON.stringify(offenders, null, 2)}`,
       ).toEqual([]);
     } finally {

--- a/cicchetto/src/AdminEndedSessionsPage.tsx
+++ b/cicchetto/src/AdminEndedSessionsPage.tsx
@@ -1,0 +1,163 @@
+import { type Component, For, Show } from "solid-js";
+import AdminBadge from "./admin/AdminBadge";
+import AdminCard from "./admin/AdminCard";
+import { AdminEmpty } from "./admin/AdminStatus";
+import AdminTable from "./admin/AdminTable";
+import { formatInstant } from "./admin/formatInstant";
+import { renderDuration, renderReason } from "./admin/sessionLogFormat";
+import type { EndedSessionRow } from "./lib/adminSubjectRows";
+
+// #1224 — sessions that are over, on their own page, with their own
+// columns.
+//
+// vjt, same iPhone dogfood pass as #1223: *"i visitor deleted son utili
+// ma vanno su sotto pagina con campi diversi perché son sempre
+// offline"*. These rows exist because `session_log_events` carries no FK
+// to the subject and outlived the CASCADE (#1158 item 4), so there is no
+// process and no DB row behind them — and three of the four columns the
+// live list dictates (`last seen`, `channels`, `actions`) were an
+// em-dash on every one of them, structurally and forever. The list was
+// paying full column width for fields that can never be populated.
+//
+// vjt's three rulings (2026-08-11):
+//   1. a SUB-PAGE of Sessions, not a sixth tab — the tab strip already
+//      overflows and scrolls on a phone;
+//   2. no `deleted` badge: once these move out, Sessions is strictly
+//      live and has nothing to mark;
+//   3. the ring caveat is not a blocker — but it is still true, so it
+//      travels with the page (see the subtitle).
+//
+// Built with #1223 item 1 already applied, as the issue asks: the
+// columns here are the ones the record actually has, no detail panel
+// repeats them, and nothing is dropped at any width — five short fields
+// stack into a card without needing a disclosure to get them back.
+//
+// The rows are PASSED IN, not re-fetched. They come out of the same five
+// endpoints the tab already merged, on the same composite key; fetching
+// again would show a second snapshot of a list the operator reached from
+// the first one.
+//
+// The identity block reuses the live list's `.admin-session-*` classes
+// on purpose: it is the same two-line shape vjt dictated for Sessions
+// (2026-08-09) and this page is one of its screens, not another tab.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
+
+export type Props = {
+  rows: EndedSessionRow[];
+  onBack: () => void;
+};
+
+const AdminEndedSessionsPage: Component<Props> = (props) => (
+  <div class="admin-ended-sessions-page" data-testid="admin-ended-sessions-page">
+    <div class="adm-scroll">
+      <header class="adm-subpage-head">
+        <button
+          type="button"
+          class="adm-btn"
+          onClick={props.onBack}
+          aria-label="back to the sessions list"
+          data-testid="admin-ended-sessions-back"
+        >
+          ← Sessions
+        </button>
+        <h2 class="adm-card-title">Ended sessions</h2>
+      </header>
+
+      <AdminCard
+        title="From the lifecycle log"
+        // The caveat had to survive the move, and it matters MORE here
+        // than it did as a badge on an inline row: a page named after a
+        // population implies it holds all of it. It does not — the ring
+        // is bounded, pruned on write and fed by an async cast from a
+        // path that includes `terminate/2`.
+        subtitle="a bounded, best-effort ring — an absent row is not evidence the session never ran, and a last event that is not a disconnect means the log never saw the end"
+        data-testid="admin-ended-sessions-card"
+      >
+        <Show
+          when={props.rows.length > 0}
+          fallback={
+            <AdminEmpty
+              message="the log remembers no session whose subject is gone"
+              testId="admin-ended-sessions-empty"
+            />
+          }
+        >
+          <AdminTable data-testid="admin-ended-sessions-table">
+            <thead>
+              <tr>
+                <th class="adm-table-grow">who</th>
+                <th>last event</th>
+                <th>at</th>
+                <th>lasted</th>
+                <th>how</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={props.rows}>
+                {(row) => (
+                  <tr
+                    class="admin-ended-session-row"
+                    data-testid={`admin-ended-session-row-${row.key}`}
+                  >
+                    {/* No `.admin-session-who`: that class exists only to
+                        give the live list's disclosure its two-line flex
+                        shape, and there is no disclosure here. */}
+                    <td class="adm-cell-title">
+                      <span class="admin-session-lines">
+                        <span class="admin-session-identity">
+                          <AdminBadge
+                            tone={row.subject_kind === "user" ? "info" : "neutral"}
+                            class="adm-badge--kind"
+                            ariaLabel={row.subject_kind}
+                          >
+                            {row.subject_kind}
+                          </AdminBadge>
+                          <span class="admin-session-nick">{renderLabel(row)}</span>
+                        </span>
+                        <span class="admin-session-network">
+                          {row.network_slug ?? `network ${row.network_id}`}
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      data-label="last event"
+                      data-testid={`admin-ended-session-event-${row.key}`}
+                    >
+                      {row.last_event.event}
+                    </td>
+                    <td data-label="at">{formatInstant(row.last_event.at)}</td>
+                    <td data-label="lasted">{renderLasted(row)}</td>
+                    <td data-label="how">{renderHow(row)}</td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </AdminTable>
+        </Show>
+      </AdminCard>
+    </div>
+  </div>
+);
+
+// The log records the nick the session answered to. `null` means it was
+// written before the session had one — say which rather than blanking,
+// the same reading the live list gives an unlabelled row.
+function renderLabel(row: EndedSessionRow): string {
+  if (row.label !== null) return row.label;
+  return `${row.subject_id.slice(0, 8)} (no nick logged)`;
+}
+
+// Only a disconnect carries a duration. An em-dash here is not the
+// structurally-empty cell #1224 is about: it says the log's last word on
+// this session was something other than its end.
+function renderLasted(row: EndedSessionRow): string {
+  const ms = row.last_event.duration_ms;
+  return ms === null ? "—" : renderDuration(ms);
+}
+
+function renderHow(row: EndedSessionRow): string {
+  return row.last_event.event === "disconnected" ? renderReason(row.last_event) : "—";
+}
+
+export default AdminEndedSessionsPage;

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -31,7 +31,7 @@ import {
   adminUpdateServer,
 } from "./lib/api";
 import { token } from "./lib/auth";
-import { isMobile } from "./lib/theme";
+import { isAdminNarrow } from "./lib/theme";
 
 // M-cluster M-10 — Networks admin tab. Operator surface for the
 // admission caps + circuit-breaker recovery + on-demand visitor reap.
@@ -206,9 +206,15 @@ const AdminNetworksTab: Component = () => {
   // the row is right there, and a network deleted by another admin
   // takes its own panel with it.
 
-  // Column count for the detail row's `colspan`. On a phone the six
-  // secondary columns are gone, so the row is slug + actions.
-  const networkColumns = (): number => (isMobile() ? 2 : NETWORK_COLUMNS);
+  // Column count for the detail row's `colspan`. Below the console's
+  // breakpoint the six secondary columns are gone, so the row is slug +
+  // actions.
+  //
+  // #1223 — the gate is `isAdminNarrow()` (899px), not `isMobile()`
+  // (768px): the split has to agree with the CSS that stacks the table,
+  // or the 769-899 band gets a card whose columns are still inline while
+  // every other tab has already moved them into the panel.
+  const networkColumns = (): number => (isAdminNarrow() ? 2 : NETWORK_COLUMNS);
 
   // The two cells that move between the row and the detail depending on
   // width. ONE definition each: the cap editor is a live control, and a
@@ -691,7 +697,7 @@ const AdminNetworksTab: Component = () => {
                       EDITORS, and the detail has to render the control
                       itself, not a copy of its value. Two live controls
                       with one test id is not a layout, it is a bug. */}
-                  <Show when={!isMobile()}>
+                  <Show when={!isAdminNarrow()}>
                     <th>visitors (live/cap)</th>
                     <th>max visitor sessions</th>
                     <th>users (live/cap)</th>
@@ -720,7 +726,7 @@ const AdminNetworksTab: Component = () => {
                             {expandedNetworkId() === net.id ? "▾" : "▸"} {net.slug}
                           </button>
                         </td>
-                        <Show when={!isMobile()}>
+                        <Show when={!isAdminNarrow()}>
                           <td data-label="visitors">{liveCount(net, "visitors")}</td>
                           <td data-label="max visitors">
                             {capEditor(net, "max_concurrent_visitor_sessions")}
@@ -785,7 +791,7 @@ const AdminNetworksTab: Component = () => {
                               there is no read-only copy of them anywhere,
                               so editing a cap stays possible on a phone
                               and Save stays up on the row. */}
-                          <Show when={isMobile()}>
+                          <Show when={isAdminNarrow()}>
                             <AdminFacts
                               facts={[
                                 {

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -533,7 +533,14 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     // would erase it.
     { label: "connection", value: row.connection_state ?? "no DB row" },
     { label: "live", value: renderLive(row) },
-    { label: "network", value: row.network_slug ?? `id ${row.network_id}` },
+    // NO `network` fact. #1223 item 1 reported the panel repeating it,
+    // and unlike the Users/Credentials repeats this one is not the
+    // `.adm-col-detail` specificity defect: Sessions drops no column at
+    // any width, and `.admin-session-network` prints the slug under the
+    // nick on DESKTOP too. Two defects, one symptom — raising the CSS
+    // selector would not have touched this one, and the second line of
+    // the identity block is dictated (vjt, 2026-08-09), so the panel is
+    // the copy that goes.
     { label: "upstream", value: renderUpstream(row) },
     // #1158 item 4 — the third source, and the only one that says
     // anything at all about a session that is over.

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -1,4 +1,5 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
+import AdminEndedSessionsPage from "./AdminEndedSessionsPage";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
 import AdminDetailPanel from "./admin/AdminDetailPanel";
@@ -7,11 +8,14 @@ import AdminRowName from "./admin/AdminRowName";
 import { AdminEmpty, AdminError } from "./admin/AdminStatus";
 import AdminTable from "./admin/AdminTable";
 import { useRefreshSlot } from "./admin/refreshSlot";
+import { renderEnded } from "./admin/sessionLogFormat";
 import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  endedSessions,
+  liveSessions,
   rowActions,
 } from "./lib/adminSubjectRows";
 import {
@@ -65,9 +69,14 @@ import { token } from "./lib/auth";
 // is the row key, so it both fills in "what did this session last do"
 // and supplies rows for subjects that no longer exist.
 //
-// The log is a bounded ring, so those rows are RECENT history, not an
-// archive, and the card subtitle says so rather than letting the table
-// imply completeness.
+// #1224 — and those log-only rows are no longer IN this list. They were
+// carrying a `deleted` badge and three em-dashes, because `last seen`,
+// `channels` and `actions` are live-process facts and there is neither a
+// process nor a row. vjt's ruling (2026-08-11): they move to a sub-page
+// of Sessions with columns the record actually has, no badge, and this
+// list becomes strictly live. The merge is unchanged — one row set, one
+// composite key, the log still enriching a live row's drill-down — and
+// `liveSessions`/`endedSessions` partition it for the two screens.
 //
 // Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
 
@@ -107,6 +116,10 @@ const AdminSessionsTab: Component = () => {
   const [logSessions, setLogSessions] = createSignal<AdminSessionLogEntry[] | null>(null);
   const [confirmingKey, setConfirmingKey] = createSignal<string | null>(null);
   const [detailKey, setDetailKey] = createSignal<string | null>(null);
+  // #1224 — the sub-page is open, or the list is. Same shape as the Users
+  // tab's drill-in to `AdminUserPage`, and deliberately not a route: the
+  // admin console has none.
+  const [endedOpen, setEndedOpen] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
 
@@ -124,6 +137,9 @@ const AdminSessionsTab: Component = () => {
         })
       : [],
   );
+
+  const live = createMemo<AdminSubjectRow[]>(() => liveSessions(rows()));
+  const ended = createMemo(() => endedSessions(rows()));
 
   const refresh = async (): Promise<void> => {
     const t = token();
@@ -226,98 +242,129 @@ const AdminSessionsTab: Component = () => {
 
   return (
     <div class="admin-sessions-tab">
-      <div class="adm-scroll">
-        <Show when={error() !== null}>
-          <AdminError message={error() ?? ""} testId="admin-sessions-error" />
-        </Show>
+      <Show when={endedOpen()}>
+        <AdminEndedSessionsPage rows={ended()} onBack={() => setEndedOpen(false)} />
+      </Show>
 
-        <Show when={networks() !== null && (networks() ?? []).length > 0}>
-          <AdminCard
-            title="Capacity per network"
-            subtitle="live_counts from the Registry — the same projection the admission policy uses"
-            data-testid="admin-sessions-network-summary"
-          >
-            <AdminTable data-testid="admin-sessions-summary-table">
-              <thead>
-                <tr>
-                  <th>network</th>
-                  <th>visitors</th>
-                  <th>users</th>
-                  <th>per-IP cap</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={networks() ?? []}>
-                  {(net) => (
-                    <tr
-                      class="admin-sessions-summary-row"
-                      data-testid={`admin-sessions-summary-row-${net.slug}`}
-                    >
-                      <td class="adm-cell-title">{net.slug}</td>
-                      <td
-                        data-label="visitors"
-                        data-testid={`admin-sessions-summary-visitors-${net.slug}`}
+      <Show when={!endedOpen()}>
+        <div class="adm-scroll">
+          <Show when={error() !== null}>
+            <AdminError message={error() ?? ""} testId="admin-sessions-error" />
+          </Show>
+
+          <Show when={networks() !== null && (networks() ?? []).length > 0}>
+            <AdminCard
+              title="Capacity per network"
+              subtitle="live_counts from the Registry — the same projection the admission policy uses"
+              data-testid="admin-sessions-network-summary"
+            >
+              <AdminTable data-testid="admin-sessions-summary-table">
+                <thead>
+                  <tr>
+                    <th>network</th>
+                    <th>visitors</th>
+                    <th>users</th>
+                    <th>per-IP cap</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={networks() ?? []}>
+                    {(net) => (
+                      <tr
+                        class="admin-sessions-summary-row"
+                        data-testid={`admin-sessions-summary-row-${net.slug}`}
                       >
-                        {net.live_counts.visitors}/{renderCap(net.max_concurrent_visitor_sessions)}
-                      </td>
-                      <td
-                        data-label="users"
-                        data-testid={`admin-sessions-summary-users-${net.slug}`}
-                      >
-                        {net.live_counts.users}/{renderCap(net.max_concurrent_user_sessions)}
-                      </td>
-                      <td
-                        data-label="per-ip"
-                        data-testid={`admin-sessions-summary-per-ip-${net.slug}`}
-                      >
-                        {renderCap(net.max_per_ip)}
-                      </td>
+                        <td class="adm-cell-title">{net.slug}</td>
+                        <td
+                          data-label="visitors"
+                          data-testid={`admin-sessions-summary-visitors-${net.slug}`}
+                        >
+                          {net.live_counts.visitors}/
+                          {renderCap(net.max_concurrent_visitor_sessions)}
+                        </td>
+                        <td
+                          data-label="users"
+                          data-testid={`admin-sessions-summary-users-${net.slug}`}
+                        >
+                          {net.live_counts.users}/{renderCap(net.max_concurrent_user_sessions)}
+                        </td>
+                        <td
+                          data-label="per-ip"
+                          data-testid={`admin-sessions-summary-per-ip-${net.slug}`}
+                        >
+                          {renderCap(net.max_per_ip)}
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </AdminTable>
+            </AdminCard>
+          </Show>
+
+          <Show when={!loaded() && error() === null}>
+            <AdminEmpty message="loading…" />
+          </Show>
+
+          {/* #1224 — the card renders whenever the data loaded, empty list
+            or not, and the empty state sits INSIDE it. The door to the
+            ended sessions lives in this header, and a live list that
+            happens to be empty is exactly when the operator most needs
+            it: gating the card on the row count would take the door away
+            with the rows. */}
+          <Show when={loaded()}>
+            <AdminCard
+              hostsRefresh
+              title="Sessions"
+              subtitle="row-backed and strictly live — parked and failed subjects are listed too, with live state joined on"
+              actions={
+                <button
+                  type="button"
+                  class="adm-btn"
+                  onClick={() => setEndedOpen(true)}
+                  data-testid="admin-sessions-ended-open"
+                >
+                  Ended sessions ({ended().length})
+                </button>
+              }
+              data-testid="admin-sessions-table-card"
+            >
+              <Show
+                when={live().length > 0}
+                fallback={
+                  // "live", not "no sessions": the log may well remember
+                  // sessions that ended, and they are one tap away.
+                  <AdminEmpty message="no live sessions" testId="admin-sessions-empty" />
+                }
+              >
+                <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
+                  <thead>
+                    <tr>
+                      <th class="adm-table-grow">who</th>
+                      <th>last seen</th>
+                      <th>channels</th>
+                      <th class="adm-table-sticky-actions">actions</th>
                     </tr>
-                  )}
-                </For>
-              </tbody>
-            </AdminTable>
-          </AdminCard>
-        </Show>
-
-        <Show when={!loaded() && error() === null}>
-          <AdminEmpty message="loading…" />
-        </Show>
-
-        <Show when={loaded() && rows().length === 0}>
-          <AdminEmpty message="no sessions" testId="admin-sessions-empty" />
-        </Show>
-
-        <Show when={loaded() && rows().length > 0}>
-          <AdminCard
-            hostsRefresh
-            title="Sessions"
-            subtitle="row-backed — parked and failed subjects are listed too, with live state joined on; rows marked deleted come from the lifecycle log, which keeps recent history only"
-            data-testid="admin-sessions-table-card"
-          >
-            <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
-              <thead>
-                <tr>
-                  <th class="adm-table-grow">who</th>
-                  <th>last seen</th>
-                  <th>channels</th>
-                  <th class="adm-table-sticky-actions">actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={rows()}>
-                  {(row) => (
-                    <>
-                      <tr class="admin-sessions-row" data-testid={`admin-session-row-${row.key}`}>
-                        <td class="admin-session-who adm-cell-title">
-                          <AdminRowName
-                            alwaysOpenable
-                            open={detailKey() === row.key}
-                            onToggle={() => setDetailKey(detailKey() === row.key ? null : row.key)}
-                            label={`details for ${renderWho(row)}`}
-                            testId={`admin-session-details-${row.key}`}
+                  </thead>
+                  <tbody>
+                    <For each={live()}>
+                      {(row) => (
+                        <>
+                          <tr
+                            class="admin-sessions-row"
+                            data-testid={`admin-session-row-${row.key}`}
                           >
-                            {/* The two dictated lines are ONE block beside the
+                            <td class="admin-session-who adm-cell-title">
+                              <AdminRowName
+                                alwaysOpenable
+                                open={detailKey() === row.key}
+                                onToggle={() =>
+                                  setDetailKey(detailKey() === row.key ? null : row.key)
+                                }
+                                label={`details for ${renderWho(row)}`}
+                                testId={`admin-session-details-${row.key}`}
+                              >
+                                {/* The two dictated lines are ONE block beside the
                                 caret, not two siblings of it. Left as siblings
                                 they are flex items of `.adm-row-expand`, and
                                 the second line can only be produced by letting
@@ -327,126 +374,124 @@ const AdminSessionsTab: Component = () => {
                                 line, losing the caret's indent and breaking the
                                 alignment the fixed-width badge exists to
                                 create. Measured at 16px of drift. */}
-                            <span class="admin-session-lines">
-                              <span class="admin-session-identity">
-                                {/* Fixed-width kind badge: "visitor" and
+                                <span class="admin-session-lines">
+                                  <span class="admin-session-identity">
+                                    {/* Fixed-width kind badge: "visitor" and
                                     "user" are different lengths, and an
                                     unpadded pair makes every nick start at
                                     a different x. */}
-                                <AdminBadge
-                                  tone={row.subject_kind === "user" ? "info" : "neutral"}
-                                  class="adm-badge--kind"
-                                  ariaLabel={row.subject_kind}
-                                >
-                                  {row.subject_kind}
-                                </AdminBadge>
-                                <span class="admin-session-nick">{renderLabel(row)}</span>
-                                {/* #1158 item 4 — this row exists only
-                                    because the lifecycle log outlived the
-                                    subject. Say so on the row itself: it
-                                    has no state to read and no verb to
-                                    press, and without the marker it reads
-                                    as a session that merely looks broken. */}
-                                <Show when={row.origin === "session_log"}>
-                                  <AdminBadge
-                                    tone="warn"
-                                    ariaLabel="subject deleted, session log only"
-                                    testId={`admin-session-gone-${row.key}`}
-                                  >
-                                    deleted
-                                  </AdminBadge>
-                                </Show>
-                              </span>
-                              <span class="admin-session-network">
-                                {row.network_slug ?? `network ${row.network_id}`}
-                              </span>
-                            </span>
-                          </AdminRowName>
-                        </td>
-                        <td
-                          class="admin-session-last-seen"
-                          data-label="last seen"
-                          data-testid={`admin-session-last-seen-${row.key}`}
-                          title={row.last_seen_at ?? "no browser session on record"}
-                        >
-                          {renderLastSeen(row.last_seen_at)}
-                        </td>
-                        <td data-label="channels" data-testid={`admin-session-channels-${row.key}`}>
-                          {renderChannels(row)}
-                        </td>
-                        <td
-                          class="admin-sessions-actions adm-table-sticky-actions"
-                          data-label="actions"
-                        >
-                          <For each={rowActions(row)}>
-                            {(kind) => (
-                              <InlineConfirmButton
-                                idleLabel={ACTION_LABEL[kind]}
-                                confirmLabel={`Confirm ${kind}`}
-                                armed={confirmingKey() === confirmKey(row.key, kind)}
-                                onArm={() => setConfirmingKey(confirmKey(row.key, kind))}
-                                onConfirm={() => runAction(row, kind)}
-                                testId={`admin-session-${kind}-${row.key}`}
-                                extraClass={`${kind}-btn`}
-                              />
-                            )}
-                          </For>
-                          {/* An empty cell reads as a rendering bug. The
+                                    <AdminBadge
+                                      tone={row.subject_kind === "user" ? "info" : "neutral"}
+                                      class="adm-badge--kind"
+                                      ariaLabel={row.subject_kind}
+                                    >
+                                      {row.subject_kind}
+                                    </AdminBadge>
+                                    {/* No `deleted` badge (#1224, vjt: "no badge
+                                    needed"). #1158 item 4 put one here
+                                    because a log-only row sat in this list
+                                    and would otherwise have read as a
+                                    session that merely looks broken; those
+                                    rows are on their own page now, so the
+                                    badge would have nothing to mark. */}
+                                    <span class="admin-session-nick">{renderLabel(row)}</span>
+                                  </span>
+                                  <span class="admin-session-network">
+                                    {row.network_slug ?? `network ${row.network_id}`}
+                                  </span>
+                                </span>
+                              </AdminRowName>
+                            </td>
+                            <td
+                              class="admin-session-last-seen"
+                              data-label="last seen"
+                              data-testid={`admin-session-last-seen-${row.key}`}
+                              title={row.last_seen_at ?? "no browser session on record"}
+                            >
+                              {renderLastSeen(row.last_seen_at)}
+                            </td>
+                            <td
+                              data-label="channels"
+                              data-testid={`admin-session-channels-${row.key}`}
+                            >
+                              {renderChannels(row)}
+                            </td>
+                            <td
+                              class="admin-sessions-actions adm-table-sticky-actions"
+                              data-label="actions"
+                            >
+                              <For each={rowActions(row)}>
+                                {(kind) => (
+                                  <InlineConfirmButton
+                                    idleLabel={ACTION_LABEL[kind]}
+                                    confirmLabel={`Confirm ${kind}`}
+                                    armed={confirmingKey() === confirmKey(row.key, kind)}
+                                    onArm={() => setConfirmingKey(confirmKey(row.key, kind))}
+                                    onConfirm={() => runAction(row, kind)}
+                                    testId={`admin-session-${kind}-${row.key}`}
+                                    extraClass={`${kind}-btn`}
+                                  />
+                                )}
+                              </For>
+                              {/* An empty cell reads as a rendering bug. The
                               dash says the absence is the answer. */}
-                          <Show when={rowActions(row).length === 0}>—</Show>
-                        </td>
-                      </tr>
-                      <Show when={detailKey() === row.key}>
-                        <AdminDetailPanel
-                          title={renderWho(row)}
-                          subtitle="the rest of the record"
-                          onClose={() => setDetailKey(null)}
-                          closeLabel="close session details"
-                          columns={SESSION_COLUMNS}
-                          data-testid={`admin-session-detail-${row.key}`}
-                        >
-                          <AdminFacts facts={detailFacts(row)} />
-                          <Show when={row.visitor !== null}>
-                            <div class="admin-session-danger">
-                              {/* Named for what it destroys. The verb is
+                              <Show when={rowActions(row).length === 0}>—</Show>
+                            </td>
+                          </tr>
+                          <Show when={detailKey() === row.key}>
+                            <AdminDetailPanel
+                              title={renderWho(row)}
+                              subtitle="the rest of the record"
+                              onClose={() => setDetailKey(null)}
+                              closeLabel="close session details"
+                              columns={SESSION_COLUMNS}
+                              data-testid={`admin-session-detail-${row.key}`}
+                            >
+                              <AdminFacts facts={detailFacts(row)} />
+                              <Show when={row.visitor !== null}>
+                                <div class="admin-session-danger">
+                                  {/* Named for what it destroys. The verb is
                                   identity-wide: it deletes the visitor
                                   and every one of its network rows, not
                                   the row this panel hangs off. */}
-                              <span class="admin-session-danger-note">
-                                deletes the whole visitor identity, on every network
-                              </span>
-                              <InlineConfirmButton
-                                idleLabel="Delete visitor"
-                                confirmLabel="Confirm delete visitor"
-                                armed={confirmingKey() === confirmKey(row.key, "delete")}
-                                onArm={() => setConfirmingKey(confirmKey(row.key, "delete"))}
-                                onConfirm={() => runDelete(row)}
-                                testId={`admin-session-delete-${row.key}`}
-                                extraClass="delete-btn"
-                              />
-                            </div>
+                                  <span class="admin-session-danger-note">
+                                    deletes the whole visitor identity, on every network
+                                  </span>
+                                  <InlineConfirmButton
+                                    idleLabel="Delete visitor"
+                                    confirmLabel="Confirm delete visitor"
+                                    armed={confirmingKey() === confirmKey(row.key, "delete")}
+                                    onArm={() => setConfirmingKey(confirmKey(row.key, "delete"))}
+                                    onConfirm={() => runDelete(row)}
+                                    testId={`admin-session-delete-${row.key}`}
+                                    extraClass="delete-btn"
+                                  />
+                                </div>
+                              </Show>
+                            </AdminDetailPanel>
                           </Show>
-                        </AdminDetailPanel>
-                      </Show>
-                    </>
-                  )}
-                </For>
-              </tbody>
-            </AdminTable>
-          </AdminCard>
-        </Show>
-      </div>
+                        </>
+                      )}
+                    </For>
+                  </tbody>
+                </AdminTable>
+              </Show>
+            </AdminCard>
+          </Show>
+        </div>
+      </Show>
     </div>
   );
 };
 
 function renderLabel(row: AdminSubjectRow): string {
   if (row.label !== null) return row.label;
-  // `null` on an orphan pid whose DB row is gone, or on a log entry the
-  // server wrote before the session had a nick. Say which rather than
-  // rendering a blank — it is the divergence, not a missing value.
-  const why = row.origin === "session_log" ? "no nick logged" : "no DB row";
-  return `${row.subject_id.slice(0, 8)} (${why})`;
+  // `null` here means an orphan pid whose DB row is gone — the one
+  // label-less class this list still holds. (The log-only class, whose
+  // entry can predate the session having a nick, is on the sub-page and
+  // has its own renderer for the same reason.) Say which rather than
+  // rendering a blank: it is the divergence, not a missing value.
+  return `${row.subject_id.slice(0, 8)} (no DB row)`;
 }
 
 function renderWho(row: AdminSubjectRow): string {
@@ -497,17 +542,6 @@ function renderExpires(row: AdminSubjectRow): string {
   return days <= 0 ? "expired" : `in ${days}d`;
 }
 
-// Human duration for a session that has ended. Raw milliseconds are
-// unreadable at the scale a bouncer session actually runs for.
-function renderDuration(ms: number): string {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  return h < 24 ? `${h}h${m % 60}m` : `${Math.floor(h / 24)}d${h % 24}h`;
-}
-
 // The last thing the lifecycle log saw this session do. `null` is NOT
 // "this session never ran": the log is a bounded global ring written
 // from an async cast, so it forgets, and saying so is the honest render.
@@ -515,14 +549,6 @@ function renderLastEvent(row: AdminSubjectRow): string {
   const e = row.last_event;
   if (e === null) return "nothing logged (bounded ring — not proof it never ran)";
   return `${e.event} · ${e.at}`;
-}
-
-// Only meaningful on a disconnect: reason / cleanliness / how long it
-// had been up. Each part is dropped when the row does not carry it.
-function renderEnded(e: AdminSessionLogEntry): string {
-  const clean = e.clean === null ? "" : e.clean ? " (clean)" : " (unclean)";
-  const lasted = e.duration_ms === null ? "" : `, lasted ${renderDuration(e.duration_ms)}`;
-  return `${e.reason ?? "no reason recorded"}${clean}${lasted}`;
 }
 
 function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
@@ -551,12 +577,10 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     facts.push({ label: "ended", value: renderEnded(row.last_event) });
   }
 
-  if (row.origin === "session_log") {
-    facts.push({
-      label: "record",
-      value: "session log only — the subject was deleted, the event outlived it",
-    });
-  }
+  // No `record: session log only` fact any more (#1224): the panel that
+  // carried it belonged to a row this list no longer holds, and on the
+  // sub-page the sentence is the page's premise rather than a per-row
+  // remark — it lives in the card subtitle there.
 
   if (row.live !== null) {
     facts.push(

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -435,48 +435,95 @@ describe("AdminSessionsTab — the drill-down keeps both sources of truth", () =
   });
 });
 
-// #1158 item 4 — vjt ruled "keep only the event" (2026-08-11): visitor
-// retention is unchanged, so an anon visitor is still purged at logout,
-// and the lifecycle log — which carries no FK to the subject — is the
-// only thing left. These tests assert the operator can still SEE that
-// session, and that the surface never pretends the subject is still there.
-describe("AdminSessionsTab — a session whose subject was deleted", () => {
-  it("lists a session that only the log remembers", async () => {
+// #1158 item 4 gave a session whose subject is gone a row in this list,
+// badged `deleted`, because the lifecycle log carries no FK to the
+// subject and outlived the CASCADE. #1224 moved it OUT: three of the four
+// dictated columns are live-process facts, so on those rows they were an
+// em-dash forever. vjt's ruling (2026-08-11): a sub-page of Sessions with
+// the record's own columns, no badge, and this list strictly live.
+//
+// The operator must still be able to SEE the session, and the surface
+// must still never pretend the subject is there — the two properties
+// #1158 item 4 established. Only the screen they hold on has changed.
+describe("AdminSessionsTab — a session whose subject was deleted (#1224)", () => {
+  it("keeps it out of the live list", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
+
+    // The live row is the pre-state: without it an empty table would
+    // satisfy this by accident.
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+    expect(screen.queryByTestId(`admin-session-row-${GONE_KEY}`)).toBeNull();
+  });
+
+  it("carries no deleted badge anywhere, because nothing needs marking", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
+
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+    expect(screen.queryByTestId(`admin-session-gone-${GONE_KEY}`)).toBeNull();
+  });
+
+  it("counts it on the door to the sub-page", async () => {
     await mountWith({ logSessions: [logEntry()] });
 
-    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
+    const door = await screen.findByTestId("admin-sessions-ended-open");
+    expect(door).toHaveTextContent("Ended sessions (1)");
+  });
+
+  // The door has to be reachable exactly when the live list is empty —
+  // that is when an operator looking for a session that is over has
+  // nothing else on screen.
+  it("offers the door even with no live session at all", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    await screen.findByTestId("admin-sessions-empty");
+    expect(screen.getByTestId("admin-sessions-ended-open")).toBeTruthy();
+  });
+
+  it("lists it on the sub-page with the record's own columns", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const row = await screen.findByTestId(`admin-ended-session-row-${GONE_KEY}`);
     expect(row.textContent).toContain("guest9");
+    expect(row.textContent).toContain("disconnected");
+    expect(row.textContent).toContain(":tcp_closed");
+    expect(row.textContent).toContain("unclean");
+    expect(row.textContent).toContain("1h0m");
   });
 
-  it("marks the row as deleted rather than letting it read as merely broken", async () => {
+  // Point 3 of the ruling: not a blocker, still true. A page named after
+  // a population implies it holds all of it, and this one cannot.
+  it("says on the page that the ring is not an archive", async () => {
     await mountWith({ logSessions: [logEntry()] });
 
-    expect(await screen.findByTestId(`admin-session-gone-${GONE_KEY}`)).toBeTruthy();
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const card = await screen.findByTestId("admin-ended-sessions-card");
+    expect(card).toHaveTextContent("not evidence the session never ran");
   });
 
-  // No credential to park, no pid to stop: every verb would resolve to a
-  // subject that is gone, so the cell offers none.
-  it("offers no verb on the row", async () => {
-    await mountWith({ logSessions: [logEntry()] });
+  // An empty page is "the ring remembers nothing", never "no session
+  // ended" — so it says so, and the caveat above it still applies.
+  it("does not claim nothing ever ended when the log is empty", async () => {
+    await mountWith({ credentials: [userCredential()], logSessions: [] });
 
-    await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
-    expect(screen.queryByTestId(`admin-session-disconnect-${GONE_KEY}`)).toBeNull();
-    expect(screen.queryByTestId(`admin-session-reconnect-${GONE_KEY}`)).toBeNull();
-    expect(screen.queryByTestId(`admin-session-terminate-${GONE_KEY}`)).toBeNull();
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const empty = await screen.findByTestId("admin-ended-sessions-empty");
+    expect(empty).toHaveTextContent("the log remembers no session whose subject is gone");
   });
 
-  it("puts why it ended in the drill-down, not in the table", async () => {
-    await mountWith({ logSessions: [logEntry()] });
+  it("goes back to the live list", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
 
-    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
-    expect(row.textContent).not.toContain(":tcp_closed");
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+    await screen.findByTestId("admin-ended-sessions-page");
+    expect(screen.queryByTestId(`admin-session-row-${VISITOR_KEY}`)).toBeNull();
 
-    fireEvent.click(screen.getByTestId(`admin-session-details-${GONE_KEY}`));
+    fireEvent.click(screen.getByTestId("admin-ended-sessions-back"));
 
-    const panel = await screen.findByTestId(`admin-session-detail-${GONE_KEY}`);
-    expect(panel).toHaveTextContent(":tcp_closed");
-    expect(panel).toHaveTextContent("unclean");
-    expect(panel).toHaveTextContent("1h0m");
+    expect(await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`)).toBeTruthy();
   });
 
   it("joins the last event onto a subject that still exists", async () => {

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -206,6 +206,29 @@ describe("AdminSessionsTab — the dictated columns", () => {
     expect(row.textContent).toContain("azzurra");
   });
 
+  // #1223 item 1 — and it shows it ONCE. The panel used to carry a
+  // `network` fact as well, so the slug was printed twice on every row,
+  // at EVERY width: this half of the report is JSX duplication, not the
+  // `.adm-col-detail` specificity defect the other tabs have, and no CSS
+  // change would have touched it.
+  it("does not repeat the network in the drill-down", async () => {
+    await mountWith({ credentials: [userCredential()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+    expect(
+      row.querySelector(".admin-session-network")?.textContent,
+      "pre-state: the identity cell is where the network is printed",
+    ).toBe("azzurra");
+
+    fireEvent.click(screen.getByTestId(`admin-session-details-${USER_KEY}`));
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+
+    const factValues = [...panel.querySelectorAll("dd")].map((dd) => dd.textContent);
+    expect(factValues, "the panel must not reprint what the row already shows").not.toContain(
+      "azzurra",
+    );
+  });
+
   it("renders the channel count from the live session", async () => {
     await mountWith({ credentials: [userCredential()] });
 

--- a/cicchetto/src/__tests__/adminCardRegime.test.tsx
+++ b/cicchetto/src/__tests__/adminCardRegime.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminNetwork, AdminUser } from "../lib/api";
+
+// #1223 item 1 — the admin console has its OWN breakpoint, and the JS has
+// to use it.
+//
+// The console turns tables into cards, drops the secondary columns and
+// swaps the desktop rail for a chip strip at 900px (`default.css`:
+// `.adm-col-detail`, the `@media (max-width: 899px)` stacking block, the
+// `.admin-pane` grid). `isMobile()` is the SHELL's breakpoint, 768px, and
+// three admin gates were reading it — so between 769px and 899px the
+// table was already a stack of cards while `AdminRowName` still rendered
+// a plain `<span>`: the columns had left and the door to the panel they
+// left through was not there (vjt, measured at `b0d5342d`).
+//
+// That band is the whole reason `isAdminNarrow()` exists. THE form factor
+// under test here is the band, not the phone: jsdom has no matchMedia, so
+// both signals are supplied explicitly and the two are set to DIFFERENT
+// values — a fix that simply read the other signal would fail this file.
+//
+// The phone (both true) is covered by `adminMobileRowDetail.test.tsx`;
+// what is on screen at each width is a CSS question and lives in
+// `e2e/tests/issue1223-admin-card-affordances.spec.ts`.
+
+const viewport = vi.hoisted(() => ({ mobile: false, adminNarrow: false }));
+
+vi.mock("../lib/theme", () => ({
+  isMobile: () => viewport.mobile,
+  isAdminNarrow: () => viewport.adminNarrow,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  token: () => "test-bearer",
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    adminListUsers: vi.fn(),
+    adminCreateUser: vi.fn(),
+    adminUpdateUserAdmin: vi.fn(),
+    adminUpdateUserPassword: vi.fn(),
+    adminDeleteUser: vi.fn(),
+    adminListNetworks: vi.fn(),
+    adminPatchNetworkCaps: vi.fn(),
+    adminRunReaper: vi.fn(),
+    adminResetCircuit: vi.fn(),
+    adminCreateNetwork: vi.fn(),
+    adminDeleteNetwork: vi.fn(),
+    adminListServers: vi.fn(),
+    adminListFeaturedChannels: vi.fn(),
+  };
+});
+
+vi.mock("../lib/socket", () => ({
+  joinAdminEvents: vi.fn(),
+}));
+
+import AdminNetworksTab from "../AdminNetworksTab";
+import AdminUsersTab from "../AdminUsersTab";
+import {
+  adminListFeaturedChannels,
+  adminListNetworks,
+  adminListServers,
+  adminListUsers,
+} from "../lib/api";
+
+const ALICE: AdminUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  name: "alice",
+  is_admin: false,
+  inserted_at: "2026-05-31T00:00:00Z",
+  updated_at: "2026-05-31T00:00:00Z",
+  live_session_count: 0,
+};
+
+const BAHAMUT: AdminNetwork = {
+  id: 1,
+  slug: "bahamut-test",
+  services_flavor: null,
+  visitor_enabled: false,
+  visitor_autoconnect: false,
+  max_concurrent_visitor_sessions: 100,
+  max_concurrent_user_sessions: 3,
+  max_per_ip: 5,
+  inserted_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-15T00:00:00Z",
+  circuit_state: null,
+  live_counts: { visitors: 0, users: 0 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  viewport.mobile = false;
+  viewport.adminNarrow = false;
+});
+
+describe("#1223 — the 769-899 band: the card regime without the shell's phone flag", () => {
+  beforeEach(() => {
+    viewport.mobile = false;
+    viewport.adminNarrow = true;
+  });
+
+  it("gives a Users row the disclosure, because the columns have already left", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE]);
+    render(() => <AdminUsersTab />);
+
+    await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+
+    // The door, and then that it opens: a button that renders but reveals
+    // nothing would satisfy a mere presence check.
+    const door = screen.getByTestId(`admin-user-details-${ALICE.id}`);
+    expect(door.tagName).toBe("BUTTON");
+
+    fireEvent.click(door);
+
+    const panel = await screen.findByTestId(`admin-user-detail-${ALICE.id}`);
+    expect(panel).toHaveTextContent("live sessions");
+    expect(panel).toHaveTextContent("inserted");
+  });
+
+  it("moves the Networks cap editors into the detail here too", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    vi.mocked(adminListServers).mockResolvedValue([]);
+    vi.mocked(adminListFeaturedChannels).mockResolvedValue([]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.querySelectorAll("td")).toHaveLength(2);
+    expect(screen.queryByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId(`admin-network-expand-${BAHAMUT.slug}`));
+
+    const panel = await screen.findByTestId(`admin-network-servers-${BAHAMUT.slug}`);
+    expect(panel.contains(screen.getByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`))).toBe(
+      true,
+    );
+  });
+});
+
+// The counter-claim, and it is why the fix is a second breakpoint rather
+// than "always render the disclosure": above 900px every column is on
+// screen, and a control that reveals what you can already see teaches the
+// operator to distrust controls (`AdminRowName`'s own reasoning).
+describe("#1223 — above the admin breakpoint nothing changes", () => {
+  it("leaves a Users row's identity as plain text", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE]);
+    render(() => <AdminUsersTab />);
+
+    const row = await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+    expect(screen.queryByTestId(`admin-user-details-${ALICE.id}`)).toBeNull();
+    expect(row.querySelector(".adm-row-name")?.textContent).toBe(ALICE.name);
+  });
+
+  it("keeps the Networks cap editors on the row", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.contains(screen.getByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`))).toBe(true);
+  });
+});

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -18,6 +18,10 @@ import type { AdminNetwork, AdminUser } from "../lib/api";
 // where the disclosure does not even render.
 vi.mock("../lib/theme", () => ({
   isMobile: () => true,
+  // #1223 — a phone is below BOTH breakpoints. The admin components now
+  // read the console's own 899px one; the shell's 768px flag stays for the
+  // shell. `adminCardRegime.test.tsx` is the file that sets them apart.
+  isAdminNarrow: () => true,
   prefersDark: () => false,
   applyTheme: vi.fn(),
 }));

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -3,6 +3,8 @@ import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  endedSessions,
+  liveSessions,
   rowActions,
   rowKey,
 } from "../lib/adminSubjectRows";
@@ -341,6 +343,51 @@ describe("buildSubjectRows — the session-log join", () => {
 
     expect(rows[0]?.subject_kind).toBe("user");
     expect(rows[0]?.origin).toBe("session_log");
+  });
+});
+
+// #1224 — the merge stays one row set; the VIEW is what splits. vjt
+// ruled that ended sessions move to a sub-page of Sessions and the list
+// that stays is strictly live, so these two functions are what each
+// screen renders.
+describe("liveSessions / endedSessions — the partition", () => {
+  const both = (): AdminSubjectRow[] =>
+    build({ visitors: [visitor()], logSessions: [logEntry({ session_id: "visitor:gone:42" })] });
+
+  it("sends the log-only row to the ended list and nothing else", () => {
+    const rows = both();
+
+    expect(rows).toHaveLength(2);
+    expect(endedSessions(rows).map((r) => r.key)).toEqual(["visitor:gone:42"]);
+  });
+
+  it("leaves every row with a subject or a pid in the live list", () => {
+    const rows = both();
+
+    expect(liveSessions(rows).map((r) => r.origin)).toEqual(["credential"]);
+  });
+
+  // A partition, not two filters: every row lands in exactly one list, so
+  // a class nobody thought about cannot fall off both screens.
+  it("puts each row in exactly one of the two", () => {
+    const rows = build({
+      visitors: [visitor()],
+      credentials: [credential()],
+      sessions: [session({ subject_id: "deadbeef-0000-0000-0000-000000000000" })],
+      logSessions: [logEntry({ session_id: "visitor:gone:42" })],
+    });
+
+    const keys = [...liveSessions(rows), ...endedSessions(rows)].map((r) => r.key);
+    expect(new Set(keys).size).toBe(rows.length);
+    expect(keys).toHaveLength(rows.length);
+  });
+
+  // The narrowing is the reason the sub-page needs no null guard: the
+  // pass that builds a log-only row builds it FROM the entry.
+  it("hands the ended list rows whose event is not nullable", () => {
+    const [ended] = endedSessions(both());
+
+    expect(ended?.last_event.event).toBe("disconnected");
   });
 });
 

--- a/cicchetto/src/admin/AdminRowName.tsx
+++ b/cicchetto/src/admin/AdminRowName.tsx
@@ -1,5 +1,5 @@
 import { type Component, type JSX, Show } from "solid-js";
-import { isMobile } from "../lib/theme";
+import { isAdminNarrow } from "../lib/theme";
 
 // Admin redesign (2026-08-07 review) — a table row's identity cell.
 //
@@ -20,6 +20,12 @@ import { isMobile } from "../lib/theme";
 // is not one of those: it carries four columns at EVERY width and keeps
 // the rest of the record in the panel, so there the disclosure is the
 // only door to it and `alwaysOpenable` keeps it on at all widths.
+//
+// #1223 — and "below 900px" is what the gate now asks. It used to ask
+// `isMobile()`, which is 768px: in the 769-899 band the table had
+// already dropped its columns into a panel this rendered no door to.
+// The door has to open wherever the columns leave, so both read the
+// SAME breakpoint (`isAdminNarrow`).
 
 export type Props = {
   /** The row's name, e.g. `vjt @ azzurra`. */
@@ -36,7 +42,7 @@ export type Props = {
 
 const AdminRowName: Component<Props> = (props) => (
   <Show
-    when={props.alwaysOpenable === true || isMobile()}
+    when={props.alwaysOpenable === true || isAdminNarrow()}
     fallback={<span class="adm-row-name">{props.children}</span>}
   >
     <button

--- a/cicchetto/src/admin/sessionLogFormat.ts
+++ b/cicchetto/src/admin/sessionLogFormat.ts
@@ -1,0 +1,42 @@
+import type { AdminSessionLogEntry } from "../lib/api";
+
+// #1224 — how a lifecycle-log record reads on screen, shared by the two
+// surfaces that render one: the Sessions drill-down (a live row whose
+// last logged event happens to be a disconnect) and the ended-sessions
+// sub-page (rows that are nothing BUT the record).
+//
+// Extracted from `AdminSessionsTab` rather than copied into the page:
+// the two would drift, and "lasted 1h0m" reading differently on two
+// screens of the same tab is the kind of drift nobody reports and
+// everybody notices.
+//
+// `AdminSessionLogTab.humanDuration` is a THIRD formatter with a
+// different shape (`1h 0m`, and `ms` below a second) and is deliberately
+// left alone: it renders a raw event log where sub-second spacing is the
+// story, and folding it into this one would change that tab's output for
+// no reason #1224 asks for.
+
+/** Human duration for a session that has ended. Raw milliseconds are
+ * unreadable at the scale a bouncer session actually runs for. */
+export function renderDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return h < 24 ? `${h}h${m % 60}m` : `${Math.floor(h / 24)}d${h % 24}h`;
+}
+
+/** Why it stopped, and whether the stop was orderly. `null` reason is
+ * "the log recorded none", which is not the same as a clean exit. */
+export function renderReason(e: AdminSessionLogEntry): string {
+  const clean = e.clean === null ? "" : e.clean ? " (clean)" : " (unclean)";
+  return `${e.reason ?? "no reason recorded"}${clean}`;
+}
+
+/** The one-line form, for a drill-down fact: reason, cleanliness and how
+ * long it had been up. Each part is dropped when the row lacks it. */
+export function renderEnded(e: AdminSessionLogEntry): string {
+  const lasted = e.duration_ms === null ? "" : `, lasted ${renderDuration(e.duration_ms)}`;
+  return `${renderReason(e)}${lasted}`;
+}

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -108,6 +108,44 @@ export type AdminSubjectRow = {
   last_event: AdminSessionLogEntry | null;
 };
 
+/**
+ * A row that is nothing BUT the lifecycle record: the subject is gone,
+ * no pid is left, and the log entry that produced the row is therefore
+ * the only thing it carries. The narrowing is the point — `last_event`
+ * is `null`-able on the general row and cannot be here, because the
+ * log-only pass builds the row FROM the entry.
+ */
+export type EndedSessionRow = AdminSubjectRow & {
+  origin: "session_log";
+  last_event: AdminSessionLogEntry;
+};
+
+function isEnded(row: AdminSubjectRow): row is EndedSessionRow {
+  return row.origin === "session_log" && row.last_event !== null;
+}
+
+/**
+ * #1224 — the two populations the admin console shows separately.
+ *
+ * vjt (2026-08-11): ended sessions move to a sub-page of Sessions and
+ * the list that stays is strictly live, with no `deleted` badge. The
+ * split is a VIEW concern, so it happens here rather than in the merge:
+ * the join is still one row set keyed on one composite, and the log
+ * still enriches a live row's drill-down.
+ *
+ * A partition, not two filters: `liveSessions` is the complement of
+ * `endedSessions`, so no row can fall out of both. A log-only row with
+ * no entry cannot exist (the pass that builds it needs the entry), but
+ * if it ever did it would show up in the live list rather than vanish.
+ */
+export function endedSessions(rows: AdminSubjectRow[]): EndedSessionRow[] {
+  return rows.filter(isEnded);
+}
+
+export function liveSessions(rows: AdminSubjectRow[]): AdminSubjectRow[] {
+  return rows.filter((row) => !isEnded(row));
+}
+
 export function rowKey(kind: "user" | "visitor", subjectId: string, networkId: number): string {
   return `${kind}:${subjectId}:${networkId}`;
 }

--- a/cicchetto/src/lib/theme.ts
+++ b/cicchetto/src/lib/theme.ts
@@ -27,6 +27,22 @@ export type ResolvedTheme = "mirc-light" | "irssi-dark";
 
 const MOBILE_QUERY = "(max-width: 768px)";
 
+// #1223 — the ADMIN console's own breakpoint, which is not the shell's.
+//
+// Everything about the console changes at 900px, not 768px: the desktop
+// nav rail (`.admin-pane` grid), the two-column form grid, the table
+// stacking block and `.adm-col-detail`'s drop are all written against
+// `900px` / `899px` in `themes/default.css`. Between 769 and 899 the
+// shell is a desktop and the console is already a stack of cards, so an
+// admin component that branches on `isMobile()` reads the wrong regime
+// for a 130px-wide band — which is how the Users and Credentials tables
+// came to drop their secondary columns while `AdminRowName` still
+// rendered a plain span, leaving the detail panel with no door.
+//
+// Same literal-in-CSS caveat as `--breakpoint-mobile`: a media query
+// cannot read a `var()`, so the number is mirrored, not shared.
+const ADMIN_NARROW_QUERY = "(max-width: 899px)";
+
 // Resolves the OS preference via matchMedia. Defensive against environments
 // without matchMedia (older browsers, SSR — neither applies to cicchetto
 // today, but the boundary is cheap).
@@ -75,6 +91,12 @@ const exports_ = moduleRoot(() => {
       : false;
   const [mobile, setMobile] = createSignal(initial);
 
+  const adminNarrowInitial =
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia(ADMIN_NARROW_QUERY).matches
+      : false;
+  const [adminNarrow, setAdminNarrow] = createSignal(adminNarrowInitial);
+
   const darkInitial =
     typeof window !== "undefined" && window.matchMedia
       ? window.matchMedia(DARK_QUERY).matches
@@ -86,6 +108,9 @@ const exports_ = moduleRoot(() => {
     const listener = (e: MediaQueryListEvent) => setMobile(e.matches);
     mm.addEventListener("change", listener);
 
+    const mmAdmin = window.matchMedia(ADMIN_NARROW_QUERY);
+    mmAdmin.addEventListener("change", (e: MediaQueryListEvent) => setAdminNarrow(e.matches));
+
     const mmDark = window.matchMedia(DARK_QUERY);
     mmDark.addEventListener("change", (e: MediaQueryListEvent) => setPrefersDark(e.matches));
 
@@ -95,14 +120,21 @@ const exports_ = moduleRoot(() => {
     void createEffect(() => {
       // Force the signals into the createRoot's tracking scope.
       void mobile();
+      void adminNarrow();
       void prefersDark();
     });
   }
 
-  return { isMobile: mobile, prefersDark };
+  return { isMobile: mobile, isAdminNarrow: adminNarrow, prefersDark };
 });
 
 export const isMobile = exports_.isMobile;
+
+// #1223 — true below the ADMIN console's 900px breakpoint (see
+// ADMIN_NARROW_QUERY). Every admin component whose behaviour has to match
+// what the console's CSS is doing at that width reads THIS, not
+// `isMobile()`; the shell's own layout keeps `isMobile()`.
+export const isAdminNarrow = exports_.isAdminNarrow;
 
 // #358 — the reactive OS dark-mode preference (true = dark). customTheme.ts's
 // apply effect subscribes to it; the gallery reads it to default the slot

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5285,7 +5285,13 @@ html.resize-dragging * {
    `ux-6-g-admin-mobile-h-scroll` still holds, in its #1074 form: pan-x
    stays PERMITTED on every admin tab (a table that fits must still not
    trap a horizontal gesture), and no tab is wider than its panel on a
-   phone. Networks was the one exemption and is not one any more. */
+   phone. Networks was the one exemption and is not one any more.
+
+   This declaration alone does NOT achieve the drop: the stacking block
+   at the bottom of this file re-declares `.adm-table td`, which outranks
+   it. The `td`-qualified twin down there is what enforces it (#1223
+   item 1). Kept here as the mobile-first default, and because it is what
+   hides the `th` partner. */
 .adm-col-detail {
   display: none;
 }
@@ -5755,6 +5761,30 @@ html.resize-dragging * {
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--adm-text-dim);
+  }
+
+  /* #1223 item 1 — the drop is REAL below 900px, which it was not.
+     `.adm-col-detail { display: none }` is (0,1,0) and the stacking rule
+     right above is `.adm-table td` (0,1,1), so every secondary cell won
+     its way back on screen as a labelled line of the card — while
+     `thead` is hidden outright, which is why the result read as designed
+     rather than broken. The panel underneath then repeated those very
+     fields under a subtitle promising the opposite ("the columns the
+     table drops on a phone"): `LIVE 2` / `INSERTED …` on the card and
+     `LIVE SESSIONS 2` / `INSERTED …` in the panel, one under the other
+     (vjt, iPhone dogfood at `b0d5342d`).
+
+     `.adm-table td.adm-col-detail` is (0,2,1) and wins. It has to live
+     INSIDE this block: the rule it is beating is in here, and the base
+     declaration outside cannot outrank it from there.
+
+     vjt's ruling on the fork (2026-08-11): drop the columns, keep the
+     panel. The alternative — dropping the panel on a phone — was
+     rejected. Note this cures ONE of the two duplications reported: the
+     Sessions NETWORK repeat is JSX, not specificity, and is fixed in
+     `AdminSessionsTab`. */
+  .adm-table td.adm-col-detail {
+    display: none;
   }
 
   /* The identity cell is the card's HEADING, not a labelled field: a

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39291,3 +39291,61 @@ drill-in (the `session_id` index exists and is still unused by any
 query), and any retention change whatsoever. If a future surface needs
 the identity rather than the event, that reopens vjt's fork; it is not
 a mechanical extension of this.
+
+---
+
+## 2026-08-11 — #1223 item 1: two defects, one symptom, and the band between two breakpoints
+
+vjt, dogfooding staging on an iPhone: *"poi abbiamo quest'idiozia di
+mostrare colonne già mostrate"*. His ruling on the fork the issue left
+open (2026-08-11): *"1223 punto 1: direi drop no?"* — the secondary
+columns really leave the card on a phone, and the detail panel stays.
+Dropping the panel instead was the rejected arm.
+
+**The panel's subtitle was the only true thing on screen, and it was
+false.** `.adm-col-detail { display: none }` is (0,1,0); the stacking
+block that turns rows into cards re-declares `.adm-table td` (0,1,1) and
+wins, so below 900px every "dropped" column came back as a labelled line
+of the card while the panel underneath printed it again under the words
+*"the columns the table drops on a phone"*. `thead` is hidden outright,
+which is why the result read as designed rather than broken. The fix is
+one `td`-qualified twin (0,2,1) inside the same block — it has to live
+there, because a rule outside a media query cannot outrank one inside it.
+
+**One symptom, two defects, and only one of them was CSS.** The issue
+read the Sessions `NETWORK` repeat as another instance of the
+specificity failure. It is not: Sessions drops no column at any width
+(four `<th>`, none secondary). Its repeat was JSX — `detailFacts`
+carried a `network` fact while `.admin-session-network` printed the slug
+under the nick, on DESKTOP too. Raising the selector would not have
+touched it, and dropping the panel on a phone would not have touched the
+desktop half of it. Curing one and calling the issue closed would have
+left the other alive, which is why the count matters more than the
+symptom.
+
+**The 769–899 band is where a half-fix would have made it worse.** The
+admin console's regime changes at 900px — the nav rail, the form grid,
+the table stacking and `.adm-col-detail` are all written against
+`900px`/`899px`. `isMobile()` is the SHELL's breakpoint, 768px, and
+three admin gates were reading it. Make the drop real without touching
+that, and between 769 and 899 the columns leave while `AdminRowName`
+still renders a plain `<span>`: the fields gone AND no door to the panel
+they went into. So the console got its own signal (`isAdminNarrow`,
+899px) and `AdminRowName` plus the Networks column split now read it.
+`refreshSlot` deliberately keeps `isMobile()`: where the refresh button
+lives is a question about the shell's rail, not about the table.
+
+**Where each half is tested, and why they differ.** The drop is a
+question about what is PAINTED — jsdom cannot see it (#1073's lesson),
+so `issue1223-admin-card-affordances.spec.ts` asserts it in a real
+browser, with the report's own oracle: no value may be on the card AND
+in the panel at once, both sides asserted non-empty first so an empty
+intersection cannot pass vacuously. The band gets a second real-browser
+test at 820px. The Sessions duplication is plain JSX that vitest sees
+perfectly well, and a browser copy of it would only be slower.
+
+**Not claimed.** Nothing here measures a real iPhone; the phone leg is
+WebKit at iPhone-15 metrics, which is the suite's standing limit. And
+`isAdminNarrow` mirrors a number CSS cannot share with JS — a media
+query still cannot read a `var()`, so 899 is written twice, exactly like
+`--breakpoint-mobile` before it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39349,3 +39349,64 @@ WebKit at iPhone-15 metrics, which is the suite's standing limit. And
 `isAdminNarrow` mirrors a number CSS cannot share with JS — a media
 query still cannot read a `var()`, so 899 is written twice, exactly like
 `--breakpoint-mobile` before it.
+
+---
+
+## 2026-08-11 — #1224: a session that is over is a record, not a row in a live console
+
+vjt, same iPhone dogfood pass as #1223: *"i visitor deleted son utili ma
+vanno su sotto pagina con campi diversi perché son sempre offline"*.
+#1158 item 4 had put those rows on screen; this is where they belong.
+
+**Three of the four dictated columns were an em-dash by construction.**
+`last seen`, `channels` and `actions` are live-process facts, and a
+log-only row has no process and no DB row — the CASCADE took the
+subject, `session_log_events` has no FK to it and stayed. So the list
+was paying full column width for fields that can never be populated, and
+the operator scanned past rows that looked broken rather than finished.
+The record is a post-mortem; the table it was being rendered into is a
+live console.
+
+**vjt's three rulings, and what each cost.** (1) A SUB-PAGE of Sessions,
+not a sixth tab — the tab strip already overflows and scrolls on a
+phone. (2) No `deleted` badge: once the rows move out, the list is
+strictly live and there is nothing to mark, so the badge #1158 item 4
+added is gone rather than kept "just in case". (3) The ring caveat is
+not a blocker — but it is still true, and a page NAMED after a
+population implies it holds all of it in a way an inline badge did not.
+So the caveat moved onto the page's card subtitle, where it is the
+premise of the screen instead of a remark on a row.
+
+**The split is a view concern, so it lives in the view's vocabulary.**
+`buildSubjectRows` is untouched: one row set, one composite key, the log
+still enriching a live row's drill-down. `liveSessions`/`endedSessions`
+partition it, and they are a PARTITION rather than two filters — the
+live list is the complement, so a class nobody anticipated cannot fall
+off both screens. `EndedSessionRow` narrows `last_event` to non-null,
+which is why the page needs no guard for a case its constructor makes
+impossible.
+
+**The door had to survive an empty list.** The Sessions card used to be
+gated on the row count, so with zero rows there was no card — and after
+the split "zero live rows, some ended ones" is a real state, exactly the
+one where an operator most wants the other screen. The card now renders
+whenever the data loaded and the empty state sits inside it, saying "no
+live sessions" rather than "no sessions", with the ended count on the
+door beside it.
+
+**Built with #1223 item 1 already applied**, as the issue asked: the
+page's columns are the ones the record actually has, no panel repeats
+them, and nothing is dropped at any width — five short fields stack into
+a card without needing a disclosure to get them back.
+
+**Deliberately not built.** No route (the console has none, and #1158
+already declined to invent its first deep link); no independent fetch —
+the page is handed the rows the tab already merged, because a second
+fetch would show a second snapshot of the list the operator reached it
+from; no retention change of any kind.
+
+**Not claimed.** That the page is complete. It cannot be: the ring is
+bounded, pruned on write, fed by an async cast from a path that includes
+`terminate/2`, and a last event that is not a disconnect means the log
+never saw the end — the subtitle says both, and the `lasted`/`how` cells
+render an em-dash rather than inventing an ending.


### PR DESCRIPTION
Four commits: #1224 had to be built with #1223 item 1 already applied rather than inheriting the duplication (vjt, on the issue), and the last two are audit results rather than features.

## 1. `cic(#1223)` — the phone column drop, and BOTH duplications

vjt's ruling (2026-08-11): *"1223 punto 1: direi drop no?"* — the secondary columns really leave the card on a phone; the detail panel stays. Dropping the panel was the rejected arm.

**One symptom, two defects.**

- **CSS specificity** (Users, the user page). `.adm-col-detail { display: none }` is (0,1,0) and the stacking block that turns rows into cards re-declares `.adm-table td` (0,1,1), so every "dropped" column came back as a labelled line of the card while the panel printed it again under a subtitle promising the opposite. `thead` is hidden outright, which is why it read as designed. Fixed with a `td`-qualified twin (0,2,1) **inside** that block — a rule outside a media query cannot outrank one inside it.
- **JSX duplication** (Sessions). Sessions drops no column at any width; `detailFacts` carried a `network` fact while `.admin-session-network` printed the slug under the nick, **on desktop too**. Raising the selector would not have touched it. The fact goes.

**The 769–899 band.** The console's regime changes at 900px (nav rail, form grid, table stacking, `.adm-col-detail`); `isMobile()` is the shell's 768px, and three admin gates were reading it. Fixing only the CSS would have made that band strictly worse — columns gone AND no disclosure to reach the panel they went into. So the console gets its own `isAdminNarrow()` (899px), read by `AdminRowName` and the Networks column split. `refreshSlot` keeps `isMobile()` deliberately: where the refresh button lives is a question about the shell's rail, not the table.

**Where each half is tested.** The drop and the band are real-browser claims (jsdom cannot see paint — #1073), asserted with the report's own oracle: no value on the card AND in the panel, both sides asserted non-empty first so an empty intersection cannot pass vacuously. The Sessions duplication is plain JSX and is pinned in vitest, with a mutation check (re-adding the fact fails exactly that one assertion).

## 2. `cic(#1224)` — ended sessions on their own sub-page

Three of the four dictated columns were an em-dash on every log-only row, structurally: `last seen`, `channels` and `actions` are live-process facts, and those rows have neither a process nor a DB row.

vjt's three rulings, applied: a **sub-page of Sessions** (not a sixth tab — the strip already overflows on a phone); **no `deleted` badge** (the list that stays is strictly live); the **ring caveat is not a blocker but travels with the page** — a page named after a population implies it holds all of it in a way an inline badge did not, so it is the sub-page card's subtitle.

- The merge is untouched: one row set, one composite key, the log still enriching a live row's drill-down. `liveSessions`/`endedSessions` partition it — a partition, not two filters, so no row class can fall off both screens. `EndedSessionRow` narrows `last_event` to non-null, so the page needs no guard for a case its constructor makes impossible.
- The Sessions card now renders whenever the data loaded, with its empty state inside it: "no live sessions, some ended ones" is a real state after the split, and gating the card on the row count would have taken the door away exactly when it is wanted.
- Page columns: who / last event / at / lasted / how. `lasted` and `how` render an em-dash when the log's last word was not a disconnect, rather than inventing an ending.

## 3. `e2e(#1224)` — the assert the move dropped

Removing a product fact edits the specs that asserted it, and this branch edited two it does not own. That is exactly where a test weakens without anyone noticing, so here is the line-by-line accounting of what changed in each, and whether the assertion **moved** or was **removed**.

### `issue1158-item4-deleted-session-row.spec.ts` — three assertions touched

| Was | Now | Verdict |
| --- | --- | --- |
| `expect(admin-session-gone-${key}).toBeVisible()` — the `deleted` badge marks the row so the operator can tell "gone" from "down" | `expect(admin-session-gone-${key}).toHaveCount(0)` in the live list, **plus** the row asserted present on the ended-sessions page | **Moved, and inverted into a witness.** The distinction is now carried by the surface the row is on, which is a stronger separation than a badge on a shared list. The inverted assert additionally proves #1224 really removed the badge instead of leaving it somewhere unseen — a claim the old spec could not make. |
| `expect(detail).toContainText("last event")` — the drill-in panel carries a last-event fact at all | `expect(admin-ended-session-event-${key}).not.toBeEmpty()` | **Moved and strengthened.** `toContainText` on a panel matched the label; `not.toBeEmpty()` on the cell asserts the value. Still not `logged.event` verbatim: terminating the session can append a newer lifecycle row between the barrier and the render. |
| `expect(detail).toContainText("session log only")` — provenance: this row exists only because the log outlived the deleted subject | *(nothing, in the first pass)* | **Removed.** The fact itself is gone from the product by design — the sub-page states it as a premise rather than repeating it per row. But the premise was asserted nowhere on a populated page: the empty-state wording is pinned in the unit twin, and an empty screen cannot witness a listed row's provenance. |

Commit 3 restores the third one: `expect(admin-ended-sessions-card).toContainText("From the lifecycle log")`, on the populated page. It is the same guarantee in a new place — the surface naming the log as the record — and it now sits where the row it describes is visible.

### `m8-admin-visitors-delete.spec.ts` — no assertion touched

+5/−3, all of it comment. The spec deliberately does not count rows (the identity-wide property lives on the verbs), and #1224 gave that choice a second reason: the count now depends on a screen this spec never opens. Nothing was weakened here because nothing executable changed.

## 4. `e2e(#1224)` — the pan guard enumerates surfaces, not tabs

Auditing the whole test tree for what #1224 moved (636 files: 389 e2e specs, 247 unit) turned up no other red spec — but it did turn up a guard that had gone stale in the same way the assert above did.

`ux-6-g-admin-mobile-h-scroll` states that "the pan is a property of the pane, not of the three tabs that happened to have tables when this spec was written", and then loops the tab list. A tab is not the only thing the pane shows: `AdminUsersTab` has opened `AdminUserPage` from inside the Users panel since #1158 (which is where the Credentials tab's job went), and #1224 adds the ended-sessions page behind the Sessions card header. Both are full-pane surfaces with tables at 393px that a loop over `ADMIN_TABS` structurally cannot reach. **The user page has been outside this guard since #1158** — #1224 would have been the second surface to be born uncovered.

- The width oracle now walks a **surface** list: every tab, plus each sub-page with the steps that open it.
- The **tab half maintains itself** — a count assertion against the pane's rendered `role="tab"` buttons fails when a tab is added without a line in the list.
- The **sub-page half cannot**, and the comment says so instead of implying coverage it lacks: a door has no marker. `admin-sessions-ended-open` is a static testid on a card header; `admin-user-networks-<id>` is a per-row button sharing its actions cell with Delete. Nothing can be crawled safely or matched honestly. One marker attribute per door would make the list derive itself; that is named as the fix, not hidden.
- Both sub-pages get an anti-hollow-green barrier on their **table**, not just their root — an empty-state card cannot overflow. It earned itself immediately: the first run used `.first()` for the user row, which lands on `admin-vjt`, a user with no IRC bind and so no networks table. The barrier failed instead of measuring an empty page.

## Gates

- `bun run check` (biome + tsc + e2e tsc): **green**, exit 0.
- `bun run test`: **green**, 280 files / 5243 tests.
- **Full `scripts/integration.sh`: green — 710 passed, 0 failed, 26.9m, exit 0.** Not a scoped `--grep`: the whole suite, on the STACK lane, against the committed tree.
- Both guards proven by mutation, each killing exactly its own assertion and leaving the siblings green:
  - *Does the new surface get measured, or just visited?* Mutant: give the ended-sessions sub-page a pannable scroller (`overflow-x: auto` + a 900px table). The oracle failed and **named it** — `{cls: "adm-table-wrap", scrollW: 900, clientW: 331, surface: "subpage:ended-sessions"}`. The other three tests in the file stayed green.
  - *Does the #1223 oracle fail without the fix?* Mutant: delete the `td`-qualified twin (`.adm-table td.adm-col-detail`). Exactly the two drop assertions went red, with the reported defect printed literally — `values printed twice — card [...,"0","2026-08-11 19:42",...], panel ["0","2026-08-11 19:42"]` — plus the 769–899 band test. The three panel-layout tests, which that rule does not govern, stayed green.


Docs: two `DESIGN_NOTES.md` entries, one per feature commit.
