### PR TITLE
login(#1130): a refused connect reports itself instead of waiting to die

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39874,3 +39874,65 @@ also joins the `nginx-csp-range-parity` pin list, where — like
 `media-src` before it — the un-widened value is a PREFIX of the widened
 one, so pinning anything shorter would let a revert sail through
 `toContain`.
+
+---
+
+## 2026-08-12 — #1130: one event carrying two duties, and the budget that made them incompatible
+
+A refused upstream connect reached the client as `:connect_timeout`
+(504), never `:upstream_unreachable` (502). `classify_down/1` maps the
+refusal correctly; it simply never ran, because in production the
+mapping is downstream of a race it always loses.
+
+**The shape of the defect.** `IRC.Client` does not die when a connect
+fails. It arms `Process.send_after({:connect_failed_giveup, reason},
+@connect_failure_sleep_ms)` and only then stops, so the reason travels
+to `Visitors.Login` **on the corpse** — as the monitored `:DOWN`. That
+made the Client's death carry two unrelated duties: pacing the
+`:transient` restart cycle (the throttle's actual job, added after
+azzurra k-lined the bouncer's IP during cluster smoke) and delivering
+the diagnosis. Prod sets the sleep to 30s and the login connect budget
+to 3s, so the `after` clause fires ten times sooner, every time. The
+`:DOWN` lands ~27s later against a caller that has already answered.
+
+**Measured, not deduced.** Before any change, a test that puts the two
+budgets in the production ORDER returned `{:error, :connect_timeout}`
+where `:upstream_unreachable` was asserted — 33 tests, 1 failure. The
+issue's diagnosis was correct as written.
+
+**Two facts that shaped the test.** `@connect_failure_sleep_ms` is
+`Application.compile_env`, baked into the module: a test cannot move it
+without a recompile, which is why the issue's own reproduction had to
+edit `config/test.exs`. The login budget, by contrast, is per-call
+(`Keyword.get(opts, :login_connect_timeout_ms, …)`). Shrinking the
+budget BELOW the compiled sleep therefore reproduces the production
+ordering in about 10ms, with no clock to wait on and no config to
+perturb — the assertion is that the classification survives the
+ordering, so host load cannot flake it. This matters because the two
+pre-existing refused-connect tests passed only by accident of
+`config/test.exs` inverting the production ratio (a 50ms sleep under a
+100ms budget): they asserted a mapping the shipped configuration could
+not produce, so they were never guarding it.
+
+**The fix separates the duties rather than retuning them.** The Client
+already announces the connect SUCCESS upward — `send(state.dispatch_to,
+:irc_connected)`. The failure is that message's sibling and now travels
+the same way, `{:irc_connect_failed, reason}`, re-fired by
+`Session.Server` through the existing `maybe_notify_session_phase/2`
+relay and received by a third arm in the login's phase-1 `receive`. The
+throttle is untouched and keeps its one job: the Client still dies on
+its own schedule, so the restart pacing is exactly what it was. The
+login classifies through `classify_down/1` on the shape the late `:DOWN`
+will carry, so the prompt path and the corpse path cannot drift.
+
+**Rejected: shortening the sleep.** It is the tempting one-liner and it
+trades a wrong error message for the reconnect storm the throttle exists
+to prevent — ~2000 attempts/sec against a refused port, which is how the
+bouncer earned a k-line in the first place.
+
+**A related thing that turned out not to be true.** The throttle was
+never protecting the login path anyway: on any phase failure
+`tear_down/4` calls `Session.stop_session`, a deliberate stop that
+`:transient` does not restart. Its real constituency is the
+bootstrap/respawn path, which this change does not touch — worth knowing
+before someone reasons about the sleep from the login side again.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -1148,6 +1148,17 @@ defmodule Grappa.IRC.Client do
         {:noreply, arm_idle(%{sent | fsm: fsm})}
 
       {:error, reason} ->
+        # #1130 — announce the failure upward NOW: the sibling of the
+        # `send(state.dispatch_to, :irc_connected)` on the success arm above.
+        # The throttle below delays this process's DEATH to pace the
+        # `:transient` restart cycle, and until #1130 that death was also the
+        # only carrier of the diagnosis — with a 30s sleep against a 3s login
+        # budget the waiting login always timed out first, so a refused
+        # upstream reached the operator as a slow network. Announcing the
+        # reason separately lets the sleep keep the single job it was added
+        # for; shortening it would have traded a wrong error for the
+        # reconnect storm it exists to prevent.
+        send(state.dispatch_to, {:irc_connect_failed, reason})
         Process.send_after(self(), {:connect_failed_giveup, reason}, @connect_failure_sleep_ms)
         {:noreply, state}
     end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2918,6 +2918,19 @@ defmodule Grappa.Session.Server do
     {:noreply, state}
   end
 
+  # #1130 — the sibling of `:irc_connected`: the Client could not reach the
+  # upstream at all. Re-fire it as a phase so `Visitors.Login`'s connect wait
+  # learns the REASON immediately, instead of inferring `:connect_timeout`
+  # from the silence while the Client sits out its restart throttle (30s in
+  # prod, ten times the login budget). Notify only: the Client still dies on
+  # its own schedule and every existing exit path — the `{:client_exit, _}`
+  # propagation, the lifecycle event, the `:transient` restart pacing — is
+  # untouched by this.
+  def handle_info({:irc_connect_failed, reason}, state) do
+    maybe_notify_session_phase(state, {:connect_failed, reason})
+    {:noreply, state}
+  end
+
   # #550 — the Client captured the upstream peer at connect. Cache it
   # (address as a string) so the admin Sessions inventory can read the
   # destination this session landed on without round-tripping the socket.

--- a/lib/grappa/visitors/login.ex
+++ b/lib/grappa/visitors/login.ex
@@ -726,7 +726,9 @@ defmodule Grappa.Visitors.Login do
   # RPL_WELCOME. Each phase carries an independent timeout budget +
   # surfaces a distinct typed error. `:DOWN` short-circuits both
   # phases as `:upstream_unreachable` (the spawned Session.Server
-  # crashed before it could complete the phase). On any timeout we
+  # crashed before it could complete the phase); #1130 adds a third
+  # phase-1 arm for the connect failure the Client reports BEFORE it
+  # dies, because its death is throttled well past this budget. On any timeout we
   # tear the session down explicitly so the `:transient` restart loop
   # stops (cluster-cascading bad otherwise — pre-fix would have
   # rapidly restarted against the same broken upstream).
@@ -746,6 +748,18 @@ defmodule Grappa.Visitors.Login do
     receive do
       {:session_phase, ^ref, :connected} ->
         :ok
+
+      # #1130 — the connect FAILED and the Client said so at the moment it
+      # happened. The `:DOWN` carrying the same reason is still coming, but
+      # only after the Client's restart throttle: 30s in production against
+      # this 3s budget, so waiting for the corpse meant `after` always won
+      # and a refused upstream was reported as `:connect_timeout` — a 504
+      # inviting the fast retry that cannot help, for what the session
+      # process had already named as `{:connect_failed, :econnrefused}`.
+      # Classified through the shape that late `:DOWN` will carry, so the
+      # prompt path and the corpse path cannot drift apart.
+      {:session_phase, ^ref, {:connect_failed, reason}} ->
+        {:error, {:down, classify_down({:client_exit, {:connect_failed, reason}})}}
 
       {:DOWN, ^monitor_ref, :process, ^pid, reason} ->
         {:error, {:down, classify_down(reason)}}

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -318,6 +318,31 @@ defmodule Grappa.Visitors.LoginTest do
       assert Visitors.resolve_identity_by_nick("vjt", network.id) == nil
     end
 
+    # #1130 — the ORDERING guard, and the reason the case above is not one.
+    # A refused connect only reaches `classify_down/1` if the Client's death
+    # beats the login's `after` clause, and the Client deliberately sits on a
+    # failed connect for `@connect_failure_sleep_ms` before dying (the
+    # restart throttle). The test config inverts production here: a 50ms
+    # sleep under a 100ms budget, so the `:DOWN` wins and the mapping looks
+    # guarded. Production ships 30s against 3s — the `after` always fires
+    # first and a refused upstream is dressed as a timeout.
+    #
+    # Reproduce the PRODUCTION ORDERING without production's clock: the
+    # sleep is `Application.compile_env` (baked, unreachable from a test),
+    # but the login budget is per-call, so putting it BELOW the sleep
+    # restores the prod order in ~10ms. What is asserted is that the
+    # diagnosis survives the ordering — no elapsed time is measured, so
+    # host load cannot flake it.
+    test "connect refused → :upstream_unreachable even when the login budget expires first (#1130)" do
+      port = pick_unused_port()
+      {network, _} = setup_visitor_network(port)
+
+      assert {:error, :upstream_unreachable} =
+               Login.login(login_input(), login_connect_timeout_ms: 10)
+
+      assert Visitors.resolve_identity_by_nick("vjt", network.id) == nil
+    end
+
     test "no 001 within budget → {:error, :welcome_timeout}, session torn down + anon row purged" do
       {_, port} = start_server()
       {network, _} = setup_visitor_network(port)


### PR DESCRIPTION
Refs #1130.

A refused upstream reached the client as `:connect_timeout` (504) and
never as `:upstream_unreachable` (502). `classify_down/1` maps the
refusal correctly — it just never ran, because the reason only travelled
on the Client's corpse and the corpse is throttled.

`IRC.Client` does not die when a connect fails: it arms
`{:connect_failed_giveup, reason}` after `@connect_failure_sleep_ms` and
stops then. So the Client's death carried **two unrelated duties** —
pacing the `:transient` restart cycle, and delivering the diagnosis.
Production sets 30s against a 3s login budget, so the `after` clause won
every time and the operator read a slow network for what the session
process had already logged as `{:connect_failed, :econnrefused}`.

## Measured before changing anything

The new test, run against unmodified `main`:

```
1) connect refused → :upstream_unreachable even when the login budget
   expires first (#1130)
   left:  {:error, :upstream_unreachable}
   right: {:error, :connect_timeout}
33 tests, 1 failure
```

The issue's diagnosis is correct as written.

## The fix separates the duties, it does not retune them

The Client already announces connect SUCCESS upward
(`send(state.dispatch_to, :irc_connected)`). The failure is that
message's sibling and now travels the same way, re-fired by
`Session.Server` through the existing `maybe_notify_session_phase/2`
relay and taken by a third arm in the login's phase-1 `receive`. It is
classified on the shape the late `:DOWN` will carry, so the prompt path
and the corpse path cannot drift apart.

**The throttle is untouched.** Shortening it is the tempting one-liner
and trades a wrong error for the reconnect storm it exists to prevent.
Related, and worth knowing: on the login path the throttle was never
protecting anything — `tear_down/4` calls `Session.stop_session`, a
deliberate stop that `:transient` does not restart. Its real
constituency is the bootstrap/respawn path, which this does not touch.

## On the test

The give-up sleep is `Application.compile_env` (baked; a test cannot
move it without a recompile), but the login budget is per-call. Dropping
the budget **below** the sleep reproduces the production ordering in
~10ms. The assertion is that the classification survives the ordering —
no elapsed time is measured, so host load cannot flake it.

The two pre-existing refused-connect cases pass today only because
`config/test.exs` inverts the production ratio (50ms sleep under a 100ms
budget). They asserted a mapping the shipped configuration could not
produce, so they were never guarding this.

## Test plan

- [x] `test/grappa/visitors/login_test.exs` — red measured first (1
      failure), green after (33/33)
- [x] `scripts/check.sh` — rc=0: 5939 tests + 8 doctests + 59
      properties, 0 failures; Dialyzer `Total errors: 0`; Credo;
      Sobelow. Working tree byte-identical before and after the run.
- [ ] e2e / integration (STACK lane not requested — no client-facing or
      wire change; the surface is the 502/504 the FallbackController
      already renders)