### PR TITLE
cic(#1235): cap the reply quote at 42 chars and space the trailing <<

### DIFF
--- a/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
+++ b/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
@@ -173,7 +173,7 @@ test("issue1067 — a left→right swipe on a message quotes it into the compose
   expect(result.transformAfter).toBe("");
 
   // THE outcome: the quote, exactly as the issue spells it, caret at the end.
-  const quote = `<${specNick()}> ${body}<< `;
+  const quote = `<${specNick()}> ${body} << `;
   await expect(composeTextarea(page)).toHaveValue(quote);
   const caret = await composeTextarea(page).evaluate(
     (el) => (el as HTMLTextAreaElement).selectionStart,
@@ -293,7 +293,7 @@ test("issue1067 — the menu's Reply item fills the compose with the same quote 
   await menuItem(page, "Reply").click();
 
   await expect(menu(page)).toHaveCount(0);
-  await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body}<< `);
+  await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body} << `);
 });
 
 // The clipboard is stubbed at the browser boundary rather than driven through
@@ -408,7 +408,7 @@ test("issue1156 — a join row refuses the swipe while the privmsg above it stil
     ]);
     expect(onSpeech.prevented).toBe(true);
     expect(onSpeech.transformDuring).toMatch(/^translateX\(\d/);
-    await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body}<< `);
+    await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body} << `);
   } finally {
     await peer.disconnect("1156 witness done");
   }

--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -42,14 +42,35 @@ test.setTimeout(90_000);
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // The issue measured the threshold at a 390px viewport: a 46-char quote
-// already wraps and already hides the caret. This body is deliberately far
-// past it — around six wrapped lines — so the required overflow below is a
-// wide margin rather than a coin toss on font metrics, while staying well
+// already wraps and already hides the caret. This body is far past it, so the
+// ROW wraps and the quote it produces is a capped one, while staying well
 // inside one PRIVMSG so the server-side split budget (#246) never turns it
 // into two scrollback rows.
 const FILLER =
   "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
   "quindi il caret finisce sotto la piega e non si vede piu' nulla";
+
+// #1235 capped the quoted body at 42 characters plus a literal `...`, so a
+// single reply can no longer BE six wrapped lines: the longest quote the
+// gesture can now produce is `<nick> ` + 45 + ` << `, about two. The overflow
+// this spec needs is therefore built the way an operator builds it — the reply
+// verb APPENDS, so three replies to the same row stack into a draft that wraps
+// well past the fold, with the caret at the very end of the third. What is
+// measured is unchanged: the caret's geometry after an append.
+//
+// Hardcoded in lockstep with `REPLY_QUOTE_BODY_LIMIT` / `REPLY_QUOTE_ELLIPSIS`
+// in `src/lib/replyQuote.ts` — the e2e package does not import from `src`, and
+// the house convention here is a mirrored constant with a lockstep comment.
+const QUOTED_BODY_LIMIT = 42;
+const QUOTED_ELLIPSIS = "...";
+const REPLIES = 3;
+
+function cappedQuotedBody(body: string): string {
+  const chars = [...body];
+  return chars.length <= QUOTED_BODY_LIMIT
+    ? body
+    : chars.slice(0, QUOTED_BODY_LIMIT).join("") + QUOTED_ELLIPSIS;
+}
 
 // A body unique per run: the e2e sqlite scrollback persists across
 // KEEP_STACK=1 re-runs, and a static string would match two rows on the
@@ -58,9 +79,10 @@ function uniqueBody(): string {
   return `issue1105 ${Date.now()} ${FILLER}`;
 }
 
-// Six-ish wrapped lines minus generous slack. Its job is to fail loudly if the
-// fixture ever stops overflowing, because then "the caret is in view" would be
-// true for the wrong reason.
+// Six-ish wrapped lines minus generous slack — three stacked quotes come to
+// about what the single uncapped one used to be. Its job is to fail loudly if
+// the fixture ever stops overflowing, because then "the caret is in view" would
+// be true for the wrong reason.
 const MIN_OVERFLOW_PX = 40;
 
 // A left→right drag on the message row whose text contains `body`. Touch
