### PR TITLE
#1225 — /notice: a NOTICE on the wire, echoed where it was typed

### DIFF
--- a/cicchetto/e2e/tests/issue1225-notice-self-echo.spec.ts
+++ b/cicchetto/e2e/tests/issue1225-notice-self-echo.spec.ts
@@ -1,0 +1,111 @@
+// Issue #1225 — /notice must reach the wire as a NOTICE and self-echo in the
+// SOURCE window, opening no window for the recipient.
+//
+// Before #1225 the verb did not exist: `/notice nick text` fell through to the
+// unknown-command error, and the only way out was `/quote NOTICE nick :text`
+// (hand-typed trailing colon, no echo at all). The send half now mirrors #640's
+// CTCP routing — echo keyed to the window it was typed in, recipient carried in
+// meta.notice_target — with a NOTICE on the wire and a `:notice` row kind.
+//
+// Two things only a real stack can prove, and this is the acceptance gate for
+// both (feedback_ux_e2e_mandatory):
+//   1. the WIRE VERB. A PRIVMSG implementation renders an identical echo; the
+//      only witness that distinguishes them is a live peer seeing `NOTICE` on
+//      its socket. jsdom cannot see a socket.
+//   2. the echo landing in the source window against a real persist +
+//      broadcast, rather than a stubbed store.
+
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#1225 — /notice <peer> reaches the peer as a NOTICE and echoes in the SOURCE window", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // Per-run unique peer nick — a fixed one is a 433/ghost time bomb under CI
+  // rerun plus bahamut's per-IP clone limit (the #591/#640 rationale).
+  const peerNick = `m1225-${crypto.randomUUID().slice(0, 5)}`;
+  const tag = crypto.randomUUID().slice(0, 8);
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    // Arm BEFORE the send: the peer's socket can deliver the frame before
+    // Playwright gets back from composeSend, and a listener attached after the
+    // fact would wait for a line that already came and went.
+    //
+    // The pattern pins the VERB and the recipient. This is the assertion a
+    // PRIVMSG-shaped implementation cannot satisfy, so it is the one that makes
+    // the whole spec worth running.
+    const noticeOnTheWire = peer.waitForLine(
+      new RegExp(`NOTICE ${peer.nick} :${tag}`),
+      `NOTICE to ${peer.nick}`,
+    );
+
+    await composeSend(page, `/notice ${peer.nick} ${tag}`);
+    await noticeOnTheWire;
+
+    // The self-echo renders where the operator typed it (we are viewing
+    // CHANNEL, so its visibility here IS "it landed in the source window"), and
+    // it names the RECIPIENT — not the window, which is what reading the
+    // routing key instead of meta.notice_target would print.
+    await expect(scrollbackLine(page, "notice", `→ -${peer.nick}- ${tag}`)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // No query window for the recipient: a notice opens none. The two awaits
+    // above are the barrier — the send is fully processed, so this absence is a
+    // decision, not a tab that has yet to render.
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
+  } finally {
+    await peer.disconnect("#1225 notice done");
+  }
+});
+
+test("#1225 — /notice #chan reaches the channel and echoes in the window it was typed in", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // A CHANNEL recipient is the form an operator actually reaches for, and the
+  // one /msg refuses. Witness is a peer sitting IN the channel: it only sees
+  // the frame if bahamut accepted and relayed a channel-targeted NOTICE.
+  const peerNick = `m1225c-${crypto.randomUUID().slice(0, 5)}`;
+  const tag = crypto.randomUUID().slice(0, 8);
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    await peer.join(CHANNEL);
+
+    const noticeOnTheWire = peer.waitForLine(
+      new RegExp(`NOTICE ${CHANNEL} :${tag}`),
+      `NOTICE to ${CHANNEL}`,
+    );
+
+    await composeSend(page, `/notice ${CHANNEL} ${tag}`);
+    await noticeOnTheWire;
+
+    // Source window and recipient coincide here, so the echo's own text is what
+    // separates a notice from a plain say: the arrow + `-recipient-` framing.
+    await expect(scrollbackLine(page, "notice", `→ -${CHANNEL}- ${tag}`)).toBeVisible({
+      timeout: 10_000,
+    });
+  } finally {
+    await peer.disconnect("#1225 channel notice done");
+  }
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -748,6 +748,27 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // the sender (a query's outbound args mean something different — see the
       // privmsg arm — so the two are deliberately NOT a shared helper). Plain
       // control-surface text (no mIRC emphasis), like the numeric/raw surfaces.
+      // #1225 — the operator's OWN outbound /notice. The server keys the echo
+      // to the SOURCE window it was typed in (a NOTICE opens no window) and
+      // puts the wire recipient in meta.notice_target, so the recipient is read
+      // OFF the message: the routing key here is the window the operator is
+      // already looking at. Its ABSENCE is what marks a :notice row inbound —
+      // the discriminator is direction, not sender, so this stays correct for a
+      // notice the operator sent from ANOTHER device (same nick, still ours).
+      // Rendered `→ -recipient- body`: the arrow is the outbound mark the CTCP
+      // echo above already uses, the `-nick-` brackets keep a notice looking
+      // like a notice. Body goes through MircBody like the inbound arm — a
+      // notice is content, not a control surface, so colours and emphasis are
+      // the sender's to choose.
+      const noticeTarget = msg.meta.notice_target;
+      if (typeof noticeTarget === "string") {
+        return (
+          <span class="scrollback-body">
+            → -{noticeTarget}-{" "}
+            <MircBody body={msg.body ?? ""} emphasis onChannelClick={onChannelClick} />
+          </span>
+        );
+      }
       const noticeCtcpVerb = msg.meta.ctcp_verb;
       if (typeof noticeCtcpVerb === "string") {
         const verb = stripCtcpDelim(noticeCtcpVerb);

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -480,6 +480,77 @@ describe("ScrollbackPane", () => {
     expect(lines[1]?.textContent ?? "").not.toContain("\x01");
   });
 
+  it("renders an own /notice self-echo in the SOURCE window, recipient read from meta — #1225", () => {
+    // #1225 — the operator's own /notice self-echoes as a :notice row keyed to
+    // the SOURCE window (msg.channel = "#grappa"), with the wire recipient in
+    // meta.notice_target. The render must name the RECIPIENT and mark the row
+    // outbound; reading the routing key instead would print the window the
+    // operator is already looking at. Fixture keeps channel DISTINCT from
+    // target so that conflation cannot pass.
+    //
+    // The second row is the inbound twin with the SAME sender and window: it
+    // pins that the two directions render differently. Without it, a render
+    // that ignored notice_target entirely would still satisfy the first
+    // assertion's "-carol-"-free text.
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa", // SOURCE window (where /notice was typed)
+        server_time: 1,
+        kind: "notice",
+        sender: "alice", // us
+        body: "rehash in 5",
+        meta: { notice_target: "carol" }, // wire recipient
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "notice",
+        sender: "carol", // a peer's notice TO us — no notice_target
+        body: "ack",
+        meta: {},
+      },
+    ];
+    setScrollback({ "freenode #grappa": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines).toHaveLength(2);
+
+    expect(lines[0]?.dataset.kind).toBe("notice");
+    // Outbound: arrow + the RECIPIENT, never the source window.
+    expect(lines[0]).toHaveTextContent("→ -carol- rehash in 5");
+    expect(lines[0]?.textContent ?? "").not.toContain("#grappa");
+    expect(lines[0]?.textContent ?? "").not.toContain("alice");
+
+    // Inbound stays the untouched `-sender- body` shape — no arrow.
+    expect(lines[1]).toHaveTextContent("-carol- ack");
+    expect(lines[1]?.textContent ?? "").not.toContain("→");
+  });
+
+  it("renders a /notice echo to a CHANNEL recipient — #1225", () => {
+    // `/notice #ops text` is legal IRC and the form an operator reaches for;
+    // the recipient being channel-shaped changes nothing about the render.
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "dave", // source window: a query
+        server_time: 1,
+        kind: "notice",
+        sender: "alice",
+        body: "rehash in 5",
+        meta: { notice_target: "#ops" },
+      },
+    ];
+    setScrollback({ "freenode dave": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="dave" kind="query" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines[0]).toHaveTextContent("→ -#ops- rehash in 5");
+  });
+
   it("falls back to the routing key for a pre-#640 echo with no ctcp_target", () => {
     // Backward-compat: rows persisted before #640 were keyed to the TARGET
     // (msg.channel) and carry no meta.ctcp_target. The render falls back to

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -435,13 +435,56 @@ describe("sendMessage ctcp_target wire field (#640)", () => {
     // /ping bob typed in #italia: the URL channel is the SOURCE window, and the
     // wire recipient rides the snake_case `ctcp_target` field (the additive wire
     // token #640 introduces).
-    await api.sendMessage("tok", "azzurra", "#italia", "\x01PING 1\x01", "bob");
+    await api.sendMessage("tok", "azzurra", "#italia", "\x01PING 1\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/networks/azzurra/channels/%23italia/messages",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ body: "\x01PING 1\x01", ctcp_target: "bob" }),
+      }),
+    );
+  });
+
+  // #1225 — the notice relay rides the SAME door with its own snake_case
+  // token. Two fields, never both: the server refuses a POST carrying both.
+  it("a /notice POSTs { body, notice_target } to the SOURCE window URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(okRow, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.sendMessage("tok", "azzurra", "#italia", "heads up", {
+      kind: "notice",
+      target: "carol",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/networks/azzurra/channels/%23italia/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ body: "heads up", notice_target: "carol" }),
+      }),
+    );
+  });
+
+  it("a /notice to a CHANNEL is a normal relay target, not a URL change", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(okRow, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // `/notice #ops text` typed in #italia: the URL stays the SOURCE window
+    // (#italia — where the echo lands), the channel recipient rides the field.
+    await api.sendMessage("tok", "azzurra", "#italia", "rehash in 5", {
+      kind: "notice",
+      target: "#ops",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/networks/azzurra/channels/%23italia/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ body: "rehash in 5", notice_target: "#ops" }),
       }),
     );
   });

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1168,10 +1168,52 @@ describe("compose submit — slash command dispatch", () => {
     expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01ACTION wavesPING x\x01");
   });
 
