### PR TITLE
#1244: admin density on a phone, and the tab strip's scroll back

### DIFF
--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -155,55 +155,30 @@ test("#1223 @webkit on a phone the whole card heading opens the row, not just th
   }
 });
 
-test("#1223 @webkit on a phone a detail fact gives its value the panel's full width", async ({
-  page,
-}) => {
-  const admin = getSeededAdmin();
-  const visitor = await mintVisitor(`facts1223-${Date.now()}`);
-
-  try {
-    await adminLogin(page);
-    await openSessionsTab(page);
-
-    const key = await adminSessionRowKey(page, "visitor", visitor.id);
-    await page.getByTestId(`admin-session-details-${key}`).tap();
-    const panel = page.getByTestId(`admin-session-detail-${key}`);
-    await expect(panel).toBeVisible({ timeout: 5_000 });
-
-    const facts = panel.locator(".adm-facts");
-    const factsBox = await boxOf(facts, "the facts list");
-    const dtBox = await boxOf(facts.locator("dt").first(), "the first fact's label");
-    const ddBox = await boxOf(facts.locator("dd").first(), "the first fact's value");
-
-    // The label is a caption ABOVE its value, not a track beside it.
-    expect(
-      ddBox.y,
-      `the value must sit under its label on a narrow panel (facts list ${Math.round(factsBox.width)}px wide)`,
-    ).toBeGreaterThanOrEqual(dtBox.y + dtBox.height - 0.5);
-
-    // And the point of moving it: the value gets the width the label track
-    // and its gap were taking. Separate from the assertion above because a
-    // collapse that left a fixed label column would satisfy that one.
-    //
-    // 🔴 The reference box is the TABLE, not the facts list, and that is the
-    // whole correction. This read `factsBox.width * 0.9` and passed for a
-    // day on a panel rendering at half the pane: the facts list is INSIDE
-    // the panel, so squeezing the panel shrinks numerator and denominator
-    // together and the ratio never moves. vjt's retest of v0.16.0 —
-    // *"the facts column renders at roughly half the available width"* —
-    // was invisible to an oracle normalised by the box being squeezed.
-    // The table is the outermost box the panel is entitled to fill, which
-    // is the claim actually being made.
-    const tableBox = await boxOf(page.getByTestId("admin-sessions-table"), "the sessions table");
-    expect(
-      ddBox.width,
-      `the value must take the table's width, not the shrunken panel's ` +
-        `(value ${Math.round(ddBox.width)}px of table ${Math.round(tableBox.width)}px)`,
-    ).toBeGreaterThanOrEqual(tableBox.width * 0.85);
-  } finally {
-    await reapVisitors(admin.token, visitor.id);
-  }
-});
+// 🔴 `on a phone a detail fact gives its value the panel's full width`
+// LIVED HERE and is now the long branch of `#1244 a panel fact is one row
+// while its value is short` (`issue1244-admin-density.spec.ts`).
+//
+// It asserted TWO things of the FIRST fact: that its value sits under its
+// label, and that the value's box is at least 85% of the TABLE's width —
+// the reference box being the table rather than the facts list is the
+// correction this file made and it is carried over verbatim.
+//
+// What did not survive is "the first fact", and the reason is a ruling
+// rather than a convenience. vjt, on #1244 (2026-08-12): *"'the four
+// asserts from #1223 stay green' was shorthand for do not regress the
+// horizontal budget, not keep those literal thresholds"*, and *"do not
+// keep the label above the value as the default — that is exactly the
+// vertical waste this issue is about"*. The panel's first fact is
+// `connection`, whose value is `connected`: nine characters that now
+// print on their label's line, so an assertion pinned to `.first()`
+// demands the stacking the next issue removed.
+//
+// The successor keeps the claim and drops the pin — every fact that DOES
+// take its own line must take 85% of the table with it, and at least one
+// must, or the long branch goes unmeasured. Moved rather than weakened:
+// squeeze the panel and `last event` fails there exactly as it would have
+// failed here.
 
 test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
   const admin = getSeededAdmin();
@@ -415,62 +390,37 @@ test("#1223 @webkit on a phone no panel value is broken mid-token", async ({ pag
   }
 });
 
-// Symptom 3. vjt: *"in the card below, the label column (last seen,
-// channels, actions) keeps a fixed wide gutter of its own, pushing the
-// values into the right half."* `flex: 0 0 5rem` on `.adm-table td::before`
-// — 80px that neither grows nor shrinks, plus the 12px flex gap, out of
-// 341px of card, charged to every field of every row.
+// 🔴 Symptom 3's assertion — `on a phone a card value starts at the card's
+// edge, not past a label track` — LIVED HERE and is now the long branch of
+// `#1244 a card field is one row while its value is short`
+// (`issue1244-admin-density.spec.ts`).
 //
-// The oracle is where the VALUE starts, which is the thing vjt could see.
-// A range over the cell's contents excludes the `::before` label by
-// construction, so this measures the painted value against the cell's own
-// left edge — no gutter means the two coincide.
-test("#1223 @webkit on a phone a card value starts at the card's edge, not past a label track", async ({
-  page,
-}) => {
-  const admin = getSeededAdmin();
-  const visitor = await mintVisitor(`label1223-${Date.now()}`);
-
-  try {
-    await adminLogin(page);
-    await openSessionsTab(page);
-
-    const key = await adminSessionRowKey(page, "visitor", visitor.id);
-    const row = page.getByTestId(`admin-session-row-${key}`);
-    await row.scrollIntoViewIfNeeded();
-    await expect(row).toBeVisible();
-
-    const cells = await row.evaluate((tr) => {
-      const out: { label: string; indent: number }[] = [];
-      // Labelled cells only: `.adm-cell-title` is the card's heading and
-      // deliberately has no label to be indented past.
-      for (const td of tr.querySelectorAll("td[data-label]")) {
-        if (td.getClientRects().length === 0) continue;
-        if (td.classList.contains("adm-cell-title")) continue;
-        const range = document.createRange();
-        range.selectNodeContents(td);
-        const content = range.getBoundingClientRect();
-        if (content.width === 0) continue;
-        out.push({
-          label: td.getAttribute("data-label") ?? "",
-          indent: Math.round(content.left - td.getBoundingClientRect().left),
-        });
-      }
-      return out;
-    });
-
-    // Non-vacuity: a row with no labelled cell painted would pass on
-    // nothing, which is how the `.adm-nav` exemption in `ux-6-g` survived.
-    expect(cells.length, "the card must have labelled cells to measure").toBeGreaterThan(0);
-
-    expect(
-      cells.filter((c) => c.indent > 2),
-      `no card value may be indented past a reserved label track — ${JSON.stringify(cells)}`,
-    ).toEqual([]);
-  } finally {
-    await reapVisitors(admin.token, visitor.id);
-  }
-});
+// vjt: *"the label column (last seen, channels, actions) keeps a fixed
+// wide gutter of its own, pushing the values into the right half"*. The
+// fix was `flex: 0 0 100%` on `.adm-table td::before` — a caption above
+// its value — and the oracle was `indent <= 2` on every labelled cell,
+// measured by a range over the cell's contents (which excludes the
+// `::before` label by construction, the technique the successor keeps).
+//
+// `indent <= 2` on EVERY cell says the value always begins at the card's
+// left edge, which is only true of the stacked layout, which is what
+// #1244 reverses: the same three cells vjt named here are the three he
+// counted as six rows there. Ruled on 2026-08-12, on #1244.
+//
+// The successor asserts the same defect and one more. A value on its own
+// line still has to start at the card's edge — that is this assertion,
+// unchanged, applied to the branch where it is the right question. A
+// value beside its label has to end at the card's RIGHT edge, which the
+// fixed 5rem track never did: it left every short value stranded in the
+// middle with slack on both sides.
+//
+// One thing it deliberately does NOT convict, so nobody reads more into
+// it than it says: a fixed label track that is WIDER than its text is now
+// invisible to it. With the value right-aligned, the label's box no
+// longer decides where the value starts, so `flex: 0 0 5rem` would cost
+// nothing until a label outgrew it. The defect was never the track's
+// existence — it was the value being pushed by it, and that is the thing
+// under guard.
 
 // The band the console's two breakpoints leave between them. 820px is a
 // portrait iPad: the CSS has already turned the table into cards and taken