@@ -116,10 +138,13 @@ test("issue1105 — replying to a wrapping message scrolls the compose caret int
   await expect(ta).toHaveValue("");
   expect((await composeCaretGeometry(page)).scrollTop).toBe(0);
 
-  await swipeRowRight(page, body);
-
-  const quote = `<${specNick()}> ${body}<< `;
-  await expect(ta).toHaveValue(quote, { timeout: 5_000 });
+  // Each reply is awaited before the next is fired: the value IS the barrier
+  // proving the previous append landed, so the swipes cannot overlap.
+  const quote = `<${specNick()}> ${cappedQuotedBody(body)} << `;
+  for (let i = 1; i <= REPLIES; i++) {
+    await swipeRowRight(page, body);
+    await expect(ta).toHaveValue(quote.repeat(i), { timeout: 5_000 });
+  }
 
   // THE regression: caret at the end of the quote AND that line inside the
   // client box. Before the fix scrollTop stayed 0 with the caret below it.

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -5998,7 +5998,7 @@ describe("ScrollbackPane", () => {
 
       swipeRight(speechRow);
 
-      expect(getDraft(KEY)).toBe("<alice> hello<< ");
+      expect(getDraft(KEY)).toBe("<alice> hello << ");
     });
   });
 });

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -4,7 +4,13 @@ import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
 import { appendToCompose } from "../lib/composeAppend";
-import { replyQuote, replyToMessage } from "../lib/replyQuote";
+import {
+  REPLY_QUOTE_BODY_LIMIT,
+  REPLY_QUOTE_ELLIPSIS,
+  REPLY_QUOTE_TAIL,
+  replyQuote,
+  replyToMessage,
+} from "../lib/replyQuote";
 
 // #1067 — the reply verb: a swipe (or the menu's Reply item) drops
 // `<nick> quoted message<< ` into the compose box with the caret at the end,