+  // #1225 — /notice routes like a CTCP query, NOT like /msg: the send is keyed
+  // to the SOURCE window (the submit's channelName, "#a") with the recipient in
+  // the relay arg, so no query window is opened and the echo lands where the
+  // operator typed. Asserting the exact call is what separates the two: routing
+  // it like /msg would put "carol" in the channel slot.
+  it("/notice <nick> <text> sends to the SOURCE window with a notice relay (#1225)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const qw = await import("../lib/queryWindows");
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/notice carol heads up");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "heads up", {
+      kind: "notice",
+      target: "carol",
+    });
+    // A notice opens no window for the recipient — the /msg door's job, not this one.
+    expect(qw.openQueryWindowState).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("/notice #chan <text> keeps the CHANNEL recipient in the relay, not the URL (#1225)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/notice #ops rehash in 5");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "rehash in 5", {
+      kind: "notice",
+      target: "#ops",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
   // #591/#640 — /ctcp <target> <verb> builds a single \x01VERB\x01 frame. #640:
   // a CTCP QUERY is a control-surface probe, so the echo is keyed to the SOURCE
   // window (the submit's channelName, "#a") and the wire recipient ("bob")
-  // rides the 4th `ctcpTarget` arg — NOT sent to the target as a DM (which
+  // rides the 4th `relay` arg ({kind:"ctcp"}) — NOT sent to the target as a DM (which
   // spawned the phantom window). No args → no trailing space inside the frame.
   it("/ctcp <target> <verb> echoes in the SOURCE window with ctcpTarget (#591/#640)", async () => {
     localStorage.setItem("grappa-token", "tok");
@@ -1185,7 +1227,10 @@ describe("compose submit — slash command dispatch", () => {
 
     // source window "#a", frame, ctcpTarget "bob" — the recipient is NOT the
     // send channel anymore (that is the whole #640 fix).
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", "bob");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
     expect(result).toEqual({ ok: true });
   });
 
@@ -1214,7 +1259,10 @@ describe("compose submit — slash command dispatch", () => {
     compose.setDraft(k, "/ctcp bob ping");
     const result = await compose.submit(k, "freenode", "#a");
 
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", "bob");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
     expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "", k, "#a", 1706743200000);
     expect(result).toEqual({ ok: true });
 
@@ -1260,14 +1308,12 @@ describe("compose submit — slash command dispatch", () => {
     const result = await compose.submit(k, "freenode", "#a");
 
     // #640 — CTCP PING frame with the timestamp token, echoed in the SOURCE
-    // window ("#a") with the wire recipient ("bob") in the 4th ctcpTarget arg —
+    // window ("#a") with the wire recipient ("bob") in the 4th relay arg —
     // never a DM to the target (no phantom window).
-    expect(sb.sendMessage).toHaveBeenCalledWith(
-      "freenode",
-      "#a",
-      "\x01PING 1706743200000\x01",
-      "bob",
-    );
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING 1706743200000\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
     // Pending registered: (networkId, nick, token, sourceKey, sourceChannel, sentAtMs).
     expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
     expect(result).toEqual({ ok: true });
@@ -1309,13 +1355,11 @@ describe("compose submit — slash command dispatch", () => {
 
     // THE RACE: with the send still unresolved, a reply arriving now MUST find a
     // registered pending entry. Pre-fix (register AFTER the await) this is 0 calls.
-    // #640 — the send targets the SOURCE window ("#a") with ctcpTarget "bob".
-    expect(sb.sendMessage).toHaveBeenCalledWith(
-      "freenode",
-      "#a",
-      "\x01PING 1706743200000\x01",
-      "bob",
-    );
+    // #640 — the send targets the SOURCE window ("#a"), relaying to "bob".
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING 1706743200000\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
     expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
 
     releaseSend();

--- a/cicchetto/src/__tests__/ctcpQuery.test.ts
+++ b/cicchetto/src/__tests__/ctcpQuery.test.ts
@@ -41,7 +41,10 @@ describe("sendCtcpQuery — #1192", () => {
 
     await sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
 
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", "bob");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
   });
 
   // Verb-agnostic means verb-agnostic: PING is the ONLY verb the seam correlates,
@@ -67,12 +70,10 @@ describe("sendCtcpQuery — #1192", () => {
 
     await sendCtcpQuery({ ...QUERY, verb: "CLIENTINFO", args: "PING TIME" });
 
-    expect(sb.sendMessage).toHaveBeenCalledWith(
-      "freenode",
-      "#a",
-      "\x01CLIENTINFO PING TIME\x01",
-      "bob",
-    );
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01CLIENTINFO PING TIME\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
   });
 
   // PING correlates. The token is the caller's `args` — opaque to this seam and
@@ -113,7 +114,10 @@ describe("sendCtcpQuery — #1192", () => {
 
     await sendCtcpQuery({ ...QUERY, verb: "PING", args: "" });
 
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", "bob");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01PING\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
     expect(pc.registerPing).toHaveBeenCalledWith(
       1,
       "bob",

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -255,7 +255,7 @@ describe("scrollback verbs", () => {
     );
   });
 
-  it("sendMessage forwards ctcpTarget to api.sendMessage for a CTCP query — #640", async () => {
+  it("sendMessage forwards the relay descriptor to api.sendMessage for a CTCP query — #640", async () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.sendMessage).mockResolvedValue({
@@ -271,14 +271,43 @@ describe("scrollback verbs", () => {
     const scrollback = await import("../lib/scrollback");
     // #640 — /ping typed in #grappa (source) targeting bob (wire recipient):
     // the source window rides the `channel` arg, the recipient the 5th.
-    await scrollback.sendMessage("freenode", "#grappa", "\x01PING 123\x01", "bob");
-    expect(api.sendMessage).toHaveBeenCalledWith(
-      "tok",
-      "freenode",
-      "#grappa",
-      "\x01PING 123\x01",
-      "bob",
-    );
+    await scrollback.sendMessage("freenode", "#grappa", "\x01PING 123\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
+    expect(api.sendMessage).toHaveBeenCalledWith("tok", "freenode", "#grappa", "\x01PING 123\x01", {
+      kind: "ctcp",
+      target: "bob",
+    });
+  });
+
+  // #1225 — the notice relay travels the same pass-through, so the own-send
+  // bookkeeping (submit-snap, cursor advance, divider re-latch) applies to a
+  // /notice echo exactly as it does to a plain send. That cursor advance is
+  // what stops the operator's own notice — an unread-COUNTING kind — from
+  // badging the window they are already looking at.
+  it("sendMessage forwards the relay descriptor for a /notice — #1225", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.sendMessage).mockResolvedValue({
+      id: 3,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: 0,
+      kind: "notice",
+      sender: "alice",
+      body: "heads up",
+      meta: { notice_target: "carol" },
+    });
+    const scrollback = await import("../lib/scrollback");
+    await scrollback.sendMessage("freenode", "#grappa", "heads up", {
+      kind: "notice",
+      target: "carol",
+    });
+    expect(api.sendMessage).toHaveBeenCalledWith("tok", "freenode", "#grappa", "heads up", {
+      kind: "notice",
+      target: "carol",
+    });
   });
 
   // Bucket D — post-success cursor advance. The id from the 201 body

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -336,6 +336,68 @@ describe("parseSlash — /nick", () => {
   });
 });
 
+// #1225 — /notice <target> <text>. Same grammar as /msg, one deliberate
+// divergence: the target may be a CHANNEL. `/notice #chan text` is legal IRC
+// and is the form an operator actually reaches for, whereas /msg refuses a
+// channel because a PRIVMSG addressed by name opened a phantom query window.
+// A notice opens no window at all, so the reason for /msg's refusal does not
+// exist here.
+describe("parseSlash — /notice (#1225)", () => {
+  it("/notice <nick> <body>", () => {
+    expect(parseSlash("/notice alice heads up")).toEqual({
+      kind: "notice",
+      target: "alice",
+      body: "heads up",
+    });
+  });
+
+  it.each(["#foo", "&local", "!12345chan", "+modeless"])(
+    "/notice to a channel (%s) is ACCEPTED, unlike /msg",
+    (chan) => {
+      expect(parseSlash(`/notice ${chan} rehash in 5`)).toEqual({
+        kind: "notice",
+        target: chan,
+        body: "rehash in 5",
+      });
+    },
+  );
+
+  it("/notice preserves interior spacing of the body", () => {
+    expect(parseSlash("/notice bob ciao  a   tutti")).toEqual({
+      kind: "notice",
+      target: "bob",
+      body: "ciao  a   tutti",
+    });
+  });
+
+  // Pin the MESSAGE, not just the error shape: an unregistered verb also
+  // yields {kind:"error", verb:"notice"} ("unknown command: /notice"), so a
+  // shape-only assertion passes with the feature absent.
+  it("/notice missing target → usage error, not unknown-command", () => {
+    const r = parseSlash("/notice");
+    expect(r).toMatchObject({ kind: "error", verb: "notice" });
+    const { message } = r as { message: string };
+    expect(message).not.toMatch(/unknown command/i);
+    expect(message).toMatch(/\/notice requires/i);
+  });
+
+  it("/notice missing body → usage error, not unknown-command", () => {
+    const r = parseSlash("/notice alice");
+    expect(r).toMatchObject({ kind: "error", verb: "notice" });
+    const { message } = r as { message: string };
+    expect(message).not.toMatch(/unknown command/i);
+    expect(message).toMatch(/text|body|message/i);
+  });
+
+  // Alias parity (issue point 3): `/n` is ALREADY /names (#122). A notice
+  // alias would silently steal a verb that has shipped for a year, so /notice
+  // ships without a short form. Pin it — the collision is invisible until
+  // someone's /n stops listing members.
+  it("/n stays /names — no alias collision with /notice", () => {
+    expect(parseSlash("/n #grappa")).toEqual({ kind: "names", target: "#grappa" });
+  });
+});
+
 describe("parseSlash — /msg", () => {
   it("/msg <target> <body>", () => {
     expect(parseSlash("/msg alice ciao!")).toEqual({

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2345,14 +2345,30 @@ export async function countMessagesAfter(
 // (NOT a query window for the recipient) and relays the frame to `ctcpTarget`.
 // Absent (a plain PRIVMSG) the POST body is unchanged, so every non-CTCP
 // caller is byte-identical to the pre-#640 request.
+// #640/#1225 — a send whose WIRE recipient differs from the window it renders
+// in. `channelName` (the URL) is always the SOURCE window the echo lands in;
+// this names who the frame actually goes to, and with which verb. Absent = a
+// plain PRIVMSG to the window itself.
+//
+// A union rather than two optional target params: `ctcp_target` and
+// `notice_target` are mutually exclusive on the wire (the server answers 400 to
+// a POST carrying both), and a union is how that gets said in the type system
+// instead of in a comment nobody reads.
+export type MessageRelay = { kind: "ctcp" | "notice"; target: string };
+
 export async function sendMessage(
   token: string,
   networkSlug: string,
   channelName: string,
   body: string,
-  ctcpTarget?: string,
+  relay?: MessageRelay,
 ): Promise<ScrollbackMessage> {
-  const payload = ctcpTarget === undefined ? { body } : { body, ctcp_target: ctcpTarget };
+  const payload =
+    relay === undefined
+      ? { body }
+      : relay.kind === "ctcp"
+        ? { body, ctcp_target: relay.target }
+        : { body, notice_target: relay.target };
   const res = await fetch(
     `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}/messages`,
     {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -33,7 +33,10 @@ import { asciiFold, nickEquals } from "./nickEquals";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 import { quitAll } from "./quit";
-import { sendMessage as sendPrivmsg } from "./scrollback";
+// #1225 — the seam sends a PRIVMSG to the window OR relays a NOTICE/CTCP to a
+// different recipient while echoing here, so it is named for the window, not
+// for one of the verbs it can carry.
+import { sendMessage as sendWindowMessage } from "./scrollback";
 import { selectedChannel, setSelectedChannel } from "./selection";
 import { openServiceModal } from "./serviceModal";
 import { isServicesSender } from "./servicesSender";
@@ -334,7 +337,7 @@ const drainPaced = async (
     // `??` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
     const { target, line } = plan[sent] ?? { target: "", line: "" };
     try {
-      await sendPrivmsg(slug, target, wireBody(line, action));
+      await sendWindowMessage(slug, target, wireBody(line, action));
       sent += 1;
       retries = 0;
       onProgress(sent);
@@ -995,7 +998,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // non-ACTION gate). The parser upper-cases the verb; guard
           // case-insensitively regardless.
           if (cmd.verb.toUpperCase() === "ACTION") {
-            await sendPrivmsg(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
+            await sendWindowMessage(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
             result = { ok: true };
             break;
           }
@@ -1042,6 +1045,26 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             verb: "PING",
             args: String(sentAtMs),
             sentAtMs,
+          });
+          result = { ok: true };
+          break;
+        }
+        // #1225 — /notice <target> <text>. Routed like a CTCP query, not like
+        // /msg: the echo persists in the window it was TYPED in (`channelName`)
+        // and no window is opened for the recipient, because a NOTICE opens
+        // none by convention (RFC 2812 §3.3.2 — it is the verb you must not
+        // reply to) and every client the operators come from echoes it where
+        // they are looking. That is also why a CHANNEL recipient is fine here
+        // while /msg refuses one: /msg's refusal exists to stop a phantom query
+        // window, and this path opens no window at all.
+        //
+        // Single await, no #666 pacing plan: a slash command is one line, so
+        // there is no multi-send to pace. A throttled send surfaces its 429 the
+        // same way a lone /msg does.
+        case "notice": {
+          await sendWindowMessage(networkSlug, channelName, cmd.body, {
+            kind: "notice",
+            target: cmd.target,
           });
           result = { ok: true };
           break;

--- a/cicchetto/src/lib/ctcpQuery.ts
+++ b/cicchetto/src/lib/ctcpQuery.ts
@@ -70,10 +70,8 @@ export const sendCtcpQuery = async (query: CtcpQuery): Promise<void> => {
     );
   }
 
-  await sendMessage(
-    query.networkSlug,
-    query.sourceChannel,
-    ctcpFrame(query.verb, query.args),
-    query.targetNick,
-  );
+  await sendMessage(query.networkSlug, query.sourceChannel, ctcpFrame(query.verb, query.args), {
+    kind: "ctcp",
+    target: query.targetNick,
+  });
 };

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -4,6 +4,7 @@ import {
   countMessagesAfter,
   listMessages,
   listMessagesAfter,
+  type MessageRelay,
   type ScrollbackMessage,
 } from "./api";
 import { token } from "./auth";
@@ -901,17 +902,21 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
   };
 
-  // #640 — `ctcpTarget` (optional) makes this a CTCP QUERY send: `name` is the
-  // SOURCE window the echo renders in (where the operator typed /ctcp or /ping),
-  // and `ctcpTarget` is the wire recipient. All the own-send bookkeeping
-  // (submit-snap, cursor advance, divider re-latch) is keyed on `name` = the
-  // source window — exactly where the echo + RTT land — so it is byte-identical
-  // to a plain send once `name` is the source. Absent, it is a normal PRIVMSG.
+  // #640/#1225 — `relay` (optional) makes this a send whose WIRE recipient is
+  // someone other than the window: a CTCP QUERY (/ctcp, /ping) or a NOTICE
+  // (/notice). `name` is the SOURCE window the echo renders in (where the
+  // operator typed the command), `relay.target` is the wire recipient. All the
+  // own-send bookkeeping (submit-snap, cursor advance, divider re-latch) is
+  // keyed on `name` = the source window — exactly where the echo lands — so it
+  // is byte-identical to a plain send once `name` is the source. That cursor
+  // advance is also what keeps the operator's OWN notice from badging them:
+  // `notice` is an unread-counting content kind, and the echo is a real row.
+  // Absent, it is a normal PRIVMSG to the window itself.
   const sendMessage = async (
     slug: string,
     name: string,
     body: string,
-    ctcpTarget?: string,
+    relay?: MessageRelay,
   ): Promise<void> => {
     const t = token();
     if (!t) return;
@@ -952,7 +957,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     // (networks ↔ selection). Three-line inline body + the doc here
     // is cheaper than hoisting `setCursorIfAdvances` to a leaf module
     // for a single second caller.
-    const row = await apiSendMessage(t, slug, name, body, ctcpTarget);
+    const row = await apiSendMessage(t, slug, name, body, relay);
     // #788 — the cursor POST below was already unreachable past a rotation, but
     // only by accident: the store purge empties the pane, `hasRenderedRow`
     // goes false, and the anti-poison gate declines. That is a guarantee owed

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -113,6 +113,13 @@ export type SlashCommand =
   | { kind: "topic-clear"; channel: string | null }
   | { kind: "nick"; nick: string }
   | { kind: "msg"; target: string; body: string }
+  // #1225 — /notice <target> <text>. Same grammar as /msg; the target may be a
+  // nick OR a channel (`/notice #chan` is legal IRC and is the oper's actual
+  // reach). It is NOT a conversation verb: compose.ts sends it through the
+  // #640 source-window seam, so the echo lands in the window it was typed in
+  // and no query window is opened — which is also why the channel target /msg
+  // refuses is harmless here.
+  | { kind: "notice"; target: string; body: string }
   // #290 — a BARE services command (`/ns`, `/cs`, `/ms`, …) opens the
   // dedicated services console modal, titled by `service`. compose.ts
   // fires `help` on open so the service help wall lands in the modal, not
@@ -507,6 +514,24 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
       );
     }
     return { kind: "msg", target, body };
+  },
+
+  // #1225 — /notice <target> <text>. Deliberately NOT sharing /msg's handler:
+  // they differ on the one rule that matters, the channel-target refusal (#12/
+  // #343). That refusal exists because a PRIVMSG addressed to a channel by
+  // name opens a phantom query window whose own-send never renders; a notice
+  // opens no window at all, so the same guard here would refuse the form opers
+  // use most. Shared grammar, opposite target policy — one handler with a flag
+  // would hide exactly the distinction worth seeing.
+  notice: (verb, rest) => {
+    const sp = rest.search(/\s/);
+    if (rest === "" || sp === -1 || sp === 0) {
+      return err(verb, "/notice requires <target> <text>");
+    }
+    const target = rest.slice(0, sp);
+    const body = rest.slice(sp + 1).trim();
+    if (body === "") return err(verb, "/notice requires message text after the target");
+    return { kind: "notice", target, body };
   },
 
   query: (_verb, rest) => {

--- a/config/config.exs
+++ b/config/config.exs
@@ -360,6 +360,11 @@ config :logger, :console,
     # (never a query window for the target). In the allowlist to satisfy the
     # known_keys↔metadata sync test even though no Logger call carries it today.
     :ctcp_target,
+    # #1225 — the wire recipient of the operator's own outbound /notice
+    # self-echo, carried in meta so the echo can be keyed to the SOURCE window
+    # (a NOTICE opens no window). In the allowlist to satisfy the
+    # known_keys↔metadata sync test even though no Logger call carries it today.
+    :notice_target,
     :nick_fallback,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -219,6 +219,26 @@ of `GET /networks`' `connection` object.
 - **REST for resources, Channels for events.** State changes are pushed
   over Channels, not polled over REST.
 
+### 5a. Sending to someone other than the window (#640, #1225)
+
+`POST /networks/{slug}/channels/{channel}/messages` normally sends a PRIVMSG
+to `{channel}` and echoes it there. Two optional, mutually exclusive fields
+relay the frame elsewhere while keeping `{channel}` as the **source window**
+the echo renders in:
+
+| field | wire verb | echo row |
+|---|---|---|
+| `ctcp_target` | `PRIVMSG <target> :\x01VERB args\x01` | `kind: "privmsg"`, `meta.ctcp_target` |
+| `notice_target` | `NOTICE <target> :<body>` | `kind: "notice"`, `meta.notice_target` |
+
+Both may name a nick; `notice_target` may also name a **channel**. Neither
+opens a query window for the recipient — a CTCP query is a probe and a NOTICE
+is the verb you must not reply to, so the echo belongs where the operator is
+looking. A POST carrying **both** fields is `400 bad_request`.
+
+Read the recipient off `meta`, never off the row's `channel`: `channel` is the
+source window. A `:notice` row **without** `meta.notice_target` is inbound.
+
 ---
 
 ## 6. Rate limiting & flood protection (#630)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39411,3 +39411,27 @@ results, though the SURFACE was already fed by reactive state (the amber
 subscription is therefore an extension of what the line already does —
 notably NOT a synthesised command result, which would have put a lie
 about provenance into the one place built to be honest about it.
+
+---
+
+## 2026-08-11 — #1225: `/notice` ships, and the echo is a persisted row rather than a local one
+
+**The issue asked where the self-echo should land, and the answer was that under its own constraint there could be no echo at all.** #1225 scoped itself to cicchetto: add `notice` to the `DISPATCH` table, done. Measured on `b0d5342d`, the only NOTICE-capable path reachable from the client is `pushRaw` (what `/quote` uses); `Session.send_raw/3` persists nothing; and cic has no way to fabricate a scrollback row, by invariant — it never originates state. So a cic-only `/notice` would have shipped a content verb that leaves no trace of what you said, on any device. vjt took the fork and chose the full path.
+
+**A notice is a CONTENT verb, and that is the whole argument for the server half.** `/kill`, `/stats`, `/rehash` legitimately ship raw frames and persist nothing: their feedback is the server's numeric. `/notice` sends words to a person. A client-local echo could only ever exist on the device that typed it — the operator's phone would never learn what their laptop said — so the echo has to be a real row, written where every other row is written.
+
+**Where it lands: the SOURCE window, which is #640's routing one verb over.** A NOTICE opens no window by convention (RFC 2812 §3.3.2 makes it the verb you must not reply to), and every client these operators come from echoes it where they are looking. `handle_ctcp_send/4` already had exactly that shape — echo keyed to the source window, `dm_with: nil`, no `maybe_open_query_window` — so `handle_notice_send/4` is its sibling with `kind: :notice` and `NOTICE` on the wire. It is a sibling and not a parameterisation: the two share only the recurse-persist-send skeleton and disagree on row kind, meta, the `dm_with` rule, the persist key's provenance and the wire verb. Four forks threaded through one function would have hidden the one distinction worth seeing.
+
+**The recipient rides `meta.notice_target`, and its ABSENCE is what marks a `:notice` row inbound.** The routing key is the source window, so reading the target off `channel` would print the window the operator is already in. Direction — not sender — is the discriminator, which keeps the render correct for a notice the operator sent from another device. cic renders `→ -recipient- body`: the arrow is the outbound mark the CTCP echo already uses, the `-nick-` brackets keep a notice looking like a notice, and the body goes through `MircBody` because a notice is content, not a control surface.
+
+**A CHANNEL recipient is accepted here while `/msg` refuses one, and that is not an inconsistency.** `/msg`'s refusal (#12/#343) exists because a PRIVMSG addressed to a channel by name opened a phantom query window whose own-send never rendered. This path opens no window at all, so the reason does not transfer — and `/notice #chan` is the form an operator actually reaches for.
+
+**`/notice` ships with no short alias: `/n` has been `/names` since #122.** Taking it would have silently stolen a verb that has worked for a year, and the theft is invisible until someone's `/n` stops listing members.
+
+**A `*serv` recipient is wire-only, mirroring the PRIVMSG door's W12 carve-out.** A fat-fingered `/notice nickserv identify <pass>` must reach the wire without archiving the secret; the same `Identifier.services_sender?/1` allowlist decides, and the reply is `{:ok, :no_persist}` → 202.
+
+**The body fragments on the PRIVMSG budget, deliberately one byte conservative.** A notice body is plain text, so an over-long one must split rather than lose its tail to the ircd's truncation. `NOTICE` framing is one byte shorter than `PRIVMSG`'s, so reusing `LineSplit.split_privmsg_body/3` can only ever produce a fragment one byte smaller than necessary — never one too long. Forking the splitter for that byte would have meant a second copy of the #246 worst-case relay ceilings and of the fragment-count table cic's preview is pinned to.
+
+**Two relay fields on one POST is `400`, by an explicit clause.** `ctcp_target` and `notice_target` are mutually exclusive; leaving the winner to clause order would make it an accident of where the arms sit in the file. cic says the same thing in the type system with a `MessageRelay` union rather than two optional target arguments.
+
+**Deliberately NOT touched: `isOperatorActionEcho`.** It classifies server-originated replies to operator actions (numeric-derived notices), and an own outbound notice is not one — it is own CONTENT, handled the way an own PRIVMSG is: the send path advances the read cursor, and the `read_cursor_set` fan-out drops the row from every other device's derived count. Widening the predicate to cover own content would have made two mechanisms responsible for the same suppression.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -351,6 +351,26 @@ defmodule Grappa.IRC.Client do
   end
 
   @doc """
+  Sends `NOTICE <target> :<body>\\r\\n` (#1225). Same guards as
+  `send_privmsg/3` — CR/LF/NUL in either field, or an empty `target`, yield
+  `{:error, :invalid_line}` rather than a malformed frame the server drops in
+  silence.
+
+  Kept as its own verb rather than a `send_privmsg/4` with a command argument:
+  the two differ in what the RECIPIENT is allowed to do about them (RFC 2812
+  §3.3.2 forbids an automatic reply to a NOTICE), so a caller choosing between
+  them is choosing semantics, not a string.
+  """
+  @spec send_notice(pid(), String.t(), String.t()) :: send_result()
+  def send_notice(client, target, body) do
+    if target != "" and Identifier.safe_line_token?(target) and Identifier.safe_line_token?(body) do
+      send_line(client, "NOTICE #{target} :#{body}\r\n")
+    else
+      reject_invalid_line(:notice)
+    end
+  end
+
+  @doc """
   Sends `JOIN <channel>\\r\\n` (when `key` is `nil`) or
   `JOIN <channel> <key>\\r\\n` (when `key` is a binary, RFC 2812 +k
   channel-key support — bucket F). Rejects CR/LF/NUL AND a malformed

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -129,6 +129,16 @@ defmodule Grappa.Scrollback.Meta do
                                                                   off the message, not off the routing key
                                                                   (`channel`). Present alongside
                                                                   ctcp_verb/ctcp_args on such echoes.)
+      :notice (own outbound echo)   →  + %{notice_target: String.t()}
+                                                                 (#1225: the operator's OWN outbound
+                                                                  /notice self-echo is keyed to the SOURCE
+                                                                  window it was typed in — a NOTICE opens
+                                                                  no window by convention. The wire
+                                                                  recipient (nick OR channel) rides here so
+                                                                  the render shows "→ notice to <target>"
+                                                                  off the message, not off the routing key.
+                                                                  Its ABSENCE on a :notice row is what
+                                                                  marks the row INBOUND.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is
@@ -168,11 +178,12 @@ defmodule Grappa.Scrollback.Meta do
             | :ctcp_verb
             | :ctcp_args
             | :ctcp_target
+            | :notice_target
             | :nick_fallback
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target nick_fallback]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target notice_target nick_fallback]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -202,6 +213,7 @@ defmodule Grappa.Scrollback.Meta do
           | :ctcp_verb
           | :ctcp_args
           | :ctcp_target
+          | :notice_target
           | :nick_fallback,
           ...
         ]

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -735,6 +735,49 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  #1225 — sends the operator's own outbound NOTICE (`/notice`) and self-echoes
+  it into the SOURCE window, NEVER a query window for the recipient.
+
+  `source` is the display/persist window the command was typed in (cic's URL
+  `channel_id`); `target` is the wire recipient — a nick OR a channel, both
+  legal (`NOTICE #chan` is what an operator reaches for). The Session.Server
+  relays `NOTICE <target> :<body>` upstream, persists the echo keyed to
+  `source` as a `:notice` row with `dm_with: nil` + `meta.notice_target`, and
+  does NOT auto-open a query window — a NOTICE by convention opens no window
+  (RFC 2812 §3.3.2: it is the verb that must not be replied to), so echoing it
+  where the operator is looking is the least surprising landing.
+
+  Routing shape is #640's (`send_ctcp/5`); what differs is the wire verb and
+  the row kind. Unlike a CTCP query the body is plain text, so it is
+  line-split like a PRIVMSG — an over-long NOTICE otherwise loses its tail to
+  the ircd's 512-byte truncation with no word to the operator.
+
+  Returns `{:ok, %Scrollback.Message{}}` (the LAST persisted fragment),
+  `{:ok, :no_persist}` for a *serv recipient (wire-only, mirroring
+  `send_privmsg/4`'s W12 carve-out: a mistyped `/notice nickserv identify
+  <pass>` must not land in scrollback), `{:error, :invalid_line}` when
+  `source`/`target`/`body` carry CRLF/NUL, or `{:error, :no_session}`.
+  """
+  @spec send_notice(subject(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, Grappa.Scrollback.Message.t()}
+          | {:ok, :no_persist}
+          | {:error, :no_session | :invalid_line | send_transport_error()}
+          | {:error, Ecto.Changeset.t()}
+  def send_notice(subject, network_id, source, target, body)
+      when is_subject(subject) and is_integer(network_id) and is_binary(source) and
+             is_binary(target) and is_binary(body) do
+    # Injection gates fire BEFORE the registry lookup (mirror send_privmsg/4 +
+    # send_ctcp/5): a malformed line against a non-existent session still
+    # surfaces as :invalid_line, and no row is persisted on rejection.
+    if Identifier.safe_line_token?(source) and Identifier.safe_line_token?(target) and
+         Identifier.safe_line_token?(body) do
+      call_session(subject, network_id, {:send_notice, source, target, body})
+    else
+      {:error, :invalid_line}
+    end
+  end
+
+  @doc """
   Queues a JOIN upstream through the session. **Synchronous call** — the
   Session.Server processes the message inline: writes
   `window_states[ch] = :pending` AND broadcasts `window_pending` on the

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1814,6 +1814,35 @@ defmodule Grappa.Session.Server do
     handle_ctcp_send(source, ctcp_target, body, state)
   end
 
+  # #1225 — /notice outbound. Routing is #640's (echo keyed to the SOURCE
+  # window, `dm_with: nil`, no `maybe_open_query_window`): a NOTICE opens no
+  # window by convention, so the echo belongs where the operator typed it.
+  # `source` is the display/persist window; `target` is the wire recipient
+  # (nick OR channel). The service-target carve-out is `{:send_privmsg, …}`'s,
+  # for the same W12 reason — a mistyped `/notice nickserv identify <pass>`
+  # must reach the wire without leaving the secret in scrollback.
+  #
+  # The line still passes the `capture_outbound_ns_secret/2` choke point even
+  # though `NSInterceptor`'s patterns are anchored on `PRIVMSG NickServ …` and
+  # cannot match a NOTICE. That is the correct outcome, not an oversight:
+  # services ignore notices, so an identify sent this way authenticates nothing
+  # and staging a `pending_auth` for it would arm a rendezvous that can never
+  # fire. Routing through the choke point anyway is what keeps this door
+  # participating automatically if the interceptor ever learns a new shape.
+  # (No @impl here — a continuation clause of handle_call/3, whose @impl rides
+  # the {:send_privmsg, …} clause above.)
+  def handle_call({:send_notice, source, target, body}, _, state)
+      when is_binary(source) and is_binary(target) and is_binary(body) do
+    line = "NOTICE #{target} :#{body}"
+    state = capture_outbound_ns_secret(state, line)
+
+    if service_target?(target) do
+      handle_service_target_notice(target, body, state)
+    else
+      handle_notice_send(source, target, body, state)
+    end
+  end
+
   # Sends `TOPIC <channel> :<body>` upstream. NO optimistic persist +
   # broadcast here — issue #22: the upstream IRC server echoes the TOPIC
   # back, EventRouter's unsolicited-TOPIC handler builds the canonical
@@ -3825,6 +3854,77 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # #1225 — persist the NOTICE self-echo to the SOURCE window + relay the wire
+  # frame to the recipient, WITHOUT opening a query window. Borrows #640's
+  # routing (source-keyed echo, `dm_with: nil`, no auto-open) and the PRIVMSG
+  # door's FRAGMENTING (a notice body is plain text, so an over-long one must
+  # split rather than lose its tail to the ircd's truncation).
+  #
+  # Deliberately a sibling of `persist_and_send_fragments/5` rather than a
+  # parameterisation of it: the two agree only on the recurse-persist-send
+  # skeleton and differ on every attribute that matters — row kind, meta, the
+  # `dm_with` rule (a notice threads nothing), the persist key's provenance
+  # (source window vs wire target) and the wire verb. A flag threading four
+  # forks through one function would read worse than the twenty lines below.
+  @spec handle_notice_send(String.t(), String.t(), String.t(), t()) ::
+          {:reply, {:ok, Scrollback.Message.t()} | {:error, term()}, t()}
+  defp handle_notice_send(source, target, body, state) do
+    key = fold_key(state, source)
+
+    # `NOTICE` is one byte SHORTER on the wire than `PRIVMSG`, so the privmsg
+    # budget is conservative by exactly that byte for a notice: fragments can
+    # come out one byte smaller than strictly necessary, never one byte too
+    # long. Reusing the sized-for-PRIVMSG splitter keeps ONE copy of the #246
+    # worst-case relay ceilings (and of the fragment-count table `cic`'s
+    # preview is pinned to) rather than forking it for a byte.
+    fragments = LineSplit.split_privmsg_body(body, target, state.linelen)
+
+    case persist_and_send_notice_fragments(key, target, fragments, state, nil) do
+      {:ok, last_message} -> {:reply, {:ok, last_message}, state}
+      {:error, _} = err -> {:reply, err, state}
+    end
+  end
+
+  @spec persist_and_send_notice_fragments(
+          String.t(),
+          String.t(),
+          [String.t()],
+          t(),
+          Scrollback.Message.t() | nil
+        ) :: {:ok, Scrollback.Message.t()} | {:error, term()}
+  defp persist_and_send_notice_fragments(_, _, [], _, last_message), do: {:ok, last_message}
+
+  defp persist_and_send_notice_fragments(key, target, [fragment | rest], state, _) do
+    attrs =
+      Session.put_subject_id(
+        %{
+          network_id: state.network_id,
+          # The persist/broadcast KEY is the SOURCE window, network-folded (NOT
+          # the wire recipient) — the recipient rides `meta.notice_target`.
+          channel: key,
+          server_time: System.system_time(:millisecond),
+          kind: :notice,
+          sender: state.nick,
+          body: fragment,
+          # No `sender_prefix` snapshot: the echo renders as "→ notice to
+          # <recipient>", which never shows the operator's channel grade, so
+          # storing it would be state nobody reads.
+          meta: %{notice_target: target},
+          # A notice threads no conversation — no DM, and (upstream in the
+          # caller) no query window for the recipient.
+          dm_with: nil
+        },
+        state.subject
+      )
+
+    with {:ok, message} <- Persistor.persist_and_broadcast(attrs, state, push: false),
+         :ok <- send_notice_or_log(state.client, target, fragment) do
+      persist_and_send_notice_fragments(key, target, rest, state, message)
+    else
+      {:error, _} = err -> err
+    end
+  end
+
   @spec persist_and_send_fragments(
           String.t(),
           String.t(),
@@ -3949,6 +4049,42 @@ defmodule Grappa.Session.Server do
         )
 
         err
+    end
+  end
+
+  # #1225 — the NOTICE twin of `send_privmsg_or_log/3`. A reject AFTER the
+  # persist means the facade's guard was bypassed; say so rather than losing
+  # the frame in silence.
+  @spec send_notice_or_log(pid(), String.t(), String.t()) :: :ok | {:error, :invalid_line}
+  defp send_notice_or_log(client, target, body) do
+    case Client.send_notice(client, target, body) do
+      :ok ->
+        :ok
+
+      {:error, :invalid_line} = err ->
+        Logger.error("client rejected notice AFTER persist — facade bypass?",
+          channel: target
+        )
+
+        err
+    end
+  end
+
+  # #1225 — the NOTICE twin of `handle_service_target_send/3`: wire-only, no
+  # row, no broadcast. Same W12 reason as the PRIVMSG door — a `/notice
+  # nickserv identify <pass>` is a fat-fingered credential, and persisting it
+  # would archive the secret the PRIVMSG carve-out exists to keep out.
+  @spec handle_service_target_notice(String.t(), String.t(), t()) ::
+          {:reply, {:ok, :no_persist} | {:error, :invalid_line}, t()}
+  defp handle_service_target_notice(target, body, state) do
+    case Client.send_notice(state.client, target, body) do
+      :ok ->
+        {:reply, {:ok, :no_persist}, state}
+
+      {:error, :invalid_line} = err ->
+        Logger.error("client rejected service-target notice", target: target)
+
+        {:reply, err, state}
     end
   end
 

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -17,7 +17,10 @@ defmodule GrappaWeb.MessagesController do
   `Grappa.Session.send_ctcp/5`, where the URL `channel_id` is the SOURCE
   window the echo renders in and `ctcp_target` is the wire recipient; no
   query window is ever opened for the recipient (a control-surface probe
-  is not a conversation). The lookup is keyed by the
+  is not a conversation). #1225: a POST carrying `"notice_target"` is an
+  outbound NOTICE (`/notice`) on the same source-window shape, via
+  `Grappa.Session.send_notice/5` — a NOTICE opens no window either, and
+  the recipient may be a nick OR a channel. The lookup is keyed by the
   `t:Grappa.Session.subject/0` ID-tuple resolved from
   `conn.assigns.current_subject` via `GrappaWeb.Subject.to_session/1`
   + `network.id` end-to-end (sub-task 2g) so two subjects on the same
@@ -229,6 +232,12 @@ defmodule GrappaWeb.MessagesController do
           Plug.Conn.t()
           | {:error, :bad_request | :no_session | :invalid_line | {:rate_limited, pos_integer()}}
           | {:error, Ecto.Changeset.t()}
+  # #1225 — two relay verbs in one POST is not a shape any client can mean.
+  # Refuse it explicitly: leaving it to clause ORDER would make the winner an
+  # accident of where the arms sit in this file.
+  def create(_, %{"channel_id" => _, "ctcp_target" => _, "notice_target" => _}),
+    do: {:error, :bad_request}
+
   def create(conn, %{"channel_id" => channel, "body" => body, "ctcp_target" => ctcp_target})
       when is_binary(body) and body != "" and is_binary(ctcp_target) and ctcp_target != "" do
     subject = Subject.to_session(conn.assigns.current_subject)
@@ -247,6 +256,27 @@ defmodule GrappaWeb.MessagesController do
          :ok <- validate_post_target_name(ctcp_target),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_ctcp(subject, network.id, channel, ctcp_target, body) do
+      render_send_result(conn, result)
+    end
+  end
+
+  def create(conn, %{"channel_id" => channel, "body" => body, "notice_target" => notice_target})
+      when is_binary(body) and body != "" and is_binary(notice_target) and notice_target != "" do
+    subject = Subject.to_session(conn.assigns.current_subject)
+    network = conn.assigns.network
+
+    # #1225 — `/notice <target> <text>`. Same door shape as the #640 CTCP arm
+    # above: `channel` (the URL) is the SOURCE window the echo renders in, so it
+    # takes `validate_target_name` (a `/notice` typed in `$server` is legit);
+    # `notice_target` is the wire recipient, so it takes the POST variant (a
+    # real nick or channel, never the read-only `$server`). One send-token, as
+    # for a plain PRIVMSG. A *serv recipient answers `{:ok, :no_persist}` (W12),
+    # which `render_send_result/2` already renders as 202.
+    with :ok <- BodyLimit.check(body),
+         :ok <- validate_target_name(channel),
+         :ok <- validate_post_target_name(notice_target),
+         :ok <- take_send_token(subject, network.id),
+         {:ok, result} <- Session.send_notice(subject, network.id, channel, notice_target, body) do
       render_send_result(conn, result)
     end
   end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3865,13 +3865,11 @@ defmodule Grappa.Session.ServerTest do
       # A notice is not a DM: no thread.
       assert msg.dm_with == nil
 
-      # NOTICE on the wire — not PRIVMSG.
-      assert {:ok, _} =
-               IRCServer.wait_for_line(
-                 server,
-                 &(&1 == "NOTICE carol :heads up"),
-                 1_000
-               )
+      # NOTICE on the wire — not PRIVMSG. Pin the WHOLE frame (the returned
+      # line, CRLF included), so verb, recipient and body are all asserted:
+      # `starts_with?` alone would pass on a truncated or re-targeted body.
+      assert {:ok, "NOTICE carol :heads up\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE carol"), 1_000)
 
       source_rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
       assert Enum.any?(source_rows, &(&1.body == "heads up" and &1.kind == :notice))
@@ -3906,13 +3904,13 @@ defmodule Grappa.Session.ServerTest do
       assert msg.meta.notice_target == "#sniffo"
       assert msg.dm_with == nil
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &(&1 == "NOTICE #sniffo :rehash in 5"), 1_000)
+      assert {:ok, "NOTICE #sniffo :rehash in 5\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE #sniffo"), 1_000)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "a services recipient is wire-only — no row, no leak of a mistyped secret",
+    test "does not archive a mistyped nickserv identify — a *serv recipient is wire-only",
          %{server: server, user: user, network: network, pid: pid} do
       # W12: a *serv target never persists (a fat-fingered `/notice nickserv
       # identify <pass>` must not land in scrollback). Same carve-out the
@@ -3927,12 +3925,8 @@ defmodule Grappa.Session.ServerTest do
                  "identify hunter2"
                )
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(
-                 server,
-                 &(&1 == "NOTICE NickServ :identify hunter2"),
-                 1_000
-               )
+      assert {:ok, "NOTICE NickServ :identify hunter2\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE NickServ"), 1_000)
 
       source_rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
       refute Enum.any?(source_rows, &(&1.body =~ "hunter2"))

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3939,9 +3939,9 @@ defmodule Grappa.Session.ServerTest do
       # A NOTICE is plain text, so it fragments exactly like a PRIVMSG — the
       # alternative is the ircd truncating the tail and the operator never
       # learning which words were lost.
-      body = String.duplicate("parola ", 120) |> String.trim()
+      body = String.trim(String.duplicate("parola ", 120))
 
-      assert {:ok, _last} =
+      assert {:ok, _} =
                Session.send_notice({:user, user.id}, network.id, "#sniffo", "carol", body)
 
       assert {:ok, _} =

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3824,6 +3824,161 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#1225 outbound NOTICE (send_notice)" do
+    # #1225 — `/notice <target> <text>` ships a NOTICE, and by IRC convention a
+    # NOTICE opens no window: its self-echo belongs in the SOURCE window the
+    # operator typed it in. Same routing shape as #640's CTCP query (source-keyed
+    # echo, `dm_with: nil`, no `maybe_open_query_window`), different wire verb and
+    # a `:notice` row kind. The recipient rides `meta.notice_target` so the render
+    # reads it OFF the message rather than the routing key.
+    setup do
+      rfc_handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(rfc_handler)
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      %{server: server, user: user, network: network, pid: pid}
+    end
+
+    test "keys the echo to the SOURCE window as :notice, tags meta.notice_target, dm_with nil",
+         %{server: server, user: user, network: network, pid: pid} do
+      assert {:ok, msg} =
+               Session.send_notice({:user, user.id}, network.id, "#sniffo", "carol", "heads up")
+
+      # Persist KEY is the SOURCE window, NOT the wire recipient.
+      assert msg.channel == "#sniffo"
+      # A NOTICE persists as a NOTICE — the row kind must match the wire verb,
+      # or cic renders the operator's own notice as a privmsg.
+      assert msg.kind == :notice
+      assert msg.body == "heads up"
+      assert msg.sender == "vjt"
+      # The recipient travels in meta so the render names it without reading the
+      # routing key (which is the source window).
+      assert msg.meta.notice_target == "carol"
+      # A notice is not a DM: no thread.
+      assert msg.dm_with == nil
+
+      # NOTICE on the wire — not PRIVMSG.
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "NOTICE carol :heads up"),
+                 1_000
+               )
+
+      source_rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
+      assert Enum.any?(source_rows, &(&1.body == "heads up" and &1.kind == :notice))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "NEVER opens a query window for the recipient",
+         %{user: user, network: network, pid: pid} do
+      net_id = network.id
+
+      # The call is synchronous, so maybe_open_query_window would have run inside
+      # it if it were going to — the refute is deterministic, no timing.
+      assert {:ok, _} =
+               Session.send_notice({:user, user.id}, net_id, "#sniffo", "carol", "heads up")
+
+      refute QueryWindows.open?({:user, user.id}, net_id, "carol")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a CHANNEL recipient is legal and still echoes to the source window",
+         %{server: server, user: user, network: network, pid: pid} do
+      # `/notice #chan text` is what an operator actually reaches for. The
+      # recipient is a channel, the echo still lands in the source window it was
+      # typed in — here a query window, to prove the two are independent.
+      assert {:ok, msg} =
+               Session.send_notice({:user, user.id}, network.id, "dave", "#sniffo", "rehash in 5")
+
+      assert msg.channel == "dave"
+      assert msg.kind == :notice
+      assert msg.meta.notice_target == "#sniffo"
+      assert msg.dm_with == nil
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "NOTICE #sniffo :rehash in 5"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a services recipient is wire-only — no row, no leak of a mistyped secret",
+         %{server: server, user: user, network: network, pid: pid} do
+      # W12: a *serv target never persists (a fat-fingered `/notice nickserv
+      # identify <pass>` must not land in scrollback). Same carve-out the
+      # PRIVMSG door applies, reached through the same `Identifier.services_sender?`
+      # allowlist.
+      assert {:ok, :no_persist} =
+               Session.send_notice(
+                 {:user, user.id},
+                 network.id,
+                 "#sniffo",
+                 "NickServ",
+                 "identify hunter2"
+               )
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "NOTICE NickServ :identify hunter2"),
+                 1_000
+               )
+
+      source_rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
+      refute Enum.any?(source_rows, &(&1.body =~ "hunter2"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an over-long body is split into fragments, every one a NOTICE frame",
+         %{server: server, user: user, network: network, pid: pid} do
+      # A NOTICE is plain text, so it fragments exactly like a PRIVMSG — the
+      # alternative is the ircd truncating the tail and the operator never
+      # learning which words were lost.
+      body = String.duplicate("parola ", 120) |> String.trim()
+
+      assert {:ok, _last} =
+               Session.send_notice({:user, user.id}, network.id, "#sniffo", "carol", body)
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE carol :"), 1_000)
+
+      rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 50, nil, false)
+      fragments = Enum.filter(rows, &(&1.kind == :notice))
+      assert length(fragments) > 1
+      assert Enum.all?(fragments, &(&1.meta.notice_target == "carol"))
+      assert Enum.all?(fragments, &(&1.channel == "#sniffo"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "rejects CRLF/NUL in source, recipient or body as :invalid_line",
+         %{user: user, network: network, pid: pid} do
+      net_id = network.id
+
+      assert {:error, :invalid_line} =
+               Session.send_notice({:user, user.id}, net_id, "#sniffo\r\nQUIT", "carol", "hi")
+
+      assert {:error, :invalid_line} =
+               Session.send_notice({:user, user.id}, net_id, "#sniffo", "carol\r\nQUIT", "hi")
+
+      assert {:error, :invalid_line} =
+               Session.send_notice({:user, user.id}, net_id, "#sniffo", "carol", "hi\r\nQUIT :bye")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#640 inbound 401 ERR_NOSUCHNICK from a CTCP probe" do
     # #640 — pinging (or /ctcp'ing) a NONEXISTENT nick makes bahamut answer
     # 401 ERR_NOSUCHNICK for the relayed frame. NumericRouter (a pure

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -236,6 +236,83 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#1225: notice_target ships a NOTICE, echoes to the SOURCE window, opens no window",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # `/notice carol heads up` typed in #sniffo: cic POSTs to the SOURCE window
+      # (the URL channel_id) with notice_target=carol. Mirror of the #640
+      # ctcp_target door — same source-keyed echo, different wire verb.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "heads up",
+          "notice_target" => "carol"
+        })
+
+      body = json_response(conn, 201)
+      assert body["channel"] == "#sniffo"
+      assert body["kind"] == "notice"
+      assert body["meta"]["notice_target"] == "carol"
+
+      assert {:ok, "NOTICE carol :heads up\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE carol"), 1_000)
+
+      rows = Scrollback.fetch({:user, vjt.id}, network.id, "#sniffo", nil, 10, nil, false)
+      assert Enum.any?(rows, &(&1.body == "heads up" and &1.kind == :notice))
+
+      refute Grappa.QueryWindows.open?({:user, vjt.id}, network.id, "carol")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#1225: notice_target = $server is rejected (read-only) as bad_request",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "heads up",
+          "notice_target" => "$server"
+        })
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#1225: a POST carrying BOTH ctcp_target and notice_target is bad_request",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # Two relay verbs in one POST is not a shape the client can mean. Refusing
+      # it out loud beats letting clause ORDER silently pick a winner.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "heads up",
+          "ctcp_target" => "carol",
+          "notice_target" => "carol"
+        })
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "#357: the send-path span [:grappa, :session, :send_privmsg] closes with outcome: :ok",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -290,6 +290,38 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#1225: a /notice to NickServ does not archive a mistyped identify password",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # The W12 carve-out at the DOOR, not just in the session: a fat-fingered
+      # `/notice nickserv identify <pass>` must reach the wire and leave nothing
+      # on disk. Asserted here as well as in server_test because a refactor that
+      # merely mirrors the PRIVMSG path is one clause away from losing it, and
+      # the cost of losing it is a password written to the scrollback DB.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "identify hunter2",
+          "notice_target" => "NickServ"
+        })
+
+      # 202 + {ok: true}: wire-only, no persisted row to render.
+      assert json_response(conn, 202) == %{"ok" => true}
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE NickServ"), 1_000)
+
+      rows = Scrollback.fetch({:user, vjt.id}, network.id, "#sniffo", nil, 10, nil, false)
+      refute Enum.any?(rows, &(&1.body =~ "hunter2"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "#1225: a POST carrying BOTH ctcp_target and notice_target is bad_request",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()


### PR DESCRIPTION
Fixes the missing send half of `/notice` (issue #1225). The receive half has
been first class since day one — `kind: "notice"` rows, unread counting,
provenance reasoning in `operatorActionEcho` — while `/notice nick text` fell
through to the unknown-command error and the workaround was
`/quote NOTICE nick :text`, colon typed by hand.

## Why this touches the server

The issue scoped itself to cicchetto. Measured on `b0d5342d`, that scope
cannot produce the self-echo the issue asks about: the only NOTICE-capable
path reachable from the client is `pushRaw`, `Session.send_raw/3` persists
nothing, and cic cannot fabricate a row (it never originates state). A
cic-only `/notice` would ship a CONTENT verb that leaves no trace of what you
said, on any device. The fork was put to vjt, who chose the full path
(analysis: #1225 comment).

## Shape

Routing is #640's, one wire verb over — the echo is keyed to the SOURCE
window, `dm_with` is nil, and no query window is opened for the recipient. A
NOTICE opens no window by convention (RFC 2812 §3.3.2), so echoing it where
the operator is looking is the least surprising landing. The recipient rides
`meta.notice_target`; its ABSENCE on a `:notice` row is what marks the row
inbound. cic renders `→ -recipient- body`.

Decisions the issue left open, and the answers:

- **Echo lands in the current (source) window** — see above.
- **Channel targets accepted.** `/msg` refuses one because a PRIVMSG addressed
  by name opens a phantom query window; this path opens no window at all, so
  the reason does not transfer, and `/notice #chan` is the oper's real reach.
- **No `/n` alias** — it has been `/names` since #122.

Other calls: a `*serv` recipient is wire-only (W12 — a mistyped
`/notice nickserv identify <pass>` must not be archived); the body fragments
on the PRIVMSG budget, conservative by the one byte `NOTICE` is shorter; a
POST carrying both `ctcp_target` and `notice_target` is `400` by an explicit
clause rather than by clause order.

Wire change is additive (`notice_target` request field + `meta.notice_target`),
so no `protocol_version` bump. `wireTypes.ts` / `wireSchema.ts` needed no
regeneration: `meta` is `Record<string, unknown>` there and `"notice"` was
already in the kind enum. `docs/CLIENT_PROTOCOL.md` §5a documents both relay
fields (it also retro-documents #640's, which was undocumented).

## ⚠️ Deploy classification: COLD

`config/config.exs` is touched — the new `meta` key is pinned by test to the
Logger `:metadata` allowlist. A config change forces a COLD deploy. (No
practical cost for the 0.17.0 cut, which is cold regardless, but it belongs in
the classification.)

## Gates (rc read from files, not from the harness)

| gate | rc | evidence |
|---|---|---|
| `scripts/check.sh` | 0 | 5935 tests / 0 failures, Dialyzer `Total errors: 0`, Credo clean, Sobelow, bats |
| `scripts/bun.sh run check` | 0 | tsc + biome, e2e specs included |
| `scripts/bun.sh run test` | 0 | 5246 / 5246 |
| `scripts/integration.sh --grep "#1225"` | 0 | 2 passed |

Mutation-tested rather than assumed:

- Remove the `*serv` carve-out → exactly the two carve-out tests fail (session
  door + REST door), nothing else.
- Send `PRIVMSG` instead of `NOTICE` on the wire → both e2e tests fail on the
  peer's `waitForLine`, while every unit test still passes. That asymmetry is
  the reason the e2e exists: a PRIVMSG implementation renders a byte-identical
  echo, and only a live peer can tell them apart.

One cic flake seen and dismissed with evidence: `subscribe.test.ts` timed out
at 5006 ms in the first full run, on a file this branch does not touch
(`git diff --stat` = 0 lines); isolated re-run green, second full run green.

Full `scripts/integration.sh` was NOT run locally — the host lane is contended
and another worker is queued behind it, so the full-suite gate is this PR's CI
job by design, not an omission.