--- a/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
+++ b/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
@@ -146,9 +146,14 @@ async function readPanelFacts(panel: Locator): Promise<PanelFact[]> {
       if (dt === null || dd === null) throw new Error("a fact pair lost its dt or its dd");
       const dtBox = dt.getBoundingClientRect();
       const ddBox = dd.getBoundingClientRect();
-      // The TEXT, not the box: `dd` grows into the line's free space, so
-      // its box reaches the right edge in both branches and only where
-      // the glyphs land says whether the value is right-aligned.
+      // The glyphs, measured against the PAIR's right edge — not against
+      // `dd`'s own box, which was this oracle's first form and proved
+      // nothing. A `dd` sized to its content holds its text flush against
+      // its own right edge wherever that box happens to sit, so the
+      // reading came out 0 for a value parked in the middle of the row.
+      // A mutation run is what said so: stopping `dd` from growing left
+      // this assertion green and was caught two assertions later, by
+      // accident, at one width out of two.
       const range = document.createRange();
       range.selectNodeContents(dd);
       const text = range.getBoundingClientRect();
@@ -158,7 +163,7 @@ async function readPanelFacts(panel: Locator): Promise<PanelFact[]> {
         // gives the two boxes different tops on the same line, and a
         // stacked pair shares no vertical extent at all.
         sameLine: ddBox.top < dtBox.bottom - 0.5,
-        valueRightGap: Math.round(ddBox.right - text.right),
+        valueRightGap: Math.round(pair.getBoundingClientRect().right - text.right),
         boxWidth: ddBox.width,
       };
     }),

