### PR TITLE
cic(#1157): the five admin residuals — collapse, autojoin, enabled, fieldset, auth

### DIFF
--- a/cicchetto/e2e/tests/admin-user-networks.spec.ts
+++ b/cicchetto/e2e/tests/admin-user-networks.spec.ts
@@ -67,17 +67,21 @@ async function openUserPage(page: import("@playwright/test").Page, userId: strin
   await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
 }
 
-/** Fill and submit the `+` form for one network. */
-async function addNetwork(
+/**
+ * Give the user one network, the #1157 way: tick the section, fill the
+ * nick the bind needs, Save. There is no `+` and no network picker —
+ * every configured network already has a section, and the tick is the
+ * whole statement about access.
+ */
+async function enableNetwork(
   page: import("@playwright/test").Page,
   networkId: number,
   nick: string,
 ): Promise<void> {
-  await page.getByTestId("admin-user-network-add").click();
-  await expect(page.getByTestId("admin-user-network-add-form")).toBeVisible();
-  await page.getByTestId("admin-user-network-add-network").selectOption(String(networkId));
-  await page.getByTestId("admin-user-network-add-nick").fill(nick);
-  await page.getByTestId("admin-user-network-add-submit").click();
+  await page.getByTestId(`admin-user-network-enabled-${networkId}`).check();
+  await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+  await page.getByTestId(`admin-user-network-nick-${networkId}`).fill(nick);
+  await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 }
 
 async function createUser(token: string, name: string): Promise<string> {
@@ -184,19 +188,22 @@ test("an operator creates a user and gives it a network in one flow", async ({ p
     await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("admin-user-page-name")).toHaveText(userName);
 
-    await addNetwork(page, networkId, "flownick");
+    await enableNetwork(page, networkId, "flownick");
 
-    // The operator-visible outcome: the user now has that network.
-    const row = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(row).toBeVisible({ timeout: 10_000 });
-    await expect(row).toContainText(netSlug);
+    // The operator-visible outcome: the section for that network is
+    // ticked, and it names the network it is about.
+    const section = page.getByTestId(`admin-user-network-${networkId}`);
+    await expect(section).toContainText(netSlug);
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
+      timeout: 10_000,
+    });
 
     // And it survives a reload, so the verdict rests on the server's answer
     // rather than on the reply the form just rendered.
     userId = await findUserId(admin.token, userName);
     await page.reload();
     await openUserPage(page, userId);
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toBeVisible({
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
       timeout: 10_000,
     });
   } finally {
@@ -215,7 +222,7 @@ test("an operator creates a user and gives it a network in one flow", async ({ p
   }
 });
 
-test("admin adds a network to an existing user — the row appears", async ({ page }) => {
+test("admin gives an existing user a network — the section ticks", async ({ page }) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-add-u");
   const netSlug = unique("e2eun-add-n");
@@ -229,15 +236,17 @@ test("admin adds a network to an existing user — the row appears", async ({ pa
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    // Pre-state: the user is on no networks, so the row this test asserts on
-    // cannot be a leftover from an earlier run.
-    await expect(page.getByTestId("admin-user-networks-empty")).toBeVisible();
+    // Pre-state: the section EXISTS (it is a configured network) and is
+    // NOT ticked, so the tick this test asserts on cannot be a leftover
+    // from an earlier run. Asserting the section's ABSENCE would be the
+    // pre-#1157 claim, and is now false by construction.
+    const tick = page.getByTestId(`admin-user-network-enabled-${networkId}`);
+    await expect(tick).toBeVisible({ timeout: 10_000 });
+    await expect(tick).not.toBeChecked();
 
-    await addNetwork(page, networkId, "boundnick");
+    await enableNetwork(page, networkId, "boundnick");
 
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(tick).toBeChecked({ timeout: 10_000 });
   } finally {
     if (userId !== null && networkId !== null) {
       await unbindBestEffort(admin.token, userId, networkId);
@@ -247,7 +256,9 @@ test("admin adds a network to an existing user — the row appears", async ({ pa
   }
 });
 
-test("admin edits a network (realname change) — the row reports left_alone", async ({ page }) => {
+test("admin edits a network (realname change) — the section reports left_alone", async ({
+  page,
+}) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-edit-u");
   const netSlug = unique("e2eun-edit-n");
@@ -262,13 +273,13 @@ test("admin edits a network (realname change) — the row reports left_alone", a
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    await page.getByTestId(`admin-user-network-edit-${networkId}`).click();
-    await expect(page.getByTestId(`admin-user-network-edit-form-${networkId}`)).toBeVisible();
+    // No Edit button to press: a bound network's settings form is simply
+    // open, because the section IS the editor.
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+    await page.getByTestId(`admin-user-network-realname-${networkId}`).fill("Updated Name");
+    await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 
-    await page.getByTestId(`admin-user-network-edit-realname-${networkId}`).fill("Updated Name");
-    await page.getByTestId(`admin-user-network-edit-submit-${networkId}`).click();
-
-    // Row state, not a toast (vjt: a toast throws four values away), and the
+    // Section state, not a toast (vjt: a toast throws four values away), and the
     // raw wire token, per the operator-console policy the banners follow.
     await expect(page.getByTestId(`admin-user-network-session-action-${networkId}`)).toContainText(
       "left_alone",
@@ -283,7 +294,7 @@ test("admin edits a network (realname change) — the row reports left_alone", a
   }
 });
 
-test("admin removes a network via inline-confirm — the row goes", async ({ page }) => {
+test("admin removes a network by unticking it — the tick clears", async ({ page }) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-rm-u");
   const netSlug = unique("e2eun-rm-n");
@@ -298,15 +309,22 @@ test("admin removes a network via inline-confirm — the row goes", async ({ pag
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    const removeBtn = page.getByTestId(`admin-user-network-remove-${networkId}`);
-    await expect(removeBtn).toHaveText(/^Remove$/);
-    await removeBtn.click();
-    await expect(removeBtn).toHaveText(/^Confirm remove$/);
-    await removeBtn.click();
+    // Two steps, as before, but over the shape this page now has:
+    // unticking ARMS and the named button fires. Unticking alone must not
+    // delete anything, which is the first assertion.
+    const tick = page.getByTestId(`admin-user-network-enabled-${networkId}`);
+    await tick.uncheck();
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-user-network-remove-${networkId}`)).toBeVisible();
 
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toHaveCount(0, {
+    await page.getByTestId(`admin-user-network-remove-${networkId}`).click();
+
+    // The credential is gone: the section stays (the network is still
+    // configured) and its tick is clear.
+    await expect(page.getByTestId(`admin-user-network-remove-${networkId}`)).toHaveCount(0, {
       timeout: 10_000,
     });
+    await expect(tick).not.toBeChecked();
   } finally {
     if (userId !== null && networkId !== null) {
       await unbindBestEffort(admin.token, userId, networkId);

--- a/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
+++ b/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
@@ -1,0 +1,120 @@
+// #1157 — the dictated column 4, on a real phone.
+//
+// vjt, 2026-08-09: the row's disconnect / terminate buttons "on mobile
+// collapse into a single button with a dropdown". `AdminSessionsTab`
+// branches on `isAdminNarrow()`, which is `matchMedia("(max-width:
+// 899px)")` — and jsdom has none, so the unit file
+// (`adminSessionsActionsMenu.test.tsx`) has to SUPPLY the regime. It
+// proves the branch; it cannot prove which side of it a phone lands on.
+// That is this file's whole job, and it is why the phone case is
+// `@webkit` (the iPhone 15 device, 393px) rather than a resized desktop.
+//
+// Both sides run, deliberately. A collapse that also fired on a 1280px
+// desktop would satisfy a phone-only file, and "desktop keeps them side
+// by side" is half the dictation.
+//
+// NOTHING here confirms a verb. The two verbs on a user row stop a real
+// seeded session, and this suite shares its stack — the m9b actions spec
+// carries an `afterEach` repair hook precisely because it does fire them.
+// The claim under test is that picking from the menu ARMS a confirmation
+// instead of running it, so arming and then cancelling is not a
+// half-measure: it is the assertion.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated, EXEMPT.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { expectShellReady, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
+
+async function adminLogin(page: Page): Promise<void> {
+  const seed = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+function idFromSubjectJson(subjectJson: string): string {
+  const subject = JSON.parse(subjectJson) as { id?: string };
+  if (typeof subject.id !== "string") {
+    throw new Error(`seeded subject carries no id: ${subjectJson}`);
+  }
+  return subject.id;
+}
+
+// A USER row, which is the only shape with two verbs to collapse — a
+// visitor row carries exactly one (`rowActions`). Addressed by the
+// `user:<id>:` prefix rather than a full composite key because the
+// network id depends on seeding order.
+async function userRowKey(page: Page): Promise<string> {
+  const id = idFromSubjectJson(getSeededVjt().subjectJson);
+  const row = page.locator(`[data-testid^='admin-session-row-user:${id}:']`).first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  const testId = await row.getAttribute("data-testid");
+  if (testId === null) throw new Error("the seeded user row lost its testid");
+  return testId.replace("admin-session-row-", "");
+}
+
+test("#1157 @webkit a phone gives the row's verbs one control, and it is the menu", async ({
+  page,
+}) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  const cell = page.locator(`[data-testid='admin-session-row-${key}'] td.admin-sessions-actions`);
+  await cell.scrollIntoViewIfNeeded();
+
+  // Exactly one, painted. A cell that merely ADDED the menu beside the
+  // verbs would still show the menu.
+  await expect(cell.locator("button")).toHaveCount(1);
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toHaveCount(0);
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
+});
+
+test("#1157 @webkit the dropdown arms a verb rather than running it", async ({ page }) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  await page.getByTestId(`admin-session-actions-menu-${key}`).click();
+
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+  await expect(menu.getByText("Disconnect")).toBeVisible();
+  await expect(menu.getByText("Terminate")).toBeVisible();
+
+  await menu.getByText("Terminate").click();
+
+  // Armed, not fired: the label is the confirmation, and the menu is
+  // gone. If the pick had run the verb the row would have reloaded and
+  // this locator would be an idle "Terminate" instead.
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveText("Confirm terminate");
+  await expect(menu).toHaveCount(0);
+  // Nothing was stopped: the error banner is where a failed or refused
+  // verb lands, and a successful one would have refreshed the list.
+  await expect(page.getByTestId("admin-sessions-error")).toHaveCount(0);
+
+  // And back out, leaving the session exactly as this spec found it.
+  await page.getByTestId(`admin-session-actions-cancel-${key}`).click();
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toBeVisible();
+});
+
+test("#1157 a desktop keeps both verbs side by side and grows no menu", async ({ page }) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toHaveCount(0);
+});

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -189,39 +189,52 @@ test("admin binds a credential from the console and the session dials out", asyn
 
     // Pre-state: the user is on no networks yet, so the row this test is about
     // to assert on cannot be a leftover from an earlier run.
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).not.toBeChecked();
 
     // The bind goes through the CONSOLE, not the API — the door the operator
     // in the issue actually used, and the one that had no other door on a
     // release image (#1158).
-    await page.getByTestId("admin-user-network-add").click();
-    await expect(page.getByTestId("admin-user-network-add-form")).toBeVisible();
-    await page.getByTestId("admin-user-network-add-network").selectOption({ label: NETWORK_SLUG });
-    await page.getByTestId("admin-user-network-add-nick").fill(nick);
-    await page.getByTestId("admin-user-network-add-auth-method").selectOption("none");
-    await page.getByTestId("admin-user-network-add-submit").click();
+    // #1157 — the bind is now "tick the network's section, fill the nick,
+    // Save". The verb on the wire is the same POST; what changed is that
+    // the console no longer asks WHICH network in a select, because the
+    // section already is one.
+    await page.getByTestId(`admin-user-network-enabled-${networkId}`).check();
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+    await page.getByTestId(`admin-user-network-nick-${networkId}`).fill(nick);
+    await page.getByTestId(`admin-user-network-auth-method-${networkId}`).selectOption("none");
+    await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 
-    const row = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(row).toHaveCount(1, { timeout: 10_000 });
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
+      timeout: 10_000,
+    });
 
     // The witness. `alive` is the BEAM reading: a Session.Server exists for
-    // this (user, network). Before #1163 this cell read `BEAM has no pid` and
-    // stayed that way until the node restarted.
-    await expect(row).toContainText("alive", { timeout: 10_000 });
-    await expect(row).not.toContainText("BEAM has no pid");
+    // this (user, network). Before #1163 this badge read `BEAM has no pid`
+    // and stayed that way until the node restarted.
+    //
+    // #1157 — read off the two BADGES rather than off the whole row's text.
+    // The section now contains the settings form as well, so a substring
+    // match over it could be satisfied by a field value rather than by the
+    // reading this spec exists to take.
+    const live = page.getByTestId(`admin-user-network-live-${networkId}`);
+    const connection = page.getByTestId(`admin-user-network-connection-${networkId}`);
+    await expect(live).toHaveText("alive", { timeout: 10_000 });
 
-    // The other half of U-0: the DB intent agrees with the BEAM. A row that
-    // says `connected` is only honest when the pid above exists.
-    await expect(row).toContainText("connected");
+    // The other half of U-0: the DB intent agrees with the BEAM. A section
+    // that says `connected` is only honest when the pid above exists.
+    await expect(connection).toHaveText("connected");
 
     // Same two readings after a fresh load, so the verdict rests on a second
-    // GET /admin/credentials rather than on the bind response the tab just
+    // GET /admin/credentials rather than on the bind response the page just
     // rendered.
     await page.reload();
     await openUserPage(page, userId);
-    const reloadedRow = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
-    await expect(reloadedRow).toContainText("connected");
+    await expect(page.getByTestId(`admin-user-network-live-${networkId}`)).toHaveText("alive", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId(`admin-user-network-connection-${networkId}`)).toHaveText(
+      "connected",
+    );
   } finally {
     if (userId !== null) {
       await unbind(admin.token, userId, networkId, testInfo);

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -148,7 +148,7 @@ function adminSurfaces(vjtUserId: string): Surface[] {
         await openTab(page, "users");
         await page.getByTestId(`admin-user-networks-${vjtUserId}`).tap();
         await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
-        await expect(page.getByTestId("admin-user-networks-table")).toBeVisible({
+        await expect(page.getByTestId("admin-user-networks-card")).toBeVisible({
           timeout: 10_000,
         });
       },

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -9,6 +9,7 @@ import { AdminEmpty, AdminError } from "./admin/AdminStatus";
 import AdminTable from "./admin/AdminTable";
 import { useRefreshSlot } from "./admin/refreshSlot";
 import { renderEnded } from "./admin/sessionLogFormat";
+import ContextMenu from "./ContextMenu";
 import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminSubjectRow,
@@ -36,6 +37,7 @@ import {
   adminTerminateSession,
 } from "./lib/api";
 import { token } from "./lib/auth";
+import { isAdminNarrow } from "./lib/theme";
 
 // #1157 — the unified admin Sessions view. The Visitors tab is gone;
 // this one lists ACTIVE AND INACTIVE sessions for both subject kinds.
@@ -102,6 +104,29 @@ function confirmKey(key: string, kind: ActionKind | "delete"): string {
   return `${key}:${kind}`;
 }
 
+// #1157 — which verbs the actions cell renders AS BUTTONS. Dictated
+// (vjt, 2026-08-09): below 900px the cell holds ONE control and the
+// verbs live behind a dropdown. Above it they stay side by side.
+//
+// A one-verb row is left alone: it already IS one control, and wrapping
+// it in a menu would charge a tap to reach a list of one. So the rule
+// the cell keeps at every width is "one control", not "always a menu".
+//
+// `armed` is the escape from the obvious bug in that: `InlineConfirmButton`
+// is sticky and the PARENT owns `armed`, so once a verb is picked its
+// confirmation has to be on screen — otherwise the menu would arm a
+// button the operator cannot see, let alone confirm.
+function cellActions(
+  row: AdminSubjectRow,
+  narrow: boolean,
+  armed: ActionKind | null,
+): ActionKind[] {
+  const verbs = rowActions(row);
+  if (!narrow) return verbs;
+  if (armed !== null) return [armed];
+  return verbs.length > 1 ? [] : verbs;
+}
+
 function renderCap(cap: number | null): string {
   // Mirrors the AdminNetworksTab cap-cell convention: `null` is the
   // "unlimited" sentinel per `Networks.update_network_caps/2`.
@@ -120,6 +145,15 @@ const AdminSessionsTab: Component = () => {
   // tab's drill-in to `AdminUserPage`, and deliberately not a route: the
   // admin console has none.
   const [endedOpen, setEndedOpen] = createSignal(false);
+  // #1157 — the open row's verb dropdown, anchored to the button that
+  // opened it. Anchored to the BUTTON RECT rather than the pointer so a
+  // keyboard activation (clientX/Y both 0) does not open it in the
+  // viewport's top-left corner.
+  const [actionsMenu, setActionsMenu] = createSignal<{
+    key: string;
+    x: number;
+    y: number;
+  } | null>(null);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
 
@@ -141,12 +175,22 @@ const AdminSessionsTab: Component = () => {
   const live = createMemo<AdminSubjectRow[]>(() => liveSessions(rows()));
   const ended = createMemo(() => endedSessions(rows()));
 
+  /** The verb this row is currently asking the operator to confirm. */
+  const armedKind = (row: AdminSubjectRow): ActionKind | null =>
+    rowActions(row).find((kind) => confirmingKey() === confirmKey(row.key, kind)) ?? null;
+
+  /** The row shows the dropdown instead of its verbs. */
+  const collapsed = (row: AdminSubjectRow): boolean =>
+    isAdminNarrow() && rowActions(row).length > 1;
+
   const refresh = async (): Promise<void> => {
     const t = token();
     if (t === null) return;
     setLoading(true);
     setError(null);
     setConfirmingKey(null);
+    // The menu names one row's verbs; the refresh may take that row away.
+    setActionsMenu(null);
     try {
       // Five endpoints, one table. The two row-backed ones supply the
       // rows, /admin/sessions supplies the live join, /admin/networks
@@ -420,7 +464,7 @@ const AdminSessionsTab: Component = () => {
                               class="admin-sessions-actions adm-table-sticky-actions"
                               data-label="actions"
                             >
-                              <For each={rowActions(row)}>
+                              <For each={cellActions(row, isAdminNarrow(), armedKind(row))}>
                                 {(kind) => (
                                   <InlineConfirmButton
                                     idleLabel={ACTION_LABEL[kind]}
@@ -433,6 +477,40 @@ const AdminSessionsTab: Component = () => {
                                   />
                                 )}
                               </For>
+                              <Show when={collapsed(row) && armedKind(row) === null}>
+                                <button
+                                  type="button"
+                                  class="adm-btn"
+                                  aria-haspopup="menu"
+                                  aria-label={`actions for ${renderWho(row)}`}
+                                  onClick={(e) => {
+                                    const box = e.currentTarget.getBoundingClientRect();
+                                    setActionsMenu({
+                                      key: row.key,
+                                      x: box.left,
+                                      y: box.bottom,
+                                    });
+                                  }}
+                                  data-testid={`admin-session-actions-menu-${row.key}`}
+                                >
+                                  Actions ▾
+                                </button>
+                              </Show>
+                              {/* The way back out of an armed verb. On desktop
+                              the sibling verb's idle button does this job —
+                              arming one disarms the other — but the collapse
+                              took the sibling away, and the button the
+                              operator tapped to get here went with it. */}
+                              <Show when={collapsed(row) && armedKind(row) !== null}>
+                                <button
+                                  type="button"
+                                  class="adm-btn"
+                                  onClick={() => setConfirmingKey(null)}
+                                  data-testid={`admin-session-actions-cancel-${row.key}`}
+                                >
+                                  Cancel
+                                </button>
+                              </Show>
                               {/* An empty cell reads as a rendering bug. The
                               dash says the absence is the answer. */}
                               <Show when={rowActions(row).length === 0}>—</Show>
@@ -479,6 +557,32 @@ const AdminSessionsTab: Component = () => {
             </AdminCard>
           </Show>
         </div>
+      </Show>
+
+      {/* #1157 — the collapsed cell's dropdown. Reuses the shell the
+          long-press menus use (portal, backdrop, Escape, measured
+          flip/clamp) rather than growing a second popover convention in
+          the console: what differs between them is the item list, which
+          is exactly the part this supplies.
+
+          Picking an item ARMS the verb — the shell closes itself on an
+          action — and the row's own confirmation is what runs it. */}
+      <Show when={actionsMenu()}>
+        {(menu) => (
+          <Show when={live().find((row) => row.key === menu().key)}>
+            {(row) => (
+              <ContextMenu
+                position={{ x: menu().x, y: menu().y }}
+                onClose={() => setActionsMenu(null)}
+                items={rowActions(row()).map((kind) => ({
+                  label: ACTION_LABEL[kind],
+                  enabled: true,
+                  action: () => setConfirmingKey(confirmKey(row().key, kind)),
+                }))}
+              />
+            )}
+          </Show>
+        )}
       </Show>
     </div>
   );

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -527,12 +527,12 @@ const AdminSessionsTab: Component = () => {
                             >
                               <AdminFacts facts={detailFacts(row)} />
                               <Show when={row.visitor !== null}>
-                                <div class="admin-session-danger">
+                                <div class="adm-danger-strip">
                                   {/* Named for what it destroys. The verb is
                                   identity-wide: it deletes the visitor
                                   and every one of its network rows, not
                                   the row this panel hangs off. */}
-                                  <span class="admin-session-danger-note">
+                                  <span class="adm-danger-note">
                                     deletes the whole visitor identity, on every network
                                   </span>
                                   <InlineConfirmButton

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -1,15 +1,11 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
-import AdminDetailPanel from "./admin/AdminDetailPanel";
-import AdminFacts from "./admin/AdminFacts";
-import AdminRowName from "./admin/AdminRowName";
 import { AdminEmpty, AdminError, AdminLoading } from "./admin/AdminStatus";
-import AdminTable from "./admin/AdminTable";
 import { connectionTone } from "./admin/connectionTone";
-import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminCredential,
+  type AdminCredentialUpdate,
   type AdminNetwork,
   type AdminUser,
   ApiError,
@@ -25,12 +21,11 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 
 // #1158 — one user, one page, and it owns that user's network access.
 //
-// This replaces the Credentials tab, which was a flat list of every
+// This replaced the Credentials tab, which was a flat list of every
 // (user, network) binding in the database fronted by a form whose first
 // two fields were "which user" and "which network". vjt's ruling: the
-// operator's object is the USER, adding a network is a `+` and removing
-// one is a button, and the old tab disappears as an operator surface.
-// The user is the page, so nothing here asks which user.
+// operator's object is the USER. The user is the page, so nothing here
+// asks which user.
 //
 // Reached from the Users tab, which owns the signal that swaps its list
 // for this page. Deliberately NOT a route: the admin console has no
@@ -38,6 +33,27 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 // an open product question. Answering it later means adding a route,
 // which is additive; guessing it now would mean inventing the console's
 // first deep link as a side effect of a credentials cleanup.
+//
+// #1157 — and the "bind a credential" flow is gone with it. vjt:
+// *"niente flusso bind credential; al suo posto una sezione per rete
+// configurata con una checkbox `enabled`, e quando e' abilitata compare
+// il form di impostazioni di quella rete."*
+//
+// So the page no longer lists the networks the user HAS beside a `+`
+// offering the ones it has not. It lists every network the server has
+// configured, once, and the checkbox is the whole statement about
+// access. That collapses three surfaces — an add form, an inline edit
+// form, and a per-row detail panel — into one form per section, because
+// they only ever differed in which subset of the same fields they showed
+// and in whether the answer went out as a POST or a PATCH.
+//
+// The checkbox is NOT a write. Enabling reveals the settings form and
+// nothing reaches the server until Save, because a bind needs a nick and
+// a checkbox cannot supply one. Disabling a network that IS bound is
+// destructive — it deletes the credential and stops the session — so it
+// arms rather than fires: the box goes unchecked and the section asks.
+// That is the same two-step as the inline-confirm buttons elsewhere in
+// the console, spread across the two controls this shape already has.
 //
 // Data comes from the endpoints that already exist — no composite
 // create-user-and-bind POST (vjt: two writes, client-driven).
@@ -47,12 +63,10 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 // another user's networks on this user's page, which is why the unit
 // suite mounts with a foreign credential in every fetch.
 //
-// `session_action` is per-ROW state, never a toast (vjt: a toast throws
-// away four values). It carries all four — `spawned` / `not_spawned`
-// from the POST, `left_alone` / `stopped` from the PATCH — plus
-// `session_error`, the only field that says why a bind did not dial.
-// The tab this replaces surfaced two of the four, and only for the
-// PATCH: its bind handler dropped the POST reply on the floor.
+// `session_action` is per-SECTION state, never a toast (vjt: a toast
+// throws away four values). It carries all four — `spawned` /
+// `not_spawned` from the POST, `left_alone` / `stopped` from the PATCH —
+// plus `session_error`, the only field that says why a bind did not dial.
 //
 // Raw wire tokens on purpose, per the operator-console policy
 // (AdminSettingsTab lines 33-35, #943): the operator reads the same
@@ -66,30 +80,21 @@ export type Props = {
   onBack: () => void;
 };
 
-type AddForm = {
-  network_id: string;
+/** The settings a credential carries, as the form holds them. */
+type NetworkForm = {
   nick: string;
+  realname: string;
+  sasl_user: string;
   auth_method: string;
   password: string;
-  sasl_user: string;
-  realname: string;
 };
 
-const EMPTY_ADD: AddForm = {
-  network_id: "",
+const EMPTY_FORM: NetworkForm = {
   nick: "",
+  realname: "",
+  sasl_user: "",
   auth_method: "none",
   password: "",
-  sasl_user: "",
-  realname: "",
-};
-
-type EditForm = {
-  nick: string;
-  realname: string;
-  sasl_user: string;
-  auth_method: string;
-  password: string;
 };
 
 /** What the last write did to the live session, for one network. */
@@ -98,29 +103,54 @@ type SessionOutcome = {
   error: NonNullable<AdminCredential["session_error"]> | null;
 };
 
-// network + nick + auth + connection + live + actions. Feeds the detail
-// row's `colspan`; derived from the count so adding a column cannot
-// silently desync it.
-const NETWORK_COLUMNS = 6;
+// The server's truth for a bound network, as a draft. `password` starts
+// empty at every seeding: the stored one is write-only (encrypted at
+// rest, never returned), so a blank box means "leave it alone" and
+// anything typed means "replace it".
+function formOf(c: AdminCredential): NetworkForm {
+  return {
+    nick: c.nick,
+    realname: c.realname ?? "",
+    sasl_user: c.sasl_user ?? "",
+    auth_method: c.auth_method,
+    password: "",
+  };
+}
+
+// Only what the operator changed goes on the wire: the server keys the
+// session kill off the CHANGE SET, so sending an unchanged password
+// would stop a live session for nothing.
+function patchOf(c: AdminCredential, f: NetworkForm): AdminCredentialUpdate {
+  const patch: AdminCredentialUpdate = {};
+  if (f.nick !== c.nick) patch.nick = f.nick;
+  if (f.realname !== (c.realname ?? "")) patch.realname = f.realname;
+  if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
+  if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
+  if (f.password !== "") patch.password = f.password;
+  return patch;
+}
 
 const AdminUserPage: Component<Props> = (props) => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
   const [networks, setNetworks] = createSignal<AdminNetwork[]>([]);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
+  const [submitting, setSubmitting] = createSignal<number | null>(null);
 
-  const [adding, setAdding] = createSignal(false);
-  const [addForm, setAddForm] = createSignal<AddForm>({ ...EMPTY_ADD });
-  const [submitting, setSubmitting] = createSignal(false);
+  // The draft per network, seeded lazily from the credential. Absent
+  // means "not touched since the last fetch", which is what lets a
+  // successful save fall back to the server's own answer by simply
+  // dropping the entry.
+  const [forms, setForms] = createSignal<Record<number, NetworkForm>>({});
+  // Enabled by the operator, not yet written — a bind needs a nick.
+  const [pendingEnable, setPendingEnable] = createSignal<Record<number, boolean>>({});
+  // The one network whose removal is armed. Single, like every other
+  // confirm in the console: two armed destructive verbs on one screen is
+  // how the wrong one gets pressed.
+  const [pendingDisable, setPendingDisable] = createSignal<number | null>(null);
 
-  const [editingId, setEditingId] = createSignal<number | null>(null);
-  const [editForm, setEditForm] = createSignal<EditForm | null>(null);
-
-  const [confirmingId, setConfirmingId] = createSignal<number | null>(null);
-  const [detailId, setDetailId] = createSignal<number | null>(null);
-
-  // Keyed by network id, which is the row. A write reports on the row it
-  // touched and says nothing about any other.
+  // Keyed by network id, which is the section. A write reports on the
+  // section it touched and says nothing about any other.
   const [outcomes, setOutcomes] = createSignal<Record<number, SessionOutcome>>({});
 
   /** This user's networks. The list endpoint returns everyone's. */
@@ -128,18 +158,53 @@ const AdminUserPage: Component<Props> = (props) => {
     (credentials() ?? []).filter((c) => c.user_id === props.user.id),
   );
 
-  /** Networks the user is not on yet — the only ones `+` can add. */
-  const addable = createMemo<AdminNetwork[]>(() => {
-    const taken = new Set(mine().map((c) => c.network_id));
-    return networks().filter((n) => !taken.has(n.id));
-  });
+  const credOf = (networkId: number): AdminCredential | undefined =>
+    mine().find((c) => c.network_id === networkId);
+
+  const formFor = (networkId: number): NetworkForm => {
+    const draft = forms()[networkId];
+    if (draft !== undefined) return draft;
+    const c = credOf(networkId);
+    return c === undefined ? { ...EMPTY_FORM } : formOf(c);
+  };
+
+  const setForm = (networkId: number, patch: Partial<NetworkForm>): void => {
+    setForms({ ...forms(), [networkId]: { ...formFor(networkId), ...patch } });
+  };
+
+  const clearForm = (networkId: number): void => {
+    const { [networkId]: _gone, ...rest } = forms();
+    setForms(rest);
+  };
+
+  /** The section shows its settings form. */
+  const enabled = (networkId: number): boolean => {
+    if (pendingDisable() === networkId) return false;
+    return credOf(networkId) !== undefined || pendingEnable()[networkId] === true;
+  };
+
+  /** What Save would send to a BOUND network; `null` when unbound. */
+  const pending = (networkId: number): AdminCredentialUpdate | null => {
+    const c = credOf(networkId);
+    if (c === undefined) return null;
+    return patchOf(c, formFor(networkId));
+  };
+
+  const savable = (networkId: number): boolean => {
+    if (submitting() !== null) return false;
+    if (formFor(networkId).nick.trim() === "") return false;
+    const patch = pending(networkId);
+    // Unbound: Save IS the bind, and a nick is all it needs. Bound: only
+    // when something actually changed, because an empty PATCH would ask
+    // the server to decide whether to stop a session over nothing.
+    return patch === null || Object.keys(patch).length > 0;
+  };
 
   const refresh = async (): Promise<void> => {
     const t = token();
     if (t === null) return;
     setLoading(true);
     setError(null);
-    setConfirmingId(null);
     try {
       const [creds, nets] = await Promise.all([adminListCredentials(t), adminListNetworks(t)]);
       setCredentials(creds);
@@ -160,104 +225,82 @@ const AdminUserPage: Component<Props> = (props) => {
     });
   };
 
-  const onAdd = async (e: Event): Promise<void> => {
+  const onToggle = (net: AdminNetwork): void => {
+    const id = net.id;
+    if (pendingDisable() === id) {
+      // Re-ticking a network whose removal was armed is the cancel.
+      setPendingDisable(null);
+      return;
+    }
+    if (credOf(id) !== undefined) {
+      setPendingDisable(id);
+      return;
+    }
+    if (pendingEnable()[id] === true) {
+      const { [id]: _gone, ...rest } = pendingEnable();
+      setPendingEnable(rest);
+      clearForm(id);
+      return;
+    }
+    setPendingEnable({ ...pendingEnable(), [id]: true });
+  };
+
+  const onSave = async (net: AdminNetwork, e: Event): Promise<void> => {
     e.preventDefault();
     const t = token();
     if (t === null) return;
-    const f = addForm();
-    if (f.network_id === "" || f.nick === "") return;
-    const networkId = Number.parseInt(f.network_id, 10);
-    if (!Number.isFinite(networkId)) {
-      setError("add network: invalid network_id");
-      return;
-    }
-    setSubmitting(true);
+    const id = net.id;
+    const f = formFor(id);
+    const existing = credOf(id);
+    setSubmitting(id);
     setError(null);
     try {
-      const created = await adminBindCredential(t, {
-        user_id: props.user.id,
-        network_id: networkId,
-        nick: f.nick,
-        auth_method: f.auth_method,
-        password: f.password === "" ? undefined : f.password,
-        sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
-        realname: f.realname === "" ? undefined : f.realname,
-      });
-      recordOutcome(networkId, created);
-      setAddForm({ ...EMPTY_ADD });
-      setAdding(false);
+      const saved =
+        existing === undefined
+          ? await adminBindCredential(t, {
+              user_id: props.user.id,
+              network_id: id,
+              nick: f.nick,
+              auth_method: f.auth_method,
+              password: f.password === "" ? undefined : f.password,
+              sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
+              realname: f.realname === "" ? undefined : f.realname,
+            })
+          : await adminUpdateCredential(t, props.user.id, id, patchOf(existing, f));
+      recordOutcome(id, saved);
+      // Drop the draft rather than rewriting it: the section then reads
+      // the server's own answer, and the typed password leaves with it.
+      clearForm(id);
+      const { [id]: _gone, ...rest } = pendingEnable();
+      setPendingEnable(rest);
       await refresh();
     } catch (err) {
-      setError(`add network: ${operatorApiError(err, "request_failed")}`);
+      setError(`${net.slug}: ${operatorApiError(err, "request_failed")}`);
     } finally {
-      setSubmitting(false);
+      setSubmitting(null);
     }
   };
 
-  const onArmEdit = (c: AdminCredential): void => {
-    setEditingId(c.network_id);
-    setEditForm({
-      nick: c.nick,
-      realname: c.realname ?? "",
-      sasl_user: c.sasl_user ?? "",
-      auth_method: c.auth_method,
-      password: "",
-    });
-  };
-
-  const onCancelEdit = (): void => {
-    setEditingId(null);
-    setEditForm(null);
-  };
-
-  const onSubmitEdit = async (c: AdminCredential): Promise<void> => {
+  const onRemove = async (net: AdminNetwork): Promise<void> => {
     const t = token();
     if (t === null) return;
-    const f = editForm();
-    if (f === null) return;
-    // Only what the operator changed goes on the wire: the server keys
-    // the session kill off the CHANGE SET, so sending an unchanged
-    // password would stop a live session for nothing.
-    const patch: Parameters<typeof adminUpdateCredential>[3] = {};
-    if (f.nick !== c.nick) patch.nick = f.nick;
-    if (f.realname !== (c.realname ?? "")) patch.realname = f.realname;
-    if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
-    if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
-    if (f.password !== "") patch.password = f.password;
-    if (Object.keys(patch).length === 0) {
-      onCancelEdit();
-      return;
-    }
+    const id = net.id;
     setError(null);
     try {
-      const updated = await adminUpdateCredential(t, props.user.id, c.network_id, patch);
-      recordOutcome(c.network_id, updated);
-      onCancelEdit();
-      await refresh();
-    } catch (err) {
-      setError(`edit ${c.network_slug}: ${operatorApiError(err, "request_failed")}`);
-    }
-  };
-
-  const onRemove = async (c: AdminCredential): Promise<void> => {
-    const t = token();
-    if (t === null) return;
-    setError(null);
-    try {
-      await adminUnbindCredential(t, props.user.id, c.network_id);
+      await adminUnbindCredential(t, props.user.id, id);
       const cur = credentials();
       if (cur !== null) {
-        setCredentials(
-          cur.filter((x) => !(x.user_id === props.user.id && x.network_id === c.network_id)),
-        );
+        setCredentials(cur.filter((x) => !(x.user_id === props.user.id && x.network_id === id)));
       }
-      // The row is gone; a verdict about its session would outlive it.
-      const { [c.network_id]: _gone, ...rest } = outcomes();
-      setOutcomes(rest);
-      setConfirmingId(null);
+      // The credential is gone; a verdict about its session would
+      // outlive it, and so would a draft of its settings.
+      const { [id]: _goneOutcome, ...restOutcomes } = outcomes();
+      setOutcomes(restOutcomes);
+      clearForm(id);
+      setPendingDisable(null);
     } catch (err) {
-      setError(`remove ${c.network_slug}: ${operatorApiError(err, "request_failed")}`);
-      setConfirmingId(null);
+      setError(`remove ${net.slug}: ${operatorApiError(err, "request_failed")}`);
+      setPendingDisable(null);
     }
   };
 
@@ -297,391 +340,217 @@ const AdminUserPage: Component<Props> = (props) => {
         <Show when={credentials() !== null}>
           <AdminCard
             title="Networks"
-            subtitle="CONNECTION is the DB state, LIVE is the BEAM pid — they can disagree"
+            subtitle="one section per configured network — tick to give this user access; CONNECTION is the DB state, LIVE is the BEAM pid, and they can disagree"
+            data-testid="admin-user-networks-card"
             actions={
-              <>
-                <button
-                  type="button"
-                  class="adm-btn"
-                  disabled={loading()}
-                  onClick={() => {
-                    void refresh();
-                  }}
-                  aria-label="refresh this user's networks"
-                  data-testid="admin-user-networks-refresh"
-                >
-                  Refresh
-                </button>
-                {/* The `+` opens the form; it is in the card head rather
-                    than in the table because the first network a user
-                    gets is added when there is no table to put it in. */}
-                <button
-                  type="button"
-                  class="adm-btn adm-btn--ok"
-                  disabled={addable().length === 0}
-                  onClick={() => setAdding(!adding())}
-                  aria-label="add a network for this user"
-                  data-testid="admin-user-network-add"
-                >
-                  + Add network
-                </button>
-              </>
+              <button
+                type="button"
+                class="adm-btn"
+                disabled={loading()}
+                onClick={() => {
+                  void refresh();
+                }}
+                aria-label="refresh this user's networks"
+                data-testid="admin-user-networks-refresh"
+              >
+                Refresh
+              </button>
             }
           >
-            <Show when={adding()}>
-              <form
-                class="admin-user-network-add-form adm-form-grid"
-                onSubmit={(e) => {
-                  void onAdd(e);
-                }}
-                data-testid="admin-user-network-add-form"
-              >
-                <select
-                  aria-label="network"
-                  value={addForm().network_id}
-                  onChange={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      network_id: (e.currentTarget as HTMLSelectElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-network"
-                  required
-                >
-                  <option value="">— network —</option>
-                  <For each={addable()}>
-                    {(n) => <option value={String(n.id)}>{n.slug}</option>}
-                  </For>
-                </select>
-                <input
-                  placeholder="nick"
-                  aria-label="nick"
-                  type="text"
-                  value={addForm().nick}
-                  onInput={(e) =>
-                    setAddForm({ ...addForm(), nick: (e.currentTarget as HTMLInputElement).value })
-                  }
-                  data-testid="admin-user-network-add-nick"
-                  required
+            <Show
+              when={networks().length > 0}
+              fallback={
+                // Not "this user is on no networks": with one section per
+                // configured network, an empty page means the SERVER has
+                // none — a different thing, fixed somewhere else.
+                <AdminEmpty
+                  message="no networks are configured on this server"
+                  testId="admin-user-networks-empty"
                 />
-                <select
-                  aria-label="auth method"
-                  value={addForm().auth_method}
-                  onChange={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      auth_method: (e.currentTarget as HTMLSelectElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-auth-method"
-                >
-                  <For each={IRCAUTH_FSMAUTH_METHOD}>
-                    {(m) => <option value={m}>auth: {m}</option>}
-                  </For>
-                </select>
-                <input
-                  placeholder="password"
-                  aria-label="password"
-                  type="password"
-                  value={addForm().password}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      password: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-password"
-                />
-                <input
-                  placeholder="sasl user"
-                  aria-label="sasl user"
-                  type="text"
-                  value={addForm().sasl_user}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      sasl_user: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-sasl-user"
-                />
-                <input
-                  placeholder="realname"
-                  aria-label="realname"
-                  type="text"
-                  value={addForm().realname}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      realname: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-realname"
-                />
-                <div class="adm-form-grid-actions">
-                  <button
-                    type="submit"
-                    class="adm-btn adm-btn--ok"
-                    disabled={submitting() || addForm().network_id === "" || addForm().nick === ""}
-                    data-testid="admin-user-network-add-submit"
+              }
+            >
+              <For each={networks()}>
+                {(net) => (
+                  <section
+                    class="adm-subsection admin-user-network"
+                    data-testid={`admin-user-network-${net.id}`}
                   >
-                    Add
-                  </button>
-                  <button
-                    type="button"
-                    class="adm-btn adm-btn--danger"
-                    onClick={() => {
-                      setAdding(false);
-                      setAddForm({ ...EMPTY_ADD });
-                    }}
-                    data-testid="admin-user-network-add-cancel"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </Show>
-
-            <Show when={mine().length === 0}>
-              <AdminEmpty
-                message="this user is on no networks"
-                testId="admin-user-networks-empty"
-              />
-            </Show>
-
-            <Show when={mine().length > 0}>
-              <AdminTable data-testid="admin-user-networks-table">
-                <thead>
-                  <tr>
-                    <th class="adm-table-grow">network</th>
-                    {/* Secondary below 900px — they move into the row's
-                        detail panel. See `AdminFacts`. */}
-                    <th class="adm-col-detail">nick</th>
-                    <th class="adm-col-detail">auth</th>
-                    <th class="adm-col-detail">connection</th>
-                    {/* LIVE stays on a phone: "the BEAM has no pid for
-                        this" is the one reading worth seeing without a
-                        tap. */}
-                    <th>live</th>
-                    <th class="adm-table-sticky-actions">actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <For each={mine()}>
-                    {(c) => (
-                      <>
-                        <tr
-                          class="admin-user-network-row"
-                          data-testid={`admin-user-network-row-${c.network_id}`}
-                        >
-                          <td class="adm-cell-title">
-                            <AdminRowName
-                              open={detailId() === c.network_id}
-                              onToggle={() =>
-                                setDetailId(detailId() === c.network_id ? null : c.network_id)
-                              }
-                              label={`details for ${c.network_slug}`}
-                              testId={`admin-user-network-details-${c.network_id}`}
+                    <div class="admin-user-network-head">
+                      <label class="adm-check">
+                        <input
+                          type="checkbox"
+                          checked={enabled(net.id)}
+                          onChange={() => onToggle(net)}
+                          aria-label={`${props.user.name} may use ${net.slug}`}
+                          data-testid={`admin-user-network-enabled-${net.id}`}
+                        />
+                        <span class="adm-subsection-title">{net.slug}</span>
+                      </label>
+                      {/* Both projections, always, for a bound network —
+                          `live: BEAM has no pid` against `connection:
+                          connected` IS the divergence signal, and deriving
+                          either from the other would erase it. */}
+                      <Show when={credOf(net.id)}>
+                        {(c) => (
+                          <span class="admin-user-network-state">
+                            <AdminBadge
+                              tone={connectionTone(c().connection_state)}
+                              testId={`admin-user-network-connection-${net.id}`}
                             >
-                              {c.network_slug}
-                            </AdminRowName>
-                            <Show when={outcomes()[c.network_id]}>
-                              {(outcome) => (
-                                <p
-                                  class="adm-card-sub"
-                                  data-testid={`admin-user-network-session-action-${c.network_id}`}
-                                >
-                                  session: {outcome().action}
-                                  <Show when={outcome().error !== null}> ({outcome().error})</Show>
-                                </p>
-                              )}
-                            </Show>
-                          </td>
-                          <td class="adm-col-detail" data-label="nick">
-                            {c.nick}
-                          </td>
-                          <td class="adm-col-detail" data-label="auth">
-                            {c.auth_method}
-                          </td>
-                          <td class="adm-col-detail" data-label="connection">
-                            <AdminBadge tone={connectionTone(c.connection_state)}>
-                              {c.connection_state}
+                              {c().connection_state}
                             </AdminBadge>
-                          </td>
-                          <td data-label="live">
                             <AdminBadge
                               tone={
-                                c.live_state === null
+                                c().live_state === null
                                   ? "neutral"
-                                  : c.live_state.alive
+                                  : c().live_state?.alive === true
                                     ? "ok"
                                     : "danger"
                               }
+                              testId={`admin-user-network-live-${net.id}`}
                             >
-                              {c.live_state === null
+                              {c().live_state === null
                                 ? "BEAM has no pid"
-                                : c.live_state.alive
+                                : c().live_state?.alive === true
                                   ? "alive"
                                   : "pid dead"}
                             </AdminBadge>
-                          </td>
-                          <td
-                            class="admin-user-network-actions adm-table-sticky-actions"
-                            data-label="actions"
+                          </span>
+                        )}
+                      </Show>
+                    </div>
+
+                    <Show when={outcomes()[net.id]}>
+                      {(outcome) => (
+                        <p
+                          class="adm-card-sub"
+                          data-testid={`admin-user-network-session-action-${net.id}`}
+                        >
+                          session: {outcome().action}
+                          <Show when={outcome().error !== null}> ({outcome().error})</Show>
+                        </p>
+                      )}
+                    </Show>
+
+                    {/* The second half of the two-step. Unticking a bound
+                        network is the arm; this is the fire, and it names
+                        what it destroys rather than repeating the word on
+                        the box. */}
+                    <Show when={pendingDisable() === net.id}>
+                      <div class="adm-danger-strip">
+                        <span class="adm-danger-note">
+                          removes this user's credential for {net.slug} and stops its session
+                        </span>
+                        <button
+                          type="button"
+                          class="adm-btn adm-btn--danger"
+                          onClick={() => {
+                            void onRemove(net);
+                          }}
+                          data-testid={`admin-user-network-remove-${net.id}`}
+                        >
+                          Remove access
+                        </button>
+                        <button
+                          type="button"
+                          class="adm-btn"
+                          onClick={() => setPendingDisable(null)}
+                          data-testid={`admin-user-network-keep-${net.id}`}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </Show>
+
+                    <Show when={enabled(net.id)}>
+                      <form
+                        class="adm-form-grid"
+                        onSubmit={(e) => {
+                          void onSave(net, e);
+                        }}
+                        data-testid={`admin-user-network-form-${net.id}`}
+                      >
+                        <input
+                          placeholder="nick"
+                          aria-label={`nick on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).nick}
+                          onInput={(e) =>
+                            setForm(net.id, { nick: (e.currentTarget as HTMLInputElement).value })
+                          }
+                          data-testid={`admin-user-network-nick-${net.id}`}
+                          required
+                        />
+                        <input
+                          placeholder="realname"
+                          aria-label={`realname on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).realname}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              realname: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-realname-${net.id}`}
+                        />
+                        <input
+                          placeholder="sasl user"
+                          aria-label={`sasl user on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).sasl_user}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              sasl_user: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-sasl-user-${net.id}`}
+                        />
+                        <select
+                          aria-label={`auth method on ${net.slug}`}
+                          value={formFor(net.id).auth_method}
+                          onChange={(e) =>
+                            setForm(net.id, {
+                              auth_method: (e.currentTarget as HTMLSelectElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-auth-method-${net.id}`}
+                        >
+                          <For each={IRCAUTH_FSMAUTH_METHOD}>
+                            {(m) => <option value={m}>auth: {m}</option>}
+                          </For>
+                        </select>
+                        <input
+                          placeholder="password"
+                          aria-label={`password on ${net.slug}`}
+                          type="password"
+                          value={formFor(net.id).password}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              password: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-password-${net.id}`}
+                        />
+                        <div class="adm-form-grid-actions">
+                          <button
+                            type="submit"
+                            class="adm-btn adm-btn--ok"
+                            disabled={!savable(net.id)}
+                            data-testid={`admin-user-network-save-${net.id}`}
                           >
-                            <button
-                              type="button"
-                              class="adm-btn"
-                              onClick={() => onArmEdit(c)}
-                              data-testid={`admin-user-network-edit-${c.network_id}`}
-                            >
-                              Edit
-                            </button>
-                            <InlineConfirmButton
-                              idleLabel="Remove"
-                              confirmLabel="Confirm remove"
-                              armed={confirmingId() === c.network_id}
-                              onArm={() => setConfirmingId(c.network_id)}
-                              onConfirm={() => onRemove(c)}
-                              testId={`admin-user-network-remove-${c.network_id}`}
-                              extraClass="delete-btn"
-                            />
-                          </td>
-                        </tr>
-                        <Show when={detailId() === c.network_id}>
-                          <AdminDetailPanel
-                            title={c.network_slug}
-                            subtitle="the columns the table drops on a phone"
-                            onClose={() => setDetailId(null)}
-                            closeLabel="close network details"
-                            columns={NETWORK_COLUMNS}
-                            data-testid={`admin-user-network-detail-${c.network_id}`}
-                          >
-                            <AdminFacts
-                              facts={[
-                                { label: "nick", value: c.nick },
-                                { label: "auth", value: c.auth_method },
-                                {
-                                  label: "connection",
-                                  value: (
-                                    <AdminBadge tone={connectionTone(c.connection_state)}>
-                                      {c.connection_state}
-                                    </AdminBadge>
-                                  ),
-                                },
-                              ]}
-                            />
-                          </AdminDetailPanel>
-                        </Show>
-                        {/* Both halves matter: `editingId` names the row and
-                            `editForm` holds the draft, set in that order, and
-                            the fields read the draft unconditionally. */}
-                        <Show when={editForm() !== null && editingId() === c.network_id}>
-                          <AdminDetailPanel
-                            title={`Edit ${c.network_slug}`}
-                            subtitle="only changed fields are sent; a password or auth-method change stops the live session"
-                            onClose={onCancelEdit}
-                            closeLabel="cancel network edit"
-                            columns={NETWORK_COLUMNS}
-                            data-testid={`admin-user-network-edit-form-${c.network_id}`}
-                          >
-                            <form
-                              class="adm-form-grid"
-                              onSubmit={(e) => {
-                                e.preventDefault();
-                                void onSubmitEdit(c);
-                              }}
-                            >
-                              <NetworkEditFields
-                                form={editForm() as EditForm}
-                                onChange={(next) => setEditForm(next)}
-                                networkId={c.network_id}
-                              />
-                              <div class="adm-form-grid-actions">
-                                <button
-                                  type="submit"
-                                  class="adm-btn adm-btn--ok"
-                                  data-testid={`admin-user-network-edit-submit-${c.network_id}`}
-                                >
-                                  Save
-                                </button>
-                                <button
-                                  type="button"
-                                  class="adm-btn adm-btn--danger"
-                                  onClick={onCancelEdit}
-                                  data-testid={`admin-user-network-edit-cancel-${c.network_id}`}
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </form>
-                          </AdminDetailPanel>
-                        </Show>
-                      </>
-                    )}
-                  </For>
-                </tbody>
-              </AdminTable>
+                            Save
+                          </button>
+                        </div>
+                      </form>
+                    </Show>
+                  </section>
+                )}
+              </For>
             </Show>
           </AdminCard>
         </Show>
       </div>
     </div>
-  );
-};
-
-// Pure controlled inputs; no internal state. The page owns the draft.
-const NetworkEditFields: Component<{
-  form: EditForm;
-  onChange: (next: EditForm) => void;
-  networkId: number;
-}> = (props) => {
-  const set = (patch: Partial<EditForm>): void => {
-    props.onChange({ ...props.form, ...patch });
-  };
-  return (
-    <>
-      <input
-        placeholder="nick"
-        aria-label="nick"
-        type="text"
-        value={props.form.nick}
-        onInput={(e) => set({ nick: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-nick-${props.networkId}`}
-      />
-      <input
-        placeholder="realname"
-        aria-label="realname"
-        type="text"
-        value={props.form.realname}
-        onInput={(e) => set({ realname: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-realname-${props.networkId}`}
-      />
-      <input
-        placeholder="sasl user"
-        aria-label="sasl user"
-        type="text"
-        value={props.form.sasl_user}
-        onInput={(e) => set({ sasl_user: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-sasl-user-${props.networkId}`}
-      />
-      <select
-        aria-label="auth method"
-        value={props.form.auth_method}
-        onChange={(e) => set({ auth_method: (e.currentTarget as HTMLSelectElement).value })}
-        data-testid={`admin-user-network-edit-auth-method-${props.networkId}`}
-      >
-        <For each={IRCAUTH_FSMAUTH_METHOD}>{(m) => <option value={m}>auth: {m}</option>}</For>
-      </select>
-      <input
-        placeholder="password"
-        aria-label="password"
-        type="password"
-        value={props.form.password}
-        onInput={(e) => set({ password: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-password-${props.networkId}`}
-      />
-    </>
   );
 };
 

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -1,6 +1,7 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
+import AdminField from "./admin/AdminField";
 import { AdminEmpty, AdminError, AdminLoading } from "./admin/AdminStatus";
 import { connectionTone } from "./admin/connectionTone";
 import {
@@ -464,73 +465,108 @@ const AdminUserPage: Component<Props> = (props) => {
 
                     <Show when={enabled(net.id)}>
                       <form
-                        class="adm-form-grid"
                         onSubmit={(e) => {
                           void onSave(net, e);
                         }}
                         data-testid={`admin-user-network-form-${net.id}`}
                       >
-                        <input
-                          placeholder="nick"
-                          aria-label={`nick on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).nick}
-                          onInput={(e) =>
-                            setForm(net.id, { nick: (e.currentTarget as HTMLInputElement).value })
-                          }
-                          data-testid={`admin-user-network-nick-${net.id}`}
-                          required
-                        />
-                        <input
-                          placeholder="realname"
-                          aria-label={`realname on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).realname}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              realname: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-realname-${net.id}`}
-                        />
-                        <input
-                          placeholder="sasl user"
-                          aria-label={`sasl user on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).sasl_user}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              sasl_user: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-sasl-user-${net.id}`}
-                        />
-                        <select
-                          aria-label={`auth method on ${net.slug}`}
-                          value={formFor(net.id).auth_method}
-                          onChange={(e) =>
-                            setForm(net.id, {
-                              auth_method: (e.currentTarget as HTMLSelectElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-auth-method-${net.id}`}
-                        >
-                          <For each={IRCAUTH_FSMAUTH_METHOD}>
-                            {(m) => <option value={m}>auth: {m}</option>}
-                          </For>
-                        </select>
-                        <input
-                          placeholder="password"
-                          aria-label={`password on ${net.slug}`}
-                          type="password"
-                          value={formFor(net.id).password}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              password: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-password-${net.id}`}
-                        />
+                        {/* #1157 — vjt: "una form piu' umana: fieldset, un
+                            campo per riga". A real `<fieldset>`, so the
+                            group has a name a screen reader reads once
+                            instead of five placeholder-only boxes, and
+                            `.adm-field-rows` (Settings' idiom) to put each
+                            label beside its own control. */}
+                        <fieldset class="adm-fieldset">
+                          <legend class="adm-fieldset-legend">{net.slug} settings</legend>
+                          <div class="adm-field-rows">
+                            <AdminField label="nick" for={`admin-user-network-nick-${net.id}`}>
+                              <input
+                                id={`admin-user-network-nick-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).nick}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    nick: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-nick-${net.id}`}
+                                required
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="realname"
+                              for={`admin-user-network-realname-${net.id}`}
+                            >
+                              <input
+                                id={`admin-user-network-realname-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).realname}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    realname: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-realname-${net.id}`}
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="sasl user"
+                              for={`admin-user-network-sasl-user-${net.id}`}
+                            >
+                              <input
+                                id={`admin-user-network-sasl-user-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).sasl_user}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    sasl_user: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-sasl-user-${net.id}`}
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="auth method"
+                              for={`admin-user-network-auth-method-${net.id}`}
+                            >
+                              <select
+                                id={`admin-user-network-auth-method-${net.id}`}
+                                value={formFor(net.id).auth_method}
+                                onChange={(e) =>
+                                  setForm(net.id, {
+                                    auth_method: (e.currentTarget as HTMLSelectElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-auth-method-${net.id}`}
+                              >
+                                <For each={IRCAUTH_FSMAUTH_METHOD}>
+                                  {(m) => <option value={m}>{m}</option>}
+                                </For>
+                              </select>
+                            </AdminField>
+                            <AdminField
+                              label="password"
+                              for={`admin-user-network-password-${net.id}`}
+                              hint={
+                                credOf(net.id) === undefined
+                                  ? undefined
+                                  : "blank leaves the stored one alone"
+                              }
+                            >
+                              <input
+                                id={`admin-user-network-password-${net.id}`}
+                                type="password"
+                                value={formFor(net.id).password}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    password: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-password-${net.id}`}
+                              />
+                            </AdminField>
+                          </div>
+                        </fieldset>
                         <div class="adm-form-grid-actions">
                           <button
                             type="submit"

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -73,7 +73,6 @@ type AddForm = {
   password: string;
   sasl_user: string;
   realname: string;
-  autojoin_channels: string;
 };
 
 const EMPTY_ADD: AddForm = {
@@ -83,7 +82,6 @@ const EMPTY_ADD: AddForm = {
   password: "",
   sasl_user: "",
   realname: "",
-  autojoin_channels: "",
 };
 
 type EditForm = {
@@ -92,7 +90,6 @@ type EditForm = {
   sasl_user: string;
   auth_method: string;
   password: string;
-  autojoin_channels: string;
 };
 
 /** What the last write did to the live session, for one network. */
@@ -105,13 +102,6 @@ type SessionOutcome = {
 // row's `colspan`; derived from the count so adding a column cannot
 // silently desync it.
 const NETWORK_COLUMNS = 6;
-
-function splitChannels(raw: string): string[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
-}
 
 const AdminUserPage: Component<Props> = (props) => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
@@ -192,8 +182,6 @@ const AdminUserPage: Component<Props> = (props) => {
         password: f.password === "" ? undefined : f.password,
         sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
         realname: f.realname === "" ? undefined : f.realname,
-        autojoin_channels:
-          f.autojoin_channels.trim() === "" ? undefined : splitChannels(f.autojoin_channels),
       });
       recordOutcome(networkId, created);
       setAddForm({ ...EMPTY_ADD });
@@ -214,7 +202,6 @@ const AdminUserPage: Component<Props> = (props) => {
       sasl_user: c.sasl_user ?? "",
       auth_method: c.auth_method,
       password: "",
-      autojoin_channels: c.autojoin_channels.join(", "),
     });
   };
 
@@ -237,10 +224,6 @@ const AdminUserPage: Component<Props> = (props) => {
     if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
     if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
     if (f.password !== "") patch.password = f.password;
-    const nextAutojoin = splitChannels(f.autojoin_channels);
-    if (JSON.stringify(nextAutojoin) !== JSON.stringify(c.autojoin_channels)) {
-      patch.autojoin_channels = nextAutojoin;
-    }
     if (Object.keys(patch).length === 0) {
       onCancelEdit();
       return;
@@ -435,19 +418,6 @@ const AdminUserPage: Component<Props> = (props) => {
                   }
                   data-testid="admin-user-network-add-realname"
                 />
-                <input
-                  placeholder="autojoin"
-                  aria-label="autojoin"
-                  type="text"
-                  value={addForm().autojoin_channels}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      autojoin_channels: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-autojoin"
-                />
                 <div class="adm-form-grid-actions">
                   <button
                     type="submit"
@@ -599,13 +569,6 @@ const AdminUserPage: Component<Props> = (props) => {
                                     </AdminBadge>
                                   ),
                                 },
-                                {
-                                  label: "autojoin",
-                                  value:
-                                    c.autojoin_channels.length === 0
-                                      ? "—"
-                                      : c.autojoin_channels.join(", "),
-                                },
                               ]}
                             />
                           </AdminDetailPanel>
@@ -717,14 +680,6 @@ const NetworkEditFields: Component<{
         value={props.form.password}
         onInput={(e) => set({ password: (e.currentTarget as HTMLInputElement).value })}
         data-testid={`admin-user-network-edit-password-${props.networkId}`}
-      />
-      <input
-        placeholder="autojoin"
-        aria-label="autojoin"
-        type="text"
-        value={props.form.autojoin_channels}
-        onInput={(e) => set({ autojoin_channels: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-autojoin-${props.networkId}`}
       />
     </>
   );

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "./lib/api";
 import { token } from "./lib/auth";
 import { operatorApiError } from "./lib/friendlyApiError";
-import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
+import type { IRCAuthFSMAuthMethod } from "./lib/wireTypes";
 
 // #1158 — one user, one page, and it owns that user's network access.
 //
@@ -80,6 +80,50 @@ export type Props = {
   user: AdminUser;
   onBack: () => void;
 };
+
+// #1157 — what the SELECTOR offers. vjt, confirmed twice (2026-08-10
+// 00:19 and again at 00:31): *"su admin credentials confermo: selettore
+// sasl / server_pass / none"*.
+//
+// This is narrower than the server's closed set on purpose, and the
+// server's set is NOT narrowed to match — measured, both survivors have
+// an owner that is not this console:
+//
+//   * `nickserv_identify` is set BY THE SERVER. `Credential.registration_changeset/2`
+//     flips a credential to it when the #349 registration wizard sees
+//     services confirm the nick (`+r`), because from then on grappa must
+//     auto-identify or the nick gets ghosted within a minute. An operator
+//     never picks it; a credential arrives holding it.
+//   * `auto` is the Bahamut/Azzurra PASS-handoff path documented in
+//     `AuthFSM` — PASS, then SASL if the server advertises it.
+//
+// Dropping either from the DB enum is a migration over live rows and
+// belongs to #1044, which owns the secret-slot reshape and which #1157's
+// own text defers this question to ("settled there and rendered here,
+// not decided twice"). So the console stops OFFERING them and never
+// rewrites one it finds — see `authOptions`.
+//
+// Typed against the codegen union rather than as bare strings: a
+// server-side rename regenerates `wireTypes.ts` and fails HERE, which is
+// the half of the #410 LOCK worth keeping.
+const OFFERED_AUTH_METHODS: readonly IRCAuthFSMAuthMethod[] = ["sasl", "server_pass", "none"];
+
+// The offered set, plus whatever this credential actually holds. A
+// `<select>` whose value matches no option renders as if the operator
+// had chosen the first one, and the next save would quietly carry that
+// choice — so a method set outside this console is shown, labelled, and
+// left alone.
+function authOptions(current: string): string[] {
+  return OFFERED_AUTH_METHODS.includes(current as IRCAuthFSMAuthMethod)
+    ? [...OFFERED_AUTH_METHODS]
+    : [...OFFERED_AUTH_METHODS, current];
+}
+
+function authOptionLabel(method: string): string {
+  return OFFERED_AUTH_METHODS.includes(method as IRCAuthFSMAuthMethod)
+    ? method
+    : `${method} (set elsewhere)`;
+}
 
 /** The settings a credential carries, as the form holds them. */
 type NetworkForm = {
@@ -539,8 +583,8 @@ const AdminUserPage: Component<Props> = (props) => {
                                 }
                                 data-testid={`admin-user-network-auth-method-${net.id}`}
                               >
-                                <For each={IRCAUTH_FSMAUTH_METHOD}>
-                                  {(m) => <option value={m}>{m}</option>}
+                                <For each={authOptions(formFor(net.id).auth_method)}>
+                                  {(m) => <option value={m}>{authOptionLabel(m)}</option>}
                                 </For>
                               </select>
                             </AdminField>

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -30,20 +30,27 @@ import {
 // #1158 — the per-user admin page, the ONE surface that owns a user's
 // network access now that the Credentials tab is gone.
 //
-// The page is per-USER, so the invariants this suite defends are the ones
-// the deleted tab never had to hold:
+// #1157 reshaped it: no bind flow, one section per CONFIGURED network,
+// and a checkbox that says whether this user has access. So the suite's
+// central fixture is a server with TWO networks where the user is on
+// ONE — the page must render both sections and disagree about them.
 //
-//   * it renders THIS user's networks and no one else's (the list endpoint
-//     is unfiltered — see the `filters` note in the page);
-//   * the user is the page, so adding a network asks for a network, never
-//     for a user;
-//   * `session_action` is per-ROW state carrying all FOUR values. The tab
-//     it replaces surfaced two, and only for PATCH: `onBind` dropped the
-//     POST reply on the floor, so `spawned` / `not_spawned` had no operator
-//     surface at all;
-//   * a row shows the DB state AND the live state side by side, which is
-//     the two-sources rule and the witness `issue1163-admin-bind-dials`
-//     reads.
+// The invariants defended here:
+//
+//   * a section is ticked for THIS user's credential and no one else's
+//     (the list endpoint is unfiltered — see the `filters` note in the
+//     page). The foreign credential in every mount fetch sits on the
+//     second network, so a missing owner filter ticks a box;
+//   * the checkbox is not a write: enabling reveals the form and calls
+//     nothing, disabling a bound network ARMS a removal and calls
+//     nothing. Only Save and the confirm reach the server;
+//   * `session_action` is per-SECTION state carrying all FOUR values.
+//     The tab this page replaced surfaced two, and only for PATCH:
+//     `onBind` dropped the POST reply on the floor, so `spawned` /
+//     `not_spawned` had no operator surface at all;
+//   * a bound section shows the DB state AND the live state side by
+//     side, which is the two-sources rule and the witness
+//     `issue1163-admin-bind-dials` reads.
 
 const USER: AdminUser = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -102,8 +109,9 @@ const CRED: AdminCredential = {
   },
 };
 
-// Same shape, different OWNER. Present in every mount fetch, so any test
-// that finds it on the page has caught a missing owner filter.
+// Same shape, different OWNER, on the network this user is NOT on.
+// Present in every mount fetch, so a missing owner filter shows up as a
+// ticked box rather than as nothing at all.
 const FOREIGN_CRED: AdminCredential = {
   ...CRED,
   user_id: OTHER_USER_ID,
@@ -112,6 +120,7 @@ const FOREIGN_CRED: AdminCredential = {
   nick: "bob",
 };
 
+// This user, on the second network, with no pid behind it.
 const ORPHAN_CRED: AdminCredential = {
   ...CRED,
   network_id: OTHER_NETWORK.id,
@@ -125,7 +134,11 @@ function mountPage(onBack: () => void = () => {}): void {
 }
 
 async function pageReady(): Promise<void> {
-  await waitFor(() => expect(screen.queryByTestId("admin-user-networks-table")).not.toBeNull());
+  await waitFor(() => expect(screen.queryByTestId("admin-user-networks-card")).not.toBeNull());
+}
+
+function checkbox(networkId: number): HTMLInputElement {
+  return screen.getByTestId(`admin-user-network-enabled-${networkId}`) as HTMLInputElement;
 }
 
 beforeEach(() => {
@@ -134,13 +147,39 @@ beforeEach(() => {
   vi.mocked(adminListNetworks).mockResolvedValue([NETWORK, OTHER_NETWORK]);
 });
 
-describe("AdminUserPage — the user's networks", () => {
-  it("renders this user's networks and never another user's", async () => {
+describe("AdminUserPage — a section per configured network (#1157)", () => {
+  it("renders every configured network, not only the ones the user is on", async () => {
     mountPage();
     await pageReady();
 
-    expect(screen.queryByTestId(`admin-user-network-row-${NETWORK.id}`)).not.toBeNull();
-    expect(screen.queryByTestId(`admin-user-network-row-${OTHER_NETWORK.id}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-${NETWORK.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-${OTHER_NETWORK.id}`)).not.toBeNull();
+  });
+
+  it("ticks this user's networks and never another user's", async () => {
+    mountPage();
+    await pageReady();
+
+    expect(checkbox(NETWORK.id).checked).toBe(true);
+    // `FOREIGN_CRED` is a credential on this very network, owned by
+    // someone else. Ticked here means the owner filter is gone.
+    expect(checkbox(OTHER_NETWORK.id).checked).toBe(false);
+  });
+
+  it("shows the settings form only for an enabled network", async () => {
+    mountPage();
+    await pageReady();
+
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-form-${OTHER_NETWORK.id}`)).toBeNull();
+  });
+
+  it("seeds an enabled section's form from the credential", async () => {
+    mountPage();
+    await pageReady();
+
+    const nick = screen.getByTestId(`admin-user-network-nick-${NETWORK.id}`) as HTMLInputElement;
+    expect(nick.value).toBe(CRED.nick);
   });
 
   it("shows the DB state and the live state side by side", async () => {
@@ -148,22 +187,23 @@ describe("AdminUserPage — the user's networks", () => {
     mountPage();
     await pageReady();
 
-    const connected = screen.getByTestId(`admin-user-network-row-${NETWORK.id}`);
-    expect(connected.textContent).toContain("connected");
-    expect(connected.textContent).toContain("alive");
+    expect(screen.getByTestId(`admin-user-network-connection-${NETWORK.id}`).textContent).toBe(
+      "connected",
+    );
+    expect(screen.getByTestId(`admin-user-network-live-${NETWORK.id}`).textContent).toBe("alive");
 
-    // U-0: a row whose DB says connected while the BEAM has no pid must say
-    // so, rather than inherit the neighbouring row's honesty.
-    const orphan = screen.getByTestId(`admin-user-network-row-${OTHER_NETWORK.id}`);
-    expect(orphan.textContent).toContain("BEAM has no pid");
+    // U-0: a section whose DB says connected while the BEAM has no pid
+    // must say so, rather than inherit its neighbour's honesty.
+    expect(screen.getByTestId(`admin-user-network-live-${OTHER_NETWORK.id}`).textContent).toBe(
+      "BEAM has no pid",
+    );
   });
 
-  it("says the user has no networks rather than rendering an empty table", async () => {
-    vi.mocked(adminListCredentials).mockResolvedValue([FOREIGN_CRED]);
+  it("blames the server, not the user, when no network is configured at all", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([]);
     mountPage();
 
     await waitFor(() => expect(screen.queryByTestId("admin-user-networks-empty")).not.toBeNull());
-    expect(screen.queryByTestId("admin-user-networks-table")).toBeNull();
   });
 
   it("calls onBack from the back control", async () => {
@@ -176,55 +216,49 @@ describe("AdminUserPage — the user's networks", () => {
   });
 });
 
-describe("AdminUserPage — adding a network", () => {
-  it("keeps the add form closed until + is pressed", async () => {
+describe("AdminUserPage — the checkbox is not a write (#1157)", () => {
+  it("reveals the form on enable without calling the server", async () => {
     mountPage();
     await pageReady();
 
-    expect(screen.queryByTestId("admin-user-network-add-form")).toBeNull();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    expect(screen.queryByTestId("admin-user-network-add-form")).not.toBeNull();
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+
+    expect(screen.queryByTestId(`admin-user-network-form-${OTHER_NETWORK.id}`)).not.toBeNull();
+    // A bind needs a nick; a checkbox cannot supply one, so nothing goes
+    // out until Save.
+    expect(adminBindCredential).not.toHaveBeenCalled();
   });
 
-  it("asks for a network, never for a user — the user IS the page", async () => {
+  it("will not save a newly enabled network until it has a nick", async () => {
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
 
-    expect(screen.queryByTestId("admin-user-network-add-network")).not.toBeNull();
-    expect(screen.queryByTestId("admin-user-network-add-user")).toBeNull();
+    const save = screen.getByTestId(
+      `admin-user-network-save-${OTHER_NETWORK.id}`,
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
+    });
+    expect(save.disabled).toBe(false);
   });
 
-  it("offers only networks the user is not already on", async () => {
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-
-    const select = screen.getByTestId("admin-user-network-add-network") as HTMLSelectElement;
-    const values = Array.from(select.options)
-      .map((o) => o.value)
-      .filter((v) => v !== "");
-    expect(values).toEqual([String(OTHER_NETWORK.id)]);
-  });
-
-  it("binds with the page's user and the parsed network id", async () => {
+  it("binds with the page's user and the section's network", async () => {
     vi.mocked(adminBindCredential).mockResolvedValue({
       ...CRED,
       network_id: OTHER_NETWORK.id,
       network_slug: OTHER_NETWORK.slug,
-      session_action: "spawned",
     });
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
 
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
       target: { value: "newnick" },
     });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
 
     await waitFor(() => {
       expect(adminBindCredential).toHaveBeenCalledWith(
@@ -239,22 +273,10 @@ describe("AdminUserPage — adding a network", () => {
   });
 
   // #1157 — vjt: *"`autojoin` makes no sense — remove it."* Channel
-  // restore rides `last_joined_channels`
-  // (`session_plan.ex`, `merge_autojoin/2`), so the admin field was never
-  // the mechanism the bouncer actually uses; offering it invited the
-  // operator to set a list that the next reconnect overwrites.
-  it("offers no autojoin control, on either form", async () => {
-    mountPage();
-    await pageReady();
-
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    expect(screen.queryByTestId(`admin-user-network-edit-autojoin-${NETWORK.id}`)).toBeNull();
-
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    expect(screen.queryByTestId("admin-user-network-add-autojoin")).toBeNull();
-  });
-
-  it("never puts autojoin_channels on a bind", async () => {
+  // restore rides `last_joined_channels` (`session_plan.ex`,
+  // `merge_autojoin/2`), so the admin field was never the mechanism the
+  // bouncer actually uses.
+  it("offers no autojoin control, and never sends one", async () => {
     vi.mocked(adminBindCredential).mockResolvedValue({
       ...CRED,
       network_id: OTHER_NETWORK.id,
@@ -262,15 +284,13 @@ describe("AdminUserPage — adding a network", () => {
     });
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    expect(screen.queryByTestId(`admin-user-network-autojoin-${NETWORK.id}`)).toBeNull();
 
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
       target: { value: "newnick" },
     });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
 
     // The KEY, not the value: the removed form used to send an explicit
     // `undefined` for an empty box, and `objectContaining` cannot tell
@@ -280,116 +300,49 @@ describe("AdminUserPage — adding a network", () => {
     expect(Object.keys(body ?? {})).not.toContain("autojoin_channels");
   });
 
-  // #410 LOCK, carried over from the deleted Credentials tab suite: the
-  // auth-method dropdown enumerates the codegen-emitted closed set, in
-  // array order. A server-side rename or reorder regenerates wireTypes.ts
-  // and must fail HERE, not reshuffle the dropdown in silence.
-  it("renders the auth-method dropdown with the closed method set in order", async () => {
+  it("arms a removal on disable instead of performing one", async () => {
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
 
-    const select = screen.getByTestId("admin-user-network-add-auth-method") as HTMLSelectElement;
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+    fireEvent.click(checkbox(NETWORK.id));
+
+    expect(adminUnbindCredential).not.toHaveBeenCalled();
+    expect(checkbox(NETWORK.id).checked).toBe(false);
+    expect(screen.queryByTestId(`admin-user-network-remove-${NETWORK.id}`)).not.toBeNull();
+    // The form goes with the tick: leaving it up would invite an edit to
+    // a credential the operator has just asked to delete.
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("removes the credential once the armed removal is confirmed", async () => {
+    vi.mocked(adminUnbindCredential).mockResolvedValue(undefined);
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(NETWORK.id));
+    fireEvent.click(screen.getByTestId(`admin-user-network-remove-${NETWORK.id}`));
+
+    await waitFor(() => {
+      expect(adminUnbindCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id);
+    });
+    await waitFor(() => expect(checkbox(NETWORK.id).checked).toBe(false));
+    expect(screen.queryByTestId(`admin-user-network-remove-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("puts the tick back when the armed removal is cancelled", async () => {
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(NETWORK.id));
+    fireEvent.click(screen.getByTestId(`admin-user-network-keep-${NETWORK.id}`));
+
+    expect(adminUnbindCredential).not.toHaveBeenCalled();
+    expect(checkbox(NETWORK.id).checked).toBe(true);
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).not.toBeNull();
   });
 });
 
-describe("AdminUserPage — session_action is per-row state", () => {
-  it("reports a bind that dialled, on the row it belongs to", async () => {
-    vi.mocked(adminBindCredential).mockResolvedValue({
-      ...CRED,
-      network_id: OTHER_NETWORK.id,
-      network_slug: OTHER_NETWORK.slug,
-      session_action: "spawned",
-    });
-    vi.mocked(adminListCredentials)
-      .mockResolvedValueOnce([CRED, FOREIGN_CRED])
-      .mockResolvedValue([CRED, FOREIGN_CRED, { ...ORPHAN_CRED, live_state: CRED.live_state }]);
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
-      target: { value: "newnick" },
-    });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
-
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
-      expect(state).not.toBeNull();
-      expect(state?.textContent).toContain("spawned");
-    });
-  });
-
-  // The half the deleted tab dropped entirely: a bind that did NOT dial
-  // still created the row, and `session_error` is the only thing that says
-  // why. Rendering the action without the reason would be a worse lie than
-  // rendering nothing.
-  it("reports a bind that did not dial, with the refusal", async () => {
-    vi.mocked(adminBindCredential).mockResolvedValue({
-      ...CRED,
-      network_id: OTHER_NETWORK.id,
-      network_slug: OTHER_NETWORK.slug,
-      connection_state: "parked",
-      live_state: null,
-      session_action: "not_spawned",
-      session_error: "user_cap_exceeded",
-    });
-    vi.mocked(adminListCredentials)
-      .mockResolvedValueOnce([CRED, FOREIGN_CRED])
-      .mockResolvedValue([CRED, FOREIGN_CRED, ORPHAN_CRED]);
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
-      target: { value: "newnick" },
-    });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
-
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
-      expect(state?.textContent).toContain("not_spawned");
-      expect(state?.textContent).toContain("user_cap_exceeded");
-    });
-  });
-
-  it("reports a stopped session on the edited row, and leaves the others alone", async () => {
-    vi.mocked(adminListCredentials).mockResolvedValue([CRED, ORPHAN_CRED]);
-    vi.mocked(adminUpdateCredential).mockResolvedValue({
-      ...CRED,
-      session_action: "stopped",
-    });
-    mountPage();
-    await pageReady();
-
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    fireEvent.input(screen.getByTestId(`admin-user-network-edit-password-${NETWORK.id}`), {
-      target: { value: "new-irc-pass" },
-    });
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-submit-${NETWORK.id}`));
-
-    await waitFor(() => {
-      expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
-        password: "new-irc-pass",
-      });
-    });
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${NETWORK.id}`);
-      expect(state?.textContent).toContain("stopped");
-    });
-    expect(
-      screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`),
-    ).toBeNull();
-  });
-});
-
-describe("AdminUserPage — editing and removing a network", () => {
+describe("AdminUserPage — editing a bound network", () => {
   it("sends only the fields the operator changed", async () => {
     vi.mocked(adminUpdateCredential).mockResolvedValue({
       ...CRED,
@@ -399,11 +352,10 @@ describe("AdminUserPage — editing and removing a network", () => {
     mountPage();
     await pageReady();
 
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    fireEvent.input(screen.getByTestId(`admin-user-network-edit-realname-${NETWORK.id}`), {
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
       target: { value: "Alice Smith" },
     });
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-submit-${NETWORK.id}`));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
 
     await waitFor(() => {
       expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
@@ -412,22 +364,92 @@ describe("AdminUserPage — editing and removing a network", () => {
     });
   });
 
-  it("removes a network behind an inline confirm", async () => {
-    vi.mocked(adminUnbindCredential).mockResolvedValue(undefined);
+  it("refuses to save a bound network nothing has changed on", async () => {
     mountPage();
     await pageReady();
 
-    const btn = screen.getByTestId(`admin-user-network-remove-${NETWORK.id}`);
-    expect(btn.textContent).toBe("Remove");
-    fireEvent.click(btn);
-    expect(btn.textContent).toBe("Confirm remove");
-    fireEvent.click(btn);
+    // An empty PATCH would ask the server to decide whether to stop a
+    // live session over nothing.
+    const save = screen.getByTestId(`admin-user-network-save-${NETWORK.id}`) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
 
-    await waitFor(() => {
-      expect(adminUnbindCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id);
+  // #410 LOCK, carried over from the deleted Credentials tab suite: the
+  // auth-method dropdown enumerates the codegen-emitted closed set, in
+  // array order. A server-side rename or reorder regenerates wireTypes.ts
+  // and must fail HERE, not reshuffle the dropdown in silence.
+  it("renders the auth-method dropdown with the closed method set in order", async () => {
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+  });
+});
+
+describe("AdminUserPage — session_action is per-section state", () => {
+  it("reports a bind that dialled, on the section it belongs to", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+      session_action: "spawned",
     });
-    await waitFor(() => {
-      expect(screen.queryByTestId(`admin-user-network-row-${NETWORK.id}`)).toBeNull();
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
     });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
+    expect(note.textContent).toContain("spawned");
+    // On the section it belongs to, and on no other.
+    expect(screen.queryByTestId(`admin-user-network-session-action-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("reports a bind that did not dial, with the refusal", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+      session_action: "not_spawned",
+      session_error: "resolve_failed",
+    });
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
+    expect(note.textContent).toContain("not_spawned");
+    // The only field that says WHY, and the reason this is not a toast.
+    expect(note.textContent).toContain("resolve_failed");
+  });
+
+  it("reports a stopped session on the edited section", async () => {
+    vi.mocked(adminUpdateCredential).mockResolvedValue({
+      ...CRED,
+      session_action: "stopped",
+    });
+    mountPage();
+    await pageReady();
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
+      target: { value: "Alice Smith" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${NETWORK.id}`);
+    expect(note.textContent).toContain("stopped");
   });
 });

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -342,6 +342,43 @@ describe("AdminUserPage — the checkbox is not a write (#1157)", () => {
   });
 });
 
+describe("AdminUserPage — the form is a named group of labelled rows (#1157)", () => {
+  // vjt: *"una form piu' umana: fieldset, un campo per riga — non
+  // stipata com'e' ora."* One field per row is CSS and is measured on a
+  // real viewport; what a DOM test can hold is the half CSS cannot fake
+  // — the group has a NAME and every control has a LABEL bound to it.
+  // The forms this replaced had five placeholder-only boxes, and a
+  // placeholder disappears the moment you type into it.
+  it("wraps the fields in a fieldset that names the network", async () => {
+    mountPage();
+    await pageReady();
+
+    const form = screen.getByTestId(`admin-user-network-form-${NETWORK.id}`);
+    const fieldset = form.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.querySelector("legend")?.textContent).toContain(NETWORK.slug);
+  });
+
+  it("binds a real label to every control in the form", async () => {
+    mountPage();
+    await pageReady();
+
+    const form = screen.getByTestId(`admin-user-network-form-${NETWORK.id}`);
+    const controls = Array.from(form.querySelectorAll("input, select"));
+    // Non-vacuity: an empty control list would satisfy the loop below
+    // without proving anything.
+    expect(controls.length).toBe(5);
+
+    for (const control of controls) {
+      const id = control.getAttribute("id");
+      expect(id, `${control.getAttribute("data-testid")} has no id to label`).not.toBeNull();
+      const label = form.querySelector(`label[for="${id}"]`);
+      expect(label, `no label points at ${id}`).not.toBeNull();
+      expect((label?.textContent ?? "").trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe("AdminUserPage — editing a bound network", () => {
   it("sends only the fields the operator changed", async () => {
     vi.mocked(adminUpdateCredential).mockResolvedValue({

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AdminCredential, AdminNetwork, AdminUser } from "../lib/api";
+import { IRCAUTH_FSMAUTH_METHOD } from "../lib/wireTypes";
 
 vi.mock("../lib/auth", () => ({
   token: () => "test-bearer",
@@ -411,19 +412,78 @@ describe("AdminUserPage — editing a bound network", () => {
     expect(save.disabled).toBe(true);
   });
 
-  // #410 LOCK, carried over from the deleted Credentials tab suite: the
-  // auth-method dropdown enumerates the codegen-emitted closed set, in
-  // array order. A server-side rename or reorder regenerates wireTypes.ts
-  // and must fail HERE, not reshuffle the dropdown in silence.
-  it("renders the auth-method dropdown with the closed method set in order", async () => {
+  // #1157 — vjt, confirmed twice: "selettore sasl / server_pass / none".
+  it("offers the three ruled auth methods and nothing else", async () => {
     mountPage();
     await pageReady();
 
     const select = screen.getByTestId(
       `admin-user-network-auth-method-${NETWORK.id}`,
     ) as HTMLSelectElement;
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(["sasl", "server_pass", "none"]);
+  });
+
+  // #410 LOCK, kept through the narrowing. It used to read "the dropdown
+  // enumerates the codegen closed set in array order", which a curated
+  // list cannot satisfy — but the REASON survives: a server-side rename
+  // regenerates `wireTypes.ts`, and an offer the server no longer knows
+  // must fail HERE rather than sit in a dropdown producing 422s. The
+  // compile-time half is the `readonly IRCAuthFSMAuthMethod[]` annotation
+  // on the offered list; this is the runtime half.
+  it("offers only values the server's closed set still contains", async () => {
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    for (const option of Array.from(select.options)) {
+      expect(IRCAUTH_FSMAUTH_METHOD as readonly string[], option.value).toContain(option.value);
+    }
+  });
+
+  // The credential this page did not create. `nickserv_identify` is set
+  // by the SERVER when the #349 registration wizard sees `+r`, so a
+  // credential can arrive holding a method the console does not offer —
+  // and a `<select>` whose value matches no option renders as if the
+  // first one had been chosen, which the next save would carry.
+  it("keeps a method it does not offer instead of silently rewriting it", async () => {
+    vi.mocked(adminListCredentials).mockResolvedValue([
+      { ...CRED, auth_method: "nickserv_identify" },
+      FOREIGN_CRED,
+    ]);
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toContain("nickserv_identify");
+    expect(select.value).toBe("nickserv_identify");
+    // Labelled, so the operator can tell it apart from a choice this
+    // console would have offered.
+    expect(select.textContent).toContain("set elsewhere");
+  });
+
+  it("does not send an auth_method the operator never touched", async () => {
+    vi.mocked(adminListCredentials).mockResolvedValue([
+      { ...CRED, auth_method: "nickserv_identify" },
+      FOREIGN_CRED,
+    ]);
+    vi.mocked(adminUpdateCredential).mockResolvedValue({ ...CRED, realname: "Alice Smith" });
+    mountPage();
+    await pageReady();
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
+      target: { value: "Alice Smith" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
+
+    await waitFor(() => {
+      expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
+        realname: "Alice Smith",
+      });
+    });
   });
 });
 

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -238,6 +238,48 @@ describe("AdminUserPage — adding a network", () => {
     });
   });
 
+  // #1157 — vjt: *"`autojoin` makes no sense — remove it."* Channel
+  // restore rides `last_joined_channels`
+  // (`session_plan.ex`, `merge_autojoin/2`), so the admin field was never
+  // the mechanism the bouncer actually uses; offering it invited the
+  // operator to set a list that the next reconnect overwrites.
+  it("offers no autojoin control, on either form", async () => {
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
+    expect(screen.queryByTestId(`admin-user-network-edit-autojoin-${NETWORK.id}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    expect(screen.queryByTestId("admin-user-network-add-autojoin")).toBeNull();
+  });
+
+  it("never puts autojoin_channels on a bind", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+    });
+    mountPage();
+    await pageReady();
+    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+
+    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
+      target: { value: String(OTHER_NETWORK.id) },
+    });
+    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+      target: { value: "newnick" },
+    });
+    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+
+    // The KEY, not the value: the removed form used to send an explicit
+    // `undefined` for an empty box, and `objectContaining` cannot tell
+    // that apart from an absent field.
+    await waitFor(() => expect(adminBindCredential).toHaveBeenCalled());
+    const body = vi.mocked(adminBindCredential).mock.calls[0]?.[1];
+    expect(Object.keys(body ?? {})).not.toContain("autojoin_channels");
+  });
+
   // #410 LOCK, carried over from the deleted Credentials tab suite: the
   // auth-method dropdown enumerates the codegen-emitted closed set, in
   // array order. A server-side rename or reorder regenerates wireTypes.ts

--- a/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
+++ b/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminCredential, AdminNetwork, AdminVisitor } from "../lib/api";
+
+// #1157 — the dictated column 4: on a phone the row's verbs "collapse
+// into ONE button with a dropdown" (vjt, 2026-08-09). Desktop keeps them
+// side by side.
+//
+// The regime is supplied explicitly because jsdom has no matchMedia, and
+// it is supplied as a MUTABLE object so this one file can assert both
+// sides of the branch: a collapse that also happened on desktop would
+// pass a narrow-only file.
+//
+// What the collapse must NOT do is skip the confirmation. Terminate is
+// destructive and `InlineConfirmButton` is sticky by design (the parent
+// owns `armed`), so the menu replaces the ARM step only — picking a verb
+// arms it, and the cell then has to offer a way back out, because on a
+// phone the sibling verb button that disarms it on desktop is not there.
+
+const viewport = vi.hoisted(() => ({ mobile: false, adminNarrow: false }));
+
+vi.mock("../lib/theme", () => ({
+  isMobile: () => viewport.mobile,
+  isAdminNarrow: () => viewport.adminNarrow,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  token: () => "test-bearer",
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    adminListVisitors: vi.fn(),
+    adminListCredentials: vi.fn(),
+    adminListSessions: vi.fn(),
+    adminListNetworks: vi.fn(),
+    adminListSessionLogSessions: vi.fn(),
+    adminDisconnectSession: vi.fn(),
+    adminReconnectSession: vi.fn(),
+    adminTerminateSession: vi.fn(),
+    adminDeleteVisitor: vi.fn(),
+  };
+});
+
+import AdminSessionsTab from "../AdminSessionsTab";
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const VISITOR_ID = "22222222-2222-2222-2222-222222222222";
+const USER_KEY = `user:${USER_ID}:1`;
+const VISITOR_KEY = `visitor:${VISITOR_ID}:1`;
+
+const NETWORK = {
+  id: 1,
+  slug: "azzurra",
+  max_concurrent_visitor_sessions: null,
+  max_concurrent_user_sessions: null,
+  max_per_ip: null,
+  live_counts: { visitors: 0, users: 0 },
+} as unknown as AdminNetwork;
+
+// A user row carries TWO verbs (`rowActions`) — the only shape the
+// collapse has anything to collapse.
+const userCredential = (): AdminCredential =>
+  ({
+    user_id: USER_ID,
+    network_id: 1,
+    network_slug: "azzurra",
+    nick: "vjt",
+    ident: null,
+    realname: null,
+    sasl_user: null,
+    auth_method: "sasl",
+    auth_command_template: null,
+    autojoin_channels: [],
+    last_joined_channels: [],
+    connection_state: "connected",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-05-16T00:00:00Z",
+    updated_at: "2026-05-16T00:00:00Z",
+    last_seen_at: "2026-08-10T00:00:00Z",
+    live_state: null,
+    ...{},
+  }) as AdminCredential;
+
+// A parked visitor carries exactly ONE (`reconnect`).
+const parkedVisitor = (): AdminVisitor =>
+  ({
+    id: VISITOR_ID,
+    expires_at: "2099-01-01T00:00:00Z",
+    identified: false,
+    ip: "1.2.3.4",
+    inserted_at: "2026-05-16T00:00:00Z",
+    last_seen_at: null,
+    networks: [
+      {
+        network_slug: "azzurra",
+        network_id: 1,
+        nick: "guest1",
+        connection_state: "parked",
+        live_state: null,
+      },
+    ],
+  }) as AdminVisitor;
+
+async function mountWith(over: {
+  visitors?: AdminVisitor[];
+  credentials?: AdminCredential[];
+}): Promise<void> {
+  const api = await import("../lib/api");
+  vi.mocked(api.adminListVisitors).mockResolvedValue(over.visitors ?? []);
+  vi.mocked(api.adminListCredentials).mockResolvedValue(over.credentials ?? []);
+  vi.mocked(api.adminListSessions).mockResolvedValue([]);
+  vi.mocked(api.adminListNetworks).mockResolvedValue([NETWORK]);
+  vi.mocked(api.adminListSessionLogSessions).mockResolvedValue([]);
+  render(() => <AdminSessionsTab />);
+}
+
+/** The row's actions cell — the box the dictation is about. */
+function actionsCell(key: string): HTMLElement {
+  const row = screen.getByTestId(`admin-session-row-${key}`);
+  const cell = row.querySelector<HTMLElement>("td.admin-sessions-actions");
+  if (cell === null) throw new Error(`no actions cell on row ${key}`);
+  return cell;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  viewport.mobile = false;
+  viewport.adminNarrow = false;
+});
+
+describe("#1157 — column 4 collapses on a phone", () => {
+  it("gives a two-verb row exactly one control, and it is the menu", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    // Exactly one: a cell that merely ADDED a menu beside the two verbs
+    // would still satisfy "the menu is there".
+    expect(actionsCell(USER_KEY).querySelectorAll("button")).toHaveLength(1);
+    expect(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeTruthy();
+    // Absent from the DOM, not CSS-hidden: a hidden copy leaves two of
+    // every verb once the menu renders its own.
+    expect(screen.queryByTestId(`admin-session-disconnect-${USER_KEY}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-session-terminate-${USER_KEY}`)).toBeNull();
+  });
+
+  it("offers both verbs inside the dropdown", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+
+    const menu = screen.getByRole("menu");
+    expect(menu.textContent).toContain("Disconnect");
+    expect(menu.textContent).toContain("Terminate");
+  });
+
+  it("arms the picked verb rather than running it", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    fireEvent.click(screen.getByText("Terminate"));
+
+    const api = await import("../lib/api");
+    // The destructive verb has NOT fired: the menu replaces the arm step,
+    // not the confirmation.
+    expect(vi.mocked(api.adminTerminateSession)).not.toHaveBeenCalled();
+    const armed = screen.getByTestId(`admin-session-terminate-${USER_KEY}`);
+    expect(armed.textContent).toBe("Confirm terminate");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("leaves a way out of the armed state, since no sibling verb can disarm it", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    fireEvent.click(screen.getByText("Terminate"));
+    fireEvent.click(screen.getByTestId(`admin-session-actions-cancel-${USER_KEY}`));
+
+    expect(screen.queryByTestId(`admin-session-terminate-${USER_KEY}`)).toBeNull();
+    expect(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeTruthy();
+  });
+
+  it("does not put a one-item menu in front of a single-verb row", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ visitors: [parkedVisitor()] });
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+
+    expect(screen.getByTestId(`admin-session-reconnect-${VISITOR_KEY}`)).toBeTruthy();
+    expect(screen.queryByTestId(`admin-session-actions-menu-${VISITOR_KEY}`)).toBeNull();
+    // Still one control — the rule is "one control in the cell", and a
+    // lone verb already satisfies it without a tap to reach it.
+    expect(actionsCell(VISITOR_KEY).querySelectorAll("button")).toHaveLength(1);
+  });
+});
+
+describe("#1157 — desktop keeps the verbs side by side", () => {
+  it("renders both verbs inline and grows no menu", async () => {
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    expect(screen.getByTestId(`admin-session-disconnect-${USER_KEY}`)).toBeTruthy();
+    expect(screen.getByTestId(`admin-session-terminate-${USER_KEY}`)).toBeTruthy();
+    expect(screen.queryByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeNull();
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6631,6 +6631,37 @@ html.resize-dragging * {
   outline-offset: -2px;
 }
 
+/* #1157 — a grouped form inside an admin card (today: one network's
+   settings on the per-user page). vjt asked for fieldsets and one field
+   per row instead of the crammed grid the add/edit forms used.
+
+   `min-inline-size: 0` is the load-bearing line, not decoration, and the
+   reason is measured: #1228 found a <fieldset> defaults to
+   `min-inline-size: min-content` and — unlike every other box here —
+   will NOT shrink below it, so ONE wide child sets a floor the whole
+   fieldset is laid out against and the entire form renders past its
+   container's right edge. The widest child here is the auth <select>,
+   whose intrinsic width comes from its longest OPTION. Same bomb, in the
+   console this time, and at 393px the overflow would land on the panel —
+   which is exactly the pan #1157 exists to delete. */
+.adm-fieldset {
+  min-inline-size: 0;
+  margin: var(--adm-space-3) 0 0;
+  padding: 0 0 var(--adm-space-2);
+  border: 1px solid var(--adm-line);
+  border-radius: var(--adm-radius-sm);
+}
+
+.adm-fieldset-legend {
+  padding: 0 var(--adm-space-2);
+  font-family: var(--adm-font);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--adm-text-dim);
+}
+
 /* A titled block nested INSIDE an expand row (today: the per-vhost
    grants disclosure). Not an `AdminCard` — a card inside a card's own
    table reads as a nesting mistake; this is the flatter, quieter

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5452,7 +5452,12 @@ html.resize-dragging * {
 
 /* Drill-down danger zone: the note names what Delete destroys, so it must
    read as one unit with the button rather than as loose text beside it. */
-.admin-session-danger {
+/* A destructive verb, its explanation, and a rule separating it from
+   whatever it sits under. Two callers now — the Sessions drill-down's
+   "delete the whole visitor identity" and the user page's "remove this
+   user's access to a network" — so the idiom is named for the SHAPE
+   rather than for either surface. */
+.adm-danger-strip {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -5462,7 +5467,7 @@ html.resize-dragging * {
   border-top: 1px solid var(--adm-line);
 }
 
-.admin-session-danger-note {
+.adm-danger-note {
   font-family: var(--adm-font);
   font-size: 0.75rem;
   color: var(--adm-text-dim);
@@ -6655,6 +6660,25 @@ html.resize-dragging * {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--adm-text-dim);
+}
+
+/* #1157 — a network section's heading: the tick and the slug, then the
+   two state badges. It WRAPS: the slug is operator-chosen and the widest
+   badge says "BEAM has no pid", so on a 393px phone this row cannot be
+   assumed to fit, and `.adm-check` is `nowrap` by design. Without the
+   wrap the overflow lands on the panel, which is the pan #1157 exists to
+   delete. */
+.admin-user-network-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--adm-space-2) var(--adm-space-3);
+}
+
+.admin-user-network-state {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--adm-space-2);
 }
 
 /* The add-form is set into its own recessed panel so it reads as "this

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39874,3 +39874,112 @@ also joins the `nginx-csp-range-parity` pin list, where — like
 `media-src` before it — the un-widened value is a PREFIX of the widened
 one, so pinning anything shorter would let a revert sail through
 `toContain`.
+
+---
+
+## 2026-08-12 — #1157 residuals: what "one control" means, and a checkbox that is not a write
+
+The audit that opened this round is the durable part: **most of #1157 had
+already shipped** (rows become cards below 900px and the pan is gone —
+`e45a6733`; Visitors merged into one row-backed Sessions view —
+`ffc8c044` / `e296e697`; all four Vhosts requirements; #1224's ended
+sub-page — `9deecc60`). What was left was five items from the tail of
+vjt's dictation, and they are recorded here because each one settled a
+question the code will otherwise re-open.
+
+### The actions cell keeps ONE control, which is not the same as "always a menu"
+
+Dictated: on mobile disconnect/terminate "collapse into a single button
+with a dropdown". Taken literally, a visitor row — which carries exactly
+one verb (`rowActions`) — would grow a menu holding a list of one, a tap
+spent to reach something already on screen. So the rule implemented is
+the one the dictation is an instance of: **the cell holds one control at
+any width**, which a one-verb row already satisfies and a two-verb row
+reaches through the menu.
+
+**Picking from the menu ARMS the verb; it does not run it.** Equating
+"opened a menu and chose" with "confirmed" would trade a destructive
+verb's confirmation for a UI affordance, and `InlineConfirmButton` stays
+the thing that fires. That creates one hazard the desktop layout never
+had — the button that opened the menu is gone while a verb is armed, and
+the sibling verb whose idle button disarms it on desktop is not rendered
+— so the collapsed cell grows a Cancel. Scoped to the collapsed case:
+nothing vanished on a single-verb row, so nothing has to come back.
+
+`ContextMenu` is reused rather than a second popover convention grown
+inside the console. What differs between a long-press message menu and
+this is the item list; the portal, backdrop, Escape and measured
+flip/clamp are the same problem already solved.
+
+### The per-user page: a checkbox is a statement, not a write
+
+vjt: *"niente flusso bind credential; al suo posto una sezione per rete
+configurata con una checkbox `enabled`."* The page used to answer "which
+networks does this user have?" with a table and "give it another" with a
+`+` opening a form whose first field picked from the networks it did not
+have — two shapes for one fact. One section per CONFIGURED network
+collapses them, and the picker disappears because the section already is
+one. The add form, the inline edit form and the per-row detail panel
+collapse with it: they differed only in which subset of the same fields
+they showed and in whether the answer left as a POST or a PATCH.
+
+Two directions, two different rules, and both are deliberate:
+
+* **Enabling writes nothing.** A bind needs a nick and a tick cannot
+  supply one, so the tick reveals the form and Save is the POST.
+* **Disabling ARMS.** It deletes the credential and stops the session, so
+  it gets the two-step every destructive verb in the console has — here
+  spread over the two controls the shape already offers (untick, then a
+  button that names what it destroys) rather than over one button's two
+  labels.
+
+### `autojoin` was never the mechanism
+
+Removed on vjt's call, and the reason is worth keeping: channel restore
+rides `last_joined_channels` (`session_plan.ex`, `merge_autojoin/2`). The
+admin column was a second, operator-authored list that the session's own
+history overwrites, so setting it invited an operator to configure
+something the next reconnect quietly disagreed with. The field stays on
+the API types and in the mix verbs — this removed the console's offer of
+it, not the server's support.
+
+### The auth selector narrows; the server's closed set does not
+
+Ruled `sasl` / `server_pass` / `none`, confirmed twice. The two dropped
+values are not the operator's to pick, which is what decided the shape:
+
+* `nickserv_identify` is set BY THE SERVER — `registration_changeset/2`
+  flips a credential to it when the #349 wizard sees `+r`, because from
+  then on grappa must auto-identify or the nick is ghosted within the
+  minute. A credential ARRIVES holding it.
+* `auto` is the Bahamut/Azzurra PASS-handoff path documented in
+  `AuthFSM`.
+
+So the DB enum is left alone: narrowing it is a migration over live rows,
+and it belongs to **#1044**, which owns the secret-slot reshape and which
+#1157's own text defers this to ("settled there and rendered here, not
+decided twice").
+
+**The case the narrowing creates is the load-bearing one.** A `<select>`
+whose value matches no option renders as if the first option had been
+chosen, and the next save carries that choice out — silently converting a
+wizard-set `nickserv_identify` into `sasl`. The stored value is therefore
+added to the options, labelled `(set elsewhere)`, and a save that did not
+touch the field sends no `auth_method` at all.
+
+The #410 LOCK could not survive verbatim — "the dropdown enumerates the
+codegen set in array order" is precisely what a curated list breaks — but
+its reason survives in two halves: the offered list is typed
+`readonly IRCAuthFSMAuthMethod[]` so a server-side rename fails the
+build, and a runtime test asserts every offered value is still a member
+of the codegen set.
+
+### The fieldset floor, one storey up from #1228
+
+`<fieldset>` defaults to `min-inline-size: min-content` and will not
+shrink below it, so one wide child sets a floor the whole group is laid
+out against. #1228 measured that on a drawer sub-page; the widest child
+here is the auth `<select>`, sized by its longest option. `.adm-fieldset`
+carries `min-inline-size: 0` for that reason and no other. The oracle
+already existed and now exercises a fieldset: the `subpage:user-page`
+surface in `ux-6-g-admin-mobile-h-scroll`.


### PR DESCRIPTION
## What this is

The tail of vjt's admin dictation on #1157, plus the two calls #1224 left
open. **Most of #1157 had already shipped** — rows become cards below
900px and the pan is gone (`e45a6733`), Visitors merged into one
row-backed Sessions view (`ffc8c044` / `e296e697`), all four Vhosts
requirements, #1224's ended sub-page (`9deecc60`). This is what was left,
one commit per item.

| item | commit |
|---|---|
| column 4 collapses into one button + dropdown on a phone | `91162728` + e2e `a8d7bb3a` |
| `autojoin` removed from the admin console | `2defe025` |
| no bind flow — a section per configured network with an `enabled` tick | `84f3cba4` |
| the settings form is a fieldset, one field per row | `d5ba4d46` |
| the auth selector offers `sasl` / `server_pass` / `none` | `387f79bf` |
| DESIGN_NOTES | `2d5745e4` |

## Two judgement calls worth reviewing

**1. The server's `auth_method` closed set is deliberately NOT narrowed.**
The selector offers three; the enum keeps five. Both survivors have an
owner that is not this console — `nickserv_identify` is written by the
SERVER (`registration_changeset/2`, when the #349 wizard sees `+r`), and
`auto` is the Bahamut/Azzurra PASS-handoff path documented in `AuthFSM`.
Narrowing the enum is a migration over live rows and belongs to **#1044**,
which #1157's own text defers this to ("settled there and rendered here,
not decided twice").

That makes the interesting case the one the narrowing CREATES: a
credential holding a method the console does not offer. A `<select>`
whose value matches no option renders as though the first option had
been chosen, and the next save carries that out — silently converting a
wizard-set `nickserv_identify` into `sasl`. So the stored value is added
to the options, labelled `(set elsewhere)`, and a save that did not touch
the field sends no `auth_method` at all. Both asserted.

**2. "One button with a dropdown" is implemented as "one control in the
cell".** A visitor row carries exactly one verb (`rowActions`), and
putting a list of one behind a tap costs an interaction to say nothing.
Only a multi-verb row collapses — which is the disconnect/terminate pair
vjt named. Picking from the menu ARMS the verb rather than running it, so
the destructive confirmation is not traded for a menu tap; the collapsed
cell grows a Cancel because the button that opened the menu is gone while
a verb is armed.

## Evidence

- `bun run check` — rc=0 (biome + tsc + e2e tsc)
- unit — 5294 passed, 281 files
- **`scripts/integration.sh` — 724 passed, 27.1m, rc=0** (full suite, not a scoped grep)
- `scripts/check.sh` — rc=0
- **17 unit mutants killed**, one assertion each where the assertions are
  independent
- **3 e2e mutants killed, with disjoint attribution**: removing the
  collapse kills the two @webkit tests and leaves the desktop one green;
  dropping the breakpoint from the gate kills the desktop test and leaves
  the two @webkit ones green; making the tick write immediately kills the
  unbind-arms test.

`ux-6-g-admin-mobile-h-scroll` now exercises the new `<fieldset>` at
393px, which is the oracle for its `min-inline-size: 0` — the #1228 trap,
one storey up.

## Test plan

- [x] full integration suite green
- [x] both sides of the mobile/desktop branch proven on a real iPhone 15
      viewport and on desktop chromium
- [x] no horizontal overflow on any admin surface at 393px (`.adm-nav`
      exempt, per vjt)
- [ ] operator dogfood of the per-user page on a real phone