### PR TITLE
union: #1157 admin residuals + #1250 IME paste guard, gated together

### DIFF
--- a/cicchetto/e2e/tests/admin-user-networks.spec.ts
+++ b/cicchetto/e2e/tests/admin-user-networks.spec.ts
@@ -67,17 +67,21 @@ async function openUserPage(page: import("@playwright/test").Page, userId: strin
   await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
 }
 
-/** Fill and submit the `+` form for one network. */
-async function addNetwork(
+/**
+ * Give the user one network, the #1157 way: tick the section, fill the
+ * nick the bind needs, Save. There is no `+` and no network picker —
+ * every configured network already has a section, and the tick is the
+ * whole statement about access.
+ */
+async function enableNetwork(
   page: import("@playwright/test").Page,
   networkId: number,
   nick: string,
 ): Promise<void> {
-  await page.getByTestId("admin-user-network-add").click();
-  await expect(page.getByTestId("admin-user-network-add-form")).toBeVisible();
-  await page.getByTestId("admin-user-network-add-network").selectOption(String(networkId));
-  await page.getByTestId("admin-user-network-add-nick").fill(nick);
-  await page.getByTestId("admin-user-network-add-submit").click();
+  await page.getByTestId(`admin-user-network-enabled-${networkId}`).check();
+  await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+  await page.getByTestId(`admin-user-network-nick-${networkId}`).fill(nick);
+  await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 }
 
 async function createUser(token: string, name: string): Promise<string> {
@@ -184,19 +188,22 @@ test("an operator creates a user and gives it a network in one flow", async ({ p
     await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("admin-user-page-name")).toHaveText(userName);
 
-    await addNetwork(page, networkId, "flownick");
+    await enableNetwork(page, networkId, "flownick");
 
-    // The operator-visible outcome: the user now has that network.
-    const row = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(row).toBeVisible({ timeout: 10_000 });
-    await expect(row).toContainText(netSlug);
+    // The operator-visible outcome: the section for that network is
+    // ticked, and it names the network it is about.
+    const section = page.getByTestId(`admin-user-network-${networkId}`);
+    await expect(section).toContainText(netSlug);
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
+      timeout: 10_000,
+    });
 
     // And it survives a reload, so the verdict rests on the server's answer
     // rather than on the reply the form just rendered.
     userId = await findUserId(admin.token, userName);
     await page.reload();
     await openUserPage(page, userId);
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toBeVisible({
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
       timeout: 10_000,
     });
   } finally {
@@ -215,7 +222,7 @@ test("an operator creates a user and gives it a network in one flow", async ({ p
   }
 });
 
-test("admin adds a network to an existing user — the row appears", async ({ page }) => {
+test("admin gives an existing user a network — the section ticks", async ({ page }) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-add-u");
   const netSlug = unique("e2eun-add-n");
@@ -229,15 +236,17 @@ test("admin adds a network to an existing user — the row appears", async ({ pa
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    // Pre-state: the user is on no networks, so the row this test asserts on
-    // cannot be a leftover from an earlier run.
-    await expect(page.getByTestId("admin-user-networks-empty")).toBeVisible();
+    // Pre-state: the section EXISTS (it is a configured network) and is
+    // NOT ticked, so the tick this test asserts on cannot be a leftover
+    // from an earlier run. Asserting the section's ABSENCE would be the
+    // pre-#1157 claim, and is now false by construction.
+    const tick = page.getByTestId(`admin-user-network-enabled-${networkId}`);
+    await expect(tick).toBeVisible({ timeout: 10_000 });
+    await expect(tick).not.toBeChecked();
 
-    await addNetwork(page, networkId, "boundnick");
+    await enableNetwork(page, networkId, "boundnick");
 
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(tick).toBeChecked({ timeout: 10_000 });
   } finally {
     if (userId !== null && networkId !== null) {
       await unbindBestEffort(admin.token, userId, networkId);
@@ -247,7 +256,9 @@ test("admin adds a network to an existing user — the row appears", async ({ pa
   }
 });
 
-test("admin edits a network (realname change) — the row reports left_alone", async ({ page }) => {
+test("admin edits a network (realname change) — the section reports left_alone", async ({
+  page,
+}) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-edit-u");
   const netSlug = unique("e2eun-edit-n");
@@ -262,13 +273,13 @@ test("admin edits a network (realname change) — the row reports left_alone", a
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    await page.getByTestId(`admin-user-network-edit-${networkId}`).click();
-    await expect(page.getByTestId(`admin-user-network-edit-form-${networkId}`)).toBeVisible();
+    // No Edit button to press: a bound network's settings form is simply
+    // open, because the section IS the editor.
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+    await page.getByTestId(`admin-user-network-realname-${networkId}`).fill("Updated Name");
+    await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 
-    await page.getByTestId(`admin-user-network-edit-realname-${networkId}`).fill("Updated Name");
-    await page.getByTestId(`admin-user-network-edit-submit-${networkId}`).click();
-
-    // Row state, not a toast (vjt: a toast throws four values away), and the
+    // Section state, not a toast (vjt: a toast throws four values away), and the
     // raw wire token, per the operator-console policy the banners follow.
     await expect(page.getByTestId(`admin-user-network-session-action-${networkId}`)).toContainText(
       "left_alone",
@@ -283,7 +294,7 @@ test("admin edits a network (realname change) — the row reports left_alone", a
   }
 });
 
-test("admin removes a network via inline-confirm — the row goes", async ({ page }) => {
+test("admin removes a network by unticking it — the tick clears", async ({ page }) => {
   const admin = getSeededAdmin();
   const userName = unique("e2eun-rm-u");
   const netSlug = unique("e2eun-rm-n");
@@ -298,15 +309,22 @@ test("admin removes a network via inline-confirm — the row goes", async ({ pag
     await adminLogin(page, admin);
     await openUserPage(page, userId);
 
-    const removeBtn = page.getByTestId(`admin-user-network-remove-${networkId}`);
-    await expect(removeBtn).toHaveText(/^Remove$/);
-    await removeBtn.click();
-    await expect(removeBtn).toHaveText(/^Confirm remove$/);
-    await removeBtn.click();
+    // Two steps, as before, but over the shape this page now has:
+    // unticking ARMS and the named button fires. Unticking alone must not
+    // delete anything, which is the first assertion.
+    const tick = page.getByTestId(`admin-user-network-enabled-${networkId}`);
+    await tick.uncheck();
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-user-network-remove-${networkId}`)).toBeVisible();
 
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toHaveCount(0, {
+    await page.getByTestId(`admin-user-network-remove-${networkId}`).click();
+
+    // The credential is gone: the section stays (the network is still
+    // configured) and its tick is clear.
+    await expect(page.getByTestId(`admin-user-network-remove-${networkId}`)).toHaveCount(0, {
       timeout: 10_000,
     });
+    await expect(tick).not.toBeChecked();
   } finally {
     if (userId !== null && networkId !== null) {
       await unbindBestEffort(admin.token, userId, networkId);

--- a/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
+++ b/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
@@ -1,0 +1,120 @@
+// #1157 — the dictated column 4, on a real phone.
+//
+// vjt, 2026-08-09: the row's disconnect / terminate buttons "on mobile
+// collapse into a single button with a dropdown". `AdminSessionsTab`
+// branches on `isAdminNarrow()`, which is `matchMedia("(max-width:
+// 899px)")` — and jsdom has none, so the unit file
+// (`adminSessionsActionsMenu.test.tsx`) has to SUPPLY the regime. It
+// proves the branch; it cannot prove which side of it a phone lands on.
+// That is this file's whole job, and it is why the phone case is
+// `@webkit` (the iPhone 15 device, 393px) rather than a resized desktop.
+//
+// Both sides run, deliberately. A collapse that also fired on a 1280px
+// desktop would satisfy a phone-only file, and "desktop keeps them side
+// by side" is half the dictation.
+//
+// NOTHING here confirms a verb. The two verbs on a user row stop a real
+// seeded session, and this suite shares its stack — the m9b actions spec
+// carries an `afterEach` repair hook precisely because it does fire them.
+// The claim under test is that picking from the menu ARMS a confirmation
+// instead of running it, so arming and then cancelling is not a
+// half-measure: it is the assertion.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated, EXEMPT.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { expectShellReady, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
+
+async function adminLogin(page: Page): Promise<void> {
+  const seed = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+function idFromSubjectJson(subjectJson: string): string {
+  const subject = JSON.parse(subjectJson) as { id?: string };
+  if (typeof subject.id !== "string") {
+    throw new Error(`seeded subject carries no id: ${subjectJson}`);
+  }
+  return subject.id;
+}
+
+// A USER row, which is the only shape with two verbs to collapse — a
+// visitor row carries exactly one (`rowActions`). Addressed by the
+// `user:<id>:` prefix rather than a full composite key because the
+// network id depends on seeding order.
+async function userRowKey(page: Page): Promise<string> {
+  const id = idFromSubjectJson(getSeededVjt().subjectJson);
+  const row = page.locator(`[data-testid^='admin-session-row-user:${id}:']`).first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  const testId = await row.getAttribute("data-testid");
+  if (testId === null) throw new Error("the seeded user row lost its testid");
+  return testId.replace("admin-session-row-", "");
+}
+
+test("#1157 @webkit a phone gives the row's verbs one control, and it is the menu", async ({
+  page,
+}) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  const cell = page.locator(`[data-testid='admin-session-row-${key}'] td.admin-sessions-actions`);
+  await cell.scrollIntoViewIfNeeded();
+
+  // Exactly one, painted. A cell that merely ADDED the menu beside the
+  // verbs would still show the menu.
+  await expect(cell.locator("button")).toHaveCount(1);
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toHaveCount(0);
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
+});
+
+test("#1157 @webkit the dropdown arms a verb rather than running it", async ({ page }) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  await page.getByTestId(`admin-session-actions-menu-${key}`).click();
+
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+  await expect(menu.getByText("Disconnect")).toBeVisible();
+  await expect(menu.getByText("Terminate")).toBeVisible();
+
+  await menu.getByText("Terminate").click();
+
+  // Armed, not fired: the label is the confirmation, and the menu is
+  // gone. If the pick had run the verb the row would have reloaded and
+  // this locator would be an idle "Terminate" instead.
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveText("Confirm terminate");
+  await expect(menu).toHaveCount(0);
+  // Nothing was stopped: the error banner is where a failed or refused
+  // verb lands, and a successful one would have refreshed the list.
+  await expect(page.getByTestId("admin-sessions-error")).toHaveCount(0);
+
+  // And back out, leaving the session exactly as this spec found it.
+  await page.getByTestId(`admin-session-actions-cancel-${key}`).click();
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toBeVisible();
+});
+
+test("#1157 a desktop keeps both verbs side by side and grows no menu", async ({ page }) => {
+  await adminLogin(page);
+  await openAdminSessionsTab(page);
+  const key = await userRowKey(page);
+
+  await expect(page.getByTestId(`admin-session-disconnect-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-terminate-${key}`)).toBeVisible();
+  await expect(page.getByTestId(`admin-session-actions-menu-${key}`)).toHaveCount(0);
+});

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -189,39 +189,52 @@ test("admin binds a credential from the console and the session dials out", asyn
 
     // Pre-state: the user is on no networks yet, so the row this test is about
     // to assert on cannot be a leftover from an earlier run.
-    await expect(page.getByTestId(`admin-user-network-row-${networkId}`)).toHaveCount(0);
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).not.toBeChecked();
 
     // The bind goes through the CONSOLE, not the API — the door the operator
     // in the issue actually used, and the one that had no other door on a
     // release image (#1158).
-    await page.getByTestId("admin-user-network-add").click();
-    await expect(page.getByTestId("admin-user-network-add-form")).toBeVisible();
-    await page.getByTestId("admin-user-network-add-network").selectOption({ label: NETWORK_SLUG });
-    await page.getByTestId("admin-user-network-add-nick").fill(nick);
-    await page.getByTestId("admin-user-network-add-auth-method").selectOption("none");
-    await page.getByTestId("admin-user-network-add-submit").click();
+    // #1157 — the bind is now "tick the network's section, fill the nick,
+    // Save". The verb on the wire is the same POST; what changed is that
+    // the console no longer asks WHICH network in a select, because the
+    // section already is one.
+    await page.getByTestId(`admin-user-network-enabled-${networkId}`).check();
+    await expect(page.getByTestId(`admin-user-network-form-${networkId}`)).toBeVisible();
+    await page.getByTestId(`admin-user-network-nick-${networkId}`).fill(nick);
+    await page.getByTestId(`admin-user-network-auth-method-${networkId}`).selectOption("none");
+    await page.getByTestId(`admin-user-network-save-${networkId}`).click();
 
-    const row = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(row).toHaveCount(1, { timeout: 10_000 });
+    await expect(page.getByTestId(`admin-user-network-enabled-${networkId}`)).toBeChecked({
+      timeout: 10_000,
+    });
 
     // The witness. `alive` is the BEAM reading: a Session.Server exists for
-    // this (user, network). Before #1163 this cell read `BEAM has no pid` and
-    // stayed that way until the node restarted.
-    await expect(row).toContainText("alive", { timeout: 10_000 });
-    await expect(row).not.toContainText("BEAM has no pid");
+    // this (user, network). Before #1163 this badge read `BEAM has no pid`
+    // and stayed that way until the node restarted.
+    //
+    // #1157 — read off the two BADGES rather than off the whole row's text.
+    // The section now contains the settings form as well, so a substring
+    // match over it could be satisfied by a field value rather than by the
+    // reading this spec exists to take.
+    const live = page.getByTestId(`admin-user-network-live-${networkId}`);
+    const connection = page.getByTestId(`admin-user-network-connection-${networkId}`);
+    await expect(live).toHaveText("alive", { timeout: 10_000 });
 
-    // The other half of U-0: the DB intent agrees with the BEAM. A row that
-    // says `connected` is only honest when the pid above exists.
-    await expect(row).toContainText("connected");
+    // The other half of U-0: the DB intent agrees with the BEAM. A section
+    // that says `connected` is only honest when the pid above exists.
+    await expect(connection).toHaveText("connected");
 
     // Same two readings after a fresh load, so the verdict rests on a second
-    // GET /admin/credentials rather than on the bind response the tab just
+    // GET /admin/credentials rather than on the bind response the page just
     // rendered.
     await page.reload();
     await openUserPage(page, userId);
-    const reloadedRow = page.getByTestId(`admin-user-network-row-${networkId}`);
-    await expect(reloadedRow).toContainText("alive", { timeout: 10_000 });
-    await expect(reloadedRow).toContainText("connected");
+    await expect(page.getByTestId(`admin-user-network-live-${networkId}`)).toHaveText("alive", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId(`admin-user-network-connection-${networkId}`)).toHaveText(
+      "connected",
+    );
   } finally {
     if (userId !== null) {
       await unbind(admin.token, userId, networkId, testInfo);

--- a/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
@@ -1,0 +1,210 @@
+// #1250 — the paste flood guard on the IME path.
+//
+// GBoard's clipboard chip does not fire a `paste` event. It commits the text
+// through the input method, which surfaces as `beforeinput` with an
+// `insertFromPaste` inputType, and both pre-#1250 doors into the router were
+// `paste` listeners. The guard was therefore not weak on that path, it was
+// ABSENT: `classifyPaste` never ran, and an operator could send a burst of any
+// size by choosing the chip over the long-press Paste menu — never shown the
+// count, never offered the .txt door that the 2026-08-06 ruling made the only
+// way out above the cap. Reporter's A/B: chip → no dialog, long-press → dialog.
+//
+// What each test here is for:
+//
+//   1-2. The IME door itself. A synthetic `beforeinput[insertFromPaste]` is the
+//        closest a browser harness gets to the chip — Playwright cannot drive
+//        GBoard, and no CDP verb commits an insertFromPaste. This is a stated
+//        LIMIT of the simulation, not a claim about GBoard: what is proven is
+//        that cic answers the event GBoard emits. The oracle is the visible
+//        outcome the reporter did NOT get — a dialog, and a composer that
+//        stays empty.
+//
+//   3.   The ORDERING, measured rather than assumed. The no-double-dialog
+//        argument in pasteRoute.ts rests on a browser contract: `paste` fires
+//        first, and only an UNCANCELLED paste produces the insertion that
+//        fires `beforeinput`, so a guarded arm's preventDefault suppresses the
+//        second report. #1250's text claims some engines fire `beforeinput`
+//        first, which would break that argument. A synthetic ClipboardEvent
+//        cannot settle it — an untrusted event performs no default action, so
+//        no `beforeinput` ever follows it and the measurement would be
+//        vacuous. This test therefore drives a REAL clipboard gesture
+//        (copy from a scratch field, paste with the keyboard) and records the
+//        order the page actually observes.
+
+import type { Page } from "@playwright/test";
+
+import {
+  composeTextarea,
+  confirmModal,
+  confirmModalBody,
+  confirmModalCancel,
+  confirmModalYes,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// The slice of TestInfo this spec uses — the attach verb only, so the shared
+// journey does not have to take the whole fixture just to record one string.
+type AttachFn = (name: string, options: { body: string; contentType: string }) => Promise<void>;
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// 7 messages — past PASTE_HARD_MESSAGE_LIMIT (5), so the hard-close arm.
+const OVER_LIMIT = ["uno", "due", "tre", "quattro", "cinque", "sei", "sette"].join("\n");
+// 4 messages — the confirm arm.
+const MID_SIZE = ["uno", "due", "tre", "quattro"].join("\n");
+
+async function openCompose(page: Page): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(composeTextarea(page)).toBeVisible();
+}
+
+// The GBoard chip, as closely as a harness can state it: the insertion event
+// an IME commit produces, carrying the text on a DataTransfer. NO `paste`
+// event is dispatched — that absence IS the bug this reproduces.
+async function imePaste(page: Page, text: string): Promise<void> {
+  await composeTextarea(page).evaluate((el, t) => {
+    const dt = new DataTransfer();
+    dt.setData("text/plain", t);
+    el.dispatchEvent(
+      new InputEvent("beforeinput", {
+        inputType: "insertFromPaste",
+        dataTransfer: dt,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }, text);
+}
+
+test("#1250 — an over-limit IME paste is hard-closed: dialog, and the block never lands", async ({
+  page,
+}) => {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+  await expect(ta).toHaveValue("");
+
+  await imePaste(page, OVER_LIMIT);
+
+  // The outcome the reporter never saw on this gesture.
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModalBody(page)).toContainText("7");
+  await expect(confirmModalBody(page)).toContainText(CHANNEL ?? "");
+  // Hard close: above the cap the paste door is gone, so the text must not be
+  // in the composer while the dialog is up.
+  await expect(ta).toHaveValue("");
+
+  // Cancel is the safe default here too — nothing lands, nothing uploads.
+  await confirmModalCancel(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+});
+
+test("#1250 — a mid-size IME paste asks, and the affirmative lands the block", async ({ page }) => {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+
+  await imePaste(page, MID_SIZE);
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModalBody(page)).toContainText("4");
+  await expect(ta).toHaveValue("");
+
+  await confirmModalYes(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue(MID_SIZE);
+});
+
+async function realPasteOrderJourney(page: Page, testInfo: { attach: AttachFn }): Promise<void> {
+  await openCompose(page);
+  const ta = composeTextarea(page);
+
+  // Record what the textarea actually receives, in order. Capture phase so the
+  // recorder cannot be skipped by the app's own handling, and it only reads.
+  await ta.evaluate((el) => {
+    const w = window as unknown as { __pasteSeq?: string[] };
+    w.__pasteSeq = [];
+    for (const type of ["paste", "beforeinput"]) {
+      el.addEventListener(
+        type,
+        (e) => {
+          w.__pasteSeq?.push(
+            type === "beforeinput" ? `beforeinput:${(e as InputEvent).inputType}` : "paste",
+          );
+        },
+        { capture: true },
+      );
+    }
+  });
+
+  // Load the OS clipboard through a real user gesture: a scratch field, then
+  // select-all + copy from the keyboard. `navigator.clipboard.writeText` is
+  // deliberately avoided — it needs a permission grant that is chromium-only,
+  // and this measurement has to mean the same thing on both engines.
+  await page.evaluate((text) => {
+    const scratch = document.createElement("textarea");
+    scratch.id = "clip-scratch";
+    scratch.value = text;
+    // Top of the viewport and above everything: at the BOTTOM the bar's
+    // network label intercepts the pointer on the 390px iPhone project, and
+    // the click never lands.
+    scratch.style.position = "fixed";
+    scratch.style.top = "0";
+    scratch.style.left = "0";
+    scratch.style.width = "120px";
+    scratch.style.height = "40px";
+    scratch.style.zIndex = "2147483647";
+    document.body.appendChild(scratch);
+  }, MID_SIZE);
+  const scratch = page.locator("#clip-scratch");
+  await scratch.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ControlOrMeta+c");
+  await page.evaluate(() => document.getElementById("clip-scratch")?.remove());
+
+  await ta.click();
+  await page.keyboard.press("ControlOrMeta+v");
+
+  // The product invariant: ONE gesture, ONE dialog. If a second report reached
+  // the router, the operator would be asked the same question twice.
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModal(page)).toHaveCount(1);
+  await expect(ta).toHaveValue("");
+
+  const seq = await page.evaluate(
+    () => (window as unknown as { __pasteSeq?: string[] }).__pasteSeq ?? [],
+  );
+  // Attached as well as asserted, so the raw observation survives in the run's
+  // artefacts for comparison after a future engine update.
+  await testInfo.attach("paste-event-order", { body: seq.join(" → "), contentType: "text/plain" });
+
+  // The PIN, and the whole reason this test drives a real gesture: exactly one
+  // report reaches the guard, and it is the `paste` one. That is the contract
+  // pasteRoute.ts's no-bookkeeping design rests on — the guarded arm cancels,
+  // so the insertion never happens and its `beforeinput` never fires. #1250's
+  // text claims some engines report `beforeinput` first; if this ever observes
+  // that, the design needs the gesture-claim it deliberately does without, and
+  // this assertion is what says so out loud instead of leaving a double dialog
+  // for an operator to find.
+  expect(
+    seq.filter((s) => s === "paste" || s === "beforeinput:insertFromPaste"),
+    `a cancelled paste must be the ONLY report the guard sees — observed: ${seq.join(" → ")}`,
+  ).toEqual(["paste"]);
+}
+
+test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order", async ({
+  page,
+}, testInfo) => {
+  await realPasteOrderJourney(page, testInfo);
+});
+
+// The same measurement on the other shipped engine. The ordering is a browser
+// contract, so one engine's answer is not the answer.
+test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order @webkit", async ({
+  page,
+}, testInfo) => {
+  await realPasteOrderJourney(page, testInfo);
+});

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -148,7 +148,7 @@ function adminSurfaces(vjtUserId: string): Surface[] {
         await openTab(page, "users");
         await page.getByTestId(`admin-user-networks-${vjtUserId}`).tap();
         await expect(page.getByTestId("admin-user-page")).toBeVisible({ timeout: 10_000 });
-        await expect(page.getByTestId("admin-user-networks-table")).toBeVisible({
+        await expect(page.getByTestId("admin-user-networks-card")).toBeVisible({
           timeout: 10_000,
         });
       },

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -9,6 +9,7 @@ import { AdminEmpty, AdminError } from "./admin/AdminStatus";
 import AdminTable from "./admin/AdminTable";
 import { useRefreshSlot } from "./admin/refreshSlot";
 import { renderEnded } from "./admin/sessionLogFormat";
+import ContextMenu from "./ContextMenu";
 import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminSubjectRow,
@@ -36,6 +37,7 @@ import {
   adminTerminateSession,
 } from "./lib/api";
 import { token } from "./lib/auth";
+import { isAdminNarrow } from "./lib/theme";
 
 // #1157 — the unified admin Sessions view. The Visitors tab is gone;
 // this one lists ACTIVE AND INACTIVE sessions for both subject kinds.
@@ -102,6 +104,29 @@ function confirmKey(key: string, kind: ActionKind | "delete"): string {
   return `${key}:${kind}`;
 }
 
+// #1157 — which verbs the actions cell renders AS BUTTONS. Dictated
+// (vjt, 2026-08-09): below 900px the cell holds ONE control and the
+// verbs live behind a dropdown. Above it they stay side by side.
+//
+// A one-verb row is left alone: it already IS one control, and wrapping
+// it in a menu would charge a tap to reach a list of one. So the rule
+// the cell keeps at every width is "one control", not "always a menu".
+//
+// `armed` is the escape from the obvious bug in that: `InlineConfirmButton`
+// is sticky and the PARENT owns `armed`, so once a verb is picked its
+// confirmation has to be on screen — otherwise the menu would arm a
+// button the operator cannot see, let alone confirm.
+function cellActions(
+  row: AdminSubjectRow,
+  narrow: boolean,
+  armed: ActionKind | null,
+): ActionKind[] {
+  const verbs = rowActions(row);
+  if (!narrow) return verbs;
+  if (armed !== null) return [armed];
+  return verbs.length > 1 ? [] : verbs;
+}
+
 function renderCap(cap: number | null): string {
   // Mirrors the AdminNetworksTab cap-cell convention: `null` is the
   // "unlimited" sentinel per `Networks.update_network_caps/2`.
@@ -120,6 +145,15 @@ const AdminSessionsTab: Component = () => {
   // tab's drill-in to `AdminUserPage`, and deliberately not a route: the
   // admin console has none.
   const [endedOpen, setEndedOpen] = createSignal(false);
+  // #1157 — the open row's verb dropdown, anchored to the button that
+  // opened it. Anchored to the BUTTON RECT rather than the pointer so a
+  // keyboard activation (clientX/Y both 0) does not open it in the
+  // viewport's top-left corner.
+  const [actionsMenu, setActionsMenu] = createSignal<{
+    key: string;
+    x: number;
+    y: number;
+  } | null>(null);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
 
@@ -141,12 +175,22 @@ const AdminSessionsTab: Component = () => {
   const live = createMemo<AdminSubjectRow[]>(() => liveSessions(rows()));
   const ended = createMemo(() => endedSessions(rows()));
 
+  /** The verb this row is currently asking the operator to confirm. */
+  const armedKind = (row: AdminSubjectRow): ActionKind | null =>
+    rowActions(row).find((kind) => confirmingKey() === confirmKey(row.key, kind)) ?? null;
+
+  /** The row shows the dropdown instead of its verbs. */
+  const collapsed = (row: AdminSubjectRow): boolean =>
+    isAdminNarrow() && rowActions(row).length > 1;
+
   const refresh = async (): Promise<void> => {
     const t = token();
     if (t === null) return;
     setLoading(true);
     setError(null);
     setConfirmingKey(null);
+    // The menu names one row's verbs; the refresh may take that row away.
+    setActionsMenu(null);
     try {
       // Five endpoints, one table. The two row-backed ones supply the
       // rows, /admin/sessions supplies the live join, /admin/networks
@@ -420,7 +464,7 @@ const AdminSessionsTab: Component = () => {
                               class="admin-sessions-actions adm-table-sticky-actions"
                               data-label="actions"
                             >
-                              <For each={rowActions(row)}>
+                              <For each={cellActions(row, isAdminNarrow(), armedKind(row))}>
                                 {(kind) => (
                                   <InlineConfirmButton
                                     idleLabel={ACTION_LABEL[kind]}
@@ -433,6 +477,40 @@ const AdminSessionsTab: Component = () => {
                                   />
                                 )}
                               </For>
+                              <Show when={collapsed(row) && armedKind(row) === null}>
+                                <button
+                                  type="button"
+                                  class="adm-btn"
+                                  aria-haspopup="menu"
+                                  aria-label={`actions for ${renderWho(row)}`}
+                                  onClick={(e) => {
+                                    const box = e.currentTarget.getBoundingClientRect();
+                                    setActionsMenu({
+                                      key: row.key,
+                                      x: box.left,
+                                      y: box.bottom,
+                                    });
+                                  }}
+                                  data-testid={`admin-session-actions-menu-${row.key}`}
+                                >
+                                  Actions ▾
+                                </button>
+                              </Show>
+                              {/* The way back out of an armed verb. On desktop
+                              the sibling verb's idle button does this job —
+                              arming one disarms the other — but the collapse
+                              took the sibling away, and the button the
+                              operator tapped to get here went with it. */}
+                              <Show when={collapsed(row) && armedKind(row) !== null}>
+                                <button
+                                  type="button"
+                                  class="adm-btn"
+                                  onClick={() => setConfirmingKey(null)}
+                                  data-testid={`admin-session-actions-cancel-${row.key}`}
+                                >
+                                  Cancel
+                                </button>
+                              </Show>
                               {/* An empty cell reads as a rendering bug. The
                               dash says the absence is the answer. */}
                               <Show when={rowActions(row).length === 0}>—</Show>
@@ -479,6 +557,32 @@ const AdminSessionsTab: Component = () => {
             </AdminCard>
           </Show>
         </div>
+      </Show>
+
+      {/* #1157 — the collapsed cell's dropdown. Reuses the shell the
+          long-press menus use (portal, backdrop, Escape, measured
+          flip/clamp) rather than growing a second popover convention in
+          the console: what differs between them is the item list, which
+          is exactly the part this supplies.
+
+          Picking an item ARMS the verb — the shell closes itself on an
+          action — and the row's own confirmation is what runs it. */}
+      <Show when={actionsMenu()}>
+        {(menu) => (
+          <Show when={live().find((row) => row.key === menu().key)}>
+            {(row) => (
+              <ContextMenu
+                position={{ x: menu().x, y: menu().y }}
+                onClose={() => setActionsMenu(null)}
+                items={rowActions(row()).map((kind) => ({
+                  label: ACTION_LABEL[kind],
+                  enabled: true,
+                  action: () => setConfirmingKey(confirmKey(row().key, kind)),
+                }))}
+              />
+            )}
+          </Show>
+        )}
       </Show>
     </div>
   );

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -527,12 +527,12 @@ const AdminSessionsTab: Component = () => {
                             >
                               <AdminFacts facts={detailFacts(row)} />
                               <Show when={row.visitor !== null}>
-                                <div class="admin-session-danger">
+                                <div class="adm-danger-strip">
                                   {/* Named for what it destroys. The verb is
                                   identity-wide: it deletes the visitor
                                   and every one of its network rows, not
                                   the row this panel hangs off. */}
-                                  <span class="admin-session-danger-note">
+                                  <span class="adm-danger-note">
                                     deletes the whole visitor identity, on every network
                                   </span>
                                   <InlineConfirmButton

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -1,15 +1,11 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
-import AdminDetailPanel from "./admin/AdminDetailPanel";
-import AdminFacts from "./admin/AdminFacts";
-import AdminRowName from "./admin/AdminRowName";
 import { AdminEmpty, AdminError, AdminLoading } from "./admin/AdminStatus";
-import AdminTable from "./admin/AdminTable";
 import { connectionTone } from "./admin/connectionTone";
-import InlineConfirmButton from "./InlineConfirmButton";
 import {
   type AdminCredential,
+  type AdminCredentialUpdate,
   type AdminNetwork,
   type AdminUser,
   ApiError,
@@ -25,12 +21,11 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 
 // #1158 — one user, one page, and it owns that user's network access.
 //
-// This replaces the Credentials tab, which was a flat list of every
+// This replaced the Credentials tab, which was a flat list of every
 // (user, network) binding in the database fronted by a form whose first
 // two fields were "which user" and "which network". vjt's ruling: the
-// operator's object is the USER, adding a network is a `+` and removing
-// one is a button, and the old tab disappears as an operator surface.
-// The user is the page, so nothing here asks which user.
+// operator's object is the USER. The user is the page, so nothing here
+// asks which user.
 //
 // Reached from the Users tab, which owns the signal that swaps its list
 // for this page. Deliberately NOT a route: the admin console has no
@@ -38,6 +33,27 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 // an open product question. Answering it later means adding a route,
 // which is additive; guessing it now would mean inventing the console's
 // first deep link as a side effect of a credentials cleanup.
+//
+// #1157 — and the "bind a credential" flow is gone with it. vjt:
+// *"niente flusso bind credential; al suo posto una sezione per rete
+// configurata con una checkbox `enabled`, e quando e' abilitata compare
+// il form di impostazioni di quella rete."*
+//
+// So the page no longer lists the networks the user HAS beside a `+`
+// offering the ones it has not. It lists every network the server has
+// configured, once, and the checkbox is the whole statement about
+// access. That collapses three surfaces — an add form, an inline edit
+// form, and a per-row detail panel — into one form per section, because
+// they only ever differed in which subset of the same fields they showed
+// and in whether the answer went out as a POST or a PATCH.
+//
+// The checkbox is NOT a write. Enabling reveals the settings form and
+// nothing reaches the server until Save, because a bind needs a nick and
+// a checkbox cannot supply one. Disabling a network that IS bound is
+// destructive — it deletes the credential and stops the session — so it
+// arms rather than fires: the box goes unchecked and the section asks.
+// That is the same two-step as the inline-confirm buttons elsewhere in
+// the console, spread across the two controls this shape already has.
 //
 // Data comes from the endpoints that already exist — no composite
 // create-user-and-bind POST (vjt: two writes, client-driven).
@@ -47,12 +63,10 @@ import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
 // another user's networks on this user's page, which is why the unit
 // suite mounts with a foreign credential in every fetch.
 //
-// `session_action` is per-ROW state, never a toast (vjt: a toast throws
-// away four values). It carries all four — `spawned` / `not_spawned`
-// from the POST, `left_alone` / `stopped` from the PATCH — plus
-// `session_error`, the only field that says why a bind did not dial.
-// The tab this replaces surfaced two of the four, and only for the
-// PATCH: its bind handler dropped the POST reply on the floor.
+// `session_action` is per-SECTION state, never a toast (vjt: a toast
+// throws away four values). It carries all four — `spawned` /
+// `not_spawned` from the POST, `left_alone` / `stopped` from the PATCH —
+// plus `session_error`, the only field that says why a bind did not dial.
 //
 // Raw wire tokens on purpose, per the operator-console policy
 // (AdminSettingsTab lines 33-35, #943): the operator reads the same
@@ -66,30 +80,21 @@ export type Props = {
   onBack: () => void;
 };
 
-type AddForm = {
-  network_id: string;
+/** The settings a credential carries, as the form holds them. */
+type NetworkForm = {
   nick: string;
+  realname: string;
+  sasl_user: string;
   auth_method: string;
   password: string;
-  sasl_user: string;
-  realname: string;
 };
 
-const EMPTY_ADD: AddForm = {
-  network_id: "",
+const EMPTY_FORM: NetworkForm = {
   nick: "",
+  realname: "",
+  sasl_user: "",
   auth_method: "none",
   password: "",
-  sasl_user: "",
-  realname: "",
-};
-
-type EditForm = {
-  nick: string;
-  realname: string;
-  sasl_user: string;
-  auth_method: string;
-  password: string;
 };
 
 /** What the last write did to the live session, for one network. */
@@ -98,29 +103,54 @@ type SessionOutcome = {
   error: NonNullable<AdminCredential["session_error"]> | null;
 };
 
-// network + nick + auth + connection + live + actions. Feeds the detail
-// row's `colspan`; derived from the count so adding a column cannot
-// silently desync it.
-const NETWORK_COLUMNS = 6;
+// The server's truth for a bound network, as a draft. `password` starts
+// empty at every seeding: the stored one is write-only (encrypted at
+// rest, never returned), so a blank box means "leave it alone" and
+// anything typed means "replace it".
+function formOf(c: AdminCredential): NetworkForm {
+  return {
+    nick: c.nick,
+    realname: c.realname ?? "",
+    sasl_user: c.sasl_user ?? "",
+    auth_method: c.auth_method,
+    password: "",
+  };
+}
+
+// Only what the operator changed goes on the wire: the server keys the
+// session kill off the CHANGE SET, so sending an unchanged password
+// would stop a live session for nothing.
+function patchOf(c: AdminCredential, f: NetworkForm): AdminCredentialUpdate {
+  const patch: AdminCredentialUpdate = {};
+  if (f.nick !== c.nick) patch.nick = f.nick;
+  if (f.realname !== (c.realname ?? "")) patch.realname = f.realname;
+  if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
+  if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
+  if (f.password !== "") patch.password = f.password;
+  return patch;
+}
 
 const AdminUserPage: Component<Props> = (props) => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
   const [networks, setNetworks] = createSignal<AdminNetwork[]>([]);
   const [error, setError] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(false);
+  const [submitting, setSubmitting] = createSignal<number | null>(null);
 
-  const [adding, setAdding] = createSignal(false);
-  const [addForm, setAddForm] = createSignal<AddForm>({ ...EMPTY_ADD });
-  const [submitting, setSubmitting] = createSignal(false);
+  // The draft per network, seeded lazily from the credential. Absent
+  // means "not touched since the last fetch", which is what lets a
+  // successful save fall back to the server's own answer by simply
+  // dropping the entry.
+  const [forms, setForms] = createSignal<Record<number, NetworkForm>>({});
+  // Enabled by the operator, not yet written — a bind needs a nick.
+  const [pendingEnable, setPendingEnable] = createSignal<Record<number, boolean>>({});
+  // The one network whose removal is armed. Single, like every other
+  // confirm in the console: two armed destructive verbs on one screen is
+  // how the wrong one gets pressed.
+  const [pendingDisable, setPendingDisable] = createSignal<number | null>(null);
 
-  const [editingId, setEditingId] = createSignal<number | null>(null);
-  const [editForm, setEditForm] = createSignal<EditForm | null>(null);
-
-  const [confirmingId, setConfirmingId] = createSignal<number | null>(null);
-  const [detailId, setDetailId] = createSignal<number | null>(null);
-
-  // Keyed by network id, which is the row. A write reports on the row it
-  // touched and says nothing about any other.
+  // Keyed by network id, which is the section. A write reports on the
+  // section it touched and says nothing about any other.
   const [outcomes, setOutcomes] = createSignal<Record<number, SessionOutcome>>({});
 
   /** This user's networks. The list endpoint returns everyone's. */
@@ -128,18 +158,53 @@ const AdminUserPage: Component<Props> = (props) => {
     (credentials() ?? []).filter((c) => c.user_id === props.user.id),
   );
 
-  /** Networks the user is not on yet — the only ones `+` can add. */
-  const addable = createMemo<AdminNetwork[]>(() => {
-    const taken = new Set(mine().map((c) => c.network_id));
-    return networks().filter((n) => !taken.has(n.id));
-  });
+  const credOf = (networkId: number): AdminCredential | undefined =>
+    mine().find((c) => c.network_id === networkId);
+
+  const formFor = (networkId: number): NetworkForm => {
+    const draft = forms()[networkId];
+    if (draft !== undefined) return draft;
+    const c = credOf(networkId);
+    return c === undefined ? { ...EMPTY_FORM } : formOf(c);
+  };
+
+  const setForm = (networkId: number, patch: Partial<NetworkForm>): void => {
+    setForms({ ...forms(), [networkId]: { ...formFor(networkId), ...patch } });
+  };
+
+  const clearForm = (networkId: number): void => {
+    const { [networkId]: _gone, ...rest } = forms();
+    setForms(rest);
+  };
+
+  /** The section shows its settings form. */
+  const enabled = (networkId: number): boolean => {
+    if (pendingDisable() === networkId) return false;
+    return credOf(networkId) !== undefined || pendingEnable()[networkId] === true;
+  };
+
+  /** What Save would send to a BOUND network; `null` when unbound. */
+  const pending = (networkId: number): AdminCredentialUpdate | null => {
+    const c = credOf(networkId);
+    if (c === undefined) return null;
+    return patchOf(c, formFor(networkId));
+  };
+
+  const savable = (networkId: number): boolean => {
+    if (submitting() !== null) return false;
+    if (formFor(networkId).nick.trim() === "") return false;
+    const patch = pending(networkId);
+    // Unbound: Save IS the bind, and a nick is all it needs. Bound: only
+    // when something actually changed, because an empty PATCH would ask
+    // the server to decide whether to stop a session over nothing.
+    return patch === null || Object.keys(patch).length > 0;
+  };
 
   const refresh = async (): Promise<void> => {
     const t = token();
     if (t === null) return;
     setLoading(true);
     setError(null);
-    setConfirmingId(null);
     try {
       const [creds, nets] = await Promise.all([adminListCredentials(t), adminListNetworks(t)]);
       setCredentials(creds);
@@ -160,104 +225,82 @@ const AdminUserPage: Component<Props> = (props) => {
     });
   };
 
-  const onAdd = async (e: Event): Promise<void> => {
+  const onToggle = (net: AdminNetwork): void => {
+    const id = net.id;
+    if (pendingDisable() === id) {
+      // Re-ticking a network whose removal was armed is the cancel.
+      setPendingDisable(null);
+      return;
+    }
+    if (credOf(id) !== undefined) {
+      setPendingDisable(id);
+      return;
+    }
+    if (pendingEnable()[id] === true) {
+      const { [id]: _gone, ...rest } = pendingEnable();
+      setPendingEnable(rest);
+      clearForm(id);
+      return;
+    }
+    setPendingEnable({ ...pendingEnable(), [id]: true });
+  };
+
+  const onSave = async (net: AdminNetwork, e: Event): Promise<void> => {
     e.preventDefault();
     const t = token();
     if (t === null) return;
-    const f = addForm();
-    if (f.network_id === "" || f.nick === "") return;
-    const networkId = Number.parseInt(f.network_id, 10);
-    if (!Number.isFinite(networkId)) {
-      setError("add network: invalid network_id");
-      return;
-    }
-    setSubmitting(true);
+    const id = net.id;
+    const f = formFor(id);
+    const existing = credOf(id);
+    setSubmitting(id);
     setError(null);
     try {
-      const created = await adminBindCredential(t, {
-        user_id: props.user.id,
-        network_id: networkId,
-        nick: f.nick,
-        auth_method: f.auth_method,
-        password: f.password === "" ? undefined : f.password,
-        sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
-        realname: f.realname === "" ? undefined : f.realname,
-      });
-      recordOutcome(networkId, created);
-      setAddForm({ ...EMPTY_ADD });
-      setAdding(false);
+      const saved =
+        existing === undefined
+          ? await adminBindCredential(t, {
+              user_id: props.user.id,
+              network_id: id,
+              nick: f.nick,
+              auth_method: f.auth_method,
+              password: f.password === "" ? undefined : f.password,
+              sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
+              realname: f.realname === "" ? undefined : f.realname,
+            })
+          : await adminUpdateCredential(t, props.user.id, id, patchOf(existing, f));
+      recordOutcome(id, saved);
+      // Drop the draft rather than rewriting it: the section then reads
+      // the server's own answer, and the typed password leaves with it.
+      clearForm(id);
+      const { [id]: _gone, ...rest } = pendingEnable();
+      setPendingEnable(rest);
       await refresh();
     } catch (err) {
-      setError(`add network: ${operatorApiError(err, "request_failed")}`);
+      setError(`${net.slug}: ${operatorApiError(err, "request_failed")}`);
     } finally {
-      setSubmitting(false);
+      setSubmitting(null);
     }
   };
 
-  const onArmEdit = (c: AdminCredential): void => {
-    setEditingId(c.network_id);
-    setEditForm({
-      nick: c.nick,
-      realname: c.realname ?? "",
-      sasl_user: c.sasl_user ?? "",
-      auth_method: c.auth_method,
-      password: "",
-    });
-  };
-
-  const onCancelEdit = (): void => {
-    setEditingId(null);
-    setEditForm(null);
-  };
-
-  const onSubmitEdit = async (c: AdminCredential): Promise<void> => {
+  const onRemove = async (net: AdminNetwork): Promise<void> => {
     const t = token();
     if (t === null) return;
-    const f = editForm();
-    if (f === null) return;
-    // Only what the operator changed goes on the wire: the server keys
-    // the session kill off the CHANGE SET, so sending an unchanged
-    // password would stop a live session for nothing.
-    const patch: Parameters<typeof adminUpdateCredential>[3] = {};
-    if (f.nick !== c.nick) patch.nick = f.nick;
-    if (f.realname !== (c.realname ?? "")) patch.realname = f.realname;
-    if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
-    if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
-    if (f.password !== "") patch.password = f.password;
-    if (Object.keys(patch).length === 0) {
-      onCancelEdit();
-      return;
-    }
+    const id = net.id;
     setError(null);
     try {
-      const updated = await adminUpdateCredential(t, props.user.id, c.network_id, patch);
-      recordOutcome(c.network_id, updated);
-      onCancelEdit();
-      await refresh();
-    } catch (err) {
-      setError(`edit ${c.network_slug}: ${operatorApiError(err, "request_failed")}`);
-    }
-  };
-
-  const onRemove = async (c: AdminCredential): Promise<void> => {
-    const t = token();
-    if (t === null) return;
-    setError(null);
-    try {
-      await adminUnbindCredential(t, props.user.id, c.network_id);
+      await adminUnbindCredential(t, props.user.id, id);
       const cur = credentials();
       if (cur !== null) {
-        setCredentials(
-          cur.filter((x) => !(x.user_id === props.user.id && x.network_id === c.network_id)),
-        );
+        setCredentials(cur.filter((x) => !(x.user_id === props.user.id && x.network_id === id)));
       }
-      // The row is gone; a verdict about its session would outlive it.
-      const { [c.network_id]: _gone, ...rest } = outcomes();
-      setOutcomes(rest);
-      setConfirmingId(null);
+      // The credential is gone; a verdict about its session would
+      // outlive it, and so would a draft of its settings.
+      const { [id]: _goneOutcome, ...restOutcomes } = outcomes();
+      setOutcomes(restOutcomes);
+      clearForm(id);
+      setPendingDisable(null);
     } catch (err) {
-      setError(`remove ${c.network_slug}: ${operatorApiError(err, "request_failed")}`);
-      setConfirmingId(null);
+      setError(`remove ${net.slug}: ${operatorApiError(err, "request_failed")}`);
+      setPendingDisable(null);
     }
   };
 
@@ -297,391 +340,217 @@ const AdminUserPage: Component<Props> = (props) => {
         <Show when={credentials() !== null}>
           <AdminCard
             title="Networks"
-            subtitle="CONNECTION is the DB state, LIVE is the BEAM pid — they can disagree"
+            subtitle="one section per configured network — tick to give this user access; CONNECTION is the DB state, LIVE is the BEAM pid, and they can disagree"
+            data-testid="admin-user-networks-card"
             actions={
-              <>
-                <button
-                  type="button"
-                  class="adm-btn"
-                  disabled={loading()}
-                  onClick={() => {
-                    void refresh();
-                  }}
-                  aria-label="refresh this user's networks"
-                  data-testid="admin-user-networks-refresh"
-                >
-                  Refresh
-                </button>
-                {/* The `+` opens the form; it is in the card head rather
-                    than in the table because the first network a user
-                    gets is added when there is no table to put it in. */}
-                <button
-                  type="button"
-                  class="adm-btn adm-btn--ok"
-                  disabled={addable().length === 0}
-                  onClick={() => setAdding(!adding())}
-                  aria-label="add a network for this user"
-                  data-testid="admin-user-network-add"
-                >
-                  + Add network
-                </button>
-              </>
+              <button
+                type="button"
+                class="adm-btn"
+                disabled={loading()}
+                onClick={() => {
+                  void refresh();
+                }}
+                aria-label="refresh this user's networks"
+                data-testid="admin-user-networks-refresh"
+              >
+                Refresh
+              </button>
             }
           >
-            <Show when={adding()}>
-              <form
-                class="admin-user-network-add-form adm-form-grid"
-                onSubmit={(e) => {
-                  void onAdd(e);
-                }}
-                data-testid="admin-user-network-add-form"
-              >
-                <select
-                  aria-label="network"
-                  value={addForm().network_id}
-                  onChange={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      network_id: (e.currentTarget as HTMLSelectElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-network"
-                  required
-                >
-                  <option value="">— network —</option>
-                  <For each={addable()}>
-                    {(n) => <option value={String(n.id)}>{n.slug}</option>}
-                  </For>
-                </select>
-                <input
-                  placeholder="nick"
-                  aria-label="nick"
-                  type="text"
-                  value={addForm().nick}
-                  onInput={(e) =>
-                    setAddForm({ ...addForm(), nick: (e.currentTarget as HTMLInputElement).value })
-                  }
-                  data-testid="admin-user-network-add-nick"
-                  required
+            <Show
+              when={networks().length > 0}
+              fallback={
+                // Not "this user is on no networks": with one section per
+                // configured network, an empty page means the SERVER has
+                // none — a different thing, fixed somewhere else.
+                <AdminEmpty
+                  message="no networks are configured on this server"
+                  testId="admin-user-networks-empty"
                 />
-                <select
-                  aria-label="auth method"
-                  value={addForm().auth_method}
-                  onChange={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      auth_method: (e.currentTarget as HTMLSelectElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-auth-method"
-                >
-                  <For each={IRCAUTH_FSMAUTH_METHOD}>
-                    {(m) => <option value={m}>auth: {m}</option>}
-                  </For>
-                </select>
-                <input
-                  placeholder="password"
-                  aria-label="password"
-                  type="password"
-                  value={addForm().password}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      password: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-password"
-                />
-                <input
-                  placeholder="sasl user"
-                  aria-label="sasl user"
-                  type="text"
-                  value={addForm().sasl_user}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      sasl_user: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-sasl-user"
-                />
-                <input
-                  placeholder="realname"
-                  aria-label="realname"
-                  type="text"
-                  value={addForm().realname}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      realname: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-realname"
-                />
-                <div class="adm-form-grid-actions">
-                  <button
-                    type="submit"
-                    class="adm-btn adm-btn--ok"
-                    disabled={submitting() || addForm().network_id === "" || addForm().nick === ""}
-                    data-testid="admin-user-network-add-submit"
+              }
+            >
+              <For each={networks()}>
+                {(net) => (
+                  <section
+                    class="adm-subsection admin-user-network"
+                    data-testid={`admin-user-network-${net.id}`}
                   >
-                    Add
-                  </button>
-                  <button
-                    type="button"
-                    class="adm-btn adm-btn--danger"
-                    onClick={() => {
-                      setAdding(false);
-                      setAddForm({ ...EMPTY_ADD });
-                    }}
-                    data-testid="admin-user-network-add-cancel"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </Show>
-
-            <Show when={mine().length === 0}>
-              <AdminEmpty
-                message="this user is on no networks"
-                testId="admin-user-networks-empty"
-              />
-            </Show>
-
-            <Show when={mine().length > 0}>
-              <AdminTable data-testid="admin-user-networks-table">
-                <thead>
-                  <tr>
-                    <th class="adm-table-grow">network</th>
-                    {/* Secondary below 900px — they move into the row's
-                        detail panel. See `AdminFacts`. */}
-                    <th class="adm-col-detail">nick</th>
-                    <th class="adm-col-detail">auth</th>
-                    <th class="adm-col-detail">connection</th>
-                    {/* LIVE stays on a phone: "the BEAM has no pid for
-                        this" is the one reading worth seeing without a
-                        tap. */}
-                    <th>live</th>
-                    <th class="adm-table-sticky-actions">actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <For each={mine()}>
-                    {(c) => (
-                      <>
-                        <tr
-                          class="admin-user-network-row"
-                          data-testid={`admin-user-network-row-${c.network_id}`}
-                        >
-                          <td class="adm-cell-title">
-                            <AdminRowName
-                              open={detailId() === c.network_id}
-                              onToggle={() =>
-                                setDetailId(detailId() === c.network_id ? null : c.network_id)
-                              }
-                              label={`details for ${c.network_slug}`}
-                              testId={`admin-user-network-details-${c.network_id}`}
+                    <div class="admin-user-network-head">
+                      <label class="adm-check">
+                        <input
+                          type="checkbox"
+                          checked={enabled(net.id)}
+                          onChange={() => onToggle(net)}
+                          aria-label={`${props.user.name} may use ${net.slug}`}
+                          data-testid={`admin-user-network-enabled-${net.id}`}
+                        />
+                        <span class="adm-subsection-title">{net.slug}</span>
+                      </label>
+                      {/* Both projections, always, for a bound network —
+                          `live: BEAM has no pid` against `connection:
+                          connected` IS the divergence signal, and deriving
+                          either from the other would erase it. */}
+                      <Show when={credOf(net.id)}>
+                        {(c) => (
+                          <span class="admin-user-network-state">
+                            <AdminBadge
+                              tone={connectionTone(c().connection_state)}
+                              testId={`admin-user-network-connection-${net.id}`}
                             >
-                              {c.network_slug}
-                            </AdminRowName>
-                            <Show when={outcomes()[c.network_id]}>
-                              {(outcome) => (
-                                <p
-                                  class="adm-card-sub"
-                                  data-testid={`admin-user-network-session-action-${c.network_id}`}
-                                >
-                                  session: {outcome().action}
-                                  <Show when={outcome().error !== null}> ({outcome().error})</Show>
-                                </p>
-                              )}
-                            </Show>
-                          </td>
-                          <td class="adm-col-detail" data-label="nick">
-                            {c.nick}
-                          </td>
-                          <td class="adm-col-detail" data-label="auth">
-                            {c.auth_method}
-                          </td>
-                          <td class="adm-col-detail" data-label="connection">
-                            <AdminBadge tone={connectionTone(c.connection_state)}>
-                              {c.connection_state}
+                              {c().connection_state}
                             </AdminBadge>
-                          </td>
-                          <td data-label="live">
                             <AdminBadge
                               tone={
-                                c.live_state === null
+                                c().live_state === null
                                   ? "neutral"
-                                  : c.live_state.alive
+                                  : c().live_state?.alive === true
                                     ? "ok"
                                     : "danger"
                               }
+                              testId={`admin-user-network-live-${net.id}`}
                             >
-                              {c.live_state === null
+                              {c().live_state === null
                                 ? "BEAM has no pid"
-                                : c.live_state.alive
+                                : c().live_state?.alive === true
                                   ? "alive"
                                   : "pid dead"}
                             </AdminBadge>
-                          </td>
-                          <td
-                            class="admin-user-network-actions adm-table-sticky-actions"
-                            data-label="actions"
+                          </span>
+                        )}
+                      </Show>
+                    </div>
+
+                    <Show when={outcomes()[net.id]}>
+                      {(outcome) => (
+                        <p
+                          class="adm-card-sub"
+                          data-testid={`admin-user-network-session-action-${net.id}`}
+                        >
+                          session: {outcome().action}
+                          <Show when={outcome().error !== null}> ({outcome().error})</Show>
+                        </p>
+                      )}
+                    </Show>
+
+                    {/* The second half of the two-step. Unticking a bound
+                        network is the arm; this is the fire, and it names
+                        what it destroys rather than repeating the word on
+                        the box. */}
+                    <Show when={pendingDisable() === net.id}>
+                      <div class="adm-danger-strip">
+                        <span class="adm-danger-note">
+                          removes this user's credential for {net.slug} and stops its session
+                        </span>
+                        <button
+                          type="button"
+                          class="adm-btn adm-btn--danger"
+                          onClick={() => {
+                            void onRemove(net);
+                          }}
+                          data-testid={`admin-user-network-remove-${net.id}`}
+                        >
+                          Remove access
+                        </button>
+                        <button
+                          type="button"
+                          class="adm-btn"
+                          onClick={() => setPendingDisable(null)}
+                          data-testid={`admin-user-network-keep-${net.id}`}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </Show>
+
+                    <Show when={enabled(net.id)}>
+                      <form
+                        class="adm-form-grid"
+                        onSubmit={(e) => {
+                          void onSave(net, e);
+                        }}
+                        data-testid={`admin-user-network-form-${net.id}`}
+                      >
+                        <input
+                          placeholder="nick"
+                          aria-label={`nick on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).nick}
+                          onInput={(e) =>
+                            setForm(net.id, { nick: (e.currentTarget as HTMLInputElement).value })
+                          }
+                          data-testid={`admin-user-network-nick-${net.id}`}
+                          required
+                        />
+                        <input
+                          placeholder="realname"
+                          aria-label={`realname on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).realname}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              realname: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-realname-${net.id}`}
+                        />
+                        <input
+                          placeholder="sasl user"
+                          aria-label={`sasl user on ${net.slug}`}
+                          type="text"
+                          value={formFor(net.id).sasl_user}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              sasl_user: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-sasl-user-${net.id}`}
+                        />
+                        <select
+                          aria-label={`auth method on ${net.slug}`}
+                          value={formFor(net.id).auth_method}
+                          onChange={(e) =>
+                            setForm(net.id, {
+                              auth_method: (e.currentTarget as HTMLSelectElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-auth-method-${net.id}`}
+                        >
+                          <For each={IRCAUTH_FSMAUTH_METHOD}>
+                            {(m) => <option value={m}>auth: {m}</option>}
+                          </For>
+                        </select>
+                        <input
+                          placeholder="password"
+                          aria-label={`password on ${net.slug}`}
+                          type="password"
+                          value={formFor(net.id).password}
+                          onInput={(e) =>
+                            setForm(net.id, {
+                              password: (e.currentTarget as HTMLInputElement).value,
+                            })
+                          }
+                          data-testid={`admin-user-network-password-${net.id}`}
+                        />
+                        <div class="adm-form-grid-actions">
+                          <button
+                            type="submit"
+                            class="adm-btn adm-btn--ok"
+                            disabled={!savable(net.id)}
+                            data-testid={`admin-user-network-save-${net.id}`}
                           >
-                            <button
-                              type="button"
-                              class="adm-btn"
-                              onClick={() => onArmEdit(c)}
-                              data-testid={`admin-user-network-edit-${c.network_id}`}
-                            >
-                              Edit
-                            </button>
-                            <InlineConfirmButton
-                              idleLabel="Remove"
-                              confirmLabel="Confirm remove"
-                              armed={confirmingId() === c.network_id}
-                              onArm={() => setConfirmingId(c.network_id)}
-                              onConfirm={() => onRemove(c)}
-                              testId={`admin-user-network-remove-${c.network_id}`}
-                              extraClass="delete-btn"
-                            />
-                          </td>
-                        </tr>
-                        <Show when={detailId() === c.network_id}>
-                          <AdminDetailPanel
-                            title={c.network_slug}
-                            subtitle="the columns the table drops on a phone"
-                            onClose={() => setDetailId(null)}
-                            closeLabel="close network details"
-                            columns={NETWORK_COLUMNS}
-                            data-testid={`admin-user-network-detail-${c.network_id}`}
-                          >
-                            <AdminFacts
-                              facts={[
-                                { label: "nick", value: c.nick },
-                                { label: "auth", value: c.auth_method },
-                                {
-                                  label: "connection",
-                                  value: (
-                                    <AdminBadge tone={connectionTone(c.connection_state)}>
-                                      {c.connection_state}
-                                    </AdminBadge>
-                                  ),
-                                },
-                              ]}
-                            />
-                          </AdminDetailPanel>
-                        </Show>
-                        {/* Both halves matter: `editingId` names the row and
-                            `editForm` holds the draft, set in that order, and
-                            the fields read the draft unconditionally. */}
-                        <Show when={editForm() !== null && editingId() === c.network_id}>
-                          <AdminDetailPanel
-                            title={`Edit ${c.network_slug}`}
-                            subtitle="only changed fields are sent; a password or auth-method change stops the live session"
-                            onClose={onCancelEdit}
-                            closeLabel="cancel network edit"
-                            columns={NETWORK_COLUMNS}
-                            data-testid={`admin-user-network-edit-form-${c.network_id}`}
-                          >
-                            <form
-                              class="adm-form-grid"
-                              onSubmit={(e) => {
-                                e.preventDefault();
-                                void onSubmitEdit(c);
-                              }}
-                            >
-                              <NetworkEditFields
-                                form={editForm() as EditForm}
-                                onChange={(next) => setEditForm(next)}
-                                networkId={c.network_id}
-                              />
-                              <div class="adm-form-grid-actions">
-                                <button
-                                  type="submit"
-                                  class="adm-btn adm-btn--ok"
-                                  data-testid={`admin-user-network-edit-submit-${c.network_id}`}
-                                >
-                                  Save
-                                </button>
-                                <button
-                                  type="button"
-                                  class="adm-btn adm-btn--danger"
-                                  onClick={onCancelEdit}
-                                  data-testid={`admin-user-network-edit-cancel-${c.network_id}`}
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </form>
-                          </AdminDetailPanel>
-                        </Show>
-                      </>
-                    )}
-                  </For>
-                </tbody>
-              </AdminTable>
+                            Save
+                          </button>
+                        </div>
+                      </form>
+                    </Show>
+                  </section>
+                )}
+              </For>
             </Show>
           </AdminCard>
         </Show>
       </div>
     </div>
-  );
-};
-
-// Pure controlled inputs; no internal state. The page owns the draft.
-const NetworkEditFields: Component<{
-  form: EditForm;
-  onChange: (next: EditForm) => void;
-  networkId: number;
-}> = (props) => {
-  const set = (patch: Partial<EditForm>): void => {
-    props.onChange({ ...props.form, ...patch });
-  };
-  return (
-    <>
-      <input
-        placeholder="nick"
-        aria-label="nick"
-        type="text"
-        value={props.form.nick}
-        onInput={(e) => set({ nick: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-nick-${props.networkId}`}
-      />
-      <input
-        placeholder="realname"
-        aria-label="realname"
-        type="text"
-        value={props.form.realname}
-        onInput={(e) => set({ realname: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-realname-${props.networkId}`}
-      />
-      <input
-        placeholder="sasl user"
-        aria-label="sasl user"
-        type="text"
-        value={props.form.sasl_user}
-        onInput={(e) => set({ sasl_user: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-sasl-user-${props.networkId}`}
-      />
-      <select
-        aria-label="auth method"
-        value={props.form.auth_method}
-        onChange={(e) => set({ auth_method: (e.currentTarget as HTMLSelectElement).value })}
-        data-testid={`admin-user-network-edit-auth-method-${props.networkId}`}
-      >
-        <For each={IRCAUTH_FSMAUTH_METHOD}>{(m) => <option value={m}>auth: {m}</option>}</For>
-      </select>
-      <input
-        placeholder="password"
-        aria-label="password"
-        type="password"
-        value={props.form.password}
-        onInput={(e) => set({ password: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-password-${props.networkId}`}
-      />
-    </>
   );
 };
 

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -1,6 +1,7 @@
 import { type Component, createMemo, createSignal, For, onMount, Show } from "solid-js";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
+import AdminField from "./admin/AdminField";
 import { AdminEmpty, AdminError, AdminLoading } from "./admin/AdminStatus";
 import { connectionTone } from "./admin/connectionTone";
 import {
@@ -464,73 +465,108 @@ const AdminUserPage: Component<Props> = (props) => {
 
                     <Show when={enabled(net.id)}>
                       <form
-                        class="adm-form-grid"
                         onSubmit={(e) => {
                           void onSave(net, e);
                         }}
                         data-testid={`admin-user-network-form-${net.id}`}
                       >
-                        <input
-                          placeholder="nick"
-                          aria-label={`nick on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).nick}
-                          onInput={(e) =>
-                            setForm(net.id, { nick: (e.currentTarget as HTMLInputElement).value })
-                          }
-                          data-testid={`admin-user-network-nick-${net.id}`}
-                          required
-                        />
-                        <input
-                          placeholder="realname"
-                          aria-label={`realname on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).realname}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              realname: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-realname-${net.id}`}
-                        />
-                        <input
-                          placeholder="sasl user"
-                          aria-label={`sasl user on ${net.slug}`}
-                          type="text"
-                          value={formFor(net.id).sasl_user}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              sasl_user: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-sasl-user-${net.id}`}
-                        />
-                        <select
-                          aria-label={`auth method on ${net.slug}`}
-                          value={formFor(net.id).auth_method}
-                          onChange={(e) =>
-                            setForm(net.id, {
-                              auth_method: (e.currentTarget as HTMLSelectElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-auth-method-${net.id}`}
-                        >
-                          <For each={IRCAUTH_FSMAUTH_METHOD}>
-                            {(m) => <option value={m}>auth: {m}</option>}
-                          </For>
-                        </select>
-                        <input
-                          placeholder="password"
-                          aria-label={`password on ${net.slug}`}
-                          type="password"
-                          value={formFor(net.id).password}
-                          onInput={(e) =>
-                            setForm(net.id, {
-                              password: (e.currentTarget as HTMLInputElement).value,
-                            })
-                          }
-                          data-testid={`admin-user-network-password-${net.id}`}
-                        />
+                        {/* #1157 — vjt: "una form piu' umana: fieldset, un
+                            campo per riga". A real `<fieldset>`, so the
+                            group has a name a screen reader reads once
+                            instead of five placeholder-only boxes, and
+                            `.adm-field-rows` (Settings' idiom) to put each
+                            label beside its own control. */}
+                        <fieldset class="adm-fieldset">
+                          <legend class="adm-fieldset-legend">{net.slug} settings</legend>
+                          <div class="adm-field-rows">
+                            <AdminField label="nick" for={`admin-user-network-nick-${net.id}`}>
+                              <input
+                                id={`admin-user-network-nick-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).nick}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    nick: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-nick-${net.id}`}
+                                required
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="realname"
+                              for={`admin-user-network-realname-${net.id}`}
+                            >
+                              <input
+                                id={`admin-user-network-realname-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).realname}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    realname: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-realname-${net.id}`}
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="sasl user"
+                              for={`admin-user-network-sasl-user-${net.id}`}
+                            >
+                              <input
+                                id={`admin-user-network-sasl-user-${net.id}`}
+                                type="text"
+                                value={formFor(net.id).sasl_user}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    sasl_user: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-sasl-user-${net.id}`}
+                              />
+                            </AdminField>
+                            <AdminField
+                              label="auth method"
+                              for={`admin-user-network-auth-method-${net.id}`}
+                            >
+                              <select
+                                id={`admin-user-network-auth-method-${net.id}`}
+                                value={formFor(net.id).auth_method}
+                                onChange={(e) =>
+                                  setForm(net.id, {
+                                    auth_method: (e.currentTarget as HTMLSelectElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-auth-method-${net.id}`}
+                              >
+                                <For each={IRCAUTH_FSMAUTH_METHOD}>
+                                  {(m) => <option value={m}>{m}</option>}
+                                </For>
+                              </select>
+                            </AdminField>
+                            <AdminField
+                              label="password"
+                              for={`admin-user-network-password-${net.id}`}
+                              hint={
+                                credOf(net.id) === undefined
+                                  ? undefined
+                                  : "blank leaves the stored one alone"
+                              }
+                            >
+                              <input
+                                id={`admin-user-network-password-${net.id}`}
+                                type="password"
+                                value={formFor(net.id).password}
+                                onInput={(e) =>
+                                  setForm(net.id, {
+                                    password: (e.currentTarget as HTMLInputElement).value,
+                                  })
+                                }
+                                data-testid={`admin-user-network-password-${net.id}`}
+                              />
+                            </AdminField>
+                          </div>
+                        </fieldset>
                         <div class="adm-form-grid-actions">
                           <button
                             type="submit"

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -73,7 +73,6 @@ type AddForm = {
   password: string;
   sasl_user: string;
   realname: string;
-  autojoin_channels: string;
 };
 
 const EMPTY_ADD: AddForm = {
@@ -83,7 +82,6 @@ const EMPTY_ADD: AddForm = {
   password: "",
   sasl_user: "",
   realname: "",
-  autojoin_channels: "",
 };
 
 type EditForm = {
@@ -92,7 +90,6 @@ type EditForm = {
   sasl_user: string;
   auth_method: string;
   password: string;
-  autojoin_channels: string;
 };
 
 /** What the last write did to the live session, for one network. */
@@ -105,13 +102,6 @@ type SessionOutcome = {
 // row's `colspan`; derived from the count so adding a column cannot
 // silently desync it.
 const NETWORK_COLUMNS = 6;
-
-function splitChannels(raw: string): string[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
-}
 
 const AdminUserPage: Component<Props> = (props) => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
@@ -192,8 +182,6 @@ const AdminUserPage: Component<Props> = (props) => {
         password: f.password === "" ? undefined : f.password,
         sasl_user: f.sasl_user === "" ? undefined : f.sasl_user,
         realname: f.realname === "" ? undefined : f.realname,
-        autojoin_channels:
-          f.autojoin_channels.trim() === "" ? undefined : splitChannels(f.autojoin_channels),
       });
       recordOutcome(networkId, created);
       setAddForm({ ...EMPTY_ADD });
@@ -214,7 +202,6 @@ const AdminUserPage: Component<Props> = (props) => {
       sasl_user: c.sasl_user ?? "",
       auth_method: c.auth_method,
       password: "",
-      autojoin_channels: c.autojoin_channels.join(", "),
     });
   };
 
@@ -237,10 +224,6 @@ const AdminUserPage: Component<Props> = (props) => {
     if (f.sasl_user !== (c.sasl_user ?? "")) patch.sasl_user = f.sasl_user;
     if (f.auth_method !== c.auth_method) patch.auth_method = f.auth_method;
     if (f.password !== "") patch.password = f.password;
-    const nextAutojoin = splitChannels(f.autojoin_channels);
-    if (JSON.stringify(nextAutojoin) !== JSON.stringify(c.autojoin_channels)) {
-      patch.autojoin_channels = nextAutojoin;
-    }
     if (Object.keys(patch).length === 0) {
       onCancelEdit();
       return;
@@ -435,19 +418,6 @@ const AdminUserPage: Component<Props> = (props) => {
                   }
                   data-testid="admin-user-network-add-realname"
                 />
-                <input
-                  placeholder="autojoin"
-                  aria-label="autojoin"
-                  type="text"
-                  value={addForm().autojoin_channels}
-                  onInput={(e) =>
-                    setAddForm({
-                      ...addForm(),
-                      autojoin_channels: (e.currentTarget as HTMLInputElement).value,
-                    })
-                  }
-                  data-testid="admin-user-network-add-autojoin"
-                />
                 <div class="adm-form-grid-actions">
                   <button
                     type="submit"
@@ -599,13 +569,6 @@ const AdminUserPage: Component<Props> = (props) => {
                                     </AdminBadge>
                                   ),
                                 },
-                                {
-                                  label: "autojoin",
-                                  value:
-                                    c.autojoin_channels.length === 0
-                                      ? "—"
-                                      : c.autojoin_channels.join(", "),
-                                },
                               ]}
                             />
                           </AdminDetailPanel>
@@ -717,14 +680,6 @@ const NetworkEditFields: Component<{
         value={props.form.password}
         onInput={(e) => set({ password: (e.currentTarget as HTMLInputElement).value })}
         data-testid={`admin-user-network-edit-password-${props.networkId}`}
-      />
-      <input
-        placeholder="autojoin"
-        aria-label="autojoin"
-        type="text"
-        value={props.form.autojoin_channels}
-        onInput={(e) => set({ autojoin_channels: (e.currentTarget as HTMLInputElement).value })}
-        data-testid={`admin-user-network-edit-autojoin-${props.networkId}`}
       />
     </>
   );

--- a/cicchetto/src/AdminUserPage.tsx
+++ b/cicchetto/src/AdminUserPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "./lib/api";
 import { token } from "./lib/auth";
 import { operatorApiError } from "./lib/friendlyApiError";
-import { IRCAUTH_FSMAUTH_METHOD } from "./lib/wireTypes";
+import type { IRCAuthFSMAuthMethod } from "./lib/wireTypes";
 
 // #1158 — one user, one page, and it owns that user's network access.
 //
@@ -80,6 +80,50 @@ export type Props = {
   user: AdminUser;
   onBack: () => void;
 };
+
+// #1157 — what the SELECTOR offers. vjt, confirmed twice (2026-08-10
+// 00:19 and again at 00:31): *"su admin credentials confermo: selettore
+// sasl / server_pass / none"*.
+//
+// This is narrower than the server's closed set on purpose, and the
+// server's set is NOT narrowed to match — measured, both survivors have
+// an owner that is not this console:
+//
+//   * `nickserv_identify` is set BY THE SERVER. `Credential.registration_changeset/2`
+//     flips a credential to it when the #349 registration wizard sees
+//     services confirm the nick (`+r`), because from then on grappa must
+//     auto-identify or the nick gets ghosted within a minute. An operator
+//     never picks it; a credential arrives holding it.
+//   * `auto` is the Bahamut/Azzurra PASS-handoff path documented in
+//     `AuthFSM` — PASS, then SASL if the server advertises it.
+//
+// Dropping either from the DB enum is a migration over live rows and
+// belongs to #1044, which owns the secret-slot reshape and which #1157's
+// own text defers this question to ("settled there and rendered here,
+// not decided twice"). So the console stops OFFERING them and never
+// rewrites one it finds — see `authOptions`.
+//
+// Typed against the codegen union rather than as bare strings: a
+// server-side rename regenerates `wireTypes.ts` and fails HERE, which is
+// the half of the #410 LOCK worth keeping.
+const OFFERED_AUTH_METHODS: readonly IRCAuthFSMAuthMethod[] = ["sasl", "server_pass", "none"];
+
+// The offered set, plus whatever this credential actually holds. A
+// `<select>` whose value matches no option renders as if the operator
+// had chosen the first one, and the next save would quietly carry that
+// choice — so a method set outside this console is shown, labelled, and
+// left alone.
+function authOptions(current: string): string[] {
+  return OFFERED_AUTH_METHODS.includes(current as IRCAuthFSMAuthMethod)
+    ? [...OFFERED_AUTH_METHODS]
+    : [...OFFERED_AUTH_METHODS, current];
+}
+
+function authOptionLabel(method: string): string {
+  return OFFERED_AUTH_METHODS.includes(method as IRCAuthFSMAuthMethod)
+    ? method
+    : `${method} (set elsewhere)`;
+}
 
 /** The settings a credential carries, as the form holds them. */
 type NetworkForm = {
@@ -539,8 +583,8 @@ const AdminUserPage: Component<Props> = (props) => {
                                 }
                                 data-testid={`admin-user-network-auth-method-${net.id}`}
                               >
-                                <For each={IRCAUTH_FSMAUTH_METHOD}>
-                                  {(m) => <option value={m}>{m}</option>}
+                                <For each={authOptions(formFor(net.id).auth_method)}>
+                                  {(m) => <option value={m}>{authOptionLabel(m)}</option>}
                                 </For>
                               </select>
                             </AdminField>

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -28,7 +28,7 @@ import { diagPush } from "./lib/diagLog";
 import { frameBudgetForTarget } from "./lib/frameBudget";
 import { frameBudgetBaseForNetwork } from "./lib/isupport";
 import { networkBySlug } from "./lib/networks";
-import { routeClipboardPaste } from "./lib/pasteRoute";
+import { routeClipboardPaste, routePastedInput } from "./lib/pasteRoute";
 import {
   claimAxis,
   type DragAxis,
@@ -524,6 +524,16 @@ const ComposeBox: Component<Props> = (props) => {
     routeClipboardPaste(e, textareaEl, props.networkSlug, props.channelName, true);
   };
 
+  // #1250 — the same guard for a paste that fires NO `paste` event. GBoard's
+  // clipboard chip commits through the input method, which surfaces only as
+  // `beforeinput` with an `insertFromPaste` inputType, so the flood cap was
+  // bypassable by picking that gesture. The router arbitrates the overlap with
+  // `onPaste` above (one gesture, one decision) — see its claim comment.
+  const onBeforeInput = (e: InputEvent) => {
+    if (textareaEl === undefined) return;
+    routePastedInput(e, textareaEl, props.networkSlug, props.channelName);
+  };
+
   // #118 — "(i/N)" counter, shown only while a multi-file batch is in
   // flight. A single upload (total 1) renders no counter.
   const batchLabel = (): string | null => {
@@ -680,6 +690,7 @@ const ComposeBox: Component<Props> = (props) => {
           onInput={onInput}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
+          onBeforeInput={onBeforeInput}
           // #974 — NOT the fix for that issue, and explicitly not the
           // mechanism behind it (the iOS auto-capitalisation hypothesis was
           // falsified on a real device). Correct on its own merits: with no

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -30,20 +30,27 @@ import {
 // #1158 — the per-user admin page, the ONE surface that owns a user's
 // network access now that the Credentials tab is gone.
 //
-// The page is per-USER, so the invariants this suite defends are the ones
-// the deleted tab never had to hold:
+// #1157 reshaped it: no bind flow, one section per CONFIGURED network,
+// and a checkbox that says whether this user has access. So the suite's
+// central fixture is a server with TWO networks where the user is on
+// ONE — the page must render both sections and disagree about them.
 //
-//   * it renders THIS user's networks and no one else's (the list endpoint
-//     is unfiltered — see the `filters` note in the page);
-//   * the user is the page, so adding a network asks for a network, never
-//     for a user;
-//   * `session_action` is per-ROW state carrying all FOUR values. The tab
-//     it replaces surfaced two, and only for PATCH: `onBind` dropped the
-//     POST reply on the floor, so `spawned` / `not_spawned` had no operator
-//     surface at all;
-//   * a row shows the DB state AND the live state side by side, which is
-//     the two-sources rule and the witness `issue1163-admin-bind-dials`
-//     reads.
+// The invariants defended here:
+//
+//   * a section is ticked for THIS user's credential and no one else's
+//     (the list endpoint is unfiltered — see the `filters` note in the
+//     page). The foreign credential in every mount fetch sits on the
+//     second network, so a missing owner filter ticks a box;
+//   * the checkbox is not a write: enabling reveals the form and calls
+//     nothing, disabling a bound network ARMS a removal and calls
+//     nothing. Only Save and the confirm reach the server;
+//   * `session_action` is per-SECTION state carrying all FOUR values.
+//     The tab this page replaced surfaced two, and only for PATCH:
+//     `onBind` dropped the POST reply on the floor, so `spawned` /
+//     `not_spawned` had no operator surface at all;
+//   * a bound section shows the DB state AND the live state side by
+//     side, which is the two-sources rule and the witness
+//     `issue1163-admin-bind-dials` reads.
 
 const USER: AdminUser = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -102,8 +109,9 @@ const CRED: AdminCredential = {
   },
 };
 
-// Same shape, different OWNER. Present in every mount fetch, so any test
-// that finds it on the page has caught a missing owner filter.
+// Same shape, different OWNER, on the network this user is NOT on.
+// Present in every mount fetch, so a missing owner filter shows up as a
+// ticked box rather than as nothing at all.
 const FOREIGN_CRED: AdminCredential = {
   ...CRED,
   user_id: OTHER_USER_ID,
@@ -112,6 +120,7 @@ const FOREIGN_CRED: AdminCredential = {
   nick: "bob",
 };
 
+// This user, on the second network, with no pid behind it.
 const ORPHAN_CRED: AdminCredential = {
   ...CRED,
   network_id: OTHER_NETWORK.id,
@@ -125,7 +134,11 @@ function mountPage(onBack: () => void = () => {}): void {
 }
 
 async function pageReady(): Promise<void> {
-  await waitFor(() => expect(screen.queryByTestId("admin-user-networks-table")).not.toBeNull());
+  await waitFor(() => expect(screen.queryByTestId("admin-user-networks-card")).not.toBeNull());
+}
+
+function checkbox(networkId: number): HTMLInputElement {
+  return screen.getByTestId(`admin-user-network-enabled-${networkId}`) as HTMLInputElement;
 }
 
 beforeEach(() => {
@@ -134,13 +147,39 @@ beforeEach(() => {
   vi.mocked(adminListNetworks).mockResolvedValue([NETWORK, OTHER_NETWORK]);
 });
 
-describe("AdminUserPage — the user's networks", () => {
-  it("renders this user's networks and never another user's", async () => {
+describe("AdminUserPage — a section per configured network (#1157)", () => {
+  it("renders every configured network, not only the ones the user is on", async () => {
     mountPage();
     await pageReady();
 
-    expect(screen.queryByTestId(`admin-user-network-row-${NETWORK.id}`)).not.toBeNull();
-    expect(screen.queryByTestId(`admin-user-network-row-${OTHER_NETWORK.id}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-${NETWORK.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-${OTHER_NETWORK.id}`)).not.toBeNull();
+  });
+
+  it("ticks this user's networks and never another user's", async () => {
+    mountPage();
+    await pageReady();
+
+    expect(checkbox(NETWORK.id).checked).toBe(true);
+    // `FOREIGN_CRED` is a credential on this very network, owned by
+    // someone else. Ticked here means the owner filter is gone.
+    expect(checkbox(OTHER_NETWORK.id).checked).toBe(false);
+  });
+
+  it("shows the settings form only for an enabled network", async () => {
+    mountPage();
+    await pageReady();
+
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).not.toBeNull();
+    expect(screen.queryByTestId(`admin-user-network-form-${OTHER_NETWORK.id}`)).toBeNull();
+  });
+
+  it("seeds an enabled section's form from the credential", async () => {
+    mountPage();
+    await pageReady();
+
+    const nick = screen.getByTestId(`admin-user-network-nick-${NETWORK.id}`) as HTMLInputElement;
+    expect(nick.value).toBe(CRED.nick);
   });
 
   it("shows the DB state and the live state side by side", async () => {
@@ -148,22 +187,23 @@ describe("AdminUserPage — the user's networks", () => {
     mountPage();
     await pageReady();
 
-    const connected = screen.getByTestId(`admin-user-network-row-${NETWORK.id}`);
-    expect(connected.textContent).toContain("connected");
-    expect(connected.textContent).toContain("alive");
+    expect(screen.getByTestId(`admin-user-network-connection-${NETWORK.id}`).textContent).toBe(
+      "connected",
+    );
+    expect(screen.getByTestId(`admin-user-network-live-${NETWORK.id}`).textContent).toBe("alive");
 
-    // U-0: a row whose DB says connected while the BEAM has no pid must say
-    // so, rather than inherit the neighbouring row's honesty.
-    const orphan = screen.getByTestId(`admin-user-network-row-${OTHER_NETWORK.id}`);
-    expect(orphan.textContent).toContain("BEAM has no pid");
+    // U-0: a section whose DB says connected while the BEAM has no pid
+    // must say so, rather than inherit its neighbour's honesty.
+    expect(screen.getByTestId(`admin-user-network-live-${OTHER_NETWORK.id}`).textContent).toBe(
+      "BEAM has no pid",
+    );
   });
 
-  it("says the user has no networks rather than rendering an empty table", async () => {
-    vi.mocked(adminListCredentials).mockResolvedValue([FOREIGN_CRED]);
+  it("blames the server, not the user, when no network is configured at all", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([]);
     mountPage();
 
     await waitFor(() => expect(screen.queryByTestId("admin-user-networks-empty")).not.toBeNull());
-    expect(screen.queryByTestId("admin-user-networks-table")).toBeNull();
   });
 
   it("calls onBack from the back control", async () => {
@@ -176,55 +216,49 @@ describe("AdminUserPage — the user's networks", () => {
   });
 });
 
-describe("AdminUserPage — adding a network", () => {
-  it("keeps the add form closed until + is pressed", async () => {
+describe("AdminUserPage — the checkbox is not a write (#1157)", () => {
+  it("reveals the form on enable without calling the server", async () => {
     mountPage();
     await pageReady();
 
-    expect(screen.queryByTestId("admin-user-network-add-form")).toBeNull();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    expect(screen.queryByTestId("admin-user-network-add-form")).not.toBeNull();
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+
+    expect(screen.queryByTestId(`admin-user-network-form-${OTHER_NETWORK.id}`)).not.toBeNull();
+    // A bind needs a nick; a checkbox cannot supply one, so nothing goes
+    // out until Save.
+    expect(adminBindCredential).not.toHaveBeenCalled();
   });
 
-  it("asks for a network, never for a user — the user IS the page", async () => {
+  it("will not save a newly enabled network until it has a nick", async () => {
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
 
-    expect(screen.queryByTestId("admin-user-network-add-network")).not.toBeNull();
-    expect(screen.queryByTestId("admin-user-network-add-user")).toBeNull();
+    const save = screen.getByTestId(
+      `admin-user-network-save-${OTHER_NETWORK.id}`,
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
+    });
+    expect(save.disabled).toBe(false);
   });
 
-  it("offers only networks the user is not already on", async () => {
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-
-    const select = screen.getByTestId("admin-user-network-add-network") as HTMLSelectElement;
-    const values = Array.from(select.options)
-      .map((o) => o.value)
-      .filter((v) => v !== "");
-    expect(values).toEqual([String(OTHER_NETWORK.id)]);
-  });
-
-  it("binds with the page's user and the parsed network id", async () => {
+  it("binds with the page's user and the section's network", async () => {
     vi.mocked(adminBindCredential).mockResolvedValue({
       ...CRED,
       network_id: OTHER_NETWORK.id,
       network_slug: OTHER_NETWORK.slug,
-      session_action: "spawned",
     });
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
 
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
       target: { value: "newnick" },
     });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
 
     await waitFor(() => {
       expect(adminBindCredential).toHaveBeenCalledWith(
@@ -239,22 +273,10 @@ describe("AdminUserPage — adding a network", () => {
   });
 
   // #1157 — vjt: *"`autojoin` makes no sense — remove it."* Channel
-  // restore rides `last_joined_channels`
-  // (`session_plan.ex`, `merge_autojoin/2`), so the admin field was never
-  // the mechanism the bouncer actually uses; offering it invited the
-  // operator to set a list that the next reconnect overwrites.
-  it("offers no autojoin control, on either form", async () => {
-    mountPage();
-    await pageReady();
-
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    expect(screen.queryByTestId(`admin-user-network-edit-autojoin-${NETWORK.id}`)).toBeNull();
-
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    expect(screen.queryByTestId("admin-user-network-add-autojoin")).toBeNull();
-  });
-
-  it("never puts autojoin_channels on a bind", async () => {
+  // restore rides `last_joined_channels` (`session_plan.ex`,
+  // `merge_autojoin/2`), so the admin field was never the mechanism the
+  // bouncer actually uses.
+  it("offers no autojoin control, and never sends one", async () => {
     vi.mocked(adminBindCredential).mockResolvedValue({
       ...CRED,
       network_id: OTHER_NETWORK.id,
@@ -262,15 +284,13 @@ describe("AdminUserPage — adding a network", () => {
     });
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    expect(screen.queryByTestId(`admin-user-network-autojoin-${NETWORK.id}`)).toBeNull();
 
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
       target: { value: "newnick" },
     });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
 
     // The KEY, not the value: the removed form used to send an explicit
     // `undefined` for an empty box, and `objectContaining` cannot tell
@@ -280,116 +300,49 @@ describe("AdminUserPage — adding a network", () => {
     expect(Object.keys(body ?? {})).not.toContain("autojoin_channels");
   });
 
-  // #410 LOCK, carried over from the deleted Credentials tab suite: the
-  // auth-method dropdown enumerates the codegen-emitted closed set, in
-  // array order. A server-side rename or reorder regenerates wireTypes.ts
-  // and must fail HERE, not reshuffle the dropdown in silence.
-  it("renders the auth-method dropdown with the closed method set in order", async () => {
+  it("arms a removal on disable instead of performing one", async () => {
     mountPage();
     await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
 
-    const select = screen.getByTestId("admin-user-network-add-auth-method") as HTMLSelectElement;
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+    fireEvent.click(checkbox(NETWORK.id));
+
+    expect(adminUnbindCredential).not.toHaveBeenCalled();
+    expect(checkbox(NETWORK.id).checked).toBe(false);
+    expect(screen.queryByTestId(`admin-user-network-remove-${NETWORK.id}`)).not.toBeNull();
+    // The form goes with the tick: leaving it up would invite an edit to
+    // a credential the operator has just asked to delete.
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("removes the credential once the armed removal is confirmed", async () => {
+    vi.mocked(adminUnbindCredential).mockResolvedValue(undefined);
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(NETWORK.id));
+    fireEvent.click(screen.getByTestId(`admin-user-network-remove-${NETWORK.id}`));
+
+    await waitFor(() => {
+      expect(adminUnbindCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id);
+    });
+    await waitFor(() => expect(checkbox(NETWORK.id).checked).toBe(false));
+    expect(screen.queryByTestId(`admin-user-network-remove-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("puts the tick back when the armed removal is cancelled", async () => {
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(NETWORK.id));
+    fireEvent.click(screen.getByTestId(`admin-user-network-keep-${NETWORK.id}`));
+
+    expect(adminUnbindCredential).not.toHaveBeenCalled();
+    expect(checkbox(NETWORK.id).checked).toBe(true);
+    expect(screen.queryByTestId(`admin-user-network-form-${NETWORK.id}`)).not.toBeNull();
   });
 });
 
-describe("AdminUserPage — session_action is per-row state", () => {
-  it("reports a bind that dialled, on the row it belongs to", async () => {
-    vi.mocked(adminBindCredential).mockResolvedValue({
-      ...CRED,
-      network_id: OTHER_NETWORK.id,
-      network_slug: OTHER_NETWORK.slug,
-      session_action: "spawned",
-    });
-    vi.mocked(adminListCredentials)
-      .mockResolvedValueOnce([CRED, FOREIGN_CRED])
-      .mockResolvedValue([CRED, FOREIGN_CRED, { ...ORPHAN_CRED, live_state: CRED.live_state }]);
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
-      target: { value: "newnick" },
-    });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
-
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
-      expect(state).not.toBeNull();
-      expect(state?.textContent).toContain("spawned");
-    });
-  });
-
-  // The half the deleted tab dropped entirely: a bind that did NOT dial
-  // still created the row, and `session_error` is the only thing that says
-  // why. Rendering the action without the reason would be a worse lie than
-  // rendering nothing.
-  it("reports a bind that did not dial, with the refusal", async () => {
-    vi.mocked(adminBindCredential).mockResolvedValue({
-      ...CRED,
-      network_id: OTHER_NETWORK.id,
-      network_slug: OTHER_NETWORK.slug,
-      connection_state: "parked",
-      live_state: null,
-      session_action: "not_spawned",
-      session_error: "user_cap_exceeded",
-    });
-    vi.mocked(adminListCredentials)
-      .mockResolvedValueOnce([CRED, FOREIGN_CRED])
-      .mockResolvedValue([CRED, FOREIGN_CRED, ORPHAN_CRED]);
-    mountPage();
-    await pageReady();
-    fireEvent.click(screen.getByTestId("admin-user-network-add"));
-    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
-      target: { value: String(OTHER_NETWORK.id) },
-    });
-    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
-      target: { value: "newnick" },
-    });
-    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
-
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
-      expect(state?.textContent).toContain("not_spawned");
-      expect(state?.textContent).toContain("user_cap_exceeded");
-    });
-  });
-
-  it("reports a stopped session on the edited row, and leaves the others alone", async () => {
-    vi.mocked(adminListCredentials).mockResolvedValue([CRED, ORPHAN_CRED]);
-    vi.mocked(adminUpdateCredential).mockResolvedValue({
-      ...CRED,
-      session_action: "stopped",
-    });
-    mountPage();
-    await pageReady();
-
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    fireEvent.input(screen.getByTestId(`admin-user-network-edit-password-${NETWORK.id}`), {
-      target: { value: "new-irc-pass" },
-    });
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-submit-${NETWORK.id}`));
-
-    await waitFor(() => {
-      expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
-        password: "new-irc-pass",
-      });
-    });
-    await waitFor(() => {
-      const state = screen.queryByTestId(`admin-user-network-session-action-${NETWORK.id}`);
-      expect(state?.textContent).toContain("stopped");
-    });
-    expect(
-      screen.queryByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`),
-    ).toBeNull();
-  });
-});
-
-describe("AdminUserPage — editing and removing a network", () => {
+describe("AdminUserPage — editing a bound network", () => {
   it("sends only the fields the operator changed", async () => {
     vi.mocked(adminUpdateCredential).mockResolvedValue({
       ...CRED,
@@ -399,11 +352,10 @@ describe("AdminUserPage — editing and removing a network", () => {
     mountPage();
     await pageReady();
 
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
-    fireEvent.input(screen.getByTestId(`admin-user-network-edit-realname-${NETWORK.id}`), {
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
       target: { value: "Alice Smith" },
     });
-    fireEvent.click(screen.getByTestId(`admin-user-network-edit-submit-${NETWORK.id}`));
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
 
     await waitFor(() => {
       expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
@@ -412,22 +364,92 @@ describe("AdminUserPage — editing and removing a network", () => {
     });
   });
 
-  it("removes a network behind an inline confirm", async () => {
-    vi.mocked(adminUnbindCredential).mockResolvedValue(undefined);
+  it("refuses to save a bound network nothing has changed on", async () => {
     mountPage();
     await pageReady();
 
-    const btn = screen.getByTestId(`admin-user-network-remove-${NETWORK.id}`);
-    expect(btn.textContent).toBe("Remove");
-    fireEvent.click(btn);
-    expect(btn.textContent).toBe("Confirm remove");
-    fireEvent.click(btn);
+    // An empty PATCH would ask the server to decide whether to stop a
+    // live session over nothing.
+    const save = screen.getByTestId(`admin-user-network-save-${NETWORK.id}`) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
 
-    await waitFor(() => {
-      expect(adminUnbindCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id);
+  // #410 LOCK, carried over from the deleted Credentials tab suite: the
+  // auth-method dropdown enumerates the codegen-emitted closed set, in
+  // array order. A server-side rename or reorder regenerates wireTypes.ts
+  // and must fail HERE, not reshuffle the dropdown in silence.
+  it("renders the auth-method dropdown with the closed method set in order", async () => {
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+  });
+});
+
+describe("AdminUserPage — session_action is per-section state", () => {
+  it("reports a bind that dialled, on the section it belongs to", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+      session_action: "spawned",
     });
-    await waitFor(() => {
-      expect(screen.queryByTestId(`admin-user-network-row-${NETWORK.id}`)).toBeNull();
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
     });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
+    expect(note.textContent).toContain("spawned");
+    // On the section it belongs to, and on no other.
+    expect(screen.queryByTestId(`admin-user-network-session-action-${NETWORK.id}`)).toBeNull();
+  });
+
+  it("reports a bind that did not dial, with the refusal", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+      session_action: "not_spawned",
+      session_error: "resolve_failed",
+    });
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(checkbox(OTHER_NETWORK.id));
+    fireEvent.input(screen.getByTestId(`admin-user-network-nick-${OTHER_NETWORK.id}`), {
+      target: { value: "newnick" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${OTHER_NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${OTHER_NETWORK.id}`);
+    expect(note.textContent).toContain("not_spawned");
+    // The only field that says WHY, and the reason this is not a toast.
+    expect(note.textContent).toContain("resolve_failed");
+  });
+
+  it("reports a stopped session on the edited section", async () => {
+    vi.mocked(adminUpdateCredential).mockResolvedValue({
+      ...CRED,
+      session_action: "stopped",
+    });
+    mountPage();
+    await pageReady();
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
+      target: { value: "Alice Smith" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
+
+    const note = await screen.findByTestId(`admin-user-network-session-action-${NETWORK.id}`);
+    expect(note.textContent).toContain("stopped");
   });
 });

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -342,6 +342,43 @@ describe("AdminUserPage — the checkbox is not a write (#1157)", () => {
   });
 });
 
+describe("AdminUserPage — the form is a named group of labelled rows (#1157)", () => {
+  // vjt: *"una form piu' umana: fieldset, un campo per riga — non
+  // stipata com'e' ora."* One field per row is CSS and is measured on a
+  // real viewport; what a DOM test can hold is the half CSS cannot fake
+  // — the group has a NAME and every control has a LABEL bound to it.
+  // The forms this replaced had five placeholder-only boxes, and a
+  // placeholder disappears the moment you type into it.
+  it("wraps the fields in a fieldset that names the network", async () => {
+    mountPage();
+    await pageReady();
+
+    const form = screen.getByTestId(`admin-user-network-form-${NETWORK.id}`);
+    const fieldset = form.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.querySelector("legend")?.textContent).toContain(NETWORK.slug);
+  });
+
+  it("binds a real label to every control in the form", async () => {
+    mountPage();
+    await pageReady();
+
+    const form = screen.getByTestId(`admin-user-network-form-${NETWORK.id}`);
+    const controls = Array.from(form.querySelectorAll("input, select"));
+    // Non-vacuity: an empty control list would satisfy the loop below
+    // without proving anything.
+    expect(controls.length).toBe(5);
+
+    for (const control of controls) {
+      const id = control.getAttribute("id");
+      expect(id, `${control.getAttribute("data-testid")} has no id to label`).not.toBeNull();
+      const label = form.querySelector(`label[for="${id}"]`);
+      expect(label, `no label points at ${id}`).not.toBeNull();
+      expect((label?.textContent ?? "").trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe("AdminUserPage — editing a bound network", () => {
   it("sends only the fields the operator changed", async () => {
     vi.mocked(adminUpdateCredential).mockResolvedValue({

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AdminCredential, AdminNetwork, AdminUser } from "../lib/api";
+import { IRCAUTH_FSMAUTH_METHOD } from "../lib/wireTypes";
 
 vi.mock("../lib/auth", () => ({
   token: () => "test-bearer",
@@ -411,19 +412,78 @@ describe("AdminUserPage — editing a bound network", () => {
     expect(save.disabled).toBe(true);
   });
 
-  // #410 LOCK, carried over from the deleted Credentials tab suite: the
-  // auth-method dropdown enumerates the codegen-emitted closed set, in
-  // array order. A server-side rename or reorder regenerates wireTypes.ts
-  // and must fail HERE, not reshuffle the dropdown in silence.
-  it("renders the auth-method dropdown with the closed method set in order", async () => {
+  // #1157 — vjt, confirmed twice: "selettore sasl / server_pass / none".
+  it("offers the three ruled auth methods and nothing else", async () => {
     mountPage();
     await pageReady();
 
     const select = screen.getByTestId(
       `admin-user-network-auth-method-${NETWORK.id}`,
     ) as HTMLSelectElement;
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toEqual(["auto", "sasl", "server_pass", "nickserv_identify", "none"]);
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(["sasl", "server_pass", "none"]);
+  });
+
+  // #410 LOCK, kept through the narrowing. It used to read "the dropdown
+  // enumerates the codegen closed set in array order", which a curated
+  // list cannot satisfy — but the REASON survives: a server-side rename
+  // regenerates `wireTypes.ts`, and an offer the server no longer knows
+  // must fail HERE rather than sit in a dropdown producing 422s. The
+  // compile-time half is the `readonly IRCAuthFSMAuthMethod[]` annotation
+  // on the offered list; this is the runtime half.
+  it("offers only values the server's closed set still contains", async () => {
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    for (const option of Array.from(select.options)) {
+      expect(IRCAUTH_FSMAUTH_METHOD as readonly string[], option.value).toContain(option.value);
+    }
+  });
+
+  // The credential this page did not create. `nickserv_identify` is set
+  // by the SERVER when the #349 registration wizard sees `+r`, so a
+  // credential can arrive holding a method the console does not offer —
+  // and a `<select>` whose value matches no option renders as if the
+  // first one had been chosen, which the next save would carry.
+  it("keeps a method it does not offer instead of silently rewriting it", async () => {
+    vi.mocked(adminListCredentials).mockResolvedValue([
+      { ...CRED, auth_method: "nickserv_identify" },
+      FOREIGN_CRED,
+    ]);
+    mountPage();
+    await pageReady();
+
+    const select = screen.getByTestId(
+      `admin-user-network-auth-method-${NETWORK.id}`,
+    ) as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toContain("nickserv_identify");
+    expect(select.value).toBe("nickserv_identify");
+    // Labelled, so the operator can tell it apart from a choice this
+    // console would have offered.
+    expect(select.textContent).toContain("set elsewhere");
+  });
+
+  it("does not send an auth_method the operator never touched", async () => {
+    vi.mocked(adminListCredentials).mockResolvedValue([
+      { ...CRED, auth_method: "nickserv_identify" },
+      FOREIGN_CRED,
+    ]);
+    vi.mocked(adminUpdateCredential).mockResolvedValue({ ...CRED, realname: "Alice Smith" });
+    mountPage();
+    await pageReady();
+
+    fireEvent.input(screen.getByTestId(`admin-user-network-realname-${NETWORK.id}`), {
+      target: { value: "Alice Smith" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-network-save-${NETWORK.id}`));
+
+    await waitFor(() => {
+      expect(adminUpdateCredential).toHaveBeenCalledWith("test-bearer", USER.id, NETWORK.id, {
+        realname: "Alice Smith",
+      });
+    });
   });
 });
 

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -238,6 +238,48 @@ describe("AdminUserPage — adding a network", () => {
     });
   });
 
+  // #1157 — vjt: *"`autojoin` makes no sense — remove it."* Channel
+  // restore rides `last_joined_channels`
+  // (`session_plan.ex`, `merge_autojoin/2`), so the admin field was never
+  // the mechanism the bouncer actually uses; offering it invited the
+  // operator to set a list that the next reconnect overwrites.
+  it("offers no autojoin control, on either form", async () => {
+    mountPage();
+    await pageReady();
+
+    fireEvent.click(screen.getByTestId(`admin-user-network-edit-${NETWORK.id}`));
+    expect(screen.queryByTestId(`admin-user-network-edit-autojoin-${NETWORK.id}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+    expect(screen.queryByTestId("admin-user-network-add-autojoin")).toBeNull();
+  });
+
+  it("never puts autojoin_channels on a bind", async () => {
+    vi.mocked(adminBindCredential).mockResolvedValue({
+      ...CRED,
+      network_id: OTHER_NETWORK.id,
+      network_slug: OTHER_NETWORK.slug,
+    });
+    mountPage();
+    await pageReady();
+    fireEvent.click(screen.getByTestId("admin-user-network-add"));
+
+    fireEvent.change(screen.getByTestId("admin-user-network-add-network"), {
+      target: { value: String(OTHER_NETWORK.id) },
+    });
+    fireEvent.input(screen.getByTestId("admin-user-network-add-nick"), {
+      target: { value: "newnick" },
+    });
+    fireEvent.click(screen.getByTestId("admin-user-network-add-submit"));
+
+    // The KEY, not the value: the removed form used to send an explicit
+    // `undefined` for an empty box, and `objectContaining` cannot tell
+    // that apart from an absent field.
+    await waitFor(() => expect(adminBindCredential).toHaveBeenCalled());
+    const body = vi.mocked(adminBindCredential).mock.calls[0]?.[1];
+    expect(Object.keys(body ?? {})).not.toContain("autojoin_channels");
+  });
+
   // #410 LOCK, carried over from the deleted Credentials tab suite: the
   // auth-method dropdown enumerates the codegen-emitted closed set, in
   // array order. A server-side rename or reorder regenerates wireTypes.ts

--- a/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
+++ b/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminCredential, AdminNetwork, AdminVisitor } from "../lib/api";
+
+// #1157 — the dictated column 4: on a phone the row's verbs "collapse
+// into ONE button with a dropdown" (vjt, 2026-08-09). Desktop keeps them
+// side by side.
+//
+// The regime is supplied explicitly because jsdom has no matchMedia, and
+// it is supplied as a MUTABLE object so this one file can assert both
+// sides of the branch: a collapse that also happened on desktop would
+// pass a narrow-only file.
+//
+// What the collapse must NOT do is skip the confirmation. Terminate is
+// destructive and `InlineConfirmButton` is sticky by design (the parent
+// owns `armed`), so the menu replaces the ARM step only — picking a verb
+// arms it, and the cell then has to offer a way back out, because on a
+// phone the sibling verb button that disarms it on desktop is not there.
+
+const viewport = vi.hoisted(() => ({ mobile: false, adminNarrow: false }));
+
+vi.mock("../lib/theme", () => ({
+  isMobile: () => viewport.mobile,
+  isAdminNarrow: () => viewport.adminNarrow,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  token: () => "test-bearer",
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    adminListVisitors: vi.fn(),
+    adminListCredentials: vi.fn(),
+    adminListSessions: vi.fn(),
+    adminListNetworks: vi.fn(),
+    adminListSessionLogSessions: vi.fn(),
+    adminDisconnectSession: vi.fn(),
+    adminReconnectSession: vi.fn(),
+    adminTerminateSession: vi.fn(),
+    adminDeleteVisitor: vi.fn(),
+  };
+});
+
+import AdminSessionsTab from "../AdminSessionsTab";
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const VISITOR_ID = "22222222-2222-2222-2222-222222222222";
+const USER_KEY = `user:${USER_ID}:1`;
+const VISITOR_KEY = `visitor:${VISITOR_ID}:1`;
+
+const NETWORK = {
+  id: 1,
+  slug: "azzurra",
+  max_concurrent_visitor_sessions: null,
+  max_concurrent_user_sessions: null,
+  max_per_ip: null,
+  live_counts: { visitors: 0, users: 0 },
+} as unknown as AdminNetwork;
+
+// A user row carries TWO verbs (`rowActions`) — the only shape the
+// collapse has anything to collapse.
+const userCredential = (): AdminCredential =>
+  ({
+    user_id: USER_ID,
+    network_id: 1,
+    network_slug: "azzurra",
+    nick: "vjt",
+    ident: null,
+    realname: null,
+    sasl_user: null,
+    auth_method: "sasl",
+    auth_command_template: null,
+    autojoin_channels: [],
+    last_joined_channels: [],
+    connection_state: "connected",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-05-16T00:00:00Z",
+    updated_at: "2026-05-16T00:00:00Z",
+    last_seen_at: "2026-08-10T00:00:00Z",
+    live_state: null,
+    ...{},
+  }) as AdminCredential;
+
+// A parked visitor carries exactly ONE (`reconnect`).
+const parkedVisitor = (): AdminVisitor =>
+  ({
+    id: VISITOR_ID,
+    expires_at: "2099-01-01T00:00:00Z",
+    identified: false,
+    ip: "1.2.3.4",
+    inserted_at: "2026-05-16T00:00:00Z",
+    last_seen_at: null,
+    networks: [
+      {
+        network_slug: "azzurra",
+        network_id: 1,
+        nick: "guest1",
+        connection_state: "parked",
+        live_state: null,
+      },
+    ],
+  }) as AdminVisitor;
+
+async function mountWith(over: {
+  visitors?: AdminVisitor[];
+  credentials?: AdminCredential[];
+}): Promise<void> {
+  const api = await import("../lib/api");
+  vi.mocked(api.adminListVisitors).mockResolvedValue(over.visitors ?? []);
+  vi.mocked(api.adminListCredentials).mockResolvedValue(over.credentials ?? []);
+  vi.mocked(api.adminListSessions).mockResolvedValue([]);
+  vi.mocked(api.adminListNetworks).mockResolvedValue([NETWORK]);
+  vi.mocked(api.adminListSessionLogSessions).mockResolvedValue([]);
+  render(() => <AdminSessionsTab />);
+}
+
+/** The row's actions cell — the box the dictation is about. */
+function actionsCell(key: string): HTMLElement {
+  const row = screen.getByTestId(`admin-session-row-${key}`);
+  const cell = row.querySelector<HTMLElement>("td.admin-sessions-actions");
+  if (cell === null) throw new Error(`no actions cell on row ${key}`);
+  return cell;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  viewport.mobile = false;
+  viewport.adminNarrow = false;
+});
+
+describe("#1157 — column 4 collapses on a phone", () => {
+  it("gives a two-verb row exactly one control, and it is the menu", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    // Exactly one: a cell that merely ADDED a menu beside the two verbs
+    // would still satisfy "the menu is there".
+    expect(actionsCell(USER_KEY).querySelectorAll("button")).toHaveLength(1);
+    expect(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeTruthy();
+    // Absent from the DOM, not CSS-hidden: a hidden copy leaves two of
+    // every verb once the menu renders its own.
+    expect(screen.queryByTestId(`admin-session-disconnect-${USER_KEY}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-session-terminate-${USER_KEY}`)).toBeNull();
+  });
+
+  it("offers both verbs inside the dropdown", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+
+    const menu = screen.getByRole("menu");
+    expect(menu.textContent).toContain("Disconnect");
+    expect(menu.textContent).toContain("Terminate");
+  });
+
+  it("arms the picked verb rather than running it", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    fireEvent.click(screen.getByText("Terminate"));
+
+    const api = await import("../lib/api");
+    // The destructive verb has NOT fired: the menu replaces the arm step,
+    // not the confirmation.
+    expect(vi.mocked(api.adminTerminateSession)).not.toHaveBeenCalled();
+    const armed = screen.getByTestId(`admin-session-terminate-${USER_KEY}`);
+    expect(armed.textContent).toBe("Confirm terminate");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("leaves a way out of the armed state, since no sibling verb can disarm it", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    fireEvent.click(screen.getByText("Terminate"));
+    fireEvent.click(screen.getByTestId(`admin-session-actions-cancel-${USER_KEY}`));
+
+    expect(screen.queryByTestId(`admin-session-terminate-${USER_KEY}`)).toBeNull();
+    expect(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeTruthy();
+  });
+
+  it("does not put a one-item menu in front of a single-verb row", async () => {
+    viewport.mobile = true;
+    viewport.adminNarrow = true;
+    await mountWith({ visitors: [parkedVisitor()] });
+    await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+
+    expect(screen.getByTestId(`admin-session-reconnect-${VISITOR_KEY}`)).toBeTruthy();
+    expect(screen.queryByTestId(`admin-session-actions-menu-${VISITOR_KEY}`)).toBeNull();
+    // Still one control — the rule is "one control in the cell", and a
+    // lone verb already satisfies it without a tap to reach it.
+    expect(actionsCell(VISITOR_KEY).querySelectorAll("button")).toHaveLength(1);
+  });
+});
+
+describe("#1157 — desktop keeps the verbs side by side", () => {
+  it("renders both verbs inline and grows no menu", async () => {
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    expect(screen.getByTestId(`admin-session-disconnect-${USER_KEY}`)).toBeTruthy();
+    expect(screen.getByTestId(`admin-session-terminate-${USER_KEY}`)).toBeTruthy();
+    expect(screen.queryByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/pasteRoute.test.ts
+++ b/cicchetto/src/__tests__/pasteRoute.test.ts
@@ -30,7 +30,7 @@ vi.mock("../lib/dropUpload", () => ({
 import { setDraft } from "../lib/compose";
 import { requestConfirm } from "../lib/confirmDialog";
 import { dropUpload } from "../lib/dropUpload";
-import { routeClipboardPaste } from "../lib/pasteRoute";
+import { routeClipboardPaste, routePastedInput } from "../lib/pasteRoute";
 
 type ClipItem = { kind: string; type: string; getAsFile: () => File | null };
 
@@ -57,6 +57,30 @@ function pasteEvent(opts: { text?: string; file?: File | null }): {
 
 function textarea(): HTMLTextAreaElement {
   return document.createElement("textarea");
+}
+
+// #1250 — synthesise the `beforeinput` an IME insertion fires. `dataTransfer`
+// is not settable through the constructor, so it is defined on the instance
+// the same way `clipboardData` is above; `data` rides the constructor, which
+// is how the engines report a plain-string commit.
+function inputEvent(opts: { inputType: string; dataTransferText?: string; data?: string }): {
+  e: InputEvent;
+  preventDefault: ReturnType<typeof vi.spyOn>;
+} {
+  const e = new InputEvent("beforeinput", {
+    inputType: opts.inputType,
+    data: opts.data ?? null,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (opts.dataTransferText !== undefined) {
+    Object.defineProperty(e, "dataTransfer", {
+      value: { getData: (t: string) => (t === "text" ? opts.dataTransferText : "") },
+      configurable: true,
+    });
+  }
+  const preventDefault = vi.spyOn(e, "preventDefault");
+  return { e, preventDefault };
 }
 
 const pngFile = (): File =>
@@ -153,5 +177,143 @@ describe("pasteRoute — routeClipboardPaste", () => {
     expect(req).toBeDefined();
     req?.onConfirm();
     expect(setDraft).toHaveBeenCalledWith("freenode #a", block);
+  });
+});
+
+// #1250 — the IME door. GBoard's clipboard chip fires NO `paste` event: it
+// commits through the input method, which surfaces only as `beforeinput` with
+// an `insertFromPaste` inputType. Before this the flood cap was not weak on
+// that path, it was absent — `classifyPaste` never ran, so an operator could
+// paste an arbitrary burst by choosing the chip over the long-press menu.
+describe("pasteRoute — routePastedInput (IME insertFromPaste, #1250)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const BLOCK_OVER_LIMIT = "a\nb\nc\nd\ne\nf\ng";
+  const BLOCK_CONFIRM = "a\nb\nc\nd";
+
+  it("over-limit IME paste → hard close: the upload dialog, and the text never lands", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK_OVER_LIMIT,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+    const req = vi.mocked(requestConfirm).mock.calls[0]?.[0];
+    // The over-limit arm is the one with no paste door: upload IS the
+    // affirmative and there is no alternative offered.
+    expect(req?.confirmLabel).toBe("Upload as .txt");
+    expect(req?.alternative).toBeNull();
+  });
+
+  it("mid-size IME paste → the same confirm dialog the clipboard door raises", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK_CONFIRM,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(vi.mocked(requestConfirm).mock.calls[0]?.[0]?.title).toBe("Paste as 4 messages?");
+  });
+
+  it("insertFromPasteAsQuotation is the same gesture and is guarded too", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPasteAsQuotation",
+      dataTransferText: BLOCK_OVER_LIMIT,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("falls back to event.data when the insertion carries no dataTransfer", () => {
+    const { e, preventDefault } = inputEvent({ inputType: "insertFromPaste", data: BLOCK_CONFIRM });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("a one-message IME paste is left to the browser — no dialog, no preventDefault", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: "one line",
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+  });
+
+  it("ordinary typing is not a paste — a big insertText is untouched", () => {
+    const { e, preventDefault } = inputEvent({ inputType: "insertText", data: BLOCK_OVER_LIMIT });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+// #1250 — one gesture, at most one dialog, with no cross-event bookkeeping.
+// A native paste IS reported twice, but the second report is the first one's
+// default action: the UA fires `paste`, and only an uncancelled `paste`
+// produces the insertion that fires `beforeinput[insertFromPaste]`. These pin
+// the two halves of that argument at the unit level — that a guarded arm
+// cancels (so the second report never exists) and that the pass-through arm is
+// idempotent if both do fire. The ORDERING itself is a browser contract, so it
+// is measured in a real browser by `paste-ime-flood-guard.spec.ts`, not
+// asserted here from a synthetic event.
+describe("pasteRoute — one gesture cannot ask twice (#1250)", () => {
+  const BLOCK = "a\nb\nc\nd";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("a guarded paste CANCELS, which is what suppresses the beforeinput that would ask again", () => {
+    const { e, preventDefault } = pasteEvent({ text: BLOCK });
+    routeClipboardPaste(e, textarea(), "freenode", "#a", true);
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    // The whole no-double-dialog argument rests on this call: no insertion,
+    // therefore no insertFromPaste, therefore no second decision.
+    expect(preventDefault).toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("the guarded IME arm cancels its own insertion the same way", () => {
+    const { e, preventDefault } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: BLOCK,
+    });
+    routePastedInput(e, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  // The one case where both reports DO reach the router: a below-threshold
+  // paste, which cancels nothing. Running the decision twice must stay a
+  // no-op — no dialog, no draft write, nothing inserted twice.
+  it("a below-threshold paste reported twice inserts once and asks nothing", () => {
+    const { e: pasted, preventDefault: pastePrevented } = pasteEvent({ text: "one line" });
+    routeClipboardPaste(pasted, textarea(), "freenode", "#a", true);
+    const { e: inserted, preventDefault: inputPrevented } = inputEvent({
+      inputType: "insertFromPaste",
+      dataTransferText: "one line",
+    });
+    routePastedInput(inserted, textarea(), "freenode", "#a");
+
+    expect(requestConfirm).not.toHaveBeenCalled();
+    expect(setDraft).not.toHaveBeenCalled();
+    expect(pastePrevented).not.toHaveBeenCalled();
+    expect(inputPrevented).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -13,6 +13,13 @@ import { categoryOf } from "./uploadCategory";
 // the document while focus sits elsewhere — resolves to the same three
 // outcomes: file → upload, big text → flood-confirm, small text → insert.
 //
+// #1250 added a THIRD door for the same reason the second one exists: an
+// IME-mediated paste (GBoard's clipboard chip) fires no `paste` event at all,
+// so the guard did not exist on that path and the message cap was bypassable
+// by choosing a different gesture. All three doors converge on
+// `routeGuardedText` — a new entry point must reuse it rather than grow a
+// fourth copy of the decision.
+//
 // The dependencies are all module-level (compose store, dropUpload,
 // confirmDialog, pasteFlood), so this is a pure function of (event, textarea,
 // target) — nothing ComposeBox-instance-bound. The textarea is passed in
@@ -113,12 +120,75 @@ export function routeClipboardPaste(
     dropUpload(files, networkSlug, channelName);
     return;
   }
+  routeGuardedText(e, data.getData("text"), ta, networkSlug, channelName, nativeInsertAvailable);
+}
+
+// #1250 — the THIRD door: an IME-mediated paste. GBoard's clipboard chip (and
+// any other input-method insertion) commits text through the input method and
+// fires NO `paste` event at all — only `beforeinput` with an `insertFromPaste`
+// inputType. The flood guard was therefore not "weak" on that path, it was
+// absent: an operator could bypass PASTE_HARD_MESSAGE_LIMIT entirely by
+// choosing the chip over the long-press Paste menu.
+//
+// Text source order mirrors what the engines actually populate: `dataTransfer`
+// when the insertion carries one, `data` for the plain-string commit. Anything
+// else is not a paste we can size, so it is left alone.
+export function routePastedInput(
+  e: InputEvent,
+  ta: HTMLTextAreaElement,
+  networkSlug: string,
+  channelName: string,
+): void {
+  if (!PASTE_INPUT_TYPES.has(e.inputType)) return;
+  const text = e.dataTransfer?.getData("text") ?? e.data ?? "";
+  // nativeInsertAvailable = true: this IS the browser's own insertion about to
+  // happen into the focused textarea, so the below-threshold arm lets it.
+  routeGuardedText(e, text, ta, networkSlug, channelName, true);
+}
+
+// `insertFromPasteAsQuotation` is the same gesture with quoting applied by the
+// UA; it becomes the same burst of PRIVMSGs, so it is sized by the same rule.
+const PASTE_INPUT_TYPES = new Set(["insertFromPaste", "insertFromPasteAsQuotation"]);
+
+// The ONE text decision, shared by all three doors (textarea `paste`, the #352
+// document listener, and the #1250 IME `beforeinput`). Takes the event as a
+// bare `Event` because all it needs from it is `preventDefault` — which is
+// also what keeps a fourth door from having to be a ClipboardEvent.
+//
+// #1250, one gesture / at most one dialog — by CONSTRUCTION, with no
+// cross-event bookkeeping. A native paste is reported twice, but the second
+// report is the FIRST one's default action: the UA fires `paste`, and only if
+// that is not cancelled does it perform the insertion, which is what fires
+// `beforeinput[insertFromPaste]`. So both guarded arms below, which
+// `preventDefault` the `paste`, structurally suppress the `beforeinput` that
+// would have asked again. The pass-through arm does let both fire, and is
+// idempotent by design: with `nativeInsertAvailable` it only ever decides "let
+// the browser do it", so classifying twice costs one extra pure call and
+// changes nothing.
+//
+// The rejected alternative was a module-level "this gesture is claimed" flag
+// released on a macrotask. It would have covered a hypothetical engine that
+// fires both reports for a CANCELLED paste — but it also makes two pastes in
+// one task indistinguishable from one, which is a state no browser can produce
+// and every existing paste test does. Three test files had to learn to yield
+// between cases before this comment was written; a guard that quietly disarms
+// itself for the next author is worse than the ordering assumption it removes.
+// The ordering is verified on both shipped engines by
+// `paste-ime-flood-guard.spec.ts` rather than assumed here.
+function routeGuardedText(
+  e: Event,
+  text: string,
+  ta: HTMLTextAreaElement,
+  networkSlug: string,
+  channelName: string,
+  nativeInsertAvailable: boolean,
+): void {
   // #737 — a paced drain owns this window's draft, so the text path has
   // nowhere to put a paste: the store refuses the write. Drop it HERE rather
   // than letting the flood modal ask "Paste 30 lines?" and then discard the
   // answer. preventDefault covers the global-listener path, whose target
   // textarea may not be the focused element and so is not protected by its own
-  // readOnly. The file branch above is untouched — an upload never touches the
+  // readOnly. The file branch is untouched — an upload never touches the
   // draft.
   if (isDraining(channelKey(networkSlug, channelName))) {
     e.preventDefault();
@@ -130,7 +200,6 @@ export function routeClipboardPaste(
   // compose by hand. `classifyPaste` owns the three-way decision; this switch
   // owns what each one looks like. Both dialogs reuse the store-driven
   // confirm (lib/confirmDialog) — Cancel is the safe default in both.
-  const text = data.getData("text");
   // Always the real count in both guarded arms, and ≥ 2 by construction, so
   // the plural is unconditional and needs no branch.
   const messages = pastedMessageCount(text);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6631,6 +6631,37 @@ html.resize-dragging * {
   outline-offset: -2px;
 }
 
+/* #1157 — a grouped form inside an admin card (today: one network's
+   settings on the per-user page). vjt asked for fieldsets and one field
+   per row instead of the crammed grid the add/edit forms used.
+
+   `min-inline-size: 0` is the load-bearing line, not decoration, and the
+   reason is measured: #1228 found a <fieldset> defaults to
+   `min-inline-size: min-content` and — unlike every other box here —
+   will NOT shrink below it, so ONE wide child sets a floor the whole
+   fieldset is laid out against and the entire form renders past its
+   container's right edge. The widest child here is the auth <select>,
+   whose intrinsic width comes from its longest OPTION. Same bomb, in the
+   console this time, and at 393px the overflow would land on the panel —
+   which is exactly the pan #1157 exists to delete. */
+.adm-fieldset {
+  min-inline-size: 0;
+  margin: var(--adm-space-3) 0 0;
+  padding: 0 0 var(--adm-space-2);
+  border: 1px solid var(--adm-line);
+  border-radius: var(--adm-radius-sm);
+}
+
+.adm-fieldset-legend {
+  padding: 0 var(--adm-space-2);
+  font-family: var(--adm-font);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--adm-text-dim);
+}
+
 /* A titled block nested INSIDE an expand row (today: the per-vhost
    grants disclosure). Not an `AdminCard` — a card inside a card's own
    table reads as a nesting mistake; this is the flatter, quieter

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5452,7 +5452,12 @@ html.resize-dragging * {
 
 /* Drill-down danger zone: the note names what Delete destroys, so it must
    read as one unit with the button rather than as loose text beside it. */
-.admin-session-danger {
+/* A destructive verb, its explanation, and a rule separating it from
+   whatever it sits under. Two callers now — the Sessions drill-down's
+   "delete the whole visitor identity" and the user page's "remove this
+   user's access to a network" — so the idiom is named for the SHAPE
+   rather than for either surface. */
+.adm-danger-strip {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -5462,7 +5467,7 @@ html.resize-dragging * {
   border-top: 1px solid var(--adm-line);
 }
 
-.admin-session-danger-note {
+.adm-danger-note {
   font-family: var(--adm-font);
   font-size: 0.75rem;
   color: var(--adm-text-dim);
@@ -6655,6 +6660,25 @@ html.resize-dragging * {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--adm-text-dim);
+}
+
+/* #1157 — a network section's heading: the tick and the slug, then the
+   two state badges. It WRAPS: the slug is operator-chosen and the widest
+   badge says "BEAM has no pid", so on a 393px phone this row cannot be
+   assumed to fit, and `.adm-check` is `nowrap` by design. Without the
+   wrap the overflow lands on the panel, which is the pan #1157 exists to
+   delete. */
+.admin-user-network-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--adm-space-2) var(--adm-space-3);
+}
+
+.admin-user-network-state {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--adm-space-2);
 }
 
 /* The add-form is set into its own recessed panel so it reads as "this

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40045,3 +40045,65 @@ here is the auth `<select>`, sized by its longest option. `.adm-fieldset`
 carries `min-inline-size: 0` for that reason and no other. The oracle
 already existed and now exercises a fieldset: the `subpage:user-page`
 surface in `ux-6-g-admin-mobile-h-scroll`.
+
+---
+
+## 2026-08-12 — #1250: a guard that did not exist on the path most people paste from
+
+The paste flood cap (#80/#816) was bypassable by picking a different gesture.
+GBoard's clipboard chip does not fire a `paste` event: it commits through the
+input method, which surfaces as `beforeinput` with an `insertFromPaste`
+inputType. Both doors into `routeClipboardPaste` were `paste` listeners, so
+`classifyPaste` never ran — the guard was not weak on Android, it was
+**absent**, and `PASTE_HARD_MESSAGE_LIMIT` was advisory rather than enforced.
+The reporter's own A/B said it plainly: chip → no dialog, long-press Paste →
+dialog. `git grep beforeinput -- cicchetto/src` returned nothing on `main`.
+
+`routePastedInput` is the third door, and the extraction that made #352's
+second door safe is what makes this one safe: `routeGuardedText` now holds the
+drain check and the three-way classify, so textarea-paste, document-paste and
+IME-insertion cannot drift. `insertFromPasteAsQuotation` rides the same arm —
+it becomes the same burst of PRIVMSGs, so it is sized by the same rule.
+
+**The interesting decision was how NOT to ask twice.** A native paste is
+reported to the app twice: as `paste`, and as the `beforeinput` for the
+insertion it causes. The first implementation was a module-level "this gesture
+is already decided" flag released on a macrotask — order-independent, and
+wrong for this codebase: it also makes two pastes *in one task*
+indistinguishable from one. No browser can produce that state; three test
+files produce it constantly, and two of them had to be taught to yield between
+cases before the shape of the mistake was obvious. A guard that quietly
+disarms itself for whoever writes the next paste test is worse than the
+ordering assumption it removes, so it was reverted.
+
+What shipped instead is a structural argument with no bookkeeping at all: the
+UA fires `paste`, and only an UNCANCELLED paste performs the insertion that
+fires `beforeinput`. Both guarded arms cancel, so the second report never
+exists; the pass-through arm lets both fire and is idempotent, because with
+`nativeInsertAvailable` its only decision is "let the browser do it".
+
+**That argument rests on a browser contract, so it was measured rather than
+believed.** #1250's text claims some engines report `beforeinput` first, which
+would mean two dialogs for one gesture. A synthetic `ClipboardEvent` cannot
+settle it — an untrusted event runs no default action, so no `beforeinput`
+ever follows and the measurement is vacuous, which is exactly the trap the
+pre-existing #80 spec's technique would have walked into. The new spec drives
+a REAL clipboard gesture (copy out of a scratch field with the keyboard, then
+paste) and pins the observed sequence. On **chromium and webkit both**, a
+guarded paste is reported exactly once, as `paste`; no `beforeinput` follows
+it. The claim in the issue is not reproduced on either engine we ship, and the
+pin is the thing that will say so out loud if a future engine differs.
+
+**Mutation-checked**, because an e2e that would pass without the fix is not
+evidence: unwiring the IME listener from ComposeBox kills exactly the two IME
+tests and leaves the two ordering tests green — the discrimination the two
+halves of the spec are supposed to have. (The first attempt at that mutant
+broke `tsc` instead, so the suite never ran and the red meant nothing; a
+mutant has to compile before its red is a measurement.)
+
+**Stated limits.** The IME tests dispatch a synthetic
+`beforeinput[insertFromPaste]`: Playwright cannot drive GBoard and no CDP verb
+commits one, so what is proven is that cic answers the event GBoard emits, not
+that GBoard emits it — the latter rests on the reporter's device A/B. And the
+issue's closing question, whether the `text === ""` arm is really iOS-only or
+the same hole in another hat, is deliberately untouched here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -39936,3 +39936,112 @@ never protecting the login path anyway: on any phase failure
 `:transient` does not restart. Its real constituency is the
 bootstrap/respawn path, which this change does not touch — worth knowing
 before someone reasons about the sleep from the login side again.
+
+---
+
+## 2026-08-12 — #1157 residuals: what "one control" means, and a checkbox that is not a write
+
+The audit that opened this round is the durable part: **most of #1157 had
+already shipped** (rows become cards below 900px and the pan is gone —
+`e45a6733`; Visitors merged into one row-backed Sessions view —
+`ffc8c044` / `e296e697`; all four Vhosts requirements; #1224's ended
+sub-page — `9deecc60`). What was left was five items from the tail of
+vjt's dictation, and they are recorded here because each one settled a
+question the code will otherwise re-open.
+
+### The actions cell keeps ONE control, which is not the same as "always a menu"
+
+Dictated: on mobile disconnect/terminate "collapse into a single button
+with a dropdown". Taken literally, a visitor row — which carries exactly
+one verb (`rowActions`) — would grow a menu holding a list of one, a tap
+spent to reach something already on screen. So the rule implemented is
+the one the dictation is an instance of: **the cell holds one control at
+any width**, which a one-verb row already satisfies and a two-verb row
+reaches through the menu.
+
+**Picking from the menu ARMS the verb; it does not run it.** Equating
+"opened a menu and chose" with "confirmed" would trade a destructive
+verb's confirmation for a UI affordance, and `InlineConfirmButton` stays
+the thing that fires. That creates one hazard the desktop layout never
+had — the button that opened the menu is gone while a verb is armed, and
+the sibling verb whose idle button disarms it on desktop is not rendered
+— so the collapsed cell grows a Cancel. Scoped to the collapsed case:
+nothing vanished on a single-verb row, so nothing has to come back.
+
+`ContextMenu` is reused rather than a second popover convention grown
+inside the console. What differs between a long-press message menu and
+this is the item list; the portal, backdrop, Escape and measured
+flip/clamp are the same problem already solved.
+
+### The per-user page: a checkbox is a statement, not a write
+
+vjt: *"niente flusso bind credential; al suo posto una sezione per rete
+configurata con una checkbox `enabled`."* The page used to answer "which
+networks does this user have?" with a table and "give it another" with a
+`+` opening a form whose first field picked from the networks it did not
+have — two shapes for one fact. One section per CONFIGURED network
+collapses them, and the picker disappears because the section already is
+one. The add form, the inline edit form and the per-row detail panel
+collapse with it: they differed only in which subset of the same fields
+they showed and in whether the answer left as a POST or a PATCH.
+
+Two directions, two different rules, and both are deliberate:
+
+* **Enabling writes nothing.** A bind needs a nick and a tick cannot
+  supply one, so the tick reveals the form and Save is the POST.
+* **Disabling ARMS.** It deletes the credential and stops the session, so
+  it gets the two-step every destructive verb in the console has — here
+  spread over the two controls the shape already offers (untick, then a
+  button that names what it destroys) rather than over one button's two
+  labels.
+
+### `autojoin` was never the mechanism
+
+Removed on vjt's call, and the reason is worth keeping: channel restore
+rides `last_joined_channels` (`session_plan.ex`, `merge_autojoin/2`). The
+admin column was a second, operator-authored list that the session's own
+history overwrites, so setting it invited an operator to configure
+something the next reconnect quietly disagreed with. The field stays on
+the API types and in the mix verbs — this removed the console's offer of
+it, not the server's support.
+
+### The auth selector narrows; the server's closed set does not
+
+Ruled `sasl` / `server_pass` / `none`, confirmed twice. The two dropped
+values are not the operator's to pick, which is what decided the shape:
+
+* `nickserv_identify` is set BY THE SERVER — `registration_changeset/2`
+  flips a credential to it when the #349 wizard sees `+r`, because from
+  then on grappa must auto-identify or the nick is ghosted within the
+  minute. A credential ARRIVES holding it.
+* `auto` is the Bahamut/Azzurra PASS-handoff path documented in
+  `AuthFSM`.
+
+So the DB enum is left alone: narrowing it is a migration over live rows,
+and it belongs to **#1044**, which owns the secret-slot reshape and which
+#1157's own text defers this to ("settled there and rendered here, not
+decided twice").
+
+**The case the narrowing creates is the load-bearing one.** A `<select>`
+whose value matches no option renders as if the first option had been
+chosen, and the next save carries that choice out — silently converting a
+wizard-set `nickserv_identify` into `sasl`. The stored value is therefore
+added to the options, labelled `(set elsewhere)`, and a save that did not
+touch the field sends no `auth_method` at all.
+
+The #410 LOCK could not survive verbatim — "the dropdown enumerates the
+codegen set in array order" is precisely what a curated list breaks — but
+its reason survives in two halves: the offered list is typed
+`readonly IRCAuthFSMAuthMethod[]` so a server-side rename fails the
+build, and a runtime test asserts every offered value is still a member
+of the codegen set.
+
+### The fieldset floor, one storey up from #1228
+
+`<fieldset>` defaults to `min-inline-size: min-content` and will not
+shrink below it, so one wide child sets a floor the whole group is laid
+out against. #1228 measured that on a drawer sub-page; the widest child
+here is the auth `<select>`, sized by its longest option. `.adm-fieldset`
+carries `min-inline-size: 0` for that reason and no other. The oracle
+already existed and now exercises a fieldset: the `subpage:user-page`
+surface in `ux-6-g-admin-mobile-h-scroll`.


### PR DESCRIPTION
Union of PR #1248 (`w2/1157-admin`) and PR #1253 (`w1/1250-ime-paste`), cherry-picked onto
current `main` `56abf983` and gated **once, together**.

Both were green against `cbbc4e01`, which `main` has since moved past twice (#1240, #1130).
A per-PR green attests to `branch + base`, never to `branch + the other branch landing beside
it` — so rather than pay two sequential `integration` runs on two stale bases, the two are
gated as the union they will actually form.

The diffs are disjoint by area (admin console vs the compose box's paste path) but that is
*textual* independence, which is not the same as semantic independence — the union run is what
actually answers the question.

## What is in here

**#1157 residuals** (7 commits): a row's verbs collapse into one menu on a phone; the autojoin
field the bouncer does not read is gone; a user's network access is a checkbox rather than a
bind flow; the network form gets a name and one field per row; the three auth methods an
operator actually chooses are offered.

**#1250** (3 commits): the paste flood cap now also guards the IME path — GBoard's clipboard
chip commits through `beforeinput`/`insertFromPaste` and fires no `paste` event at all, so the
cap did not exist there rather than being weak.

## Provenance

Contribution verified two-sided: the union's `--numstat` against `main` equals the **sum** of
the two branches' own numstats, file by file, 14 files, additions and deletions both. That
check caught the DESIGN_NOTES separator being eaten in **both** cherry-picks (3 lines each, 171
additions arriving as 165, zero deletions); each `---` was restored folded into its own entry's
docs commit, never as a separate commit.

Supersedes #1248 and #1253, which are closed by content — the cherry-pick rewrote the SHAs, so
GitHub cannot close them itself.