@@ -44,14 +50,14 @@ beforeEach(() => {
 
 describe("replyQuote", () => {
   it("renders the irssi-shaped quote the issue specifies", () => {
-    expect(replyQuote(msg({}))).toBe("<vjt> ciao mondo<< ");
+    expect(replyQuote(msg({}))).toBe("<vjt> ciao mondo << ");
   });
 
   // The body on the wire can carry mIRC colour/bold control bytes; the operator
   // is quoting what they SEE, and a control byte pasted into compose would be
   // re-sent verbatim as formatting they never chose.
   it("strips mIRC control codes out of the quoted body", () => {
-    expect(replyQuote(msg({ body: "\x02bold\x02 plain" }))).toBe("<vjt> bold plain<< ");
+    expect(replyQuote(msg({ body: "\x02bold\x02 plain" }))).toBe("<vjt> bold plain << ");
   });
 
   // Presence rows (join/part/quit/mode/…) have no author speaking and often no
@@ -71,7 +77,7 @@ describe("replyQuote", () => {
   });
 
   it("quotes a notice like speech — it has an author and a body", () => {
-    expect(replyQuote(msg({ kind: "notice" }))).toBe("<vjt> ciao mondo<< ");
+    expect(replyQuote(msg({ kind: "notice" }))).toBe("<vjt> ciao mondo << ");
   });
 
   // #1126 — a real action row carries the wire envelope (`\x01ACTION …\x01`);
@@ -81,7 +87,7 @@ describe("replyQuote", () => {
   // ended up in the compose box and from there onto the wire.
   it("quotes an action in ACTION form, envelope stripped — #1126", () => {
     expect(replyQuote(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
-      "* vjt si dà alla fuga<< ",
+      "* vjt si dà alla fuga << ",
     );
   });
 
@@ -98,7 +104,7 @@ describe("replyQuote", () => {
   // future server-side pre-strip, or a row persisted before the wire form was
   // stored). The action SHAPE must not depend on the envelope being there.
   it("still uses action form when the envelope is absent — #1126", () => {
-    expect(replyQuote(msg({ kind: "action", body: "ciao mondo" }))).toBe("* vjt ciao mondo<< ");
+    expect(replyQuote(msg({ kind: "action", body: "ciao mondo" }))).toBe("* vjt ciao mondo << ");
   });
 
   // An envelope with nothing inside is not a quotable action: after the strip
@@ -114,7 +120,7 @@ describe("replyQuote", () => {
 describe("replyQuote — a previous quote is dropped (#1123)", () => {
   it("quotes only what the sender wrote, not the quote they were answering", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
-      "<alice> answer<< ",
+      "<alice> answer << ",
     );
   });
 
@@ -124,14 +130,14 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   it("cuts at the last tail, not the first", () => {
     expect(
       replyQuote(msg({ sender: "carol", body: "<alice> <bob> original<< answer<< reply" })),
-    ).toBe("<carol> reply<< ");
+    ).toBe("<carol> reply << ");
   });
 
   // #1126 gave actions their own quote head (`* nick …`), so the client emits
   // two shapes and both nest. One bug, both doors.
   it("drops a previous action-shaped quote too", () => {
     expect(replyQuote(msg({ sender: "alice", body: "* bob waves<< sure" }))).toBe(
-      "<alice> sure<< ",
+      "<alice> sure << ",
     );
   });
 
@@ -140,7 +146,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
       replyQuote(
         msg({ kind: "action", sender: "alice", body: "\x01ACTION <bob> orig<< nods\x01" }),
       ),
-    ).toBe("* alice nods<< ");
+    ).toBe("* alice nods << ");
   });
 
   // Every legal nick special (RFC 2812 `special` plus the tail-only dash),
@@ -148,7 +154,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   // instead of derived would silently refuse to strip these.
   it("recognises a head with every legal nick special", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<_a[b]\\c{d}|e^f`g-1> quoted<< mine" }))).toBe(
-      "<alice> mine<< ",
+      "<alice> mine << ",
     );
   });
 
@@ -158,7 +164,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
     const nick = `n${"x".repeat(29)}`;
     expect(nick).toHaveLength(30);
     expect(replyQuote(msg({ sender: "alice", body: `<${nick}> quoted<< mine` }))).toBe(
-      "<alice> mine<< ",
+      "<alice> mine << ",
     );
   });
 
@@ -176,7 +182,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   // typed after a wider gap would arrive with the gap still on it.
   it("does not carry the gap after the tail into the new quote", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<   spaced" }))).toBe(
-      "<alice> spaced<< ",
+      "<alice> spaced << ",
     );
   });
 });
@@ -186,17 +192,17 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
   // which is worse than the nesting it fixes.
   it("leaves a shift expression alone", () => {
     expect(replyQuote(msg({ body: "shift << 2 gives four" }))).toBe(
-      "<vjt> shift << 2 gives four<< ",
+      "<vjt> shift << 2 gives four << ",
     );
   });
 
   it("leaves a heredoc alone", () => {
-    expect(replyQuote(msg({ body: "cat <<EOF > f" }))).toBe("<vjt> cat <<EOF > f<< ");
+    expect(replyQuote(msg({ body: "cat <<EOF > f" }))).toBe("<vjt> cat <<EOF > f << ");
   });
 
   it("leaves a leading angle bracket that is not a nick head alone", () => {
-    expect(replyQuote(msg({ body: "<3 you << me" }))).toBe("<vjt> <3 you << me<< ");
-    expect(replyQuote(msg({ body: "<two words> a << b" }))).toBe("<vjt> <two words> a << b<< ");
+    expect(replyQuote(msg({ body: "<3 you << me" }))).toBe("<vjt> <3 you << me << ");
+    expect(replyQuote(msg({ body: "<two words> a << b" }))).toBe("<vjt> <two words> a << b << ");
   });
 
   // The head must be at position 0. `appendToCompose` drops the quote AFTER an
@@ -204,8 +210,109 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
   // sender's own words — cutting there would delete what they wrote.
   it("leaves a quote that is not at the start of the body alone", () => {
     expect(replyQuote(msg({ sender: "alice", body: "bozza <bob> ciao<< risposta" }))).toBe(
-      "<alice> bozza <bob> ciao<< risposta<< ",
+      "<alice> bozza <bob> ciao<< risposta << ",
     );
+  });
+});
+
+// #1235 — vjt: "sul reply limitiamo a 42 i caratteri di cui facciamo reply, se
+// sforano mettiamo un ellipsis `...`, e poi mettiamo sempre uno spazio prima
+// del `<<` finale". The cap lives in the WRAPPER, never in `quotableBody`:
+// that helper is shared with `!addquote` (#1107), which archives the line and
+// must keep it whole. `addQuote.test.ts` is the control group for that.
+describe("replyQuote — the quoted body is capped (#1235)", () => {
+  const AT_LIMIT = "a".repeat(REPLY_QUOTE_BODY_LIMIT);
+
+  it("leaves a body at the limit whole, with no ellipsis", () => {
+    expect(replyQuote(msg({ body: AT_LIMIT }))).toBe(`<vjt> ${AT_LIMIT} << `);
+  });
+
+  // The first body over the limit is where an off-by-one shows: one way it
+  // clips a body that fits, the other it lets a 43rd character through.
+  it("caps the first body that overflows", () => {
+    expect(replyQuote(msg({ body: `${AT_LIMIT}b` }))).toBe(`<vjt> ${AT_LIMIT}... << `);
+  });
+
+  // The 42 counts BODY characters and the ellipsis is ADDED past them — the
+  // quoted run is 45, not 42 with three of them spent on dots.
+  it("keeps a full 42 characters and adds the ellipsis after them", () => {
+    const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
+    const quoted = quote.slice("<vjt> ".length, -REPLY_QUOTE_TAIL.length);
+    expect(quoted).toBe(`${"x".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}`);
+    expect(quoted).toHaveLength(REPLY_QUOTE_BODY_LIMIT + REPLY_QUOTE_ELLIPSIS.length);
+  });
+
+  // Hardcoded on purpose, against the constant: the request spells the marker
+  // `...`, and a U+2026 that renders identically would still be a different
+  // byte sequence going onto the wire.
+  it("marks the overflow with three ASCII dots, not U+2026", () => {
+    const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
+    expect(quote).toContain("x...");
+    expect(quote).not.toContain("…");
+  });
+
+  // A flat cut, with no backing off to the last word boundary: that is
+  // "limitiamo a 42 i caratteri" read literally, and a word-boundary rule would
+  // make the quote length depend on where the spaces happen to fall.
+  it("cuts flat at the limit, mid-word", () => {
+    const body = `${"parola ".repeat(5)}spezzata`;
+    expect(body).toHaveLength(43);
+    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(5)}spezzat... << `);
+  });
+
+  // The cap is on the BODY: a long nick does not eat into what the sender said.
+  it("does not count the nick head against the limit", () => {
+    const nick = "n".repeat(30);
+    expect(replyQuote(msg({ sender: nick, body: AT_LIMIT }))).toBe(`<${nick}> ${AT_LIMIT} << `);
+  });
+
+  // The cap runs AFTER the #1123 de-nesting cut, on what the sender actually
+  // wrote. Capping first would spend the whole budget on the quote they were
+  // answering and truncate their answer to nothing.
+  it("counts what the sender wrote, not the quote they were answering", () => {
+    const body = `<bob> ${"o".repeat(200)}<< breve`;
+    expect(replyQuote(msg({ sender: "alice", body }))).toBe("<alice> breve << ");
+  });
+
+  // A UTF-16 slice at 42 can land between the halves of a surrogate pair and
+  // emit a lone surrogate — an unpaired code unit in the compose box, and from
+  // there onto the wire. The cut counts code points.
+  it("does not cut an astral character in half", () => {
+    const quote = replyQuote(msg({ body: `${"a".repeat(41)}🍺x` })) ?? "";
+    expect(quote).toBe(`<vjt> ${"a".repeat(41)}🍺... << `);
+    expect(quote.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "")).not.toMatch(/[\uD800-\uDFFF]/);
+  });
+});
+
+// #1235 — the tail grew a leading space. The de-nesting regex
+// (`quotableBody.ts`) is `^(?:<nick>|\* nick) [\s\S]*<<(?: |$)`, whose greedy
+// head absorbs a space as happily as a word character, so the nesting cut is
+// supposed to keep working on BOTH spellings. That is the one thing which would
+// silently break every line already persisted, so it is asserted, not assumed.
+describe("replyQuote — the spaced tail still de-nests, both spellings (#1235)", () => {
+  it("strips a quote persisted with the OLD flush tail", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+
+  it("strips a quote written with the NEW spaced tail", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original << answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+
+  // The full round trip: what the wrapper emits today, quoted again tomorrow.
+  it("round-trips its own output", () => {
+    const first = replyQuote(msg({ sender: "bob", body: "original" })) ?? "";
+    expect(replyQuote(msg({ sender: "alice", body: `${first}answer` }))).toBe("<alice> answer << ");
+  });
+
+  // And the same trip on a CAPPED line, where the tail follows an ellipsis
+  // rather than a word — the shape the cap makes commonplace.
+  it("round-trips a capped quote", () => {
+    const first = replyQuote(msg({ sender: "bob", body: "o".repeat(200) })) ?? "";
+    expect(replyQuote(msg({ sender: "alice", body: `${first}answer` }))).toBe("<alice> answer << ");
   });
 });
 
@@ -249,7 +356,7 @@ describe("replyToMessage", () => {
   it("fills an empty compose with exactly the quote", () => {
     mountCompose();
     replyToMessage(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("<vjt> ciao mondo<< ");
+    expect(getDraft(KEY)).toBe("<vjt> ciao mondo << ");
   });
 
   // Never destroy work in progress: the quote lands AFTER what is already
@@ -258,7 +365,7 @@ describe("replyToMessage", () => {
     mountCompose();
     setDraft(KEY, "bozza ");
     replyToMessage(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("bozza <vjt> ciao mondo<< ");
+    expect(getDraft(KEY)).toBe("bozza <vjt> ciao mondo << ");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -9,15 +9,41 @@ import { quotableBody } from "./quotableBody";
 // text also carries the timestamp and the per-message prefix glyph (@/+), and
 // scraping those back out is a parser nobody asked for.
 
-// The tail the issue specifies verbatim: `<nick> quoted message<< `, trailing
-// space included, so the answer is typed straight after the caret.
-export const REPLY_QUOTE_TAIL = "<< ";
+// The tail the issue specifies verbatim: `<nick> quoted message << `, spaces on
+// both sides — leading so the tail never sits flush against the last word
+// (#1235), trailing so the answer is typed straight after the caret.
+export const REPLY_QUOTE_TAIL = " << ";
+
+// #1235 — how much of the quoted line comes along. Without a cap, replying to a
+// long message drags the whole thing into the compose box and buries the answer.
+//
+// Four readings of "limitiamo a 42 i caratteri" are all defensible; these are
+// the ones ruled on, deliberately kept to one constant plus one function so a
+// change of mind is a one-line edit:
+//   - 42 counts BODY characters and the ellipsis is ADDED past them (45 quoted,
+//     not 42 with three spent on dots);
+//   - the marker is the literal `...` the request spells, not `…` U+2026;
+//   - the cut is flat at 42, with no backing off to a word boundary;
+//   - the head (`<nick> ` / `* nick `) is outside the count — the nick is not
+//     what overflows.
+export const REPLY_QUOTE_BODY_LIMIT = 42;
+export const REPLY_QUOTE_ELLIPSIS = "...";
+
+// The quoted body, cut to the limit. Counted in CODE POINTS: a UTF-16 slice can
+// land between the halves of a surrogate pair and put a lone surrogate in the
+// compose box, and from there onto the wire.
+function capQuotedBody(body: string): string {
+  const chars = [...body];
+  if (chars.length <= REPLY_QUOTE_BODY_LIMIT) return body;
+  return chars.slice(0, REPLY_QUOTE_BODY_LIMIT).join("") + REPLY_QUOTE_ELLIPSIS;
+}
 
 // The quote for a message, or null when there is nothing to reply to.
 //
 // #1107 — the gate and the plain-text extraction moved to `quotableBody`, which
 // `addQuoteCommand` now shares. What stays here is the WRAPPER, which is the
-// only part reply owns.
+// only part reply owns — and that is why the #1235 cap lives here and not in
+// the helper: `!addquote` archives the line and must keep it whole.
 export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
@@ -26,7 +52,7 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   // the `* nick …` form the scrollback renders. Ruled on the least-surprise
   // tiebreak; privmsg/notice keep the `<nick> …` shape unchanged.
   const head = msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
-  return `${head} ${body}${REPLY_QUOTE_TAIL}`;
+  return `${head} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A


### PR DESCRIPTION
vjt, verbatim: *"sul reply limitiamo a 42 i caratteri di cui facciamo reply, se
sforano mettiamo un ellipsis `...`, e poi mettiamo sempre uno spazio prima del
`<<` finale"*.

Two changes, both in the reply-quote WRAPPER (`cicchetto/src/lib/replyQuote.ts`).

## Where the cap lives, and the control group

The cap is in `replyQuote`, never in `quotableBody`. That helper is shared with
`addQuoteCommand` (#1107), which archives the line and must keep it whole, so a
cap there would have silently clipped `!addquote`.

**`addQuote.test.ts` is the control group and it does not move — zero lines
changed in that file.** If one of its seven `<<`-shaped expectations had shifted,
the cap would have landed in the wrong module.

## The four open readings, and who decided them

The issue left four cheap-but-visible choices open. They were **decided by the
orchestrator and since ratified by vjt**, not by the implementation, and they are
parked in one constant plus one function so a change of mind stays a one-line
edit:

- **42 counts BODY characters and the ellipsis is ADDED past them** — the quoted
  run is 45, not 42 with three spent on dots.
- **The marker is the literal `...`**, three ASCII dots as the request spells it,
  not `…` U+2026.
- **The cut is flat at 42**, with no backing off to a word boundary.
- **The cap applies to the body only** — the `<nick> ` head is outside the count.

One further call was made at the keyboard, and it is an implementation
correctness matter rather than a product one: **the cut counts CODE POINTS, not
UTF-16 units.** A `slice(0, 42)` can land between the halves of a surrogate pair
and put a lone surrogate in the compose box, and from there onto the wire.

## The de-nesting claim, tested rather than cited

The issue asserts that #1123's de-nesting regex (`[\s\S]*<<(?: |$)`) keeps
working with the new tail and on lines persisted with the old one. That is now
four assertions, not a citation: old flush tail, new spaced tail, a round trip
through the wrapper's own output, and a round trip through a CAPPED quote (where
the tail follows an ellipsis rather than a word).

## Mutation results — which test dies, and to what

Five mutants, each applied to the real file, each verified to have landed before
the run (`git diff` non-empty), each reverted after. Baseline is 40 passed.

| # | Mutant | Killed by |
|---|--------|-----------|
| 1 | cap removed (`${body}` back in the template) | **5** tests, all in the #1235 cap block |
| 2 | leading space removed from the tail | **28** tests |
| 3 | ellipsis eats into the 42 (`39 + "..."`) | **4** tests |
| 4 | `...` replaced with `…` U+2026 | **4** tests, incl. the hardcoded-dots one |
| 5 | `[...body]` replaced with `body.split("")` | **1** test — the astral one, exactly |

Mutant 4 is why two ellipsis tests exist: the one written against
`REPLY_QUOTE_ELLIPSIS` is circular and survives it; the one that hardcodes `...`
is what kills it.

## What was measured, and what is still only reasoned

**The e2e ran, on the STACK lane, and it is green.** Union of every spec that
exercises the reply quote (`issue1105|issue1067|issue1156`), fresh stack with no
`KEEP_STACK` because cic `src` changed and the served bundle had to be rebuilt:
**12 passed**.

**#1105's rebuilt fixture measures — proven by displacement, not by passing.**
Its regression needs the compose box to overflow by at least 40px, and the cap
shortens the longest possible quote to ~61 characters. Dropping the fixture to a
single reply and rerunning turns the spec RED on exactly the overflow assertion:

```
expect(g.scrollHeight).toBeGreaterThan(g.clientHeight + minOverflowPx)
Expected: > 82      Received: 73
```

With `clientHeight` at 42, one reply buys **31px of overflow against the 40px
bar** — the earlier PR text called that "nowhere near", reasoned; it is now a
number. Three replies pass. So the three are not a guess: at one it breaks, and
the spec is not green for the wrong reason.

**Still not claimed:** that re-swiping the same row cannot race its own snap-back
transition. Each append is awaited before the next swipe fires, and the run was
green, but that is ONE green run — it is evidence, not a flake verdict.

**No `DESIGN_NOTES.md` entry.** The durable rationale sits at the seam it
governs — the four rulings on the constant, the wrapper-not-helper argument on
`replyQuote`, the cap-vs-overflow consequence in #1105's own header. An entry
would restate them a second time. Happy to add one if the call goes the other
way.
