### PR TITLE
cic(#1223): give the admin console its horizontal budget back on a phone

### DIFF
--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -184,10 +184,22 @@ test("#1223 @webkit on a phone a detail fact gives its value the panel's full wi
     // And the point of moving it: the value gets the width the label track
     // and its gap were taking. Separate from the assertion above because a
     // collapse that left a fixed label column would satisfy that one.
+    //
+    // 🔴 The reference box is the TABLE, not the facts list, and that is the
+    // whole correction. This read `factsBox.width * 0.9` and passed for a
+    // day on a panel rendering at half the pane: the facts list is INSIDE
+    // the panel, so squeezing the panel shrinks numerator and denominator
+    // together and the ratio never moves. vjt's retest of v0.16.0 —
+    // *"the facts column renders at roughly half the available width"* —
+    // was invisible to an oracle normalised by the box being squeezed.
+    // The table is the outermost box the panel is entitled to fill, which
+    // is the claim actually being made.
+    const tableBox = await boxOf(page.getByTestId("admin-sessions-table"), "the sessions table");
     expect(
       ddBox.width,
-      "the value track must take essentially the whole panel width",
-    ).toBeGreaterThanOrEqual(factsBox.width * 0.9);
+      `the value must take the table's width, not the shrunken panel's ` +
+        `(value ${Math.round(ddBox.width)}px of table ${Math.round(tableBox.width)}px)`,
+    ).toBeGreaterThanOrEqual(tableBox.width * 0.85);
   } finally {
     await reapVisitors(admin.token, visitor.id);
   }
@@ -264,6 +276,185 @@ test("#1223 @webkit on a phone no field is on the card and in the panel at once"
     factValues.filter((value) => cardValues.includes(value)),
     `values printed twice — card ${JSON.stringify(cardValues)}, panel ${JSON.stringify(factValues)}`,
   ).toEqual([]);
