### PR TITLE
union: gate #1029, #1223 p1 + #1224, and #1235 together

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1025,6 +1025,27 @@ export async function openAdminSessionsTab(page: Page): Promise<Locator> {
   return table;
 }
 
+// #1224 — the ended-sessions sub-page, reached the only way an operator can:
+// through the Sessions tab's card header. Deliberately NOT routed through
+// `openAdminSessionsTab`: that one waits on `admin-sessions-table`, which does
+// not render when the live list is empty, and an empty live list is exactly
+// when a spec is most likely to be looking for a session that is over. The
+// door itself is the barrier — it renders as soon as the tab's data loads.
+// Idempotent about how it got there: a spec that already opened the Sessions
+// tab must not be sent back through the rail launcher, which is a TOGGLE and
+// would close the pane it is standing in.
+export async function openAdminEndedSessions(page: Page): Promise<Locator> {
+  const door = page.getByTestId("admin-sessions-ended-open");
+  if ((await door.count()) === 0) {
+    await openAdminConsole(page);
+    await page.getByTestId("admin-tab-sessions").click();
+  }
+  await door.click({ timeout: 15_000 });
+  const subpage = page.getByTestId("admin-ended-sessions-page");
+  await expect(subpage).toBeVisible({ timeout: 10_000 });
+  return subpage;
+}
+
 // A row's testid suffix is the composite `<kind>:<subject_id>:<network_id>` —
 // the same string the `/admin/sessions/:id/*` verbs parse. A spec knows the
 // subject id (a minted visitor id, a seeded user id) but not the network's

--- a/cicchetto/e2e/nginx-test.conf
+++ b/cicchetto/e2e/nginx-test.conf
@@ -24,6 +24,12 @@ http {
     keepalive_timeout 65;
     server_tokens   off;
 
+    # Access-log shape — the same snippet the native-host substrate includes
+    # (#1029), so a diagnosis rehearsed here reads like the production one.
+    # http context: `log_format` is not valid inside `server { }`. Resolved
+    # from the ../../infra/snippets bind mount, like locations-api.conf.
+    include /etc/nginx/snippets/log-format.conf;
+
     upstream grappa_upstream {
         server grappa:4000;
         keepalive 32;

--- a/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
+++ b/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
@@ -173,7 +173,7 @@ test("issue1067 — a left→right swipe on a message quotes it into the compose
   expect(result.transformAfter).toBe("");
 
   // THE outcome: the quote, exactly as the issue spells it, caret at the end.
-  const quote = `<${specNick()}> ${body}<< `;
+  const quote = `<${specNick()}> ${body} << `;
   await expect(composeTextarea(page)).toHaveValue(quote);
   const caret = await composeTextarea(page).evaluate(
     (el) => (el as HTMLTextAreaElement).selectionStart,
@@ -293,7 +293,7 @@ test("issue1067 — the menu's Reply item fills the compose with the same quote 
   await menuItem(page, "Reply").click();
 
   await expect(menu(page)).toHaveCount(0);
-  await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body}<< `);
+  await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body} << `);
 });
 
 // The clipboard is stubbed at the browser boundary rather than driven through
@@ -408,7 +408,7 @@ test("issue1156 — a join row refuses the swipe while the privmsg above it stil
     ]);
     expect(onSpeech.prevented).toBe(true);
     expect(onSpeech.transformDuring).toMatch(/^translateX\(\d/);
-    await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body}<< `);
+    await expect(composeTextarea(page)).toHaveValue(`<${specNick()}> ${body} << `);
   } finally {
     await peer.disconnect("1156 witness done");
   }

--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -42,14 +42,35 @@ test.setTimeout(90_000);
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // The issue measured the threshold at a 390px viewport: a 46-char quote
-// already wraps and already hides the caret. This body is deliberately far
-// past it — around six wrapped lines — so the required overflow below is a
-// wide margin rather than a coin toss on font metrics, while staying well
+// already wraps and already hides the caret. This body is far past it, so the
+// ROW wraps and the quote it produces is a capped one, while staying well
 // inside one PRIVMSG so the server-side split budget (#246) never turns it
 // into two scrollback rows.
 const FILLER =
   "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
   "quindi il caret finisce sotto la piega e non si vede piu' nulla";
+
+// #1235 capped the quoted body at 42 characters plus a literal `...`, so a
+// single reply can no longer BE six wrapped lines: the longest quote the
+// gesture can now produce is `<nick> ` + 45 + ` << `, about two. The overflow
+// this spec needs is therefore built the way an operator builds it — the reply
+// verb APPENDS, so three replies to the same row stack into a draft that wraps
+// well past the fold, with the caret at the very end of the third. What is
+// measured is unchanged: the caret's geometry after an append.
+//
+// Hardcoded in lockstep with `REPLY_QUOTE_BODY_LIMIT` / `REPLY_QUOTE_ELLIPSIS`
+// in `src/lib/replyQuote.ts` — the e2e package does not import from `src`, and
+// the house convention here is a mirrored constant with a lockstep comment.
+const QUOTED_BODY_LIMIT = 42;
+const QUOTED_ELLIPSIS = "...";
+const REPLIES = 3;
+
+function cappedQuotedBody(body: string): string {
+  const chars = [...body];
+  return chars.length <= QUOTED_BODY_LIMIT
+    ? body
+    : chars.slice(0, QUOTED_BODY_LIMIT).join("") + QUOTED_ELLIPSIS;
+}
 
 // A body unique per run: the e2e sqlite scrollback persists across
 // KEEP_STACK=1 re-runs, and a static string would match two rows on the
@@ -58,9 +79,10 @@ function uniqueBody(): string {
   return `issue1105 ${Date.now()} ${FILLER}`;
 }
 
-// Six-ish wrapped lines minus generous slack. Its job is to fail loudly if the
-// fixture ever stops overflowing, because then "the caret is in view" would be
-// true for the wrong reason.
+// Six-ish wrapped lines minus generous slack — three stacked quotes come to
+// about what the single uncapped one used to be. Its job is to fail loudly if
+// the fixture ever stops overflowing, because then "the caret is in view" would
+// be true for the wrong reason.
 const MIN_OVERFLOW_PX = 40;
 
 // A left→right drag on the message row whose text contains `body`. Touch
@@ -116,10 +138,13 @@ test("issue1105 — replying to a wrapping message scrolls the compose caret int
   await expect(ta).toHaveValue("");
   expect((await composeCaretGeometry(page)).scrollTop).toBe(0);
 
-  await swipeRowRight(page, body);
-
-  const quote = `<${specNick()}> ${body}<< `;
-  await expect(ta).toHaveValue(quote, { timeout: 5_000 });
+  // Each reply is awaited before the next is fired: the value IS the barrier
+  // proving the previous append landed, so the swipes cannot overlap.
+  const quote = `<${specNick()}> ${cappedQuotedBody(body)} << `;
+  for (let i = 1; i <= REPLIES; i++) {
+    await swipeRowRight(page, body);
+    await expect(ta).toHaveValue(quote.repeat(i), { timeout: 5_000 });
+  }
 
   // THE regression: caret at the end of the quote AND that line inside the
   // client box. Before the fix scrollTop stayed 0 with the caret below it.

--- a/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
+++ b/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
@@ -107,11 +107,19 @@ test("#1158 item 4 a deleted visitor's session survives on the ended-sessions pa
     // claim is that the page names the event it is showing.
     await expect(page.getByTestId(`admin-ended-session-event-${key}`)).not.toBeEmpty();
 
+    // PROVENANCE. Before #1224 the drill-in carried `record: session log
+    // only — the subject was deleted, the event outlived it`, and the
+    // assert on it is the one claim the move did not relocate by itself:
+    // the sub-page states it as its premise instead of per-row, but a
+    // premise nobody asserts is not covered. So it is asserted here, on a
+    // POPULATED page — the empty-state wording is pinned in the unit
+    // twin, and an empty screen cannot witness this.
+    const card = page.getByTestId("admin-ended-sessions-card");
+    await expect(card).toContainText("From the lifecycle log");
+
     // The caveat survived the move — a page named after a population
     // implies it holds all of it, and a bounded ring does not.
-    await expect(page.getByTestId("admin-ended-sessions-card")).toContainText(
-      "not evidence the session never ran",
-    );
+    await expect(card).toContainText("not evidence the session never ran");
 
     // No credential to park, no pid to stop: every verb would resolve to
     // a subject that is gone, so none is offered on either screen.

--- a/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
+++ b/cicchetto/e2e/tests/issue1158-item4-deleted-session-row.spec.ts
@@ -10,11 +10,16 @@
 // `<kind>:<id>:<network>` composite the admin session rows are, which is
 // what makes the unified Sessions view able to list them.
 //
-// What this spec pins is the SURFACE contract, in the one direction the
-// product actually promises:
+// #1224 moved the SURFACE, not the property. Those rows used to sit inline
+// in the live list with a `deleted` badge and three em-dashes — `last
+// seen`, `channels` and `actions` are live-process facts, and there is
+// neither a process nor a row. vjt (2026-08-11): a sub-page of Sessions
+// with the record's own columns, no badge, and the live list strictly
+// live. So what this spec pins is now:
 //
 //     given the log remembers a session, and no subject row does,
-//     the Sessions view lists it, marks it deleted, and offers no verb.
+//     the ENDED-SESSIONS page lists it, the live list does not, and
+//     nothing anywhere offers a verb against it.
 //
 // It deliberately does NOT assert the converse. The log is a bounded
 // global ring written from an async telemetry cast on a path that
@@ -29,12 +34,12 @@
 // the admin class reaches the console, and reachability for the other
 // two is covered by `m7-admin-gate-settings-drawer.spec.ts`.
 
