### PR TITLE
cic(#1250): guard the paste flood cap on the IME path, where it did not exist

### DIFF
--- a/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
@@ -1,0 +1,210 @@
+// #1250 — the paste flood guard on the IME path.
+//
+// GBoard's clipboard chip does not fire a `paste` event. It commits the text
+// through the input method, which surfaces as `beforeinput` with an
+// `insertFromPaste` inputType, and both pre-#1250 doors into the router were
+// `paste` listeners. The guard was therefore not weak on that path, it was
+// ABSENT: `classifyPaste` never ran, and an operator could send a burst of any
+// size by choosing the chip over the long-press Paste menu — never shown the
+// count, never offered the .txt door that the 2026-08-06 ruling made the only
+// way out above the cap. Reporter's A/B: chip → no dialog, long-press → dialog.
+//
+// What each test here is for:
+//
+//   1-2. The IME door itself. A synthetic `beforeinput[insertFromPaste]` is the
+//        closest a browser harness gets to the chip — Playwright cannot drive
+//        GBoard, and no CDP verb commits an insertFromPaste. This is a stated
+//        LIMIT of the simulation, not a claim about GBoard: what is proven is
+//        that cic answers the event GBoard emits. The oracle is the visible
+//        outcome the reporter did NOT get — a dialog, and a composer that
+//        stays empty.
+//
+//   3.   The ORDERING, measured rather than assumed. The no-double-dialog
+//        argument in pasteRoute.ts rests on a browser contract: `paste` fires
+//        first, and only an UNCANCELLED paste produces the insertion that
+//        fires `beforeinput`, so a guarded arm's preventDefault suppresses the
+//        second report. #1250's text claims some engines fire `beforeinput`
+//        first, which would break that argument. A synthetic ClipboardEvent
+//        cannot settle it — an untrusted event performs no default action, so
+//        no `beforeinput` ever follows it and the measurement would be
+//        vacuous. This test therefore drives a REAL clipboard gesture
+//        (copy from a scratch field, paste with the keyboard) and records the
+//        order the page actually observes.
+
+import type { Page } from "@playwright/test";
+
+import {
+  composeTextarea,
+  confirmModal,
+  confirmModalBody,
+  confirmModalCancel,
+  confirmModalYes,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// The slice of TestInfo this spec uses — the attach verb only, so the shared
+// journey does not have to take the whole fixture just to record one string.
+type AttachFn = (name: string, options: { body: string; contentType: string }) => Promise<void>;
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// 7 messages — past PASTE_HARD_MESSAGE_LIMIT (5), so the hard-close arm.
+const OVER_LIMIT = ["uno", "due", "tre", "quattro", "cinque", "sei", "sette"].join("\n");
+// 4 messages — the confirm arm.
+const MID_SIZE = ["uno", "due", "tre", "quattro"].join("\n");
+
+async function openCompose(page: Page): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(composeTextarea(page)).toBeVisible();
+}
+
+// The GBoard chip, as closely as a harness can state it: the insertion event
+// an IME commit produces, carrying the text on a DataTransfer. NO `paste`
+// event is dispatched — that absence IS the bug this reproduces.
+async function imePaste(page: Page, text: string): Promise<void> {
+  await composeTextarea(page).evaluate((el, t) => {
+    const dt = new DataTransfer();
+    dt.setData("text/plain", t);
+    el.dispatchEvent(
+      new InputEvent("beforeinput", {
+        inputType: "insertFromPaste",
+        dataTransfer: dt,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }, text);
+}
+
+test("#1250 — an over-limit IME paste is hard-closed: dialog, and the block never lands", async ({
+  page,
+}) => {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+  await expect(ta).toHaveValue("");
+
+  await imePaste(page, OVER_LIMIT);
+
+  // The outcome the reporter never saw on this gesture.
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModalBody(page)).toContainText("7");
+  await expect(confirmModalBody(page)).toContainText(CHANNEL ?? "");
+  // Hard close: above the cap the paste door is gone, so the text must not be
+  // in the composer while the dialog is up.
+  await expect(ta).toHaveValue("");
+
+  // Cancel is the safe default here too — nothing lands, nothing uploads.
+  await confirmModalCancel(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+});
+
+test("#1250 — a mid-size IME paste asks, and the affirmative lands the block", async ({ page }) => {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+
+  await imePaste(page, MID_SIZE);
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModalBody(page)).toContainText("4");
+  await expect(ta).toHaveValue("");
+
+  await confirmModalYes(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue(MID_SIZE);
+});
+
+async function realPasteOrderJourney(page: Page, testInfo: { attach: AttachFn }): Promise<void> {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+
+  // Record what the textarea actually receives, in order. Capture phase so the
+  // recorder cannot be skipped by the app's own handling, and it only reads.
+  await ta.evaluate((el) => {
+    const w = window as unknown as { __pasteSeq?: string[] };
+    w.__pasteSeq = [];
+    for (const type of ["paste", "beforeinput"]) {
+      el.addEventListener(
+        type,
+        (e) => {
+          w.__pasteSeq?.push(
+            type === "beforeinput" ? `beforeinput:${(e as InputEvent).inputType}` : "paste",
+          );
+        },
+        { capture: true },
+      );
+    }
+  });
+
+  // Load the OS clipboard through a real user gesture: a scratch field, then
+  // select-all + copy from the keyboard. `navigator.clipboard.writeText` is
+  // deliberately avoided — it needs a permission grant that is chromium-only,
+  // and this measurement has to mean the same thing on both engines.
+  await page.evaluate((text) => {
+    const scratch = document.createElement("textarea");
+    scratch.id = "clip-scratch";
+    scratch.value = text;
+    // Top of the viewport and above everything: at the BOTTOM the bar's
+    // network label intercepts the pointer on the 390px iPhone project, and
+    // the click never lands.
+    scratch.style.position = "fixed";
+    scratch.style.top = "0";
+    scratch.style.left = "0";
+    scratch.style.width = "120px";
+    scratch.style.height = "40px";
+    scratch.style.zIndex = "2147483647";
+    document.body.appendChild(scratch);
+  }, MID_SIZE);
+  const scratch = page.locator("#clip-scratch");
+  await scratch.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ControlOrMeta+c");
+  await page.evaluate(() => document.getElementById("clip-scratch")?.remove());
+
+  await ta.click();
+  await page.keyboard.press("ControlOrMeta+v");
+
+  // The product invariant: ONE gesture, ONE dialog. If a second report reached
+  // the router, the operator would be asked the same question twice.
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModal(page)).toHaveCount(1);
+  await expect(ta).toHaveValue("");
+
+  const seq = await page.evaluate(
+    () => (window as unknown as { __pasteSeq?: string[] }).__pasteSeq ?? [],
+  );
+  // Attached as well as asserted, so the raw observation survives in the run's
+  // artefacts for comparison after a future engine update.
+  await testInfo.attach("paste-event-order", { body: seq.join(" → "), contentType: "text/plain" });
+
+  // The PIN, and the whole reason this test drives a real gesture: exactly one
+  // report reaches the guard, and it is the `paste` one. That is the contract
+  // pasteRoute.ts's no-bookkeeping design rests on — the guarded arm cancels,
+  // so the insertion never happens and its `beforeinput` never fires. #1250's
+  // text claims some engines report `beforeinput` first; if this ever observes
+  // that, the design needs the gesture-claim it deliberately does without, and
+  // this assertion is what says so out loud instead of leaving a double dialog
+  // for an operator to find.
+  expect(
+    seq.filter((s) => s === "paste" || s === "beforeinput:insertFromPaste"),
+    `a cancelled paste must be the ONLY report the guard sees — observed: ${seq.join(" → ")}`,
+  ).toEqual(["paste"]);
+}
+
+test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order", async ({
+  page,
+}, testInfo) => {
+  await realPasteOrderJourney(page, testInfo);
+});
+
+// The same measurement on the other shipped engine. The ordering is a browser
+// contract, so one engine's answer is not the answer.
+test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order @webkit", async ({
+  page,
+}, testInfo) => {
+  await realPasteOrderJourney(page, testInfo);
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -28,7 +28,7 @@ import { diagPush } from "./lib/diagLog";
 import { frameBudgetForTarget } from "./lib/frameBudget";
 import { frameBudgetBaseForNetwork } from "./lib/isupport";
 import { networkBySlug } from "./lib/networks";
-import { routeClipboardPaste } from "./lib/pasteRoute";
+import { routeClipboardPaste, routePastedInput } from "./lib/pasteRoute";
 import {
   claimAxis,
   type DragAxis,
@@ -524,6 +524,16 @@ const ComposeBox: Component<Props> = (props) => {
     routeClipboardPaste(e, textareaEl, props.networkSlug, props.channelName, true);
   };
 
+  // #1250 — the same guard for a paste that fires NO `paste` event. GBoard's
+  // clipboard chip commits through the input method, which surfaces only as
+  // `beforeinput` with an `insertFromPaste` inputType, so the flood cap was
+  // bypassable by picking that gesture. The router arbitrates the overlap with
+  // `onPaste` above (one gesture, one decision) — see its claim comment.
+  const onBeforeInput = (e: InputEvent) => {
+    if (textareaEl === undefined) return;
+    routePastedInput(e, textareaEl, props.networkSlug, props.channelName);
+  };
+
   // #118 — "(i/N)" counter, shown only while a multi-file batch is in
   // flight. A single upload (total 1) renders no counter.
   const batchLabel = (): string | null => {
@@ -680,6 +690,7 @@ const ComposeBox: Component<Props> = (props) => {
           onInput={onInput}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
+          onBeforeInput={onBeforeInput}
           // #974 — NOT the fix for that issue, and explicitly not the
           // mechanism behind it (the iOS auto-capitalisation hypothesis was
           // falsified on a real device). Correct on its own merits: with no

--- a/cicchetto/src/__tests__/pasteRoute.test.ts
+++ b/cicchetto/src/__tests__/pasteRoute.test.ts
@@ -30,7 +30,7 @@ vi.mock("../lib/dropUpload", () => ({
 import { setDraft } from "../lib/compose";
 import { requestConfirm } from "../lib/confirmDialog";
 import { dropUpload } from "../lib/dropUpload";
-import { routeClipboardPaste } from "../lib/pasteRoute";
+import { routeClipboardPaste, routePastedInput } from "../lib/pasteRoute";
 
 type ClipItem = { kind: string; type: string; getAsFile: () => File | null };
 
@@ -57,6 +57,30 @@ function pasteEvent(opts: { text?: string; file?: File | null }): {
 
 function textarea(): HTMLTextAreaElement {
   return document.createElement("textarea");
+}
+
+// #1250 — synthesise the `beforeinput` an IME insertion fires. `dataTransfer`
+// is not settable through the constructor, so it is defined on the instance
+// the same way `clipboardData` is above; `data` rides the constructor, which
+// is how the engines report a plain-string commit.
+function inputEvent(opts: { inputType: string; dataTransferText?: string; data?: string }): {
+  e: InputEvent;
+  preventDefault: ReturnType<typeof vi.spyOn>;
+} {
+  const e = new InputEvent("beforeinput", {
+    inputType: opts.inputType,
+    data: opts.data ?? null,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (opts.dataTransferText !== undefined) {
+    Object.defineProperty(e, "dataTransfer", {
+      value: { getData: (t: string) => (t === "text" ? opts.dataTransferText : "") },
+      configurable: true,
+    });
+  }
+  const preventDefault = vi.spyOn(e, "preventDefault");
+  return { e, preventDefault };
 }
 
 const pngFile = (): File =>
@@ -153,5 +177,143 @@ describe("pasteRoute — routeClipboardPaste", () => {
     expect(req).toBeDefined();
     req?.onConfirm();
     expect(setDraft).toHaveBeenCalledWith("freenode #a", block);
+  });
+});
+
+// #1250 — the IME door. GBoard's clipboard chip fires NO `paste` event: it
+// commits through the input method, which surfaces only as `beforeinput` with
+// an `insertFromPaste` inputType. Before this the flood cap was not weak on
+// that path, it was absent — `classifyPaste` never ran, so an operator could
+// paste an arbitrary burst by choosing the chip over the long-press menu.
+describe("pasteRoute — routePastedInput (IME insertFromPaste, #1250)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const BLOCK_OVER_LIMIT = "a\nb\nc\nd\ne\nf\ng";
+  const BLOCK_CONFIRM = "a\nb\nc\nd";
+
+  it("over-limit IME paste → hard close: the upload dialog, and the text never lands", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK_OVER_LIMIT,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+    const req = vi.mocked(requestConfirm).mock.calls[0]?.[0];
+    // The over-limit arm is the one with no paste door: upload IS the
+    // affirmative and there is no alternative offered.
+    expect(req?.confirmLabel).toBe("Upload as .txt");
+    expect(req?.alternative).toBeNull();
+  });
+
+  it("mid-size IME paste → the same confirm dialog the clipboard door raises", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK_CONFIRM,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(vi.mocked(requestConfirm).mock.calls[0]?.[0]?.title).toBe("Paste as 4 messages?");
+  });
+
+  it("insertFromPasteAsQuotation is the same gesture and is guarded too", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPasteAsQuotation",
+      dataTransferText: BLOCK_OVER_LIMIT,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("falls back to event.data when the insertion carries no dataTransfer", () => {
+    const { e, preventDefault } = inputEvent({ inputType: "insertFromPaste", data: BLOCK_CONFIRM });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("a one-message IME paste is left to the browser — no dialog, no preventDefault", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: "one line",
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+  });
+
+  it("ordinary typing is not a paste — a big insertText is untouched", () => {
+    const { e, preventDefault } = inputEvent({ inputType: "insertText", data: BLOCK_OVER_LIMIT });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+// #1250 — one gesture, at most one dialog, with no cross-event bookkeeping.
+// A native paste IS reported twice, but the second report is the first one's
+// default action: the UA fires `paste`, and only an uncancelled `paste`
+// produces the insertion that fires `beforeinput[insertFromPaste]`. These pin
+// the two halves of that argument at the unit level — that a guarded arm
+// cancels (so the second report never exists) and that the pass-through arm is
+// idempotent if both do fire. The ORDERING itself is a browser contract, so it
+// is measured in a real browser by `paste-ime-flood-guard.spec.ts`, not
+// asserted here from a synthetic event.
+describe("pasteRoute — one gesture cannot ask twice (#1250)", () => {
+  const BLOCK = "a\nb\nc\nd";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("a guarded paste CANCELS, which is what suppresses the beforeinput that would ask again", () => {
+    const { e, preventDefault } = pasteEvent({ text: BLOCK });
+    routeClipboardPaste(e, textarea(), "freenode", "#a", true);
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    // The whole no-double-dialog argument rests on this call: no insertion,
+    // therefore no insertFromPaste, therefore no second decision.
+    expect(preventDefault).toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("the guarded IME arm cancels its own insertion the same way", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  // The one case where both reports DO reach the router: a below-threshold
+  // paste, which cancels nothing. Running the decision twice must stay a
+  // no-op — no dialog, no draft write, nothing inserted twice.
+  it("a below-threshold paste reported twice inserts once and asks nothing", () => {
+    const { e: pasted, preventDefault: pastePrevented } = pasteEvent({ text: "one line" });
+    routeClipboardPaste(pasted, textarea(), "freenode", "#a", true);
+    const { e: inserted, preventDefault: inputPrevented } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: "one line",
+    });
+    routePastedInput(inserted, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+    expect(pastePrevented).not.toHaveBeenCalled();
+    expect(inputPrevented).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -13,6 +13,13 @@ import { categoryOf } from "./uploadCategory";
 // the document while focus sits elsewhere — resolves to the same three
 // outcomes: file → upload, big text → flood-confirm, small text → insert.
 //
+// #1250 added a THIRD door for the same reason the second one exists: an
+// IME-mediated paste (GBoard's clipboard chip) fires no `paste` event at all,
+// so the guard did not exist on that path and the message cap was bypassable
+// by choosing a different gesture. All three doors converge on
+// `routeGuardedText` — a new entry point must reuse it rather than grow a
+// fourth copy of the decision.
+//
 // The dependencies are all module-level (compose store, dropUpload,
 // confirmDialog, pasteFlood), so this is a pure function of (event, textarea,
 // target) — nothing ComposeBox-instance-bound. The textarea is passed in
@@ -113,12 +120,75 @@ export function routeClipboardPaste(
     dropUpload(files, networkSlug, channelName);
     return;
   }
+  routeGuardedText(e, data.getData("text"), ta, networkSlug, channelName, nativeInsertAvailable);
+}
+
+// #1250 — the THIRD door: an IME-mediated paste. GBoard's clipboard chip (and
+// any other input-method insertion) commits text through the input method and
+// fires NO `paste` event at all — only `beforeinput` with an `insertFromPaste`
+// inputType. The flood guard was therefore not "weak" on that path, it was
+// absent: an operator could bypass PASTE_HARD_MESSAGE_LIMIT entirely by
+// choosing the chip over the long-press Paste menu.
+//
+// Text source order mirrors what the engines actually populate: `dataTransfer`
+// when the insertion carries one, `data` for the plain-string commit. Anything
+// else is not a paste we can size, so it is left alone.
+export function routePastedInput(
+  e: InputEvent,
+  ta: HTMLTextAreaElement,
+  networkSlug: string,
+  channelName: string,
+): void {
+  if (!PASTE_INPUT_TYPES.has(e.inputType)) return;
+  const text = e.dataTransfer?.getData("text") ?? e.data ?? "";
+  // nativeInsertAvailable = true: this IS the browser's own insertion about to
+  // happen into the focused textarea, so the below-threshold arm lets it.
+  routeGuardedText(e, text, ta, networkSlug, channelName, true);
+}
+
+// `insertFromPasteAsQuotation` is the same gesture with quoting applied by the
+// UA; it becomes the same burst of PRIVMSGs, so it is sized by the same rule.
+const PASTE_INPUT_TYPES = new Set(["insertFromPaste", "insertFromPasteAsQuotation"]);
+
+// The ONE text decision, shared by all three doors (textarea `paste`, the #352
+// document listener, and the #1250 IME `beforeinput`). Takes the event as a
+// bare `Event` because all it needs from it is `preventDefault` — which is
+// also what keeps a fourth door from having to be a ClipboardEvent.
+//
+// #1250, one gesture / at most one dialog — by CONSTRUCTION, with no
+// cross-event bookkeeping. A native paste is reported twice, but the second
+// report is the FIRST one's default action: the UA fires `paste`, and only if
+// that is not cancelled does it perform the insertion, which is what fires
+// `beforeinput[insertFromPaste]`. So both guarded arms below, which
+// `preventDefault` the `paste`, structurally suppress the `beforeinput` that
+// would have asked again. The pass-through arm does let both fire, and is
+// idempotent by design: with `nativeInsertAvailable` it only ever decides "let
+// the browser do it", so classifying twice costs one extra pure call and
+// changes nothing.
+//
+// The rejected alternative was a module-level "this gesture is claimed" flag
+// released on a macrotask. It would have covered a hypothetical engine that
+// fires both reports for a CANCELLED paste — but it also makes two pastes in
+// one task indistinguishable from one, which is a state no browser can produce
+// and every existing paste test does. Three test files had to learn to yield
+// between cases before this comment was written; a guard that quietly disarms
+// itself for the next author is worse than the ordering assumption it removes.
+// The ordering is verified on both shipped engines by
+// `paste-ime-flood-guard.spec.ts` rather than assumed here.
+function routeGuardedText(
+  e: Event,
+  text: string,
+  ta: HTMLTextAreaElement,
+  networkSlug: string,
+  channelName: string,
+  nativeInsertAvailable: boolean,
+): void {
   // #737 — a paced drain owns this window's draft, so the text path has
   // nowhere to put a paste: the store refuses the write. Drop it HERE rather
   // than letting the flood modal ask "Paste 30 lines?" and then discard the
   // answer. preventDefault covers the global-listener path, whose target
   // textarea may not be the focused element and so is not protected by its own
-  // readOnly. The file branch above is untouched — an upload never touches the
+  // readOnly. The file branch is untouched — an upload never touches the
   // draft.
   if (isDraining(channelKey(networkSlug, channelName))) {
     e.preventDefault();
@@ -130,7 +200,6 @@ export function routeClipboardPaste(
   // compose by hand. `classifyPaste` owns the three-way decision; this switch
   // owns what each one looks like. Both dialogs reuse the store-driven
   // confirm (lib/confirmDialog) — Cancel is the safe default in both.
-  const text = data.getData("text");
   // Always the real count in both guarded arms, and ≥ 2 by construction, so
   // the plural is unconditional and needs no branch.
   const messages = pastedMessageCount(text);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39874,3 +39874,65 @@ also joins the `nginx-csp-range-parity` pin list, where — like
 `media-src` before it — the un-widened value is a PREFIX of the widened
 one, so pinning anything shorter would let a revert sail through
 `toContain`.
+
+---
+
+## 2026-08-12 — #1250: a guard that did not exist on the path most people paste from
+
+The paste flood cap (#80/#816) was bypassable by picking a different gesture.
+GBoard's clipboard chip does not fire a `paste` event: it commits through the
+input method, which surfaces as `beforeinput` with an `insertFromPaste`
+inputType. Both doors into `routeClipboardPaste` were `paste` listeners, so
+`classifyPaste` never ran — the guard was not weak on Android, it was
+**absent**, and `PASTE_HARD_MESSAGE_LIMIT` was advisory rather than enforced.
+The reporter's own A/B said it plainly: chip → no dialog, long-press Paste →
+dialog. `git grep beforeinput -- cicchetto/src` returned nothing on `main`.
+
+`routePastedInput` is the third door, and the extraction that made #352's
+second door safe is what makes this one safe: `routeGuardedText` now holds the
+drain check and the three-way classify, so textarea-paste, document-paste and
+IME-insertion cannot drift. `insertFromPasteAsQuotation` rides the same arm —
+it becomes the same burst of PRIVMSGs, so it is sized by the same rule.
+
+**The interesting decision was how NOT to ask twice.** A native paste is
+reported to the app twice: as `paste`, and as the `beforeinput` for the
+insertion it causes. The first implementation was a module-level "this gesture
+is already decided" flag released on a macrotask — order-independent, and
+wrong for this codebase: it also makes two pastes *in one task*
+indistinguishable from one. No browser can produce that state; three test
+files produce it constantly, and two of them had to be taught to yield between
+cases before the shape of the mistake was obvious. A guard that quietly
+disarms itself for whoever writes the next paste test is worse than the
+ordering assumption it removes, so it was reverted.
+
+What shipped instead is a structural argument with no bookkeeping at all: the
+UA fires `paste`, and only an UNCANCELLED paste performs the insertion that
+fires `beforeinput`. Both guarded arms cancel, so the second report never
+exists; the pass-through arm lets both fire and is idempotent, because with
+`nativeInsertAvailable` its only decision is "let the browser do it".
+
+**That argument rests on a browser contract, so it was measured rather than
+believed.** #1250's text claims some engines report `beforeinput` first, which
+would mean two dialogs for one gesture. A synthetic `ClipboardEvent` cannot
+settle it — an untrusted event runs no default action, so no `beforeinput`
+ever follows and the measurement is vacuous, which is exactly the trap the
+pre-existing #80 spec's technique would have walked into. The new spec drives
+a REAL clipboard gesture (copy out of a scratch field with the keyboard, then
+paste) and pins the observed sequence. On **chromium and webkit both**, a
+guarded paste is reported exactly once, as `paste`; no `beforeinput` follows
+it. The claim in the issue is not reproduced on either engine we ship, and the
+pin is the thing that will say so out loud if a future engine differs.
+
+**Mutation-checked**, because an e2e that would pass without the fix is not
+evidence: unwiring the IME listener from ComposeBox kills exactly the two IME
+tests and leaves the two ordering tests green — the discrimination the two
+halves of the spec are supposed to have. (The first attempt at that mutant
+broke `tsc` instead, so the suite never ran and the red meant nothing; a
+mutant has to compile before its red is a measurement.)
+
+**Stated limits.** The IME tests dispatch a synthetic
+`beforeinput[insertFromPaste]`: Playwright cannot drive GBoard and no CDP verb
+commits one, so what is proven is that cic answers the event GBoard emits, not
+that GBoard emits it — the latter rests on the reporter's device A/B. And the
+issue's closing question, whether the `text === ""` arm is really iOS-only or
+the same hole in another hat, is deliberately untouched here.


### PR DESCRIPTION
Refs #1250.

GBoard's clipboard chip fires **no `paste` event** — it commits through the
input method, which surfaces as `beforeinput` with an `insertFromPaste`
inputType. Both doors into `routeClipboardPaste` are `paste` listeners, so
`classifyPaste` never ran: the guard was not weak on that path, it was
**absent**, and `PASTE_HARD_MESSAGE_LIMIT` was advisory rather than enforced.
Reporter's A/B: chip → no dialog, long-press Paste → dialog. Verified on
`origin/main`: `git grep beforeinput -- cicchetto/src cicchetto/e2e` returns
nothing.

`routePastedInput` is the third door and converges on the same decision —
`routeGuardedText` now owns the drain check and the three-way classify, so the
textarea paste, the #352 document listener and the IME insertion cannot drift.
`insertFromPasteAsQuotation` rides the same arm.

## Not asking twice, and why there is no bookkeeping

A native paste is reported twice: as `paste`, and as the `beforeinput` for the
insertion it causes. The first implementation was a module-level gesture claim
released on a macrotask. **It was reverted**: it is order-independent, but it
also makes two pastes *in one task* indistinguishable from one — a state no
browser can produce and every existing paste test does. Two test files had
already been taught to yield between cases before that became obvious, and a
guard that disarms itself for the next author is worse than the assumption it
removes.

What ships is structural: the UA fires `paste`, and only an **uncancelled**
paste performs the insertion that fires `beforeinput`. Both guarded arms
cancel, so the second report never exists. The pass-through arm lets both fire
and is idempotent.

## The ordering was measured, not assumed

The issue says some engines report `beforeinput` first, which would break that
argument. A synthetic `ClipboardEvent` cannot settle it — an untrusted event
runs no default action, so no `beforeinput` ever follows and the measurement
would be vacuous. The new spec drives a **real** clipboard gesture and pins the
observed sequence:

- **chromium**: `["paste"]`
- **webkit (iPhone 15)**: `["paste"]`

A guarded paste is reported exactly once, as `paste`, on both engines we ship.
The issue's claim is not reproduced on either. If a future engine differs, that
pin reddens instead of leaving a double dialog for an operator to find.

## Test plan

- [x] `bun run test` — 5290 passing, incl. 17 in `pasteRoute.test.ts`
- [x] `bun run check` — biome + tsc + tsc `-p e2e/tsconfig.json`
- [x] `scripts/integration.sh --grep "#1250"` — 4/4 across both projects
- [x] **Mutation**: unwiring the IME listener from ComposeBox kills exactly the
      two IME tests and leaves the two ordering tests green. (The first mutant
      broke `tsc`, so the suite never ran and its red meant nothing — a mutant
      has to compile before its red is a measurement.)

## Stated limits

The IME tests dispatch a synthetic `beforeinput[insertFromPaste]`: Playwright
cannot drive GBoard and no CDP verb commits one. What is proven is that cic
answers the event GBoard emits — that GBoard emits it rests on the reporter's
device A/B. The issue's closing question about the `text === ""` iOS arm is
left open, not folded in.