### PR TITLE
cic(#1240): cross-host image and video links open the media viewer

### DIFF
--- a/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
@@ -9,8 +9,10 @@
 // navigates IN PLACE (raw media doc, no chrome). Fix: cic admits any
 // host in the server-provided alias set (Grappa.HttpHosts →
 // serverSettings().httpHostAliases) and re-roots the click onto the
-// PAGE origin, so the modal's <img> stays same-origin → CSP
-// `img-src 'self'` is UNTOUCHED.
+// PAGE origin, so the modal's <img> stays same-origin. What this spec
+// pins is the RE-ROOTING, which #1240 did not change: a foreign host is
+// now viewer-eligible too, but with its href UNCHANGED — only an
+// admitted host is rewritten onto the page origin.
 //
 // Simulation: the e2e server advertises a synthetic sibling host via
 // `EXTRA_CHECK_ORIGINS=https://alias-b.test` (compose.yaml), so the WS
@@ -76,10 +78,12 @@ async function aliasModalJourney(page: Page): Promise<void> {
   // No navigation — the modal opened in place.
   expect(page.url()).toBe(cicUrl);
 
-  // Re-rooted onto the PAGE origin, NOT alias-b.test → same-origin <img>
-  // → CSP img-src 'self' untouched. naturalWidth>0 proves the bytes
-  // loaded through nginx under the prod CSP (the _cspGuard fixture fails
-  // the spec on a securitypolicyviolation).
+  // Re-rooted onto the PAGE origin, NOT alias-b.test → the <img> is
+  // same-origin, admitted by `img-src 'self'` alone (the #1240 `https:`
+  // token is what the FOREIGN-host spec needs, not this one).
+  // naturalWidth>0 proves the bytes loaded through nginx under the prod
+  // CSP (the _cspGuard fixture fails the spec on a
+  // securitypolicyviolation).
   const img = viewer.locator("img.media-viewer-media");
   await expect(img).toHaveAttribute("src", url);
   await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
@@ -90,9 +94,11 @@ async function aliasModalJourney(page: Page): Promise<void> {
   await expect(viewer).toBeHidden({ timeout: 5_000 });
 
   // Negative: a genuinely third-party host (NOT in the alias set) with
-  // the same emoji + uploads shape must still be rejected — plain
-  // anchor, no media class (never re-root a foreign host onto the page
-  // origin).
+  // the same emoji + EXTENSIONLESS uploads shape must still be rejected —
+  // plain anchor, no media class. #1240 admits a foreign host by URL
+  // EXTENSION only; the emoji is a same-host-legacy signal and never
+  // types a foreign link, so this stays the boundary case that proves a
+  // foreign host is never re-rooted onto the page origin.
   const thirdPartyUrl = `https://litter.catbox.moe/uploads/${slug}`;
   await composeSend(page, `📸 ${thirdPartyUrl}`);
   const thirdRow = scrollbackLine(page, "privmsg", "litter.catbox.moe");

--- a/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
@@ -1,0 +1,164 @@
+// Cross-host media viewer (#1240) — e2e for the on-click in-app viewer
+// opening on a link whose host is GENUINELY foreign: not the page
+// origin, not one of the #324 server-advertised deployment aliases.
+//
+// Field case: an upload link minted by ANOTHER grappa instance, tapped
+// from this one. Two aliases of one deployment are #324's job; two
+// separate deployments can never be covered that way, so the classifier
+// admits a foreign host by URL EXTENSION alone (`externalMediaLink`,
+// widening #607's audio-only carve-out to image + video) and returns the
+// href UNCHANGED — re-rooting a foreign URL onto the page origin would
+// 404.
+//
+// WHY THIS SPEC EXISTS AT THE e2e LAYER: the classifier half is unit
+// tested (mediaLink.test.ts), but shipping it ALONE is worse than a
+// no-op — with `img-src 'self' data:` the browser blocks the modal's
+// <img> and the operator gets an EMPTY modal instead of a working
+// browser tab. Only a real browser against the real server can prove the
+// CSP admits the load. The header here is the REAL one
+// (GrappaWeb.Plugs.SecurityHeaders through the e2e nginx proxy, asserted
+// below), never a mock.
+//
+// The foreign BYTES are `page.route`-fulfilled, and that does not weaken
+// the CSP proof: CSP is enforced BEFORE the request leaves the browser,
+// so a blocked <img> never reaches the route handler — it fires
+// `securitypolicyviolation` (the `_cspGuard` fixture fails the spec) and
+// leaves naturalWidth at 0. Stubbing is what lets the spec name a host
+// that resolves nowhere, which is exactly what "genuinely foreign" means
+// inside the compose network.
+//
+// Video needs no CSP edit of its own: `media-src 'self' blob: https:`
+// already carries the `https:` token from #607 (audio) and governs
+// <video> too. The video case is pinned here anyway — the admission is
+// new even where the directive was not.
+//
+// chromium only (untagged): the interception of a non-resolving host is
+// what makes the spec hermetic, and duplicating it on the iPhone project
+// would buy engine coverage of Playwright's stub, not of the product.
+// Engine parity for the classifier wiring lives in the @webkit copy of
+// media-link-alias-modal.spec.ts.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+// NOT the page origin (nginx-test) and NOT the advertised alias
+// (alias-b.test, compose.yaml EXTRA_CHECK_ORIGINS) — a third deployment.
+const FOREIGN_HOST = "other-grappa.test";
+const IMAGE_URL = `https://${FOREIGN_HOST}/uploads/cross-host.png`;
+const VIDEO_URL = `https://${FOREIGN_HOST}/uploads/cross-host.mp4`;
+// Same host, same extension, http → still refused (mixed content on the
+// https page). The scheme leniency of the same-host branch (legacy
+// http-minted upload links) deliberately does not reach a foreign host.
+const INSECURE_IMAGE_URL = `http://${FOREIGN_HOST}/uploads/insecure.png`;
+
+const PNG_BYTES = Buffer.from(TINY_PNG_HEX, "hex");
+const MP4_BYTES = readFileSync(fileURLToPath(new URL("../fixtures/tiny.mp4", import.meta.url)));
+
+// Stand in for the other deployment's /uploads store. Only reached when
+// the CSP admits the element — see the header note.
+async function serveForeignMedia(page: Page): Promise<void> {
+  await page.route(`https://${FOREIGN_HOST}/**`, async (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith(".png")) {
+      await route.fulfill({ contentType: "image/png", body: PNG_BYTES });
+      return;
+    }
+    if (pathname.endsWith(".mp4")) {
+      await route.fulfill({ contentType: "video/mp4", body: MP4_BYTES });
+      return;
+    }
+    await route.abort();
+  });
+}
+
+async function openChannel(page: Page): Promise<void> {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+}
+
+// Send the URL as a bare message body (no 📸/🎬 prefix): the emoji is a
+// same-host legacy signal and never types a foreign link, so a green
+// assertion here can only come from the EXTENSION path.
+async function foreignLink(page: Page, url: string) {
+  await composeSend(page, url);
+  const row = scrollbackLine(page, "privmsg", FOREIGN_HOST).filter({ hasText: url });
+  await expect(row.first()).toBeVisible({ timeout: 15_000 });
+  return row.first().locator(".scrollback-link").first();
+}
+
+test("cross-host https image link opens the media viewer, href unchanged, bytes CSP-admitted (#1240)", async ({
+  page,
+}) => {
+  await serveForeignMedia(page);
+  await openChannel(page);
+
+  // The CSP the browser is enforcing came from the server, and it must
+  // carry the widened token — pin it here so a plug revert reddens this
+  // spec with a legible message instead of a bare naturalWidth of 0.
+  const csp = (await page.request.get("/")).headers()["content-security-policy"];
+  expect(csp, "server-served CSP must widen img-src for cross-host images").toContain(
+    "img-src 'self' data: https:",
+  );
+
+  const link = await foreignLink(page, IMAGE_URL);
+  await expect(link).toHaveClass(/scrollback-media-link/);
+  await expect(link).toHaveAttribute("href", IMAGE_URL);
+
+  const cicUrl = page.url();
+  await link.click();
+  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  // No navigation — the modal opened in place.
+  expect(page.url()).toBe(cicUrl);
+
+  const img = viewer.locator("img.media-viewer-media");
+  // UNCHANGED — a foreign host is never re-rooted onto the page origin.
+  await expect(img).toHaveAttribute("src", IMAGE_URL);
+  await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
+  // The load oracle: `complete` also goes true on a CSP block, decoded
+  // pixels do not.
+  const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
+  expect(naturalWidth, "cross-host image must decode under the prod CSP").toBeGreaterThan(0);
+
+  await viewer.getByRole("button", { name: "Close media viewer" }).click();
+  await expect(viewer).toBeHidden({ timeout: 5_000 });
+
+  // Negative: same host, same extension, http → plain anchor.
+  const insecure = await foreignLink(page, INSECURE_IMAGE_URL);
+  await expect(insecure).not.toHaveClass(/scrollback-media-link/);
+  await expect(insecure).toHaveAttribute("href", INSECURE_IMAGE_URL);
+});
+
+test("cross-host https video link opens the media viewer, href unchanged, metadata decoded (#1240)", async ({
+  page,
+}) => {
+  await serveForeignMedia(page);
+  await openChannel(page);
+
+  const link = await foreignLink(page, VIDEO_URL);
+  await expect(link).toHaveClass(/scrollback-media-link/);
+  await expect(link).toHaveAttribute("href", VIDEO_URL);
+
+  const cicUrl = page.url();
+  await link.click();
+  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  expect(page.url()).toBe(cicUrl);
+
+  const video = viewer.locator("video.media-viewer-media");
+  await expect(video).toHaveAttribute("src", VIDEO_URL);
+  // videoWidth stays 0 until the decoder has read the metadata, so this
+  // is the same "real bytes arrived" oracle naturalWidth is for images
+  // (preload="metadata" on the element, so no full download).
+  await expect
+    .poll(async () => video.evaluate((el) => (el as HTMLVideoElement).videoWidth), {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+});

--- a/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
+++ b/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
@@ -39,6 +39,11 @@ const LOAD_BEARING_DIRECTIVES = [
   // docked mini-player); the old "media-src 'self' blob:" pin is a PREFIX
   // of this, so `toContain` would pass silently without the widened token.
   "media-src 'self' blob: https:",
+  // #1240 — same prefix trap: the old "img-src 'self' data:" pin is a
+  // PREFIX of the widened value, so it must be pinned WITH the `https:`
+  // token or a revert would sail through `toContain`. Losing it opens the
+  // cross-host image viewer as an EMPTY modal.
+  "img-src 'self' data: https:",
   "worker-src 'self' blob:",
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -36,10 +36,12 @@ import { maybeEscapePwaClick } from "./lib/platform";
 // shipped version navigating the PWA), so plain clicks delegate to the
 // shared maybeEscapePwaClick intercept, which hands the URL to real
 // Safari via the x-safari-https:// scheme (iOS 17+; inert tap on 16 —
-// acceptable degrade). The media element needs no CSP change:
-// `img-src 'self' data:` / `media-src 'self' blob:` already cover
-// same-origin sources, and the classifier never admits cross-origin
-// URLs.
+// acceptable degrade). The media element's sources ARE CSP-governed:
+// `'self'` covers the same-origin case, and the cross-host links the
+// classifier admits (#607 audio, #1240 image + video) need the `https:`
+// token in `media-src` / `img-src` — without it this modal opens EMPTY.
+// The widening rides in the same change as each admission; the plug
+// moduledoc (GrappaWeb.Plugs.SecurityHeaders) is the SSOT.
 //
 // #232 — Escape routes through the shared overlay ESC stack
 // (createOverlayLock's onEscape → the single keybindings keydown listener →

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4021,7 +4021,13 @@ describe("ScrollbackPane", () => {
       expect(mediaViewerState()).toBeNull();
     });
 
-    it("cross-origin 📸 URL (litterbox host) is NOT intercepted", () => {
+    // #1240 — a cross-origin image link IS intercepted now, and the
+    // viewer gets the href UNCHANGED (never re-rooted onto the page
+    // origin, which would 404 the foreign host). Pre-#1240 this asserted
+    // the opposite; the CSP `img-src https:` widening ships with it, so
+    // the modal renders instead of opening empty.
+    it("cross-origin image URL (litterbox host) opens the viewer with the href unchanged", () => {
+      const href = "https://litter.catbox.moe/abc.png";
       setScrollback({
         "freenode #grappa": [
           {
@@ -4031,7 +4037,30 @@ describe("ScrollbackPane", () => {
             server_time: 1,
             kind: "privmsg",
             sender: "alice",
-            body: "📸 https://litter.catbox.moe/abc.png",
+            body: `📸 ${href}`,
+            meta: {},
+          },
+        ],
+      });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const link = document.querySelector(".scrollback-link") as HTMLAnchorElement;
+      expect(link.classList.contains("scrollback-media-link")).toBe(true);
+
+      link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      expect(mediaViewerState()).toEqual({ kind: "image", href });
+    });
+
+    it("cross-origin http image URL is NOT intercepted (mixed content on the https page)", () => {
+      setScrollback({
+        "freenode #grappa": [
+          {
+            id: 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: 1,
+            kind: "privmsg",
+            sender: "alice",
+            body: "📸 http://litter.catbox.moe/abc.png",
             meta: {},
           },
         ],

--- a/cicchetto/src/__tests__/mediaLink.test.ts
+++ b/cicchetto/src/__tests__/mediaLink.test.ts
@@ -13,11 +13,11 @@ import { classifyMediaLink, sameHostHref } from "../lib/mediaLink";
 // value — a separate normalize step was a misuse footgun). A URL is
 // admitted when its host is the page origin's OR (#324) any of the
 // deployment's server-provided HTTP host aliases (`aliasHosts`). #607
-// adds ONE exception: a genuinely third-party host is admitted only for
-// an https AUDIO link, returned with its absolute href UNCHANGED (never
-// re-rooted onto the page origin — that would 404 the foreign host).
-// Every other third-party link (http → mixed content; image/video →
-// #341 non-goal, Safari-view already opens them) is still null.
+// added ONE exception and #1240 widened it to every kind: a genuinely
+// third-party host is admitted for an https AUDIO, IMAGE or VIDEO link,
+// returned with its absolute href UNCHANGED (never re-rooted onto the
+// page origin — that would 404 the foreign host). Third-party http is
+// still null (mixed content).
 
 const ORIGIN = "https://grappa.example";
 // 26 chars of lowercase base32 (a-z2-7) — mirrors Grappa.Uploads
@@ -119,41 +119,40 @@ describe("classifyMediaLink", () => {
     });
   });
 
-  describe("third-party (non-deployment) non-audio links are never modal-eligible (#607 admits audio only)", () => {
-    it("third-party uploads-shaped URL with emoji is null", () => {
+  describe("third-party links carrying no admitted extension are never modal-eligible", () => {
+    it("third-party uploads-shaped URL with emoji is null (no extension — the emoji is same-host-only)", () => {
       expect(
         classifyMediaLink(`https://other.example/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
       ).toBeNull();
     });
 
-    it("third-party image-extension URL is null (litterbox path — Safari view already works)", () => {
-      expect(
-        classifyMediaLink("https://litter.catbox.moe/abc.png", "📸 ", ORIGIN, NO_ALIASES),
-      ).toBeNull();
+    it("same hostname but different port is NOT re-rooted (host comparison includes the port)", () => {
+      // Foreign by port, so it takes the external branch: an admitted
+      // extension classifies, but the href must stay on :4000 — re-rooting
+      // onto the page origin would serve the wrong file.
+      const href = "https://grappa.example:4000/files/shot.png";
+      expect(classifyMediaLink(href, "📸 ", ORIGIN, NO_ALIASES)).toEqual({ kind: "image", href });
     });
 
-    it("a third-party host stays null even when an alias set is advertised", () => {
-      expect(
-        classifyMediaLink("https://litter.catbox.moe/abc.png", "📸 ", ORIGIN, WITH_ALIAS_B),
-      ).toBeNull();
-    });
-
-    it("same hostname but different port is null (host comparison includes the port)", () => {
+    it("same hostname but different port with no extension is null", () => {
       expect(
         classifyMediaLink(`https://grappa.example:4000/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
       ).toBeNull();
     });
   });
 
-  // #607 — a third-party host is admitted for an https AUDIO link only, so
-  // it opens in the docked mini-player (cross-channel playback) instead of
-  // navigating the tab. The href is returned UNCHANGED (never re-rooted onto
-  // the page origin — that would 404 the foreign host). http is rejected
-  // (mixed content on the https page); external image/video stay null (#341
-  // declared inline previews a non-goal, and the Safari view already opens
-  // them). The CSP `media-src` is widened to `https:` in the same change so
-  // the <audio> element is not blocked.
-  describe("external (cross-host) https audio is modal-eligible (#607)", () => {
+  // #607 — a third-party host is admitted for an https AUDIO link, so it
+  // opens in the docked mini-player (cross-channel playback) instead of
+  // navigating the tab. #1240 admits https IMAGE and VIDEO the same way (an
+  // upload link minted by ANOTHER grappa instance, tapped from this one).
+  // In every case the href is returned UNCHANGED (never re-rooted onto the
+  // page origin — that would 404 the foreign host) and http is rejected
+  // (mixed content on the https page). The CSP directive governing the
+  // element must admit `https:` in the SAME change or the modal opens
+  // empty: `media-src` already does (widened by #607 for the audio
+  // mini-player, and it governs <video> too), `img-src` is widened by
+  // #1240.
+  describe("external (cross-host) https media is modal-eligible (#607 audio, #1240 image + video)", () => {
     const EXT_AUDIO = "https://media.example.org/podcast/ep1.mp3";
 
     it("external https audio extension → audio with the absolute href UNCHANGED", () => {
@@ -181,16 +180,39 @@ describe("classifyMediaLink", () => {
       ).toBeNull();
     });
 
-    it("external https image extension stays null (audio-only scope)", () => {
+    it("external https image extension → image with the absolute href UNCHANGED (#1240)", () => {
+      const href = "https://media.example.org/shot.png";
+      expect(classifyMediaLink(href, "", ORIGIN, NO_ALIASES)).toEqual({ kind: "image", href });
+    });
+
+    it("external image href is NOT re-rooted — path, query and hash stay on the foreign host", () => {
+      const href = "https://other.grappa.example/uploads/abc.png?v=2#top";
+      expect(classifyMediaLink(href, "", ORIGIN, NO_ALIASES)).toEqual({ kind: "image", href });
+    });
+
+    it("external http image is null (mixed content on the https page)", () => {
       expect(
-        classifyMediaLink("https://media.example.org/shot.png", "", ORIGIN, NO_ALIASES),
+        classifyMediaLink("http://media.example.org/shot.png", "", ORIGIN, NO_ALIASES),
       ).toBeNull();
     });
 
-    it("external https video extension stays null (audio-only scope)", () => {
+    it("external https video extension → video with the absolute href UNCHANGED (#1240)", () => {
+      const href = "https://media.example.org/clip.mp4";
+      expect(classifyMediaLink(href, "", ORIGIN, NO_ALIASES)).toEqual({ kind: "video", href });
+    });
+
+    it("external http video is null (mixed content on the https page)", () => {
       expect(
-        classifyMediaLink("https://media.example.org/clip.mp4", "", ORIGIN, NO_ALIASES),
+        classifyMediaLink("http://media.example.org/clip.mp4", "", ORIGIN, NO_ALIASES),
       ).toBeNull();
+    });
+
+    it("external https image is admitted regardless of the advertised alias set", () => {
+      const href = "https://litter.catbox.moe/abc.png";
+      expect(classifyMediaLink(href, "📸 ", ORIGIN, WITH_ALIAS_B)).toEqual({
+        kind: "image",
+        href,
+      });
     });
 
     it("external https non-media extension is null", () => {

--- a/cicchetto/src/lib/mediaLink.ts
+++ b/cicchetto/src/lib/mediaLink.ts
@@ -19,29 +19,22 @@
 //
 // ## Classification rules
 //
-// 1. Host NOT in the admitted set → null, always. The admitted set is
-//    the page-origin host ∪ the deployment's server-provided HTTP host
-//    aliases (`aliasHosts` param, #324 — from `serverSettings()`'s
-//    `httpHostAliases`, ultimately `Grappa.HttpHosts`; NEVER a client-
-//    baked list). A genuinely foreign host is excluded for image/video —
-//    two reasons: (a) the modal's `<img>`/`<video>` would need a CSP
-//    loosening this design refused for cross-origin images (#341 non-goal);
-//    (b) cross-host image/video links don't have the standalone bug and open
-//    fine in the iOS Safari view. #607 carves ONE exception: a foreign host
-//    IS admitted for an https AUDIO link (`externalAudioLink`), because audio
-//    wants the docked mini-player's cross-channel playback the Safari view
-//    can't give — the href is returned UNCHANGED (a foreign host is NEVER
-//    re-rooted; that would 404), http is rejected (mixed content), and the
-//    CSP `media-src` is widened to `https:` in the same change so the
-//    `<audio>` element is not blocked.
+// 1. Host NOT in the admitted set → re-rooting is off the table, and the
+//    link is modal-eligible only through the EXTERNAL branch below. The
+//    admitted set is the page-origin host ∪ the deployment's
+//    server-provided HTTP host aliases (`aliasHosts` param, #324 — from
+//    `serverSettings()`'s `httpHostAliases`, ultimately `Grappa.HttpHosts`;
+//    NEVER a client-baked list). A foreign host used to be excluded from
+//    the viewer outright; #607 carved out https audio and #1240 finished
+//    the job for image + video (`externalMediaLink`) — see that function
+//    for the per-kind admission and why the href is returned UNCHANGED.
 //    #324 — a deployment can answer on several hostname aliases
 //    (`irc.sindro.me`, `irc.sniffo.org`) that reverse-proxy to ONE
 //    instance + shared /uploads store; a link minted under one alias
 //    viewed from another must still open the viewer. Because the
 //    returned `href` is re-rooted on the PAGE origin (below), the modal's
-//    `<img src>` stays SAME-ORIGIN even for an alias link → CSP
-//    `img-src 'self'` is UNTOUCHED (no loosening). A foreign host is
-//    NEVER re-rooted onto the page origin (that would 404 / load the
+//    `<img src>` stays SAME-ORIGIN even for an alias link. A foreign host
+//    is NEVER re-rooted onto the page origin (that would 404 / load the
 //    wrong file) — only admitted hosts pass.
 //    Host-equality (hostname + port), NOT full-origin equality: pre-fix
 //    prod minted `http://host/uploads/<slug>` (Endpoint `url:` carried
@@ -202,9 +195,9 @@ export function sameHostHref(
 
 /**
  * Classify a scrollback link as modal-viewable media. Returns the kind
- * plus the viewer-safe href (re-rooted on the page origin — path,
- * query and hash preserved), or null when the default anchor behavior
- * should stand.
+ * plus the viewer-safe href — re-rooted on the page origin (path, query
+ * and hash preserved) for an admitted host, returned UNCHANGED for a
+ * foreign one — or null when the default anchor behavior should stand.
  *
  * @param href urlSegment.href (always scheme-qualified — linkify's
  *   toHref prepends https:// to bare-www matches).
@@ -216,8 +209,9 @@ export function sameHostHref(
  *   (#324, bare lowercased hostnames from `serverSettings()`'s
  *   `httpHostAliases`). A URL whose host is any of these — OR the page
  *   origin's own host — is admitted and re-rooted onto the page origin;
- *   a third-party host still returns null. Empty set = page origin only
- *   (pre-#324 behaviour). Injected so the classifier stays pure.
+ *   a third-party host takes the `externalMediaLink` branch instead
+ *   (https + media extension, href unchanged). Empty set = page origin
+ *   only (pre-#324 behaviour). Injected so the classifier stays pure.
  */
 export function classifyMediaLink(
   href: string,
@@ -226,9 +220,9 @@ export function classifyMediaLink(
   aliasHosts: readonly string[],
 ): MediaLink | null {
   const match = sameHostUrl(href, origin, aliasHosts);
-  // Foreign host (or non-http(s) / unparseable): the only cross-host link
-  // that reaches the in-app viewer is #607 external https audio.
-  if (match === null) return externalAudioLink(href);
+  // Foreign host (or non-http(s) / unparseable): an https link with a media
+  // extension still reaches the viewer, with its href UNCHANGED.
+  if (match === null) return externalMediaLink(href);
 
   const kind = kindOf(match.url, precedingText);
   if (kind === null) return null;
@@ -251,25 +245,34 @@ function kindOf(url: URL, precedingText: string): MediaKind | null {
 }
 
 /**
- * #607 external branch. A genuinely third-party host is modal-eligible ONLY
- * for an https AUDIO link, so it opens in the docked mini-player (#115) —
- * cross-channel playback the iOS Safari view can't give — instead of
- * navigating the tab. Returns the absolute href UNCHANGED: a foreign host is
- * NEVER re-rooted onto the page origin (that would 404 / load the wrong file).
+ * External branch (#607 audio, #1240 image + video). A genuinely third-party
+ * host is modal-eligible by URL EXTENSION alone, and the absolute href is
+ * returned UNCHANGED: a foreign host is NEVER re-rooted onto the page origin
+ * (that would 404 / load the wrong file).
  *
  * - https only — an http media element on the https page is mixed content and
  *   is blocked (the same-host branch stays scheme-agnostic for legacy uploads;
  *   that leniency deliberately does NOT extend to foreign hosts).
- * - audio only — external image/video stay null (#341 declared inline previews
- *   a non-goal, and the Safari view already opens them fine).
+ * - the emoji fallback (rule 2) does NOT apply: it keys off a same-host
+ *   extensionless `/uploads/<slug>` shape we only mint ourselves, so a foreign
+ *   link without an extension has no type signal and stays null.
  *
- * The CSP `media-src` is widened to `https:` in the same change (#607) so the
- * <audio> element is not blocked. No `crossorigin` attribute on the element —
- * it would require `Access-Control-Allow-Origin` from the foreign host and
- * break otherwise-working playback; scrub/seek is best-effort on the remote
- * server's Range support.
+ * #607 admitted audio first, for the docked mini-player (#115) — cross-channel
+ * playback the iOS Safari view can't give. #1240 admitted image and video: the
+ * motivating case is an upload link minted by ANOTHER grappa instance, tapped
+ * from this one, which #324's alias set cannot cover because the two instances
+ * are genuinely different deployments.
+ *
+ * CSP is the load-bearing half of that admission — an element the policy
+ * blocks yields an EMPTY modal, strictly worse than the anchor it replaced.
+ * `media-src 'self' blob: https:` already covers <audio> and <video> (#607
+ * widened it); `img-src` gets `https:` in the #1240 change for <img>. No
+ * `crossorigin` attribute on any of them — it would require
+ * `Access-Control-Allow-Origin` from the foreign host and break otherwise
+ * working loads; scrub/seek is best-effort on the remote server's Range
+ * support.
  */
-function externalAudioLink(href: string): MediaLink | null {
+function externalMediaLink(href: string): MediaLink | null {
   let url: URL;
   try {
     url = new URL(href);
@@ -278,7 +281,7 @@ function externalAudioLink(href: string): MediaLink | null {
   }
 
   if (url.protocol !== "https:") return null;
-  if (extensionKind(url) !== "audio") return null;
 
-  return { kind: "audio", href };
+  const kind = extensionKind(url);
+  return kind === null ? null : { kind, href };
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39802,3 +39802,75 @@ regime, and vjt measured the viewport one. The vertical rhythm is not
 asserted as a pixel budget either — any threshold would encode a font
 metric and the seed's row count. What is asserted is the row COUNT per
 fact, which is the thing that changed.
+
+---
+
+## 2026-08-12 — #1240: a cross-host media link, and the CSP half that makes the other half worth shipping
+
+`classifyMediaLink` now admits a **genuinely foreign host** — not the
+page origin, not one of the #324 server-advertised deployment aliases —
+for any https URL carrying a media extension, and returns that href
+**UNCHANGED**. #607 had already carved the shape out for audio
+(`externalAudioLink`, so a third-party `.mp3` reaches the docked
+mini-player); this generalises it to every kind and renames it
+`externalMediaLink`. The motivating case is an upload link minted by
+**another grappa instance**, tapped from this one: two hostnames of ONE
+deployment are exactly what #324's alias set covers, and two separate
+deployments are exactly what it cannot.
+
+**The ruling.** #389 asked for this outcome in July and was dropped, for
+two stated reasons. The first — server-side unfurl is SSRF-by-design and
+de-anonymises the bouncer's IP — **still stands and is untouched here**;
+nothing in this change reaches the server's network. The second was that
+the CSP would block the image anyway, which made the client change a
+no-op. That is a reason to widen the CSP, not a reason to refuse, and
+vjt ruled accordingly on 2026-08-11 (client-side URL match, `img-src`
+widened, `*` explicitly acceptable). He extended it to **video** on
+2026-08-12, on the same terms as images.
+
+**Both halves ship in one change, and that is the whole point.** The
+classifier alone trades "opens in a browser tab" for "opens an EMPTY
+modal" — strictly worse than the anchor it replaces. So `img-src 'self'
+data:` becomes `img-src 'self' data: https:`. `data:` stays (favicons,
+manifest icons, SolidJS inline SVGs would break without it).
+
+Two measured notes against the plan as written:
+
+- **`media-src` needed no edit.** The amendment asked for it to be
+  widened "alongside" `img-src` for video, but #607 already widened it to
+  `'self' blob: https:` for external audio, and that directive governs
+  `<video>` as well as `<audio>`. Cross-host video was one classifier
+  line away from working; the CSP was already there.
+- **`https:`, not `*`.** `*` was granted, and on an https page the two
+  are indistinguishable in practice — an `http:` image is refused as
+  mixed content under either. `https:` is chosen because it is the same
+  token `media-src` already carries: one directive shape to reason
+  about, and the narrower written grant costs nothing real.
+
+**What stays refused**, deliberately: `http` to a foreign host (mixed
+content — the same-host branch's scheme leniency exists for legacy
+http-minted upload links and does not extend outward); and a foreign
+extensionless `/uploads/<slug>` with a 📸 prefix, because the emoji is a
+pre-#418 same-host signal that never types a foreign link. IRC stays
+text-only — this changes what a CLICK does, never what scrollback
+renders.
+
+**Disclosure, named rather than discovered later.** Opening the modal on
+a foreign image tells that host the viewer's IP. It happens on an
+explicit click, not on arrival, so it is not the tracking-pixel problem
+#341 refused; and the plain-anchor path made the same disclosure, since
+tapping the link loaded the image either way.
+
+**The e2e had to see the real header.** `media-link-cross-host-modal`
+composes a link on a host that resolves nowhere and `page.route`s the
+bytes, which does NOT weaken the CSP claim: CSP is enforced *before* the
+request leaves the browser, so a blocked `<img>` never reaches the route
+handler — it fires `securitypolicyviolation` (the `_cspGuard` fixture
+turns that into a failure) and leaves `naturalWidth` at 0. The policy
+under test is the one the plug served through the proxy, asserted inline
+in the spec; only the remote deployment is stubbed. `videoWidth` is the
+same oracle for the video case. The `img-src 'self' data: https:` token
+also joins the `nginx-csp-range-parity` pin list, where — like
+`media-src` before it — the un-widened value is a PREFIX of the widened
+one, so pinning anything shorter would let a revert sail through
+`toContain`.

--- a/lib/grappa_web/plugs/security_headers.ex
+++ b/lib/grappa_web/plugs/security_headers.ex
@@ -41,10 +41,10 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       covers `ws://$host` / `wss://$host` per CSP3, so this is deployment-host
       agnostic — no edit when `PHX_HOST` changes); Cloudflare Turnstile +
       hCaptcha verification XHRs; `litterbox.catbox.moe` receives cic's
-      image-upload XHR. The response host `litter.catbox.moe` needs NO `img-src`
-      entry — cic never renders the image; the user clicks the link and the
-      browser opens it as its own document load outside our CSP. IRC stays
-      text only (CLAUDE.md).
+      image-upload XHR. The response host `litter.catbox.moe` needs no entry of
+      its OWN — since #1240 a click on that link renders the image in the media
+      viewer, but the widened `img-src https:` below already covers it. IRC
+      stays text only (CLAUDE.md): the modal is on-click, never on arrival.
     * `script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='
       https://challenges.cloudflare.com https://*.hcaptcha.com` — Vite modules +
       the Turnstile / hCaptcha widget loaders. Each loader injects a small
@@ -59,7 +59,16 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       dynamic style tags during interactive renders; rejecting `'unsafe-inline'`
       would break the irssi-shape theme system. hCaptcha loads its own sheet
       from `assets.hcaptcha.com`.
-    * `img-src 'self' data:` — favicons + manifest icons + SolidJS inline `data:` SVGs.
+    * `img-src 'self' data: https:` — `'self'` + `data:` for favicons, manifest
+      icons and SolidJS inline `data:` SVGs; `https:` (#1240) so the media
+      viewer's `<img>` can load a CROSS-HOST image link (an upload minted by
+      another grappa instance, or a litterbox URL) that `mediaLink.ts`
+      `externalMediaLink` admits client-side. Without it the classifier change
+      is worse than a no-op — the modal opens EMPTY. Scheme-scoped to https,
+      never http, so no mixed content; vjt granted `*` explicitly, and `https:`
+      is the narrower spelling of the same practical grant (an http image on an
+      https page is refused as mixed content either way) that keeps this
+      directive shaped like its `media-src` sibling.
     * `font-src 'self'` — system fonts only.
     * `manifest-src 'self'` — PWA install manifest.
     * `media-src 'self' blob: https:` — `blob:` for the video-upload duration
@@ -68,9 +77,11 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       fallback and direct navigation to `/uploads/<slug>` videos (the 🎬 link
       — browsers render mp4 in a media document governed by this header) needs
       it; `https:` (#607) so the docked audio mini-player can play a
-      third-party `.mp3`/`.m4a` link's `<audio>` element (external audio only,
-      admitted client-side by `mediaLink.ts` `externalAudioLink` — the widening
-      is scheme-scoped to https, never http, so no mixed content). This is a
+      third-party `.mp3`/`.m4a` link's `<audio>` element (admitted client-side
+      by `mediaLink.ts` `externalMediaLink` — the widening is scheme-scoped to
+      https, never http, so no mixed content). #1240 admitted cross-host VIDEO
+      to the viewer as well and needed NO edit here: `media-src` governs
+      `<video>` too, so the #607 `https:` token already covers it. This is a
       deliberate, documented loosening of the "restate only `'self'`" rule
       above; the plug test + `nginx-csp-range-parity.spec.ts` pin it.
     * `worker-src 'self' blob:` — the SW shell-cache worker, plus mediabunny
@@ -94,7 +105,7 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
   import Plug.Conn
 
-  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   # HTTP header names are lower-cased (HTTP/2 + Plug convention); the VALUES
   # are byte-identical to the retired nginx snippet.

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -8,10 +8,11 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
 
   The golden literal below started as the CSP that shipped byte-for-byte
   in the retired `infra/snippets/security-headers.conf`; #607 widened
-  `media-src` to `https:` (external audio in the docked mini-player) — a
-  deliberate, pinned deviation. It is intentionally hardcoded here (not
-  read from the plug) so this test PINS the plug against drift — a
-  characterization contract, not a mirror.
+  `media-src` to `https:` (external audio in the docked mini-player) and
+  #1240 widened `img-src` the same way (cross-host images in the media
+  viewer) — deliberate, pinned deviations. It is intentionally hardcoded
+  here (not read from the plug) so this test PINS the plug against drift —
+  a characterization contract, not a mirror.
   """
   use ExUnit.Case, async: true
 
@@ -20,10 +21,10 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
   alias GrappaWeb.Plugs.SecurityHeaders
 
   # The plug's Content-Security-Policy SSOT (was byte-identical to the
-  # deleted nginx snippet; #607 widened media-src to https:). If the app
-  # must change the policy, change it in ONE place (the plug) and update
-  # this pin deliberately.
-  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  # deleted nginx snippet; #607 widened media-src to https:, #1240 img-src).
+  # If the app must change the policy, change it in ONE place (the plug) and
+  # update this pin deliberately.
+  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   defp sent(status) do
     :get
@@ -32,7 +33,7 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
     |> send_resp(status, "body")
   end
 
-  test "csp/0 matches the golden pin (SSOT, incl. the #607 media-src https: widening)" do
+  test "csp/0 matches the golden pin (SSOT, incl. the #607 media-src + #1240 img-src https: widenings)" do
     assert SecurityHeaders.csp() == @golden_csp
   end
 


### PR DESCRIPTION
Refs #1240.

A media link minted by **another grappa instance** is something #324's
alias set can never cover — aliases describe one deployment answering on
several hostnames, this is two deployments. `classifyMediaLink` now
admits a genuinely foreign **https** host by URL extension alone and
returns the href **UNCHANGED** (re-rooting onto the page origin would
404), generalising #607's audio-only carve-out to image and video per
vjt's ruling of 2026-08-12.

## Both halves ship together

Shipping the classifier alone is worse than a no-op: under `img-src
'self' data:` the modal opens and the image is then CSP-blocked — an
empty dialog in place of a working browser tab. So `https:` joins
`img-src`; `data:` stays (favicons, manifest icons, inline SVGs).

Two measured corrections to the plan:

- **`media-src` needed no edit.** #607 already widened it to `'self'
  blob: https:` for external audio, and it governs `<video>` too —
  cross-host video was one classifier line away.
- **`https:` rather than the granted `*`.** On an https page the two are
  indistinguishable (an http image is mixed content under either);
  `https:` is the token `media-src` already carries, so both directives
  keep one shape.

Still refused, deliberately: foreign `http` (mixed content), and a
foreign extensionless `/uploads/<slug>` even with a 📸 prefix — the emoji
is a pre-#418 same-host signal that cannot type a foreign link. #389's
refusal of server-side unfurl is untouched; nothing here reaches the
server's network.

## Test plan

- [x] `bun run test` — 5281 passing, incl. flipped `mediaLink` /
      `ScrollbackPane` cases that previously asserted the rejection
- [x] `bun run check` — biome + tsc + tsc `-p e2e/tsconfig.json`
- [ ] `mix test` on the plug's golden CSP pin (COMPILE lane)
- [ ] `media-link-cross-host-modal.spec.ts` + the two touched media specs
      (STACK lane)

The new e2e asserts the **real served CSP**: the foreign bytes are
`page.route`-fulfilled, but CSP is enforced before the request leaves the
browser, so a blocked `<img>` never reaches the handler — it fires
`securitypolicyviolation` (the `_cspGuard` fixture fails the spec) and
leaves `naturalWidth` at 0. Only the other deployment is stubbed; the
policy under test is the one the plug served through the proxy.