-import { openAdminSessionDetail, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { openAdminEndedSessions, openAdminSessionsTab } from "../fixtures/cicchettoPage";
 import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-test("#1158 item 4 a deleted visitor's session survives as a log-only row with no verbs", async ({
+test("#1158 item 4 a deleted visitor's session survives on the ended-sessions page", async ({
   page,
 }) => {
   const admin = getSeededAdmin();
@@ -81,35 +86,41 @@ test("#1158 item 4 a deleted visitor's session survives as a log-only row with n
       [admin.token, admin.subjectJson] as const,
     );
     await page.goto("/");
+
+    // #1224's half: the live list is strictly live. The table itself is
+    // the barrier — asserting absence against a tab that has not rendered
+    // would pass on an empty screen.
     await openAdminSessionsTab(page);
+    await expect(page.getByTestId(`admin-session-row-${key}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-session-gone-${key}`)).toHaveCount(0);
 
     // THE property. Without the log join this row cannot exist at all:
     // both row-backed endpoints lost the subject with the CASCADE.
-    const row = page.getByTestId(`admin-session-row-${key}`);
+    const subpage = await openAdminEndedSessions(page);
+    const row = subpage.getByTestId(`admin-ended-session-row-${key}`);
     await expect(row).toBeVisible({ timeout: 15_000 });
     await expect(row).toContainText(visitorNick);
 
-    // Marked, so it does not read as a live session that merely looks
-    // broken — the operator must be able to tell "gone" from "down".
-    await expect(page.getByTestId(`admin-session-gone-${key}`)).toBeVisible();
+    // The record's own columns, which is what the move was for. Not
+    // `logged.event`: terminating the session can append a newer
+    // lifecycle row between the barrier and the render, so the stable
+    // claim is that the page names the event it is showing.
+    await expect(page.getByTestId(`admin-ended-session-event-${key}`)).not.toBeEmpty();
+
+    // The caveat survived the move — a page named after a population
+    // implies it holds all of it, and a bounded ring does not.
+    await expect(page.getByTestId("admin-ended-sessions-card")).toContainText(
+      "not evidence the session never ran",
+    );
 
     // No credential to park, no pid to stop: every verb would resolve to
-    // a subject that is gone, so none is offered. Asserting all three
-    // matters — a single surviving button is a guaranteed failed request.
+    // a subject that is gone, so none is offered on either screen.
+    // Asserting all four matters — a single surviving button is a
+    // guaranteed failed request.
     await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-reconnect-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
     await expect(page.getByTestId(`admin-session-delete-${key}`)).toHaveCount(0);
-
-    // The dictated shape: the row stays a summary, the record lives in
-    // the drill-in ("nei dettagli mostrare tutte le info", vjt 2026-08-11).
-    // Not `logged.event`: terminating the session can append a newer
-    // lifecycle row between the barrier and the render, so the stable
-    // claim is that the panel names the log as the record, and carries a
-    // last-event fact at all.
-    const detail = await openAdminSessionDetail(page, key);
-    await expect(detail).toContainText("session log only");
-    await expect(detail).toContainText("last event");
   } finally {
     if (!deleted) await reapVisitors(admin.token, visitor.id);
   }

--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -1,11 +1,12 @@
-// #1223 items 2 and 3 — what an admin row card does on a phone, once
-// #1157 turned rows into cards.
+// #1223 — what an admin row card does on a phone, once #1157 turned rows
+// into cards.
 //
 // vjt, dogfooding staging on an iPhone: *"abbiamo tap target solo sul testo
-// quando invece dovrebbe esser tutta l'area, parlo ad es dei nomi visitor"*.
-// Two separate defects behind that reading, both of them layout, both
-// therefore invisible to jsdom (`feedback_cicchetto_browser_smoke`) and to
-// every vitest suite that mounts these components:
+// quando invece dovrebbe esser tutta l'area, parlo ad es dei nomi visitor"*
+// and *"poi abbiamo quest'idiozia di mostrare colonne già mostrate"*.
+// Separate defects behind those readings, all of them layout, all therefore
+// invisible to jsdom (`feedback_cicchetto_browser_smoke`) and to every
+// vitest suite that mounts these components:
 //
 //   2. `.adm-row-expand` puts the 44px `--tap-min` floor on HEIGHT only and
 //      sizes its box with `inline-flex`, so the door to the row's detail is
@@ -19,11 +20,24 @@
 //      wraps timestamps over several lines. Asserted as the value track
 //      taking the panel's full width, with the label above it.
 //
-// Item 1 of the same issue (the detail panel repeating fields the card
-// already shows) is NOT in scope here: it needs a product call between
-// dropping the columns for real and dropping the panel on mobile, and it is
-// the only one of the three that changes what is on screen rather than where
-// it is.
+//   1. the detail panel repeats fields the card already shows. vjt ruled the
+//      fork on 2026-08-11 — *"1223 punto 1: direi drop no?"* — so the columns
+//      really leave the card and the panel stays the only place they live.
+//
+//      Two defects share that symptom, and only ONE of them is in this file.
+//      The `.adm-col-detail` specificity failure (Users, Credentials) is a
+//      question about what is PAINTED, invisible to jsdom, so it is asserted
+//      here. The Sessions repeat is JSX — `detailFacts` carried a `network`
+//      fact while the identity cell printed the slug at every width, desktop
+//      included — which vitest sees perfectly well and
+//      `AdminSessionsTab.test.tsx` pins. Bringing it here too would buy a
+//      slower copy of a test that already exists.
+//
+//      Also asserted here: the 769-899 BAND. The console's card regime starts
+//      at 900px and `isMobile()` is 768px, so a fix that only raised the CSS
+//      selector would have made that band strictly worse — columns gone,
+//      `AdminRowName` still a plain span, no door to the panel they went
+//      into. That is a real-browser claim as much as the drop is.
 //
 // The desktop test is the counter-claim, and it is why item 3's fix is a
 // `@container` rule rather than a blanket single column: at a width where two
@@ -62,6 +76,25 @@ async function openSessionsTab(page: Page): Promise<void> {
   await openAdminConsole(page);
   await page.getByTestId("admin-tab-sessions").click();
   await expect(page.getByTestId("admin-sessions-table")).toBeVisible({ timeout: 10_000 });
+}
+
+async function openUsersTab(page: Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-users").click();
+  await expect(page.getByTestId("admin-users-table")).toBeVisible({ timeout: 10_000 });
+}
+
+// The card's cells that are actually PAINTED. `getClientRects()` rather than
+// a computed-style read: a `display: none` cell has no boxes, which is the
+// property under test, and it costs nothing on WebKit (where reading computed
+// style has bitten this suite before).
+async function paintedCellTexts(row: Locator): Promise<string[]> {
+  return row.locator("td").evaluateAll((tds) =>
+    tds
+      .filter((td) => td.getClientRects().length > 0)
+      .map((td) => (td.textContent ?? "").trim())
+      .filter((text) => text !== ""),
+  );
 }
 
 type Box = { x: number; y: number; width: number; height: number };
@@ -186,4 +219,84 @@ test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
   } finally {
     await reapVisitors(admin.token, visitor.id);
   }
+});
+
+// Item 1, the half only a browser can see. The panel's subtitle promises
+// "the columns the table drops on a phone", and until #1223 it was the one
+// thing on screen that was false: `.adm-col-detail { display: none }` is
+// (0,1,0) and lost to the `.adm-table td` stacking rule (0,1,1), so every
+// dropped column came back as a labelled line of the card and the panel
+// underneath said it a second time.
+//
+// The oracle is the report itself — no value may be on the card AND in the
+// panel — rather than a check that a particular selector is hidden: that is
+// the property vjt read off the screen, and it survives the next tab growing
+// a column.
+test("#1223 @webkit on a phone no field is on the card and in the panel at once", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
+
+  await adminLogin(page);
+  await openUsersTab(page);
+
+  const row = page.getByTestId(`admin-user-row-${adminId}`);
+  await row.scrollIntoViewIfNeeded();
+  await expect(row).toBeVisible();
+
+  const panel = page.getByTestId(`admin-user-detail-${adminId}`);
+  await expect(panel).toHaveCount(0);
+  await page.getByTestId(`admin-user-details-${adminId}`).tap();
+  await expect(panel).toBeVisible({ timeout: 5_000 });
+
+  const cardValues = await paintedCellTexts(row);
+  const factValues = (await panel.locator("dd").allTextContents())
+    .map((t) => t.trim())
+    .filter((t) => t !== "");
+
+  // Non-vacuity, both sides: an empty card or an empty panel would make the
+  // intersection trivially empty and the test a mirror.
+  expect(cardValues.length, "the row card must still show something").toBeGreaterThan(0);
+  expect(factValues.length, "the panel must carry the dropped columns").toBeGreaterThan(0);
+
+  expect(
+    factValues.filter((value) => cardValues.includes(value)),
+    `values printed twice — card ${JSON.stringify(cardValues)}, panel ${JSON.stringify(factValues)}`,
+  ).toEqual([]);
+});
+
+// The band the console's two breakpoints leave between them. 820px is a
+// portrait iPad: the CSS has already turned the table into cards and taken
+// the secondary columns away, and `isMobile()` — 768px — says desktop.
+test.describe("#1223 the 769-899 band", () => {
+  test.use({ viewport: { width: 820, height: 1180 } });
+
+  test("#1223 the columns leave and the door to their panel is there", async ({ page }) => {
+    const admin = getSeededAdmin();
+    const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
+
+    await adminLogin(page);
+    await openUsersTab(page);
+
+    const row = page.getByTestId(`admin-user-row-${adminId}`);
+    await expect(row).toBeVisible();
+
+    // Gone from the card: this is the width at which the drop applies.
+    const dropped = row.locator("td.adm-col-detail");
+    expect(await dropped.count(), "the secondary cells must still be in the DOM").toBeGreaterThan(
+      0,
+    );
+    for (let i = 0; i < (await dropped.count()); i++) {
+      await expect(dropped.nth(i)).toBeHidden();
+    }
+
+    // And reachable: the disclosure has to exist wherever the columns leave,
+    // or this band is where the record becomes unreadable.
+    await page.getByTestId(`admin-user-details-${adminId}`).click();
+    const panel = page.getByTestId(`admin-user-detail-${adminId}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    await expect(panel).toContainText("live sessions");
+    await expect(panel).toContainText("inserted");
+  });
 });

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -92,9 +92,11 @@ test("M-8 admin deletes a minted visitor from the unified Sessions view (inline 
     //
     // #1158 item 4 changed what that looks like on screen, not what the
     // verb does. The identity is still destroyed — but `session_log_events`
-    // has no FK to the subject, so a row can SURVIVE the CASCADE as the
-    // log-only class: badged "deleted", no DB state, no verbs. Counting
-    // rows would now assert the pre-item-4 world.
+    // has no FK to the subject, so the session can SURVIVE the CASCADE as
+    // the log-only class: no DB state, no pid, no verbs. (#1224 then moved
+    // that class off this list onto the ended-sessions sub-page, which is
+    // one more reason not to count rows here: the count now depends on a
+    // screen this spec is not looking at.)
     //
     // So the identity-wide property moves onto the verbs. `rowActions`
     // gives a credential-backed visitor row exactly one of Disconnect /

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -23,7 +23,8 @@
 // not exist any more.
 //
 // The replacement is a claim no relocation of the scroller can satisfy: at
-// 393px, on EVERY tab, no scroll container inside the admin pane may have
+// 393px, on EVERY surface (#1224 — tabs AND the sub-pages that open from
+// inside one), no scroll container inside the admin pane may have
 // `scrollWidth > clientWidth`. Moving `overflow-x` one level in or out —
 // the exact trap the deleted CSS comment documented, and the thing #1074
 // did — fails it, because the offender is reported wherever it lands.
@@ -52,16 +53,14 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 
-// Every tab AdminPane mounts (`TABS` in AdminPane.tsx). The pan is a
-// property of the pane, not of the three tabs that happened to have tables
-// when this spec was written, so the oracle visits all of them.
+// Every tab AdminPane mounts (`TABS` in AdminPane.tsx).
 const ADMIN_TABS = [
   "sessions",
   "events",
@@ -78,10 +77,89 @@ const ADMIN_TABS = [
   "debug",
 ] as const;
 
+// #1224 — the width oracle enumerates SURFACES, not tabs.
+//
+// This comment used to say "the pan is a property of the pane, not of the
+// three tabs that happened to have tables" and then loop the tab list. Both
+// halves were true when written and the second stopped being true: a tab is
+// not the only thing the pane shows. `AdminUsersTab` has opened
+// `AdminUserPage` from inside the Users panel since #1158 (which is where
+// the Credentials tab went), and #1224 added the ended-sessions page behind
+// the Sessions card header. Two full-pane surfaces with tables, at 393px,
+// that a loop over `ADMIN_TABS` structurally cannot reach — the guard had
+// quietly become a list of the places that existed when it was written.
+//
+// So the list of TABS stays (it is what the touch-action tests below are
+// about — `#admin-tab-<key>` is a real element with a real CSS contract),
+// and the width claim moves onto this list of surfaces instead.
+//
+// 🔴 Why the sub-page half is still hand-written, and what would fix it.
+// A surface is discoverable once you are ON it — both sub-pages render
+// `.adm-subpage-head`. A DOOR is not: `admin-sessions-ended-open` is a
+// static testid on a card-header button, `admin-user-networks-<id>` is a
+// per-row button in an actions cell, they share no convention, and the
+// cells they sit in also hold Delete. There is nothing a crawl could press
+// safely and nothing a selector could match honestly. Giving every door one
+// marker attribute would make this list derive itself; until then the
+// completeness assertion below covers the TAB half automatically, and a new
+// sub-page needs a line here. That is a real gap, stated rather than
+// papered over — a comment that claims coverage it does not have is exactly
+// how this one went stale.
+type Surface = {
+  name: string;
+  open: (page: Page) => Promise<void>;
+};
+
+async function openTab(page: Page, tab: string): Promise<void> {
+  await page.getByTestId(`admin-tab-${tab}`).tap();
+  await expect(page.locator(`#admin-tab-${tab}`)).toBeVisible({ timeout: 10_000 });
+}
+
+// Takes the subject's id because the user page is per-user and only one
+// user will do: its networks TABLE renders under `mine().length > 0`, and
+// the seeded `admin-vjt` — which `.first()` reaches, being row one — has no
+// IRC bind, so it shows the empty state and the surface would be measured
+// with nothing on it. `vjt` has the bind. Measured, not assumed: `.first()`
+// is what the first run of this extension did, and the barrier caught it.
+function adminSurfaces(vjtUserId: string): Surface[] {
+  return [
+    ...ADMIN_TABS.map((tab) => ({
+      name: `tab:${tab}`,
+      open: (page: Page) => openTab(page, tab),
+    })),
+    {
+      name: "subpage:ended-sessions",
+      open: async (page: Page) => {
+        await openTab(page, "sessions");
+        await page.getByTestId("admin-sessions-ended-open").tap();
+        await expect(page.getByTestId("admin-ended-sessions-page")).toBeVisible({
+          timeout: 10_000,
+        });
+        // Anti-hollow-green: measure a POPULATED page or fail here. An
+        // empty-state card cannot overflow and would pass on nothing.
+        await expect(page.getByTestId("admin-ended-sessions-table")).toBeVisible({
+          timeout: 10_000,
+        });
+      },
+    },
+    {
+      name: "subpage:user-page",
+      open: async (page: Page) => {
+        await openTab(page, "users");
+        await page.getByTestId(`admin-user-networks-${vjtUserId}`).tap();
+        await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
+        await expect(page.getByTestId("admin-user-networks-table")).toBeVisible({
+          timeout: 10_000,
+        });
+      },
+    },
+  ];
+}
+
 test.setTimeout(180_000);
 
 type Offender = {
-  tab: string;
+  surface: string;
   tag: string;
   testId: string | null;
   cls: string;
@@ -145,6 +223,28 @@ async function createSeedVhost(adminToken: string): Promise<number | null> {
   return ((await res.json()) as { id: number }).id;
 }
 
+// A row on the ended-sessions sub-page. The only thing that puts one there
+// is a session the lifecycle log remembers whose subject no longer exists
+// (#1158 item 4), so this mints a visitor, waits for the sink to write its
+// row, then destroys the identity — the same arrange `issue1158-item4` uses.
+// No teardown: the subject is already gone, and the log row is the point.
+async function seedEndedSession(adminToken: string): Promise<void> {
+  const visitor = await mintVisitor(`ux6g-ended-${Date.now()}`);
+  const prefix = `visitor:${visitor.id}:`;
+  await expect
+    .poll(
+      async () =>
+        (await listSessionLogSessions(adminToken)).filter((e) => e.session_id.startsWith(prefix))
+          .length,
+      {
+        timeout: 20_000,
+        message: `precondition: session_log never recorded ${prefix}* — the ended-sessions surface cannot be populated, so measuring it would prove nothing`,
+      },
+    )
+    .toBeGreaterThan(0);
+  await reapVisitors(adminToken, visitor.id);
+}
+
 async function deleteSeedVhost(adminToken: string, id: number | null): Promise<void> {
   if (id === null) return;
   await fetch(`${GRAPPA_BASE_URL}/admin/vhosts/${id}`, {
@@ -185,26 +285,38 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
   }
 
-  test("@webkit admin on mobile — no tab can be panned sideways", async ({ page }) => {
+  test("@webkit admin on mobile — no surface can be panned sideways", async ({ page }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`ux6g-${Date.now()}`);
     let vhostId: number | null = null;
 
     try {
       vhostId = await createSeedVhost(admin.token);
+      // A row on the ended-sessions sub-page, by the only route that makes
+      // one: a session the log remembers whose subject is gone. Without it
+      // that surface renders an empty-state card and measuring it would be
+      // the very "an empty tab cannot overflow" pass this spec was rewritten
+      // to stop doing.
+      await seedEndedSession(admin.token);
       await openAdminPane(page);
+
+      // The TAB half of the surface list maintains itself: a tab added to
+      // `TABS` without a line here fails on the count rather than going
+      // unmeasured. The sub-page half cannot (see the note on `Surface`).
+      await expect(
+        page.getByTestId("admin-pane").locator("[role='tab']"),
+        "a tab exists that the surface list does not name — add it to ADMIN_TABS",
+      ).toHaveCount(ADMIN_TABS.length);
 
       const offenders: Offender[] = [];
 
-      for (const tab of ADMIN_TABS) {
-        await page.getByTestId(`admin-tab-${tab}`).tap();
-        const panel = page.locator(`#admin-tab-${tab}`);
-        await expect(panel).toBeVisible({ timeout: 10_000 });
+      for (const surface of adminSurfaces(vjtUserId)) {
+        await surface.open(page);
 
         // The pane, not just the panel: the pre-#1157 arrangement made the
         // PANEL the scroller, and a future one could push it further out.
         const found = await page.getByTestId("admin-pane").evaluate((root) => {
-          const out: Omit<Offender, "tab">[] = [];
+          const out: Omit<Offender, "surface">[] = [];
           const consider = (el: Element): void => {
             // NAMED EXEMPTION, not a filter that makes the red go away.
             // `.adm-nav` is the tab strip: nine chips, `overflow-x: auto`
@@ -232,12 +344,12 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
           return out;
         });
 
-        offenders.push(...found.map((o) => ({ ...o, tab })));
+        offenders.push(...found.map((o) => ({ ...o, surface: surface.name })));
       }
 
       expect(
         offenders,
-        `nothing in the admin pane may be pannable at 393px, on any tab — ` +
+        `nothing in the admin pane may be pannable at 393px, on any surface — ` +
           `offenders: ${JSON.stringify(offenders, null, 2)}`,
       ).toEqual([]);
     } finally {

--- a/cicchetto/src/AdminEndedSessionsPage.tsx
+++ b/cicchetto/src/AdminEndedSessionsPage.tsx
@@ -1,0 +1,163 @@
+import { type Component, For, Show } from "solid-js";
+import AdminBadge from "./admin/AdminBadge";
+import AdminCard from "./admin/AdminCard";
+import { AdminEmpty } from "./admin/AdminStatus";
+import AdminTable from "./admin/AdminTable";
+import { formatInstant } from "./admin/formatInstant";
+import { renderDuration, renderReason } from "./admin/sessionLogFormat";
+import type { EndedSessionRow } from "./lib/adminSubjectRows";
+
+// #1224 — sessions that are over, on their own page, with their own
+// columns.
+//
+// vjt, same iPhone dogfood pass as #1223: *"i visitor deleted son utili
+// ma vanno su sotto pagina con campi diversi perché son sempre
+// offline"*. These rows exist because `session_log_events` carries no FK
+// to the subject and outlived the CASCADE (#1158 item 4), so there is no
+// process and no DB row behind them — and three of the four columns the
+// live list dictates (`last seen`, `channels`, `actions`) were an
+// em-dash on every one of them, structurally and forever. The list was
+// paying full column width for fields that can never be populated.
+//
+// vjt's three rulings (2026-08-11):
+//   1. a SUB-PAGE of Sessions, not a sixth tab — the tab strip already
+//      overflows and scrolls on a phone;
+//   2. no `deleted` badge: once these move out, Sessions is strictly
+//      live and has nothing to mark;
+//   3. the ring caveat is not a blocker — but it is still true, so it
+//      travels with the page (see the subtitle).
+//
+// Built with #1223 item 1 already applied, as the issue asks: the
+// columns here are the ones the record actually has, no detail panel
+// repeats them, and nothing is dropped at any width — five short fields
+// stack into a card without needing a disclosure to get them back.
+//
+// The rows are PASSED IN, not re-fetched. They come out of the same five
+// endpoints the tab already merged, on the same composite key; fetching
+// again would show a second snapshot of a list the operator reached from
+// the first one.
+//
+// The identity block reuses the live list's `.admin-session-*` classes
+// on purpose: it is the same two-line shape vjt dictated for Sessions
+// (2026-08-09) and this page is one of its screens, not another tab.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
+
+export type Props = {
+  rows: EndedSessionRow[];
+  onBack: () => void;
+};
+
+const AdminEndedSessionsPage: Component<Props> = (props) => (
+  <div class="admin-ended-sessions-page" data-testid="admin-ended-sessions-page">
+    <div class="adm-scroll">
+      <header class="adm-subpage-head">
+        <button
+          type="button"
+          class="adm-btn"
+          onClick={props.onBack}
+          aria-label="back to the sessions list"
+          data-testid="admin-ended-sessions-back"
+        >
+          ← Sessions
+        </button>
+        <h2 class="adm-card-title">Ended sessions</h2>
+      </header>
+
+      <AdminCard
+        title="From the lifecycle log"
+        // The caveat had to survive the move, and it matters MORE here
+        // than it did as a badge on an inline row: a page named after a
+        // population implies it holds all of it. It does not — the ring
+        // is bounded, pruned on write and fed by an async cast from a
+        // path that includes `terminate/2`.
+        subtitle="a bounded, best-effort ring — an absent row is not evidence the session never ran, and a last event that is not a disconnect means the log never saw the end"
+        data-testid="admin-ended-sessions-card"
+      >
+        <Show
+          when={props.rows.length > 0}
+          fallback={
+            <AdminEmpty
+              message="the log remembers no session whose subject is gone"
+              testId="admin-ended-sessions-empty"
+            />
+          }
+        >
+          <AdminTable data-testid="admin-ended-sessions-table">
+            <thead>
+              <tr>
+                <th class="adm-table-grow">who</th>
+                <th>last event</th>
+                <th>at</th>
+                <th>lasted</th>
+                <th>how</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={props.rows}>
+                {(row) => (
+                  <tr
+                    class="admin-ended-session-row"
+                    data-testid={`admin-ended-session-row-${row.key}`}
+                  >
+                    {/* No `.admin-session-who`: that class exists only to
+                        give the live list's disclosure its two-line flex
+                        shape, and there is no disclosure here. */}
+                    <td class="adm-cell-title">
+                      <span class="admin-session-lines">
+                        <span class="admin-session-identity">
+                          <AdminBadge
+                            tone={row.subject_kind === "user" ? "info" : "neutral"}
+                            class="adm-badge--kind"
+                            ariaLabel={row.subject_kind}
+                          >
+                            {row.subject_kind}
+                          </AdminBadge>
+                          <span class="admin-session-nick">{renderLabel(row)}</span>
+                        </span>
+                        <span class="admin-session-network">
+                          {row.network_slug ?? `network ${row.network_id}`}
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      data-label="last event"
+                      data-testid={`admin-ended-session-event-${row.key}`}
+                    >
+                      {row.last_event.event}
+                    </td>
+                    <td data-label="at">{formatInstant(row.last_event.at)}</td>
+                    <td data-label="lasted">{renderLasted(row)}</td>
+                    <td data-label="how">{renderHow(row)}</td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </AdminTable>
+        </Show>
+      </AdminCard>
+    </div>
+  </div>
+);
+
+// The log records the nick the session answered to. `null` means it was
+// written before the session had one — say which rather than blanking,
+// the same reading the live list gives an unlabelled row.
+function renderLabel(row: EndedSessionRow): string {
+  if (row.label !== null) return row.label;
+  return `${row.subject_id.slice(0, 8)} (no nick logged)`;
+}
+
+// Only a disconnect carries a duration. An em-dash here is not the
+// structurally-empty cell #1224 is about: it says the log's last word on
+// this session was something other than its end.
+function renderLasted(row: EndedSessionRow): string {
+  const ms = row.last_event.duration_ms;
+  return ms === null ? "—" : renderDuration(ms);
+}
+
+function renderHow(row: EndedSessionRow): string {
+  return row.last_event.event === "disconnected" ? renderReason(row.last_event) : "—";
+}
+
+export default AdminEndedSessionsPage;

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -31,7 +31,7 @@ import {
   adminUpdateServer,
 } from "./lib/api";
 import { token } from "./lib/auth";
-import { isMobile } from "./lib/theme";
+import { isAdminNarrow } from "./lib/theme";
 
 // M-cluster M-10 — Networks admin tab. Operator surface for the
 // admission caps + circuit-breaker recovery + on-demand visitor reap.
@@ -206,9 +206,15 @@ const AdminNetworksTab: Component = () => {
   // the row is right there, and a network deleted by another admin
   // takes its own panel with it.
 
-  // Column count for the detail row's `colspan`. On a phone the six
-  // secondary columns are gone, so the row is slug + actions.
-  const networkColumns = (): number => (isMobile() ? 2 : NETWORK_COLUMNS);
+  // Column count for the detail row's `colspan`. Below the console's
+  // breakpoint the six secondary columns are gone, so the row is slug +
+  // actions.
+  //
+  // #1223 — the gate is `isAdminNarrow()` (899px), not `isMobile()`
+  // (768px): the split has to agree with the CSS that stacks the table,
+  // or the 769-899 band gets a card whose columns are still inline while
+  // every other tab has already moved them into the panel.
+  const networkColumns = (): number => (isAdminNarrow() ? 2 : NETWORK_COLUMNS);
 
   // The two cells that move between the row and the detail depending on
   // width. ONE definition each: the cap editor is a live control, and a
@@ -691,7 +697,7 @@ const AdminNetworksTab: Component = () => {
                       EDITORS, and the detail has to render the control
                       itself, not a copy of its value. Two live controls
                       with one test id is not a layout, it is a bug. */}
-                  <Show when={!isMobile()}>
+                  <Show when={!isAdminNarrow()}>
                     <th>visitors (live/cap)</th>
                     <th>max visitor sessions</th>
                     <th>users (live/cap)</th>
@@ -720,7 +726,7 @@ const AdminNetworksTab: Component = () => {
                             {expandedNetworkId() === net.id ? "▾" : "▸"} {net.slug}
                           </button>
                         </td>
-                        <Show when={!isMobile()}>
+                        <Show when={!isAdminNarrow()}>
                           <td data-label="visitors">{liveCount(net, "visitors")}</td>
                           <td data-label="max visitors">
                             {capEditor(net, "max_concurrent_visitor_sessions")}
@@ -785,7 +791,7 @@ const AdminNetworksTab: Component = () => {
                               there is no read-only copy of them anywhere,
                               so editing a cap stays possible on a phone
                               and Save stays up on the row. */}
-                          <Show when={isMobile()}>
+                          <Show when={isAdminNarrow()}>
                             <AdminFacts
                               facts={[
                                 {

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -533,7 +533,14 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     // would erase it.
     { label: "connection", value: row.connection_state ?? "no DB row" },
     { label: "live", value: renderLive(row) },
-    { label: "network", value: row.network_slug ?? `id ${row.network_id}` },
+    // NO `network` fact. #1223 item 1 reported the panel repeating it,
+    // and unlike the Users/Credentials repeats this one is not the
+    // `.adm-col-detail` specificity defect: Sessions drops no column at
+    // any width, and `.admin-session-network` prints the slug under the
+    // nick on DESKTOP too. Two defects, one symptom — raising the CSS
+    // selector would not have touched this one, and the second line of
+    // the identity block is dictated (vjt, 2026-08-09), so the panel is
+    // the copy that goes.
     { label: "upstream", value: renderUpstream(row) },
     // #1158 item 4 — the third source, and the only one that says
     // anything at all about a session that is over.

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -1,4 +1,5 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
+import AdminEndedSessionsPage from "./AdminEndedSessionsPage";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
 import AdminDetailPanel from "./admin/AdminDetailPanel";
@@ -7,11 +8,14 @@ import AdminRowName from "./admin/AdminRowName";
 import { AdminEmpty, AdminError } from "./admin/AdminStatus";
 import AdminTable from "./admin/AdminTable";
 import { useRefreshSlot } from "./admin/refreshSlot";
+import { renderEnded } from "./admin/sessionLogFormat";
 import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  endedSessions,
+  liveSessions,
   rowActions,
 } from "./lib/adminSubjectRows";
 import {
@@ -65,9 +69,14 @@ import { token } from "./lib/auth";
 // is the row key, so it both fills in "what did this session last do"
 // and supplies rows for subjects that no longer exist.
 //
-// The log is a bounded ring, so those rows are RECENT history, not an
-// archive, and the card subtitle says so rather than letting the table
-// imply completeness.
+// #1224 — and those log-only rows are no longer IN this list. They were
+// carrying a `deleted` badge and three em-dashes, because `last seen`,
+// `channels` and `actions` are live-process facts and there is neither a
+// process nor a row. vjt's ruling (2026-08-11): they move to a sub-page
+// of Sessions with columns the record actually has, no badge, and this
+// list becomes strictly live. The merge is unchanged — one row set, one
+// composite key, the log still enriching a live row's drill-down — and
+// `liveSessions`/`endedSessions` partition it for the two screens.
 //
 // Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
 
@@ -107,6 +116,10 @@ const AdminSessionsTab: Component = () => {
   const [logSessions, setLogSessions] = createSignal<AdminSessionLogEntry[] | null>(null);
   const [confirmingKey, setConfirmingKey] = createSignal<string | null>(null);
   const [detailKey, setDetailKey] = createSignal<string | null>(null);
+  // #1224 — the sub-page is open, or the list is. Same shape as the Users
+  // tab's drill-in to `AdminUserPage`, and deliberately not a route: the
+  // admin console has none.
+  const [endedOpen, setEndedOpen] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
 
@@ -124,6 +137,9 @@ const AdminSessionsTab: Component = () => {
         })
       : [],
   );
+
+  const live = createMemo<AdminSubjectRow[]>(() => liveSessions(rows()));
+  const ended = createMemo(() => endedSessions(rows()));
 
   const refresh = async (): Promise<void> => {
     const t = token();
@@ -226,98 +242,129 @@ const AdminSessionsTab: Component = () => {
 
   return (
     <div class="admin-sessions-tab">
-      <div class="adm-scroll">
-        <Show when={error() !== null}>
-          <AdminError message={error() ?? ""} testId="admin-sessions-error" />
-        </Show>
+      <Show when={endedOpen()}>
+        <AdminEndedSessionsPage rows={ended()} onBack={() => setEndedOpen(false)} />
+      </Show>
 
-        <Show when={networks() !== null && (networks() ?? []).length > 0}>
-          <AdminCard
-            title="Capacity per network"
-            subtitle="live_counts from the Registry — the same projection the admission policy uses"
-            data-testid="admin-sessions-network-summary"
-          >
-            <AdminTable data-testid="admin-sessions-summary-table">
-              <thead>
-                <tr>
-                  <th>network</th>
-                  <th>visitors</th>
-                  <th>users</th>
-                  <th>per-IP cap</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={networks() ?? []}>
-                  {(net) => (
-                    <tr
-                      class="admin-sessions-summary-row"
-                      data-testid={`admin-sessions-summary-row-${net.slug}`}
-                    >
-                      <td class="adm-cell-title">{net.slug}</td>
-                      <td
-                        data-label="visitors"
-                        data-testid={`admin-sessions-summary-visitors-${net.slug}`}
+      <Show when={!endedOpen()}>
+        <div class="adm-scroll">
+          <Show when={error() !== null}>
+            <AdminError message={error() ?? ""} testId="admin-sessions-error" />
+          </Show>
+
+          <Show when={networks() !== null && (networks() ?? []).length > 0}>
+            <AdminCard
+              title="Capacity per network"
+              subtitle="live_counts from the Registry — the same projection the admission policy uses"
+              data-testid="admin-sessions-network-summary"
+            >
+              <AdminTable data-testid="admin-sessions-summary-table">
+                <thead>
+                  <tr>
+                    <th>network</th>
+                    <th>visitors</th>
+                    <th>users</th>
+                    <th>per-IP cap</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={networks() ?? []}>
+                    {(net) => (
+                      <tr
+                        class="admin-sessions-summary-row"
+                        data-testid={`admin-sessions-summary-row-${net.slug}`}
                       >
-                        {net.live_counts.visitors}/{renderCap(net.max_concurrent_visitor_sessions)}
-                      </td>
-                      <td
-                        data-label="users"
-                        data-testid={`admin-sessions-summary-users-${net.slug}`}
-                      >
-                        {net.live_counts.users}/{renderCap(net.max_concurrent_user_sessions)}
-                      </td>
-                      <td
-                        data-label="per-ip"
-                        data-testid={`admin-sessions-summary-per-ip-${net.slug}`}
-                      >
-                        {renderCap(net.max_per_ip)}
-                      </td>
+                        <td class="adm-cell-title">{net.slug}</td>
+                        <td
+                          data-label="visitors"
+                          data-testid={`admin-sessions-summary-visitors-${net.slug}`}
+                        >
+                          {net.live_counts.visitors}/
+                          {renderCap(net.max_concurrent_visitor_sessions)}
+                        </td>
+                        <td
+                          data-label="users"
+                          data-testid={`admin-sessions-summary-users-${net.slug}`}
+                        >
+                          {net.live_counts.users}/{renderCap(net.max_concurrent_user_sessions)}
+                        </td>
+                        <td
+                          data-label="per-ip"
+                          data-testid={`admin-sessions-summary-per-ip-${net.slug}`}
+                        >
+                          {renderCap(net.max_per_ip)}
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </AdminTable>
+            </AdminCard>
+          </Show>
+
+          <Show when={!loaded() && error() === null}>
+            <AdminEmpty message="loading…" />
+          </Show>
+
+          {/* #1224 — the card renders whenever the data loaded, empty list
+            or not, and the empty state sits INSIDE it. The door to the
+            ended sessions lives in this header, and a live list that
+            happens to be empty is exactly when the operator most needs
+            it: gating the card on the row count would take the door away
+            with the rows. */}
+          <Show when={loaded()}>
+            <AdminCard
+              hostsRefresh
+              title="Sessions"
+              subtitle="row-backed and strictly live — parked and failed subjects are listed too, with live state joined on"
+              actions={
+                <button
+                  type="button"
+                  class="adm-btn"
+                  onClick={() => setEndedOpen(true)}
+                  data-testid="admin-sessions-ended-open"
+                >
+                  Ended sessions ({ended().length})
+                </button>
+              }
+              data-testid="admin-sessions-table-card"
+            >
+              <Show
+                when={live().length > 0}
+                fallback={
+                  // "live", not "no sessions": the log may well remember
+                  // sessions that ended, and they are one tap away.
+                  <AdminEmpty message="no live sessions" testId="admin-sessions-empty" />
+                }
+              >
+                <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
+                  <thead>
+                    <tr>
+                      <th class="adm-table-grow">who</th>
+                      <th>last seen</th>
+                      <th>channels</th>
+                      <th class="adm-table-sticky-actions">actions</th>
                     </tr>
-                  )}
-                </For>
-              </tbody>
-            </AdminTable>
-          </AdminCard>
-        </Show>
-
-        <Show when={!loaded() && error() === null}>
-          <AdminEmpty message="loading…" />
-        </Show>
-
-        <Show when={loaded() && rows().length === 0}>
-          <AdminEmpty message="no sessions" testId="admin-sessions-empty" />
-        </Show>
-
-        <Show when={loaded() && rows().length > 0}>
-          <AdminCard
-            hostsRefresh
-            title="Sessions"
-            subtitle="row-backed — parked and failed subjects are listed too, with live state joined on; rows marked deleted come from the lifecycle log, which keeps recent history only"
-            data-testid="admin-sessions-table-card"
-          >
-            <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
-              <thead>
-                <tr>
-                  <th class="adm-table-grow">who</th>
-                  <th>last seen</th>
-                  <th>channels</th>
-                  <th class="adm-table-sticky-actions">actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={rows()}>
-                  {(row) => (
-                    <>
-                      <tr class="admin-sessions-row" data-testid={`admin-session-row-${row.key}`}>
-                        <td class="admin-session-who adm-cell-title">
-                          <AdminRowName
-                            alwaysOpenable
-                            open={detailKey() === row.key}
-                            onToggle={() => setDetailKey(detailKey() === row.key ? null : row.key)}
-                            label={`details for ${renderWho(row)}`}
-                            testId={`admin-session-details-${row.key}`}
+                  </thead>
+                  <tbody>
+                    <For each={live()}>
+                      {(row) => (
+                        <>
+                          <tr
+                            class="admin-sessions-row"
+                            data-testid={`admin-session-row-${row.key}`}
                           >
-                            {/* The two dictated lines are ONE block beside the
+                            <td class="admin-session-who adm-cell-title">
+                              <AdminRowName
+                                alwaysOpenable
+                                open={detailKey() === row.key}
+                                onToggle={() =>
+                                  setDetailKey(detailKey() === row.key ? null : row.key)
+                                }
+                                label={`details for ${renderWho(row)}`}
+                                testId={`admin-session-details-${row.key}`}
+                              >
+                                {/* The two dictated lines are ONE block beside the
                                 caret, not two siblings of it. Left as siblings
                                 they are flex items of `.adm-row-expand`, and
                                 the second line can only be produced by letting
@@ -327,126 +374,124 @@ const AdminSessionsTab: Component = () => {
                                 line, losing the caret's indent and breaking the
                                 alignment the fixed-width badge exists to
                                 create. Measured at 16px of drift. */}
-                            <span class="admin-session-lines">
-                              <span class="admin-session-identity">
-                                {/* Fixed-width kind badge: "visitor" and
+                                <span class="admin-session-lines">
+                                  <span class="admin-session-identity">
+                                    {/* Fixed-width kind badge: "visitor" and
                                     "user" are different lengths, and an
                                     unpadded pair makes every nick start at
                                     a different x. */}
-                                <AdminBadge
-                                  tone={row.subject_kind === "user" ? "info" : "neutral"}
-                                  class="adm-badge--kind"
-                                  ariaLabel={row.subject_kind}
-                                >
-                                  {row.subject_kind}
-                                </AdminBadge>
-                                <span class="admin-session-nick">{renderLabel(row)}</span>
-                                {/* #1158 item 4 — this row exists only
-                                    because the lifecycle log outlived the
-                                    subject. Say so on the row itself: it
-                                    has no state to read and no verb to
-                                    press, and without the marker it reads
-                                    as a session that merely looks broken. */}
-                                <Show when={row.origin === "session_log"}>
-                                  <AdminBadge
-                                    tone="warn"
-                                    ariaLabel="subject deleted, session log only"
-                                    testId={`admin-session-gone-${row.key}`}
-                                  >
-                                    deleted
-                                  </AdminBadge>
-                                </Show>
-                              </span>
-                              <span class="admin-session-network">
-                                {row.network_slug ?? `network ${row.network_id}`}
-                              </span>
-                            </span>
-                          </AdminRowName>
-                        </td>
-                        <td
-                          class="admin-session-last-seen"
-                          data-label="last seen"
-                          data-testid={`admin-session-last-seen-${row.key}`}
-                          title={row.last_seen_at ?? "no browser session on record"}
-                        >
-                          {renderLastSeen(row.last_seen_at)}
-                        </td>
-                        <td data-label="channels" data-testid={`admin-session-channels-${row.key}`}>
-                          {renderChannels(row)}
-                        </td>
-                        <td
-                          class="admin-sessions-actions adm-table-sticky-actions"
-                          data-label="actions"
-                        >
-                          <For each={rowActions(row)}>
-                            {(kind) => (
-                              <InlineConfirmButton
-                                idleLabel={ACTION_LABEL[kind]}
-                                confirmLabel={`Confirm ${kind}`}
-                                armed={confirmingKey() === confirmKey(row.key, kind)}
-                                onArm={() => setConfirmingKey(confirmKey(row.key, kind))}
-                                onConfirm={() => runAction(row, kind)}
-                                testId={`admin-session-${kind}-${row.key}`}
-                                extraClass={`${kind}-btn`}
-                              />
-                            )}
-                          </For>
-                          {/* An empty cell reads as a rendering bug. The
+                                    <AdminBadge
+                                      tone={row.subject_kind === "user" ? "info" : "neutral"}
+                                      class="adm-badge--kind"
+                                      ariaLabel={row.subject_kind}
+                                    >
+                                      {row.subject_kind}
+                                    </AdminBadge>
+                                    {/* No `deleted` badge (#1224, vjt: "no badge
+                                    needed"). #1158 item 4 put one here
+                                    because a log-only row sat in this list
+                                    and would otherwise have read as a
+                                    session that merely looks broken; those
+                                    rows are on their own page now, so the
+                                    badge would have nothing to mark. */}
+                                    <span class="admin-session-nick">{renderLabel(row)}</span>
+                                  </span>
+                                  <span class="admin-session-network">
+                                    {row.network_slug ?? `network ${row.network_id}`}
+                                  </span>
+                                </span>
+                              </AdminRowName>
+                            </td>
+                            <td
+                              class="admin-session-last-seen"
+                              data-label="last seen"
+                              data-testid={`admin-session-last-seen-${row.key}`}
+                              title={row.last_seen_at ?? "no browser session on record"}
+                            >
+                              {renderLastSeen(row.last_seen_at)}
+                            </td>
+                            <td
+                              data-label="channels"
+                              data-testid={`admin-session-channels-${row.key}`}
+                            >
+                              {renderChannels(row)}
+                            </td>
+                            <td
+                              class="admin-sessions-actions adm-table-sticky-actions"
+                              data-label="actions"
+                            >
+                              <For each={rowActions(row)}>
+                                {(kind) => (
+                                  <InlineConfirmButton
+                                    idleLabel={ACTION_LABEL[kind]}
+                                    confirmLabel={`Confirm ${kind}`}
+                                    armed={confirmingKey() === confirmKey(row.key, kind)}
+                                    onArm={() => setConfirmingKey(confirmKey(row.key, kind))}
+                                    onConfirm={() => runAction(row, kind)}
+                                    testId={`admin-session-${kind}-${row.key}`}
+                                    extraClass={`${kind}-btn`}
+                                  />
+                                )}
+                              </For>
+                              {/* An empty cell reads as a rendering bug. The
                               dash says the absence is the answer. */}
-                          <Show when={rowActions(row).length === 0}>—</Show>
-                        </td>
-                      </tr>
-                      <Show when={detailKey() === row.key}>
-                        <AdminDetailPanel
-                          title={renderWho(row)}
-                          subtitle="the rest of the record"
-                          onClose={() => setDetailKey(null)}
-                          closeLabel="close session details"
-                          columns={SESSION_COLUMNS}
-                          data-testid={`admin-session-detail-${row.key}`}
-                        >
-                          <AdminFacts facts={detailFacts(row)} />
-                          <Show when={row.visitor !== null}>
-                            <div class="admin-session-danger">
-                              {/* Named for what it destroys. The verb is
+                              <Show when={rowActions(row).length === 0}>—</Show>
+                            </td>
+                          </tr>
+                          <Show when={detailKey() === row.key}>
+                            <AdminDetailPanel
+                              title={renderWho(row)}
+                              subtitle="the rest of the record"
+                              onClose={() => setDetailKey(null)}
+                              closeLabel="close session details"
+                              columns={SESSION_COLUMNS}
+                              data-testid={`admin-session-detail-${row.key}`}
+                            >
+                              <AdminFacts facts={detailFacts(row)} />
+                              <Show when={row.visitor !== null}>
+                                <div class="admin-session-danger">
+                                  {/* Named for what it destroys. The verb is
                                   identity-wide: it deletes the visitor
                                   and every one of its network rows, not
                                   the row this panel hangs off. */}
-                              <span class="admin-session-danger-note">
-                                deletes the whole visitor identity, on every network
-                              </span>
-                              <InlineConfirmButton
-                                idleLabel="Delete visitor"
-                                confirmLabel="Confirm delete visitor"
-                                armed={confirmingKey() === confirmKey(row.key, "delete")}
-                                onArm={() => setConfirmingKey(confirmKey(row.key, "delete"))}
-                                onConfirm={() => runDelete(row)}
-                                testId={`admin-session-delete-${row.key}`}
-                                extraClass="delete-btn"
-                              />
-                            </div>
+                                  <span class="admin-session-danger-note">
+                                    deletes the whole visitor identity, on every network
+                                  </span>
+                                  <InlineConfirmButton
+                                    idleLabel="Delete visitor"
+                                    confirmLabel="Confirm delete visitor"
+                                    armed={confirmingKey() === confirmKey(row.key, "delete")}
+                                    onArm={() => setConfirmingKey(confirmKey(row.key, "delete"))}
+                                    onConfirm={() => runDelete(row)}
+                                    testId={`admin-session-delete-${row.key}`}
+                                    extraClass="delete-btn"
+                                  />
+                                </div>
+                              </Show>
+                            </AdminDetailPanel>
                           </Show>
-                        </AdminDetailPanel>
-                      </Show>
-                    </>
-                  )}
-                </For>
-              </tbody>
-            </AdminTable>
-          </AdminCard>
-        </Show>
-      </div>
+                        </>
+                      )}
+                    </For>
+                  </tbody>
+                </AdminTable>
+              </Show>
+            </AdminCard>
+          </Show>
+        </div>
+      </Show>
     </div>
   );
 };
 
 function renderLabel(row: AdminSubjectRow): string {
   if (row.label !== null) return row.label;
-  // `null` on an orphan pid whose DB row is gone, or on a log entry the
-  // server wrote before the session had a nick. Say which rather than
-  // rendering a blank — it is the divergence, not a missing value.
-  const why = row.origin === "session_log" ? "no nick logged" : "no DB row";
-  return `${row.subject_id.slice(0, 8)} (${why})`;
+  // `null` here means an orphan pid whose DB row is gone — the one
+  // label-less class this list still holds. (The log-only class, whose
+  // entry can predate the session having a nick, is on the sub-page and
+  // has its own renderer for the same reason.) Say which rather than
+  // rendering a blank: it is the divergence, not a missing value.
+  return `${row.subject_id.slice(0, 8)} (no DB row)`;
 }
 
 function renderWho(row: AdminSubjectRow): string {
@@ -497,17 +542,6 @@ function renderExpires(row: AdminSubjectRow): string {
   return days <= 0 ? "expired" : `in ${days}d`;
 }
 
-// Human duration for a session that has ended. Raw milliseconds are
-// unreadable at the scale a bouncer session actually runs for.
-function renderDuration(ms: number): string {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  return h < 24 ? `${h}h${m % 60}m` : `${Math.floor(h / 24)}d${h % 24}h`;
-}
-
 // The last thing the lifecycle log saw this session do. `null` is NOT
 // "this session never ran": the log is a bounded global ring written
 // from an async cast, so it forgets, and saying so is the honest render.
@@ -515,14 +549,6 @@ function renderLastEvent(row: AdminSubjectRow): string {
   const e = row.last_event;
   if (e === null) return "nothing logged (bounded ring — not proof it never ran)";
   return `${e.event} · ${e.at}`;
-}
-
-// Only meaningful on a disconnect: reason / cleanliness / how long it
-// had been up. Each part is dropped when the row does not carry it.
-function renderEnded(e: AdminSessionLogEntry): string {
-  const clean = e.clean === null ? "" : e.clean ? " (clean)" : " (unclean)";
-  const lasted = e.duration_ms === null ? "" : `, lasted ${renderDuration(e.duration_ms)}`;
-  return `${e.reason ?? "no reason recorded"}${clean}${lasted}`;
 }
 
 function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
@@ -551,12 +577,10 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     facts.push({ label: "ended", value: renderEnded(row.last_event) });
   }
 
-  if (row.origin === "session_log") {
-    facts.push({
-      label: "record",
-      value: "session log only — the subject was deleted, the event outlived it",
-    });
-  }
+  // No `record: session log only` fact any more (#1224): the panel that
+  // carried it belonged to a row this list no longer holds, and on the
+  // sub-page the sentence is the page's premise rather than a per-row
+  // remark — it lives in the card subtitle there.
 
   if (row.live !== null) {
     facts.push(

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -435,48 +435,95 @@ describe("AdminSessionsTab — the drill-down keeps both sources of truth", () =
   });
 });
 
-// #1158 item 4 — vjt ruled "keep only the event" (2026-08-11): visitor
-// retention is unchanged, so an anon visitor is still purged at logout,
-// and the lifecycle log — which carries no FK to the subject — is the
-// only thing left. These tests assert the operator can still SEE that
-// session, and that the surface never pretends the subject is still there.
-describe("AdminSessionsTab — a session whose subject was deleted", () => {
-  it("lists a session that only the log remembers", async () => {
+// #1158 item 4 gave a session whose subject is gone a row in this list,
+// badged `deleted`, because the lifecycle log carries no FK to the
+// subject and outlived the CASCADE. #1224 moved it OUT: three of the four
+// dictated columns are live-process facts, so on those rows they were an
+// em-dash forever. vjt's ruling (2026-08-11): a sub-page of Sessions with
+// the record's own columns, no badge, and this list strictly live.
+//
+// The operator must still be able to SEE the session, and the surface
+// must still never pretend the subject is there — the two properties
+// #1158 item 4 established. Only the screen they hold on has changed.
+describe("AdminSessionsTab — a session whose subject was deleted (#1224)", () => {
+  it("keeps it out of the live list", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
+
+    // The live row is the pre-state: without it an empty table would
+    // satisfy this by accident.
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+    expect(screen.queryByTestId(`admin-session-row-${GONE_KEY}`)).toBeNull();
+  });
+
+  it("carries no deleted badge anywhere, because nothing needs marking", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
+
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+    expect(screen.queryByTestId(`admin-session-gone-${GONE_KEY}`)).toBeNull();
+  });
+
+  it("counts it on the door to the sub-page", async () => {
     await mountWith({ logSessions: [logEntry()] });
 
-    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
+    const door = await screen.findByTestId("admin-sessions-ended-open");
+    expect(door).toHaveTextContent("Ended sessions (1)");
+  });
+
+  // The door has to be reachable exactly when the live list is empty —
+  // that is when an operator looking for a session that is over has
+  // nothing else on screen.
+  it("offers the door even with no live session at all", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    await screen.findByTestId("admin-sessions-empty");
+    expect(screen.getByTestId("admin-sessions-ended-open")).toBeTruthy();
+  });
+
+  it("lists it on the sub-page with the record's own columns", async () => {
+    await mountWith({ logSessions: [logEntry()] });
+
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const row = await screen.findByTestId(`admin-ended-session-row-${GONE_KEY}`);
     expect(row.textContent).toContain("guest9");
+    expect(row.textContent).toContain("disconnected");
+    expect(row.textContent).toContain(":tcp_closed");
+    expect(row.textContent).toContain("unclean");
+    expect(row.textContent).toContain("1h0m");
   });
 
-  it("marks the row as deleted rather than letting it read as merely broken", async () => {
+  // Point 3 of the ruling: not a blocker, still true. A page named after
+  // a population implies it holds all of it, and this one cannot.
+  it("says on the page that the ring is not an archive", async () => {
     await mountWith({ logSessions: [logEntry()] });
 
-    expect(await screen.findByTestId(`admin-session-gone-${GONE_KEY}`)).toBeTruthy();
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const card = await screen.findByTestId("admin-ended-sessions-card");
+    expect(card).toHaveTextContent("not evidence the session never ran");
   });
 
-  // No credential to park, no pid to stop: every verb would resolve to a
-  // subject that is gone, so the cell offers none.
-  it("offers no verb on the row", async () => {
-    await mountWith({ logSessions: [logEntry()] });
+  // An empty page is "the ring remembers nothing", never "no session
+  // ended" — so it says so, and the caveat above it still applies.
+  it("does not claim nothing ever ended when the log is empty", async () => {
+    await mountWith({ credentials: [userCredential()], logSessions: [] });
 
-    await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
-    expect(screen.queryByTestId(`admin-session-disconnect-${GONE_KEY}`)).toBeNull();
-    expect(screen.queryByTestId(`admin-session-reconnect-${GONE_KEY}`)).toBeNull();
-    expect(screen.queryByTestId(`admin-session-terminate-${GONE_KEY}`)).toBeNull();
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+
+    const empty = await screen.findByTestId("admin-ended-sessions-empty");
+    expect(empty).toHaveTextContent("the log remembers no session whose subject is gone");
   });
 
-  it("puts why it ended in the drill-down, not in the table", async () => {
-    await mountWith({ logSessions: [logEntry()] });
+  it("goes back to the live list", async () => {
+    await mountWith({ visitors: [parkedVisitor()], logSessions: [logEntry()] });
 
-    const row = await screen.findByTestId(`admin-session-row-${GONE_KEY}`);
-    expect(row.textContent).not.toContain(":tcp_closed");
+    fireEvent.click(await screen.findByTestId("admin-sessions-ended-open"));
+    await screen.findByTestId("admin-ended-sessions-page");
+    expect(screen.queryByTestId(`admin-session-row-${VISITOR_KEY}`)).toBeNull();
 
-    fireEvent.click(screen.getByTestId(`admin-session-details-${GONE_KEY}`));
+    fireEvent.click(screen.getByTestId("admin-ended-sessions-back"));
 
-    const panel = await screen.findByTestId(`admin-session-detail-${GONE_KEY}`);
-    expect(panel).toHaveTextContent(":tcp_closed");
-    expect(panel).toHaveTextContent("unclean");
-    expect(panel).toHaveTextContent("1h0m");
+    expect(await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`)).toBeTruthy();
   });
 
   it("joins the last event onto a subject that still exists", async () => {

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -206,6 +206,29 @@ describe("AdminSessionsTab — the dictated columns", () => {
     expect(row.textContent).toContain("azzurra");
   });
 
+  // #1223 item 1 — and it shows it ONCE. The panel used to carry a
+  // `network` fact as well, so the slug was printed twice on every row,
+  // at EVERY width: this half of the report is JSX duplication, not the
+  // `.adm-col-detail` specificity defect the other tabs have, and no CSS
+  // change would have touched it.
+  it("does not repeat the network in the drill-down", async () => {
+    await mountWith({ credentials: [userCredential()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+    expect(
+      row.querySelector(".admin-session-network")?.textContent,
+      "pre-state: the identity cell is where the network is printed",
+    ).toBe("azzurra");
+
+    fireEvent.click(screen.getByTestId(`admin-session-details-${USER_KEY}`));
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+
+    const factValues = [...panel.querySelectorAll("dd")].map((dd) => dd.textContent);
+    expect(factValues, "the panel must not reprint what the row already shows").not.toContain(
+      "azzurra",
+    );
+  });
+
   it("renders the channel count from the live session", async () => {
     await mountWith({ credentials: [userCredential()] });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -6069,7 +6069,7 @@ describe("ScrollbackPane", () => {
 
       swipeRight(speechRow);
 
-      expect(getDraft(KEY)).toBe("<alice> hello<< ");
+      expect(getDraft(KEY)).toBe("<alice> hello << ");
     });
   });
 });

--- a/cicchetto/src/__tests__/adminCardRegime.test.tsx
+++ b/cicchetto/src/__tests__/adminCardRegime.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminNetwork, AdminUser } from "../lib/api";
+
+// #1223 item 1 — the admin console has its OWN breakpoint, and the JS has
+// to use it.
+//
+// The console turns tables into cards, drops the secondary columns and
+// swaps the desktop rail for a chip strip at 900px (`default.css`:
+// `.adm-col-detail`, the `@media (max-width: 899px)` stacking block, the
+// `.admin-pane` grid). `isMobile()` is the SHELL's breakpoint, 768px, and
+// three admin gates were reading it — so between 769px and 899px the
+// table was already a stack of cards while `AdminRowName` still rendered
+// a plain `<span>`: the columns had left and the door to the panel they
+// left through was not there (vjt, measured at `b0d5342d`).
+//
+// That band is the whole reason `isAdminNarrow()` exists. THE form factor
+// under test here is the band, not the phone: jsdom has no matchMedia, so
+// both signals are supplied explicitly and the two are set to DIFFERENT
+// values — a fix that simply read the other signal would fail this file.
+//
+// The phone (both true) is covered by `adminMobileRowDetail.test.tsx`;
+// what is on screen at each width is a CSS question and lives in
+// `e2e/tests/issue1223-admin-card-affordances.spec.ts`.
+
+const viewport = vi.hoisted(() => ({ mobile: false, adminNarrow: false }));
+
+vi.mock("../lib/theme", () => ({
+  isMobile: () => viewport.mobile,
+  isAdminNarrow: () => viewport.adminNarrow,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  token: () => "test-bearer",
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    adminListUsers: vi.fn(),
+    adminCreateUser: vi.fn(),
+    adminUpdateUserAdmin: vi.fn(),
+    adminUpdateUserPassword: vi.fn(),
+    adminDeleteUser: vi.fn(),
+    adminListNetworks: vi.fn(),
+    adminPatchNetworkCaps: vi.fn(),
+    adminRunReaper: vi.fn(),
+    adminResetCircuit: vi.fn(),
+    adminCreateNetwork: vi.fn(),
+    adminDeleteNetwork: vi.fn(),
+    adminListServers: vi.fn(),
+    adminListFeaturedChannels: vi.fn(),
+  };
+});
+
+vi.mock("../lib/socket", () => ({
+  joinAdminEvents: vi.fn(),
+}));
+
+import AdminNetworksTab from "../AdminNetworksTab";
+import AdminUsersTab from "../AdminUsersTab";
+import {
+  adminListFeaturedChannels,
+  adminListNetworks,
+  adminListServers,
+  adminListUsers,
+} from "../lib/api";
+
+const ALICE: AdminUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  name: "alice",
+  is_admin: false,
+  inserted_at: "2026-05-31T00:00:00Z",
+  updated_at: "2026-05-31T00:00:00Z",
+  live_session_count: 0,
+};
+
+const BAHAMUT: AdminNetwork = {
+  id: 1,
+  slug: "bahamut-test",
+  services_flavor: null,
+  visitor_enabled: false,
+  visitor_autoconnect: false,
+  max_concurrent_visitor_sessions: 100,
+  max_concurrent_user_sessions: 3,
+  max_per_ip: 5,
+  inserted_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-15T00:00:00Z",
+  circuit_state: null,
+  live_counts: { visitors: 0, users: 0 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  viewport.mobile = false;
+  viewport.adminNarrow = false;
+});
+
+describe("#1223 — the 769-899 band: the card regime without the shell's phone flag", () => {
+  beforeEach(() => {
+    viewport.mobile = false;
+    viewport.adminNarrow = true;
+  });
+
+  it("gives a Users row the disclosure, because the columns have already left", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE]);
+    render(() => <AdminUsersTab />);
+
+    await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+
+    // The door, and then that it opens: a button that renders but reveals
+    // nothing would satisfy a mere presence check.
+    const door = screen.getByTestId(`admin-user-details-${ALICE.id}`);
+    expect(door.tagName).toBe("BUTTON");
+
+    fireEvent.click(door);
+
+    const panel = await screen.findByTestId(`admin-user-detail-${ALICE.id}`);
+    expect(panel).toHaveTextContent("live sessions");
+    expect(panel).toHaveTextContent("inserted");
+  });
+
+  it("moves the Networks cap editors into the detail here too", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    vi.mocked(adminListServers).mockResolvedValue([]);
+    vi.mocked(adminListFeaturedChannels).mockResolvedValue([]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.querySelectorAll("td")).toHaveLength(2);
+    expect(screen.queryByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId(`admin-network-expand-${BAHAMUT.slug}`));
+
+    const panel = await screen.findByTestId(`admin-network-servers-${BAHAMUT.slug}`);
+    expect(panel.contains(screen.getByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`))).toBe(
+      true,
+    );
+  });
+});
+
+// The counter-claim, and it is why the fix is a second breakpoint rather
+// than "always render the disclosure": above 900px every column is on
+// screen, and a control that reveals what you can already see teaches the
+// operator to distrust controls (`AdminRowName`'s own reasoning).
+describe("#1223 — above the admin breakpoint nothing changes", () => {
+  it("leaves a Users row's identity as plain text", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE]);
+    render(() => <AdminUsersTab />);
+
+    const row = await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+    expect(screen.queryByTestId(`admin-user-details-${ALICE.id}`)).toBeNull();
+    expect(row.querySelector(".adm-row-name")?.textContent).toBe(ALICE.name);
+  });
+
+  it("keeps the Networks cap editors on the row", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.contains(screen.getByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`))).toBe(true);
+  });
+});

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -18,6 +18,10 @@ import type { AdminNetwork, AdminUser } from "../lib/api";
 // where the disclosure does not even render.
 vi.mock("../lib/theme", () => ({
   isMobile: () => true,
+  // #1223 — a phone is below BOTH breakpoints. The admin components now
+  // read the console's own 899px one; the shell's 768px flag stays for the
+  // shell. `adminCardRegime.test.tsx` is the file that sets them apart.
+  isAdminNarrow: () => true,
   prefersDark: () => false,
   applyTheme: vi.fn(),
 }));

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -3,6 +3,8 @@ import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  endedSessions,
+  liveSessions,
   rowActions,
   rowKey,
 } from "../lib/adminSubjectRows";
@@ -341,6 +343,51 @@ describe("buildSubjectRows — the session-log join", () => {
 
     expect(rows[0]?.subject_kind).toBe("user");
     expect(rows[0]?.origin).toBe("session_log");
+  });
+});
+
+// #1224 — the merge stays one row set; the VIEW is what splits. vjt
+// ruled that ended sessions move to a sub-page of Sessions and the list
+// that stays is strictly live, so these two functions are what each
+// screen renders.
+describe("liveSessions / endedSessions — the partition", () => {
+  const both = (): AdminSubjectRow[] =>
+    build({ visitors: [visitor()], logSessions: [logEntry({ session_id: "visitor:gone:42" })] });
+
+  it("sends the log-only row to the ended list and nothing else", () => {
+    const rows = both();
+
+    expect(rows).toHaveLength(2);
+    expect(endedSessions(rows).map((r) => r.key)).toEqual(["visitor:gone:42"]);
+  });
+
+  it("leaves every row with a subject or a pid in the live list", () => {
+    const rows = both();
+
+    expect(liveSessions(rows).map((r) => r.origin)).toEqual(["credential"]);
+  });
+
+  // A partition, not two filters: every row lands in exactly one list, so
+  // a class nobody thought about cannot fall off both screens.
+  it("puts each row in exactly one of the two", () => {
+    const rows = build({
+      visitors: [visitor()],
+      credentials: [credential()],
+      sessions: [session({ subject_id: "deadbeef-0000-0000-0000-000000000000" })],
+      logSessions: [logEntry({ session_id: "visitor:gone:42" })],
+    });
+
+    const keys = [...liveSessions(rows), ...endedSessions(rows)].map((r) => r.key);
+    expect(new Set(keys).size).toBe(rows.length);
+    expect(keys).toHaveLength(rows.length);
+  });
+
+  // The narrowing is the reason the sub-page needs no null guard: the
+  // pass that builds a log-only row builds it FROM the entry.
+  it("hands the ended list rows whose event is not nullable", () => {
+    const [ended] = endedSessions(both());
+
+    expect(ended?.last_event.event).toBe("disconnected");
   });
 });
 

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -4,7 +4,13 @@ import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
 import { appendToCompose } from "../lib/composeAppend";
-import { replyQuote, replyToMessage } from "../lib/replyQuote";
+import {
+  REPLY_QUOTE_BODY_LIMIT,
+  REPLY_QUOTE_ELLIPSIS,
+  REPLY_QUOTE_TAIL,
+  replyQuote,
+  replyToMessage,
+} from "../lib/replyQuote";
 
 // #1067 — the reply verb: a swipe (or the menu's Reply item) drops
 // `<nick> quoted message<< ` into the compose box with the caret at the end,
@@ -44,14 +50,14 @@ beforeEach(() => {
 
 describe("replyQuote", () => {
   it("renders the irssi-shaped quote the issue specifies", () => {
-    expect(replyQuote(msg({}))).toBe("<vjt> ciao mondo<< ");
+    expect(replyQuote(msg({}))).toBe("<vjt> ciao mondo << ");
   });
 
   // The body on the wire can carry mIRC colour/bold control bytes; the operator
   // is quoting what they SEE, and a control byte pasted into compose would be
   // re-sent verbatim as formatting they never chose.
   it("strips mIRC control codes out of the quoted body", () => {
-    expect(replyQuote(msg({ body: "\x02bold\x02 plain" }))).toBe("<vjt> bold plain<< ");
+    expect(replyQuote(msg({ body: "\x02bold\x02 plain" }))).toBe("<vjt> bold plain << ");
   });
 
   // Presence rows (join/part/quit/mode/…) have no author speaking and often no
@@ -71,7 +77,7 @@ describe("replyQuote", () => {
   });
 
   it("quotes a notice like speech — it has an author and a body", () => {
-    expect(replyQuote(msg({ kind: "notice" }))).toBe("<vjt> ciao mondo<< ");
+    expect(replyQuote(msg({ kind: "notice" }))).toBe("<vjt> ciao mondo << ");
   });
 
   // #1126 — a real action row carries the wire envelope (`\x01ACTION …\x01`);
@@ -81,7 +87,7 @@ describe("replyQuote", () => {
   // ended up in the compose box and from there onto the wire.
   it("quotes an action in ACTION form, envelope stripped — #1126", () => {
     expect(replyQuote(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
-      "* vjt si dà alla fuga<< ",
+      "* vjt si dà alla fuga << ",
     );
   });
 
@@ -98,7 +104,7 @@ describe("replyQuote", () => {
   // future server-side pre-strip, or a row persisted before the wire form was
   // stored). The action SHAPE must not depend on the envelope being there.
   it("still uses action form when the envelope is absent — #1126", () => {
-    expect(replyQuote(msg({ kind: "action", body: "ciao mondo" }))).toBe("* vjt ciao mondo<< ");
+    expect(replyQuote(msg({ kind: "action", body: "ciao mondo" }))).toBe("* vjt ciao mondo << ");
   });
 
   // An envelope with nothing inside is not a quotable action: after the strip
@@ -114,7 +120,7 @@ describe("replyQuote", () => {
 describe("replyQuote — a previous quote is dropped (#1123)", () => {
   it("quotes only what the sender wrote, not the quote they were answering", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
-      "<alice> answer<< ",
+      "<alice> answer << ",
     );
   });
 
@@ -124,14 +130,14 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   it("cuts at the last tail, not the first", () => {
     expect(
       replyQuote(msg({ sender: "carol", body: "<alice> <bob> original<< answer<< reply" })),
-    ).toBe("<carol> reply<< ");
+    ).toBe("<carol> reply << ");
   });
 
   // #1126 gave actions their own quote head (`* nick …`), so the client emits
   // two shapes and both nest. One bug, both doors.
   it("drops a previous action-shaped quote too", () => {
     expect(replyQuote(msg({ sender: "alice", body: "* bob waves<< sure" }))).toBe(
-      "<alice> sure<< ",
+      "<alice> sure << ",
     );
   });
 
@@ -140,7 +146,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
       replyQuote(
         msg({ kind: "action", sender: "alice", body: "\x01ACTION <bob> orig<< nods\x01" }),
       ),
-    ).toBe("* alice nods<< ");
+    ).toBe("* alice nods << ");
   });
 
   // Every legal nick special (RFC 2812 `special` plus the tail-only dash),
@@ -148,7 +154,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   // instead of derived would silently refuse to strip these.
   it("recognises a head with every legal nick special", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<_a[b]\\c{d}|e^f`g-1> quoted<< mine" }))).toBe(
-      "<alice> mine<< ",
+      "<alice> mine << ",
     );
   });
 
@@ -158,7 +164,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
     const nick = `n${"x".repeat(29)}`;
     expect(nick).toHaveLength(30);
     expect(replyQuote(msg({ sender: "alice", body: `<${nick}> quoted<< mine` }))).toBe(
-      "<alice> mine<< ",
+      "<alice> mine << ",
     );
   });
 
@@ -176,7 +182,7 @@ describe("replyQuote — a previous quote is dropped (#1123)", () => {
   // typed after a wider gap would arrive with the gap still on it.
   it("does not carry the gap after the tail into the new quote", () => {
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<<   spaced" }))).toBe(
-      "<alice> spaced<< ",
+      "<alice> spaced << ",
     );
   });
 });
@@ -186,17 +192,17 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
   // which is worse than the nesting it fixes.
   it("leaves a shift expression alone", () => {
     expect(replyQuote(msg({ body: "shift << 2 gives four" }))).toBe(
-      "<vjt> shift << 2 gives four<< ",
+      "<vjt> shift << 2 gives four << ",
     );
   });
 
   it("leaves a heredoc alone", () => {
-    expect(replyQuote(msg({ body: "cat <<EOF > f" }))).toBe("<vjt> cat <<EOF > f<< ");
+    expect(replyQuote(msg({ body: "cat <<EOF > f" }))).toBe("<vjt> cat <<EOF > f << ");
   });
 
   it("leaves a leading angle bracket that is not a nick head alone", () => {
-    expect(replyQuote(msg({ body: "<3 you << me" }))).toBe("<vjt> <3 you << me<< ");
-    expect(replyQuote(msg({ body: "<two words> a << b" }))).toBe("<vjt> <two words> a << b<< ");
+    expect(replyQuote(msg({ body: "<3 you << me" }))).toBe("<vjt> <3 you << me << ");
+    expect(replyQuote(msg({ body: "<two words> a << b" }))).toBe("<vjt> <two words> a << b << ");
   });
 
   // The head must be at position 0. `appendToCompose` drops the quote AFTER an
@@ -204,8 +210,109 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
   // sender's own words — cutting there would delete what they wrote.
   it("leaves a quote that is not at the start of the body alone", () => {
     expect(replyQuote(msg({ sender: "alice", body: "bozza <bob> ciao<< risposta" }))).toBe(
-      "<alice> bozza <bob> ciao<< risposta<< ",
+      "<alice> bozza <bob> ciao<< risposta << ",
     );
+  });
+});
+
+// #1235 — vjt: "sul reply limitiamo a 42 i caratteri di cui facciamo reply, se
+// sforano mettiamo un ellipsis `...`, e poi mettiamo sempre uno spazio prima
+// del `<<` finale". The cap lives in the WRAPPER, never in `quotableBody`:
+// that helper is shared with `!addquote` (#1107), which archives the line and
+// must keep it whole. `addQuote.test.ts` is the control group for that.
+describe("replyQuote — the quoted body is capped (#1235)", () => {
+  const AT_LIMIT = "a".repeat(REPLY_QUOTE_BODY_LIMIT);
+
+  it("leaves a body at the limit whole, with no ellipsis", () => {
+    expect(replyQuote(msg({ body: AT_LIMIT }))).toBe(`<vjt> ${AT_LIMIT} << `);
+  });
+
+  // The first body over the limit is where an off-by-one shows: one way it
+  // clips a body that fits, the other it lets a 43rd character through.
+  it("caps the first body that overflows", () => {
+    expect(replyQuote(msg({ body: `${AT_LIMIT}b` }))).toBe(`<vjt> ${AT_LIMIT}... << `);
+  });
+
+  // The 42 counts BODY characters and the ellipsis is ADDED past them — the
+  // quoted run is 45, not 42 with three of them spent on dots.
+  it("keeps a full 42 characters and adds the ellipsis after them", () => {
+    const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
+    const quoted = quote.slice("<vjt> ".length, -REPLY_QUOTE_TAIL.length);
+    expect(quoted).toBe(`${"x".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}`);
+    expect(quoted).toHaveLength(REPLY_QUOTE_BODY_LIMIT + REPLY_QUOTE_ELLIPSIS.length);
+  });
+
+  // Hardcoded on purpose, against the constant: the request spells the marker
+  // `...`, and a U+2026 that renders identically would still be a different
+  // byte sequence going onto the wire.
+  it("marks the overflow with three ASCII dots, not U+2026", () => {
+    const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
+    expect(quote).toContain("x...");
+    expect(quote).not.toContain("…");
+  });
+
+  // A flat cut, with no backing off to the last word boundary: that is
+  // "limitiamo a 42 i caratteri" read literally, and a word-boundary rule would
+  // make the quote length depend on where the spaces happen to fall.
+  it("cuts flat at the limit, mid-word", () => {
+    const body = `${"parola ".repeat(5)}spezzata`;
+    expect(body).toHaveLength(43);
+    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(5)}spezzat... << `);
+  });
+
+  // The cap is on the BODY: a long nick does not eat into what the sender said.
+  it("does not count the nick head against the limit", () => {
+    const nick = "n".repeat(30);
+    expect(replyQuote(msg({ sender: nick, body: AT_LIMIT }))).toBe(`<${nick}> ${AT_LIMIT} << `);
+  });
+
+  // The cap runs AFTER the #1123 de-nesting cut, on what the sender actually
+  // wrote. Capping first would spend the whole budget on the quote they were
+  // answering and truncate their answer to nothing.
+  it("counts what the sender wrote, not the quote they were answering", () => {
+    const body = `<bob> ${"o".repeat(200)}<< breve`;
+    expect(replyQuote(msg({ sender: "alice", body }))).toBe("<alice> breve << ");
+  });
+
+  // A UTF-16 slice at 42 can land between the halves of a surrogate pair and
+  // emit a lone surrogate — an unpaired code unit in the compose box, and from
+  // there onto the wire. The cut counts code points.
+  it("does not cut an astral character in half", () => {
+    const quote = replyQuote(msg({ body: `${"a".repeat(41)}🍺x` })) ?? "";
+    expect(quote).toBe(`<vjt> ${"a".repeat(41)}🍺... << `);
+    expect(quote.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "")).not.toMatch(/[\uD800-\uDFFF]/);
+  });
+});
+
+// #1235 — the tail grew a leading space. The de-nesting regex
+// (`quotableBody.ts`) is `^(?:<nick>|\* nick) [\s\S]*<<(?: |$)`, whose greedy
+// head absorbs a space as happily as a word character, so the nesting cut is
+// supposed to keep working on BOTH spellings. That is the one thing which would
+// silently break every line already persisted, so it is asserted, not assumed.
+describe("replyQuote — the spaced tail still de-nests, both spellings (#1235)", () => {
+  it("strips a quote persisted with the OLD flush tail", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+
+  it("strips a quote written with the NEW spaced tail", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original << answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+
+  // The full round trip: what the wrapper emits today, quoted again tomorrow.
+  it("round-trips its own output", () => {
+    const first = replyQuote(msg({ sender: "bob", body: "original" })) ?? "";
+    expect(replyQuote(msg({ sender: "alice", body: `${first}answer` }))).toBe("<alice> answer << ");
+  });
+
+  // And the same trip on a CAPPED line, where the tail follows an ellipsis
+  // rather than a word — the shape the cap makes commonplace.
+  it("round-trips a capped quote", () => {
+    const first = replyQuote(msg({ sender: "bob", body: "o".repeat(200) })) ?? "";
+    expect(replyQuote(msg({ sender: "alice", body: `${first}answer` }))).toBe("<alice> answer << ");
   });
 });
 
@@ -249,7 +356,7 @@ describe("replyToMessage", () => {
   it("fills an empty compose with exactly the quote", () => {
     mountCompose();
     replyToMessage(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("<vjt> ciao mondo<< ");
+    expect(getDraft(KEY)).toBe("<vjt> ciao mondo << ");
   });
 
   // Never destroy work in progress: the quote lands AFTER what is already
@@ -258,7 +365,7 @@ describe("replyToMessage", () => {
     mountCompose();
     setDraft(KEY, "bozza ");
     replyToMessage(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("bozza <vjt> ciao mondo<< ");
+    expect(getDraft(KEY)).toBe("bozza <vjt> ciao mondo << ");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/admin/AdminRowName.tsx
+++ b/cicchetto/src/admin/AdminRowName.tsx
@@ -1,5 +1,5 @@
 import { type Component, type JSX, Show } from "solid-js";
-import { isMobile } from "../lib/theme";
+import { isAdminNarrow } from "../lib/theme";
 
 // Admin redesign (2026-08-07 review) — a table row's identity cell.
 //
@@ -20,6 +20,12 @@ import { isMobile } from "../lib/theme";
 // is not one of those: it carries four columns at EVERY width and keeps
 // the rest of the record in the panel, so there the disclosure is the
 // only door to it and `alwaysOpenable` keeps it on at all widths.
+//
+// #1223 — and "below 900px" is what the gate now asks. It used to ask
+// `isMobile()`, which is 768px: in the 769-899 band the table had
+// already dropped its columns into a panel this rendered no door to.
+// The door has to open wherever the columns leave, so both read the
+// SAME breakpoint (`isAdminNarrow`).
 
 export type Props = {
   /** The row's name, e.g. `vjt @ azzurra`. */
@@ -36,7 +42,7 @@ export type Props = {
 
 const AdminRowName: Component<Props> = (props) => (
   <Show
-    when={props.alwaysOpenable === true || isMobile()}
+    when={props.alwaysOpenable === true || isAdminNarrow()}
     fallback={<span class="adm-row-name">{props.children}</span>}
   >
     <button

--- a/cicchetto/src/admin/sessionLogFormat.ts
+++ b/cicchetto/src/admin/sessionLogFormat.ts
@@ -1,0 +1,42 @@
+import type { AdminSessionLogEntry } from "../lib/api";
+
+// #1224 — how a lifecycle-log record reads on screen, shared by the two
+// surfaces that render one: the Sessions drill-down (a live row whose
+// last logged event happens to be a disconnect) and the ended-sessions
+// sub-page (rows that are nothing BUT the record).
+//
+// Extracted from `AdminSessionsTab` rather than copied into the page:
+// the two would drift, and "lasted 1h0m" reading differently on two
+// screens of the same tab is the kind of drift nobody reports and
+// everybody notices.
+//
+// `AdminSessionLogTab.humanDuration` is a THIRD formatter with a
+// different shape (`1h 0m`, and `ms` below a second) and is deliberately
+// left alone: it renders a raw event log where sub-second spacing is the
+// story, and folding it into this one would change that tab's output for
+// no reason #1224 asks for.
+
+/** Human duration for a session that has ended. Raw milliseconds are
+ * unreadable at the scale a bouncer session actually runs for. */
+export function renderDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return h < 24 ? `${h}h${m % 60}m` : `${Math.floor(h / 24)}d${h % 24}h`;
+}
+
+/** Why it stopped, and whether the stop was orderly. `null` reason is
+ * "the log recorded none", which is not the same as a clean exit. */
+export function renderReason(e: AdminSessionLogEntry): string {
+  const clean = e.clean === null ? "" : e.clean ? " (clean)" : " (unclean)";
+  return `${e.reason ?? "no reason recorded"}${clean}`;
+}
+
+/** The one-line form, for a drill-down fact: reason, cleanliness and how
+ * long it had been up. Each part is dropped when the row lacks it. */
+export function renderEnded(e: AdminSessionLogEntry): string {
+  const lasted = e.duration_ms === null ? "" : `, lasted ${renderDuration(e.duration_ms)}`;
+  return `${renderReason(e)}${lasted}`;
+}

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -108,6 +108,44 @@ export type AdminSubjectRow = {
   last_event: AdminSessionLogEntry | null;
 };
 
+/**
+ * A row that is nothing BUT the lifecycle record: the subject is gone,
+ * no pid is left, and the log entry that produced the row is therefore
+ * the only thing it carries. The narrowing is the point — `last_event`
+ * is `null`-able on the general row and cannot be here, because the
+ * log-only pass builds the row FROM the entry.
+ */
+export type EndedSessionRow = AdminSubjectRow & {
+  origin: "session_log";
+  last_event: AdminSessionLogEntry;
+};
+
+function isEnded(row: AdminSubjectRow): row is EndedSessionRow {
+  return row.origin === "session_log" && row.last_event !== null;
+}
+
+/**
+ * #1224 — the two populations the admin console shows separately.
+ *
+ * vjt (2026-08-11): ended sessions move to a sub-page of Sessions and
+ * the list that stays is strictly live, with no `deleted` badge. The
+ * split is a VIEW concern, so it happens here rather than in the merge:
+ * the join is still one row set keyed on one composite, and the log
+ * still enriches a live row's drill-down.
+ *
+ * A partition, not two filters: `liveSessions` is the complement of
+ * `endedSessions`, so no row can fall out of both. A log-only row with
+ * no entry cannot exist (the pass that builds it needs the entry), but
+ * if it ever did it would show up in the live list rather than vanish.
+ */
+export function endedSessions(rows: AdminSubjectRow[]): EndedSessionRow[] {
+  return rows.filter(isEnded);
+}
+
+export function liveSessions(rows: AdminSubjectRow[]): AdminSubjectRow[] {
+  return rows.filter((row) => !isEnded(row));
+}
+
 export function rowKey(kind: "user" | "visitor", subjectId: string, networkId: number): string {
   return `${kind}:${subjectId}:${networkId}`;
 }

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -9,15 +9,41 @@ import { quotableBody } from "./quotableBody";
 // text also carries the timestamp and the per-message prefix glyph (@/+), and
 // scraping those back out is a parser nobody asked for.
 
-// The tail the issue specifies verbatim: `<nick> quoted message<< `, trailing
-// space included, so the answer is typed straight after the caret.
-export const REPLY_QUOTE_TAIL = "<< ";
+// The tail the issue specifies verbatim: `<nick> quoted message << `, spaces on
+// both sides — leading so the tail never sits flush against the last word
+// (#1235), trailing so the answer is typed straight after the caret.
+export const REPLY_QUOTE_TAIL = " << ";
+
+// #1235 — how much of the quoted line comes along. Without a cap, replying to a
+// long message drags the whole thing into the compose box and buries the answer.
+//
+// Four readings of "limitiamo a 42 i caratteri" are all defensible; these are
+// the ones ruled on, deliberately kept to one constant plus one function so a
+// change of mind is a one-line edit:
+//   - 42 counts BODY characters and the ellipsis is ADDED past them (45 quoted,
+//     not 42 with three spent on dots);
+//   - the marker is the literal `...` the request spells, not `…` U+2026;
+//   - the cut is flat at 42, with no backing off to a word boundary;
+//   - the head (`<nick> ` / `* nick `) is outside the count — the nick is not
+//     what overflows.
+export const REPLY_QUOTE_BODY_LIMIT = 42;
+export const REPLY_QUOTE_ELLIPSIS = "...";
+
+// The quoted body, cut to the limit. Counted in CODE POINTS: a UTF-16 slice can
+// land between the halves of a surrogate pair and put a lone surrogate in the
+// compose box, and from there onto the wire.
+function capQuotedBody(body: string): string {
+  const chars = [...body];
+  if (chars.length <= REPLY_QUOTE_BODY_LIMIT) return body;
+  return chars.slice(0, REPLY_QUOTE_BODY_LIMIT).join("") + REPLY_QUOTE_ELLIPSIS;
+}
 
 // The quote for a message, or null when there is nothing to reply to.
 //
 // #1107 — the gate and the plain-text extraction moved to `quotableBody`, which
 // `addQuoteCommand` now shares. What stays here is the WRAPPER, which is the
-// only part reply owns.
+// only part reply owns — and that is why the #1235 cap lives here and not in
+// the helper: `!addquote` archives the line and must keep it whole.
 export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
@@ -26,7 +52,7 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   // the `* nick …` form the scrollback renders. Ruled on the least-surprise
   // tiebreak; privmsg/notice keep the `<nick> …` shape unchanged.
   const head = msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
-  return `${head} ${body}${REPLY_QUOTE_TAIL}`;
+  return `${head} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A

--- a/cicchetto/src/lib/theme.ts
+++ b/cicchetto/src/lib/theme.ts
@@ -27,6 +27,22 @@ export type ResolvedTheme = "mirc-light" | "irssi-dark";
 
 const MOBILE_QUERY = "(max-width: 768px)";
 
+// #1223 — the ADMIN console's own breakpoint, which is not the shell's.
+//
+// Everything about the console changes at 900px, not 768px: the desktop
+// nav rail (`.admin-pane` grid), the two-column form grid, the table
+// stacking block and `.adm-col-detail`'s drop are all written against
+// `900px` / `899px` in `themes/default.css`. Between 769 and 899 the
+// shell is a desktop and the console is already a stack of cards, so an
+// admin component that branches on `isMobile()` reads the wrong regime
+// for a 130px-wide band — which is how the Users and Credentials tables
+// came to drop their secondary columns while `AdminRowName` still
+// rendered a plain span, leaving the detail panel with no door.
+//
+// Same literal-in-CSS caveat as `--breakpoint-mobile`: a media query
+// cannot read a `var()`, so the number is mirrored, not shared.
+const ADMIN_NARROW_QUERY = "(max-width: 899px)";
+
 // Resolves the OS preference via matchMedia. Defensive against environments
 // without matchMedia (older browsers, SSR — neither applies to cicchetto
 // today, but the boundary is cheap).
@@ -75,6 +91,12 @@ const exports_ = moduleRoot(() => {
       : false;
   const [mobile, setMobile] = createSignal(initial);
 
+  const adminNarrowInitial =
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia(ADMIN_NARROW_QUERY).matches
+      : false;
+  const [adminNarrow, setAdminNarrow] = createSignal(adminNarrowInitial);
+
   const darkInitial =
     typeof window !== "undefined" && window.matchMedia
       ? window.matchMedia(DARK_QUERY).matches
@@ -86,6 +108,9 @@ const exports_ = moduleRoot(() => {
     const listener = (e: MediaQueryListEvent) => setMobile(e.matches);
     mm.addEventListener("change", listener);
 
+    const mmAdmin = window.matchMedia(ADMIN_NARROW_QUERY);
+    mmAdmin.addEventListener("change", (e: MediaQueryListEvent) => setAdminNarrow(e.matches));
+
     const mmDark = window.matchMedia(DARK_QUERY);
     mmDark.addEventListener("change", (e: MediaQueryListEvent) => setPrefersDark(e.matches));
 
@@ -95,14 +120,21 @@ const exports_ = moduleRoot(() => {
     void createEffect(() => {
       // Force the signals into the createRoot's tracking scope.
       void mobile();
+      void adminNarrow();
       void prefersDark();
     });
   }
 
-  return { isMobile: mobile, prefersDark };
+  return { isMobile: mobile, isAdminNarrow: adminNarrow, prefersDark };
 });
 
 export const isMobile = exports_.isMobile;
+
+// #1223 — true below the ADMIN console's 900px breakpoint (see
+// ADMIN_NARROW_QUERY). Every admin component whose behaviour has to match
+// what the console's CSS is doing at that width reads THIS, not
+// `isMobile()`; the shell's own layout keeps `isMobile()`.
+export const isAdminNarrow = exports_.isAdminNarrow;
 
 // #358 — the reactive OS dark-mode preference (true = dark). customTheme.ts's
 // apply effect subscribes to it; the gallery reads it to default the slot

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5304,7 +5304,13 @@ html.resize-dragging * {
    `ux-6-g-admin-mobile-h-scroll` still holds, in its #1074 form: pan-x
    stays PERMITTED on every admin tab (a table that fits must still not
    trap a horizontal gesture), and no tab is wider than its panel on a
-   phone. Networks was the one exemption and is not one any more. */
+   phone. Networks was the one exemption and is not one any more.
+
+   This declaration alone does NOT achieve the drop: the stacking block
+   at the bottom of this file re-declares `.adm-table td`, which outranks
+   it. The `td`-qualified twin down there is what enforces it (#1223
+   item 1). Kept here as the mobile-first default, and because it is what
+   hides the `th` partner. */
 .adm-col-detail {
   display: none;
 }
@@ -5774,6 +5780,30 @@ html.resize-dragging * {
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--adm-text-dim);
+  }
+
+  /* #1223 item 1 — the drop is REAL below 900px, which it was not.
+     `.adm-col-detail { display: none }` is (0,1,0) and the stacking rule
+     right above is `.adm-table td` (0,1,1), so every secondary cell won
+     its way back on screen as a labelled line of the card — while
+     `thead` is hidden outright, which is why the result read as designed
+     rather than broken. The panel underneath then repeated those very
+     fields under a subtitle promising the opposite ("the columns the
+     table drops on a phone"): `LIVE 2` / `INSERTED …` on the card and
+     `LIVE SESSIONS 2` / `INSERTED …` in the panel, one under the other
+     (vjt, iPhone dogfood at `b0d5342d`).
+
+     `.adm-table td.adm-col-detail` is (0,2,1) and wins. It has to live
+     INSIDE this block: the rule it is beating is in here, and the base
+     declaration outside cannot outrank it from there.
+
+     vjt's ruling on the fork (2026-08-11): drop the columns, keep the
+     panel. The alternative — dropping the panel on a phone — was
+     rejected. Note this cures ONE of the two duplications reported: the
+     Sessions NETWORK repeat is JSX, not specificity, and is fixed in
+     `AdminSessionsTab`. */
+  .adm-table td.adm-col-detail {
+    display: none;
   }
 
   /* The identity cell is the card's HEADING, not a labelled field: a

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39493,3 +39493,64 @@ WebKit at iPhone-15 metrics, which is the suite's standing limit. And
 `isAdminNarrow` mirrors a number CSS cannot share with JS — a media
 query still cannot read a `var()`, so 899 is written twice, exactly like
 `--breakpoint-mobile` before it.
+
+---
+
+## 2026-08-11 — #1224: a session that is over is a record, not a row in a live console
+
+vjt, same iPhone dogfood pass as #1223: *"i visitor deleted son utili ma
+vanno su sotto pagina con campi diversi perché son sempre offline"*.
+#1158 item 4 had put those rows on screen; this is where they belong.
+
+**Three of the four dictated columns were an em-dash by construction.**
+`last seen`, `channels` and `actions` are live-process facts, and a
+log-only row has no process and no DB row — the CASCADE took the
+subject, `session_log_events` has no FK to it and stayed. So the list
+was paying full column width for fields that can never be populated, and
+the operator scanned past rows that looked broken rather than finished.
+The record is a post-mortem; the table it was being rendered into is a
+live console.
+
+**vjt's three rulings, and what each cost.** (1) A SUB-PAGE of Sessions,
+not a sixth tab — the tab strip already overflows and scrolls on a
+phone. (2) No `deleted` badge: once the rows move out, the list is
+strictly live and there is nothing to mark, so the badge #1158 item 4
+added is gone rather than kept "just in case". (3) The ring caveat is
+not a blocker — but it is still true, and a page NAMED after a
+population implies it holds all of it in a way an inline badge did not.
+So the caveat moved onto the page's card subtitle, where it is the
+premise of the screen instead of a remark on a row.
+
+**The split is a view concern, so it lives in the view's vocabulary.**
+`buildSubjectRows` is untouched: one row set, one composite key, the log
+still enriching a live row's drill-down. `liveSessions`/`endedSessions`
+partition it, and they are a PARTITION rather than two filters — the
+live list is the complement, so a class nobody anticipated cannot fall
+off both screens. `EndedSessionRow` narrows `last_event` to non-null,
+which is why the page needs no guard for a case its constructor makes
+impossible.
+
+**The door had to survive an empty list.** The Sessions card used to be
+gated on the row count, so with zero rows there was no card — and after
+the split "zero live rows, some ended ones" is a real state, exactly the
+one where an operator most wants the other screen. The card now renders
+whenever the data loaded and the empty state sits inside it, saying "no
+live sessions" rather than "no sessions", with the ended count on the
+door beside it.
+
+**Built with #1223 item 1 already applied**, as the issue asked: the
+page's columns are the ones the record actually has, no panel repeats
+them, and nothing is dropped at any width — five short fields stack into
+a card without needing a disclosure to get them back.
+
+**Deliberately not built.** No route (the console has none, and #1158
+already declined to invent its first deep link); no independent fetch —
+the page is handed the rows the tab already merged, because a second
+fetch would show a second snapshot of the list the operator reached it
+from; no retention change of any kind.
+
+**Not claimed.** That the page is complete. It cannot be: the ring is
+bounded, pruned on write, fed by an async cast from a path that includes
+`terminate/2`, and a last event that is not a disconnect means the log
+never saw the end — the subtitle says both, and the `lasted`/`how` cells
+render an em-dash rather than inventing an ending.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39435,3 +39435,61 @@ about provenance into the one place built to be honest about it.
 **Two relay fields on one POST is `400`, by an explicit clause.** `ctcp_target` and `notice_target` are mutually exclusive; leaving the winner to clause order would make it an accident of where the arms sit in the file. cic says the same thing in the type system with a `MessageRelay` union rather than two optional target arguments.
 
 **Deliberately NOT touched: `isOperatorActionEcho`.** It classifies server-originated replies to operator actions (numeric-derived notices), and an own outbound notice is not one — it is own CONTENT, handled the way an own PRIVMSG is: the send path advances the read cursor, and the `read_cursor_set` fan-out drops the row from every other device's derived count. Widening the predicate to cover own content would have made two mechanisms responsible for the same suppression.
+
+---
+
+## 2026-08-11 — #1223 item 1: two defects, one symptom, and the band between two breakpoints
+
+vjt, dogfooding staging on an iPhone: *"poi abbiamo quest'idiozia di
+mostrare colonne già mostrate"*. His ruling on the fork the issue left
+open (2026-08-11): *"1223 punto 1: direi drop no?"* — the secondary
+columns really leave the card on a phone, and the detail panel stays.
+Dropping the panel instead was the rejected arm.
+
+**The panel's subtitle was the only true thing on screen, and it was
+false.** `.adm-col-detail { display: none }` is (0,1,0); the stacking
+block that turns rows into cards re-declares `.adm-table td` (0,1,1) and
+wins, so below 900px every "dropped" column came back as a labelled line
+of the card while the panel underneath printed it again under the words
+*"the columns the table drops on a phone"*. `thead` is hidden outright,
+which is why the result read as designed rather than broken. The fix is
+one `td`-qualified twin (0,2,1) inside the same block — it has to live
+there, because a rule outside a media query cannot outrank one inside it.
+
+**One symptom, two defects, and only one of them was CSS.** The issue
+read the Sessions `NETWORK` repeat as another instance of the
+specificity failure. It is not: Sessions drops no column at any width
+(four `<th>`, none secondary). Its repeat was JSX — `detailFacts`
+carried a `network` fact while `.admin-session-network` printed the slug
+under the nick, on DESKTOP too. Raising the selector would not have
+touched it, and dropping the panel on a phone would not have touched the
+desktop half of it. Curing one and calling the issue closed would have
+left the other alive, which is why the count matters more than the
+symptom.
+
+**The 769–899 band is where a half-fix would have made it worse.** The
+admin console's regime changes at 900px — the nav rail, the form grid,
+the table stacking and `.adm-col-detail` are all written against
+`900px`/`899px`. `isMobile()` is the SHELL's breakpoint, 768px, and
+three admin gates were reading it. Make the drop real without touching
+that, and between 769 and 899 the columns leave while `AdminRowName`
+still renders a plain `<span>`: the fields gone AND no door to the panel
+they went into. So the console got its own signal (`isAdminNarrow`,
+899px) and `AdminRowName` plus the Networks column split now read it.
+`refreshSlot` deliberately keeps `isMobile()`: where the refresh button
+lives is a question about the shell's rail, not about the table.
+
+**Where each half is tested, and why they differ.** The drop is a
+question about what is PAINTED — jsdom cannot see it (#1073's lesson),
+so `issue1223-admin-card-affordances.spec.ts` asserts it in a real
+browser, with the report's own oracle: no value may be on the card AND
+in the panel at once, both sides asserted non-empty first so an empty
+intersection cannot pass vacuously. The band gets a second real-browser
+test at 820px. The Sessions duplication is plain JSX that vitest sees
+perfectly well, and a browser copy of it would only be slower.
+
+**Not claimed.** Nothing here measures a real iPhone; the phone leg is
+WebKit at iPhone-15 metrics, which is the suite's standing limit. And
+`isAdminNarrow` mirrors a number CSS cannot share with JS — a media
+query still cannot read a `var()`, so 899 is written twice, exactly like
+`--breakpoint-mobile` before it.

--- a/infra/linux/install_nginx.sh
+++ b/infra/linux/install_nginx.sh
@@ -2,7 +2,8 @@
 # Install the dumb reverse-proxy nginx config + shared snippet on a native
 # Linux host, enable/reload the service. The BEAM self-serves the SPA and
 # owns every header (#485), so there is no cicchetto-dist symlink and no
-# security-headers snippet — only the substrate-agnostic proxy snippet.
+# security-headers snippet — only the two substrate-agnostic snippets: the
+# proxy locations and the shared access-log format (#1029).
 #
 # Idempotent — re-run after `git pull` (or to change
 # LISTEN_ADDR/TRUSTED_UPSTREAM_CIDR) to refresh the config.
@@ -48,6 +49,9 @@ echo "[install_nginx] installing config + snippets"
 install -o root -g root -m 0644 "${tmp_conf}" "${NGINX_ETC}/nginx.conf"
 mkdir -p "${NGINX_ETC}/snippets"
 install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/locations-api.conf" "${NGINX_ETC}/snippets/locations-api.conf"
+# #1029 — nginx.conf includes this one too; miss it and `nginx -t` below
+# fails AFTER the config has already been written to /etc/nginx.
+install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/log-format.conf" "${NGINX_ETC}/snippets/log-format.conf"
 
 echo "[install_nginx] nginx -t"
 nginx -t

--- a/infra/linux/nginx.conf
+++ b/infra/linux/nginx.conf
@@ -14,7 +14,7 @@
 # Installed by install_nginx.sh, which:
 #   1. cp this file → /etc/nginx/nginx.conf (substituting @LISTEN_ADDR@ and
 #      the optional allow/deny block)
-#   2. cp ../snippets/locations-api.conf → /etc/nginx/snippets/
+#   2. cp ../snippets/{locations-api,log-format}.conf → /etc/nginx/snippets/
 #   3. nginx -t && systemctl enable --now nginx (or reload if already up)
 
 worker_processes auto;
@@ -26,6 +26,11 @@ http {
     sendfile        on;
     keepalive_timeout 65;
     server_tokens   off;
+
+    # Access-log shape — shared with every other nginx substrate (#1029).
+    # Must sit here in the http context: `log_format` is not valid inside
+    # `server { }`, which is where locations-api.conf is included.
+    include snippets/log-format.conf;
 
     upstream grappa_upstream {
         server 127.0.0.1:4000;

--- a/infra/snippets/log-format.conf
+++ b/infra/snippets/log-format.conf
@@ -1,0 +1,59 @@
+# grappa — shared nginx access-log format (http context)
+#
+# THE single definition of the access-log line, included from every nginx
+# substrate that still exists (#1029):
+#   - infra/linux/nginx.conf         (native systemd host)
+#   - cicchetto/e2e/nginx-test.conf  (the e2e :80 + :443 TLS surface)
+# Sibling of locations-api.conf, same reason: three substrates each growing
+# their own nearly-identical format means the three logs stop being
+# comparable a month later. `log_format` is http-context only, which is why
+# this is a second snippet rather than a block inside locations-api.conf
+# (that one is included inside `server { }`).
+#
+# WHY THESE FIELDS — #394 counted 20 client aborts over 45,135 requests at
+# the edge and could not attribute a single one, because the default
+# `combined` format answers none of the questions:
+#   rt=$request_time              is an abort our own 8s bootFetch ceiling or
+#                                 a client teardown? did the server take long,
+#                                 or was it fast and the client left? is a 499
+#                                 really the 60s edge ceiling? five of the six
+#                                 questions need only this one field.
+#   urt=$upstream_response_time   separates "the BEAM was slow" from "the edge
+#   us=$upstream_status           was slow", and exposes a retry.
+#   rid=$sent_http_x_request_id   THE join key to the BEAM log. Phoenix
+#                                 already sets the x-request-id response
+#                                 header (Plug.RequestId) and already carries
+#                                 request_id in its Logger metadata
+#                                 (config/config.exs) — but nginx never logged
+#                                 it, so the two logs could not be joined at
+#                                 all. This is that one field.
+#   msec=$msec                    ms resolution: with second-granular
+#                                 $time_local a single suspend event is
+#                                 indistinguishable from N independent aborts.
+#
+# WHY APPENDED AND NOT INTERLEAVED — this shape is byte-identical to the one
+# vjt applied to the m42 HOST vhost (out of this repo) on 2026-08-08, and it
+# must stay that way. Those logs are shipped by syslog-ng into a telegraf
+# collector that parses `combined` POSITIONALLY: client IP, then the first
+# quoted string is the request line, the next two tokens are status and
+# bytes, then referer and user-agent are the first two quoted strings of the
+# remainder. A field inserted ANYWHERE before the user-agent silently
+# mis-assigns every one of them; a field appended after it is ignored by the
+# parser and stays greppable in the raw message. Verified against
+# VictoriaLogs after the host reload, not assumed.
+#
+# The name is `main` to match the host vhost, so a grep written for one log
+# reads the other.
+
+log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                '$status $body_bytes_sent "$http_referer" '
+                '"$http_user_agent" "$http_x_forwarded_for" '
+                'rt=$request_time urt=$upstream_response_time us=$upstream_status '
+                'rid=$sent_http_x_request_id msec=$msec';
+
+# http-context default, so every server block in every includer inherits it
+# and no substrate can half-adopt the format. The path is nginx's own
+# default location: on a native host it is the file logrotate already
+# rotates, and in the nginx:alpine image it is symlinked to /dev/stdout, so
+# the e2e surface logs to `docker logs` with no per-substrate override.
+access_log /var/log/nginx/access.log main;

--- a/test/infra/nginx_log_format_test.bats
+++ b/test/infra/nginx_log_format_test.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+#
+# GH #1029 — the nginx access log carries no duration and no correlation id,
+# so a request-level diagnosis is blind. The #394 re-measurement counted 20
+# client aborts over 45,135 requests and could not attribute ONE of them.
+#
+# The host half (m42's `/usr/local/etc/nginx/sites/irc.openssl.it`) is out of
+# this repo and already live. This suite guards the IN-REPO half: the
+# substrates must log the SAME shape, or a diagnosis rehearsed locally reads
+# differently from the one run in production — which is the whole point of
+# the parity ask, not a tidiness preference.
+#
+# The subject is the SHAPE OF THE LOG LINE an operator gets, and the failure
+# mode being guarded is DRIFT: three substrates each growing their own
+# slightly-different `log_format` until the logs stop being comparable. So
+# every assertion here is derived from the tree rather than hardcoded —
+# "every conf with an http block includes the one snippet", not "these two
+# files contain this string". A NEW substrate added next year fails this
+# suite until it joins the format, which a hardcoded list would not do.
+#
+# What this suite does NOT do: run `nginx -t`. That needs a real nginx, and
+# the e2e stack already provides one — `cicchetto/e2e/nginx-test.conf` mounts
+# the snippet and nginx-test refuses to start on a syntax error, taking every
+# e2e spec down with it. Syntax is gated there; SHAPE is gated here.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SNIPPET="infra/snippets/log-format.conf"
+
+# Every nginx conf in the worktree, whatever its context — the search space
+# for a stray second definition.
+#
+# `--cached --others --exclude-standard`, not plain `ls-files`: a conf that
+# has been WRITTEN but not yet staged is exactly the moment this guard is
+# most useful, and a tracked-only listing would wave it through while still
+# reporting green. `--exclude-standard` keeps gitignored trees (node_modules,
+# _build) out.
+all_confs() {
+    git -C "$REPO_ROOT" ls-files --cached --others --exclude-standard -- '*.conf' 2>/dev/null
+}
+
+# The confs that open an `http { }` block, i.e. the ones that can host a
+# `log_format` (the directive is http-context only). Derived, so a new
+# substrate is in scope the day it appears.
+#
+# This deliberately EXCLUDES infra/nginx-tls-frontend.example.conf: it is a
+# server-context fragment dropped into an operator's own nginx, so it can
+# neither define a format nor reference one this repo controls.
+http_context_confs() {
+    all_confs | while IFS= read -r f; do
+        grep -q '^http {' "$REPO_ROOT/$f" && printf '%s\n' "$f"
+    done || true
+}
+
+@test "log_format is defined exactly once, in the shared snippet (#1029)" {
+    # `|| true` on the substitution, not inside: the loop's status is the LAST
+    # grep's, so a final non-matching conf would abort the body under errexit
+    # before the comparison ever runs.
+    definers="$(all_confs | while IFS= read -r f; do
+        grep -qE '^[[:space:]]*log_format[[:space:]]' "$REPO_ROOT/$f" && printf '%s\n' "$f"
+    done || true)"
+
+    [ "$definers" = "$SNIPPET" ] || {
+        echo "expected exactly one log_format definition site ($SNIPPET), got:" >&2
+        printf '%s\n' "${definers:-<none>}" >&2
+        return 1
+    }
+}
+
+@test "the shared format carries every field the #1029 diagnosis needs" {
+    fmt="$REPO_ROOT/$SNIPPET"
+
+    # $request_time answers five of the six questions in the issue on its own
+    # (8s bootFetch ceiling vs teardown, the 60s edge ceiling wearing a 499,
+    # aborts per second-in-flight, slow-server vs departed-client).
+    grep -q 'rt=\$request_time' "$fmt" || { echo "missing rt=\$request_time" >&2; return 1; }
+
+    # upstream_* separates "the BEAM was slow" from "the edge was slow", and
+    # exposes a retry.
+    grep -q 'urt=\$upstream_response_time' "$fmt" || { echo "missing urt=\$upstream_response_time" >&2; return 1; }
+    grep -q 'us=\$upstream_status' "$fmt" || { echo "missing us=\$upstream_status" >&2; return 1; }
+
+    # THE join key. Phoenix already emits x-request-id (Plug.RequestId) and
+    # already logs request_id in its Logger metadata; without this field the
+    # two logs cannot be joined at all, which is the single line this issue
+    # is really about.
+    grep -q 'rid=\$sent_http_x_request_id' "$fmt" || { echo "missing rid=\$sent_http_x_request_id" >&2; return 1; }
+
+    # Millisecond resolution — with $time_local alone, one suspend event is
+    # indistinguishable from N independent aborts in the same second.
+    grep -q 'msec=\$msec' "$fmt" || { echo "missing msec=\$msec" >&2; return 1; }
+}
+
+@test "the appended fields come AFTER the user-agent, positionally (#1029)" {
+    # Not cosmetic. These logs are shipped off m42 by syslog-ng into a
+    # telegraf collector that parses `combined` POSITIONALLY: client IP
+    # first, then the first quoted string is the request line, the next two
+    # tokens are status and bytes, then referer and user-agent are the first
+    # two quoted strings of the remainder. Anything INTERLEAVED silently
+    # mis-assigns every downstream field; anything appended is ignored.
+    # vjt verified this against VictoriaLogs when applying the host half.
+    fmt="$REPO_ROOT/$SNIPPET"
+    flat="$(tr -d " \n'" < "$fmt")"
+
+    case "$flat" in
+        *'"$http_user_agent""$http_x_forwarded_for"rt=$request_time'*) ;;
+        *)
+            echo "the rt=/urt=/us=/rid=/msec= tail must follow the user-agent and" >&2
+            echo "x-forwarded-for pair verbatim — an interleaved field breaks the" >&2
+            echo "positional collector parser on m42. Got:" >&2
+            cat "$fmt" >&2
+            return 1
+            ;;
+    esac
+}
+
+@test "the shared snippet USES the format it defines (#1029)" {
+    # Defining a format nobody references changes not one byte of the log —
+    # the hollow-green version of this whole change. The format NAME is read
+    # back out of the definition rather than hardcoded, so renaming it in one
+    # place and not the other still fails here.
+    fmt="$REPO_ROOT/$SNIPPET"
+
+    name="$(sed -nE 's/^[[:space:]]*log_format[[:space:]]+([A-Za-z0-9_]+).*/\1/p' "$fmt" | head -n1)"
+    [ -n "$name" ] || { echo "could not read the log_format name out of $SNIPPET" >&2; return 1; }
+
+    grep -qE "^[[:space:]]*access_log[[:space:]]+\S+[[:space:]]+${name}[[:space:]]*;" "$fmt" || {
+        echo "no access_log references the '${name}' format in $SNIPPET:" >&2
+        cat "$fmt" >&2
+        return 1
+    }
+}
+
+@test "every http-context nginx conf includes the shared snippet (#1029)" {
+    confs="$(http_context_confs)"
+
+    # Anti-vacuous: two substrates exist today (infra/linux, cicchetto/e2e).
+    # A broken derivation returning nothing would otherwise pass loudly.
+    count="$(printf '%s\n' "$confs" | grep -c . || true)"
+    [ "$count" -ge 2 ] || {
+        echo "expected >=2 http-context nginx confs, found $count — the derivation is wrong:" >&2
+        printf '%s\n' "$confs" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$confs" | while IFS= read -r f; do
+        grep -q 'include .*log-format\.conf;' "$REPO_ROOT/$f" || printf '%s\n' "$f"
+    done)"
+
+    [ -z "$violations" ] || {
+        echo "nginx conf(s) with an http block that do NOT include $SNIPPET (#1029):" >&2
+        printf '%s\n' "$violations" >&2
+        return 1
+    }
+}
+
+@test "install_nginx.sh installs every snippet the linux conf includes (#1029)" {
+    # The native-host failure this closes: the conf includes a snippet the
+    # installer never copies, so `nginx -t` fails at install time on a real
+    # host — after the config has already been written to /etc/nginx.
+    # Derived from the conf's own include lines, so the next snippet added is
+    # covered without touching this test.
+    conf="$REPO_ROOT/infra/linux/nginx.conf"
+    installer="$REPO_ROOT/infra/linux/install_nginx.sh"
+
+    includes="$(sed -nE 's@^[[:space:]]*include[[:space:]]+snippets/([A-Za-z0-9_.-]+);.*@\1@p' "$conf")"
+
+    count="$(printf '%s\n' "$includes" | grep -c . || true)"
+    [ "$count" -ge 2 ] || {
+        echo "expected >=2 snippet includes in infra/linux/nginx.conf, found $count:" >&2
+        printf '%s\n' "$includes" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$includes" | while IFS= read -r snip; do
+        grep -q "snippets/${snip}" "$installer" || printf '%s\n' "$snip"
+    done)"
+
+    [ -z "$violations" ] || {
+        echo "snippet(s) included by nginx.conf but never installed by install_nginx.sh:" >&2
+        printf '%s\n' "$violations" >&2
+        return 1
+    }
+}
+
+@test "the e2e stack mounts the snippets directory into nginx-test (#1029)" {
+    # The e2e includer resolves /etc/nginx/snippets/log-format.conf from a
+    # bind mount of the whole infra/snippets dir. Drop the mount and nginx
+    # dies at startup, taking the whole e2e run with it — a slow, confusing
+    # red compared to this line.
+    compose="$REPO_ROOT/cicchetto/e2e/compose.yaml"
+
+    grep -qE '^\s*-\s*\.\./\.\./infra/snippets:/etc/nginx/snippets:ro\s*$' "$compose" || {
+        echo "cicchetto/e2e/compose.yaml no longer mounts infra/snippets into nginx-test:" >&2
+        grep -n 'snippets' "$compose" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
Three PRs were each green against a **different** base, and none of them had
ever been gated **alongside the others**. Merging them separately would pay
three gates and still never answer that question. This is the union: one
branch, one PR, one gate.

Cherry-picked onto `origin/main` = `ce930c47`, in this order:

| PR | branch | head | base (merge-base) | commits |
|----|--------|------|-------------------|---------|
| #1237 (#1029) | `issue1029` | `eb8801f6` | `5bb1d168` | 1 |
| #1233 (#1223 p1 + #1224) | `w2-1223p1-1224` | `a25ecd9a` | `0ea07ff6` | 4 |
| #1238 (#1235) | `issue1235` | `228725a8` | `98ec54a0` | 2 |

**7 of 7 commits applied, no conflicts.** Every head and merge-base in the
table was re-verified against the local and remote refs before picking, and
each local branch was identical to its `origin/` counterpart.

## The decision-log separator

Only #1233 touches `docs/DESIGN_NOTES.md` (+119/-0). Cherry-picking that onto
a `main` that has since gained entries is exactly the three-way merge that
resolves a `blank`/`---`/`blank` boundary as *already present* — and it bites
with every commit otherwise intact, because it costs **additions, not
deletions**. Whoever reads `deletions=0` reads a clean rebase that is not
clean.

It bit here, and the numstat comparison caught it:

- before (contribution of #1233 against its own merge-base): `119 0 docs/DESIGN_NOTES.md`
- after the raw cherry-picks: `116 0 docs/DESIGN_NOTES.md` — **3 additions gone, deletions still 0**

The three lost lines were the separator itself. On the real file the #1223
entry's heading followed the previous entry's closing prose directly, with no
blank, no `---`, and no blank — while the #1224 entry, in the same branch, kept
the canonical `prose / blank / --- / blank / heading` shape.

Fixed by folding the boundary back into the #1223 entry's own commit with
`--amend` (not as a separate `---`-only commit, which is how this class of
damage gets started in the first place). After the fix:

- `119 0 docs/DESIGN_NOTES.md` — identical to the recorded baseline
- both 2026-08-11 boundaries now read `prose / blank / --- / blank / heading`

As a check that nothing else silently lost lines the same way, the per-file
numstat of the three PRs summed against their own merge-bases was compared
with the union's numstat against `ce930c47`: **28 files, byte-identical on
both sides.**

## Housekeeping

The cherry-picks rewrite the SHAs, so GitHub will not close the three original
PRs on merge — **#1237, #1233 and #1238 remain to be closed by hand, on
content.** vjt closes them; this PR does not touch them.