--- a/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
+++ b/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
@@ -1,0 +1,369 @@
+// #1244 — what the admin console spends VERTICALLY on a phone, after
+// #1223 bought its horizontal budget by stacking every label above its
+// value.
+//
+// vjt, retesting `e0ef575c` on a 440px iPhone: *"every fact now stacks
+// its label above its value, so a three-fact card is six rows where three
+// would do"* — `VISITORS` / `0/∞`, `USERS` / `1/3`, `PER-IP` / `5`, two
+// full rows each to print four characters, and the same again for `LAST
+// SEEN` / `CHANNELS` / `ACTIONS` on the session card below.
+//
+// The layout that answers it has TWO branches, and both are asserted here
+// because a fix that only did one of them would be the previous round
+// again in the other direction:
+//
+//   short — the label and its value share one line, label at the card's
+//     left edge, value flush with its right one. This is the row that was
+//     costing two.
+//   long — a value whose content does not fit beside its label moves to
+//     the next line, where it is alone and starts at the card's left edge
+//     with the full width to wrap into. This is #1223's stacked layout,
+//     kept for the values that need it.
+//
+// 🔴 These two branches are the successor to two #1223 asserts, by vjt's
+// ruling on this issue (2026-08-12): *"'the four asserts from #1223 stay
+// green' was shorthand for do not regress the horizontal budget, not keep
+// those literal thresholds"*. `a card value starts at the card's edge`
+// (`indent <= 2` on every labelled cell) and `a detail fact gives its
+// value the panel's full width` (`dd` under `dt`, `dd >= 0.85 * table`)
+// both encode the stacked layout as the ONLY correct answer, which is
+// what the issue reverses. They become the LONG branch below, and the
+// short branch gets the new claim. The two tests they came from carry a
+// pointer to here rather than a weakened threshold, so nobody has to
+// reconstruct which of the two rounds is current.
+//
+// What does NOT move: nothing in the console may overflow the viewport
+// horizontally (`ux-6-g-admin-mobile-h-scroll`, with the single named
+// `.adm-nav` exemption vjt restored on the same retest), no panel value
+// may be broken mid-token, and the detail panel still fills its cell.
+// Those are the horizontal budget, and this issue is not allowed to
+// spend it.
+//
+// Measured at 393px AND 440px. 393 is the width every other admin guard
+// runs at and the one the h-scroll oracle is calibrated to; 440 is the
+// device vjt actually reported from, and the two are far enough apart
+// that a value can fit beside its label at one and not at the other. A
+// fix proven at one width is not proven at his.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated, the EXEMPT
+// shape — non-admin cannot reach this surface at all.
+
+import type { Locator, Page } from "@playwright/test";
+import { adminSessionRowKey, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// admin-vjt has no network bind, so `loginAs`'s network-section
+// shell-ready selector would time out. Same shape as #1223 / #1073.
+async function adminLogin(page: Page): Promise<void> {
+  const seed = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+async function openSessionsTab(page: Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-sessions").click();
+  await expect(page.getByTestId("admin-sessions-table")).toBeVisible({ timeout: 10_000 });
+}
+
+// One labelled field of a record card, as the three numbers that decide
+// which branch it is in and whether that branch is correct.
+//
+// The value is read through a `Range` over the cell's CONTENTS, which
+// excludes the `::before` label by construction — a pseudo-element is not
+// in the DOM and cannot be ranged. So these measure the painted value
+// against the cell's own content box, with no way to accidentally
+// measure the label instead.
+type CardField = {
+  label: string;
+  // Distance from the value's first line to the top of the cell's
+  // content box. 0 means the value shares the label's line; a label line
+  // above it puts this at ~15px.
+  fromTop: number;
+  // Distance from the cell's left content edge to where the value
+  // starts, and from where it ends to the right one.
+  indent: number;
+  rightGap: number;
+};
+
+async function readCardFields(row: Locator): Promise<CardField[]> {
+  return row.evaluate((tr) => {
+    const out: CardField[] = [];
+    for (const td of tr.querySelectorAll("td[data-label]")) {
+      // Painted only: the secondary columns are `display: none` on a
+      // phone and have no boxes, which is a different guard's business.
+      if (td.getClientRects().length === 0) continue;
+      // `.adm-cell-title` is the card's HEADING, deliberately label-less
+      // — there is no pair to put on one line.
+      if (td.classList.contains("adm-cell-title")) continue;
+
+      const range = document.createRange();
+      range.selectNodeContents(td);
+      const content = range.getBoundingClientRect();
+      if (content.width === 0) continue;
+
+      const box = td.getBoundingClientRect();
+      const style = window.getComputedStyle(td);
+      const padTop = Number.parseFloat(style.paddingTop);
+      const padLeft = Number.parseFloat(style.paddingLeft);
+      const padRight = Number.parseFloat(style.paddingRight);
+
+      out.push({
+        label: td.getAttribute("data-label") ?? "",
+        fromTop: Math.round(content.top - (box.top + padTop)),
+        indent: Math.round(content.left - (box.left + padLeft)),
+        rightGap: Math.round(box.right - padRight - content.right),
+      });
+    }
+    return out;
+  });
+}
+
+// The same reading for the detail panel, where both halves of the pair
+// are real elements and can be measured directly.
+type PanelFact = {
+  label: string;
+  sameLine: boolean;
+  valueRightGap: number;
+  boxWidth: number;
+};
+
+async function readPanelFacts(panel: Locator): Promise<PanelFact[]> {
+  return panel.locator(".adm-fact").evaluateAll((pairs) =>
+    pairs.map((pair) => {
+      const dt = pair.querySelector("dt");
+      const dd = pair.querySelector("dd");
+      if (dt === null || dd === null) throw new Error("a fact pair lost its dt or its dd");
+      const dtBox = dt.getBoundingClientRect();
+      const ddBox = dd.getBoundingClientRect();
+      // The TEXT, not the box: `dd` grows into the line's free space, so
+      // its box reaches the right edge in both branches and only where
+      // the glyphs land says whether the value is right-aligned.
+      const range = document.createRange();
+      range.selectNodeContents(dd);
+      const text = range.getBoundingClientRect();
+      return {
+        label: (dt.textContent ?? "").trim(),
+        // Vertical overlap, not a top comparison: `align-items: baseline`
+        // gives the two boxes different tops on the same line, and a
+        // stacked pair shares no vertical extent at all.
+        sameLine: ddBox.top < dtBox.bottom - 0.5,
+        valueRightGap: Math.round(ddBox.right - text.right),
+        boxWidth: ddBox.width,
+      };
+    }),
+  );
+}
+
+for (const width of [393, 440]) {
+  test.describe(`#1244 admin density at ${width}px`, () => {
+    // 393 is what every other admin guard measures; 440 is vjt's device.
+    // The height is the same at both so a difference in the readings can
+    // only come from the width under test.
+    test.use({ viewport: { width, height: 956 } });
+
+    test(`#1244 @webkit at ${width}px a card field is one row while its value is short`, async ({
+      page,
+    }) => {
+      const admin = getSeededAdmin();
+      const visitor = await mintVisitor(`dens1244-${Date.now()}`);
+
+      try {
+        await adminLogin(page);
+        await openSessionsTab(page);
+
+        const key = await adminSessionRowKey(page, "visitor", visitor.id);
+        const row = page.getByTestId(`admin-session-row-${key}`);
+        await row.scrollIntoViewIfNeeded();
+        await expect(row).toBeVisible();
+
+        const fields = await readCardFields(row);
+
+        // Non-vacuity, and the claim of this issue in one assertion: at
+        // least one field prints its label and its value on the SAME
+        // line. Under #1223's `flex: 0 0 100%` every field stacks and
+        // this is the assertion that goes red — which is the point, that
+        // layout is what #1244 reverses.
+        expect(
+          fields.filter((f) => f.fromTop <= 2).map((f) => f.label),
+          `no card field puts its value on its label's line — ${JSON.stringify(fields)}`,
+        ).not.toEqual([]);
+
+        // The short branch: a value beside its label is flush with the
+        // card's right edge. Without that it sits wherever the label
+        // happens to end, which is the ragged, half-empty row the fixed
+        // 5rem track used to produce.
+        expect(
+          fields.filter((f) => f.fromTop <= 2 && f.rightGap > 2),
+          `a value on its label's line must end at the card's right edge — ${JSON.stringify(fields)}`,
+        ).toEqual([]);
+
+        // A value beside its label must have the label BEFORE it. A zero
+        // indent on the label's line would mean the label is not being
+        // painted at all, which would satisfy the assertion above for
+        // the wrong reason.
+        expect(
+          fields.filter((f) => f.fromTop <= 2 && f.indent <= 2),
+          `a value on its label's line must start past the label — ${JSON.stringify(fields)}`,
+        ).toEqual([]);
+
+        // The long branch, and the surviving half of #1223's `a card
+        // value starts at the card's edge`: a value that took its own
+        // line gets the whole of it. Not required to OCCUR — the values
+        // on a session card are all short at both widths, which is vjt's
+        // whole complaint — so this is a rule over whatever lands there
+        // rather than a claim that something does. The branch is
+        // exercised for real in the panel test below, where `last event`
+        // is long at both widths and a stacked fact is REQUIRED.
+        expect(
+          fields.filter((f) => f.fromTop > 2 && f.indent > 2),
+          `a value on its own line must start at the card's edge — ${JSON.stringify(fields)}`,
+        ).toEqual([]);
+      } finally {
+        await reapVisitors(admin.token, visitor.id);
+      }
+    });
+
+    test(`#1244 @webkit at ${width}px a panel fact is one row while its value is short`, async ({
+      page,
+    }) => {
+      const admin = getSeededAdmin();
+      const visitor = await mintVisitor(`densp1244-${Date.now()}`);
+
+      try {
+        await adminLogin(page);
+        await openSessionsTab(page);
+
+        const key = await adminSessionRowKey(page, "visitor", visitor.id);
+        await page.getByTestId(`admin-session-details-${key}`).tap();
+        const panel = page.getByTestId(`admin-session-detail-${key}`);
+        await expect(panel).toBeVisible({ timeout: 5_000 });
+
+        const facts = await readPanelFacts(panel);
+        const inline = facts.filter((f) => f.sameLine);
+        const stacked = facts.filter((f) => !f.sameLine);
+
+        // BOTH branches must occur here, and this panel is the one place
+        // in the console where both reliably do: `connection` prints
+        // `connected`, `last event` prints an event name and an ISO
+        // instant. A panel showing only one kind would let half the
+        // layout go unmeasured.
+        expect(
+          inline.map((f) => f.label),
+          `no panel fact puts its value on its label's line — ${JSON.stringify(facts)}`,
+        ).not.toEqual([]);
+        expect(
+          stacked.map((f) => f.label),
+          `no panel fact is long enough to stack — nothing exercises the long branch: ${JSON.stringify(facts)}`,
+        ).not.toEqual([]);
+
+        // Short branch: right-aligned, so the values line up down the
+        // panel's right edge instead of each starting wherever its own
+        // label ended.
+        expect(
+          inline.filter((f) => f.valueRightGap > 2),
+          `a value on its label's line must end at the panel's right edge — ${JSON.stringify(inline)}`,
+        ).toEqual([]);
+
+        // Long branch, and the surviving half of #1223's `a detail fact
+        // gives its value the panel's full width`: the reference box is
+        // still the TABLE, not the facts list. That correction is the
+        // whole point of the assertion it comes from — the list is
+        // INSIDE the panel, so a ratio against it shrinks numerator and
+        // denominator together and cannot see a squeezed panel.
+        const tableBox = await page.getByTestId("admin-sessions-table").boundingBox();
+        expect(tableBox, "the sessions table must have a box to measure against").not.toBeNull();
+        const tableWidth = tableBox?.width ?? 0;
+        expect(tableWidth, "the table must have a width to fill").toBeGreaterThan(200);
+
+        expect(
+          stacked.filter((f) => f.boxWidth < tableWidth * 0.85).map((f) => f.label),
+          `a value on its own line must take the table's width, not the shrunken panel's — ` +
+            `${JSON.stringify(stacked.map((f) => ({ label: f.label, box: Math.round(f.boxWidth) })))} ` +
+            `of table ${Math.round(tableWidth)}px`,
+        ).toEqual([]);
+      } finally {
+        await reapVisitors(admin.token, visitor.id);
+      }
+    });
+  });
+}
+
+// Item 2 of the issue, which is about the boxes rather than about what is
+// in them: *"three nested containers (tab panel → section card →
+// per-network card) each contribute their own border and padding,
+// stacking ~3 frames around a value that is five characters long"*.
+//
+// The oracle counts FRAMES rather than pixels, because that is the thing
+// vjt described and a pixel budget would have to be re-argued the day a
+// border changes width. A frame is any box between the record card and
+// the pane that insets its own contents — border or padding, either
+// counts, since both put a gap where the value could be.
+//
+// Run at 440px only: the count is a property of the box tree, not of the
+// width, and 440 is the screen it was reported from.
+test.describe("#1244 the nesting around a record card", () => {
+  test.use({ viewport: { width: 440, height: 956 } });
+
+  test("#1244 @webkit a record card sits inside one frame, not three", async ({ page }) => {
+    const admin = getSeededAdmin();
+    const visitor = await mintVisitor(`frame1244-${Date.now()}`);
+
+    try {
+      await adminLogin(page);
+      await openSessionsTab(page);
+
+      const key = await adminSessionRowKey(page, "visitor", visitor.id);
+      const row = page.getByTestId(`admin-session-row-${key}`);
+      await row.scrollIntoViewIfNeeded();
+      await expect(row).toBeVisible();
+
+      const frames = await row.evaluate((tr) => {
+        const pane = tr.closest("[data-testid='admin-pane']");
+        if (pane === null) throw new Error("the row is not inside the admin pane");
+        const out: { name: string; inset: number }[] = [];
+        for (let n: Element | null = tr; n !== null && n !== pane; n = n.parentElement) {
+          const style = window.getComputedStyle(n);
+          const inset =
+            Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.borderLeftWidth);
+          if (inset <= 0) continue;
+          const name = n.getAttribute("data-testid") ?? String(n.className || n.tagName);
+          out.push({ name: String(name).slice(0, 40), inset: Math.round(inset) });
+        }
+        return out;
+      });
+
+      // The pane's own `1rem` gutter is NOT in this walk and is not up
+      // for discussion: it is the console's edge, shared by every
+      // surface it holds, cards or not. What the issue is about is the
+      // frames INSIDE it, and the record card is the one that earns its
+      // place — it is the only line saying where one record stops and
+      // the next starts.
+      expect(
+        frames,
+        `only the record card may frame a value between it and the pane — chain: ${JSON.stringify(frames)}`,
+      ).toHaveLength(1);
+
+      // Non-vacuity: the walk must have found real boxes. A selector
+      // drift that made `frames` empty would satisfy a `<= 1` check
+      // while measuring nothing, which is the failure mode the whole
+      // #1223 round was about.
+      expect(
+        frames[0]?.inset ?? 0,
+        "the record card must be the frame that remains",
+      ).toBeGreaterThan(0);
+    } finally {
+      await reapVisitors(admin.token, visitor.id);
+    }
+  });
+});

--- a/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
+++ b/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
@@ -189,6 +189,12 @@ for (const width of [393, 440]) {
 
         const fields = await readCardFields(row);
 
+        // Non-vacuity first, and separately, so a card that stopped
+        // painting labelled cells reads as that rather than as a density
+        // regression: every assertion below filters this list, and an
+        // empty list would fail them with the wrong sentence.
+        expect(fields.length, "the card must have labelled fields to measure").toBeGreaterThan(0);
+
         // Non-vacuity, and the claim of this issue in one assertion: at
         // least one field prints its label and its value on the SAME
         // line. Under #1223's `flex: 0 0 100%` every field stacks and

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -318,23 +318,37 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
         const found = await page.getByTestId("admin-pane").evaluate((root) => {
           const out: Omit<Offender, "surface">[] = [];
           const consider = (el: Element): void => {
-            // The `.adm-nav` exemption that used to sit here is GONE, and
-            // it is the reason this oracle stayed green through the defect
-            // it exists to catch. It read: the tab strip is "a navigation
-            // affordance an operator swipes to CHOOSE a tab ... not a
-            // record whose columns you must pan to READ", with the caveat
-            // "if it is ever meant to be in scope, that is a separate
-            // product call". vjt made that call by retesting v0.16.0 on a
-            // phone and listing the strip fourth among the defects —
-            // *"Sessions … Vhosts fill the row and the next tab is cut at
-            // the right edge"*. The strip wraps now (default.css
-            // `.adm-nav`), so there is nothing to exempt.
+            // 🔴 NAMED EXEMPTION — restored on purpose, by whom and when:
+            // vjt, on the 2026-08-12 retest of `e0ef575c`, filing #1244.
+            // *"la top bar che faceva hor scroll andava bene — mo sto wrap
+            // leva spazio"*, and on the issue itself: *"that call was mine
+            // and it was wrong"*.
             //
-            // Worth keeping as a lesson rather than deleting silently: an
-            // exemption written as a product argument is indistinguishable
-            // from an exemption written to make a red go away, and neither
-            // can fail. This guard's whole claim is "nothing in the pane
-            // pans", and it was carrying a named counter-example.
+            // The history matters, because this exemption was deleted for
+            // a good reason and is coming back for a different one. #1223
+            // removed it as an oracle that could not fail: it was written
+            // as a product argument ("a navigation affordance an operator
+            // swipes to CHOOSE a tab ... not a record whose columns you
+            // must pan to READ"), it exempted the one box that was
+            // actually panning, and it carried its own escape hatch — "if
+            // it is ever meant to be in scope, that is a separate product
+            // call". An exemption phrased that way is indistinguishable
+            // from one written to make a red go away.
+            //
+            // What is different now is the cost, measured on the device
+            // rather than argued: wrapping the eight chips puts them on
+            // two rows, and the second row is 44px of a 440px screen
+            // spent on navigation, on every tab. #1244 is the issue about
+            // exactly that budget. vjt has now seen both layouts on the
+            // phone and chosen the pan.
+            //
+            // And it is no longer unfalsifiable. `the tab strip is one
+            // row, and it pans` below asserts the strip does the thing
+            // this line waves through — so removing the pan turns a test
+            // red instead of quietly widening the exemption into a hole.
+            // A documented exemption with a guard on the exempted
+            // behaviour is a decision; a silent one is a defect.
+            if (el.classList.contains("adm-nav")) return;
             const overflowX = window.getComputedStyle(el).overflowX;
             if (overflowX !== "auto" && overflowX !== "scroll") return;
             if (el.scrollWidth <= el.clientWidth + 1) return;
@@ -388,41 +402,66 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     }
   });
 
-  // #1223 retest, symptom 4. Strictly stronger than the width oracle above
-  // and deliberately not folded into it: that one only looks at boxes whose
-  // computed `overflow-x` can pan, so a strip switched to `hidden` would
-  // clip three tabs off the screen and go unseen. This asserts what vjt
-  // actually reported — a tab CUT AT THE RIGHT EDGE — which is true of a
-  // clipped strip and of a scrolling one alike.
-  test("@webkit admin on mobile — every tab chip is on screen, none cut off", async ({ page }) => {
+  // #1244 — the guard ON the exemption above, and the reason restoring it
+  // is a decision rather than a hole.
+  //
+  // It replaces `every tab chip is on screen, none cut off`, which was
+  // #1223's symptom 4 and asserted the opposite: that no chip is cut at
+  // the right edge, i.e. that the strip does not pan. vjt reverted that
+  // call on the 2026-08-12 retest — the wrap costs a full 44px row of a
+  // 440px screen, which is the budget #1244 exists to win back — so the
+  // old assertion is not weakened here, it is contradicted, and it goes.
+  //
+  // What takes its place is the shape he asked for, stated so that
+  // undoing it turns something red: ONE row, and pannable. The two halves
+  // fail to different mutations, which is why they are both here — a
+  // strip switched to `overflow-x: hidden` stays one row and stops
+  // panning (chips clipped, unreachable), and a strip given `flex-wrap:
+  // wrap` stops being one row. Neither is visible to the width oracle
+  // above: the first because a `hidden` box is not in its scope, the
+  // second because a wrapped strip does not overflow.
+  test("@webkit admin on mobile — the tab strip is one row, and it pans", async ({ page }) => {
     await openAdminPane(page);
 
-    const chips = await page.getByTestId("admin-pane").evaluate((pane) => {
+    const strip = await page.getByTestId("admin-pane").evaluate((pane) => {
       const nav = pane.querySelector(".adm-nav");
       if (nav === null) throw new Error(".adm-nav is gone — the tab strip's class drifted");
-      const navRect = nav.getBoundingClientRect();
-      // The CLIENT box: `clientWidth` excludes border and any scrollbar, so
-      // this is the region a chip can be painted in and still be readable.
-      const left = navRect.left + nav.clientLeft;
-      const right = left + nav.clientWidth;
-      return [...nav.querySelectorAll("[role='tab']")].map((el) => {
-        const r = el.getBoundingClientRect();
-        return {
-          label: (el.textContent ?? "").trim(),
-          overflowRight: Math.round(r.right - right),
-          overflowLeft: Math.round(left - r.left),
-        };
-      });
+      const chips = [...nav.querySelectorAll("[role='tab']")];
+      return {
+        count: chips.length,
+        // Distinct line positions. Rounded, because baseline alignment
+        // leaves sub-pixel differences between chips on the SAME row and
+        // a second row is 44px away — no threshold argument available.
+        rows: new Set(chips.map((el) => Math.round(el.getBoundingClientRect().top))).size,
+        overflowX: window.getComputedStyle(nav).overflowX,
+        scrollW: nav.scrollWidth,
+        clientW: nav.clientWidth,
+      };
     });
 
-    // Non-vacuity: an empty strip would make every filter below trivially
-    // empty. `ADMIN_TABS` is the same list the count assertion pins.
-    expect(chips.length, "the tab strip must have chips to measure").toBe(ADMIN_TABS.length);
+    // Non-vacuity: one chip is trivially one row, and an empty strip is
+    // trivially not overflowing. `ADMIN_TABS` is the list the count
+    // assertion in the width oracle pins.
+    expect(strip.count, "the tab strip must have chips to measure").toBe(ADMIN_TABS.length);
 
     expect(
-      chips.filter((c) => c.overflowRight > 1 || c.overflowLeft > 1),
-      `every admin tab must be inside the strip at 393px — cut chips: ${JSON.stringify(chips, null, 2)}`,
-    ).toEqual([]);
+      strip.rows,
+      `the tab strip must stay on one row at 393px — chips found on ${strip.rows} rows`,
+    ).toBe(1);
+
+    // And it must be REACHABLE by the gesture, not merely clipped: the
+    // exemption above waves through a box that pans, so if this strip
+    // stopped panning the exemption would be waving through nothing and
+    // three destinations would be unreachable.
+    expect(
+      strip.overflowX,
+      "the tab strip must be able to pan — that is what the h-scroll exemption is for",
+    ).toMatch(/auto|scroll/);
+    expect(
+      strip.scrollW,
+      `the tab strip must actually overflow, or the exemption guards nothing ` +
+        `(scrollWidth ${strip.scrollW} vs clientWidth ${strip.clientW})`,
+    ).toBeGreaterThan(strip.clientW + 1);
   });
 
   test("@webkit admin on mobile — vertical scroll inside the pane still works", async ({

--- a/cicchetto/src/AdminDebugTab.tsx
+++ b/cicchetto/src/AdminDebugTab.tsx
@@ -191,33 +191,65 @@ const AdminDebugTab: Component = () => {
             <p class="adm-matrix-prompt" aria-hidden="true">
               grappa@cicchetto:~$ tail -f /dev/viewport
             </p>
+            {/* #1244 — `.adm-fact` per pair, like `AdminFacts` renders.
+                This list is hand-written because each value is its own
+                signal read, and it shares the class, so it shares the
+                markup contract: the narrow layout keys off the wrapper,
+                and a `.adm-facts` without one silently keeps the old
+                grid the day this panel gains a query container. */}
             <dl class="adm-facts adm-matrix-facts">
-              <dt>vv.height</dt>
-              <dd data-testid="diag-vv-h">{Math.round(diagVvH())}</dd>
-              <dt>vv.width</dt>
-              <dd data-testid="diag-vv-w">{Math.round(diagVvW())}</dd>
-              <dt>window.innerHeight</dt>
-              <dd data-testid="diag-win-h">{Math.round(diagWinH())}</dd>
-              <dt>window.innerWidth</dt>
-              <dd data-testid="diag-win-w">{Math.round(diagWinW())}</dd>
-              <dt>Δ (winH − vvH)</dt>
-              <dd data-testid="diag-delta">{Math.round(diagWinH() - diagVvH())}</dd>
-              <dt>vv.scale</dt>
-              <dd>{diagVvScale().toFixed(2)}</dd>
-              <dt>vv.offsetTop</dt>
-              <dd>{Math.round(diagVvOffsetTop())}</dd>
-              <dt>--viewport-height</dt>
-              <dd data-testid="diag-css-var">{diagCssVar()}</dd>
-              <dt>--vh</dt>
-              <dd data-testid="diag-vh-var">{diagVhVar()}</dd>
-              <dt>html.is-ios</dt>
-              <dd data-testid="diag-is-ios">{diagIsIos() ? "true" : "false"}</dd>
-              <dt>active element</dt>
-              <dd data-testid="diag-focus">{diagFocusedTag()}</dd>
-              <dt>event tick</dt>
-              <dd data-testid="diag-event-tick">{diagEventTick()}</dd>
-              <dt>last event</dt>
-              <dd data-testid="diag-last-event">{diagLastEvent()}</dd>
+              <div class="adm-fact">
+                <dt>vv.height</dt>
+                <dd data-testid="diag-vv-h">{Math.round(diagVvH())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>vv.width</dt>
+                <dd data-testid="diag-vv-w">{Math.round(diagVvW())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>window.innerHeight</dt>
+                <dd data-testid="diag-win-h">{Math.round(diagWinH())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>window.innerWidth</dt>
+                <dd data-testid="diag-win-w">{Math.round(diagWinW())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>Δ (winH − vvH)</dt>
+                <dd data-testid="diag-delta">{Math.round(diagWinH() - diagVvH())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>vv.scale</dt>
+                <dd>{diagVvScale().toFixed(2)}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>vv.offsetTop</dt>
+                <dd>{Math.round(diagVvOffsetTop())}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>--viewport-height</dt>
+                <dd data-testid="diag-css-var">{diagCssVar()}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>--vh</dt>
+                <dd data-testid="diag-vh-var">{diagVhVar()}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>html.is-ios</dt>
+                <dd data-testid="diag-is-ios">{diagIsIos() ? "true" : "false"}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>active element</dt>
+                <dd data-testid="diag-focus">{diagFocusedTag()}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>event tick</dt>
+                <dd data-testid="diag-event-tick">{diagEventTick()}</dd>
+              </div>
+              <div class="adm-fact">
+                <dt>last event</dt>
+                <dd data-testid="diag-last-event">{diagLastEvent()}</dd>
+              </div>
             </dl>
           </div>
         </AdminCard>

--- a/cicchetto/src/admin/AdminFacts.tsx
+++ b/cicchetto/src/admin/AdminFacts.tsx
@@ -26,14 +26,23 @@ export type Props = {
   facts: Fact[];
 };
 
+// #1244 — the pair travels in a `.adm-fact` wrapper, which HTML defines
+// for exactly this (a `<div>` between `<dl>` and its `<dt>`/`<dd>`) so
+// the semantics do not change. It exists because the narrow layout puts
+// ONE pair on one line and stacks a pair that does not fit, and a
+// flat `<dl>` gives CSS nothing to hang that decision on: a flex line
+// cannot be broken per pair, and a grid row cannot let one value take
+// both columns because its length is unknown to the stylesheet. On a
+// panel with room the wrapper is `display: contents` and the list is one
+// grid again, labels aligned across pairs.
 const AdminFacts: Component<Props> = (props) => (
   <dl class="adm-facts">
     <For each={props.facts}>
       {(fact) => (
-        <>
+        <div class="adm-fact">
           <dt>{fact.label}</dt>
           <dd>{fact.value}</dd>
-        </>
+        </div>
       )}
     </For>
   </dl>

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4592,41 +4592,40 @@ html.resize-dragging * {
 }
 
 /* Admin redesign Layer 2/3 — `AdminNav` (cicchetto/src/admin/AdminNav.tsx).
-   Mobile-first: a WRAPPING chip strip (`.adm-nav`), grouped by a
-   non-interactive label. The ≥900px media query below (next to
-   `.admin-pane`'s own desktop rule) turns the SAME markup into a vertical
-   rail — no DOM duplication, so the 10 `admin-tab-<key>` buttons stay
-   singular and clickable in one click regardless of viewport.
+   Mobile-first: a horizontal SCROLLING chip strip (`.adm-nav` row +
+   `.adm-nav-group` row), grouped by a non-interactive label. The ≥900px
+   media query below (next to `.admin-pane`'s own desktop rule) turns the
+   SAME markup into a vertical rail — no DOM duplication, so the 10
+   `admin-tab-<key>` buttons stay singular and clickable in one click
+   regardless of viewport.
 
-   #1223 retest — it used to be a horizontal SCROLLING strip, and vjt
-   listed that as a defect on a portrait phone: *"the section tab strip
-   still pans horizontally: Sessions … Vhosts fill the row and the next
-   tab is cut at the right edge"*. Eight chips measure ~680px against
-   361px of pane content, so three of them were off-screen behind a
-   gesture with nothing on screen to suggest it.
+   🔴 #1244 — the strip PANS, deliberately, and the h-scroll guard exempts
+   it just as deliberately. #1223 made it wrap instead, on vjt's reading
+   that a chip cut at the right edge was a defect; he reverted that call on
+   the 2026-08-12 retest of `e0ef575c`, in the same breath as filing #1244:
+   *"la top bar che faceva hor scroll andava bene — mo sto wrap leva
+   spazio"*, and on the issue, *"that call was mine and it was wrong"*.
 
-   Wrapping, not stacking. `ux-6-g`'s exemption comment argued the strip
-   had to keep the pan because "stacking it would cost most of the screen
-   before the first row" — true of a one-per-line rail (8 × 44px), and not
-   true of wrapping, which packs the same chips into two rows. That costs
-   ~44px of height once, and buys back a tab bar where every destination
-   is visible.
+   The trade is vertical, and #1244 is the issue about vertical. Wrapping
+   eight chips into two rows costs a full 44px row of a 440px device, on
+   every tab, forever — which is most of what one denser fact row buys
+   back. Panning costs nothing vertically and hides three destinations
+   behind a gesture. vjt has now seen both on the device and picked this
+   one.
 
-   `display: contents` on the group is what makes it two rows rather than
-   three: the chips pack greedily across the whole strip instead of
-   breaking at group boundaries, where `live` (264px) would leave 97px of
-   the first row empty. The group box carries no paint on a phone — its
-   heading is visually hidden here — so removing it costs nothing, and the
-   desktop rail below puts it back.
+   So the exemption in `ux-6-g-admin-mobile-h-scroll` is a CHOICE with a
+   date and an owner on it, not the unfalsifiable product argument #1223
+   deleted. What keeps it honest is that it is no longer silent: the strip
+   has its own oracle there (`the tab strip is one row, and it pans`),
+   which fails if the pan goes away — so the exemption cannot quietly
+   become a hole again, and a future reader finds the ruling instead of
+   guessing at a gap.
 
-   `overflow-x: auto` STAYS. Nothing overflows now, so it is inert; what it
-   buys is that a future chip which does overflow shows up in
-   `ux-6-g-admin-mobile-h-scroll`, whose oracle only considers boxes that
-   CAN pan. Switching it to `hidden` would silently clip instead. */
+   `flex-wrap` is therefore absent (the initial `nowrap`): a wrap here is
+   the reverted layout, not a tweak. */
 .adm-nav {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
   align-items: center;
   gap: var(--adm-space-3);
   overflow-x: auto;
@@ -4636,12 +4635,16 @@ html.resize-dragging * {
   margin: 0 0 var(--adm-space-2);
 }
 
-/* Boxless on the chip strip (see `.adm-nav`): the buttons become direct
-   flex children of the strip and wrap wherever the row ends, rather than
-   travelling in three indivisible blocks. The desktop rail restores the
-   box, which is where the grouping is actually drawn. */
+/* A real box again on the chip strip: with nothing wrapping there is no
+   packing problem for `display: contents` to solve, and the group travels
+   as one indivisible run of chips, which is the grouping the rail draws
+   explicitly. */
 .adm-nav-group {
-  display: contents;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--adm-space-2);
+  flex-shrink: 0;
 }
 
 /* Hidden on the mobile chip strip — three headings cost a whole line of
@@ -4726,14 +4729,9 @@ html.resize-dragging * {
     gap: var(--adm-space-5);
   }
 
-  /* `display: flex` re-establishes the box the chip strip dissolves with
-     `display: contents` — on the rail the group is a real column with a
-     real heading, which is the layout the grouping exists for. */
   .adm-nav-group {
-    display: flex;
     flex-direction: column;
     align-items: stretch;
-    flex-shrink: 0;
     gap: 2px;
   }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5477,6 +5477,21 @@ html.resize-dragging * {
   margin: 0;
 }
 
+/* #1244 — each `<dt>`/`<dd>` pair travels in a wrapper (`AdminFacts`), so
+   the narrow layout below can put ONE pair on one line and let a pair
+   that does not fit stack on its own. A `<div>` between `<dl>` and its
+   pairs is what HTML defines for grouping them, so the semantics are
+   unchanged.
+
+   `display: contents` dissolves the wrapper here: on a panel with room
+   the list is still one grid, which is what lines the labels up into a
+   column across pairs. The group box only becomes real in the container
+   query below — the same idiom, and for the same reason, as
+   `.adm-nav-group` on the desktop rail. */
+.adm-fact {
+  display: contents;
+}
+
 .adm-facts dt {
   font-family: var(--adm-font);
   font-size: 0.68rem;
@@ -5510,12 +5525,48 @@ html.resize-dragging * {
    30rem, i.e. the width below which the value track can no longer hold
    one line of what this list actually renders: 6rem of label track plus
    the 1rem gap is chrome, and the panel's values are timestamps and
-   `host:port` pairs of ~20 mono characters. Below that the pair reads
-   better stacked — the label is a caption for the value, and a caption
-   above costs one line and buys the value the whole width. */
+   `host:port` pairs of ~20 mono characters.
+
+   #1244 — below that the pair stops being a grid ROW and becomes a flex
+   LINE, which is the only way one rule can serve both of this list's
+   values. `grid-template-columns: 1fr` put every label on a line of its
+   own, and half of what the panel prints is `connected` or `2` — four
+   characters bought with a whole row. A two-column grid instead squeezes
+   the long half against a track sized by the longest label, and the
+   squeeze comes back as a `host:port` broken mid-token, which is the
+   defect `no panel value is broken mid-token` exists to catch.
+
+   As a flex line the pair chooses per value: the label takes its own
+   width, `dd` grows into the rest and prints right-aligned, and a value
+   whose max-content does not fit moves to the next line, where it is
+   alone and grows to the panel's full width. Same two branches as the
+   card's `td::before`, so the panel and the card still read as one
+   idiom (#1223's rule, kept).
+
+   `dd` GROWS rather than being pushed right by an auto margin on `dt` —
+   which is what the card does — because here there is a real element to
+   grow. The card's value is an anonymous flex item (a bare text node in
+   a `<td>`) with no way to set `flex` or `text-align` on it, so the two
+   surfaces reach the same layout by the only means each has. */
 @container (max-width: 30rem) {
   .adm-facts {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
+    gap: var(--adm-space-2);
+  }
+
+  .adm-fact {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--adm-space-3);
+    row-gap: var(--adm-space-1);
+  }
+
+  .adm-fact dd {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: right;
   }
 }
 
@@ -5788,12 +5839,16 @@ html.resize-dragging * {
      Users tab that measured 373px of content in a 331px wrapper, which is
      a 42px pan straight back. Wrapping lets the value fall under its own
      label instead of pushing the card wider. */
+  /* #1244 — `row-gap` is the space between a value and the label ABOVE
+     it, which is now the exception rather than every field: 8px was the
+     rhythm of a card where every pair stacked, and between a caption and
+     the thing it captions it reads as a break. 4px binds them. */
   .adm-table td {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: var(--adm-space-3);
-    row-gap: var(--adm-space-2);
+    row-gap: var(--adm-space-1);
     border-bottom: 0;
     padding: var(--adm-space-1) 0;
     white-space: normal;
@@ -5801,22 +5856,46 @@ html.resize-dragging * {
     min-width: 0;
   }
 
-  /* #1223 retest — the label is a CAPTION ABOVE its value, not a track
-     beside it. It was `flex: 0 0 5rem`, which neither grows nor shrinks:
-     80px plus the 12px column gap, reserved out of 341px of card, on every
-     field of every row. vjt read it off a portrait screenshot — *"the label
-     column (last seen, channels, actions) keeps a fixed wide gutter of its
-     own, pushing the values into the right half"*.
-     `100%` rather than a smaller fixed track because the alternatives both
-     lose: `auto` sizes each label to its own text, so the values stop
-     lining up and the card reads as scattered; a narrower track still
-     charges every value for a gutter and only argues about the price.
-     The card now spends one line on the label and gives the value all
-     341px, which is the same trade `.adm-facts` already makes in the panel
-     — one idiom for the same problem, at both ends of the card. */
+  /* #1244 — the label sits BESIDE its value while the value is short, and
+     the pair stacks only when it will not fit. Three sizings in three
+     rounds, so the reasoning for this one has to name what it beats:
+
+       - `flex: 0 0 5rem` (pre-#1223): 80px reserved on every field of
+         every row whether the label needs it or not, values pushed into
+         the right half. Rejected on width.
+       - `flex: 0 0 100%` (#1223): the label is a caption on its own line.
+         It cures the width and charges a line of height for it — three
+         facts, six rows. vjt measured that on a 440px phone and filed
+         #1244: `VISITORS` / `0/∞` is two full rows to print four
+         characters.
+       - `flex: 0 0 auto` + `margin-right: auto` (here): the label is as
+         wide as its own text and the auto margin pushes the value to the
+         far end of the line. Nothing is reserved, and a three-fact card
+         is three rows again.
+
+     `margin-right: auto` is doing the work that a fixed track used to,
+     and doing it without a track: an auto margin absorbs the line's free
+     space AFTER line breaking, so it exists only on a line that has one.
+     The consequences are the two branches this layout is:
+
+       - the value fits → one line, label left, value flush right.
+       - it does not → the value's max-content exceeds what is left, so it
+         goes to the next flex line. There it is the only item, there is
+         no auto margin on that line, and it starts at the card's left
+         edge with the full width to wrap into. That is #1223's stacked
+         layout, reached by measurement rather than by decree, and it is
+         what keeps `a card value starts at the card's edge` true for
+         every value that needs the width.
+
+     #1223 rejected `auto` because "per-label sizing stops the values
+     lining up and the card reads as scattered". True of a left-aligned
+     value; the values line up at the RIGHT edge here, which is a
+     stronger column than the old one — the labels are what go ragged,
+     and they are the part you read one of, not down. */
   .adm-table td::before {
     content: attr(data-label);
-    flex: 0 0 100%;
+    flex: 0 0 auto;
+    margin-right: auto;
     font-family: var(--adm-font);
     font-size: 0.68rem;
     letter-spacing: 0.1em;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5813,6 +5813,45 @@ html.resize-dragging * {
    name) would keep a stacked cell wider than the screen and put the pan
    straight back. */
 @media (max-width: 899px) {
+  /* #1244 item 2 — *"three nested containers (tab panel → section card →
+     per-network card) each contribute their own border and padding,
+     stacking ~3 frames around a value that is five characters long"*.
+
+     Counted from the value outwards at 393px, the insets were: the pane's
+     `padding: 1rem`, this scroll body's second `1rem`, the section card's
+     1px border, and the record card's 1px + 8px. 42px a side, 84px of a
+     393px screen, to say the same thing four times.
+
+     Two of the four go, and which two is the whole judgement. The pane's
+     gutter stays: it is the console's edge and every surface shares it,
+     cards or not. The record card's frame stays: it is the only line that
+     says where one record ends and the next begins, which is what a card
+     regime is FOR. What goes is the pair in the middle, whose entire job
+     was to inset a card inside a backdrop the card already covers — so
+     the section card runs edge to edge in the pane's gutter and keeps its
+     identity from the top stripe and the head it already has.
+
+     Vertical falls out of the same change: the block padding halves and
+     the inter-card gap comes down a step, both of which were sized when
+     each card was half again as tall. */
+  .adm-scroll {
+    padding: var(--adm-space-2) 0;
+    gap: var(--adm-space-3);
+  }
+
+  /* The side borders drew the frame that just went; the top stripe (the
+     section's group colour) and the bottom edge are what remain, and they
+     are the two that carry meaning. */
+  .adm-card {
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+  }
+
+  .adm-card-head {
+    padding: var(--adm-space-2) var(--adm-space-4);
+  }
+
   .adm-table,
   .adm-table tbody,
   .adm-table tr,

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5841,14 +5841,24 @@ html.resize-dragging * {
 
   /* The side borders drew the frame that just went; the top stripe (the
      section's group colour) and the bottom edge are what remain, and they
-     are the two that carry meaning. */
-  .adm-card {
+     are the two that carry meaning.
+
+     🔴 `.adm-scroll > .adm-card`, not `.adm-card`, and the reason is the
+     trap #1223 hit twice and wrote down: a media query buys NO
+     specificity, and `.adm-card`'s base rule sits ~330 lines FURTHER DOWN
+     this file, so a bare `.adm-card` here loses on source order and does
+     nothing at all. Measured, not deduced — the frame oracle reported the
+     card still contributing its 1px with the rule in place. (0,2,0) wins
+     on its own merits, and it also says something true: the frame being
+     removed is the one a card gets for sitting inside the scroll body's
+     backdrop, so a card nested anywhere else keeps its own. */
+  .adm-scroll > .adm-card {
     border-left: 0;
     border-right: 0;
     border-radius: 0;
   }
 
-  .adm-card-head {
+  .adm-scroll > .adm-card > .adm-card-head {
     padding: var(--adm-space-2) var(--adm-space-4);
   }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39693,3 +39693,112 @@ empty page is how the exemption above survived.
 different query over a different width regime and vjt measured the
 viewport one; at 55rem of container a 5rem track is cheap, and stacking
 it there would cost scannability for a defect nobody has observed.
+
+---
+
+## 2026-08-12 — #1244: the console's vertical budget, and an exemption that comes back with a guard on it
+
+vjt retested `e0ef575c` on a 440px phone the same afternoon #1223's
+retest landed. The horizontal complaints were gone; the bill for them was
+on screen. **Every fact stacked its label above its value**, so
+`VISITORS` / `0/∞`, `USERS` / `1/3`, `PER-IP` / `5` took two rows each to
+print four characters, three nested containers put ~3 frames around them,
+and two networks plus one session filled the screen.
+
+**The layout is two branches, and the second is what makes the first
+safe.** `.adm-table td::before` goes from `flex: 0 0 100%` (a caption on
+its own line) to `flex: 0 0 auto` + `margin-right: auto`: the label is as
+wide as its own text and the auto margin pushes the value to the far end
+of the line. An auto margin resolves AFTER line breaking, so it only
+exists on a line that has free space — a value whose max-content does not
+fit in what is left moves to the next flex line, where it is alone, no
+margin pushes it, and it starts at the card's edge with the full width to
+wrap into. **That is #1223's stacked layout, reached by measurement
+rather than by decree**, which is why the horizontal budget survives: a
+`host:port` still gets the whole card, and still wraps between tokens
+rather than through one.
+
+**The panel needed a wrapper element to say the same thing.** A flex line
+cannot be broken per pair and a grid row cannot let one value take both
+columns on the strength of its length, so `AdminFacts` renders
+`.adm-fact` per `<dt>`/`<dd>` — the `<div>` HTML defines for grouping
+them — and `display: contents` dissolves it again above 30rem so the
+labels still line up in a column. `AdminDebugTab` hand-writes the same
+list and got the same wrapper: one class, one markup contract.
+
+**Where card and panel differ is forced.** In the panel `dd` grows and
+prints right-aligned; on the card the value is an ANONYMOUS flex item —
+a bare text node in a `<td>` — with no way to set `flex` or `text-align`
+on it, so the auto margin does the same job from the other side. Worth
+knowing before someone "unifies" them.
+
+**Two of four frames go, and which two is the judgement.** Counted
+outwards at 393px: the pane's `padding: 1rem`, the scroll body's second
+`1rem`, the section card's border, the record card's border + padding —
+42px a side. The pane's gutter stays (it is the console's edge, shared by
+every surface). The record card's frame stays (it is the only line saying
+where one record ends). The pair in the middle went: their job was to
+inset a card inside a backdrop the card already covers.
+
+### The `.adm-nav` exemption, deleted by #1223 and restored here
+
+vjt reverted his own call: *"la top bar che faceva hor scroll andava bene
+— mo sto wrap leva spazio"*, and on the issue, *"that call was mine and
+it was wrong"*. Wrapping eight chips into two rows costs a full 44px row
+of a 440px screen on every tab — most of what the density work buys back
+— to reveal destinations that were already reachable.
+
+**The lesson #1223 recorded still stands, and the fix for it is not
+"never exempt".** That exemption was deleted because it could not fail:
+argued as a product position, waving through the one box that was
+panning, carrying its own escape hatch. What comes back is the same line
+with three things it did not have — a date, an owner, and a test that
+asserts the exempted behaviour: `the tab strip is one row, and it pans`.
+Remove the pan and it goes red. **An exemption with a guard on the
+exempted behaviour is a decision; a silent one is a defect.**
+
+### The two #1223 asserts this contradicts, and vjt's ruling
+
+`a card value starts at the card's edge` (`indent <= 2` on every labelled
+cell) and `a detail fact gives its value the panel's full width` (`dd`
+under `dt`, `dd >= 0.85 * table`) **encode the stacked layout as the only
+correct answer**. A left-hand label on the same row breaks the first by
+construction (~75px of indent on the three cells vjt named); the panel's
+first fact is `connection: connected`, nine characters, which cannot
+satisfy the second inline.
+
+Ruled on the issue (2026-08-12): *"'the four asserts from #1223 stay
+green' was shorthand for do not regress the horizontal budget, not keep
+those literal thresholds"*, and *"do not keep the label above the value
+as the default — that is exactly the vertical waste this issue is
+about"*. **Both become the LONG branch**, keeping their technique: the
+range that excludes the `::before` label by construction, and the TABLE
+as the reference box rather than the facts list. What must not regress is
+narrower and clearer than "four asserts": nothing in the console
+overflows the viewport horizontally, `.adm-nav` alone excepted.
+
+**Measured at 393px AND 440px.** 393 is what every other admin guard runs
+at; 440 is the device the report came from, and a value can fit beside
+its label at one width and not the other.
+
+### Two things the new guard deliberately does not claim
+
+**A reserved label track wider than its text is now invisible to it.**
+With the value right-aligned, the label's box no longer decides where the
+value starts, so `flex: 0 0 5rem` would cost nothing until a label
+outgrew it. The defect was never the track's existence, it was the value
+being pushed by it.
+
+**The card's long branch is a rule, not an occurrence.** Every value on a
+session card is short at both widths — that IS the complaint — so the
+card test requires a one-row field and applies the long-branch rule to
+whatever lands there. The branch is exercised for real in the panel,
+where `last event` is long at both widths and a stacked fact is required.
+
+**Not changed, deliberately.** `.adm-table--stack` inside `@container
+(max-width: 56rem)` keeps its 5rem track and its non-wrapping cells, for
+the reason #1223 left it alone: a different query over a different width
+regime, and vjt measured the viewport one. The vertical rhythm is not
+asserted as a pixel budget either — any threshold would encode a font
+metric and the seed's row count. What is asserted is the row COUNT per
+fact, which is the thing that changed.


### PR DESCRIPTION
Follow-up to #1223. The width fix landed and paid for it in vertical
space; this is the bill, plus the revert vjt asked for in the same
retest.

## What changed

- **The tab strip pans again.** vjt reverted his own #1223 call —
  wrapping eight chips into two rows costs a full 44px row of a 440px
  screen on every tab. The `.adm-nav` exemption in the h-scroll guard
  comes back with a date, an owner and a reason in the comment, AND with
  a test on the exempted behaviour (`the tab strip is one row, and it
  pans`), so it cannot quietly become a hole again.
- **Label beside value while the value is short**, on the record card
  and in the detail panel. A value that does not fit takes the next line
  alone, at the card's edge, with the full width — #1223's stacked
  layout, kept where it earns its keep.
- **Two of four frames removed** around a record card. The pane's gutter
  and the record card's own border stay; the pair in the middle, which
  only inset a card inside a backdrop the card already covers, goes.

## Two #1223 asserts move rather than break

Per vjt's ruling on the issue: *"'the four asserts from #1223 stay
green' was shorthand for do not regress the horizontal budget, not keep
those literal thresholds"*. `a card value starts at the card's edge` and
`a detail fact gives its value the panel's full width` both encode the
stacked layout as the only correct answer. Each becomes the LONG branch
of the new spec, keeping its technique; both sites carry a tombstone
naming where the claim went.

The horizontal budget itself does not move: nothing in the console
overflows the viewport, `.adm-nav` alone excepted.

## Test plan

- [x] `bun run check` (biome + tsc over `src` AND `e2e`) — rc=0
- [x] vitest — 280 files, 5277 tests green
- [x] new spec at **393px and 440px** — 5/5
- [x] full `scripts/integration.sh` — **721 passed, 0 failed** (27.2m)
- [x] mutation map, 10 mutants, each killing its assertion — including
      one that removes the `.adm-nav` exemption and one that removes the
      pan, so neither is unguarded
- [x] two of my own oracles were found weak BY the mutation run and
      corrected: a `.adm-card` override that lost on source order inside
      `@media` (the trap #1223 documented), and a right-edge check that
      measured `dd` against its own box