### PR TITLE
#1030: raise Bandit's read_timeout above every nginx upstream idle

### DIFF
--- a/cicchetto/e2e/nginx-test.conf
+++ b/cicchetto/e2e/nginx-test.conf
@@ -33,6 +33,10 @@ http {
     upstream grappa_upstream {
         server grappa:4000;
         keepalive 32;
+        # #1030 — pinned, not defaulted: this idle MUST expire before the
+        # BEAM's (Bandit read_timeout, config/config.exs). Same value as
+        # nginx's default today; pinned so the default cannot move under us.
+        keepalive_timeout 60s;
     }
 
     # :80 — plain HTTP, retained for backwards-compat with non-push specs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -260,6 +260,21 @@ config :grappa, Grappa.Repo,
 config :grappa, GrappaWeb.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,
+  # #1030 — the nginx→BEAM keepalive pool must be closed by its CLIENT.
+  # thousand_island's `read_timeout` is the server-side idle between two
+  # requests on a pooled connection, and it defaults to 60_000 ms — the
+  # SAME value as nginx's upstream idle default. Equal timers arm a race:
+  # nginx dispatches onto a socket Bandit is closing in that instant and
+  # can only answer 502. Every in-repo upstream now pins `keepalive_timeout
+  # 60s` explicitly; this sits strictly above it, with enough headroom that
+  # scheduler and clock jitter cannot close the gap.
+  #
+  # Declared ONCE here, on the env-agnostic endpoint config, and deep-merged
+  # into the per-env `http:` lists by Config — the same merge that already
+  # carries `url: [host: "localhost"]` into runtime.exs's `url: [host: …,
+  # port: 443]` in prod. Phoenix hands `:http` verbatim to Bandit, which
+  # accepts `read_timeout` only under `:thousand_island_options`.
+  http: [thousand_island_options: [read_timeout: 75_000]],
   render_errors: [
     formats: [json: GrappaWeb.ErrorJSON],
     layout: false

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39554,3 +39554,56 @@ bounded, pruned on write, fed by an async cast from a path that includes
 `terminate/2`, and a last event that is not a disconnect means the log
 never saw the end — the subtitle says both, and the `lasted`/`how` cells
 render an em-dash rather than inventing an ending.
+
+---
+
+## 2026-08-11 — #1030: two idle timers of the same length, and which side has to blink first
+
+A pooled nginx→BEAM connection carries two idle timers. nginx's upstream
+idle (`keepalive_timeout` inside `upstream { }`) defaults to 60s; Bandit's
+`read_timeout` — thousand_island's between-requests idle, the timer that
+actually closes a keepalive socket server-side — defaults to 60_000 ms, and
+grappa overrode it nowhere. Equal timers arm a race: nginx dispatches onto a
+socket the BEAM is closing in the same instant, the request dies at the
+connection layer, and the only thing nginx can report is a 502.
+
+**This is read, not measured, and it ships ahead of its own evidence.** No
+502 log line has been inspected; the causal link between the two defaults
+and #1030's 35 events is inferred from the code alone. A re-read of the m42
+edge on 2026-08-11 found **zero** 502s across all retained logs (6372 lines,
+2026-08-10 18:00 → 2026-08-11 20:17) — which proves nothing either way: the
+original sample was 45,135 requests at a 0.078% rate, this window carries
+roughly a seventh of that volume, so about five events were expected and
+zero is inside the noise. #1029's `$request_time` + `$request_id` remain the
+discriminator that would settle it.
+
+**vjt's ruling (#grappa, 2026-08-11): raise the read timeout above nginx**,
+rather than lowering nginx. The rule for a keepalive pool is that its CLIENT
+gives up first, and nginx is the client.
+
+**Both sides are pinned, not just the one that moves.** Bandit goes to
+75_000 ms and every in-repo upstream block gets an explicit
+`keepalive_timeout 60s` — the value nginx defaults to today. Leaving one
+side on a default would make the inequality depend on a number upstream can
+change without telling us, and it would vanish in silence rather than in
+red. The Elixir value is declared ONCE, on the env-agnostic endpoint config
+in `config/config.exs`, and reaches the per-env `http:` lists through
+Config's keyword deep-merge — the same merge that already carries
+`url: [host: "localhost"]` into runtime.exs's prod `url:`.
+
+**The guard reads the real values, and says what it cannot see.**
+`test/grappa/infra/keepalive_idle_ordering_test.exs` globs the repo for
+`upstream` blocks that actually pool (`keepalive <n>;`), parses each block's
+pinned idle out of the file, and compares it against the MERGED application
+env rather than a grep of `config.exs` — only the merged read witnesses that
+the deep-merge happened at all. A third assertion pins the four known
+substrates so a glob that stops matching cannot turn the other two green
+over an empty list. The m42 production edge terminates TLS in a HOST nginx
+vhost that belongs to the operator, not this repo; its idle is unreachable
+from any test here and the moduledoc says so instead of implying coverage.
+The census is five in-repo pools, not the three the issue names —
+`infra/cloud/first-boot.sh` writes an upstream inline and
+`infra/nginx-tls-frontend.example.conf` ships one for operators to copy.
+`infra/freebsd/nginx.conf`, which the ruling text cites, does not exist.
+
+Touching `config/*.exs` makes this a COLD deploy.

--- a/infra/cloud/first-boot.sh
+++ b/infra/cloud/first-boot.sh
@@ -190,6 +190,10 @@ write_nginx_site() {
 upstream grappa_upstream {
     server 127.0.0.1:4000;
     keepalive 32;
+    # #1030 — pinned, not defaulted: this idle MUST expire before the
+    # BEAM's (Bandit read_timeout, config/config.exs). Same value as
+    # nginx's default today; pinned so the default cannot move under us.
+    keepalive_timeout 60s;
 }
 server {
     listen 80 default_server;

--- a/infra/linux/nginx.conf
+++ b/infra/linux/nginx.conf
@@ -35,6 +35,10 @@ http {
     upstream grappa_upstream {
         server 127.0.0.1:4000;
         keepalive 32;
+        # #1030 — pinned, not defaulted: this idle MUST expire before the
+        # BEAM's (Bandit read_timeout, config/config.exs). Same value as
+        # nginx's default today; pinned so the default cannot move under us.
+        keepalive_timeout 60s;
     }
 
     server {

--- a/infra/nginx-tls-frontend.example.conf
+++ b/infra/nginx-tls-frontend.example.conf
@@ -34,6 +34,13 @@ upstream grappa_stack {
   # 127.0.0.1:4000. Point this at whichever you use.
   server 127.0.0.1:3000;
   keepalive 32;
+  # #1030 — pinned, not defaulted: this idle MUST expire before the BEAM's
+  # (Bandit read_timeout, 75s). Equal timers on a pooled connection let nginx
+  # dispatch onto a socket the BEAM is closing in the same instant, and the
+  # only thing nginx can report is a 502. If you raise it past 75s, raise
+  # read_timeout too. Same value as nginx's default today; pinned so the
+  # default cannot move under an operator who never reads this file.
+  keepalive_timeout 60s;
 }
 
 server {

--- a/infra/snippets/locations-api.conf
+++ b/infra/snippets/locations-api.conf
@@ -4,6 +4,8 @@
 # every nginx substrate that still exists:
 #   - infra/linux/nginx.conf         (native systemd host)
 #   - cicchetto/e2e/nginx-test.conf  (the e2e :80 + :443 TLS surface)
+#   - infra/cloud/first-boot.sh      (fetches this file at boot and writes
+#                                     a site that includes it)
 # Two substrates dropped their nginx entirely and are NOT includers: the
 # Docker `--profile prod` container went in #485, and the m42 bastille
 # jail followed — both publish the BEAM directly, with nothing in front
@@ -30,6 +32,18 @@
 # The includer declares `upstream grappa_upstream { ... }` plus the
 # per-substrate `listen` / `server_name` / TLS bits. This file is
 # substrate-agnostic: no `root`, no `listen`, no cert.
+#
+# #1030 — CONTRACT ON THAT UPSTREAM BLOCK. `location /` below sends an empty
+# Connection header, so the includer's `keepalive` pool is live and two idle
+# timers now sit on every proxied connection: the includer's
+# `keepalive_timeout` (inside `upstream { }`, nginx default 60s) and the
+# BEAM's `read_timeout` (75s, config/config.exs). The pool's CLIENT must give
+# up FIRST — with the server closing at or before nginx, nginx dispatches onto
+# a socket Bandit is closing in that instant and the request dies as a 502.
+# So: pin `keepalive_timeout` inside the upstream block, strictly BELOW the
+# BEAM's read_timeout. Every in-repo includer does. An includer that lives
+# outside this repo — the m42 host vhost is one — is on the operator, and no
+# test here can see it.
 
 # Single body ceiling — reconciled DOWN from the old 160m to match
 # Plug.Parsers' 128 MiB multipart cap (lib/grappa_web/endpoint.ex, the one

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -101,6 +101,10 @@ if [ "$SRC_ROOT" != "$REPO_ROOT" ]; then
         -v "$SRC_ROOT/.env.example:/app/.env.example:ro"
         #   bin/         → operator_help_drift_test.exs (#1086)
         -v "$SRC_ROOT/bin:/app/bin:ro"
+        #   cicchetto/e2e/ → keepalive_idle_ordering_test.exs (#1030). The
+        #   only cic path a server-side test reads; cicchetto/src above is
+        #   mounted for a different reason and does not cover it.
+        -v "$SRC_ROOT/cicchetto/e2e:/app/cicchetto/e2e:ro"
     )
 fi
 

--- a/test/grappa/infra/keepalive_idle_ordering_test.exs
+++ b/test/grappa/infra/keepalive_idle_ordering_test.exs
@@ -117,7 +117,7 @@ defmodule Grappa.Infra.KeepaliveIdleOrderingTest do
   defp upstream_blocks(source) do
     ~r/upstream\s+(\S+)\s*\{([^}]*)\}/
     |> Regex.scan(source)
-    |> Enum.map(fn [_all, name, body] -> {name, body} end)
+    |> Enum.map(fn [_, name, body] -> {name, body} end)
   end
 
   # `keepalive <n>;` (the pool-size directive) is what makes the connection
@@ -128,8 +128,8 @@ defmodule Grappa.Infra.KeepaliveIdleOrderingTest do
   defp idle_ms(body) do
     case Regex.run(~r/^\s*keepalive_timeout\s+(\d+)(ms|s|m|h)?\s*;/m, body) do
       nil -> nil
-      [_all, value] -> String.to_integer(value) * 1000
-      [_all, value, unit] -> String.to_integer(value) * unit_ms(unit)
+      [_, value] -> String.to_integer(value) * 1000
+      [_, value, unit] -> String.to_integer(value) * unit_ms(unit)
     end
   end
 

--- a/test/grappa/infra/keepalive_idle_ordering_test.exs
+++ b/test/grappa/infra/keepalive_idle_ordering_test.exs
@@ -1,0 +1,141 @@
+defmodule Grappa.Infra.KeepaliveIdleOrderingTest do
+  @moduledoc """
+  #1030 — the nginx→BEAM keepalive pool must be closed by its CLIENT.
+
+  Two idle timers sit on every pooled nginx→Bandit connection: nginx's
+  upstream idle (`keepalive_timeout` inside `upstream { }`, default 60s)
+  and Bandit's `read_timeout` (thousand_island's between-requests idle,
+  default 60_000 ms). With both at the default they are EQUAL, and the
+  race is armed: nginx dispatches onto a socket Bandit is closing in the
+  same instant, the request dies at the connection layer and nginx has
+  only a 502 to report.
+
+  The rule for a keepalive pool is that the pool's client gives up
+  FIRST. This guard asserts it as an inequality over the REAL values —
+  the confs are parsed, the Elixir side is read out of the merged
+  application env — so neither side can drift without reddening.
+
+  ## What this guard CANNOT see
+
+  The m42 production edge terminates TLS in a HOST nginx vhost that is
+  the operator's, not this repo's (`infra/snippets/locations-api.conf`
+  says so: the includer declares its own `upstream`). Its
+  `keepalive_timeout` is unreachable from here and this guard does NOT
+  cover it — the repo asserts its own half and no more. Pretending
+  otherwise is how a guard ends up green over an unfixed edge.
+
+  Discovery is by glob, not by a hand-kept file list, so a NEW substrate
+  is picked up the moment it lands. The blind spot that remains is a
+  pool declared in a file shape the globs miss.
+  """
+
+  use ExUnit.Case, async: true
+
+  @conf_globs ["infra/**/*.conf", "infra/**/*.sh", "cicchetto/e2e/**/*.conf"]
+
+  describe "nginx→BEAM keepalive pools" do
+    test "every in-repo upstream pool pins its idle explicitly" do
+      for pool <- pools() do
+        assert pool.idle_ms,
+               """
+               #{pool.file}: upstream `#{pool.name}` keeps a keepalive pool to \
+               the BEAM but does not pin `keepalive_timeout` inside the block, \
+               so its idle is nginx's default. A default can move under us and \
+               the #1030 inequality would vanish silently — pin it.\
+               """
+      end
+    end
+
+    test "Bandit's read_timeout outlives every pinned upstream idle" do
+      read_timeout_ms = bandit_read_timeout_ms()
+
+      for pool <- pools(), is_integer(pool.idle_ms) do
+        assert read_timeout_ms > pool.idle_ms,
+               """
+               #{pool.file}: upstream `#{pool.name}` idles for #{pool.idle_ms} ms \
+               while Bandit's read_timeout is #{read_timeout_ms} ms. The pool's \
+               CLIENT must give up first (#1030) — with the server closing at or \
+               before nginx, nginx dispatches onto a dying socket and answers 502.\
+               """
+      end
+    end
+
+    # Anti-vacuity. The two assertions above iterate `pools()`, so a glob that
+    # stops matching turns both of them green over nothing. This is the one
+    # place a hand-kept list is right: a substrate leaving the repo (as
+    # infra/freebsd/nginx.conf did) SHOULD force a deliberate edit here.
+    test "the discovery globs still find the known substrates" do
+      files = pools() |> Enum.map(& &1.file) |> MapSet.new()
+
+      for known <- [
+            "infra/linux/nginx.conf",
+            "infra/cloud/first-boot.sh",
+            "infra/nginx-tls-frontend.example.conf",
+            "cicchetto/e2e/nginx-test.conf"
+          ] do
+        assert known in files,
+               "#{known} declares a keepalive pool to the BEAM but the globs no longer reach it"
+      end
+    end
+  end
+
+  # The value Bandit actually receives: Phoenix hands the `:http` keyword
+  # list straight to `Bandit.child_spec/1`, which validates `read_timeout`
+  # under `:thousand_island_options` (Bandit.PhoenixAdapter.child_specs/2 →
+  # Bandit.start_link/1). Reading the MERGED application env rather than
+  # grepping config.exs is deliberate: the value is declared once in
+  # config.exs and reaches the endpoint through Config's keyword deep-merge,
+  # and only the merged read witnesses that the merge happened.
+  defp bandit_read_timeout_ms do
+    :grappa
+    |> Application.fetch_env!(GrappaWeb.Endpoint)
+    |> Keyword.fetch!(:http)
+    |> Keyword.fetch!(:thousand_island_options)
+    |> Keyword.fetch!(:read_timeout)
+  end
+
+  defp pools do
+    for path <- Enum.flat_map(@conf_globs, &Path.wildcard/1),
+        {name, body} <- path |> File.read!() |> strip_comments() |> upstream_blocks(),
+        pooled?(body) do
+      %{file: path, name: name, idle_ms: idle_ms(body)}
+    end
+  end
+
+  # Both nginx and sh comment with `#`. Dropping them before the parse keeps
+  # prose about an upstream block from being read as one — and makes a
+  # commented-out `keepalive_timeout` correctly count as absent.
+  defp strip_comments(source) do
+    source
+    |> String.split("\n")
+    |> Enum.reject(&String.starts_with?(String.trim_leading(&1), "#"))
+    |> Enum.join("\n")
+  end
+
+  # nginx upstream blocks hold no nested braces, so a run of non-`}` bytes is
+  # the whole body.
+  defp upstream_blocks(source) do
+    ~r/upstream\s+(\S+)\s*\{([^}]*)\}/
+    |> Regex.scan(source)
+    |> Enum.map(fn [_all, name, body] -> {name, body} end)
+  end
+
+  # `keepalive <n>;` (the pool-size directive) is what makes the connection
+  # pooled — and therefore raceable. An upstream without it opens a fresh
+  # socket per request and has no idle timer to order.
+  defp pooled?(body), do: Regex.match?(~r/^\s*keepalive\s+\d+\s*;/m, body)
+
+  defp idle_ms(body) do
+    case Regex.run(~r/^\s*keepalive_timeout\s+(\d+)(ms|s|m|h)?\s*;/m, body) do
+      nil -> nil
+      [_all, value] -> String.to_integer(value) * 1000
+      [_all, value, unit] -> String.to_integer(value) * unit_ms(unit)
+    end
+  end
+
+  # nginx time units; a bare number is seconds.
+  defp unit_ms("ms"), do: 1
+  defp unit_ms("s"), do: 1000
+  defp unit_ms("m"), do: 60 * 1000
+  defp unit_ms("h"), do: 60 * 60 * 1000
+end

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -44,8 +44,16 @@ ROSTER=(
 # Comments are prose, not behaviour: version.sh's own header NAMES every
 # carrier, and _lib.sh mentions cicchetto-build in a note. Matching them would
 # make the guard lie in both directions, so strip trailing comments first.
+#
+# A `-v host:container` argument is data, not an invocation, for the same
+# reason: it hands a path to a container, it does not launch anything. #1030
+# added a `-v "$SRC_ROOT/cicchetto/e2e:…:ro"` overlay to scripts/_lib.sh, which
+# made the `cicchetto/e2e` signal read a bind-mount as an e2e bring-up. The
+# real drivers name the dir by ASSIGNMENT (`E2E_DIR="$SRC_ROOT/cicchetto/e2e"`
+# in scripts/integration.sh + scripts/testnet.sh), so stripping mount specs
+# leaves them caught — pinned by the two cases at the bottom of this file.
 code_of() {
-    sed -e 's/[[:space:]]*#.*$//' "$1"
+    sed -e 's/[[:space:]]*#.*$//' -e 's/-v "[^"]*"//g' -e 's/--volume "[^"]*"//g' "$1"
 }
 
 # Every predicate below feeds grep a HERE-STRING, never a pipe. A pipe into
@@ -253,4 +261,49 @@ EOF
     run --separate-stderr unexported_launchers "$fake"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
+}
+
+@test "scan: a bind-mount of the e2e dir is data, not a launcher" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/_lib.sh" <<'EOF'
+#!/usr/bin/env bash
+WORKTREE_VOLUMES=(
+    -v "$SRC_ROOT/cicchetto/e2e:/app/cicchetto/e2e:ro"
+)
+EOF
+
+    run --separate-stderr discovered_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "scan: RED — mounting the e2e dir does not hide a build in the same file" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/_lib.sh" <<'EOF'
+#!/usr/bin/env bash
+WORKTREE_VOLUMES=(
+    -v "$SRC_ROOT/cicchetto/e2e:/app/cicchetto/e2e:ro"
+)
+docker compose --profile prod run --rm cicchetto-build
+EOF
+
+    run --separate-stderr unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/_lib.sh" ]
+}
+
+@test "scan: naming the e2e dir by assignment is still a launcher" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/integration.sh" <<'EOF'
+#!/usr/bin/env bash
+E2E_DIR="$SRC_ROOT/cicchetto/e2e"
+cd "$E2E_DIR" && docker compose up -d
+EOF
+
+    run --separate-stderr unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/integration.sh" ]
 }


### PR DESCRIPTION
## What

A pooled nginx→BEAM connection carries two idle timers, and until now both sat on the same default of 60s:

- nginx's upstream idle — `keepalive_timeout` inside `upstream { }`, nginx default 60s;
- Bandit's `read_timeout` — thousand_island's between-requests idle, the timer that actually closes a keepalive socket server-side (`deps/thousand_island/lib/thousand_island/server_config.ex:39`), which grappa overrode nowhere.

Equal timers arm a race: nginx dispatches onto a socket the BEAM is closing in the same instant, the request dies at the connection layer, and the only thing nginx can report is a 502.

Per vjt's ruling on the issue — *"raise read timeout above nginx"* — the server side moves up rather than nginx moving down. The rule for a keepalive pool is that its CLIENT gives up first, and nginx is the client.

## The shape

**Both sides are pinned, not just the one that moves.** `read_timeout` goes to `75_000` ms; every in-repo `upstream` block now states `keepalive_timeout 60s` explicitly — the value nginx defaults to today. Leaving one side on a default would make the inequality depend on a number upstream can change without telling us, and it would then vanish in silence rather than in red.

**The Elixir value is declared once.** It sits on the env-agnostic endpoint config in `config/config.exs` and reaches the per-env `http:` lists through Config's keyword deep-merge — the same merge that already carries `url: [host: "localhost"]` into `runtime.exs`'s prod `url:`. Phoenix hands `:http` verbatim to `Bandit.child_spec/1` (`Bandit.PhoenixAdapter.child_specs/2`), which accepts `read_timeout` only under `:thousand_island_options`; it is not a top-level Bandit key.

## What I refused to claim

- **The mechanism is READ IN THE CODE, NOT MEASURED.** No 502 log line has been inspected. The causal link between the two defaults and the issue's 35 events is inferred from the source alone, and this fix ships ahead of its own evidence. #1029's `$request_time` + `$request_id` remain the discriminator that would settle it.
- **A re-read of the m42 edge on 2026-08-11 found zero 502s** across all retained logs (6372 lines, 2026-08-10 18:00 → 2026-08-11 20:17). That is **not** evidence the defect is gone: the original sample was 45,135 requests at a 0.078% rate, this window carries roughly a seventh of that volume, so about five events were expected and zero sits inside the noise.
- **The m42 host vhost is not covered.** It terminates TLS outside this repo, declares its own `upstream irc_grappa`, and no test here can read its idle. `infra/snippets/locations-api.conf` states the contract for out-of-repo includers; the guard's moduledoc says plainly that it does not cover them, rather than implying coverage it does not have.

## Census correction

The issue names three substrates. There are **five** in-repo pools to the BEAM:

| file | upstream |
|---|---|
| `infra/linux/nginx.conf:30` | `grappa_upstream` |
| `cicchetto/e2e/nginx-test.conf:27` | `grappa_upstream` |
| `infra/cloud/first-boot.sh:190` | `grappa_upstream` (written inline at boot) |
| `infra/nginx-tls-frontend.example.conf:29` | `grappa_stack` (shipped for operators to copy) |
| `infra/snippets/locations-api.conf` | no block of its own — the includer declares it |

`infra/freebsd/nginx.conf`, which the ruling text cites, **does not exist**; that nginx was deleted with the jail's. The code wins over the text.

## The guard

`test/grappa/infra/keepalive_idle_ordering_test.exs` globs the repo for `upstream` blocks that actually pool (`keepalive <n>;`), parses each block's pinned idle out of the file, and compares it against the value Bandit really receives.

Two choices are deliberate. The Elixir side is read from the **merged application env**, not grepped out of `config.exs` — only the merged read witnesses that the deep-merge happened at all; a source pin would stay green if it silently stopped. And a block with no `keepalive_timeout` fails on its own assertion rather than being skipped, because inheriting nginx's default is the state this issue is about. A third assertion pins the four known substrates, because two assertions that iterate a list both go green when the list goes empty.

### Mutants

Baseline green (`3 tests, 0 failures`, rc=0). Four mutants, each a one-edit delta from the committed state, each killing exactly one assertion:

| mutant | result | names |
|---|---|---|
| M1 — `read_timeout` back to `60_000` (the pre-fix world) | red, 1 failure | `infra/linux/nginx.conf` |
| M2 — one substrate un-pinned, back on nginx's default | red, 1 failure | `infra/linux/nginx.conf` |
| M3 — one substrate idles to `90s`, past the server | red, 1 failure | `cicchetto/e2e/nginx-test.conf` only |
| M4 — a discovery glob stops matching | red, 1 failure | `infra/cloud/first-boot.sh` |

**The baseline was red on the first run**, and it was not the change's fault: the worktree overlay in `scripts/_lib.sh` mounts `cicchetto/src` but nothing else under `cicchetto/`, so a container run from a worktree parsed **main's** `nginx-test.conf`. The guard would have been green on main and red from every worktree — a gate whose verdict depends on where you are standing is a gate people learn to ignore. Fixed by adding the overlay, the same remedy the four drift-pin mounts above it already document.

## `scripts/_lib.sh` is shared infrastructure, and it broke two guards

Kept as its own commit, because every worker's container runs go through it.

**It did break something, and the gate caught it.** `test/infra/cic_version_export_test.bats` scans shell entrypoints for signals that they can reach a cic build, and the literal `cicchetto/e2e` is one of them — the e2e drivers `cd` into that dir and run a bare `compose up`, so the service name never appears in their code. My read-only bind-mount put that same literal into `_lib.sh`, and the scanner reported it both as a launcher missing `export GRAPPA_VERSION` and as missing from the roster. `check.sh` came back `rc=1` on exactly those two tests, with `5938 tests, 0 failures` and dialyzer clean beside them.

The resolution is not to add `_lib.sh` to the roster — it launches nothing. A `-v host:container` argument hands a path to a container; it invokes nothing, so `code_of` now strips it for the same reason it already strips trailing comments: the guard must match behaviour, not text that merely names a thing. The strip is narrow (quoted specs only), and the real drivers name the dir by ASSIGNMENT (`E2E_DIR="$SRC_ROOT/cicchetto/e2e"` in `scripts/integration.sh` and `scripts/testnet.sh`), so they stay caught.

Proven by mutation, both directions — a strip that is too wide blinds the guard rather than sharpening it:

| mutant | result |
|---|---|
| MB1 — remove the strip (the pre-fix state) | red: cases 2 and 3 (the real `_lib.sh`) plus the new case 8 |
| MB2 — over-strip, deleting every line that names the dir | red: **only** case 10, the assignment form |

### Why this does not disturb the other workers

- `in_oneshot` (`scripts/_lib.sh:200`) is the **only** consumer of `WORKTREE_VOLUMES`. The e2e and integration stacks bring themselves up from `cicchetto/e2e/compose.yaml` on the host and never see that array.
- The array is **empty** when `SRC_ROOT == REPO_ROOT`, so a run from main is unchanged.
- The mount is additive and read-only, and the path is git-tracked so it exists in every worktree. The `cicchetto/e2e/infra` submodule beneath it may be uninitialised; an empty dir mounts fine.
- Net effect: a run from a worktree reads its **own** `cicchetto/e2e` instead of main's. Strictly more correct, never less.

## Deploy

Touches `config/*.exs` → **COLD deploy**. For 0.17.0.
