### PR TITLE
ops(#1029): give the in-repo nginx substrates the production log format

### DIFF
--- a/cicchetto/e2e/nginx-test.conf
+++ b/cicchetto/e2e/nginx-test.conf
@@ -24,6 +24,12 @@ http {
     keepalive_timeout 65;
     server_tokens   off;
 
+    # Access-log shape — the same snippet the native-host substrate includes
+    # (#1029), so a diagnosis rehearsed here reads like the production one.
+    # http context: `log_format` is not valid inside `server { }`. Resolved
+    # from the ../../infra/snippets bind mount, like locations-api.conf.
+    include /etc/nginx/snippets/log-format.conf;
+
     upstream grappa_upstream {
         server grappa:4000;
         keepalive 32;

--- a/infra/linux/install_nginx.sh
+++ b/infra/linux/install_nginx.sh
@@ -2,7 +2,8 @@
 # Install the dumb reverse-proxy nginx config + shared snippet on a native
 # Linux host, enable/reload the service. The BEAM self-serves the SPA and
 # owns every header (#485), so there is no cicchetto-dist symlink and no
-# security-headers snippet — only the substrate-agnostic proxy snippet.
+# security-headers snippet — only the two substrate-agnostic snippets: the
+# proxy locations and the shared access-log format (#1029).
 #
 # Idempotent — re-run after `git pull` (or to change
 # LISTEN_ADDR/TRUSTED_UPSTREAM_CIDR) to refresh the config.
@@ -48,6 +49,9 @@ echo "[install_nginx] installing config + snippets"
 install -o root -g root -m 0644 "${tmp_conf}" "${NGINX_ETC}/nginx.conf"
 mkdir -p "${NGINX_ETC}/snippets"
 install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/locations-api.conf" "${NGINX_ETC}/snippets/locations-api.conf"
+# #1029 — nginx.conf includes this one too; miss it and `nginx -t` below
+# fails AFTER the config has already been written to /etc/nginx.
+install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/log-format.conf" "${NGINX_ETC}/snippets/log-format.conf"
 
 echo "[install_nginx] nginx -t"
 nginx -t

--- a/infra/linux/nginx.conf
+++ b/infra/linux/nginx.conf
@@ -14,7 +14,7 @@
 # Installed by install_nginx.sh, which:
 #   1. cp this file → /etc/nginx/nginx.conf (substituting @LISTEN_ADDR@ and
 #      the optional allow/deny block)
-#   2. cp ../snippets/locations-api.conf → /etc/nginx/snippets/
+#   2. cp ../snippets/{locations-api,log-format}.conf → /etc/nginx/snippets/
 #   3. nginx -t && systemctl enable --now nginx (or reload if already up)
 
 worker_processes auto;
@@ -26,6 +26,11 @@ http {
     sendfile        on;
     keepalive_timeout 65;
     server_tokens   off;
+
+    # Access-log shape — shared with every other nginx substrate (#1029).
+    # Must sit here in the http context: `log_format` is not valid inside
+    # `server { }`, which is where locations-api.conf is included.
+    include snippets/log-format.conf;
 
     upstream grappa_upstream {
         server 127.0.0.1:4000;

--- a/infra/snippets/log-format.conf
+++ b/infra/snippets/log-format.conf
@@ -1,0 +1,59 @@
+# grappa — shared nginx access-log format (http context)
+#
+# THE single definition of the access-log line, included from every nginx
+# substrate that still exists (#1029):
+#   - infra/linux/nginx.conf         (native systemd host)
+#   - cicchetto/e2e/nginx-test.conf  (the e2e :80 + :443 TLS surface)
+# Sibling of locations-api.conf, same reason: three substrates each growing
+# their own nearly-identical format means the three logs stop being
+# comparable a month later. `log_format` is http-context only, which is why
+# this is a second snippet rather than a block inside locations-api.conf
+# (that one is included inside `server { }`).
+#
+# WHY THESE FIELDS — #394 counted 20 client aborts over 45,135 requests at
+# the edge and could not attribute a single one, because the default
+# `combined` format answers none of the questions:
+#   rt=$request_time              is an abort our own 8s bootFetch ceiling or
+#                                 a client teardown? did the server take long,
+#                                 or was it fast and the client left? is a 499
+#                                 really the 60s edge ceiling? five of the six
+#                                 questions need only this one field.
+#   urt=$upstream_response_time   separates "the BEAM was slow" from "the edge
+#   us=$upstream_status           was slow", and exposes a retry.
+#   rid=$sent_http_x_request_id   THE join key to the BEAM log. Phoenix
+#                                 already sets the x-request-id response
+#                                 header (Plug.RequestId) and already carries
+#                                 request_id in its Logger metadata
+#                                 (config/config.exs) — but nginx never logged
+#                                 it, so the two logs could not be joined at
+#                                 all. This is that one field.
+#   msec=$msec                    ms resolution: with second-granular
+#                                 $time_local a single suspend event is
+#                                 indistinguishable from N independent aborts.
+#
+# WHY APPENDED AND NOT INTERLEAVED — this shape is byte-identical to the one
+# vjt applied to the m42 HOST vhost (out of this repo) on 2026-08-08, and it
+# must stay that way. Those logs are shipped by syslog-ng into a telegraf
+# collector that parses `combined` POSITIONALLY: client IP, then the first
+# quoted string is the request line, the next two tokens are status and
+# bytes, then referer and user-agent are the first two quoted strings of the
+# remainder. A field inserted ANYWHERE before the user-agent silently
+# mis-assigns every one of them; a field appended after it is ignored by the
+# parser and stays greppable in the raw message. Verified against
+# VictoriaLogs after the host reload, not assumed.
+#
+# The name is `main` to match the host vhost, so a grep written for one log
+# reads the other.
+
+log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                '$status $body_bytes_sent "$http_referer" '
+                '"$http_user_agent" "$http_x_forwarded_for" '
+                'rt=$request_time urt=$upstream_response_time us=$upstream_status '
+                'rid=$sent_http_x_request_id msec=$msec';
+
+# http-context default, so every server block in every includer inherits it
+# and no substrate can half-adopt the format. The path is nginx's own
+# default location: on a native host it is the file logrotate already
+# rotates, and in the nginx:alpine image it is symlinked to /dev/stdout, so
+# the e2e surface logs to `docker logs` with no per-substrate override.
+access_log /var/log/nginx/access.log main;

--- a/test/infra/nginx_log_format_test.bats
+++ b/test/infra/nginx_log_format_test.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+#
+# GH #1029 — the nginx access log carries no duration and no correlation id,
+# so a request-level diagnosis is blind. The #394 re-measurement counted 20
+# client aborts over 45,135 requests and could not attribute ONE of them.
+#
+# The host half (m42's `/usr/local/etc/nginx/sites/irc.openssl.it`) is out of
+# this repo and already live. This suite guards the IN-REPO half: the
+# substrates must log the SAME shape, or a diagnosis rehearsed locally reads
+# differently from the one run in production — which is the whole point of
+# the parity ask, not a tidiness preference.
+#
+# The subject is the SHAPE OF THE LOG LINE an operator gets, and the failure
+# mode being guarded is DRIFT: three substrates each growing their own
+# slightly-different `log_format` until the logs stop being comparable. So
+# every assertion here is derived from the tree rather than hardcoded —
+# "every conf with an http block includes the one snippet", not "these two
+# files contain this string". A NEW substrate added next year fails this
+# suite until it joins the format, which a hardcoded list would not do.
+#
+# What this suite does NOT do: run `nginx -t`. That needs a real nginx, and
+# the e2e stack already provides one — `cicchetto/e2e/nginx-test.conf` mounts
+# the snippet and nginx-test refuses to start on a syntax error, taking every
+# e2e spec down with it. Syntax is gated there; SHAPE is gated here.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SNIPPET="infra/snippets/log-format.conf"
+
+# Every nginx conf in the worktree, whatever its context — the search space
+# for a stray second definition.
+#
+# `--cached --others --exclude-standard`, not plain `ls-files`: a conf that
+# has been WRITTEN but not yet staged is exactly the moment this guard is
+# most useful, and a tracked-only listing would wave it through while still
+# reporting green. `--exclude-standard` keeps gitignored trees (node_modules,
+# _build) out.
+all_confs() {
+    git -C "$REPO_ROOT" ls-files --cached --others --exclude-standard -- '*.conf' 2>/dev/null
+}
+
+# The confs that open an `http { }` block, i.e. the ones that can host a
+# `log_format` (the directive is http-context only). Derived, so a new
+# substrate is in scope the day it appears.
+#
+# This deliberately EXCLUDES infra/nginx-tls-frontend.example.conf: it is a
+# server-context fragment dropped into an operator's own nginx, so it can
+# neither define a format nor reference one this repo controls.
+http_context_confs() {
+    all_confs | while IFS= read -r f; do
+        grep -q '^http {' "$REPO_ROOT/$f" && printf '%s\n' "$f"
+    done || true
+}
+
+@test "log_format is defined exactly once, in the shared snippet (#1029)" {
+    # `|| true` on the substitution, not inside: the loop's status is the LAST
+    # grep's, so a final non-matching conf would abort the body under errexit
+    # before the comparison ever runs.
+    definers="$(all_confs | while IFS= read -r f; do
+        grep -qE '^[[:space:]]*log_format[[:space:]]' "$REPO_ROOT/$f" && printf '%s\n' "$f"
+    done || true)"
+
+    [ "$definers" = "$SNIPPET" ] || {
+        echo "expected exactly one log_format definition site ($SNIPPET), got:" >&2
+        printf '%s\n' "${definers:-<none>}" >&2
+        return 1
+    }
+}
+
+@test "the shared format carries every field the #1029 diagnosis needs" {
+    fmt="$REPO_ROOT/$SNIPPET"
+
+    # $request_time answers five of the six questions in the issue on its own
+    # (8s bootFetch ceiling vs teardown, the 60s edge ceiling wearing a 499,
+    # aborts per second-in-flight, slow-server vs departed-client).
+    grep -q 'rt=\$request_time' "$fmt" || { echo "missing rt=\$request_time" >&2; return 1; }
+
+    # upstream_* separates "the BEAM was slow" from "the edge was slow", and
+    # exposes a retry.
+    grep -q 'urt=\$upstream_response_time' "$fmt" || { echo "missing urt=\$upstream_response_time" >&2; return 1; }
+    grep -q 'us=\$upstream_status' "$fmt" || { echo "missing us=\$upstream_status" >&2; return 1; }
+
+    # THE join key. Phoenix already emits x-request-id (Plug.RequestId) and
+    # already logs request_id in its Logger metadata; without this field the
+    # two logs cannot be joined at all, which is the single line this issue
+    # is really about.
+    grep -q 'rid=\$sent_http_x_request_id' "$fmt" || { echo "missing rid=\$sent_http_x_request_id" >&2; return 1; }
+
+    # Millisecond resolution — with $time_local alone, one suspend event is
+    # indistinguishable from N independent aborts in the same second.
+    grep -q 'msec=\$msec' "$fmt" || { echo "missing msec=\$msec" >&2; return 1; }
+}
+
+@test "the appended fields come AFTER the user-agent, positionally (#1029)" {
+    # Not cosmetic. These logs are shipped off m42 by syslog-ng into a
+    # telegraf collector that parses `combined` POSITIONALLY: client IP
+    # first, then the first quoted string is the request line, the next two
+    # tokens are status and bytes, then referer and user-agent are the first
+    # two quoted strings of the remainder. Anything INTERLEAVED silently
+    # mis-assigns every downstream field; anything appended is ignored.
+    # vjt verified this against VictoriaLogs when applying the host half.
+    fmt="$REPO_ROOT/$SNIPPET"
+    flat="$(tr -d " \n'" < "$fmt")"
+
+    case "$flat" in
+        *'"$http_user_agent""$http_x_forwarded_for"rt=$request_time'*) ;;
+        *)
+            echo "the rt=/urt=/us=/rid=/msec= tail must follow the user-agent and" >&2
+            echo "x-forwarded-for pair verbatim — an interleaved field breaks the" >&2
+            echo "positional collector parser on m42. Got:" >&2
+            cat "$fmt" >&2
+            return 1
+            ;;
+    esac
+}
+
+@test "the shared snippet USES the format it defines (#1029)" {
+    # Defining a format nobody references changes not one byte of the log —
+    # the hollow-green version of this whole change. The format NAME is read
+    # back out of the definition rather than hardcoded, so renaming it in one
+    # place and not the other still fails here.
+    fmt="$REPO_ROOT/$SNIPPET"
+
+    name="$(sed -nE 's/^[[:space:]]*log_format[[:space:]]+([A-Za-z0-9_]+).*/\1/p' "$fmt" | head -n1)"
+    [ -n "$name" ] || { echo "could not read the log_format name out of $SNIPPET" >&2; return 1; }
+
+    grep -qE "^[[:space:]]*access_log[[:space:]]+\S+[[:space:]]+${name}[[:space:]]*;" "$fmt" || {
+        echo "no access_log references the '${name}' format in $SNIPPET:" >&2
+        cat "$fmt" >&2
+        return 1
+    }
+}
+
+@test "every http-context nginx conf includes the shared snippet (#1029)" {
+    confs="$(http_context_confs)"
+
+    # Anti-vacuous: two substrates exist today (infra/linux, cicchetto/e2e).
+    # A broken derivation returning nothing would otherwise pass loudly.
+    count="$(printf '%s\n' "$confs" | grep -c . || true)"
+    [ "$count" -ge 2 ] || {
+        echo "expected >=2 http-context nginx confs, found $count — the derivation is wrong:" >&2
+        printf '%s\n' "$confs" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$confs" | while IFS= read -r f; do
+        grep -q 'include .*log-format\.conf;' "$REPO_ROOT/$f" || printf '%s\n' "$f"
+    done)"
+
+    [ -z "$violations" ] || {
+        echo "nginx conf(s) with an http block that do NOT include $SNIPPET (#1029):" >&2
+        printf '%s\n' "$violations" >&2
+        return 1
+    }
+}
+
+@test "install_nginx.sh installs every snippet the linux conf includes (#1029)" {
+    # The native-host failure this closes: the conf includes a snippet the
+    # installer never copies, so `nginx -t` fails at install time on a real
+    # host — after the config has already been written to /etc/nginx.
+    # Derived from the conf's own include lines, so the next snippet added is
+    # covered without touching this test.
+    conf="$REPO_ROOT/infra/linux/nginx.conf"
+    installer="$REPO_ROOT/infra/linux/install_nginx.sh"
+
+    includes="$(sed -nE 's@^[[:space:]]*include[[:space:]]+snippets/([A-Za-z0-9_.-]+);.*@\1@p' "$conf")"
+
+    count="$(printf '%s\n' "$includes" | grep -c . || true)"
+    [ "$count" -ge 2 ] || {
+        echo "expected >=2 snippet includes in infra/linux/nginx.conf, found $count:" >&2
+        printf '%s\n' "$includes" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$includes" | while IFS= read -r snip; do
+        grep -q "snippets/${snip}" "$installer" || printf '%s\n' "$snip"
+    done)"
+
+    [ -z "$violations" ] || {
+        echo "snippet(s) included by nginx.conf but never installed by install_nginx.sh:" >&2
+        printf '%s\n' "$violations" >&2
+        return 1
+    }
+}
+
+@test "the e2e stack mounts the snippets directory into nginx-test (#1029)" {
+    # The e2e includer resolves /etc/nginx/snippets/log-format.conf from a
+    # bind mount of the whole infra/snippets dir. Drop the mount and nginx
+    # dies at startup, taking the whole e2e run with it — a slow, confusing
+    # red compared to this line.
+    compose="$REPO_ROOT/cicchetto/e2e/compose.yaml"
+
+    grep -qE '^\s*-\s*\.\./\.\./infra/snippets:/etc/nginx/snippets:ro\s*$' "$compose" || {
+        echo "cicchetto/e2e/compose.yaml no longer mounts infra/snippets into nginx-test:" >&2
+        grep -n 'snippets' "$compose" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
The in-repo half of #1029. The host half (m42's `/usr/local/etc/nginx/sites/irc.openssl.it`) is
out of this repo and **already live** — vjt applied and reloaded it on 2026-08-08.

## What was blind

`infra/linux/nginx.conf` and `cicchetto/e2e/nginx-test.conf` defined **no `log_format` and no
`access_log` at all**, so they inherited nginx's `combined` default: status, path, user-agent, and
nothing else. The #394 re-measurement counted 20 client aborts over 45,135 requests and could not
attribute a single one, because every discriminator it needed is a field `combined` does not carry —
was this our own 8s `bootFetch` ceiling or a client teardown, did the server take long or did the
client leave, is one suspend event being counted as N.

## What this does

One new `infra/snippets/log-format.conf`, included by both substrates:

```nginx
log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                '$status $body_bytes_sent "$http_referer" '
                '"$http_user_agent" "$http_x_forwarded_for" '
                'rt=$request_time urt=$upstream_response_time us=$upstream_status '
                'rid=$sent_http_x_request_id msec=$msec';

access_log /var/log/nginx/access.log main;
```

- **Defined once, not pasted twice.** Two nearly-identical copies stop being comparable the first
  time somebody edits one, and comparability is the entire point. It is a *second* snippet rather
  than a block inside `locations-api.conf` because `log_format` is http-context only and that one is
  included inside `server { }`.
- **Byte-identical to the live host vhost, with the tail APPENDED.** Those logs are shipped by
  syslog-ng into a collector that parses `combined` *positionally*; a field inserted anywhere before
  the user-agent silently mis-assigns every one after it.
- `rid=$sent_http_x_request_id` is the join key to the BEAM log — Phoenix already sets the header
  (`Plug.RequestId`) and already logs `request_id`; nginx just never wrote it down.
- `install_nginx.sh` now installs the new snippet. The e2e stack already bind-mounts the whole
  `infra/snippets` dir, so it needs no wiring.

### Correction to the issue text

`infra/freebsd/nginx.conf` does not exist — the jail has no nginx (its host vhost is the one out of
repo). The in-repo substrates with an `http { }` block are **two**, not three.

## Verification

| gate | result |
|---|---|
| `scripts/bats.sh` (full set) | exit 0 — 445 ok, 0 not ok |
| new `test/infra/nginx_log_format_test.bats` | 7 cases, all green |
| mutation run, 7 mutants | 7 killed, **one assertion each** |
| real `nginx -t`, `infra/linux/nginx.conf` | `test is successful` |
| real `nginx -t`, `cicchetto/e2e/nginx-test.conf` | `test is successful` |
| deliberately corrupted snippet | `[emerg] … test failed` — the check can fail |

Run against the digest-pinned `nginx:alpine`, with the installer's two placeholders rendered exactly
as `install_nginx.sh` renders them. A real nginx was then started and probed, to confirm the line
actually comes out — and comes out on stdout, as the snippet's comment claims:

```
192.168.65.1 - - [11/Aug/2026:19:53:43 +0000] "GET /healthz HTTP/1.1" 502 150 "-"
"grappa-1029-probe/1.0" "-" rt=0.000 urt=0.000 us=502 rid=- msec=1786478023.235
```

`rid=-` because no BEAM was behind it (hence the 502); vjt's live m42 line shows it populated.

The guard is derived from the tree rather than hardcoded — "every conf with an `http` block includes
the one snippet", "the installer installs every snippet the conf includes" — so a new substrate, or
a new snippet, is in scope the day it appears.

## Still manual, and still open

- **The m42 host vhost half is NOT in this PR** and stays a manual host-side apply. It is already
  done and live; nothing here touches it, and nothing here connects to m42.
- **Retention is untouched** — the other half of the blindness the issue raises, and a host-side
  decision. Worth noting: this change adds **71 bytes per request** (measured on the live m42 line),
  so a *size*-based rotation now retains proportionally less time than it did yesterday.
- `infra/nginx-tls-frontend.example.conf` is deliberately left alone: it is a server-context fragment
  dropped into an operator's own nginx, so it cannot define a format or reference one this repo owns.

## Deploy

**nginx config only — applies with a `reload`. No BEAM restart, no migration, no code.** Nothing here
is on the hot/cold axis: it does not touch `config/`, `mix.exs`, `VERSION`, or any `.ex`.