+});
+
+// #1223 RETEST (vjt, v0.16.0-8412fb40, portrait phone). The card/detail
+// split landed and the horizontal budget did not: *"the layout still spends
+// width on gutters and label columns rather than on the values."*
+//
+// Symptom 1, as the two numbers that name it. The panel's host row was
+// being charged the card regime three times — an empty `td::before` label
+// track (80px + a 12px gap, `attr(data-label)` on a cell that has no
+// `data-label`), `.adm-table tr`'s own border and padding (18px), and a
+// `.adm-expand-row td` padding (32px) whose mobile override was dead on
+// specificity. That is the "inset container with a wide empty gutter on
+// both sides", measured rather than described.
+//
+// Asserted as GUTTERS rather than as a width ratio on purpose: a ratio
+// answers "is it big enough", which invites a threshold argument, while vjt
+// reported empty space at the edges and the honest claim is that there is
+// none of it.
+test("#1223 @webkit on a phone the detail panel spans its table, with no gutters", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`gutter1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    await page.getByTestId(`admin-session-details-${key}`).tap();
+    const panel = page.getByTestId(`admin-session-detail-${key}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    const tableBox = await boxOf(page.getByTestId("admin-sessions-table"), "the sessions table");
+    const panelBox = await boxOf(panel, "the detail panel");
+
+    // Non-vacuity: a table collapsed to nothing would make both gutters
+    // zero and the assertion a mirror.
+    expect(tableBox.width, "the table must have a width to fill").toBeGreaterThan(200);
+
+    expect(
+      {
+        left: Math.round(panelBox.x - tableBox.x),
+        right: Math.round(tableBox.x + tableBox.width - (panelBox.x + panelBox.width)),
+      },
+      "the detail panel must start and end where its table does",
+    ).toEqual({ left: 0, right: 0 });
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});
+
+// Symptom 2. vjt: *"a long value such as the `last event` timestamp wraps
+// mid-token instead of using the space the gutters are holding."*
+//
+// The oracle is the TOKEN, not the line count. A line count would encode a
+// font metric and fail on the day someone changes the mono stack; and
+// `last event` reads `<event> · <instant>`, so a break at the separator is
+// legitimate and only a break INSIDE a run is the defect. Generalised over
+// every value in the panel rather than the one vjt happened to name — the
+// rule is that no value is broken mid-token, and the timestamp is one
+// instance of it.
+//
+// `Range.getClientRects()` returns one rect per line box the range covers,
+// so a token on two lines reports two distinct `top`s. Pseudo-elements are
+// not in the DOM and cannot be ranged, which is exactly right here: the
+// label track is not part of the value.
+test("#1223 @webkit on a phone no panel value is broken mid-token", async ({ page }) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`token1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    await page.getByTestId(`admin-session-details-${key}`).tap();
+    const panel = page.getByTestId(`admin-session-detail-${key}`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    const measured = await panel.locator(".adm-facts").evaluate((facts) => {
+      const out: { token: string; lines: number }[] = [];
+      for (const dd of facts.querySelectorAll("dd")) {
+        for (const node of dd.childNodes) {
+          if (node.nodeType !== Node.TEXT_NODE) continue;
+          const text = node.textContent ?? "";
+          // Whitespace-delimited runs: every one of them is a place the
+          // renderer is entitled to break BETWEEN and not WITHIN.
+          for (const m of text.matchAll(/\S+/g)) {
+            const start = m.index;
+            const range = document.createRange();
+            range.setStart(node, start);
+            range.setEnd(node, start + m[0].length);
+            const tops = new Set(
+              [...range.getClientRects()].filter((r) => r.width > 0).map((r) => Math.round(r.top)),
+            );
+            out.push({ token: m[0], lines: tops.size });
+          }
+        }
+      }
+      return out;
+    });
+
+    // Non-vacuity, and the reason it is worth stating: if the seeded row
+    // renders only short words, nothing here CAN wrap and a green proves
+    // nothing. 16 characters is past what a broken panel could hold.
+    const longest = measured.reduce((best, t) => (t.token.length > best.token.length ? t : best), {
+      token: "",
+      lines: 0,
+    });
+    expect(
+      longest.token.length,
+      `no value long enough to test wrapping — measured ${JSON.stringify(measured.map((t) => t.token))}`,
+    ).toBeGreaterThanOrEqual(16);
+
+    expect(
+      measured.filter((t) => t.lines > 1),
+      "a value may wrap between its tokens, never inside one",
+    ).toEqual([]);
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});
+
+// Symptom 3. vjt: *"in the card below, the label column (last seen,
+// channels, actions) keeps a fixed wide gutter of its own, pushing the
+// values into the right half."* `flex: 0 0 5rem` on `.adm-table td::before`
+// — 80px that neither grows nor shrinks, plus the 12px flex gap, out of
+// 341px of card, charged to every field of every row.
+//
+// The oracle is where the VALUE starts, which is the thing vjt could see.
+// A range over the cell's contents excludes the `::before` label by
+// construction, so this measures the painted value against the cell's own
+// left edge — no gutter means the two coincide.
+test("#1223 @webkit on a phone a card value starts at the card's edge, not past a label track", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitor = await mintVisitor(`label1223-${Date.now()}`);
+
+  try {
+    await adminLogin(page);
+    await openSessionsTab(page);
+
+    const key = await adminSessionRowKey(page, "visitor", visitor.id);
+    const row = page.getByTestId(`admin-session-row-${key}`);
+    await row.scrollIntoViewIfNeeded();
+    await expect(row).toBeVisible();
+
+    const cells = await row.evaluate((tr) => {
+      const out: { label: string; indent: number }[] = [];
+      // Labelled cells only: `.adm-cell-title` is the card's heading and
+      // deliberately has no label to be indented past.
+      for (const td of tr.querySelectorAll("td[data-label]")) {
+        if (td.getClientRects().length === 0) continue;
+        if (td.classList.contains("adm-cell-title")) continue;
+        const range = document.createRange();
+        range.selectNodeContents(td);
+        const content = range.getBoundingClientRect();
+        if (content.width === 0) continue;
+        out.push({
+          label: td.getAttribute("data-label") ?? "",
+          indent: Math.round(content.left - td.getBoundingClientRect().left),
+        });
+      }
+      return out;
+    });
+
+    // Non-vacuity: a row with no labelled cell painted would pass on
+    // nothing, which is how the `.adm-nav` exemption in `ux-6-g` survived.
+    expect(cells.length, "the card must have labelled cells to measure").toBeGreaterThan(0);
+
+    expect(
+      cells.filter((c) => c.indent > 2),
+      `no card value may be indented past a reserved label track — ${JSON.stringify(cells)}`,
+    ).toEqual([]);
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
 });
 
 // The band the console's two breakpoints leave between them. 820px is a

--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -316,13 +316,28 @@ test("#1223 @webkit on a phone the detail panel spans its table, with no gutters
     // zero and the assertion a mirror.
     expect(tableBox.width, "the table must have a width to fill").toBeGreaterThan(200);
 
+    // `top` is measured against the panel's own CELL, not the table: the
+    // row above is a legitimate thing to sit below, an empty strip inside
+    // the cell is not. It is here because a mutation run found the rule
+    // that suppresses that strip — `.adm-expand-row td::before { content:
+    // none }` — killed no assertion at all. The cell's `::before` still
+    // resolves `attr(data-label)` to the empty string on a cell that has
+    // no such attribute, and an empty inline box is still a box. Without
+    // this number the rule was unfalsifiable, which is the same defect as
+    // an exemption: code no guard can convict.
+    const cellBox = await boxOf(
+      panel.locator("xpath=ancestor::td[1]"),
+      "the cell hosting the detail panel",
+    );
+
     expect(
       {
         left: Math.round(panelBox.x - tableBox.x),
         right: Math.round(tableBox.x + tableBox.width - (panelBox.x + panelBox.width)),
+        top: Math.round(panelBox.y - cellBox.y),
       },
-      "the detail panel must start and end where its table does",
-    ).toEqual({ left: 0, right: 0 });
+      "the detail panel must fill the cell it is given, on all three sides",
+    ).toEqual({ left: 0, right: 0, top: 0 });
   } finally {
     await reapVisitors(admin.token, visitor.id);
   }

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -474,10 +474,10 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
         const out: Record<string, number> = {};
         for (let n = el.parentElement, i = 0; n !== null; n = n.parentElement, i++) {
           if (n.scrollHeight <= n.clientHeight) continue;
-          const name = n.getAttribute("data-testid") ?? n.className || n.tagName.toLowerCase();
+          const name = n.getAttribute("data-testid") ?? (n.className || n.tagName.toLowerCase());
           out[`${i}:${String(name).slice(0, 40)}`] = n.scrollTop;
         }
-        out["window"] = window.scrollY;
+        out.window = window.scrollY;
         return out;
       });
 

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -451,6 +451,21 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
 
     const expander = page.locator("[data-testid^='admin-network-expand-']").first();
     await expect(expander).toBeVisible({ timeout: 5_000 });
