### PR TITLE
#1247: keep the STATUSMSG level the route peels, and badge the row

### DIFF
--- a/cicchetto/e2e/tests/issue1247-statusmsg-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue1247-statusmsg-badge.spec.ts
@@ -1,0 +1,94 @@
+// #1247 — an ops-only NOTICE (`NOTICE @#chan`) must READ as ops-only.
+//
+// #218 fixed the routing half: the row lands in the channel window. It did
+// NOT record WHICH level delivered it — `strip_statusmsg_target/2` peeled the
+// sigil to route and dropped it, so neither the scrollback row nor the PubSub
+// payload carried it and cic had nothing to badge with. The information was
+// destroyed at ingress, not merely unrendered.
+//
+// Two things only a real stack proves, and this is the acceptance gate for
+// both (feedback_ux_e2e_mandatory):
+//   1. the DELIVERY is genuinely ops-only — bahamut relays `@#chan` to
+//      channel ops alone, so the row exists at all only because the peer
+//      opped us first. jsdom cannot exercise upstream STATUSMSG delivery.
+//   2. LIVE and RELOADED agree. The badge on arrival comes off the PubSub
+//      payload; the badge after a reload comes off the persisted row read
+//      back over REST. If the level rode only the broadcast, the second
+//      assertion fails and the defect is merely displaced — which is the
+//      whole point of the issue's "a reload and a live message must say the
+//      same thing".
+//
+// Shape (mirrors issue218-statusmsg-notice, whose setup this inherits):
+//   1. a peer founds a fresh per-run channel → the founder auto-ops (@)
+//   2. the operator (vjt-grappa) joins it as a plain member
+//   3. the peer ops vjt-grappa so bahamut DELIVERS the `@#chan` notice
+//   4. the peer sends `NOTICE @#chan :…` → the row renders badged
+//   5. reload → the same row, read back from the store, is still badged
+
+import {
+  composeSend,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test("#1247 — an ops-only NOTICE is badged on arrival AND after a reload", async ({ page }) => {
+  // Per-run unique channel + peer nick: a module-level constant makes the
+  // spec un-`--repeat-each`-able (a second pass would re-found a channel it
+  // already parted and race a 433 on the peer nick).
+  const suffix = crypto.randomUUID().slice(0, 6);
+  const channel = `#s1247-${suffix}`;
+  const peerNick = `s1247p${suffix.slice(0, 5)}`;
+  const body = `ops-only heads up ${suffix}`;
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first to confirm login + WS-ready and mount
+  // the compose box before issuing the /join (issue240 boot order — after
+  // login cic lands on Home, which renders no ComposeBox).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    // The founding JOINer auto-ops on the testnet leaf (NO_CHANOPS_WHEN_SPLIT
+    // undef'd — the basis issue218 / cp15-b6 rely on), so the peer holds @ and
+    // can both op vjt and send a STATUSMSG.
+    await peer.join(channel);
+
+    await composeSend(page, `/join ${channel}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // Op vjt-grappa: STATUSMSG `@` reaches only members at op status, so
+    // without this the notice never arrives and the spec would pass vacuously
+    // on the negative assertions alone.
+    await peer.mode(channel, "+o", specNick());
+
+    peer.notice(`@${channel}`, body);
+
+    // LIVE: the badge off the broadcast.
+    const liveRow = scrollbackLine(page, "notice", body);
+    await expect(liveRow).toBeVisible({ timeout: 15_000 });
+    await expect(liveRow.getByTestId("statusmsg-badge")).toHaveText("ops-only");
+
+    // RELOADED: the badge off the persisted row. Pre-fix BOTH of these fail;
+    // with the level on the broadcast only, this one alone fails.
+    await page.reload();
+    await expect(page.locator(".sidebar-network-header").first()).toBeVisible({ timeout: 10_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    const reloadedRow = scrollbackLine(page, "notice", body);
+    await expect(reloadedRow).toBeVisible({ timeout: 15_000 });
+    await expect(reloadedRow.getByTestId("statusmsg-badge")).toHaveText("ops-only");
+  } finally {
+    await peer.disconnect("issue1247 done");
+    // `/join` persists the channel into vjt's autojoin set; PART restores
+    // pre-test state. Idempotent — swallow 404 if the test bailed early.
+    await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+  }
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -617,6 +617,32 @@ const renderNumeric = (raw: NumericEvent): JSX.Element => {
   );
 };
 
+// #1247 — the STATUSMSG level a message was delivered at, recorded by the
+// server into `meta.statusmsg` when it peeled the sigil to route the row
+// (#218). A `@#chan` notice reaches channel ops ONLY; rendered like any other
+// notice it reads as a broadcast everyone saw, which is the reported symptom.
+//
+// The sigil set is per-network and open-ended (ISUPPORT `STATUSMSG=`; bahamut
+// advertises `@+`, others `@%+`), so only the two levels the issue names get a
+// word. An unnamed one renders as its own sigil rather than falling back to no
+// badge — "unknown level" and "everyone" must not look alike.
+const STATUSMSG_LABEL: Record<string, string> = { "@": "ops-only", "+": "voice-only" };
+
+// Row-level, not per-kind: a STATUSMSG target is legal on PRIVMSG as well as
+// NOTICE, and the level describes who the line REACHED — a property of the
+// row, not of one render arm.
+const statusmsgBadge = (meta: ScrollbackMessage["meta"]): JSX.Element | null => {
+  const level = meta?.statusmsg;
+  if (typeof level !== "string" || level === "") return null;
+  return (
+    <>
+      <span class="scrollback-statusmsg" data-testid="statusmsg-badge">
+        {STATUSMSG_LABEL[level] ?? level}
+      </span>{" "}
+    </>
+  );
+};
+
 const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element => {
   // #648 — click-to-join affordance for a `#channel` in a CONTENT body. Passed
   // ONLY to the privmsg / notice / action MircBody calls below — the same set
@@ -994,6 +1020,7 @@ const ScrollbackLine: Component<{
       data-msg-id={props.msg.id}
     >
       <span class="scrollback-time">{formatTime(props.msg.server_time)}</span>{" "}
+      {statusmsgBadge(props.msg.meta)}
       {renderBody(props.msg, handlers)}
     </div>
   );

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor, within } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScrollbackMessage, WhoisBundle } from "../lib/api";
@@ -528,6 +528,87 @@ describe("ScrollbackPane", () => {
     // Inbound stays the untouched `-sender- body` shape — no arrow.
     expect(lines[1]).toHaveTextContent("-carol- ack");
     expect(lines[1]?.textContent ?? "").not.toContain("→");
+  });
+
+  it("badges an ops-only row from meta.statusmsg and leaves a plain one alone — #1247", () => {
+    // #1247 — an ops-only NOTICE (`NOTICE @#chan`) is delivered to channel ops
+    // only. #218 routes it to the channel window; without a badge it is
+    // indistinguishable from the plain channel notice sitting next to it, so
+    // the second row here is the control: the discriminator must be the badge,
+    // not "it is a notice".
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "carol",
+        body: "rehash in 5",
+        meta: { statusmsg: "@" },
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "notice",
+        sender: "carol",
+        body: "rehash in 5",
+        meta: {},
+      },
+    ];
+    setScrollback({ "freenode #grappa": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+
+    expect(within(lines[0] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent(
+      "ops-only",
+    );
+    // The body still renders — the badge annotates the row, it does not
+    // replace it.
+    expect(lines[0]).toHaveTextContent("-carol- rehash in 5");
+
+    expect(within(lines[1] as HTMLElement).queryByTestId("statusmsg-badge")).toBeNull();
+  });
+
+  it("badges a voice-only row and an unnamed level by its raw sigil — #1247", () => {
+    // `+` is the other level bahamut advertises by default. A network
+    // advertising `STATUSMSG=@%+` can deliver a `%` too, and the sigil set is
+    // per-network and open-ended: an unnamed level renders as itself rather
+    // than silently dropping to "no badge", which would read as "everyone".
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "carol",
+        body: "voiced folks",
+        meta: { statusmsg: "+" },
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "privmsg",
+        sender: "carol",
+        body: "halfops chatter",
+        meta: { statusmsg: "%" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+
+    expect(within(lines[0] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent(
+      "voice-only",
+    );
+    // A PRIVMSG can bear a STATUSMSG target too — the badge is a property of
+    // the row, not of the notice arm.
+    expect(within(lines[1] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent("%");
   });
 
   it("renders a /notice echo to a CHANNEL recipient — #1225", () => {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3002,6 +3002,16 @@ html.resize-dragging * {
   color: var(--mode-op);
 }
 
+/* #1247 — the STATUSMSG delivery level (`@#chan` ops-only, `+#chan` voice).
+   Reuses --mode-op, the red already carrying "this is an op thing" on @op
+   nicks and error notices, per the total-consistency rule — no new token.
+   Sized like the sidebar away/reconnect badges so it reads as a passive
+   annotation on the row, not as part of what the sender said. */
+.scrollback-statusmsg {
+  color: var(--mode-op);
+  font-size: 0.75rem;
+}
+
 /* CP13 S10: mIRC inline formatting toggles. Each Run rendered by
    parseMircFormat is a <span> with one or more of these classes for
    the active toggles. Color codes (fg/bg) ride inline style on the

--- a/config/config.exs
+++ b/config/config.exs
@@ -380,6 +380,11 @@ config :logger, :console,
     # (a NOTICE opens no window). In the allowlist to satisfy the
     # known_keys↔metadata sync test even though no Logger call carries it today.
     :notice_target,
+    # #1247 — the STATUSMSG membership sigil an inbound message was delivered
+    # at (`@#chan` ops-only, `+#chan` voice), kept rather than dropped when the
+    # #218 route peels it. In the allowlist to satisfy the known_keys↔metadata
+    # sync test even though no Logger call carries it today.
+    :statusmsg,
     :nick_fallback,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -239,6 +239,26 @@ looking. A POST carrying **both** fields is `400 bad_request`.
 Read the recipient off `meta`, never off the row's `channel`: `channel` is the
 source window. A `:notice` row **without** `meta.notice_target` is inbound.
 
+### 5b. Ops-only / voice-only delivery (#218, #1247)
+
+An inbound message addressed to a **STATUSMSG target** (`@#chan` ops-only,
+`+#chan` voice) reaches only the members at that level. grappa routes it to
+the CHANNEL window like any other channel message (#218) and records the level
+it was delivered at in `meta.statusmsg`:
+
+| field | value |
+|---|---|
+| `meta.statusmsg` | the membership sigil, verbatim from the wire — `"@"`, `"+"`, or whatever the network's ISUPPORT `STATUSMSG=` advertises (`"%"` on a `@%+` network) |
+
+The key is **absent** on an ordinary channel message; there is no `null` form,
+so presence is the test. It rides `:notice` and `:privmsg` rows alike, and the
+persisted row (REST) and the live push carry the same value.
+
+Render it. Without it an ops-only broadcast is indistinguishable from one the
+whole channel saw — which is the defect #1247 exists to fix. The sigil set is
+per-network and open-ended, so treat an unrecognised level as "restricted",
+never as "everyone".
+
 ---
 
 ## 6. Rate limiting & flood protection (#630)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40107,3 +40107,99 @@ commits one, so what is proven is that cic answers the event GBoard emits, not
 that GBoard emits it — the latter rests on the reporter's device A/B. And the
 issue's closing question, whether the `text === ""` arm is really iOS-only or
 the same hole in another hat, is deliberately untouched here.
+
+---
+
+## 2026-08-12 — #1247: the STATUSMSG level was destroyed at ingress, not merely unrendered
+
+A NOTICE to `@#chan` reaches channel ops only. #218 taught the router to
+route it to the channel window; it did not teach anything to remember
+WHY that message was different. `strip_statusmsg_target/2` peeled the
+sigil to get past the channel-prefix dispatch and rebuilt `params`
+without it, and nothing downstream ever saw it again — no scrollback
+row, no PubSub payload. So the reporter's complaint ("it reads like a
+private notice") was not a rendering gap cic could close on its own:
+**the information was gone before persistence, and a client cannot badge
+what never reached the store.** #218 named this in writing as the
+optional half it was leaving open. The routing half shipped in
+`595d6fb6`; the meta half is this.
+
+**The peel now returns what it peeled.** `strip_statusmsg_target/2`
+answers `{msg, sigil}` and the sigil rides `meta.statusmsg` on the rows
+that message produced. One record, read by both doors — the REST fetch
+and the live push serialise the same `meta` through the same
+`Scrollback.Wire.to_json/1`, so a reload and an arrival cannot disagree
+by construction rather than by discipline.
+
+**Where the annotation is applied, and the two carriers rejected.** The
+sigil is known only at the peel, and the persist rows are built ~50
+`do_route/2` clauses later. Threading a third argument would touch every
+one of those clauses to serve the two commands that can bear a sigil.
+Putting a field on `%Grappa.IRC.Message{}` would hang a router
+annotation on the parser's struct — that struct is the wire's shape, and
+extending it for our own bookkeeping is how a parser stops being the
+single source of truth about framing. So the level is applied to the
+ROUTED RESULT: `tag_statusmsg/2` merges it into the meta of the persist
+effects the message produced. It merges (`Map.put` onto the row's own
+map) rather than replaces, because #25's `sender_prefix` and #1070's
+`sender_kind` are already in there — a producer that replaced would pass
+every "is the level recorded?" assertion and silently drop both, which
+is why the router test asserts all three keys on one row.
+
+Every persist effect of the message is tagged, not only the one keyed to
+the stripped channel. A sigil is peeled only off a genuine channel
+target, so every row that message produces describes the same ops-only
+delivery; a channel-equality guard would have been a filter with no case
+that exercises it.
+
+**Absent, never `nil`.** An ordinary channel message carries no
+`statusmsg` key at all. A key present-and-null on every row would make
+"no level" and "level unknown" the same value at the client, and the
+client's test is presence. The `+chan` collision guard (#218's: `+` is
+both a channel sigil and the voice sigil) returns `nil` for the same
+reason — inventing a voice level on a modeless channel anyone can read
+would be worse than the bug being fixed.
+
+**The value is verbatim from the wire, and the set is not ours to
+close.** ISUPPORT `STATUSMSG=` is per-network — bahamut advertises `@+`,
+others `@%+`. This is the documented exception to the closed-set rule:
+the atom-keyed `Meta` allowlist stays closed (`:statusmsg` is on it),
+but the VALUE is whatever the network advertised, because enumerating it
+here would mean silently dropping a level some ircd advertises tomorrow.
+cic gives a word to the two the issue names (`@` → `ops-only`, `+` →
+`voice-only`) and renders any other level as its own sigil — "unknown
+level" and "everyone" must not look alike.
+
+**The badge is a property of the row, not of the notice arm.** It
+renders next to the timestamp, before the body, for every kind: a
+STATUSMSG target is legal on PRIVMSG as well as NOTICE, and putting the
+badge inside the `case "notice"` arm would have left the privmsg form
+silently unmarked — the same class of half-fix this issue is about.
+
+**The e2e's second assertion is the whole point.** The spec badges the
+row on arrival and then RELOADS and badges it again. The first read
+comes off the broadcast, the second off the persisted row; an
+implementation that carried the level on the push alone passes the first
+and fails the second. Without the reload the spec would have proven the
+easy half and left the defect displaced rather than fixed. The peer must
+op us first or bahamut never delivers the notice at all — without that
+`+o` the spec would pass vacuously.
+
+**No wire codegen moved, and that is a fact rather than an assumption.**
+`Scrollback.Wire.t/0` types `meta` as `Meta.t()`, which
+`mix grappa.gen_wire_types` emits as an opaque `Record<string, unknown>`
+(`S_ScrollbackMetaT = {r: "x"}`), so a new meta key does not change
+`wireTypes.ts` or its runtime twin `wireSchema.ts`. Checked with
+`gen_wire_types --check` rather than reasoned about, because the twin is
+exactly the file that stays green when you only update the other one.
+
+**Not done, deliberately.** The issue asks whether the IRC facade
+re-attaches the sigil on the way out. There is no facade: the Phase 6
+IRCv3 listener is unbuilt, and `lib/grappa/irc/` holds the client, the
+parser and CTCP only. When it is built, `meta.statusmsg` is what it will
+read to render `NOTICE @#chan` to a classic client — which is the reason
+to persist the level rather than compute a badge at the WS edge. The
+operator's OWN outbound `/notice @#chan` needed nothing: #1225 already
+keeps the raw wire target in `meta.notice_target`, sigil intact, so
+nothing is destroyed on that path. And #1247's routing is untouched —
+`@#chan` still lands in the channel window.

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -139,6 +139,23 @@ defmodule Grappa.Scrollback.Meta do
                                                                   off the message, not off the routing key.
                                                                   Its ABSENCE on a :notice row is what
                                                                   marks the row INBOUND.)
+      :notice  | :privmsg           →  + %{statusmsg: String.t()}
+                                                                 (#1247: the STATUSMSG membership sigil
+                                                                  the message was DELIVERED at —
+                                                                  `@#chan` reaches channel ops only,
+                                                                  `+#chan` voiced members. #218 peels the
+                                                                  sigil to route the row to the channel
+                                                                  window; this is the peeled sigil kept
+                                                                  rather than dropped, so a consumer can
+                                                                  tell an ops-only broadcast from one the
+                                                                  whole channel saw. Verbatim from the
+                                                                  wire, so the value set is whatever the
+                                                                  network's ISUPPORT STATUSMSG=
+                                                                  advertises (bahamut `@+`, others
+                                                                  `@%+`) — NOT a closed set this end can
+                                                                  enumerate. ABSENT on an ordinary
+                                                                  channel message; there is no nil form,
+                                                                  presence IS the test.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is
@@ -179,11 +196,12 @@ defmodule Grappa.Scrollback.Meta do
             | :ctcp_args
             | :ctcp_target
             | :notice_target
+            | :statusmsg
             | :nick_fallback
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target notice_target nick_fallback]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target notice_target statusmsg nick_fallback]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -214,6 +232,7 @@ defmodule Grappa.Scrollback.Meta do
           | :ctcp_args
           | :ctcp_target
           | :notice_target
+          | :statusmsg
           | :nick_fallback,
           ...
         ]

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -265,12 +265,13 @@ defmodule Grappa.Session.EventRouter do
   @spec route(Message.t(), state()) :: {:cont, state(), [effect()]}
   def route(%Message{} = msg, state) do
     isupport = Map.get(state, :isupport, ISupport.default())
-    statusmsg = ISupport.statusmsg(isupport)
+
+    {msg, statusmsg_level} = strip_statusmsg_target(msg, ISupport.statusmsg(isupport))
 
     msg
-    |> strip_statusmsg_target(statusmsg)
     |> canonicalize_channel_params(ISupport.casemapping(isupport))
     |> do_route(state)
+    |> tag_statusmsg(statusmsg_level)
   end
 
   # Rewrites `msg.params` so every channel-shape param is canonicalised
@@ -359,28 +360,65 @@ defmodule Grappa.Session.EventRouter do
   # fn reading `state()`) so the strip stays a pure fn of msg + sigil-set
   # and doesn't tighten whole-module `state` inference. This is the
   # remaining STATUSMSG gap of the #78/#128 route-by-target class.
-  @spec strip_statusmsg_target(Message.t(), [String.t()]) :: Message.t()
+  #
+  # #1247 — the peeled sigil is RETURNED alongside the message rather than
+  # dropped. It is the only record that the message was delivered ops-only;
+  # peeling it to route the row and then discarding it destroys the level at
+  # ingress, so no consumer downstream can badge what never reached the store.
+  # `nil` when nothing was peeled — the vast majority of traffic.
+  @spec strip_statusmsg_target(Message.t(), [String.t()]) :: {Message.t(), String.t() | nil}
   defp strip_statusmsg_target(%Message{command: cmd, params: [target | rest]} = msg, statusmsg)
        when cmd in [:notice, :privmsg] and is_binary(target) do
-    %{msg | params: [strip_statusmsg_prefix(target, statusmsg) | rest]}
+    {stripped, level} = strip_statusmsg_prefix(target, statusmsg)
+    {%{msg | params: [stripped | rest]}, level}
   end
 
-  defp strip_statusmsg_target(msg, _), do: msg
+  defp strip_statusmsg_target(msg, _), do: {msg, nil}
 
   # Peels ONE leading statusmsg sigil iff (a) it is in the network's
   # advertised set AND (b) a channel sigil (`#&!+`) immediately follows —
   # so a real `+chan` (voice-typed channel, `+` NOT followed by a channel
   # sigil) is never mis-stripped (the `+` collision: `+` is both a channel
-  # sigil and the voice membership sigil). Returns the underlying channel,
-  # else the target unchanged. Reuses `channel_target?/1` so the
-  # "what follows is a channel" test agrees byte-for-byte with the
-  # channel-NOTICE dispatch guard.
-  @spec strip_statusmsg_prefix(binary(), [String.t()]) :: binary()
+  # sigil and the voice membership sigil). Returns `{underlying channel,
+  # peeled sigil}`, else `{target unchanged, nil}` — the `nil` is what keeps
+  # the collision guard from inventing a voice level on a modeless `+chan`.
+  # Reuses `channel_target?/1` so the "what follows is a channel" test agrees
+  # byte-for-byte with the channel-NOTICE dispatch guard.
+  @spec strip_statusmsg_prefix(binary(), [String.t()]) :: {binary(), String.t() | nil}
   defp strip_statusmsg_prefix(<<sigil::binary-size(1), rest::binary>> = target, statusmsg) do
-    if sigil in statusmsg and channel_target?(rest), do: rest, else: target
+    if sigil in statusmsg and channel_target?(rest), do: {rest, sigil}, else: {target, nil}
   end
 
-  defp strip_statusmsg_prefix(target, _), do: target
+  defp strip_statusmsg_prefix(target, _), do: {target, nil}
+
+  # #1247 — record the delivery level on the rows this message produced.
+  #
+  # Applied to the ROUTED RESULT rather than threaded into `do_route/2`: the
+  # sigil is known only where it is peeled, and the alternatives are worse.
+  # A third argument would touch every one of the ~50 `do_route/2` clauses to
+  # serve the two commands that can bear a sigil; a field on `%IRC.Message{}`
+  # would put a router annotation on the parser's struct, which is the wire's
+  # shape and not ours to extend.
+  #
+  # Every persist effect from the message is tagged, not just the one keyed to
+  # the stripped channel: a sigil is only ever peeled off a genuine channel
+  # target, so every row derived from that message describes the same
+  # ops-only delivery. `Map.put` MERGES into the meta the row already built
+  # (#25's sender_prefix, #1070's sender_kind) — the map is the row's, this
+  # only adds to it.
+  @spec tag_statusmsg({:cont, state(), [effect()]}, String.t() | nil) ::
+          {:cont, state(), [effect()]}
+  defp tag_statusmsg(routed, nil), do: routed
+
+  defp tag_statusmsg({:cont, state, effects}, level) do
+    {:cont, state, Enum.map(effects, &put_statusmsg(&1, level))}
+  end
+
+  @spec put_statusmsg(effect(), String.t()) :: effect()
+  defp put_statusmsg({:persist, kind, attrs}, level),
+    do: {:persist, kind, %{attrs | meta: Map.put(attrs.meta, :statusmsg, level)}}
+
+  defp put_statusmsg(effect, _), do: effect
 
   @spec do_route(Message.t(), state()) :: {:cont, state(), [effect()]}
   # CTCP VERSION query — body is `\x01VERSION\x01` or `\x01VERSION ...\x01`

--- a/test/grappa/scrollback/meta_test.exs
+++ b/test/grappa/scrollback/meta_test.exs
@@ -44,6 +44,17 @@ defmodule Grappa.Scrollback.MetaTest do
                Meta.load(%{"nick_fallback" => %{"requested" => "vjt", "registered" => "vjt_"}})
     end
 
+    # #1247 — same failure shape as the nick_fallback case above: the router
+    # emits the level onto every ops-only row, and an allowlist that does not
+    # know the key rejects the whole cast, so the row never reaches the DB and
+    # the badge never reaches anyone. The router test asserts the EFFECT and
+    # would stay green throughout.
+    test "the STATUSMSG level survives cast, load and dump" do
+      assert {:ok, %{statusmsg: "@"}} = Meta.cast(%{statusmsg: "@"})
+      assert {:ok, %{statusmsg: "+"}} = Meta.load(%{"statusmsg" => "+"})
+      assert {:ok, %{"statusmsg" => "@"}} = Meta.dump(%{statusmsg: "@"})
+    end
+
     test "string-keyed map: known keys atomized" do
       assert {:ok, %{target: "alice"}} = Meta.cast(%{"target" => "alice"})
 

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1360,6 +1360,98 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
+  # #1247 — the sigil #218 peels is the ONLY record that a message was
+  # ops-only. Peeling it to route the row and then dropping it destroys the
+  # level at ingress: no consumer can badge what never reached the store.
+  # The peel now RETURNS the sigil and it rides `meta.statusmsg` on the row
+  # keyed to the stripped channel — so a reload (REST) and a live push
+  # (PubSub) answer the same thing, both reading the same persisted meta.
+  describe "route/2 — #1247 the peeled STATUSMSG level survives as meta" do
+    test "NOTICE @#chan carries meta.statusmsg == \"@\"" do
+      state = base_state()
+
+      m = msg(:notice, ["@#italia", "ops-only heads up"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "@"
+    end
+
+    test "NOTICE +#chan carries meta.statusmsg == \"+\"" do
+      state = base_state()
+
+      m = msg(:notice, ["+#italia", "voiced folks only"], {:nick, "someone", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "+"
+    end
+
+    test "PRIVMSG @#chan carries meta.statusmsg == \"@\" (same ingress, same record)" do
+      state = base_state()
+
+      m = msg(:privmsg, ["@#italia", "ops chatter"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "@"
+    end
+
+    test "the level is the ADVERTISED sigil, not a hardcoded @/+" do
+      # A network advertising `STATUSMSG=@%+` delivers a halfop-only notice;
+      # the recorded level must be the `%` that was actually on the wire.
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:notice, ["%#italia", "halfops heads up"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "%"
+    end
+
+    test "a plain #chan NOTICE carries NO :statusmsg key (absence, not nil)" do
+      # ABSENT, not `nil`: an always-present key would make every ordinary
+      # channel row claim a level it never had, and cic reads presence.
+      state = base_state()
+
+      m = msg(:notice, ["#italia", "everyone"], {:nick, "someone", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      refute Map.has_key?(attrs.meta, :statusmsg)
+    end
+
+    test "the +chan collision guard records no level either" do
+      # `+chan` is a modeless CHANNEL, not a voice-targeted `+#chan`. #218
+      # already routes it whole; recording a `+` level here would invent an
+      # ops-only badge on a channel anyone can read.
+      state = base_state()
+
+      m = msg(:notice, ["+chan", "hello modeless channel"], {:nick, "someone", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "+chan"
+      refute Map.has_key?(attrs.meta, :statusmsg)
+    end
+
+    test "the level does not disturb the meta the row already carried" do
+      # #1070's sender_kind and #25's sender_prefix ride the same map. A
+      # producer that REPLACED meta instead of merging into it would pass
+      # every assertion above and silently drop them.
+      state = base_state(%{members: %{"#italia" => %{"op" => ["@"]}}})
+
+      m = msg(:notice, ["@#italia", "ops-only heads up"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "@"
+      assert attrs.meta.sender_kind == "user"
+      assert attrs.meta.sender_prefix == "@"
+    end
+  end
+
   describe "route/2 — #127 server-reply modals (INFO/VERSION/MOTD)" do
     # Explicit /motd primes state.motd_pending; the 375/372 burst folds and
     # 376 RPL_ENDOFMOTD drains ONE {:server_reply, :motd, lines} effect in


### PR DESCRIPTION
## What was wrong

A NOTICE to a STATUSMSG target (`/notice @#chan …`, ops-only) lands in the right
window — #218 fixed that — but reads exactly like any other notice. The reporter
could not tell an ops-only broadcast from a normal one.

This is not a rendering gap cic could close on its own. `strip_statusmsg_target/2`
peeled the sigil to get past the channel-prefix dispatch and rebuilt `params`
without it, then **dropped it**: no scrollback row and no PubSub payload recorded
which level delivered the message. **The information was destroyed at ingress** —
a client cannot badge what never reached the store. #218 named this in writing as
the optional half it was leaving open; the routing half shipped in `595d6fb6`.

## What changed

- **`EventRouter`** — the peel answers `{msg, sigil}`, and `tag_statusmsg/2` merges
  the level into `meta.statusmsg` on the persist effects that message produced.
  Persisted row and live broadcast carry one record through one serializer, so
  a reload and an arrival agree by construction.
- **`Scrollback.Meta`** — `:statusmsg` on the allowlist (mirrored into the Logger
  metadata allowlist the sync test pins).
- **cic** — a row-level badge (`ops-only` / `voice-only`).
- **docs** — DESIGN_NOTES for the reasoning, `CLIENT_PROTOCOL.md` §5b for the
  client-author contract.

Routing is untouched: `@#chan` still lands in the channel window.

## Decisions worth arguing with

- **Applied to the routed RESULT**, not threaded through `do_route/2`. A third
  argument would touch ~50 clauses to serve the two commands that can bear a
  sigil; a field on `%IRC.Message{}` would hang a router annotation on the
  parser's struct, which is the wire's shape.
- **It merges, never replaces.** #25's `sender_prefix` and #1070's `sender_kind`
  share that map. One test asserts all three keys on one row precisely because a
  replacing producer would satisfy every "is the level recorded?" assertion.
- **Absent, never `nil`.** Presence is the client's test. #218's `+chan` collision
  guard reports no level rather than inventing voice on a modeless channel.
- **Every persist effect of the message is tagged**, not only the one keyed to the
  stripped channel: a sigil is peeled only off a genuine channel target, so a
  channel-equality guard would be a filter with no case that exercises it.
- **The value is verbatim from the wire.** The allowlist stays closed on the KEY;
  the VALUE set is per-network ISUPPORT `STATUSMSG=` (bahamut `@+`, others `@%+`).
  cic names the two levels the issue names and renders any other as its own sigil —
  "unknown level" and "everyone" must not look alike.

## Test plan

- [x] Unit — 6 router cases + a `Meta` cast/load/dump case. The Meta one is not
      redundant: the router asserts the emitted EFFECT, and an allowlist missing
      the key rejects the whole cast so the row never reaches the DB — the exact
      way #676's `nick_fallback` advisory went unnoticed.
- [x] Mutation, three mutants, three distinct outcomes: sigil discarded → 5 dead
      (the positive assertions; #218's routing tests stay green, so the mutant
      removed the record and not the route); replace-instead-of-merge → exactly 1
      dead; tag-when-nothing-was-peeled → 23 dead, including both absence
      assertions, so those are not vacuous.
- [x] `scripts/check.sh` green: 5946 tests / 0 failures, Dialyzer 0 errors, Credo
      clean, Sobelow, `deps.audit` clean, bats 448/448. Working tree byte-identical
      before and after.
- [x] `mix grappa.gen_wire_types --check` — both `wireTypes.ts` and `wireSchema.ts`
      in sync (`meta` codegens opaque, so no generated file moves).
- [x] cic — `bun run check` and `bun run test` (5283 tests) green.
- [x] e2e `issue1247-statusmsg-badge.spec.ts` — 1/1, and 3/3 under `--repeat-each 3`.
      With the defect reinstated it fails at the BADGE assertion and not at the
      row-visible assertion above it, so the notice genuinely arrived and the spec
      cannot pass vacuously.

## Named limits

- **There is no IRC facade to fix.** The issue asks whether it re-emits the sigil.
  The Phase 6 IRCv3 listener is unbuilt — `lib/grappa/irc/` holds the client, the
  parser and CTCP only. `meta.statusmsg` is what it will read when it exists,
  which is the reason to persist the level rather than compute a badge at the edge.
- **The outbound echo needed nothing.** #1225 already keeps the raw wire target in
  `meta.notice_target`, sigil intact.
- **The reload assertion is a regression guard, not a discriminator today.** Both
  doors share `Scrollback.Wire.to_json/1`, so live/reload agreement is structural;
  what the reload pins is that the level was PERSISTED rather than computed at the
  WS edge.
- **The local gates were measured before the rebase onto `b71ba69e`.** CI is the
  authoritative signal for the current base.