### PR TITLE
test(#1225): stop the NOTICE fixture from contradicting itself on the nick

### DIFF
--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3831,19 +3831,51 @@ defmodule Grappa.Session.ServerTest do
     # echo, `dm_with: nil`, no `maybe_open_query_window`), different wire verb and
     # a `:notice` row kind. The recipient rides `meta.notice_target` so the render
     # reads it OFF the message rather than the routing key.
+
+    # The registered nick, spelled ONCE, because the fixture used to spell it
+    # twice and differently: the credential seeded `vjt` while the fake server
+    # welcomed `grappa-test` (the `credential_fixture` default, left behind when
+    # this describe overrode the nick). The welcome wins — `EventRouter`'s
+    # numeric-1 arm assigns `state.nick = welcomed_nick`, and `send_notice`
+    # stamps `sender: state.nick` — so the fixture was contradicting itself and
+    # the assertion below was reading whichever side got there first. Same
+    # shape, and the same reason, as #581's `@recover_nick`.
+    @notice_nick "vjt"
+
     setup do
       rfc_handler = fn state, line ->
         if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
+          {:reply, ":server 001 #{@notice_nick} :Welcome\r\n", state}
         else
           {:reply, nil, state}
         end
       end
 
       {server, port} = start_server(rfc_handler)
-      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+      {user, network, _} = setup_user_and_network(port, %{nick: @notice_nick})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+
+      # Barrier: PAST the welcome, not merely past `USER`. `await_handshake`
+      # returns when the client SENDS `USER` — the very line the 001 answers —
+      # so it can return before the session has processed the welcome, leaving
+      # that welcome and this test's `GenServer.call` to race in one mailbox.
+      #
+      # `MODE <nick>` is the #229 umode query, emitted from inside the numeric-1
+      # `handle_info`. Note it is emitted BEFORE the reconciliation, which
+      # happens at the END of that same callback (`delegate/2` → `EventRouter`).
+      # What makes it a sound barrier is not its position but the GenServer
+      # contract: callbacks are serialised, so seeing this line proves the 001
+      # callback has STARTED, and the `GenServer.call` below cannot be served
+      # until it RETURNS — reconciliation included. A barrier on state the
+      # session actually reached, not a sleep and not a wider timeout.
+      #
+      # The two deliberate-mismatch tests above (`grappa-actual`, proving the
+      # welcomed nick wins) use the autojoin `JOIN` for the same purpose. The
+      # umode query is preferred here because it is unconditional in the 001
+      # arm, where autojoin is contingent on the credential's channel list and
+      # on the #347 `+r` deferral.
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "MODE #{@notice_nick}\r\n"), 1_000)
+
       %{server: server, user: user, network: network, pid: pid}
     end
 


### PR DESCRIPTION
`ci` on main went red at `6ca46dcc` with **one failure out of 5935** —
`test/grappa/session/server_test.exs:3850`, `assert msg.sender == "vjt"`,
`left: "grappa-test"`. The same tree had been green 5/5 on the PR. Same tree,
different outcome: non-determinism, not a code regression.

## The race

The fixture spelled the registered nick twice, and differently. The credential
seeded `vjt`; the fake server's `rfc_handler` welcomed `grappa-test`, which is
`credential_fixture`'s DEFAULT nick — left behind when this describe overrode
the nick. The welcome is authoritative: `EventRouter`'s numeric-1 arm assigns
`state.nick = welcomed_nick`, and `send_notice` stamps `sender: state.nick`. So
the two spellings were a race, not a redundancy.

`await_handshake/1` is what let it through: it returns when the client SENDS
`USER`, and the 001 is the reply to that very line, so it can return before the
session has processed the welcome. The welcome and the test's `GenServer.call`
then land in one mailbox in whichever order the scheduler picks.

Losing the race also fabricated a second wrong thing: mismatched nicks take
`EventRouter`'s `nick_fallback_row` arm (#676) and write a `$server` row
announcing a rename this describe is not about.

## The cure — both halves, deliberately

- **The nick is spelled ONCE**, in `@notice_nick`, used by the credential AND
  the welcome, so the fixture cannot contradict itself again. This is an
  established shape here, not an invention: #581's `@recover_nick`, and
  `@configured_nick` in `badge_count_live_nick_test.exs` and
  `nick_change_observability_test.exs`.
- **The setup waits PAST the welcome**, not merely past `USER`, on the `MODE
  <nick>` umode query (#229). The same file already uses this exact barrier at
  `:1778`; the two deliberate-mismatch tests use the autojoin `JOIN` for the
  same purpose. The umode query is preferred here because it is unconditional
  in the 001 arm, where autojoin is contingent on the credential's channel list
  and on the #347 `+r` deferral.

Note the barrier is sound for a subtler reason than "it is emitted last" — it
is NOT: the query goes out at `server.ex:3171`, while reconciliation happens at
the END of the same callback (`delegate/2` → `EventRouter`). What makes it work
is that GenServer callbacks are SERIALISED, so seeing the line proves the 001
callback has started, and the `GenServer.call` cannot be served until it
returns, reconciliation included.

Aligning the nick alone would have made today's assertion deterministic while
leaving the hazard armed for the next assertion added to this describe. The
barrier alone would have frozen the contradiction into the expectation.
**The assertion is untouched and no timeout was moved.**

## Proof by displacement, not by "it passes now"

Forcing the losing order — the PRE-cure fixture from `origin/main`, plus ONLY a
wait on `MODE grappa-test`, nothing else changed:

| Step | Fixture | Result |
|------|---------|--------|
| R ×3 | pre-cure + forced order | **6 tests, 1 failure** — `left: "grappa-test", right: "vjt"`, byte-identical to CI |
| G ×3 | the cure | **6 tests, 0 failures** |
| F | whole file, the cure | **1 property, 397 tests, 0 failures** |

The runner asserts its own tree before starting: worktree root, branch, clean
tree, and `@notice_nick` present here AND absent from `git show
origin/main:<file>` — this host's default cwd is a stale `main` checkout, and a
gate started there would have measured a tree missing the fix.

## The class, censused

- **Live: 1.** Only this one combines a contradictory fixture, an assertion on
  the post-001 nick, and no barrier. The only other `sender: "vjt"` assertion in
  the file (`:2523`) runs on a passthrough handler that never sends a 001, so
  `state.nick` never moves.
- **Deliberate, do NOT sweep: 2.** The `001 grappa-actual` pair — one is
  literally named *"RPL_WELCOME echoes welcomed nick"*. The mismatch IS the
  subject, and both already wait on the autojoin `JOIN`.
- **Latent but unloaded: 2.** `#640 send_ctcp` (`:3700`) and `#640 401`
  (`:3992`) carry byte-identical setups but assert nothing about the nick.
  Left alone here on purpose — flagged for a separate call.
- **Root cause of the spread:** `credential_fixture` defaults to nick
  `grappa-test`, and 18 seeds across 8 describes overrode the credential to
  `vjt` without touching their handler's 001.
- **The other 11 test files with a 001-replying handler are clean** — matching
  nicks, interpolated nicks, or deliberate fallback mismatches.

No `refute_receive`, broadcast count or user-topic subscription exists in the
affected describes, so the phantom `$server` row could not have perturbed
anything beyond the one assertion.