+
+    // A DURABLE pre-state, and the reason it is here. `tap()` scrolls its
+    // target into view first, so a row sitting near the fold makes the tap
+    // itself move the page and the delta below measures Playwright rather
+    // than the layout. This test passed for as long as the pane's chrome
+    // happened to leave row one comfortably on screen, and #1223 changed
+    // that chrome — the tab strip wraps to two rows now, and every card is
+    // taller by a label line. Scrolling first means any movement left is
+    // the layout's.
+    await expander.scrollIntoViewIfNeeded();
+
+    const paneScroll = (): Promise<number> =>
+      page.getByTestId("admin-pane").evaluate((el) => el.scrollTop);
+
+    const scrollBefore = await paneScroll();
     const before = await expander.boundingBox();
     expect(before, "expander must have a box before the tap").not.toBeNull();
 
@@ -464,10 +479,13 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     // viewport up to the card, leaving the operator somewhere they had
     // not asked to be. In the row's own position the row stays put.
     const after = await expander.boundingBox();
+    const scrollAfter = await paneScroll();
     expect(after, "expander must still have a box after the tap").not.toBeNull();
     expect(
       Math.abs((after?.y ?? 0) - (before?.y ?? 0)),
-      "the row an operator tapped must not move when its detail opens",
+      `the row an operator tapped must not move when its detail opens ` +
+        `(pane scrollTop ${scrollBefore} → ${scrollAfter}: unchanged means the LAYOUT moved, ` +
+        `a change means the tap scrolled and the barrier above did not hold)`,
     ).toBeLessThanOrEqual(1);
   });
 });

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -318,16 +318,23 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
         const found = await page.getByTestId("admin-pane").evaluate((root) => {
           const out: Omit<Offender, "surface">[] = [];
           const consider = (el: Element): void => {
-            // NAMED EXEMPTION, not a filter that makes the red go away.
-            // `.adm-nav` is the tab strip: nine chips, `overflow-x: auto`
-            // by design (default.css), 717px in a 365px pane. It is a
-            // navigation affordance an operator swipes to CHOOSE a tab,
-            // which is the same gesture every phone tab bar uses — not a
-            // record whose columns you must pan to READ, which is the
-            // defect vjt reported and this bucket exists for. Stacking it
-            // would cost most of the screen before the first row. If it is
-            // ever meant to be in scope, that is a separate product call.
-            if (el.classList.contains("adm-nav")) return;
+            // The `.adm-nav` exemption that used to sit here is GONE, and
+            // it is the reason this oracle stayed green through the defect
+            // it exists to catch. It read: the tab strip is "a navigation
+            // affordance an operator swipes to CHOOSE a tab ... not a
+            // record whose columns you must pan to READ", with the caveat
+            // "if it is ever meant to be in scope, that is a separate
+            // product call". vjt made that call by retesting v0.16.0 on a
+            // phone and listing the strip fourth among the defects —
+            // *"Sessions … Vhosts fill the row and the next tab is cut at
+            // the right edge"*. The strip wraps now (default.css
+            // `.adm-nav`), so there is nothing to exempt.
+            //
+            // Worth keeping as a lesson rather than deleting silently: an
+            // exemption written as a product argument is indistinguishable
+            // from an exemption written to make a red go away, and neither
+            // can fail. This guard's whole claim is "nothing in the pane
+            // pans", and it was carrying a named counter-example.
             const overflowX = window.getComputedStyle(el).overflowX;
             if (overflowX !== "auto" && overflowX !== "scroll") return;
             if (el.scrollWidth <= el.clientWidth + 1) return;
@@ -379,6 +386,43 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
       const panelTouch = await panel.evaluate((el) => window.getComputedStyle(el).touchAction);
       expect(panelTouch, `admin-tab-panel(${tab}) touch-action must allow pan-x`).toMatch(/pan-x/);
     }
+  });
+
+  // #1223 retest, symptom 4. Strictly stronger than the width oracle above
+  // and deliberately not folded into it: that one only looks at boxes whose
+  // computed `overflow-x` can pan, so a strip switched to `hidden` would
+  // clip three tabs off the screen and go unseen. This asserts what vjt
+  // actually reported — a tab CUT AT THE RIGHT EDGE — which is true of a
+  // clipped strip and of a scrolling one alike.
+  test("@webkit admin on mobile — every tab chip is on screen, none cut off", async ({ page }) => {
+    await openAdminPane(page);
+
+    const chips = await page.getByTestId("admin-pane").evaluate((pane) => {
+      const nav = pane.querySelector(".adm-nav");
+      if (nav === null) throw new Error(".adm-nav is gone — the tab strip's class drifted");
+      const navRect = nav.getBoundingClientRect();
+      // The CLIENT box: `clientWidth` excludes border and any scrollbar, so
+      // this is the region a chip can be painted in and still be readable.
+      const left = navRect.left + nav.clientLeft;
+      const right = left + nav.clientWidth;
+      return [...nav.querySelectorAll("[role='tab']")].map((el) => {
+        const r = el.getBoundingClientRect();
+        return {
+          label: (el.textContent ?? "").trim(),
+          overflowRight: Math.round(r.right - right),
+          overflowLeft: Math.round(left - r.left),
+        };
+      });
+    });
+
+    // Non-vacuity: an empty strip would make every filter below trivially
+    // empty. `ADMIN_TABS` is the same list the count assertion pins.
+    expect(chips.length, "the tab strip must have chips to measure").toBe(ADMIN_TABS.length);
+
+    expect(
+      chips.filter((c) => c.overflowRight > 1 || c.overflowLeft > 1),
+      `every admin tab must be inside the strip at 393px — cut chips: ${JSON.stringify(chips, null, 2)}`,
+    ).toEqual([]);
   });
 
   test("@webkit admin on mobile — vertical scroll inside the pane still works", async ({

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -462,10 +462,26 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     // the layout's.
     await expander.scrollIntoViewIfNeeded();
 
-    const paneScroll = (): Promise<number> =>
-      page.getByTestId("admin-pane").evaluate((el) => el.scrollTop);
+    // EVERY scrollable ancestor, not `.admin-pane` alone. The first version
+    // of this diagnostic read the pane and reported `0 → 0`, which says
+    // nothing: `.admin-tab-panel` is `overflow-y: auto` too and is the box
+    // that actually scrolls the tab's content. Reading one named box and
+    // concluding from its silence is the same error as normalising a width
+    // by the box being squeezed — measure the ancestor CHAIN and let it say
+    // which link moved.
+    const scrollChain = (): Promise<Record<string, number>> =>
+      expander.evaluate((el) => {
+        const out: Record<string, number> = {};
+        for (let n = el.parentElement, i = 0; n !== null; n = n.parentElement, i++) {
+          if (n.scrollHeight <= n.clientHeight) continue;
+          const name = n.getAttribute("data-testid") ?? n.className || n.tagName.toLowerCase();
+          out[`${i}:${String(name).slice(0, 40)}`] = n.scrollTop;
+        }
+        out["window"] = window.scrollY;
+        return out;
+      });
 
-    const scrollBefore = await paneScroll();
+    const scrollBefore = await scrollChain();
     const before = await expander.boundingBox();
     expect(before, "expander must have a box before the tap").not.toBeNull();
 
@@ -479,13 +495,13 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     // viewport up to the card, leaving the operator somewhere they had
     // not asked to be. In the row's own position the row stays put.
     const after = await expander.boundingBox();
-    const scrollAfter = await paneScroll();
+    const scrollAfter = await scrollChain();
     expect(after, "expander must still have a box after the tap").not.toBeNull();
     expect(
       Math.abs((after?.y ?? 0) - (before?.y ?? 0)),
-      `the row an operator tapped must not move when its detail opens ` +
-        `(pane scrollTop ${scrollBefore} → ${scrollAfter}: unchanged means the LAYOUT moved, ` +
-        `a change means the tap scrolled and the barrier above did not hold)`,
+      `the row an operator tapped must not move when its detail opens — ` +
+        `scrollable ancestors ${JSON.stringify(scrollBefore)} → ${JSON.stringify(scrollAfter)}: ` +
+        `all unchanged means the LAYOUT moved, any change means the tap scrolled`,
     ).toBeLessThanOrEqual(1);
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4592,15 +4592,41 @@ html.resize-dragging * {
 }
 
 /* Admin redesign Layer 2/3 — `AdminNav` (cicchetto/src/admin/AdminNav.tsx).
-   Mobile-first: a horizontal scrolling chip strip (`.adm-nav` row +
-   `.adm-nav-group` row), grouped by a non-interactive label. The
-   ≥900px media query below (next to `.admin-pane`'s own desktop
-   rule) turns the SAME markup into a vertical rail — no DOM
-   duplication, so the 10 `admin-tab-<key>` buttons stay singular and
-   clickable in one click regardless of viewport. */
+   Mobile-first: a WRAPPING chip strip (`.adm-nav`), grouped by a
+   non-interactive label. The ≥900px media query below (next to
+   `.admin-pane`'s own desktop rule) turns the SAME markup into a vertical
+   rail — no DOM duplication, so the 10 `admin-tab-<key>` buttons stay
+   singular and clickable in one click regardless of viewport.
+
+   #1223 retest — it used to be a horizontal SCROLLING strip, and vjt
+   listed that as a defect on a portrait phone: *"the section tab strip
+   still pans horizontally: Sessions … Vhosts fill the row and the next
+   tab is cut at the right edge"*. Eight chips measure ~680px against
+   361px of pane content, so three of them were off-screen behind a
+   gesture with nothing on screen to suggest it.
+
+   Wrapping, not stacking. `ux-6-g`'s exemption comment argued the strip
+   had to keep the pan because "stacking it would cost most of the screen
+   before the first row" — true of a one-per-line rail (8 × 44px), and not
+   true of wrapping, which packs the same chips into two rows. That costs
+   ~44px of height once, and buys back a tab bar where every destination
+   is visible.
+
+   `display: contents` on the group is what makes it two rows rather than
+   three: the chips pack greedily across the whole strip instead of
+   breaking at group boundaries, where `live` (264px) would leave 97px of
+   the first row empty. The group box carries no paint on a phone — its
+   heading is visually hidden here — so removing it costs nothing, and the
+   desktop rail below puts it back.
+
+   `overflow-x: auto` STAYS. Nothing overflows now, so it is inert; what it
+   buys is that a future chip which does overflow shows up in
+   `ux-6-g-admin-mobile-h-scroll`, whose oracle only considers boxes that
+   CAN pan. Switching it to `hidden` would silently clip instead. */
 .adm-nav {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--adm-space-3);
   overflow-x: auto;
@@ -4610,12 +4636,12 @@ html.resize-dragging * {
   margin: 0 0 var(--adm-space-2);
 }
 
+/* Boxless on the chip strip (see `.adm-nav`): the buttons become direct
+   flex children of the strip and wrap wherever the row ends, rather than
+   travelling in three indivisible blocks. The desktop rail restores the
+   box, which is where the grouping is actually drawn. */
 .adm-nav-group {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--adm-space-2);
-  flex-shrink: 0;
+  display: contents;
 }
 
 /* Hidden on the mobile chip strip — three headings cost a whole line of
@@ -4700,9 +4726,14 @@ html.resize-dragging * {
     gap: var(--adm-space-5);
   }
 
+  /* `display: flex` re-establishes the box the chip strip dissolves with
+     `display: contents` — on the rail the group is a real column with a
+     real heading, which is the layout the grouping exists for. */
   .adm-nav-group {
+    display: flex;
     flex-direction: column;
     align-items: stretch;
+    flex-shrink: 0;
     gap: 2px;
   }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5901,23 +5901,33 @@ html.resize-dragging * {
      on both sides, so the facts column renders at roughly half the
      available width while the gutters carry nothing."*
 
-     Three separate rules above were billing it, ~130px of a 359px card:
+     MEASURED at 393px on the pre-fix tree, because the arithmetic and the
+     device disagreed. The two gutters are 25px each, and they are exactly:
 
-     - `.adm-table td::before` gave its `<td colspan>` a label track like
-       any other cell. There is no `data-label` on it, so `attr()` rendered
-       the empty string — into a box that still occupied 80px, plus the
-       12px flex gap. That is the "wide empty gutter", literally: a label
-       box with no label in it.
-     - `.adm-table tr` drew a bordered, padded, filled card around it, so
-       the panel — itself a card, with its own border and accent edge —
-       came out as a card inside a card (18px).
-     - `.adm-expand-row td { padding: 12px 16px }` (32px). A mobile override
+     - `.adm-table tr`, which drew a bordered, padded, filled card around a
+       row whose only child is itself a card, so the panel came out nested
+       inside a second one — 1px border + 8px padding.
+     - `.adm-expand-row td { padding: 12px 16px }` — 16px. A mobile override
        for exactly this already existed here and did nothing: it read
        `.adm-expand-row td`, (0,1,1), the same specificity as the base rule
        further down the file, which therefore won on source order. Being
        inside a media query buys no specificity. The rules below are
        `.adm-table …`, (0,2,1), so they win on their own merits rather than
        on where they happen to sit.
+
+     🔴 NOT a third cause, though it reads like the obvious one:
+     `.adm-table td::before` does give this `<td colspan>` a label track,
+     and `attr(data-label)` on a cell with no such attribute does render the
+     empty string into a box declared `flex: 0 0 5rem`. It costs nothing.
+     `.adm-detail`'s flex basis is its content, which does not fit beside an
+     80px item, so the panel wrapped to the next flex line and started at
+     the cell's edge regardless — 25px of gutter, not 105px. `display:
+     block` below then removes the flex context entirely, at which point the
+     empty `::before` is an empty inline box contributing no height either.
+     A `content: none` rule sat here for one round and was deleted when a
+     mutation run showed it killed no assertion: the panel's left, right and
+     top are all pinned by `issue1223-admin-card-affordances`, and all three
+     stayed green with the rule removed.
 
      The panel keeps its own margin-bottom from `.adm-table tr`, which is
      the gap to the next row card. */
@@ -5931,10 +5941,6 @@ html.resize-dragging * {
   .adm-table .adm-expand-row td {
     display: block;
     padding: 0;
-  }
-
-  .adm-table .adm-expand-row td::before {
-    content: none;
   }
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5772,9 +5772,22 @@ html.resize-dragging * {
     min-width: 0;
   }
 
+  /* #1223 retest — the label is a CAPTION ABOVE its value, not a track
+     beside it. It was `flex: 0 0 5rem`, which neither grows nor shrinks:
+     80px plus the 12px column gap, reserved out of 341px of card, on every
+     field of every row. vjt read it off a portrait screenshot — *"the label
+     column (last seen, channels, actions) keeps a fixed wide gutter of its
+     own, pushing the values into the right half"*.
+     `100%` rather than a smaller fixed track because the alternatives both
+     lose: `auto` sizes each label to its own text, so the values stop
+     lining up and the card reads as scattered; a narrower track still
+     charges every value for a gutter and only argues about the price.
+     The card now spends one line on the label and gives the value all
+     341px, which is the same trade `.adm-facts` already makes in the panel
+     — one idiom for the same problem, at both ends of the card. */
   .adm-table td::before {
     content: attr(data-label);
-    flex: 0 0 5rem;
+    flex: 0 0 100%;
     font-family: var(--adm-font);
     font-size: 0.68rem;
     letter-spacing: 0.1em;
@@ -5850,10 +5863,47 @@ html.resize-dragging * {
     width: auto;
   }
 
-  /* An expanded detail row is a block inside the card, not a colspan cell
-     spanning columns that no longer exist. */
-  .adm-expand-row td {
-    padding: var(--adm-space-3) 0 0;
+  /* #1223 retest — the expand row HOSTS the detail panel, it is not a
+     record card, and it was being charged for being one three times over.
+     vjt on a portrait phone: *"the detail panel does not use the pane
+     width. It sits inside its own inset container with a wide empty gutter
+     on both sides, so the facts column renders at roughly half the
+     available width while the gutters carry nothing."*
+
+     Three separate rules above were billing it, ~130px of a 359px card:
+
+     - `.adm-table td::before` gave its `<td colspan>` a label track like
+       any other cell. There is no `data-label` on it, so `attr()` rendered
+       the empty string — into a box that still occupied 80px, plus the
+       12px flex gap. That is the "wide empty gutter", literally: a label
+       box with no label in it.
+     - `.adm-table tr` drew a bordered, padded, filled card around it, so
+       the panel — itself a card, with its own border and accent edge —
+       came out as a card inside a card (18px).
+     - `.adm-expand-row td { padding: 12px 16px }` (32px). A mobile override
+       for exactly this already existed here and did nothing: it read
+       `.adm-expand-row td`, (0,1,1), the same specificity as the base rule
+       further down the file, which therefore won on source order. Being
+       inside a media query buys no specificity. The rules below are
+       `.adm-table …`, (0,2,1), so they win on their own merits rather than
+       on where they happen to sit.
+
+     The panel keeps its own margin-bottom from `.adm-table tr`, which is
+     the gap to the next row card. */
+  .adm-table tr.adm-expand-row {
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background: none;
+  }
+
+  .adm-table .adm-expand-row td {
+    display: block;
+    padding: 0;
+  }
+
+  .adm-table .adm-expand-row td::before {
+    content: none;
   }
 }
 
@@ -6128,10 +6178,14 @@ html.resize-dragging * {
 }
 
 /* Detail panel for the row a table has open (`admin/AdminDetailPanel`).
-   A sibling of the table, NOT a row inside it: a `<td colspan>` inherits
-   the table's width, and admin tables are deliberately wider than the
-   viewport, so a form in there could only be reached by swiping
-   sideways. Out here it is viewport-wide and its contents wrap.
+   A `<tr class="adm-expand-row">` INSIDE the table, in the row's own
+   position — this comment used to say the opposite ("a sibling of the
+   table, NOT a row inside it"), which described the arrangement #1074
+   reverted and is why the next reader looked for the panel's width in the
+   wrong box. The `<td colspan>` inherits the table's width, which was the
+   original objection and stopped applying once no table is wider than the
+   phone; on a phone the expand row is stripped of the card regime so the
+   panel gets that width whole (#1223, `@media (max-width: 899px)`).
 
    Styled as a card with an accent left edge instead of a top stripe, so
    it reads as attached to the table above rather than as a peer of it. */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39607,3 +39607,89 @@ The census is five in-repo pools, not the three the issue names —
 `infra/freebsd/nginx.conf`, which the ruling text cites, does not exist.
 
 Touching `config/*.exs` makes this a COLD deploy.
+
+---
+
+## 2026-08-12 — #1223 retest: the admin console's horizontal budget, and two guards that could not fail
+
+vjt retested v0.16.0-8412fb40 on a portrait phone and put #1223 back in
+the queue. The card/detail split from #1230 had landed; the width had
+not. Four symptoms, of which three are one mechanism.
+
+**The mechanism: a cell regime charging a row that is not a record.**
+Below 900px the admin tables stack into cards, and three rules implement
+that — `.adm-table tr` draws the card, `.adm-table td` lays out a field,
+`.adm-table td::before` prints the field's label from `data-label`. The
+expand row that HOSTS a detail panel is a `tr` with a `td` in it, so it
+collected all three. It has no `data-label`, so `attr()` rendered the
+empty string — into a box that still occupied `flex: 0 0 5rem`, 80px,
+plus the 12px flex gap. That is vjt's "wide empty gutter" exactly: a
+label box with no label in it. Add `.adm-table tr`'s own border and
+padding (a card drawn around a row whose only child is a card) and a
+`.adm-expand-row td` padding, and the panel had ~229px of a 359px card.
+The facts column at "roughly half the available width" was that number.
+
+**A dead override, and why it was dead.** A mobile rule intended to strip
+exactly this padding already existed inside the media block and had never
+applied. `.adm-expand-row td` is (0,1,1) both inside the media query and
+in the base rule further down the file, and **a media query buys no
+specificity** — so the base rule won on source order. The replacements
+are `.adm-table …`, (0,2,1), and win on their own merits rather than on
+where they sit in the file. General rule for this stylesheet: an override
+that only differs from its target by being inside `@media` is a coin
+flip decided by line number.
+
+**Symptom 2 gets no fix of its own.** A `last event` timestamp wrapping
+mid-token is downstream of the gutters: with them returned the value has
+~323px instead of ~181px. `overflow-wrap: anywhere` stays as the backstop
+for a genuinely unbreakable value — treating it as the cure would have
+been treating the consequence.
+
+**The tab strip: the product call was made by retesting.**
+`.adm-nav` was a deliberate horizontal scroller and `ux-6-g` carried a
+NAMED EXEMPTION for it, arguing a tab bar is an affordance you swipe and
+that "stacking it would cost most of the screen before the first row".
+That is true of stacking (eight rows of 44px) and false of WRAPPING,
+which packs the same eight chips into two rows for ~44px of height once.
+`display: contents` on `.adm-nav-group` is what makes it two rows and not
+three: the three groups are otherwise indivisible flex items, and `live`
+(264px) would break the first row with 97px still free. The group box
+paints nothing on a phone, so dissolving it costs nothing; the desktop
+rail re-establishes it.
+
+**Two guards were watching this viewport and both stayed green.** Worth
+recording as a pair, because the failure modes are different and both
+are easy to write again.
+
+1. *An exemption written as a product argument.* `ux-6-g` claims nothing
+   in the admin pane may pan at 393px and skipped `.adm-nav` by class
+   name, with a note conceding "if it is ever meant to be in scope, that
+   is a separate product call". A guard carrying a named counter-example
+   to its own claim cannot fail on that counter-example, and the prose
+   quality of the exemption is not evidence: an exemption written to be
+   right and an exemption written to make a red go away are the same
+   artefact.
+2. *An oracle normalised by the box being squeezed.* `issue1223` asserted
+   `ddBox.width >= factsBox.width * 0.9`. The facts list is INSIDE the
+   panel, so squeezing the panel moves numerator and denominator
+   together and the ratio never budges — it would have passed at any
+   width down to zero. **A ratio oracle must take its denominator from
+   OUTSIDE the box under test**; here the table, the outermost box the
+   panel is entitled to fill.
+
+**The replacements assert what vjt could see.** The panel's gutters
+against its table (gutters, not a ratio: a ratio invites a threshold
+argument and he reported empty space at the edges); no value broken
+mid-token, measured per whitespace-delimited run via `Range` client rects
+deduped by line-box top, generalised over every value rather than the one
+he named; no card value indented past a reserved label track, ranged over
+the cell's contents so the `::before` label is excluded by construction.
+Each carries a non-vacuity assertion — the seeded row must actually
+render a token long enough that it COULD wrap — because passing on an
+empty page is how the exemption above survived.
+
+**Not changed, deliberately.** The `.adm-table--stack` twin inside
+`@container (max-width: 56rem)` keeps its 5rem label track. It is a
+different query over a different width regime and vjt measured the
+viewport one; at 55rem of container a 5rem track is cheap, and stacking
+it there would cost scannability for a defect nobody has observed.


### PR DESCRIPTION
vjt retested `v0.16.0-8412fb40` on a portrait phone and returned #1223 to the queue:
the card/detail split landed, the horizontal budget did not. Four symptoms, of which
three turn out to be one mechanism.

## The mechanism

Below 900px the admin tables stack into cards, implemented by three rules:
`.adm-table tr` draws the card, `.adm-table td` lays out a field, `.adm-table
td::before` prints the field label from `data-label`. The expand row that HOSTS a
detail panel is a `tr` with a `td` in it, so it collected all three.

Measured at 393px on the pre-fix tree, the gutter is **25px per side**: `.adm-table
tr` drawing a bordered, padded card around a row whose only child is itself a card
(1px + 8px), plus `.adm-expand-row td`'s desktop padding (16px). The panel got 281px
of a 331px table, and its facts column 245px — 74%.

The obvious third suspect is innocent and it is worth saying so, because it is the
one everybody reaches for: `.adm-table td::before` does give this `<td colspan>` a
label track, and `attr(data-label)` on a cell with no such attribute does render the
empty string into a box declared `flex: 0 0 5rem`. It costs nothing. `.adm-detail`'s
flex basis is its content, which does not fit beside an 80px item, so the panel
wrapped to the next flex line and started at the cell's edge anyway. See the
measured table at the bottom — this branch shipped that claim once on box-model
arithmetic and the device overruled it.

**A mobile override for that last one already existed and had never applied.** Both
selectors are `.adm-expand-row td`, (0,1,1), and a media query buys no specificity —
so the base rule further down the file won on source order. The replacements are
`.adm-table …`, (0,2,1), and win on their own merits rather than on their line number.

Symptom 2 — the `last event` timestamp wrapping mid-token — gets **no fix of its
own**: it is downstream of the gutters, and with them returned the value has ~323px
instead of ~181px. `overflow-wrap: anywhere` stays as the backstop for a genuinely
unbreakable value; treating it as the cure would be treating the consequence.

Symptom 3, the card's own label track, goes from `flex: 0 0 5rem` to `100%` — a
caption above its value. `auto` was rejected (per-label sizing stops the values
lining up); a narrower fixed track still charges every value for a gutter and only
argues about the price. It is the trade `.adm-facts` already makes inside the panel,
so the card now uses one idiom at both ends.

## The tab strip

`.adm-nav` was a deliberate horizontal scroller. It wraps now. `ux-6-g`'s exemption
argued that "stacking it would cost most of the screen before the first row" — true
of stacking (eight rows of 44px), false of wrapping, which packs the same chips into
two rows for ~44px of height once. `display: contents` on `.adm-nav-group` is what
makes it two rows and not three: the three groups are otherwise indivisible flex
items and `live` (264px) would break the first row with 97px still free. The group
box paints nothing on a phone; the desktop rail re-establishes it.

`overflow-x: auto` stays. Inert now, and it is what keeps a future over-long chip
visible to the width oracle, whose rule only considers boxes that CAN pan.

## Two guards were watching this viewport and both stayed green

- **`ux-6-g-admin-mobile-h-scroll` exempted `.adm-nav` by class name**, behind a
  product argument that conceded "if it is ever meant to be in scope, that is a
  separate product call". vjt made that call by listing the strip fourth among the
  defects. A guard carrying a named counter-example to its own claim cannot fail on
  it, and the prose quality of the exemption is not evidence.
- **`issue1223`'s facts-width oracle read `ddBox.width >= factsBox.width * 0.9`.**
  The facts list is inside the panel, so squeezing the panel moves numerator and
  denominator together — it would have passed at any width down to zero. The
  reference box is the TABLE now.

Three new oracles, each stated as the thing vjt could see: the panel starts and ends
where its table does (gutters, not a ratio — a ratio invites a threshold argument and
he reported empty space at the edges); no value is broken mid-token (per
whitespace-delimited run, `Range` client rects deduped by line-box top — a line count
would encode a font metric, and `<event> · <instant>` may legitimately break at the
separator); no card value is indented past a reserved label track (ranged over the
cell's contents, so `::before` is excluded by construction). Each carries a
non-vacuity assertion, because passing on an empty page is how the exemption survived.

## Not changed, deliberately

The `.adm-table--stack` twin inside `@container (max-width: 56rem)` keeps its 5rem
label track. Different query, different width regime; vjt measured the viewport one,
and at 55rem of container a 5rem track is cheap.

## Gates

- `scripts/bun.sh run check` -> rc=0 (biome + `tsc --noEmit` + the e2e tsconfig)
- `scripts/bun.sh run test` -> rc=0, 280 files / 5277 tests
- `scripts/integration.sh --grep "#1223|UX-6-G"` -> 13/13 on the fixed tree
- full `scripts/integration.sh` -> **718 passed / 0 failed / 27.4m**, local, at `e0ef575c`

---

## Measured, and where the arithmetic above was wrong

Everything in the sections above that reads as a number was originally read off
the CSS box model. Two of those readings were wrong and are corrected here from
a run at 393px on the pre-fix tree (`origin/main` CSS, iPhone 15, Sessions tab).

| claim | box-model reading | measured | verdict |
|---|---|---|---|
| detail panel gutters | 117px left (80 label + 12 gap + 16 + 9) | **25px left, 25px right** | wrong |
| facts value vs table | 181px of 359px (50%) | **245px of 331px (74%)** | wrong |
| card value indent | 92px | **82px** | close |
| `.adm-nav` overflow | ~680px in 361px | **624px scrollWidth in a 365px client**; Vhosts cut by 39px, Users 103, Settings 180, Debug 251 | close |

**The empty label track is not a gutter.** `attr(data-label)` on a cell that has
none does render the empty string into a box declared `flex: 0 0 5rem`, and it
costs nothing horizontally: `.adm-detail`'s flex basis is its content, which does
not fit beside an 80px item, so the panel wrapped to the next flex line and
started at the cell's edge anyway. The 25px per side is `.adm-table tr` (1px
border + 8px padding) plus `.adm-expand-row td` (16px padding), and nothing else.
The rule written to suppress that track — `content: none` — was **deleted** after
a mutation run put it back and every assertion stayed green, including the
panel's `top`, which was added for exactly that question. A rule no guard can
convict is an exemption in the other direction.

**vjt's "roughly half" is not reproduced.** The measurement says 74% of the
table, 62% of the screen. The direction is his and the fix takes it to 89%, but
this branch cannot claim to have seen half, and the difference may be a tab this
run does not open.

**Symptom 2 reproduced exactly**, and it was the one thing the arithmetic could
not have predicted: `2026-08-12T08:25:37.065625Z` and
`azzurra-leaf4.grappa-e2e_grappa-e2e` each render over two lines, broken inside
the token. Both are single-line after the fix.

## Mutant → assertion

Every assertion was proven by putting the defect back. Each row is one run of
`scripts/integration.sh --grep "#1223|UX-6-G"`, 13 tests.

| mutant | kills | survives |
|---|---|---|
| revert the whole CSS diff | panel gutters, facts-vs-table width, mid-token, card indent, pan oracle, chips — **6** | tap target, no-duplicate-field, wide-panel two columns, 769-899 band, pan-x, vertical scroll, row-does-not-move |
| `flex: 0 0 100%` → `5rem` | card indent — **exactly 1** | everything else |
| drop `display: block` from the expand row's cell | panel gutters, facts-vs-table width, mid-token — **3** | the rest |
| drop `flex-wrap: wrap` from `.adm-nav` | pan oracle + chips — **2** | the rest |
| `.adm-nav` → no wrap AND `overflow-x: hidden` | chips — **1**; the pan oracle **survives** | — |
| restore `content: none`'s absence, i.e. put the `::before` back | **nothing** | — (rule deleted) |

Two of those are worth reading rather than counting.

- The last row is why `content: none` is gone. Zero kills is a result, not an
  inconvenience.
- The fifth row is why the chip assertion is not folded into the pan oracle. With
  `overflow-x: hidden` the strip still cuts four tabs off the screen and the pan
  oracle goes blind, because its rule only considers boxes that CAN pan. The
  claim that the chip check is strictly stronger is measured, not argued.

The three-kill and two-kill mutants are single declarations with several visible
consequences — the panel's width, what fits on a line in it, and whether it fills
its cell are one fact reported three ways. That is stated rather than hidden
behind a 1:1 table.

## The row-does-not-move red, and why the oracle was not softened

CI went red at `e8dc3e39` on `ux-6-g`'s `opening a row's detail does not move the
row`, at 9px against a 1px tolerance — a test that is green on `origin/main` and
green under the full CSS revert, so it belongs to this branch.

**The tolerance is untouched.** What the test gained is a `scrollIntoViewIfNeeded`
BEFORE the pre-state measurement. `tap()` scrolls its target into view first, so a
row near the fold makes the tap move the page and the delta measures Playwright.
This branch pushed the row down — the strip wraps to two rows, every card gained
a label line — and the row crossed that threshold.

**Measured, after a first attempt that measured the wrong box.** The diagnostic
initially read `.admin-pane`'s scrollTop, got `0 → 0`, and that was nearly written
up as proof the layout had moved. It proves nothing: `.admin-tab-panel` is
`overflow-y: auto` as well and is what actually scrolls a tab's content — the same
error as normalising a width by the box being squeezed, made by the same hand two
hours later. The diagnostic now walks every scrollable ancestor, and with the
barrier removed it reports:

```
{"9:admin-tab-panel":0,"window":0} → {"9:admin-tab-panel":9,"window":0}
```

Nine pixels of scroll for nine pixels of displacement. The layout is innocent, and
the failure message now names which link of the chain moved instead of leaving the
next reader to re-derive it.
