### PR TITLE
#1251: make every type-A channel list queryable, not just +b

### DIFF
--- a/cicchetto/e2e/tests/issue1251-list-modes.spec.ts
+++ b/cicchetto/e2e/tests/issue1251-list-modes.spec.ts
@@ -1,0 +1,125 @@
+// #1251 — every type-A (list) channel mode the network advertises must be
+// reachable, not just `+b`, proven end-to-end against the live upstream.
+//
+// The bug: the whole list path was hardcoded to `b`. `MODE #chan z` was never
+// sent, 728/729 were never delegated, and nothing rendered — so on Azzurra
+// (bahamut, `CHANMODES=bz`) the ircd's own restrict list was invisible, and
+// bahamut has no `+e`/`+I` at all, so "add +e and +I" would have left the
+// home network exactly as unreachable as before.
+//
+// The witness is the SECOND list, seen by a user: a `+z` entry set upstream
+// renders in the modal after switching to it, and the `+b` entry does not.
+// That single assertion exercises the entire chain, and each link is a place
+// the pre-fix code was silent:
+//
+//   * the 005 `CHANMODES=bz` reaching cic as `list_modes_queryable: [b, z]`
+//     (the switcher only has a second button if the server published one),
+//   * `MODE #chan z` actually leaving the bouncer,
+//   * 728 RPL_RESTRICTLIST being DELEGATED (undelegated it persists as a
+//     `$server` notice carrying the bare set-timestamp — the #376 leak
+//     shape) and folding into the `{channel, z}` accumulator,
+//   * the mode letter read OFF THE WIRE rather than assumed — bahamut spends
+//     728/729 on `z` and solanum on `q`, so an assumed letter would strand
+//     one of the two networks,
+//   * the bundle carrying `mode`, which is what stops the previously-fetched
+//     `+b` rows from being re-labelled as restrict rows.
+//
+// jsdom/vitest cannot do this: it needs the live ircd MODE + 728/729 round
+// trip. Mirrors #536's shape — vjt creates a fresh per-run channel (→ sole
+// op, which bahamut REQUIRES to even read the restrict list, `channel.c`
+// `case 'z'`) and PARTs it in `finally`.
+
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+test("#1251 — the +z restrict list is reachable, and renders as itself", async ({ page }) => {
+  const vjt = specUser();
+  const stamp = Date.now() % 1_000_000;
+  const channel = `#t1251lm-${Date.now()}`;
+  // Two literal masks, one per list. They must be DISTINCT: the oracle is
+  // that each list shows its own entry and not the other's, which is exactly
+  // what a dropped `mode` field would break.
+  const banMask = `banned1251-${stamp}!*@*`;
+  const restrictMask = `rogue1251-${stamp}!*@*`;
+  const peer = await IrcPeer.connect({ nick: `lm1251-${stamp}` });
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  try {
+    // vjt creates the channel → sole op (@) → both +b and +z are allowed,
+    // and the restrict list is readable (bahamut refuses it to non-ops).
+    await composeSend(page, `/join ${channel}`);
+    await expect(
+      page.locator(".sidebar-network-section li").filter({ hasText: channel }),
+    ).toHaveCount(1, { timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // Peer joins so it receives the channel MODE broadcasts — the wire
+    // witness that serialises "the entry landed upstream" before we query
+    // (the list numerics carry no request-id, so racing them re-introduces
+    // the #386 marker race).
+    await peer.join(channel);
+    await expect(page.locator(".members-pane .member-name", { hasText: peer.nick })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const sawBan = peer.waitForLine(
+      new RegExp(`MODE ${escapeRe(channel)} \\+b ${escapeRe(banMask)}`),
+      "MODE +b <mask>",
+      15_000,
+    );
+    await composeSend(page, `/mode ${channel} +b ${banMask}`);
+    await sawBan;
+
+    const sawRestrict = peer.waitForLine(
+      new RegExp(`MODE ${escapeRe(channel)} \\+z ${escapeRe(restrictMask)}`),
+      "MODE +z <mask>",
+      15_000,
+    );
+    await composeSend(page, `/mode ${channel} +z ${restrictMask}`);
+    await sawRestrict;
+
+    // Baseline: the `b` list is the one that already worked. Asserting it
+    // FIRST also proves the two masks are distinguishable in the UI, so the
+    // switch below cannot pass by rendering a stale bundle.
+    await composeSend(page, `/banlist`);
+    const modal = page.getByTestId("banlist-modal");
+    await expect(modal).toBeVisible({ timeout: 15_000 });
+    await expect(modal.locator(".banlist-modal-mask")).toContainText(banMask, { timeout: 20_000 });
+    await expect(modal).toContainText(`Bans: ${channel}`);
+    await expect(modal).not.toContainText(restrictMask);
+
+    // The switcher exists only because the SERVER published `z` as queryable
+    // for this network — cic never derives that set.
+    const switcher = modal.getByTestId("banlist-mode-switcher");
+    await expect(switcher).toBeVisible();
+    await switcher.getByTestId("banlist-mode-z").click();
+
+    // THE #1251 WITNESS: the restrict entry renders, under its own heading,
+    // and the ban entry is gone. Pre-fix there was no way to ask for this
+    // list at all; a hardcoded `z`-vs-`q` or a bundle without `mode` shows
+    // the ban rows here instead.
+    await expect(modal).toContainText(`Restricted: ${channel}`);
+    await expect(modal.locator(".banlist-modal-mask")).toContainText(restrictMask, {
+      timeout: 20_000,
+    });
+    await expect(modal).not.toContainText(banMask);
+
+    // The other lists are a viewer for now — the add/remove controls belong
+    // to `+b` only (the ban/unban verbs derive masks and chunk per MODES=).
+    await expect(modal.getByTestId("banlist-modal-readonly")).toBeVisible();
+    await expect(modal.getByTestId("banlist-add-btn")).toHaveCount(0);
+
+    // Close the modal so the compose textarea is actionable for cleanup.
+    await modal.getByRole("button", { name: "close ban list" }).click();
+    await expect(modal).toHaveCount(0);
+  } finally {
+    await peer.disconnect("bye").catch(() => {});
+    await composeSend(page, `/part ${channel}`).catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue1251-list-modes.spec.ts
+++ b/cicchetto/e2e/tests/issue1251-list-modes.spec.ts
@@ -30,11 +30,8 @@
 // `case 'z'`) and PARTs it in `finally`.
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-
-const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 test("#1251 — the +z restrict list is reachable, and renders as itself", async ({ page }) => {
   const vjt = specUser();
@@ -45,7 +42,6 @@ test("#1251 — the +z restrict list is reachable, and renders as itself", async
   // what a dropped `mode` field would break.
   const banMask = `banned1251-${stamp}!*@*`;
   const restrictMask = `rogue1251-${stamp}!*@*`;
-  const peer = await IrcPeer.connect({ nick: `lm1251-${stamp}` });
 
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
@@ -59,30 +55,31 @@ test("#1251 — the +z restrict list is reachable, and renders as itself", async
     ).toHaveCount(1, { timeout: 15_000 });
     await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
 
-    // Peer joins so it receives the channel MODE broadcasts — the wire
-    // witness that serialises "the entry landed upstream" before we query
-    // (the list numerics carry no request-id, so racing them re-introduces
-    // the #386 marker race).
-    await peer.join(channel);
-    await expect(page.locator(".members-pane .member-name", { hasText: peer.nick })).toBeVisible({
-      timeout: 15_000,
-    });
+    // Barrier: the ircd's own MODE echo, rendered as a scrollback row. It
+    // serialises "the entry landed upstream" before we query — the list
+    // numerics carry no request-id, so racing them re-introduces the #386
+    // marker race — and it is a DURABLE pre-state (the row is persisted),
+    // not a transient we might miss.
+    //
+    // A joined peer CANNOT witness this, which is what the first run of this
+    // spec measured: bahamut writes `b` into both `mbuf` and `stripped_mbuf`
+    // (`channel.c` case 'b') so the ban echo reaches the whole channel, but
+    // case 'z' writes `mbuf` ONLY — `stripped_mcount != mcount` then routes
+    // the echo through `sendto_chanops_butserv` (`channel.c` ~:1120), i.e.
+    // to OPS ALONE. The restrict list is op-private on both the read and the
+    // write side; a non-op peer waiting for `MODE +z` waits forever.
+    const modeEcho = (modes: string, mask: string) =>
+      expect(
+        page.locator(".scrollback-body", {
+          hasText: `sets mode ${modes} ${mask} on ${channel}`,
+        }),
+      ).toBeVisible({ timeout: 15_000 });
 
-    const sawBan = peer.waitForLine(
-      new RegExp(`MODE ${escapeRe(channel)} \\+b ${escapeRe(banMask)}`),
-      "MODE +b <mask>",
-      15_000,
-    );
     await composeSend(page, `/mode ${channel} +b ${banMask}`);
-    await sawBan;
+    await modeEcho("+b", banMask);
 
-    const sawRestrict = peer.waitForLine(
-      new RegExp(`MODE ${escapeRe(channel)} \\+z ${escapeRe(restrictMask)}`),
-      "MODE +z <mask>",
-      15_000,
-    );
     await composeSend(page, `/mode ${channel} +z ${restrictMask}`);
-    await sawRestrict;
+    await modeEcho("+z", restrictMask);
 
     // Baseline: the `b` list is the one that already worked. Asserting it
     // FIRST also proves the two masks are distinguishable in the UI, so the
@@ -119,7 +116,6 @@ test("#1251 — the +z restrict list is reachable, and renders as itself", async
     await modal.getByRole("button", { name: "close ban list" }).click();
     await expect(modal).toHaveCount(0);
   } finally {
-    await peer.disconnect("bye").catch(() => {});
     await composeSend(page, `/part ${channel}`).catch(() => {});
   }
 });

--- a/cicchetto/src/BanlistModal.tsx
+++ b/cicchetto/src/BanlistModal.tsx
@@ -1,10 +1,12 @@
 import { type Component, createSignal, For, Show } from "solid-js";
 import { banlistCardBySlug } from "./lib/banlistCard";
-import { banlistModalState, closeBanlistModal } from "./lib/banlistModal";
+import { banlistModalState, closeBanlistModal, openBanlistModal } from "./lib/banlistModal";
 import { type BanMaskForm, buildBanMask } from "./lib/banMask";
 import { ownHoldsChannelEditorSigil } from "./lib/channelEditPerm";
 import { canonicalChannel, channelKey } from "./lib/channelKey";
 import { friendlyError } from "./lib/friendlyError";
+import { isupportForNetwork } from "./lib/isupport";
+import { listModeLabel, listModeTitle } from "./lib/listModes";
 import { networks } from "./lib/networks";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import {
@@ -32,8 +34,13 @@ import {
 //     (cic has no per-member host); a cache MISS is fail-closed (vjt decision
 //     #1: no wider-mask guess — surface "run /whois first").
 //
-// v1 scope: `+b` only (vjt decision #3 — `+e`/`+I` are the same UI with a
-// different mode letter, a later afternoon).
+// #1251 — the surface is now EVERY type-A list the network offers, not just
+// `+b`: the mode switcher renders `isupport.listModesQueryable` (server data,
+// never derived here) and each switch re-queries. Editing stays `+b`-only —
+// the ADD/REMOVE path goes through the `ban`/`unban` verbs, which derive a
+// mask from a bare nick and chunk per ISUPPORT `MODES=`; generalising that is
+// a separate verb pair, not a widened modal. For the other lists this is a
+// viewer, and the hint points at the `/mode` form that edits them.
 
 // cic owns time formatting (moved from the #376 BanlistCard). `set_ts` is the
 // raw upstream unix-epoch STRING; render it in the viewer's locale, NaN-guarded.
@@ -63,15 +70,41 @@ const BanlistModal: Component = () => {
     return t ? networks()?.find((n) => n.slug === t.networkSlug)?.id : undefined;
   };
 
-  // Ban rows for THIS modal's channel. The #376 store holds one bundle per
-  // network; show it only when its (folded) channel matches the modal target,
-  // so a stale prior-channel bundle doesn't flash during the open→re-query.
+  // Rows for THIS modal's channel AND mode. The #376 store holds one bundle
+  // per network; show it only when its (folded) channel matches the modal
+  // target, so a stale prior-channel bundle doesn't flash during the
+  // open→re-query. #1251 adds the mode to that guard for the same reason:
+  // after switching b→e the ban bundle is still the newest one in the store,
+  // and rendering it under an "Exempts" heading would be a lie.
   const bundle = () => {
     const t = target();
     if (!t) return undefined;
     const b = banlistCardBySlug()[t.networkSlug];
     if (!b) return undefined;
+    if (b.mode !== t.mode) return undefined;
     return canonicalChannel(b.channel) === canonicalChannel(t.channel) ? b : undefined;
+  };
+
+  // #1251 — the letters this NETWORK can be asked for, straight from 005 (the
+  // server publishes the intersection with what it can parse). Never derived
+  // here; an unseeded network falls back to the shared default table.
+  const queryableModes = (): string[] => {
+    const id = networkId();
+    return id === undefined ? [] : isupportForNetwork(id).listModesQueryable;
+  };
+
+  // Editing is `+b` only for now — `ban`/`unban` are the verbs that derive a
+  // mask from a bare nick and chunk per ISUPPORT MODES=. The other lists are
+  // read-only here and edited with `/mode #chan +e <mask>`.
+  const editable = (): boolean => (target()?.mode ?? "b") === "b";
+
+  const switchMode = (mode: string): void => {
+    const t = target();
+    const id = networkId();
+    if (!t || id === undefined || t.mode === mode) return;
+    setError(null);
+    openBanlistModal(t.networkSlug, t.channel, mode);
+    pushChannelBanlist(id, t.channel, mode);
   };
 
   // Op-gate HINT only (never a hard block, vjt decision #2).
@@ -85,7 +118,7 @@ const BanlistModal: Component = () => {
   const refresh = (): void => {
     const t = target();
     const id = networkId();
-    if (t && id !== undefined) pushChannelBanlist(id, t.channel);
+    if (t && id !== undefined) pushChannelBanlist(id, t.channel, t.mode);
   };
 
   const onAdd = async (): Promise<void> => {
@@ -176,7 +209,7 @@ const BanlistModal: Component = () => {
           >
             <header class="banlist-modal-header">
               <h2 id="banlist-modal-title">
-                Ban list: {t().channel}
+                {listModeTitle(t().mode, t().channel)}
                 <Show when={!canEdit()}>
                   <span class="banlist-modal-hint"> (not opped — the server decides)</span>
                 </Show>
@@ -198,47 +231,88 @@ const BanlistModal: Component = () => {
                 </p>
               </Show>
 
+              {/* #1251 — one button per list this network offers. Rendered
+                  only when there is a choice to make: on a network with a
+                  single queryable list the switcher would be furniture. */}
+              <Show when={queryableModes().length > 1}>
+                <div class="banlist-modal-modes" data-testid="banlist-mode-switcher">
+                  <For each={queryableModes()}>
+                    {(mode) => (
+                      <button
+                        type="button"
+                        class="banlist-modal-mode-btn"
+                        classList={{ "banlist-modal-mode-active": mode === t().mode }}
+                        aria-pressed={mode === t().mode}
+                        data-testid={`banlist-mode-${mode}`}
+                        onClick={() => switchMode(mode)}
+                      >
+                        {listModeLabel(mode)}
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+
+              <Show when={!editable()}>
+                <p class="banlist-modal-readonly muted" data-testid="banlist-modal-readonly">
+                  read-only here — set with{" "}
+                  <code>
+                    /mode {t().channel} +{t().mode} &lt;mask&gt;
+                  </code>
+                </p>
+              </Show>
+
               {/* Add row — de-emphasised when not opped, but ALWAYS clickable. */}
-              <div class="banlist-modal-add" classList={{ "banlist-modal-deemph": !canEdit() }}>
-                <input
-                  type="text"
-                  class="banlist-modal-add-input"
-                  data-testid="banlist-add-input"
-                  aria-label="nick or mask to ban"
-                  placeholder="nick or mask"
-                  value={maskInput()}
-                  onInput={(e) => setMaskInput(e.currentTarget.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") void onAdd();
-                  }}
-                />
-                <select
-                  class="banlist-modal-add-form"
-                  data-testid="banlist-add-form"
-                  aria-label="ban mask form"
-                  value={form()}
-                  onChange={(e) => setForm(e.currentTarget.value as BanMaskForm)}
-                >
-                  <For each={FORMS}>{(f) => <option value={f.value}>{f.label}</option>}</For>
-                </select>
-                <button
-                  type="button"
-                  class="banlist-modal-add-btn"
-                  data-testid="banlist-add-btn"
-                  onClick={() => void onAdd()}
-                >
-                  Add ban
-                </button>
-              </div>
+              <Show when={editable()}>
+                <div class="banlist-modal-add" classList={{ "banlist-modal-deemph": !canEdit() }}>
+                  <input
+                    type="text"
+                    class="banlist-modal-add-input"
+                    data-testid="banlist-add-input"
+                    aria-label="nick or mask to ban"
+                    placeholder="nick or mask"
+                    value={maskInput()}
+                    onInput={(e) => setMaskInput(e.currentTarget.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") void onAdd();
+                    }}
+                  />
+                  <select
+                    class="banlist-modal-add-form"
+                    data-testid="banlist-add-form"
+                    aria-label="ban mask form"
+                    value={form()}
+                    onChange={(e) => setForm(e.currentTarget.value as BanMaskForm)}
+                  >
+                    <For each={FORMS}>{(f) => <option value={f.value}>{f.label}</option>}</For>
+                  </select>
+                  <button
+                    type="button"
+                    class="banlist-modal-add-btn"
+                    data-testid="banlist-add-btn"
+                    onClick={() => void onAdd()}
+                  >
+                    Add ban
+                  </button>
+                </div>
+              </Show>
 
               <Show
                 when={bundle()}
-                fallback={<p class="banlist-modal-empty muted">Loading ban list…</p>}
+                fallback={
+                  <p class="banlist-modal-empty muted">
+                    Loading {listModeLabel(t().mode).toLowerCase()}…
+                  </p>
+                }
               >
                 {(b) => (
                   <Show
                     when={b().entries.length > 0}
-                    fallback={<p class="banlist-modal-empty muted">no bans set on {t().channel}</p>}
+                    fallback={
+                      <p class="banlist-modal-empty muted">
+                        no {listModeLabel(t().mode).toLowerCase()} set on {t().channel}
+                      </p>
+                    }
                   >
                     <ul class="banlist-modal-rows">
                       <For each={b().entries}>
@@ -251,16 +325,18 @@ const BanlistModal: Component = () => {
                             <Show when={formatBanSetAt(entry.set_ts)}>
                               {(time) => <span class="banlist-modal-time muted">{time()}</span>}
                             </Show>
-                            <button
-                              type="button"
-                              class="banlist-modal-remove"
-                              classList={{ "banlist-modal-deemph": !canEdit() }}
-                              data-testid="banlist-remove-btn"
-                              aria-label={`remove ban ${entry.mask}`}
-                              onClick={() => void onRemove(entry.mask)}
-                            >
-                              ×
-                            </button>
+                            <Show when={editable()}>
+                              <button
+                                type="button"
+                                class="banlist-modal-remove"
+                                classList={{ "banlist-modal-deemph": !canEdit() }}
+                                data-testid="banlist-remove-btn"
+                                aria-label={`remove ban ${entry.mask}`}
+                                onClick={() => void onRemove(entry.mask)}
+                              >
+                                ×
+                              </button>
+                            </Show>
                           </li>
                         )}
                       </For>

--- a/cicchetto/src/__tests__/BanlistModal.test.tsx
+++ b/cicchetto/src/__tests__/BanlistModal.test.tsx
@@ -4,6 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // #386 — ban-management modal. Interactive `/banlist` surface: list rows,
 // add a ban via the mask builder (on-demand userhost lookup, fail-closed),
 // remove a ban, op-gate as a HINT (never a hard block — vjt decision #2).
+// #1251 — the same surface for EVERY type-A list the network offers: a mode
+// switcher driven by the server-published queryable set, and editing that
+// stays `b`-only (the other lists are a viewer).
 
 const socketMock = vi.hoisted(() => ({
   resolveUserhost: vi.fn(),
@@ -22,6 +25,14 @@ vi.mock("../lib/channelEditPerm", () => ({
   ownHoldsChannelEditorSigil: () => editPermMock.canEdit,
 }));
 
+// #1251 — the modal reads the network's queryable list-mode set from the
+// isupport store. Default here is a solanum-ish multi-list network so the
+// switcher renders; the single-list case gets its own test.
+const isupportMock = vi.hoisted(() => ({ listModesQueryable: ["b", "e", "I"] }));
+vi.mock("../lib/isupport", () => ({
+  isupportForNetwork: () => ({ listModesQueryable: isupportMock.listModesQueryable }),
+}));
+
 vi.mock("../lib/networks", () => ({
   networks: vi.fn(() => [
     { id: 1, slug: "bahamut", nick: "vjt", inserted_at: "x", updated_at: "y" },
@@ -35,6 +46,7 @@ import { closeBanlistModal, openBanlistModal } from "../lib/banlistModal";
 const BUNDLE = {
   network: "bahamut",
   channel: "#bofh",
+  mode: "b",
   entries: [
     { mask: "*!*@banned.host", setter: "op!u@h", set_ts: "1784572878" },
     { mask: "evil!*@spam.net", setter: null, set_ts: null },
@@ -45,6 +57,7 @@ describe("BanlistModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     editPermMock.canEdit = true;
+    isupportMock.listModesQueryable = ["b", "e", "I"];
     closeBanlistModal();
   });
 
@@ -55,7 +68,7 @@ describe("BanlistModal", () => {
 
   it("lists the channel's bans (mask + setter) when open for that channel", () => {
     setBanlistBundle("bahamut", BUNDLE);
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
     const modal = screen.getByTestId("banlist-modal");
     expect(modal.textContent).toContain("#bofh");
@@ -67,7 +80,7 @@ describe("BanlistModal", () => {
   it("add-by-nick with host form → resolves userhost, bans *!*@host, re-queries", async () => {
     socketMock.resolveUserhost.mockResolvedValue({ user: "ident", host: "evil.host.net" });
     setBanlistBundle("bahamut", BUNDLE);
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
 
     fireEvent.input(screen.getByTestId("banlist-add-input"), { target: { value: "alice" } });
@@ -78,12 +91,12 @@ describe("BanlistModal", () => {
     expect(socketMock.resolveUserhost).toHaveBeenCalledWith(1, "alice");
     expect(socketMock.pushChannelBan).toHaveBeenCalledWith(1, "#bofh", "*!*@evil.host.net");
     // re-query after a successful add
-    expect(socketMock.pushChannelBanlist).toHaveBeenCalledWith(1, "#bofh");
+    expect(socketMock.pushChannelBanlist).toHaveBeenCalledWith(1, "#bofh", "b");
   });
 
   it("add-by-nick host form with unknown host → fail-closed error, NO ban", async () => {
     socketMock.resolveUserhost.mockResolvedValue(null); // cache miss
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
 
     fireEvent.input(screen.getByTestId("banlist-add-input"), { target: { value: "ghost" } });
@@ -96,7 +109,7 @@ describe("BanlistModal", () => {
   });
 
   it("explicit mask input passes verbatim (no userhost lookup)", async () => {
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
 
     fireEvent.input(screen.getByTestId("banlist-add-input"), {
@@ -111,7 +124,7 @@ describe("BanlistModal", () => {
 
   it("remove button unbans the mask and re-queries", async () => {
     setBanlistBundle("bahamut", BUNDLE);
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
 
     const [firstRemove] = screen.getAllByTestId("banlist-remove-btn");
@@ -120,13 +133,13 @@ describe("BanlistModal", () => {
 
     await waitFor(() => expect(socketMock.pushChannelUnban).toHaveBeenCalled());
     expect(socketMock.pushChannelUnban).toHaveBeenCalledWith(1, "#bofh", "*!*@banned.host");
-    expect(socketMock.pushChannelBanlist).toHaveBeenCalledWith(1, "#bofh");
+    expect(socketMock.pushChannelBanlist).toHaveBeenCalledWith(1, "#bofh", "b");
   });
 
   it("op-gate is a HINT: non-op sees the note but the Add button stays clickable", async () => {
     editPermMock.canEdit = false;
     socketMock.resolveUserhost.mockResolvedValue({ user: "ident", host: "evil.host.net" });
-    openBanlistModal("bahamut", "#bofh");
+    openBanlistModal("bahamut", "#bofh", "b");
     render(() => <BanlistModal />);
 
     // the hint is shown
@@ -139,10 +152,52 @@ describe("BanlistModal", () => {
     await waitFor(() => expect(socketMock.pushChannelBan).toHaveBeenCalled());
   });
 
+  // #1251 — the switcher renders the SERVER's queryable set, re-queries on
+  // switch, and the stale-bundle guard now covers the mode as well as the
+  // channel: a `b` bundle must not render under an "Exempts" heading.
+  it("mode switcher lists the network's queryable lists and re-queries on switch", () => {
+    setBanlistBundle("bahamut", BUNDLE);
+    openBanlistModal("bahamut", "#bofh", "b");
+    render(() => <BanlistModal />);
+
+    expect(screen.getByTestId("banlist-mode-switcher").textContent).toContain("Exempts");
+    expect(screen.getByTestId("banlist-modal").textContent).toContain("Bans: #bofh");
+
+    fireEvent.click(screen.getByTestId("banlist-mode-e"));
+
+    expect(socketMock.pushChannelBanlist).toHaveBeenCalledWith(1, "#bofh", "e");
+    const modal = screen.getByTestId("banlist-modal");
+    expect(modal.textContent).toContain("Exempts: #bofh");
+    // the +b rows are NOT re-labelled as exempts while the +e reply is in flight
+    expect(modal.textContent).not.toContain("*!*@banned.host");
+  });
+
+  it("a single-list network (bahamut: b only) renders no switcher", () => {
+    isupportMock.listModesQueryable = ["b"];
+    setBanlistBundle("bahamut", BUNDLE);
+    openBanlistModal("bahamut", "#bofh", "b");
+    render(() => <BanlistModal />);
+
+    expect(screen.queryByTestId("banlist-mode-switcher")).toBeNull();
+    expect(screen.getByTestId("banlist-modal").textContent).toContain("*!*@banned.host");
+  });
+
+  it("a non-b list is read-only: rows render, add/remove do not", () => {
+    setBanlistBundle("bahamut", { ...BUNDLE, mode: "e" });
+    openBanlistModal("bahamut", "#bofh", "e");
+    render(() => <BanlistModal />);
+
+    const modal = screen.getByTestId("banlist-modal");
+    expect(modal.textContent).toContain("*!*@banned.host");
+    expect(screen.queryByTestId("banlist-add-btn")).toBeNull();
+    expect(screen.queryAllByTestId("banlist-remove-btn")).toHaveLength(0);
+    expect(screen.getByTestId("banlist-modal-readonly").textContent).toContain("/mode #bofh +e");
+  });
+
   it("guards a stale prior-channel bundle (shows Loading until the right one arrives)", () => {
     // bundle is for #bofh; modal opened for #other → don't render #bofh's bans.
     setBanlistBundle("bahamut", BUNDLE);
-    openBanlistModal("bahamut", "#other");
+    openBanlistModal("bahamut", "#other", "b");
     render(() => <BanlistModal />);
     const modal = screen.getByTestId("banlist-modal");
     expect(modal.textContent).not.toContain("*!*@banned.host");

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -150,6 +150,7 @@ describe("ModeModal", () => {
     seedIsupport(1, {
       chanmodes: DEFAULT_ISUPPORT.chanmodes,
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      listModesQueryable: DEFAULT_ISUPPORT.listModesQueryable,
       frameBudgetBase: null,
     });
     mockModes[KEY] = { modes: [], params: {} };

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -166,6 +166,7 @@ describe("WireChannelEvent canonical union (H3)", () => {
         chanmodes_b: ["k"],
         chanmodes_c: ["l"],
         chanmodes_d: ["n", "t", "s"],
+        list_modes_queryable: ["b", "e", "I"],
         prefix: { o: "@", h: "%", v: "+" },
         frame_budget_base: 393,
       },

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -90,6 +90,7 @@ describe("availableModes", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t", "Z"] },
       prefix: {},
+      listModesQueryable: [],
       frameBudgetBase: null,
     };
     const modes = availableModes(isupport);
@@ -131,6 +132,7 @@ describe("editorSigils", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t"] },
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      listModesQueryable: [],
       frameBudgetBase: null,
     };
     const e = editorSigils(isupport);
@@ -145,6 +147,7 @@ describe("editorSigils", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: [] },
       prefix: { v: "+" },
+      listModesQueryable: [],
       frameBudgetBase: null,
     };
     const e = editorSigils(isupport);

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -214,6 +214,14 @@ vi.mock("../lib/banlistModal", () => ({
   closeBanlistModal: vi.fn(),
 }));
 
+// #1251 — compose decides "list QUERY vs mode change" from the network's 005
+// (`listModesQueryable`, published by the server). Default here is a
+// bahamut-shaped network: `b` and `z` are lists, everything else is a flag.
+const isupportMock = vi.hoisted(() => ({ listModesQueryable: ["b", "z"] }));
+vi.mock("../lib/isupport", () => ({
+  isupportForNetwork: () => ({ listModesQueryable: isupportMock.listModesQueryable }),
+}));
+
 vi.mock("../lib/modeModal", () => ({
   openModeModal: vi.fn(),
   closeModeModal: vi.fn(),
@@ -3361,9 +3369,104 @@ describe("compose submit — channel ops verbs", () => {
 
     // #386 — /banlist is now the modal surface (supersedes the inline card):
     // open it AND fire a fresh 367/368 re-query so the list is live on open.
-    expect(banlistModal.openBanlistModal).toHaveBeenCalledWith("freenode", "#a");
-    expect(socket.pushChannelBanlist).toHaveBeenCalledWith(1, "#a");
+    expect(banlistModal.openBanlistModal).toHaveBeenCalledWith("freenode", "#a", "b");
+    expect(socket.pushChannelBanlist).toHaveBeenCalledWith(1, "#a", "b");
     expect(result).toEqual({ ok: true });
+  });
+
+  // #536/#1251 — the list-QUERY interception moved from the pure parser to
+  // here, because only compose can see the network's 005. These pin BOTH
+  // sides of the decision: a letter this network lists opens the modal, and
+  // a letter it does not stays a raw MODE on the wire.
+  describe("#1251 list-mode query interception", () => {
+    it("/mode #chan +b opens the list modal and re-queries — no raw MODE", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode #a +b");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).toHaveBeenCalledWith("freenode", "#a", "b");
+      expect(socket.pushChannelBanlist).toHaveBeenCalledWith(1, "#a", "b");
+      expect(socket.pushChannelMode).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("/mode +z (bare, current channel) opens the z list on a network that has one", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode +z");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).toHaveBeenCalledWith("freenode", "#a", "z");
+      expect(socket.pushChannelBanlist).toHaveBeenCalledWith(1, "#a", "z");
+      expect(socket.pushChannelMode).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true });
+    });
+
+    // The discriminating case: `e` IS a list mode on solanum, and this
+    // network doesn't have it. Guessing from the letter alone would swallow
+    // a real mode change; the 005 is what decides.
+    it("/mode #chan +e on a network without +e stays a raw MODE", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode #a +e");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(socket.pushChannelMode).toHaveBeenCalledWith(1, "#a", "+e", []);
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("/mode #chan -m (a flag mode, no param) stays a raw MODE with its sign", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode #a -m");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(socket.pushChannelMode).toHaveBeenCalledWith(1, "#a", "-m", []);
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("/mode #chan +b <mask> (a MUTATION) stays a raw MODE", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode #a +b nick!*@*");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(socket.pushChannelMode).toHaveBeenCalledWith(1, "#a", "+b", ["nick!*@*"]);
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("/banlist <letter> the network doesn't offer is an inline error, not a ban list", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/banlist e");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(socket.pushChannelBanlist).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: "/banlist: this network has no +e list (it offers +b +z)",
+      });
+    });
   });
 
   // #386 — /kb <nick> [reason]: ban FIRST (`*!*@host`, host from the on-demand

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -51,6 +51,7 @@ describe("isupport store", () => {
     const entry: IsupportEntry = {
       chanmodes: { a: ["b", "e", "I"], b: ["k"], c: ["l"], d: ["i", "m", "n", "s", "t"] },
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      listModesQueryable: ["b", "e", "I"],
       frameBudgetBase: 393,
     };
     seedIsupport(7, entry);

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -675,8 +675,38 @@ describe("parseSlash — channel ops verbs", () => {
     });
   });
 
-  it("/banlist bare → banlist for the current channel (null)", () => {
-    expect(parseSlash("/banlist")).toEqual({ kind: "banlist", channel: null });
+  it("/banlist bare → banlist for the current channel (null), mode b", () => {
+    expect(parseSlash("/banlist")).toEqual({ kind: "banlist", channel: null, mode: "b" });
+  });
+
+  // #1251 — `/banlist [#chan] [mode]`: both optional, classified by SHAPE so
+  // either order works. The mode test wins over the channel test because a
+  // `+`-sigil channel named `+e` is extinct while `/banlist +e` is obvious.
+  it("/banlist <mode> → that list on the current channel", () => {
+    expect(parseSlash("/banlist e")).toEqual({ kind: "banlist", channel: null, mode: "e" });
+    expect(parseSlash("/banlist +e")).toEqual({ kind: "banlist", channel: null, mode: "e" });
+    expect(parseSlash("/banlist I")).toEqual({ kind: "banlist", channel: null, mode: "I" });
+  });
+
+  it("/banlist #chan <mode> → that list on that channel, either token order", () => {
+    expect(parseSlash("/banlist #sniffo z")).toEqual({
+      kind: "banlist",
+      channel: "#sniffo",
+      mode: "z",
+    });
+
+    expect(parseSlash("/banlist q #sniffo")).toEqual({
+      kind: "banlist",
+      channel: "#sniffo",
+      mode: "q",
+    });
+  });
+
+  // The letter's CASE is the mode's identity: `I` (invex) and `i`
+  // (invite-only) are different modes.
+  it("/banlist keeps the mode letter's case", () => {
+    expect(parseSlash("/banlist I")).toEqual({ kind: "banlist", channel: null, mode: "I" });
+    expect(parseSlash("/banlist i")).toEqual({ kind: "banlist", channel: null, mode: "i" });
   });
 
   it("/invite <nick>", () => {
@@ -769,31 +799,58 @@ describe("parseSlash — channel ops verbs", () => {
     });
   });
 
-  // #536 — a list-mode QUERY form of /mode (the `b` letter, optionally
-  // signed, with NO mask param) is the no-args shape: it must open the
-  // banlist modal (the /banlist path), NOT execute a raw MODE whose
-  // 367/368 reply is silently dropped for lack of banlist_pending. The
-  // parser stays pure and emits `banlist` carrying the resolved channel
-  // (explicit for `/mode #chan +b`; null = current for `/mode +b`).
-  // Scope: `b` only (#536 constraints — +e/+I stay silent).
-  it("/mode #chan +b (list-mode query, no mask) → banlist for that channel", () => {
-    expect(parseSlash("/mode #sniffo +b")).toEqual({ kind: "banlist", channel: "#sniffo" });
+  // #536/#1251 — the list-mode QUERY form of /mode (a single letter,
+  // optionally signed, NO mask) must open the list modal instead of putting
+  // a raw MODE on the wire whose reply rows nothing collects. Since #1251
+  // that decision needs the network's 005 (which letters are type A), so the
+  // PARSER keeps the literal shape and compose.ts intercepts — see
+  // "list-mode query interception" in compose.test.ts for the behaviour.
+  // These cases pin that the parser hands compose everything it needs: the
+  // channel (or its absence), the SIGN, and the empty param list.
+  it("/mode #chan +b (list-mode query, no mask) → mode, verbatim, for compose to intercept", () => {
+    expect(parseSlash("/mode #sniffo +b")).toEqual({
+      kind: "mode",
+      target: "#sniffo",
+      modes: "+b",
+      params: [],
+    });
   });
 
-  it("/mode #chan b (unsigned list-mode query) → banlist for that channel", () => {
-    expect(parseSlash("/mode #sniffo b")).toEqual({ kind: "banlist", channel: "#sniffo" });
+  it("/mode #chan b (unsigned list-mode query) → mode, sign absent, params empty", () => {
+    expect(parseSlash("/mode #sniffo b")).toEqual({
+      kind: "mode",
+      target: "#sniffo",
+      modes: "b",
+      params: [],
+    });
   });
 
-  it("/mode #chan -b (signed list-mode query) → banlist for that channel", () => {
-    expect(parseSlash("/mode #sniffo -b")).toEqual({ kind: "banlist", channel: "#sniffo" });
+  // The sign is CARRIED, not normalised: `-m` with no param is a real mode
+  // change on a flag mode, so a parser that dropped the sign would turn a
+  // removal into an addition on every non-list letter.
+  it("/mode #chan -b (signed list-mode query) → mode, sign preserved", () => {
+    expect(parseSlash("/mode #sniffo -b")).toEqual({
+      kind: "mode",
+      target: "#sniffo",
+      modes: "-b",
+      params: [],
+    });
   });
 
-  it("/mode +b (bare list-mode query, no channel) → banlist for the current channel (null)", () => {
-    expect(parseSlash("/mode +b")).toEqual({ kind: "banlist", channel: null });
+  it("/mode +b (bare list-mode query, no channel) → mode-apply-current", () => {
+    expect(parseSlash("/mode +b")).toEqual({
+      kind: "mode-apply-current",
+      modes: "+b",
+      params: [],
+    });
   });
 
-  it("/mode -b (bare signed list-mode query) → banlist for the current channel (null)", () => {
-    expect(parseSlash("/mode -b")).toEqual({ kind: "banlist", channel: null });
+  it("/mode -b (bare signed list-mode query) → mode-apply-current, sign preserved", () => {
+    expect(parseSlash("/mode -b")).toEqual({
+      kind: "mode-apply-current",
+      modes: "-b",
+      params: [],
+    });
   });
 
   // A mask parameter turns the list-mode letter into a MUTATION, not a
@@ -823,11 +880,10 @@ describe("parseSlash — channel ops verbs", () => {
     expect(parseSlash("/mode b")).toEqual({ kind: "umode-target-view", target: "b" });
   });
 
-  // #536 regex-boundary guards — the discriminator is a single `b`, exact.
-  // A future careless widening of isBanlistQuery must NOT swallow these:
-  // `+bb` (repeated), `+be` (combined list letters — +e is out of scope),
-  // and uppercase `+B` (a DISTINCT, case-sensitive mode letter on bahamut)
-  // all stay raw MODE executes, not banlist queries.
+  // #536/#1251 boundary guards — the query discriminator is ONE letter,
+  // exact. `+bb` (repeated), `+be` (two list letters at once) and uppercase
+  // `+B` (a DISTINCT, case-sensitive mode on bahamut) are mode changes, and
+  // compose's interception regex must never swallow them either.
   it("/mode #chan +bb (repeated letter) → mode (not a banlist query)", () => {
     expect(parseSlash("/mode #sniffo +bb")).toEqual({
       kind: "mode",

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -417,6 +417,10 @@ describe("userTopic", () => {
       expect(isupport.seedIsupport).toHaveBeenCalledWith(7, {
         chanmodes: { a: ["b", "e", "I"], b: ["k"], c: ["l"], d: ["n", "t", "s"] },
         prefix: { q: "~", o: "@", v: "+" },
+        // #1251 — this envelope predates `list_modes_queryable`, and such a
+        // server can only ever answer one list. Deriving the set from
+        // `chanmodes_a` here would offer +e and +I queries it cannot serve.
+        listModesQueryable: ["b"],
         // #1108 — this envelope carried no budget, so none is seeded.
         frameBudgetBase: null,
       });
@@ -1357,11 +1361,31 @@ describe("userTopic", () => {
       expect(bc.setBanlistBundle).toHaveBeenCalledWith("azzurra", {
         network: "azzurra",
         channel: "#test",
+        // #1251 — a payload with no `mode` is a pre-#1251 server, which could
+        // only ever have sent the ban list (unknown-is-never-fatal, #447).
+        mode: "b",
         entries: [
           { mask: "*!*@banned.host", setter: "op!u@h", set_ts: "1784572878" },
           { mask: "evil!*@spam.net", setter: "mod!u@h", set_ts: "1784564620" },
         ],
       });
+    });
+
+    // #1251 — the letter travels with the bundle: without it the modal would
+    // render solanum's quiet list under a "Bans" heading.
+    it("carries the mode letter through to the store", async () => {
+      const bc = await import("../lib/banlistCard");
+      channelMock.fireEvent({
+        kind: "banlist_bundle",
+        network: "azzurra",
+        channel: "#test",
+        mode: "z",
+        entries: [{ mask: "*!*@rogue", setter: "op", set_ts: "1" }],
+      });
+      expect(bc.setBanlistBundle).toHaveBeenCalledWith(
+        "azzurra",
+        expect.objectContaining({ mode: "z" }),
+      );
     });
 
     it("accepts empty entries (channel with no bans)", async () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -712,6 +712,12 @@ export type WireChannelEvent =
       chanmodes_b: string[];
       chanmodes_c: string[];
       chanmodes_d: string[];
+      // #1251 — the subset of `chanmodes_a` the SERVER can query (it knows
+      // the reply numerics). cic offers exactly these and never derives the
+      // set itself; a letter in `chanmodes_a` but not here is the quiet
+      // degradation. Absent (pre-#1251 server, e.g. a cic-only bundle
+      // deploy) → `["b"]`, the capability that server does have.
+      list_modes_queryable: string[];
       prefix: Record<string, string>;
       // #1108 — `null` when the server published no budget. Narrowed
       // permissively on purpose: the wire is additive-only, so a server
@@ -1027,6 +1033,12 @@ export type WireUserEvent =
       chanmodes_b: string[];
       chanmodes_c: string[];
       chanmodes_d: string[];
+      // #1251 — the subset of `chanmodes_a` the SERVER can query (it knows
+      // the reply numerics). cic offers exactly these and never derives the
+      // set itself; a letter in `chanmodes_a` but not here is the quiet
+      // degradation. Absent (pre-#1251 server, e.g. a cic-only bundle
+      // deploy) → `["b"]`, the capability that server does have.
+      list_modes_queryable: string[];
       prefix: Record<string, string>;
       // #1108 — `null` when the server published no budget. Narrowed
       // permissively on purpose: the wire is additive-only, so a server

--- a/cicchetto/src/lib/banlistModal.ts
+++ b/cicchetto/src/lib/banlistModal.ts
@@ -19,13 +19,17 @@ import { moduleRoot } from "./moduleRoot";
 // identity-scoped survival state. A logout unmounts the shell so a stale-open
 // modal disappears with it.
 
-export type BanlistModalTarget = { networkSlug: string; channel: string };
+// #1251 — `mode` is the type-A letter the modal is showing (`b` bans, `e`
+// exempts, `I` invex, `z`/`q` restrict/quiet). It lives in the OPEN state
+// rather than in the modal component so the switcher, `/banlist e` and
+// `/mode #chan +e` all drive the same one source of truth.
+export type BanlistModalTarget = { networkSlug: string; channel: string; mode: string };
 
 const exports_ = moduleRoot(() => {
   const [banlistModalState, setBanlistModalState] = createSignal<BanlistModalTarget | null>(null);
 
-  const openBanlistModal = (networkSlug: string, channel: string): void => {
-    setBanlistModalState({ networkSlug, channel });
+  const openBanlistModal = (networkSlug: string, channel: string, mode: string): void => {
+    setBanlistModalState({ networkSlug, channel, mode });
   };
 
   const closeBanlistModal = (): void => {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -23,6 +23,7 @@ import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
+import { isupportForNetwork } from "./isupport";
 import { markLusersRequested } from "./lusersBundle";
 import { membersByChannel } from "./members";
 import { clearMentionsBundle } from "./mentionsWindow";
@@ -86,6 +87,24 @@ import { windowStateByChannel } from "./windowState";
 // TODO(#30): plumb CHANTYPES through `isupport_changed` and read it per
 // network instead of assuming the RFC set.
 const CHANNEL_SIGIL = /^[#&+!]/;
+
+// #536/#1251 — is this `/mode` a type-A LIST QUERY rather than a mode change?
+// Three conditions, all necessary: no parameter (a mask makes it a MUTATION,
+// `/mode #chan +b nick!*@*`), exactly one optionally-signed letter, and that
+// letter is one this NETWORK offers as a queryable list (server-published, in
+// `isupport.listModesQueryable` — cic never derives it).
+//
+// Why it lives here and not in the pure parser: the third condition is 005
+// data. `/mode #chan +i` on a network where `i` is a flag must stay a mode
+// change, and no letter is a list mode everywhere — `q` is a LIST on solanum
+// and a founder-status prefix elsewhere. Returns the bare letter, or null
+// when the caller should execute the MODE verbatim.
+const listModeQueryLetter = (modes: string, params: string[], networkId: number): string | null => {
+  if (params.length > 0) return null;
+  const letter = /^[+-]?([A-Za-z])$/.exec(modes)?.[1];
+  if (letter === undefined) return null;
+  return isupportForNetwork(networkId).listModesQueryable.includes(letter) ? letter : null;
+};
 
 // #1003 — IRC nicks wear decoration (`_omino_`, `bob^`, `gio-vanni`), so
 // Tab must reach `_omino_` from the bare `omi`. Deliberately NOT taught to
@@ -1516,21 +1535,30 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "banlist": {
-          // #386 — /banlist is now the ban-management MODAL surface (it
+          // #386 — /banlist is the channel list-mode MODAL surface (it
           // supersedes the #376 inline BanlistCard, mirroring how the #169
           // /who modal replaced the inline WHO dump). Open the modal AND fire
-          // a fresh re-query so the 367/368 list is live on open (pre-#386 it
+          // a fresh re-query so the list is live on open (pre-#386 it
           // was fire-and-forget only).
-          // #536 — the list-mode query form of /mode (`/mode #chan +b`)
-          // resolves an explicit channel in the parser; bare /banlist and
-          // `/mode +b` carry null → the current channel (same resolver
+          // An explicit `/banlist #chan` resolves in the parser; a bare
+          // /banlist carries null → the current channel (same resolver
           // every channel-scoped verb uses).
           const chanOrErr = cmd.channel ?? requireChannel("banlist");
           if (typeof chanOrErr !== "string") return chanOrErr;
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/banlist: network not found" };
-          openBanlistModal(networkSlug, chanOrErr);
-          pushChannelBanlist(networkId, chanOrErr);
+          // #1251 — an explicitly typed letter this network cannot answer is
+          // an ERROR, not a silent fallback to bans: the operator asked for a
+          // specific list and would otherwise read the ban list as the
+          // exempt list. The offered set is server-published, never derived.
+          const offered = isupportForNetwork(networkId).listModesQueryable;
+          if (!offered.includes(cmd.mode)) {
+            return {
+              error: `/banlist: this network has no +${cmd.mode} list (it offers ${offered.map((m) => `+${m}`).join(" ")})`,
+            };
+          }
+          openBanlistModal(networkSlug, chanOrErr, cmd.mode);
+          pushChannelBanlist(networkId, chanOrErr, cmd.mode);
           result = { ok: true };
           break;
         }
@@ -1601,6 +1629,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // requirement (#216: mode-args present → apply).
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/mode: network not found" };
+          // #536/#1251 — a bare list letter with NO mask is a QUERY, not a
+          // mutation: open the list modal instead of putting a raw MODE on
+          // the wire whose reply rows nothing is primed to collect.
+          const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
+          if (listMode !== null && CHANNEL_SIGIL.test(cmd.target)) {
+            openBanlistModal(networkSlug, cmd.target, listMode);
+            pushChannelBanlist(networkId, cmd.target, listMode);
+            result = { ok: true };
+            break;
+          }
           await pushChannelMode(networkId, cmd.target, cmd.modes, cmd.params);
           result = { ok: true };
           break;
@@ -1624,6 +1662,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           if (typeof chanOrErr !== "string") return chanOrErr;
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/mode: network not found" };
+          // #536/#1251 — same list-QUERY interception as the explicit-channel
+          // arm above; `/mode +b` and `/mode #chan +b` must behave alike.
+          const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
+          if (listMode !== null) {
+            openBanlistModal(networkSlug, chanOrErr, listMode);
+            pushChannelBanlist(networkId, chanOrErr, listMode);
+            result = { ok: true };
+            break;
+          }
           await pushChannelMode(networkId, chanOrErr, cmd.modes, cmd.params);
           result = { ok: true };
           break;

--- a/cicchetto/src/lib/friendlyChannelError.ts
+++ b/cicchetto/src/lib/friendlyChannelError.ts
@@ -113,6 +113,13 @@ function friendlyKnown(code: ErrorTokensChannelErrorToken): string {
       // silently dropping the first bundle). The in-flight request's map is
       // still coming; the user just retries once it lands.
       return "A network map request is already loading — try again in a moment.";
+    case "unsupported_list_mode":
+      // #1251 — a channel list-mode query for a letter this network doesn't
+      // advertise as type A (or one grappa knows no reply numerics for). cic
+      // only offers the server-published set, so reaching this means the
+      // network's 005 changed under an open modal — the honest answer is
+      // that the list isn't there, not that something failed.
+      return "This network doesn't have that channel list.";
 
     // ── #411 D6b — the 8 previously-unmapped channel tokens (product copy,
     //    vetted by vjt). Same actionable-copy contract as the REST sibling.

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -30,6 +30,12 @@ export type IsupportEntry = {
     d: string[];
   };
   prefix: Record<string, string>;
+  // #1251 — the type-A (list) modes this network advertises AND the server
+  // knows the reply numerics for, in 005 order. The BanlistModal's mode
+  // switcher renders exactly this set: a letter the network advertises but
+  // the server cannot query never appears, so cic can never ask for a list
+  // whose reply would never arrive.
+  listModesQueryable: string[];
   // #1108 — the target-independent per-frame body budget, from the same 005
   // (see `frameBudget.ts` for what cic may and may not derive from it).
   // `null` when the server published none: unlike the capability table, this
@@ -47,6 +53,7 @@ export const DEFAULT_ISUPPORT: IsupportEntry = {
     d: ["C", "D", "R", "c", "d", "i", "m", "n", "p", "r", "s", "t"],
   },
   prefix: { o: "@", h: "%", v: "+" },
+  listModesQueryable: ["b", "e", "I"],
   frameBudgetBase: null,
 };
 
@@ -85,6 +92,7 @@ export function isupportEntryFromWire(payload: {
   chanmodes_b: string[];
   chanmodes_c: string[];
   chanmodes_d: string[];
+  list_modes_queryable: string[];
   prefix: Record<string, string>;
   frame_budget_base: number | null;
 }): IsupportEntry {
@@ -96,6 +104,7 @@ export function isupportEntryFromWire(payload: {
       d: payload.chanmodes_d,
     },
     prefix: payload.prefix,
+    listModesQueryable: payload.list_modes_queryable,
     frameBudgetBase: payload.frame_budget_base,
   };
 }

--- a/cicchetto/src/lib/listModes.ts
+++ b/cicchetto/src/lib/listModes.ts
@@ -1,0 +1,30 @@
+// #1251 — display names for the type-A (list) channel modes.
+//
+// This file holds LABELS ONLY. Which letters exist, and which of them can be
+// queried, is server data: the network's 005 arrives as
+// `isupport.listModesQueryable` (see `isupport.ts`), and cic renders exactly
+// that set — it never derives it, because the reply-numeric table that makes
+// a letter queryable lives on the server.
+//
+// A letter with no label here still renders (as `+x`), so a server that
+// learns a new list mode needs no cic release to be usable.
+
+const LABELS: Record<string, string> = {
+  b: "Bans",
+  e: "Exempts",
+  I: "Invites",
+  // bahamut/Azzurra: the restrict list (728/729 RPL_RESTRICTLIST).
+  z: "Restricted",
+  // solanum/Libera: the quiet list, same numerics, different letter.
+  q: "Quiets",
+};
+
+/** Human label for a list mode: "Bans", or `+x` for a letter we have no name for. */
+export function listModeLabel(mode: string): string {
+  return LABELS[mode] ?? `+${mode}`;
+}
+
+/** Modal title for a list mode + channel, e.g. `Bans: #bofh`. */
+export function listModeTitle(mode: string, channel: string): string {
+  return `${listModeLabel(mode)}: ${channel}`;
+}

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -150,12 +150,16 @@ export type SlashCommand =
   | { kind: "kill"; nick: string; reason: string }
   | { kind: "ban"; mask: string }
   | { kind: "unban"; mask: string }
-  // #386 /banlist opens the ban-management modal. #536 — the list-mode
-  // QUERY form of /mode (`/mode #chan +b`, `/mode +b`) also maps here, so
-  // the shape carries the resolved channel: an explicit channel for
-  // `/mode #chan +b`, or null (= the current window, resolved in
-  // compose.ts) for bare `/banlist` and `/mode +b`.
-  | { kind: "banlist"; channel: string | null }
+  // #386 /banlist opens the channel list-mode modal. The shape carries the
+  // resolved channel — an explicit `/banlist #chan`, or null (= the current
+  // window, resolved in compose.ts) — and, since #1251, WHICH type-A list
+  // (`b` bans, `e` exempts, `I` invex, `z`/`q` restrict/quiet).
+  //
+  // #536's `/mode #chan +b` route no longer lands here: whether a bare
+  // `+<letter>` is a LIST query or a flag toggle depends on the network's
+  // 005, which this pure parser cannot see, so the `mode` arms keep their
+  // literal shape and compose.ts (which has the isupport table) intercepts.
+  | { kind: "banlist"; channel: string | null; mode: string }
   | { kind: "invite"; nick: string; channel: string | null }
   | { kind: "umode"; modes: string }
   // #229 — no-mode-args umode forms open the umode viewer/editor modal.
@@ -237,17 +241,6 @@ function err(verb: string, message: string): SlashCommand {
 // Parse a list of whitespace-delimited tokens from `rest`.
 function tokens(rest: string): string[] {
   return rest === "" ? [] : rest.split(/\s+/).filter((t) => t.length > 0);
-}
-
-// #536 — a /mode "list-mode query" is the `b` letter, optionally signed,
-// with NO mask parameter (`+b`, `-b`, `b`). That is the no-args shape
-// #216/#229 route to the modal: it must open the banlist, not execute a
-// raw MODE whose 367/368 reply is dropped for lack of banlist_pending.
-// A mask parameter makes it a MUTATION (`/mode #chan +b nick!*@*`),
-// which stays an execute verb. Scope is `b` only (#536 constraint —
-// +e/+I are also type-A list modes but have no accumulator/modal yet).
-function isBanlistQuery(modes: string, params: string[]): boolean {
-  return params.length === 0 && /^[+-]?b$/.test(modes);
 }
 
 // Parse nicks-requiring ops verbs (/op /deop /voice /devoice).
@@ -606,7 +599,23 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     return { kind: "unban", mask };
   },
 
-  banlist: (_verb, _rest) => ({ kind: "banlist", channel: null }),
+  // #386/#1251 — `/banlist [#chan] [mode]`. Both args optional, order-free,
+  // classified by SHAPE: a single (optionally signed) letter is the mode, a
+  // sigil-led token is the channel. The mode test runs FIRST because `+e` is
+  // both a signed mode and a `+`-sigil channel name — and a channel literally
+  // named `+e` is extinct, while `/banlist +e` is the obvious spelling.
+  // Defaults: current window's channel (resolved in compose.ts) and `b`.
+  banlist: (_verb, rest) => {
+    let channel: string | null = null;
+    let mode = "b";
+
+    for (const tok of tokens(rest)) {
+      if (/^[+-]?[A-Za-z]$/.test(tok)) mode = tok.replace(/^[+-]/, "");
+      else if (/^[#&!+]/.test(tok)) channel = tok;
+    }
+
+    return { kind: "banlist", channel, mode };
+  },
 
   invite: (verb, rest) => {
     // Codebase audit type-A9 — destructure + guard so the index access
@@ -658,10 +667,10 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     const isChannel = /^[#&!]/.test(first);
 
     if (isModeString) {
-      // /mode +b (list-mode query, no mask) → banlist for the current
-      // channel (#536). compose.ts resolves the null channel.
-      if (isBanlistQuery(first, restToks)) return { kind: "banlist", channel: null };
-      // /mode +s [params] → apply to the current channel.
+      // /mode +s [params] → apply to the current channel. #536/#1251: a bare
+      // `+b`/`+e` with no mask is a LIST QUERY on a network that advertises
+      // that letter as type A — but only compose.ts can tell, so the
+      // interception lives there and this arm keeps the literal shape.
       return { kind: "mode-apply-current", modes: first, params: restToks };
     }
 
@@ -669,10 +678,9 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
       const [modes, ...params] = restToks;
       // /mode #chan (no modes) → open the modal for that channel.
       if (!modes) return { kind: "mode-view", channel: first };
-      // /mode #chan +b (list-mode query, no mask) → banlist for that
-      // channel (#536), not a raw MODE whose 367s are dropped.
-      if (isBanlistQuery(modes, params)) return { kind: "banlist", channel: first };
-      // /mode #chan +s [params] → execute directly.
+      // /mode #chan +s [params] → execute directly (or, for a bare list
+      // letter with no mask, get intercepted into the list modal by
+      // compose.ts — see the mode-string branch above).
       return { kind: "mode", target: first, modes, params };
     }
 

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -608,11 +608,14 @@ export function pushChannelUnban(networkId: number, channel: string, mask: strin
   return pushUserChannelVerb("unban", { network_id: networkId, channel, mask });
 }
 
-// /banlist → MODE #chan b (query form, no sign); server replies 367/368.
-// Read-only query — stays fire-and-forget (no error to surface inline).
-export function pushChannelBanlist(networkId: number, channel: string): void {
+// /banlist → MODE #chan <mode> (type-A list query form, no sign); the server
+// replies with that list's numerics (b 367/368, e 348/349, I 346/347, z|q
+// 728/729). Read-only query — stays fire-and-forget (no error to surface
+// inline). #1251: `mode` is always sent explicitly; the server's own default
+// for an absent field is `b`, which is what a pre-#1251 client relies on.
+export function pushChannelBanlist(networkId: number, channel: string, mode: string): void {
   if (_userChannel === null) return;
-  _userChannel.push("banlist", { network_id: networkId, channel });
+  _userChannel.push("banlist", { network_id: networkId, channel, mode });
 }
 
 // #386 — resolve a nick's userhost on demand. cic has NO per-member host

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -859,9 +859,9 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         not_found: r.not_found,
       };
     case "banlist_bundle": {
-      // #376 — BANLIST bundle. All entries ship (a ban list is a set of
-      // rows). cic owns the rendering (single card per network,
-      // last-write-wins per /banlist). Each element is narrowed against
+      // #376/#1251 — channel LIST-MODE bundle. All entries ship (a list mode
+      // is a set of rows). cic owns the rendering (single card per network,
+      // last-write-wins per query). Each element is narrowed against
       // the wire shape; ANY malformed element drops the whole bundle.
       if (
         typeof r.network !== "string" ||
@@ -879,6 +879,10 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         kind: "banlist_bundle",
         network: r.network,
         channel: r.channel,
+        // #1251 — WHICH list this is. Additive-tolerant like links_bundle's
+        // `mask`: a grappa that predates the field could only ever have sent
+        // the ban list, so absent means `b` (unknown-is-never-fatal, #447).
+        mode: typeof r.mode === "string" ? r.mode : "b",
         entries,
       };
     }
@@ -1424,7 +1428,9 @@ moduleRoot(() => {
         }
 
         case "banlist_bundle": {
-          // #376 — BANLIST bundle. Last-write-wins per-network. Renders
+          // #376/#1251 — list-mode bundle. Last-write-wins per-network; the
+          // bundle's `mode` is what lets the modal tell "no reply yet for
+          // +e" from "here is the +b list I asked for before". Renders
           // inline above the active window scrollback (mirrors WhoisCard/
           // WhowasCard). No focus change: operator typed /banlist from the
           // window they're looking at; the card renders there.

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -186,6 +186,12 @@ export function narrowIsupportChanged(
     chanmodes_b: b,
     chanmodes_c: c,
     chanmodes_d: d,
+    // #1251 — absent means a server that predates the field (a cic-only
+    // bundle deploy is the realistic case), and that server can query
+    // exactly one list: `b`. Falling back to the empty set would silently
+    // remove /banlist; deriving the set from `chanmodes_a` would offer
+    // queries that server cannot answer.
+    list_modes_queryable: narrowStringArray(r.list_modes_queryable) ?? ["b"],
     prefix,
     // #1108 — absent or malformed means ABSENT, never a rejected envelope:
     // the /mode toggles this payload seeds must survive a server that

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -885,6 +885,7 @@ export const S_SessionWireBanlistBundlePayload = {
     kind: { l: "banlist_bundle" },
     network: "s",
     channel: "s",
+    mode: "s",
     entries: { a: S_SessionWireBanlistEntry },
   },
 } as const;
@@ -952,6 +953,7 @@ export const S_SessionWireIsupportChangedPayload = {
     chanmodes_b: { a: "s" },
     chanmodes_c: { a: "s" },
     chanmodes_d: { a: "s" },
+    list_modes_queryable: { a: "s" },
     prefix: { r: "s" },
     frame_budget_base: "i",
   },
@@ -1466,6 +1468,7 @@ export const S_ErrorTokensChannelErrorToken = {
     { l: "persist_failed" },
     { l: "invalid_channel" },
     { l: "links_in_flight" },
+    { l: "unsupported_list_mode" },
     { l: "nothing_to_recover" },
     { l: "already_identified" },
     { l: "recovery_in_progress" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -909,6 +909,7 @@ export type SessionWireIsupportChangedPayload = {
   chanmodes_b: string[];
   chanmodes_c: string[];
   chanmodes_d: string[];
+  list_modes_queryable: string[];
   prefix: Record<string, string>;
   frame_budget_base: number;
 };
@@ -1199,6 +1200,7 @@ export type SessionWireBanlistBundlePayload = {
   kind: "banlist_bundle";
   network: string;
   channel: string;
+  mode: string;
   entries: SessionWireBanlistEntry[];
 };
 
@@ -1555,6 +1557,7 @@ export const ERROR_TOKENS_CHANNEL_ERROR_TOKEN = [
   "persist_failed",
   "invalid_channel",
   "links_in_flight",
+  "unsupported_list_mode",
   "nothing_to_recover",
   "already_identified",
   "recovery_in_progress",

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10505,6 +10505,43 @@ html.resize-dragging * {
   font-size: 0.85rem;
 }
 
+/* #1251 — list-mode switcher: one button per type-A list the network
+   advertises AND the server can query. Rendered only when there is more than
+   one, so a bahamut-only-`b` network sees no furniture. */
+.banlist-modal-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.banlist-modal-mode-btn {
+  min-height: var(--tap-min);
+  padding: 0.3rem 0.7rem;
+  background: var(--bg-alt);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.banlist-modal-mode-btn:hover {
+  border-color: var(--accent, var(--fg));
+}
+
+.banlist-modal-mode-active {
+  border-color: var(--accent, var(--fg));
+  background: var(--bg);
+  font-weight: bold;
+}
+
+/* #1251 — the non-`b` lists are a viewer here; the note names the verb that
+   edits them instead of showing dead controls. */
+.banlist-modal-readonly {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 /* Add-ban row: nick/mask input + form selector + Add button. */
 .banlist-modal-add {
   display: flex;

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -258,6 +258,33 @@ Render it. Without it an ops-only broadcast is indistinguishable from one the
 whole channel saw — which is the defect #1247 exists to fix. The sigil set is
 per-network and open-ended, so treat an unrecognised level as "restricted",
 never as "everyone".
+### 5c. Channel list modes — ask the server which ones exist (#1251)
+
+A type-A channel mode is a LIST, not a flag, and WHICH letters are type A is
+per-network 005 data. Two fields carry this:
+
+| where | field | meaning |
+|---|---|---|
+| `isupport_changed` | `chanmodes_a` | every type-A letter the network advertises |
+| `isupport_changed` | `list_modes_queryable` | the subset grappa can actually QUERY |
+| `banlist_bundle` | `mode` | which list this bundle answers for |
+
+Query one with the `"banlist"` channel verb, whose optional `"mode"` field
+defaults to `"b"`: `{"network_id": 3, "channel": "#bofh", "mode": "z"}`. The
+reply is a `banlist_bundle` on your user topic (see §4 — it reaches only the
+socket that asked) carrying the same `mode`.
+
+**Offer `list_modes_queryable`, not `chanmodes_a`.** The difference between
+the two is a letter the network has and grappa cannot read the replies for;
+asking for it earns `unsupported_list_mode` rather than a request that never
+terminates. Do not derive the set from the letters yourself — the numeric
+table behind it is server knowledge, and it is not a constant: `728/729`
+carry bahamut's restrict list (`z`) on one network and solanum's quiet list
+(`q`) on another.
+
+The names are historical. The event is `banlist_bundle` and the verb is
+`"banlist"` because the contract is additive-only (§2) and renaming a
+published kind is a removal; both have carried every list since #1251.
 
 ---
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40261,6 +40261,21 @@ the same treatment, not a modal that quietly sends raw MODE lines for four
 letters and a chunked one for the fifth. For the other lists the modal is a
 viewer and says so, pointing at `/mode #chan +e <mask>`.
 
+**The restrict list is op-private on the WRITE side too, which cost the e2e
+its first witness.** The spec originally used a joined peer waiting for the
+`MODE +z` broadcast as its "the entry landed upstream" barrier — the shape
+that works for `+b`. It timed out, and the ircd was right: bahamut's
+`channel.c` writes `b` into BOTH `mbuf` and `stripped_mbuf` (case 'b',
+gated only on `MODE_HIDEBANS`), but case 'z' writes `mbuf` alone. The
+mode-change sender then compares the two counts, and on `stripped_mcount !=
+mcount` it routes the echo through `sendto_chanops_butserv` (~:1120) instead
+of `sendto_channel_butserv` — so a non-op peer never sees `+z` at all. Read
+AND write are op-only, not just the read the paragraph above describes. The
+barrier is now the MODE echo as a scrollback row: the bouncer holds op, the
+row is persisted, and it witnesses the same upstream fact without a second
+client. Nothing in the product changed — the first run's failure was the
+test asking a non-op to witness an op-only event.
+
 **Named, not fixed: a non-op query does not terminate.** solanum
 (`ircd/chmode.c`, the `MODE_QUERY` branch) answers a non-op `MODE #chan e`
 with 482 and no terminator, and bahamut (`src/channel.c:1478`) does the same

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40203,3 +40203,74 @@ operator's OWN outbound `/notice @#chan` needed nothing: #1225 already
 keeps the raw wire target in `meta.notice_target`, sigil intact, so
 nothing is destroyed on that path. And #1247's routing is untouched —
 `@#chan` still lands in the channel window.
+
+---
+
+## 2026-08-12 — #1251: a type-A mode is a list, and which numeric answers it is not a constant
+
+Only `+b` was reachable. `/banlist` had a complete path — verb, accumulator,
+367/368 clauses, modal — and every OTHER type-A channel mode had none of it:
+`346/347/348/349/728/729` appeared nowhere in `lib/`. vjt's ruling on the
+issue was "supportarle tutte", so the fix is not "+e and +I" but the generic
+form: the query is driven by `ISupport.chanmodes.a` (per-network 005 data),
+the accumulator is keyed by `{channel, mode}` instead of by channel alone,
+and `Grappa.Session.ListModes` holds the numeric-pair table.
+
+**Both ircds were read before a line was written, and the issue's own table
+turned out to be half right.** bahamut `src/s_err.c:812` and solanum
+`include/messages.h:231` both define 728, and they hardcode a DIFFERENT
+letter into the format string: `":%s 728 %s %s z %s %s %lu"` (restrict list)
+against `":%s 728 %s %s q %s %s %lu"` (quiet list). So `z → 728/729` is a
+bahamut fact, not a protocol fact — the same pair is `q` on the Libera
+family. The 346/348/367 rows carry no letter at all; their numeric IS the
+letter. That asymmetry is the whole design: two clause pairs in
+`EventRouter`, one that names its mode from the numeric and one that reads it
+off the wire. A hardcoded `z` would have dropped every quiet row on solanum,
+and it would have looked like a working feature on Azzurra.
+
+**The queryable set is published, not derived.** `isupport_changed` gained
+`list_modes_queryable` — `chanmodes_a` filtered through the pair table — and
+cic renders exactly that. The alternative was for the client to hold its own
+copy of the numeric table, which would let it offer a query the server cannot
+answer. A letter the network advertises and grappa has no pair for appears in
+`chanmodes_a` and NOT in `list_modes_queryable`: that difference IS the quiet
+degradation vjt asked for, visible rather than implicit. `Session.Server`
+re-checks the letter against the live 005 anyway (`unsupported_list_mode`, a
+typed token rather than the catch-all's `upstream_unavailable` lie) — the
+published set is an affordance, not the gate.
+
+**The wire kind stays `banlist_bundle`.** It now carries `mode`, which is
+additive; renaming the kind would be a REMOVAL, which the #447 contract does
+not allow. The same reasoning keeps the `"banlist"` channel verb, whose new
+`"mode"` field defaults to `"b"` — that default is precisely what a
+pre-#1251 client relies on. The names are historical; the payload is honest.
+
+**The "is this a list query?" decision moved from the parser to compose.**
+`/mode #chan +b` used to become a `banlist` command inside `slashCommands.ts`
+via a `/^[+-]?b$/` test. That cannot generalise: whether a bare `+q` is a
+LIST or a flag is 005 data, and the parser is pure. So the parser now keeps
+the literal `mode` / `mode-apply-current` shape — sign included, because
+`-m` with no param is a real mode change — and `compose.ts`, which can see
+`isupportForNetwork`, intercepts. The fallback when the letter is not a list
+on this network is the pre-existing execute path, unchanged.
+
+**Editing stays `+b`-only, deliberately.** Add/remove in the modal go through
+the `ban`/`unban` verbs, which derive a mask from a bare nick and chunk per
+ISUPPORT `MODES=`. Generalising that wants a list-add/remove verb pair with
+the same treatment, not a modal that quietly sends raw MODE lines for four
+letters and a chunked one for the fifth. For the other lists the modal is a
+viewer and says so, pointing at `/mode #chan +e <mask>`.
+
+**Named, not fixed: a non-op query does not terminate.** solanum
+(`ircd/chmode.c`, the `MODE_QUERY` branch) answers a non-op `MODE #chan e`
+with 482 and no terminator, and bahamut (`src/channel.c:1478`) does the same
+for `z` — it `break`s before RPL_ENDOFRESTRICTLIST. The accumulator is
+bounded regardless (the S10 lazy `@pending_ttl_ms` sweep evicts it on the
+next prime) and the 482 itself stays a VISIBLE red row in the channel window,
+which is why 482 was NOT delegated: it is a generic channel-op error shared
+by kick/topic/mode, and delegating it globally to reach one accumulator would
+strip the severity off all of them. What the operator sees is the error plus
+a modal that keeps saying "Loading". Pre-#1251 this could not happen, because
+both ircds let anyone read the ban list; it becomes reachable exactly because
+the other lists are now reachable. A server-side watchdog that flushed a
+`timed_out` bundle is the obvious cure and is deliberately not in this change.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -672,19 +672,27 @@ defmodule Grappa.IRC.Client do
   end
 
   @doc """
-  Sends `MODE <channel> b\\r\\n` — the banlist query form (no sign,
-  just the mode letter). Numerics 367 RPL_BANLIST + 368
-  RPL_ENDOFBANLIST reply with the ban list. Validates the channel
-  syntax with `{:error, :invalid_line}` on rejection.
+  Sends `MODE <channel> <mode>\\r\\n` — the type-A list QUERY form (no sign,
+  just the mode letter). The ircd answers with that list's row numerics and
+  its terminator (`b` → 367/368, `e` → 348/349, `I` → 346/347, `z`/`q` →
+  728/729; see `Grappa.Session.ListModes`).
+
+  Validates the channel syntax AND the mode letter with
+  `{:error, :invalid_line}` on rejection: `mode` reaches here from a client
+  frame, so a single ASCII letter is the only shape allowed on the wire — a
+  multi-token value would forge a MODE argument list. WHICH letters are
+  meaningful is a per-network 005 question and is gated upstream of here, in
+  `Grappa.Session.Server`'s `:send_list_mode` arm.
 
   Consolidates the raw `send_line` arm previously open-coded in
-  `Grappa.Session.Server`'s `:send_banlist` handle_call (resp-A4 close).
+  `Grappa.Session.Server`'s list-query handle_call (resp-A4 close),
+  generalised from `b`-only to every type-A letter by #1251.
   """
-  @spec send_banlist(pid(), String.t()) :: send_result()
-  def send_banlist(client, channel) do
-    if Identifier.valid_channel?(channel),
-      do: send_line(client, "MODE #{channel} b\r\n"),
-      else: reject_invalid_line(:banlist)
+  @spec send_list_mode(pid(), String.t(), String.t()) :: send_result()
+  def send_list_mode(client, channel, mode) do
+    if Identifier.valid_channel?(channel) and mode =~ ~r/\A[A-Za-z]\z/,
+      do: send_line(client, "MODE #{channel} #{mode}\r\n"),
+      else: reject_invalid_line(:list_mode)
   end
 
   @doc """
@@ -697,9 +705,9 @@ defmodule Grappa.IRC.Client do
   arm (#216) to make channel modes visible from the moment of join.
 
   Validates the channel syntax with `{:error, :invalid_line}` on
-  rejection. Sibling to `send_banlist/2` — same `MODE <channel> …` verb,
-  the only difference is the absent trailing `b` (query-all-modes vs
-  query-banlist).
+  rejection. Sibling to `send_list_mode/3` — same `MODE <channel> …` verb,
+  the only difference is the absent trailing mode letter (query-all-modes vs
+  query-one-list).
   """
   @spec send_channel_modes(pid(), String.t()) :: send_result()
   def send_channel_modes(client, channel) do
@@ -1037,7 +1045,7 @@ defmodule Grappa.IRC.Client do
            | :pong
            | :kick
            | :invite
-           | :banlist
+           | :list_mode
            | :umode
            | :umode_query
            | :topic_clear

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1857,26 +1857,36 @@ defmodule Grappa.Session do
   end
 
   @doc """
-  Sends `MODE <channel> b` upstream — the banlist query form (no sign) —
-  and primes the per-channel accumulator in `state.banlist_pending` so
-  EventRouter folds the 367 RPL_BANLIST rows into it. On 368
-  RPL_ENDOFBANLIST the bundle is broadcast on `Topic.user/1` as a
-  `banlist_bundle` event (#376). The accumulator keys on the
+  Sends `MODE <channel> <mode>` upstream — the type-A list QUERY form (no
+  sign) — and primes the `{channel, mode}` accumulator in
+  `state.list_mode_pending` so EventRouter folds that list's row numerics
+  into it. On the end numeric the bundle is broadcast on `Topic.user/1` as a
+  `banlist_bundle` event (#376/#1251). The accumulator keys on the
   ASCII-folded channel (#364/#525) so the rows drain regardless of upstream
   casing.
 
-  Ephemeral — NOT persisted in scrollback. Bundle replaces any prior
-  bundle for the same channel.
+  `mode` is a single type-A letter (`b` bans, `e` exempts, `I` invex, `z`
+  bahamut restrict, `q` solanum quiet). It is validated against THIS
+  network's 005 (`ISupport.chanmodes.a` ∩ `Grappa.Session.ListModes`), so a
+  letter the network doesn't advertise — or one grappa has no numeric pair
+  for — is refused with `{:error, :unsupported_list_mode}` instead of
+  becoming a query that can never terminate.
 
-  Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
-  if the channel syntax is rejected by `Grappa.IRC.Client.send_banlist/2`.
+  Ephemeral — NOT persisted in scrollback. Bundle replaces any prior
+  bundle for the same channel + mode.
+
+  Returns `:ok`, `{:error, :no_session}`, `{:error, :unsupported_list_mode}`,
+  or `{:error, :invalid_line}` if the syntax is rejected by
+  `Grappa.IRC.Client.send_list_mode/3`.
   """
-  @spec send_banlist(subject(), integer(), String.t(), reply_to()) ::
-          :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_banlist(subject, network_id, channel, reply_to)
+  @spec send_list_mode(subject(), integer(), String.t(), String.t(), reply_to()) ::
+          :ok
+          | {:error,
+             :no_session | :invalid_line | :unsupported_list_mode | send_transport_error()}
+  def send_list_mode(subject, network_id, channel, mode, reply_to)
       when is_subject(subject) and is_integer(network_id) and is_binary(channel) and
-             (is_binary(reply_to) or is_nil(reply_to)) do
-    call_session(subject, network_id, {:send_banlist, channel, reply_to})
+             is_binary(mode) and (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_list_mode, channel, mode, reply_to})
   end
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1881,8 +1881,7 @@ defmodule Grappa.Session do
   """
   @spec send_list_mode(subject(), integer(), String.t(), String.t(), reply_to()) ::
           :ok
-          | {:error,
-             :no_session | :invalid_line | :unsupported_list_mode | send_transport_error()}
+          | {:error, :no_session | :invalid_line | :unsupported_list_mode | send_transport_error()}
   def send_list_mode(subject, network_id, channel, mode, reply_to)
       when is_subject(subject) and is_integer(network_id) and is_binary(channel) and
              is_binary(mode) and (is_binary(reply_to) or is_nil(reply_to)) do

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -90,7 +90,7 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, Message}
   alias Grappa.{Scrollback, Session}
-  alias Grappa.Session.{IdentityState, ISupport, NumericRouter, Presence}
+  alias Grappa.Session.{IdentityState, ISupport, ListModes, NumericRouter, Presence}
 
   @typedoc """
   The Session.Server state subset this module reads + mutates. The
@@ -217,7 +217,8 @@ defmodule Grappa.Session.EventRouter do
           | {:invited, channel :: String.t(), inviter :: String.t()}
           | {:lusers_bundle, accum :: map()}
           | {:whowas_bundle, target :: String.t(), accum :: map(), Grappa.Session.reply_to()}
-          | {:banlist_bundle, channel :: String.t(), accum :: map(), Grappa.Session.reply_to()}
+          | {:list_mode_bundle, channel :: String.t(), mode :: ListModes.mode(), accum :: map(),
+             Grappa.Session.reply_to()}
           | {:links_bundle, accum :: map(), Grappa.Session.reply_to()}
           | {:umode_changed, modes :: [String.t()]}
           | {:supported_umodes_changed, modes :: [String.t()]}
@@ -2076,57 +2077,74 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
-  # #376 — BANLIST bundle (367 / 368). Bahamut emits one 367 RPL_BANLIST
-  # row per ban entry, terminated by 368 RPL_ENDOFBANLIST. Mirror of the
-  # WHOWAS shape but keyed by FOLDED channel (#364 channel pattern), not
-  # nick:
-  #   * `:send_banlist` primes `state.banlist_pending[folded_chan] =
-  #     %{channel_display, entries: []}` (Server.handle_call).
-  #   * 367 appends one `%{mask, setter, set_ts}` entry.
-  #   * 368 emits `{:banlist_bundle, channel_display, accum}` and clears
-  #     the pending entry.
+  # #376/#1251 — channel LIST-MODE bundle. A type-A channel mode is a LIST:
+  # `MODE #chan <letter>` streams one row numeric per entry, terminated by an
+  # end numeric. Mirror of the WHOWAS shape but keyed by `{FOLDED channel
+  # (#364 channel pattern), mode letter}`, not nick:
+  #   * `:send_list_mode` primes `state.list_mode_pending[{folded_chan, mode}]
+  #     = %{channel_display, mode, entries: []}` (Server.handle_call).
+  #   * a row numeric appends one `%{mask, setter, set_ts}` entry.
+  #   * the end numeric emits `{:list_mode_bundle, channel_display, mode,
+  #     accum, reply_to}` and clears the pending entry.
   # The channel key is already folded by `canonicalize_channel_params/1`
   # (route/2 runs it before do_route); `normalize_channel/1` here keeps the
   # key-derivation explicit + idempotent, matching the prime site.
+  #
+  # The pairs (`Grappa.Session.ListModes`, cited to both ircds' sources)
+  # split into TWO wire shapes, which is why there are two clause pairs:
+  #   * 367 `b` / 348 `e` / 346 `I` — the NUMERIC is the letter.
+  #   * 728 / 729 — bahamut's restrict list (`z`) and solanum's quiet list
+  #     (`q`) share the pair, and BOTH hardcode their letter into the format
+  #     string as a middle param, so the letter is read off the WIRE.
 
-  # 367 RPL_BANLIST: `:server 367 own_nick #chan <mask> [setter] [set_ts]`.
-  # setter/set_ts are OPTIONAL — older ircds / solanum may send only the
-  # mask (see reference_solanum_vs_bahamut_shapes). Append a new entry.
-  # Skips when no banlist_pending entry exists (unsolicited 367 — operator
-  # never issued /banlist; not actionable).
+  # 367 RPL_BANLIST / 348 RPL_EXCEPTLIST / 346 RPL_INVITELIST:
+  # `:server <n> own_nick #chan <mask> [setter] [set_ts]`.
+  # setter/set_ts are OPTIONAL — older ircds may send only the mask (see
+  # reference_solanum_vs_bahamut_shapes). Skips when no accumulator exists
+  # (unsolicited row — the operator never asked; not actionable).
   defp do_route(
-         %Message{command: {:numeric, 367}, params: [_, channel, mask | rest]},
+         %Message{command: {:numeric, numeric}, params: [_, channel, mask | rest]},
          state
        )
-       when is_binary(channel) and is_binary(mask) do
+       when numeric in [367, 348, 346] and is_binary(channel) and is_binary(mask) do
     entry = %{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
-    {:cont, banlist_append_entry(state, channel, entry), []}
+    {:cont, list_mode_append_entry(state, channel, numeric_list_mode(numeric), entry), []}
   end
 
-  # 368 RPL_ENDOFBANLIST: `:server 368 own_nick #chan :End of Channel Ban List`.
-  # Emits the bundle (carrying the case-preserved `channel_display`) + drops
-  # the pending entry. Silently ignored if no accumulator exists (unsolicited
-  # terminator).
+  # 728 RPL_RESTRICTLIST (bahamut `z`) / RPL_QUIETLIST (solanum `q`):
+  # `:server 728 own_nick #chan <mode> <mask> [setter] [set_ts]`. The mode
+  # letter is the wire's, never assumed — the SAME numeric carries `z` on one
+  # ircd and `q` on the other.
   defp do_route(
-         %Message{command: {:numeric, 368}, params: [_, channel | _]},
+         %Message{command: {:numeric, 728}, params: [_, channel, mode, mask | rest]},
          state
        )
-       when is_binary(channel) do
-    pending = Map.get(state, :banlist_pending, %{})
-    chan_key = normalize_channel(channel, casemapping(state))
+       when is_binary(channel) and is_binary(mask) and byte_size(mode) == 1 do
+    entry = %{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
+    {:cont, list_mode_append_entry(state, channel, mode, entry), []}
+  end
 
-    case Map.fetch(pending, chan_key) do
-      {:ok, accum} ->
-        next_state = %{state | banlist_pending: Map.delete(pending, chan_key)}
+  # 368 RPL_ENDOFBANLIST / 349 RPL_ENDOFEXCEPTLIST / 347 RPL_ENDOFINVITELIST:
+  # `:server <n> own_nick #chan :End of Channel … List`. Emits the bundle
+  # (carrying the case-preserved `channel_display`) + drops the pending entry.
+  # Silently ignored if no accumulator exists (unsolicited terminator).
+  defp do_route(
+         %Message{command: {:numeric, numeric}, params: [_, channel | _]},
+         state
+       )
+       when numeric in [368, 349, 347] and is_binary(channel) do
+    flush_list_mode(state, channel, numeric_list_mode(numeric))
+  end
 
-        {:cont, next_state,
-         [
-           {:banlist_bundle, Map.get(accum, :channel_display, channel), accum, Map.get(accum, :reply_to)}
-         ]}
-
-      :error ->
-        {:cont, state, []}
-    end
+  # 729 RPL_ENDOFRESTRICTLIST / RPL_ENDOFQUIETLIST: `:server 729 own_nick
+  # #chan <mode> :End of Channel … List` — same letter-on-the-wire shape as
+  # its 728 rows.
+  defp do_route(
+         %Message{command: {:numeric, 729}, params: [_, channel, mode | _]},
+         state
+       )
+       when is_binary(channel) and byte_size(mode) == 1 do
+    flush_list_mode(state, channel, mode)
   end
 
   # #238 — LINKS topology bundle (364 / 365). On-demand server-mesh query;
@@ -3918,27 +3936,63 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
-  # #376 — append one ban entry to `banlist_pending[folded_chan].entries`.
-  # Entries are stored REVERSED (head = most recent 367) for an O(1)
-  # prepend (Credo's MapInto check rejects the O(n) `++ [entry]` shape);
-  # `Wire.banlist_bundle/3` reverses to restore the wire order. Skips when
-  # no banlist_pending entry exists (unsolicited 367 — operator never
-  # issued /banlist; not actionable). Mirror of `whowas_append_entry/3`
-  # but keyed by folded channel (#364), not nick.
-  @spec banlist_append_entry(state(), String.t(), map()) :: state()
-  defp banlist_append_entry(state, channel, entry)
-       when is_binary(channel) and is_map(entry) do
-    pending = Map.get(state, :banlist_pending, %{})
-    chan_key = normalize_channel(channel, casemapping(state))
+  # #1251 — the mode letter a row/end numeric names by ITSELF (the 728/729
+  # pair is excluded on purpose: it carries its letter as a param, because
+  # bahamut spends it on `z` and solanum on `q`).
+  @spec numeric_list_mode(pos_integer()) :: ListModes.mode()
+  defp numeric_list_mode(367), do: "b"
+  defp numeric_list_mode(368), do: "b"
+  defp numeric_list_mode(348), do: "e"
+  defp numeric_list_mode(349), do: "e"
+  defp numeric_list_mode(346), do: "I"
+  defp numeric_list_mode(347), do: "I"
 
-    case Map.fetch(pending, chan_key) do
+  # #376/#1251 — append one entry to
+  # `list_mode_pending[{folded_chan, mode}].entries`. Entries are stored
+  # REVERSED (head = most recent row) for an O(1) prepend (Credo's MapInto
+  # check rejects the O(n) `++ [entry]` shape); `Wire.list_mode_bundle/4`
+  # reverses to restore the wire order. Skips when no accumulator exists
+  # (unsolicited row — the operator never issued the query; not actionable).
+  # Mirror of `whowas_append_entry/3` but keyed by `{folded channel (#364),
+  # mode}`, not nick.
+  @spec list_mode_append_entry(state(), String.t(), ListModes.mode(), map()) :: state()
+  defp list_mode_append_entry(state, channel, mode, entry)
+       when is_binary(channel) and is_binary(mode) and is_map(entry) do
+    pending = Map.get(state, :list_mode_pending, %{})
+    key = {normalize_channel(channel, casemapping(state)), mode}
+
+    case Map.fetch(pending, key) do
       :error ->
         state
 
       {:ok, accum} ->
         entries = [entry | Map.get(accum, :entries, [])]
         merged = Map.put(accum, :entries, entries)
-        %{state | banlist_pending: Map.put(pending, chan_key, merged)}
+        Map.put(state, :list_mode_pending, Map.put(pending, key, merged))
+    end
+  end
+
+  # #1251 — drain the `{folded_chan, mode}` accumulator on its end numeric.
+  # Silently ignored when nothing is pending (unsolicited terminator).
+  @spec flush_list_mode(state(), String.t(), ListModes.mode()) ::
+          {:cont, state(), [effect()]}
+  defp flush_list_mode(state, channel, mode)
+       when is_binary(channel) and is_binary(mode) do
+    pending = Map.get(state, :list_mode_pending, %{})
+    key = {normalize_channel(channel, casemapping(state)), mode}
+
+    case Map.fetch(pending, key) do
+      {:ok, accum} ->
+        next_state = Map.put(state, :list_mode_pending, Map.delete(pending, key))
+
+        {:cont, next_state,
+         [
+           {:list_mode_bundle, Map.get(accum, :channel_display, channel), mode, accum,
+            Map.get(accum, :reply_to)}
+         ]}
+
+      :error ->
+        {:cont, state, []}
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -3939,7 +3939,7 @@ defmodule Grappa.Session.EventRouter do
   # #1251 — the mode letter a row/end numeric names by ITSELF (the 728/729
   # pair is excluded on purpose: it carries its letter as a param, because
   # bahamut spends it on `z` and solanum on `q`).
-  @spec numeric_list_mode(pos_integer()) :: ListModes.mode()
+  @spec numeric_list_mode(346 | 347 | 348 | 349 | 367 | 368) :: ListModes.mode()
   defp numeric_list_mode(367), do: "b"
   defp numeric_list_mode(368), do: "b"
   defp numeric_list_mode(348), do: "e"
@@ -3987,8 +3987,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state,
          [
-           {:list_mode_bundle, Map.get(accum, :channel_display, channel), mode, accum,
-            Map.get(accum, :reply_to)}
+           {:list_mode_bundle, Map.get(accum, :channel_display, channel), mode, accum, Map.get(accum, :reply_to)}
          ]}
 
       :error ->

--- a/lib/grappa/session/list_modes.ex
+++ b/lib/grappa/session/list_modes.ex
@@ -1,0 +1,89 @@
+defmodule Grappa.Session.ListModes do
+  @moduledoc """
+  #1251 — the type-A (list) channel modes grappa can QUERY, and the numeric
+  pair each one answers on.
+
+  A type-A mode is a LIST, not a flag: `MODE #chan <letter>` with no argument
+  asks the ircd to stream the list, one numeric per entry, terminated by a
+  second numeric. WHICH letters are type A is per-network 005 data
+  (`ISupport.chanmodes.a`, from `CHANMODES=`), not a constant — bahamut/Azzurra
+  advertises `bz` and has no `+e`/`+I` at all, while solanum advertises `eIbq`.
+
+  ## The pair table, measured in both ircds' sources
+
+  | mode | list | end | ircd                                              |
+  |------|------|-----|---------------------------------------------------|
+  | `b`  | 367  | 368 | both (bahamut `src/s_err.c:414`, solanum `include/messages.h:129`) |
+  | `e`  | 348  | 349 | solanum (`:114`) — bahamut has no `+e`            |
+  | `I`  | 346  | 347 | solanum (`:112`) — bahamut has no `+I`            |
+  | `z`  | 728  | 729 | bahamut restrict list (`src/s_err.c:812`)         |
+  | `q`  | 728  | 729 | solanum quiet list (`include/messages.h:231`)     |
+
+  **728/729 are shared by two different letters, and that is why the letter
+  travels ON THE WIRE for that pair only.** Both ircds hardcode it into the
+  format string as a literal middle param — bahamut
+  `":%s 728 %s %s z %s %s %lu"`, solanum `":%s 728 %s %s q %s %s %lu"` — so
+  the reply itself says which list it is, and `EventRouter` reads it from
+  `params` instead of assuming. The 346/348/367 rows carry no letter (their
+  numeric IS the letter). The issue text's `z → 728/729` was true only for
+  bahamut; reading the param covers both networks with one clause.
+
+  ## Silent degradation
+
+  A network may advertise a type-A letter this table does not know (`a`, `X`,
+  a future letter). `queryable/1` intersects the advertised set with the table,
+  so an unknown letter is simply never offered — no command, no accumulator,
+  no request that can never terminate (vjt's ruling on #1251).
+
+  Pure module: a table plus two lookups. No process, no side effects.
+  """
+
+  alias Grappa.Session.ISupport
+
+  @typedoc """
+  A single-character channel list-mode letter (`"b"`, `"e"`, `"I"`, `"z"`,
+  `"q"`). Case is significant — `I` (invite exception) and `i` (invite-only,
+  a type-D flag) are different modes.
+  """
+  @type mode :: String.t()
+
+  @typedoc "The `{list_numeric, end_numeric}` pair a mode's entries stream on."
+  @type pair :: {pos_integer(), pos_integer()}
+
+  @pairs %{
+    "b" => {367, 368},
+    "e" => {348, 349},
+    "I" => {346, 347},
+    "z" => {728, 729},
+    "q" => {728, 729}
+  }
+
+  @doc """
+  The full mode → `{list, end}` numeric table. Exposed so tests (and the
+  `EventRouter` numeric clauses' coverage test) drive off the production
+  table rather than restating it.
+  """
+  @spec pairs() :: %{mode() => pair()}
+  def pairs, do: @pairs
+
+  @doc """
+  Whether grappa knows the numeric pair for `mode` — i.e. whether a
+  `MODE #chan <mode>` query is guaranteed to terminate. Unknown letters are
+  never queried.
+  """
+  @spec known?(mode()) :: boolean()
+  def known?(mode) when is_binary(mode), do: Map.has_key?(@pairs, mode)
+
+  @doc """
+  The list modes this network both ADVERTISES (005 `CHANMODES=` type A) and
+  grappa knows a numeric pair for, in the order the network advertised them.
+
+  This is the set the client may offer and the set `Session.Server` accepts —
+  one source of truth for both doors, so cic can never offer a query the
+  server would refuse.
+  """
+  @spec queryable(ISupport.t()) :: [mode()]
+  def queryable(%{chanmodes: %{a: type_a}}) when is_list(type_a) do
+    Enum.filter(type_a, &known?/1)
+  end
+end

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -576,8 +576,8 @@ defmodule Grappa.Session.NumericRouter do
                         # #376 — BANLIST bundle (367 RPL_BANLIST, 368
                         # RPL_ENDOFBANLIST). EventRouter accumulates one
                         # {mask, setter, set_ts} entry per 367 into
-                        # banlist_pending[folded_chan] and emits a
-                        # :banlist_bundle effect on 368. Without delegation,
+                        # list_mode_pending[{folded_chan, "b"}] and emits a
+                        # :list_mode_bundle effect on 368. Without delegation,
                         # `param_derived_route/3` falls through to `scan_params/2`
                         # → default `{:server, nil}` and Server persists each 367
                         # as a bare `:notice` row whose body is the trailing param
@@ -586,6 +586,23 @@ defmodule Grappa.Session.NumericRouter do
                         # the same commit per the delegation contract.
                         367,
                         368,
+                        # #1251 — the REST of the type-A list family, wired
+                        # in the same commit as their EventRouter clauses per
+                        # the delegation contract above. Same disease shape as
+                        # 367 pre-#376: undelegated, `param_derived_route/3`
+                        # persists every row as a bare `$server` :notice whose
+                        # body is the set-timestamp. 348/349 EXCEPT (+e) and
+                        # 346/347 INVITE (+I) are solanum's; 728/729 are
+                        # SHARED — bahamut spends them on the restrict list
+                        # (+z), solanum on the quiet list (+q) — which is why
+                        # the EventRouter clause reads the mode letter off the
+                        # wire rather than assuming it.
+                        346,
+                        347,
+                        348,
+                        349,
+                        728,
+                        729,
                         # LUSERS bundle (251, 252, 253, 254, 255, 265, 266)
                         251,
                         252,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -104,6 +104,7 @@ defmodule Grappa.Session.Server do
     GhostRecovery,
     IdentityState,
     ISupport,
+    ListModes,
     ModeChunker,
     NSInterceptor,
     NumericRouter,
@@ -895,14 +896,19 @@ defmodule Grappa.Session.Server do
           # (typically 0-1 at a time) AND the S10 lazy @pending_ttl_ms sweep
           # (withheld 369/406 can't strand the entry). NOT persisted.
           whowas_pending: %{String.t() => map()},
-          # #376 — pending BANLIST accumulators keyed by FOLDED channel
-          # (#364), not nick. Set up on `:send_banlist`; 367 RPL_BANLIST
-          # appends a `%{mask, setter, set_ts}` entry to `entries`; 368
-          # RPL_ENDOFBANLIST emits `{:banlist_bundle, channel_display,
-          # accum}` and clears the entry. Bounded by in-flight /banlist
-          # commands AND the S10 lazy @pending_ttl_ms sweep (a withheld 368
-          # can't strand the entry). NOT persisted across crashes.
-          banlist_pending: %{String.t() => map()},
+          # #376/#1251 — pending channel LIST-MODE accumulators keyed by
+          # `{FOLDED channel (#364), mode letter}`, not nick. A type-A mode is
+          # a LIST (`b` bans, `e` exempts, `I` invex, `z`/`q` restrict/quiet),
+          # so the key carries WHICH list: two lists of the same channel can
+          # stream concurrently without colliding. Set up on
+          # `:send_list_mode`; each row numeric appends a
+          # `%{mask, setter, set_ts}` entry to `entries`; the end numeric
+          # emits `{:list_mode_bundle, channel_display, mode, accum}` and
+          # clears the entry. Bounded by in-flight queries AND the S10 lazy
+          # @pending_ttl_ms sweep (a withheld terminator — e.g. the 482 an
+          # ircd answers a non-op `MODE #chan e` with — can't strand the
+          # entry). NOT persisted across crashes.
+          list_mode_pending: %{{String.t(), ListModes.mode()} => map()},
           # Channel directory (#84) refresh tunables — config-derived at
           # boot (`config :grappa, Grappa.ChannelDirectory`), opts-overridable
           # in `do_init/1` so tests can pin them. Read by later tasks: the
@@ -1330,11 +1336,11 @@ defmodule Grappa.Session.Server do
       # emits a not_found bundle. Bounded by in-flight /whowas commands
       # (typically 0-1 at a time). NOT persisted across crashes.
       whowas_pending: %{},
-      # #376 — pending BANLIST accumulators keyed by folded channel (#364).
-      # Set up on `:send_banlist`; 367 appends entries; 368 emits
-      # :banlist_bundle and clears. Bounded by in-flight /banlist commands.
-      # NOT persisted across crashes.
-      banlist_pending: %{},
+      # #376/#1251 — pending list-mode accumulators keyed by `{folded channel
+      # (#364), mode letter}`. Set up on `:send_list_mode`; the row numeric
+      # appends entries; the end numeric emits :list_mode_bundle and clears.
+      # Bounded by in-flight queries. NOT persisted across crashes.
+      list_mode_pending: %{},
       # Channel directory (#84) refresh tunables — config default
       # (`@directory_*` from `config :grappa, Grappa.ChannelDirectory`),
       # opts-overridable so tests can pin a short timeout / small batch.
@@ -2153,30 +2159,46 @@ defmodule Grappa.Session.Server do
     {:reply, {:error, :not_visitor}, state}
   end
 
-  # #376 — /banlist <#chan>. Mirror of :send_whowas shape but keyed by
-  # channel, not nick. Two effects: (1) prime the accumulator in
-  # state.banlist_pending so EventRouter folds 367 RPL_BANLIST rows into
-  # it (368 RPL_ENDOFBANLIST drains it as :banlist_bundle); (2) emit
-  # `MODE #chan b\r\n`. #537 — the facade now passes `channel` RAW; the
+  # #376/#1251 — /banlist <#chan> [mode]. Mirror of :send_whowas shape but
+  # keyed by `{channel, mode}`, not nick. Two effects: (1) prime the
+  # accumulator in state.list_mode_pending so EventRouter folds the list rows
+  # into it (the end numeric drains it as :list_mode_bundle); (2) emit
+  # `MODE #chan <mode>\r\n`. #537 — the facade passes `channel` RAW; the
   # accumulator KEY folds network-aware here (`fold_key/2`), and
   # `channel_display` is the FOLDED key (channels have no separate display
   # form — the card header shows the canonical spelling, per #364/option B;
   # unlike WHOWAS, which is nick-keyed and preserves display case). The
   # MODE line ships the RAW `channel` upstream (wire stays as-typed). On
   # send_line failure the accumulator stays primed — harmless until the
-  # next /banlist replaces the entry.
-  def handle_call({:send_banlist, channel, reply_to}, _, state) when is_binary(channel) do
-    chan_key = fold_key(state, channel)
+  # next query replaces the entry, and the S10 sweep evicts it anyway.
+  #
+  # #1251 — the mode is GATED on this network's own 005: only a letter the
+  # ircd advertises as type A (`CHANMODES` class a) AND grappa knows the
+  # numeric pair for is accepted. A letter outside that set is refused here
+  # rather than put on the wire, because a query whose reply numerics we
+  # cannot recognise would never terminate (vjt's ruling). The same set is
+  # published to clients on `isupport_changed`, so a well-behaved client
+  # never reaches this arm.
+  def handle_call({:send_list_mode, channel, mode, reply_to}, _, state)
+      when is_binary(channel) and is_binary(mode) do
+    isupport = Map.get(state, :isupport, ISupport.default())
 
-    next_pending =
-      prime_pending(state.banlist_pending, chan_key, %{
-        channel_display: chan_key,
-        entries: [],
-        reply_to: reply_to
-      })
+    if mode in ListModes.queryable(isupport) do
+      chan_key = fold_key(state, channel)
 
-    next_state = %{state | banlist_pending: next_pending}
-    {:reply, Client.send_banlist(state.client, channel), next_state}
+      next_pending =
+        prime_pending(state.list_mode_pending, {chan_key, mode}, %{
+          channel_display: chan_key,
+          mode: mode,
+          entries: [],
+          reply_to: reply_to
+        })
+
+      next_state = %{state | list_mode_pending: next_pending}
+      {:reply, Client.send_list_mode(state.client, channel, mode), next_state}
+    else
+      {:reply, {:error, :unsupported_list_mode}, state}
+    end
   end
 
   # C2 — /whois <nick>. Two effects: (1) prime the accumulator entry in
@@ -4838,8 +4860,8 @@ defmodule Grappa.Session.Server do
   # `*_bundle` builders read the accumulator via explicit `Map.get` field
   # extraction — and dies with the entry on drain (Map.delete of the whole key),
   # so no drain site needs to know about it.
-  @spec prime_pending(%{optional(String.t()) => map()}, String.t(), map()) ::
-          %{optional(String.t()) => map()}
+  @spec prime_pending(%{optional(term()) => map()}, term(), map()) ::
+          %{optional(term()) => map()}
   defp prime_pending(pending, key, value) when is_map(pending) and is_map(value) do
     now = System.monotonic_time(:millisecond)
 
@@ -5733,17 +5755,18 @@ defmodule Grappa.Session.Server do
     apply_effects(rest, state)
   end
 
-  # #376 — BANLIST bundle ephemeral. Broadcast on the user-level topic
-  # (mirrors :whowas_bundle — the wire payload carries its own `network` +
-  # `channel` fields). cic dispatches in `userTopic.ts`'s `banlist_bundle`
-  # arm into the per-network `banlistCard.ts` store (last-write-wins per
-  # network). NOT persisted — operator types /banlist to refresh.
-  defp apply_effects([{:banlist_bundle, channel, accum, reply_to} | rest], state) do
+  # #376/#1251 — channel LIST-MODE bundle ephemeral. Broadcast on the
+  # user-level topic (mirrors :whowas_bundle — the wire payload carries its
+  # own `network` + `channel` + `mode` fields). cic dispatches in
+  # `userTopic.ts`'s `banlist_bundle` arm into the per-network
+  # `banlistCard.ts` store (last-write-wins per network+mode). NOT persisted
+  # — the operator re-queries to refresh.
+  defp apply_effects([{:list_mode_bundle, channel, mode, accum, reply_to} | rest], state) do
     :ok =
       Broadcaster.to_requester(
         state,
         reply_to,
-        SessionWire.banlist_bundle(state.network_slug, channel, accum)
+        SessionWire.banlist_bundle(state.network_slug, channel, mode, accum)
       )
 
     apply_effects(rest, state)

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -59,7 +59,7 @@ defmodule Grappa.Session.Wire do
 
   alias Grappa.IRC.LineSplit
   alias Grappa.Scrollback.Message
-  alias Grappa.Session.{EventRouter, ISupport}
+  alias Grappa.Session.{EventRouter, ISupport, ListModes}
 
   @typedoc """
   The closed set of event kinds emitted by Session. Useful when
@@ -139,6 +139,7 @@ defmodule Grappa.Session.Wire do
           chanmodes_b: [String.t()],
           chanmodes_c: [String.t()],
           chanmodes_d: [String.t()],
+          list_modes_queryable: [String.t()],
           prefix: %{String.t() => String.t()},
           frame_budget_base: integer()
         }
@@ -685,19 +686,28 @@ defmodule Grappa.Session.Wire do
         }
 
   @typedoc """
-  #376 — BANLIST bundle. Aggregated reply to operator-issued `/banlist`
-  (or a raw `MODE #chan b`). Unlike `whowas_bundle` (which projects only
-  the most-recent historical entry into flat fields) the banlist ships
-  ALL `entries` — a channel's ban list is a set of rows. `entries` are in
-  the wire order the ircd sent them. `channel` is the ASCII-folded
-  channel (#364/#525) — the card renders it as the surface header. cic owns the
-  human-readable rendering (mask · set-by · set-time); the server never
-  emits a bare set-timestamp (the #376 leak).
+  #376 — channel LIST-MODE bundle. Aggregated reply to an operator-issued
+  list query (`/banlist`, or a raw `MODE #chan <letter>`). Unlike
+  `whowas_bundle` (which projects only the most-recent historical entry into
+  flat fields) it ships ALL `entries` — a channel list mode IS a set of rows.
+  `entries` are in the wire order the ircd sent them. `channel` is the
+  ASCII-folded channel (#364/#525) — the card renders it as the surface
+  header. cic owns the human-readable rendering (mask · set-by · set-time);
+  the server never emits a bare set-timestamp (the #376 leak).
+
+  `mode` (#1251) is the type-A letter this bundle answers for — `b` bans,
+  `e` exempts, `I` invex, `z` bahamut restrict, `q` solanum quiet. It is
+  ADDITIVE on a kind that used to be `b`-only: the `kind` stays
+  `banlist_bundle` because the client wire contract is additive-only (GH
+  #447) — renaming a published frame kind is a removal, and a client that
+  predates the field cannot receive a non-`b` bundle anyway, since it can
+  only ask for the list it knows how to ask for.
   """
   @type banlist_bundle_payload :: %{
           kind: :banlist_bundle,
           network: String.t(),
           channel: String.t(),
+          mode: String.t(),
           entries: [banlist_entry()]
         }
 
@@ -882,6 +892,15 @@ defmodule Grappa.Session.Wire do
   `linelen` is the session's live LINELEN (005, or the RFC 2812 default);
   it is published as the derived per-frame budget, never raw, so cic never
   holds a second copy of the #246 framing reserve (#1108).
+
+  `list_modes_queryable` (#1251) is the subset of `chanmodes_a` grappa can
+  actually QUERY — the letters it knows the reply numerics for. It is
+  published rather than derived client-side for the same reason as the frame
+  budget: the pair table is server knowledge, and a client that guessed it
+  would offer a query the server refuses (or, worse, one that never
+  terminates). A letter the network advertises and grappa has no pair for
+  appears in `chanmodes_a` and NOT here — that difference IS the quiet
+  degradation.
   """
   @spec isupport_changed(integer(), ISupport.t(), pos_integer()) :: isupport_changed_payload()
   def isupport_changed(network_id, %{chanmodes: cm, prefix: prefix}, linelen)
@@ -893,6 +912,7 @@ defmodule Grappa.Session.Wire do
       chanmodes_b: Enum.sort(cm.b),
       chanmodes_c: Enum.sort(cm.c),
       chanmodes_d: Enum.sort(cm.d),
+      list_modes_queryable: ListModes.queryable(%{chanmodes: cm}),
       prefix: prefix,
       frame_budget_base: LineSplit.frame_budget_base(linelen)
     }
@@ -1564,21 +1584,24 @@ defmodule Grappa.Session.Wire do
   end
 
   @doc """
-  #376 — BANLIST bundle. Broadcast on `Topic.user/1` (mirrors
-  `whowas_bundle/3` — single-surface ephemeral data). cic dispatches in
-  `userTopic.ts`'s `banlist_bundle` arm into the per-network
-  `banlistCard.ts` store (last-write-wins replacement).
+  #376/#1251 — channel LIST-MODE bundle. Broadcast on `Topic.user/1`
+  (mirrors `whowas_bundle/3` — single-surface ephemeral data). cic
+  dispatches in `userTopic.ts`'s `banlist_bundle` arm into the per-network
+  `banlistCard.ts` store (last-write-wins replacement per network + mode).
 
-  Unlike whowas, ALL `entries` are shipped (a ban list is a set of rows).
-  EventRouter stores entries REVERSED (head = most recent 367, for an O(1)
-  prepend); this restores the wire order via `Enum.reverse/1`. Each entry
-  is normalised to the `banlist_entry/0` wire shape so a missing
-  `setter`/`set_ts` (older ircds) ships as nil. NOT persisted — operator
-  types /banlist to refresh.
+  Unlike whowas, ALL `entries` are shipped (a channel list mode is a set of
+  rows). EventRouter stores entries REVERSED (head = most recent row, for an
+  O(1) prepend); this restores the wire order via `Enum.reverse/1`. Each
+  entry is normalised to the `banlist_entry/0` wire shape so a missing
+  `setter`/`set_ts` (older ircds) ships as nil. NOT persisted — the operator
+  re-queries to refresh.
+
+  `mode` is the type-A letter the bundle answers for; see
+  `banlist_bundle_payload/0` for why the kind keeps its `b`-era name.
   """
-  @spec banlist_bundle(String.t(), String.t(), map()) :: banlist_bundle_payload()
-  def banlist_bundle(network_slug, channel, accum)
-      when is_binary(network_slug) and is_binary(channel) and is_map(accum) do
+  @spec banlist_bundle(String.t(), String.t(), String.t(), map()) :: banlist_bundle_payload()
+  def banlist_bundle(network_slug, channel, mode, accum)
+      when is_binary(network_slug) and is_binary(channel) and is_binary(mode) and is_map(accum) do
     entries =
       accum
       |> Map.get(:entries, [])
@@ -1595,6 +1618,7 @@ defmodule Grappa.Session.Wire do
       kind: :banlist_bundle,
       network: network_slug,
       channel: channel,
+      mode: mode,
       entries: entries
     }
   end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -903,7 +903,7 @@ defmodule Grappa.Session.Wire do
   degradation.
   """
   @spec isupport_changed(integer(), ISupport.t(), pos_integer()) :: isupport_changed_payload()
-  def isupport_changed(network_id, %{chanmodes: cm, prefix: prefix}, linelen)
+  def isupport_changed(network_id, %{chanmodes: cm, prefix: prefix} = isupport, linelen)
       when is_integer(network_id) and is_integer(linelen) do
     %{
       kind: :isupport_changed,
@@ -912,7 +912,7 @@ defmodule Grappa.Session.Wire do
       chanmodes_b: Enum.sort(cm.b),
       chanmodes_c: Enum.sort(cm.c),
       chanmodes_d: Enum.sort(cm.d),
-      list_modes_queryable: ListModes.queryable(%{chanmodes: cm}),
+      list_modes_queryable: ListModes.queryable(isupport),
       prefix: prefix,
       frame_budget_base: LineSplit.frame_budget_base(linelen)
     }

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -85,8 +85,13 @@ defmodule GrappaWeb.GrappaChannel do
   - `"invite"` — invite a nick. Payload: `%{"network_id" => id, "channel" => chan,
     "nick" => nick}`.
 
-  - `"banlist"` — query the channel ban list. Payload: `%{"network_id" => id,
-    "channel" => chan}`. Issues `MODE #chan b` (no sign); server replies with 367/368.
+  - `"banlist"` — query one of the channel's type-A (list) modes. Payload:
+    `%{"network_id" => id, "channel" => chan}`, plus an OPTIONAL
+    `"mode" => letter` (#1251) which defaults to `"b"`. Issues
+    `MODE #chan <letter>` (no sign); the ircd replies with that list's row +
+    end numerics (`b` 367/368, `e` 348/349, `I` 346/347, `z`/`q` 728/729).
+    The letter must be in the network's `list_modes_queryable` (published on
+    `isupport_changed`), else `unsupported_list_mode`.
 
   - `"resolve_userhost"` — on-demand per-nick userhost lookup (#386). Payload:
     `%{"network_id" => id, "nick" => nick}`. Replies `{:ok, %{user, host}}` from
@@ -745,27 +750,39 @@ defmodule GrappaWeb.GrappaChannel do
     )
   end
 
-  # /banlist  →  MODE #chan b (query form, no sign)
+  # /banlist  →  MODE #chan <mode> (type-A list query form, no sign)
   #
   # CP24 bucket B reviewer add-on: read-only verb — visitors are
   # entitled to issue it. #376 wired the real handler: EventRouter
-  # accumulates the 367 RPL_BANLIST rows keyed by folded channel and
-  # 368 RPL_ENDOFBANLIST emits a `banlist_bundle` broadcast on the
+  # accumulates the list rows keyed by folded channel and the end numeric
+  # emits a `banlist_bundle` broadcast on the
   # subject's own subject_label topic (mirror of WHOWAS), which cic's
   # `banlistCard.ts` store feeds to the #386 BanlistModal (the interactive
   # /banlist surface that superseded the original inline card). Pre-#376
   # this comment described the design but no such clause existed — 367/368
   # leaked the bare set-timestamp as a `$server` :notice row.
+  #
+  # #1251 — `mode` is OPTIONAL and defaults to `"b"`: the verb name and the
+  # absent-field default are what keep a pre-#1251 client working unchanged
+  # (additive-only wire, GH #447), while a current client asks for any
+  # letter the server published in `isupport_changed.list_modes_queryable`.
+  # The letter is authoritative-checked against THIS network's 005 in
+  # `Session.Server` — `unsupported_list_mode` is the refusal, never a
+  # query put on the wire on spec.
   defp do_handle_in(
          "banlist",
-         %{"network_id" => network_id, "channel" => channel},
+         %{"network_id" => network_id, "channel" => channel} = payload,
          socket
        )
        when is_integer(network_id) and is_binary(channel) do
+    mode = Map.get(payload, "mode", "b")
+
     dispatch_subject_verb(
       socket,
-      fn -> validate_args(channel: channel) end,
-      fn subject -> Session.send_banlist(subject, network_id, channel, reply_to(socket)) end
+      fn -> validate_args(channel: channel, list_mode: mode) end,
+      fn subject ->
+        Session.send_list_mode(subject, network_id, channel, mode, reply_to(socket))
+      end
     )
   end
 
@@ -1728,6 +1745,19 @@ defmodule GrappaWeb.GrappaChannel do
       else: {:error, :invalid_nick}
   end
 
+  # #1251 — a type-A channel list-mode letter off a client frame. SHAPE gate
+  # only: exactly one ASCII letter, so a multi-token value can never forge
+  # extra MODE arguments (and a non-binary from a hand-rolled client can
+  # never reach the `is_binary` guards downstream). WHICH letters this
+  # network supports is a 005 question, answered in `Session.Server` against
+  # `ISupport.chanmodes.a` — `:invalid_line` is the shape refusal,
+  # `:unsupported_list_mode` the semantic one.
+  defp validate_args([{:list_mode, value} | rest]) do
+    if is_binary(value) and value =~ ~r/\A[A-Za-z]\z/,
+      do: validate_args(rest),
+      else: {:error, :invalid_line}
+  end
+
   defp validate_args([{:mask, value} | rest]) do
     if Identifier.safe_line_token?(value) and value != "",
       do: validate_args(rest),
@@ -1947,6 +1977,14 @@ defmodule GrappaWeb.GrappaChannel do
       # nothing ever emits.
       {:error, :links_in_flight} ->
         {:reply, {:error, %{error: "links_in_flight"}}, socket}
+
+      # #1251 — the list-mode query was refused BEFORE the wire: the letter
+      # is not in this network's 005 type-A set (or grappa knows no numeric
+      # pair for it). Typed for the same reason as `links_in_flight` above:
+      # the catch-all's `upstream_unavailable` would lie about a request
+      # that never left the building.
+      {:error, :unsupported_list_mode} ->
+        {:reply, {:error, %{error: "unsupported_list_mode"}}, socket}
 
       # #581 recover gating (Session.recover_identity/2). A missing live
       # pid is the same "no upstream to act against" as `no_session`; a

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -1675,6 +1675,10 @@ defmodule GrappaWeb.GrappaChannel do
            | {:nick, String.t()}
            | {:nicks, [String.t()]}
            | {:mask, String.t()}
+           # #1251 — a type-A channel list-mode letter. The VALUE arrives
+           # from a client frame, so the clause still guards `is_binary`:
+           # this type is the caller contract, not a runtime guarantee.
+           | {:list_mode, String.t()}
            | {:who_target, String.t()}
            | {:line, String.t()}
            | {:oper_token, String.t()}

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -185,6 +185,13 @@ defmodule GrappaWeb.ErrorTokens do
           | :persist_failed
           | :invalid_channel
           | :links_in_flight
+          # #1251 — a channel list-mode query (`banlist`) for a letter this
+          # NETWORK does not advertise as type A, or that grappa knows no
+          # reply-numeric pair for. Typed rather than folded into
+          # `upstream_unavailable`: nothing upstream failed — the query was
+          # refused here precisely so it could never be one that never
+          # terminates.
+          | :unsupported_list_mode
           | :nothing_to_recover
           | :already_identified
           | :recovery_in_progress

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -357,7 +357,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     # cluster #9 (resp-A4 close): typed helpers for KICK / INVITE /
-    # banlist-query / umode / topic-clear. Each helper validates its
+    # list-query / umode / topic-clear. Each helper validates its
     # identifier args via `Grappa.IRC.Identifier` predicates and
     # returns `{:error, :invalid_line}` on rejection — same boundary
     # discipline as the helpers above. Mirrors the
@@ -424,21 +424,44 @@ defmodule Grappa.IRC.ClientTest do
                Client.send_invite(client, "#sniffo", "bad nick")
     end
 
-    test "send_banlist/2 emits MODE #chan b framing" do
+    test "send_list_mode/3 emits MODE #chan b framing" do
       {server, port} = start_server()
       client = start_client(port)
 
-      :ok = Client.send_banlist(client, "#sniffo")
+      :ok = Client.send_list_mode(client, "#sniffo", "b")
 
       assert {:ok, "MODE #sniffo b\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE #sniffo b\r\n"), 1_000)
     end
 
-    test "send_banlist/2 rejects malformed channel with {:error, :invalid_line}" do
+    # #1251 — the letter is not `b` any more. `I` also pins that the case is
+    # carried verbatim: lowercasing it would query the invite-ONLY flag.
+    test "send_list_mode/3 emits the requested letter, case verbatim" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_list_mode(client, "#sniffo", "I")
+
+      assert {:ok, "MODE #sniffo I\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "MODE #sniffo I\r\n"), 1_000)
+    end
+
+    test "send_list_mode/3 rejects malformed channel with {:error, :invalid_line}" do
       {_, port} = start_server()
       client = start_client(port)
 
-      assert {:error, :invalid_line} = Client.send_banlist(client, "no-prefix")
+      assert {:error, :invalid_line} = Client.send_list_mode(client, "no-prefix", "b")
+    end
+
+    # #1251 — `mode` arrives from a client frame, so the wire builder gates
+    # its SHAPE: anything but one ASCII letter could forge MODE arguments.
+    test "send_list_mode/3 rejects a multi-token mode (argument forgery)" do
+      {_, port} = start_server()
+      client = start_client(port)
+
+      assert {:error, :invalid_line} = Client.send_list_mode(client, "#sniffo", "b *!*@x")
+      assert {:error, :invalid_line} = Client.send_list_mode(client, "#sniffo", "")
+      assert {:error, :invalid_line} = Client.send_list_mode(client, "#sniffo", "be")
     end
 
     test "send_channel_modes/2 emits bare MODE #chan query framing" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -5484,7 +5484,7 @@ defmodule Grappa.Session.EventRouterTest do
     # would ship a query whose terminator nothing recognises — exactly the
     # never-terminating request the mode gate exists to prevent.
     test "every mode in ListModes.pairs/0 has a terminator clause that flushes it" do
-      for {mode, {_row, fin}} <- Grappa.Session.ListModes.pairs() do
+      for {mode, {_, fin}} <- Grappa.Session.ListModes.pairs() do
         state = list_mode_pending_state("#test", mode)
 
         params =

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -5225,21 +5225,30 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
-  # #376 — BANLIST bundle (367 RPL_BANLIST / 368 RPL_ENDOFBANLIST). Mirror
-  # of the WHOWAS shape but keyed by FOLDED channel (#364), not nick:
-  # send_banlist primes banlist_pending[folded_chan]; 367 appends one
-  # {mask, setter, set_ts} entry; 368 emits :banlist_bundle + clears.
-  # setter/set_ts are OPTIONAL (older ircds/solanum may omit).
+  # #376/#1251 — channel LIST-MODE bundle. Mirror of the WHOWAS shape but
+  # keyed by `{FOLDED channel (#364), mode}`, not nick: `send_list_mode`
+  # primes list_mode_pending[{folded_chan, mode}]; the row numeric appends one
+  # {mask, setter, set_ts} entry; the end numeric emits :list_mode_bundle +
+  # clears. setter/set_ts are OPTIONAL (older ircds may omit).
   describe "#376 — BANLIST bundle (367 / 368)" do
     defp banlist_pending_state(channel_display) do
+      list_mode_pending_state(channel_display, "b")
+    end
+
+    defp list_mode_pending_state(channel_display, mode) do
       base_state(%{
-        banlist_pending: %{
-          Grappa.IRC.Identifier.canonical_target(channel_display) => %{
+        list_mode_pending: %{
+          {Grappa.IRC.Identifier.canonical_target(channel_display), mode} => %{
             channel_display: channel_display,
+            mode: mode,
             entries: []
           }
         }
       })
+    end
+
+    defp entries_for(state, channel, mode) do
+      state.list_mode_pending[{Grappa.IRC.Identifier.canonical_target(channel), mode}][:entries]
     end
 
     test "367 RPL_BANLIST appends a ban entry to entries list" do
@@ -5254,13 +5263,13 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.banlist_pending["#test"][:entries] == [
+      assert entries_for(new_state, "#test", "b") == [
                %{mask: "*!*@banned.host", setter: "op!u@h", set_ts: "1784572878"}
              ]
     end
 
-    test "367 with no banlist_pending entry is silently ignored (unsolicited)" do
-      state = base_state(%{banlist_pending: %{}})
+    test "367 with no pending accumulator is silently ignored (unsolicited)" do
+      state = base_state(%{list_mode_pending: %{}})
 
       m =
         msg(
@@ -5270,7 +5279,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.banlist_pending == %{}
+      assert new_state.list_mode_pending == %{}
     end
 
     test "367 with missing setter/set_ts (older ircd shape) folds nils" do
@@ -5280,7 +5289,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.banlist_pending["#test"][:entries] == [
+      assert entries_for(new_state, "#test", "b") == [
                %{mask: "*!*@old.host", setter: nil, set_ts: nil}
              ]
     end
@@ -5298,7 +5307,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s2, []} = EventRouter.route(m2, s1)
 
       m368 = msg({:numeric, 368}, ["vjt", "#test", "End of Channel Ban List"], {:server, "irc.test.org"})
-      {:cont, _, [{:banlist_bundle, _, accum, _}]} = EventRouter.route(m368, s2)
+      {:cont, _, [{:list_mode_bundle, _, "b", accum, _}]} = EventRouter.route(m368, s2)
 
       # The EFFECT accum stores entries reversed (head = most recent 367,
       # O(1) prepend); `Wire.banlist_bundle/3` reverses to restore the wire
@@ -5306,12 +5315,13 @@ defmodule Grappa.Session.EventRouterTest do
       assert Enum.map(accum[:entries], & &1[:mask]) == ["b!*@2", "a!*@1"]
     end
 
-    test "368 RPL_ENDOFBANLIST emits :banlist_bundle effect + drops entry" do
+    test "368 RPL_ENDOFBANLIST emits :list_mode_bundle effect + drops entry" do
       state =
         base_state(%{
-          banlist_pending: %{
-            "#test" => %{
+          list_mode_pending: %{
+            {"#test", "b"} => %{
               channel_display: "#Test",
+              mode: "b",
               entries: [%{mask: "*!*@h", setter: "op", set_ts: "1784572878"}]
             }
           }
@@ -5324,19 +5334,19 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "irc.test.org"}
         )
 
-      {:cont, new_state, [{:banlist_bundle, channel, accum, _}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:list_mode_bundle, channel, "b", accum, _}]} = EventRouter.route(m, state)
       # The router carries `channel_display` through VERBATIM (whatever was
       # primed) — proven here with a mixed-case value so a stray fold in the
       # router would fail. In production the facade (`Session.send_banlist/3`)
       # already folded it, so the live `channel_display` is the canonical
-      # spelling (#364) — see the server.ex :send_banlist comment.
+      # spelling (#364) — see the server.ex :send_list_mode comment.
       assert channel == "#Test"
       assert length(accum[:entries]) == 1
-      assert new_state.banlist_pending == %{}
+      assert new_state.list_mode_pending == %{}
     end
 
     test "368 with no pending entry is silently ignored (unsolicited terminator)" do
-      state = base_state(%{banlist_pending: %{}})
+      state = base_state(%{list_mode_pending: %{}})
 
       m =
         msg(
@@ -5346,7 +5356,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.banlist_pending == %{}
+      assert new_state.list_mode_pending == %{}
     end
 
     test "367/368 channel lookup folds ASCII (#364/#525) — primed #chan, wire #CHAN" do
@@ -5356,14 +5366,136 @@ defmodule Grappa.Session.EventRouterTest do
         msg({:numeric, 367}, ["vjt", "#CHAN", "*!*@h", "op", "111"], {:server, "irc.test.org"})
 
       {:cont, s1, []} = EventRouter.route(m367, state)
-      assert length(s1.banlist_pending["#chan"][:entries]) == 1
+      assert length(entries_for(s1, "#chan", "b")) == 1
 
       m368 =
         msg({:numeric, 368}, ["vjt", "#CHAN", "End"], {:server, "irc.test.org"})
 
-      {:cont, s2, [{:banlist_bundle, _, accum, _}]} = EventRouter.route(m368, s1)
+      {:cont, s2, [{:list_mode_bundle, _, "b", accum, _}]} = EventRouter.route(m368, s1)
       assert length(accum[:entries]) == 1
-      assert s2.banlist_pending == %{}
+      assert s2.list_mode_pending == %{}
+    end
+  end
+
+  # #1251 — every OTHER type-A list, not just `b`. Two wire shapes: the
+  # 367/348/346 family names its letter by NUMERIC, while 728/729 carry the
+  # letter as a middle param because bahamut spends the pair on `z` (restrict)
+  # and solanum on `q` (quiet) — measured in both sources, see
+  # `Grappa.Session.ListModes`.
+  describe "#1251 — every type-A list mode (346/347, 348/349, 728/729)" do
+    test "348 RPL_EXCEPTLIST appends under mode e, 349 flushes it" do
+      state = list_mode_pending_state("#test", "e")
+
+      m348 =
+        msg({:numeric, 348}, ["vjt", "#test", "*!*@safe.host", "op", "111"], {:server, "irc.t"})
+
+      {:cont, s1, []} = EventRouter.route(m348, state)
+      assert entries_for(s1, "#test", "e") == [%{mask: "*!*@safe.host", setter: "op", set_ts: "111"}]
+
+      m349 = msg({:numeric, 349}, ["vjt", "#test", "End of Channel Exception List"], {:server, "irc.t"})
+      {:cont, s2, [{:list_mode_bundle, "#test", "e", accum, _}]} = EventRouter.route(m349, s1)
+
+      assert length(accum[:entries]) == 1
+      assert s2.list_mode_pending == %{}
+    end
+
+    test "346 RPL_INVITELIST appends under mode I, 347 flushes it" do
+      state = list_mode_pending_state("#test", "I")
+
+      m346 = msg({:numeric, 346}, ["vjt", "#test", "*!*@invited", "op", "222"], {:server, "irc.t"})
+      {:cont, s1, []} = EventRouter.route(m346, state)
+      assert length(entries_for(s1, "#test", "I")) == 1
+
+      m347 = msg({:numeric, 347}, ["vjt", "#test", "End of Channel Invite List"], {:server, "irc.t"})
+      {:cont, _, [{:list_mode_bundle, "#test", "I", accum, _}]} = EventRouter.route(m347, s1)
+      assert length(accum[:entries]) == 1
+    end
+
+    # bahamut src/s_err.c:812 — `":%s 728 %s %s z %s %s %lu"`.
+    test "728 with bahamut's z (restrict) reads the mode off the WIRE" do
+      state = list_mode_pending_state("#test", "z")
+
+      m728 =
+        msg({:numeric, 728}, ["vjt", "#test", "z", "*!*@rogue", "op", "333"], {:server, "irc.t"})
+
+      {:cont, s1, []} = EventRouter.route(m728, state)
+      assert entries_for(s1, "#test", "z") == [%{mask: "*!*@rogue", setter: "op", set_ts: "333"}]
+
+      m729 = msg({:numeric, 729}, ["vjt", "#test", "z", "End of Channel Restrict List"], {:server, "irc.t"})
+      {:cont, s2, [{:list_mode_bundle, "#test", "z", accum, _}]} = EventRouter.route(m729, s1)
+
+      assert length(accum[:entries]) == 1
+      assert s2.list_mode_pending == %{}
+    end
+
+    # solanum include/messages.h:231 — the SAME numeric, `":%s 728 %s %s q …"`.
+    # A hardcoded `z` here would drop every quiet row on Libera-family ircds.
+    test "728 with solanum's q (quiet) lands in the q accumulator, not z" do
+      state = list_mode_pending_state("#test", "q")
+
+      m728 =
+        msg({:numeric, 728}, ["vjt", "#test", "q", "*!*@muted", "op", "444"], {:server, "irc.t"})
+
+      {:cont, s1, []} = EventRouter.route(m728, state)
+      assert length(entries_for(s1, "#test", "q")) == 1
+
+      m729 = msg({:numeric, 729}, ["vjt", "#test", "q", "End of Channel Quiet List"], {:server, "irc.t"})
+      {:cont, _, [{:list_mode_bundle, "#test", "q", _, _}]} = EventRouter.route(m729, s1)
+    end
+
+    test "a 728 row for a mode nobody asked for is ignored (z primed, q on the wire)" do
+      state = list_mode_pending_state("#test", "z")
+
+      m728 =
+        msg({:numeric, 728}, ["vjt", "#test", "q", "*!*@muted", "op", "444"], {:server, "irc.t"})
+
+      {:cont, new_state, []} = EventRouter.route(m728, state)
+      assert entries_for(new_state, "#test", "z") == []
+      refute Map.has_key?(new_state.list_mode_pending, {"#test", "q"})
+    end
+
+    test "two lists of the SAME channel accumulate independently" do
+      state =
+        base_state(%{
+          list_mode_pending: %{
+            {"#test", "b"} => %{channel_display: "#test", mode: "b", entries: []},
+            {"#test", "e"} => %{channel_display: "#test", mode: "e", entries: []}
+          }
+        })
+
+      m367 = msg({:numeric, 367}, ["vjt", "#test", "*!*@banned", "op", "1"], {:server, "irc.t"})
+      m348 = msg({:numeric, 348}, ["vjt", "#test", "*!*@exempt", "op", "2"], {:server, "irc.t"})
+
+      {:cont, s1, []} = EventRouter.route(m367, state)
+      {:cont, s2, []} = EventRouter.route(m348, s1)
+
+      assert Enum.map(entries_for(s2, "#test", "b"), & &1[:mask]) == ["*!*@banned"]
+      assert Enum.map(entries_for(s2, "#test", "e"), & &1[:mask]) == ["*!*@exempt"]
+
+      # And the ban terminator drains ONLY the ban list.
+      m368 = msg({:numeric, 368}, ["vjt", "#test", "End of Channel Ban List"], {:server, "irc.t"})
+      {:cont, s3, [{:list_mode_bundle, _, "b", _, _}]} = EventRouter.route(m368, s2)
+
+      assert Map.keys(s3.list_mode_pending) == [{"#test", "e"}]
+    end
+
+    # Anti-drift: the table and the router clauses are two halves of one
+    # fact. Adding a letter to `ListModes.pairs/0` without its clause here
+    # would ship a query whose terminator nothing recognises — exactly the
+    # never-terminating request the mode gate exists to prevent.
+    test "every mode in ListModes.pairs/0 has a terminator clause that flushes it" do
+      for {mode, {_row, fin}} <- Grappa.Session.ListModes.pairs() do
+        state = list_mode_pending_state("#test", mode)
+
+        params =
+          if fin == 729,
+            do: ["vjt", "#test", mode, "End of list"],
+            else: ["vjt", "#test", "End of list"]
+
+        assert {:cont, _, [{:list_mode_bundle, "#test", ^mode, _, _}]} =
+                 EventRouter.route(msg({:numeric, fin}, params, {:server, "irc.t"}), state),
+               "no EventRouter terminator clause flushes mode #{mode} on numeric #{fin}"
+      end
     end
   end
 

--- a/test/grappa/session/list_modes_test.exs
+++ b/test/grappa/session/list_modes_test.exs
@@ -1,0 +1,77 @@
+defmodule Grappa.Session.ListModesTest do
+  @moduledoc """
+  #1251 — the type-A (list) channel-mode table.
+
+  The two facts worth locking are the ones measured in the ircds' own
+  sources, not guessed: `z` and `q` SHARE the 728/729 pair (bahamut's
+  restrict list vs solanum's quiet list), and a type-A letter with no known
+  pair must be dropped from the queryable set rather than offered.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.{ISupport, ListModes}
+
+  describe "pairs/0" do
+    test "each known letter maps to its measured {row, end} numeric pair" do
+      assert ListModes.pairs() == %{
+               "b" => {367, 368},
+               "e" => {348, 349},
+               "I" => {346, 347},
+               "z" => {728, 729},
+               "q" => {728, 729}
+             }
+    end
+
+    test "z and q share 728/729 — the pair does NOT identify the list" do
+      pairs = ListModes.pairs()
+      assert pairs["z"] == pairs["q"]
+    end
+  end
+
+  describe "known?/1" do
+    test "true for every letter in the table" do
+      for {mode, _} <- ListModes.pairs(), do: assert(ListModes.known?(mode))
+    end
+
+    test "false for a type-A letter we have no numeric pair for" do
+      refute ListModes.known?("a")
+    end
+
+    test "case is significant — I is invex, i is the invite-only flag" do
+      assert ListModes.known?("I")
+      refute ListModes.known?("i")
+    end
+  end
+
+  describe "queryable/1" do
+    test "bahamut/Azzurra (CHANMODES=bz,k,l,…) offers exactly b and z" do
+      isupport = ISupport.merge_isupport(["CHANMODES=bz,k,l,BcdijmMnOprRsStuU"], ISupport.default())
+
+      assert ListModes.queryable(isupport) == ["b", "z"]
+    end
+
+    test "solanum (CHANMODES=eIbq,…) offers all four of its list modes" do
+      isupport = ISupport.merge_isupport(["CHANMODES=eIbq,k,flj,CFLMPQScgimnprstuz"], ISupport.default())
+
+      assert ListModes.queryable(isupport) == ["e", "I", "b", "q"]
+    end
+
+    test "a type-A letter with no known pair degrades quietly — advertised, not offered" do
+      isupport = ISupport.merge_isupport(["CHANMODES=bX,k,l,imnpst"], ISupport.default())
+
+      assert "X" in isupport.chanmodes.a
+      refute "X" in ListModes.queryable(isupport)
+      assert ListModes.queryable(isupport) == ["b"]
+    end
+
+    test "a network advertising NO type-A modes offers nothing" do
+      isupport = ISupport.merge_isupport(["CHANMODES=,k,l,imnpst"], ISupport.default())
+
+      assert ListModes.queryable(isupport) == []
+    end
+
+    test "the pre-005 default seed is queryable (b, e, I — bahamut's own seed)" do
+      assert ListModes.queryable(ISupport.default()) == ["b", "e", "I"]
+    end
+  end
+end

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -192,6 +192,15 @@ defmodule Grappa.Session.NumericRouterTest do
     # disease as 333.
     367,
     368,
+    # #1251 — the rest of the type-A list family: 348/349 EXCEPT (+e),
+    # 346/347 INVITE (+I), and the SHARED 728/729 (bahamut +z restrict,
+    # solanum +q quiet). Same delegation reason as 367/368 above.
+    346,
+    347,
+    348,
+    349,
+    728,
+    729,
     # ---- added by #922: the 27 codes this mirror had drifted away from ----
     # #229 — 221 RPL_UMODEIS (EventRouter parses the umode string into
     # the per-session set and emits {:umode_changed, modes}).
@@ -713,6 +722,23 @@ defmodule Grappa.Session.NumericRouterTest do
     test "368 RPL_ENDOFBANLIST is delegated (#376)" do
       m = msg(368, ["vjt", "#test", "End of Channel Ban List"])
       assert :delegated = NumericRouter.route(m, state())
+    end
+
+    # #1251 — the other three pairs, same leak shape. 728 is the sharp one:
+    # its params carry the mode letter, so an undelegated 728 would scan to
+    # the CHANNEL window and persist the set-timestamp there.
+    test "the whole type-A list family is delegated (#1251)" do
+      for {numeric, params} <- [
+            {346, ["vjt", "#test", "*!*@invited", "op", "1"]},
+            {347, ["vjt", "#test", "End of Channel Invite List"]},
+            {348, ["vjt", "#test", "*!*@exempt", "op", "1"]},
+            {349, ["vjt", "#test", "End of Channel Exception List"]},
+            {728, ["vjt", "#test", "z", "*!*@rogue", "op", "1"]},
+            {729, ["vjt", "#test", "z", "End of Channel Restrict List"]}
+          ] do
+        assert :delegated = NumericRouter.route(msg(numeric, params), state()),
+               "numeric #{numeric} is not delegated — its rows will leak as $server notices"
+      end
     end
 
     # #276 — away acks are delegated (never a persist destination). The

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -10192,7 +10192,7 @@ defmodule Grappa.Session.ServerTest do
       network: network,
       pid: pid
     } do
-      assert :ok = Session.send_banlist({:user, user.id}, network.id, "#test", nil)
+      assert :ok = Session.send_list_mode({:user, user.id}, network.id, "#test", "b", nil)
 
       assert {:ok, "MODE #test b\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE #test b\r\n"), 1_000)
@@ -10247,7 +10247,7 @@ defmodule Grappa.Session.ServerTest do
       assert {:error, :no_session} = Session.send_ban({:user, uid}, 9_999, "#x", "a")
       assert {:error, :no_session} = Session.send_unban({:user, uid}, 9_999, "#x", "*!*@h")
       assert {:error, :no_session} = Session.send_invite({:user, uid}, 9_999, "#x", "a")
-      assert {:error, :no_session} = Session.send_banlist({:user, uid}, 9_999, "#x", nil)
+      assert {:error, :no_session} = Session.send_list_mode({:user, uid}, 9_999, "#x", "b", nil)
       assert {:error, :no_session} = Session.send_umode({:user, uid}, 9_999, "+i")
       assert {:error, :no_session} = Session.send_mode({:user, uid}, 9_999, "#x", "+m", [])
       assert {:error, :no_session} = Session.send_whois({:user, uid}, 9_999, "alice", nil, :user, nil)
@@ -10804,8 +10804,8 @@ defmodule Grappa.Session.ServerTest do
          } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      # Operator issues /banlist #test — primes banlist_pending["#test"].
-      assert :ok = Grappa.Session.send_banlist({:user, user.id}, network.id, "#test", nil)
+      # Operator issues /banlist #test — primes list_mode_pending[{"#test", "b"}].
+      assert :ok = Grappa.Session.send_list_mode({:user, user.id}, network.id, "#test", "b", nil)
 
       # Bahamut emits the ban list: 367 rows then 368 terminator.
       IRCServer.feed(
@@ -10831,6 +10831,7 @@ defmodule Grappa.Session.ServerTest do
 
       assert ev.network == network.slug
       assert ev.channel == "#test"
+      assert ev.mode == "b"
       assert length(ev.entries) == 2
 
       # Wire order preserved; first ban carries mask/setter/set_ts (NOT a
@@ -10842,6 +10843,81 @@ defmodule Grappa.Session.ServerTest do
              }
 
       assert Enum.at(ev.entries, 1)[:mask] == "evil!*@spam.net"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1251 — the SAME path for a list that is not `b`, end to end: the 005
+    # gate opens `z`, the query reaches the wire as `MODE #test z`, and the
+    # 728/729 burst (bahamut's restrict list, letter ON the wire) drains into
+    # a bundle tagged `z`.
+    test "#1251 /banlist z on a bz network: MODE #test z upstream, 728/729 burst → mode z bundle",
+         %{server: server, user: user, network: network, pid: pid} do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 005 grappa-test CHANMODES=bz,k,l,imnpst :are supported\r\n"
+      )
+
+      # Barrier: the gate below reads state.isupport, so the 005 must be
+      # APPLIED before the query — a GenServer call serialises behind it.
+      assert {:ok, isupport} = Grappa.Session.get_isupport({:user, user.id}, network.id)
+      assert "z" in isupport.chanmodes.a
+
+      assert :ok = Grappa.Session.send_list_mode({:user, user.id}, network.id, "#test", "z", nil)
+
+      assert {:ok, "MODE #test z\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "MODE #test z\r\n"), 1_000)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 728 grappa-test #test z *!*@rogue.host op!u@h 1784572878\r\n"
+      )
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 729 grappa-test #test z :End of Channel Restrict List\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :banlist_bundle} = ev
+                     },
+                     1_500
+
+      assert ev.mode == "z"
+      assert ev.channel == "#test"
+      assert ev.entries == [%{mask: "*!*@rogue.host", setter: "op!u@h", set_ts: "1784572878"}]
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1251 — the quiet-degradation gate. `e` is a real list mode on OTHER
+    # ircds, so the refusal must come from THIS network's 005, not from a
+    # global allowlist — and nothing may reach the wire, because a query
+    # whose replies this ircd never sends would never terminate.
+    test "#1251 a letter this network does not advertise is refused, and never reaches the wire",
+         %{server: server, user: user, network: network, pid: pid} do
+      IRCServer.feed(
+        server,
+        ":irc.test.org 005 grappa-test CHANMODES=bz,k,l,imnpst :are supported\r\n"
+      )
+
+      assert {:ok, isupport} = Grappa.Session.get_isupport({:user, user.id}, network.id)
+      refute "e" in isupport.chanmodes.a
+
+      assert {:error, :unsupported_list_mode} =
+               Grappa.Session.send_list_mode({:user, user.id}, network.id, "#test", "e", nil)
+
+      # A `b` query DOES reach the wire right after, which is what makes the
+      # absence above a refusal rather than a dead socket.
+      assert :ok = Grappa.Session.send_list_mode({:user, user.id}, network.id, "#test", "b", nil)
+
+      assert {:ok, line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "MODE #test "), 1_000)
+
+      assert line == "MODE #test b\r\n"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -10860,8 +10860,17 @@ defmodule Grappa.Session.ServerTest do
         ":irc.test.org 005 grappa-test CHANMODES=bz,k,l,imnpst :are supported\r\n"
       )
 
-      # Barrier: the gate below reads state.isupport, so the 005 must be
-      # APPLIED before the query — a GenServer call serialises behind it.
+      # Barrier: `feed` only puts bytes on the socket, and the gate below
+      # reads `state.isupport` — so wait for the broadcast the merge emits
+      # before asking. Without it the query races the 005 and the session
+      # still holds the pre-005 seed (which HAS `e`, so the test would fail
+      # by reporting the opposite of what it measures).
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :isupport_changed}
+                     },
+                     1_500
+
       assert {:ok, isupport} = Grappa.Session.get_isupport({:user, user.id}, network.id)
       assert "z" in isupport.chanmodes.a
 
@@ -10899,10 +10908,21 @@ defmodule Grappa.Session.ServerTest do
     # whose replies this ircd never sends would never terminate.
     test "#1251 a letter this network does not advertise is refused, and never reaches the wire",
          %{server: server, user: user, network: network, pid: pid} do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
       IRCServer.feed(
         server,
         ":irc.test.org 005 grappa-test CHANMODES=bz,k,l,imnpst :are supported\r\n"
       )
+
+      # Same barrier as the sibling above — and here it is load-bearing for
+      # the MEANING of the test: the pre-005 seed advertises `e`, so a raced
+      # read would assert against a table that has not been narrowed yet.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :isupport_changed}
+                     },
+                     1_500
 
       assert {:ok, isupport} = Grappa.Session.get_isupport({:user, user.id}, network.id)
       refute "e" in isupport.chanmodes.a

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -89,6 +89,20 @@ defmodule Grappa.Session.WireTest do
       assert payload.prefix == %{"o" => "@", "h" => "%", "v" => "+"}
     end
 
+    # #1251 — the queryable set is PUBLISHED, not left for the client to
+    # derive: it is `chanmodes_a` minus the letters grappa knows no reply
+    # numerics for. The difference between the two lists is the quiet
+    # degradation a client must be able to see.
+    test "publishes list_modes_queryable — advertised type-A minus the unknown letters" do
+      isupport =
+        ISupport.merge_isupport(["CHANMODES=bzX,k,l,imnpst"], ISupport.default())
+
+      payload = Wire.isupport_changed(7, isupport, 512)
+
+      assert payload.chanmodes_a == ["X", "b", "z"]
+      assert payload.list_modes_queryable == ["b", "z"]
+    end
+
     # #1108 — the builder takes LINELEN and publishes the BUDGET, and the
     # number is checked the way a CLIENT will spend it: subtract the target's
     # bytes, fill a body with that many, and the worst-case relayed frame
@@ -921,7 +935,7 @@ defmodule Grappa.Session.WireTest do
   # entry) the banlist ships ALL entries — a channel's ban list is a set
   # of rows. EventRouter stores entries reversed (O(1) prepend); the wire
   # builder restores wire order.
-  describe "banlist_bundle/3" do
+  describe "banlist_bundle/4" do
     test "ships all entries in wire order with mask/setter/set_ts" do
       # EventRouter prepends (head = most recent 367); wire builder reverses.
       accum = %{
@@ -932,12 +946,13 @@ defmodule Grappa.Session.WireTest do
         ]
       }
 
-      payload = Wire.banlist_bundle("azzurra", "#Test", accum)
+      payload = Wire.banlist_bundle("azzurra", "#Test", "b", accum)
 
       assert payload == %{
                kind: :banlist_bundle,
                network: "azzurra",
                channel: "#Test",
+               mode: "b",
                entries: [
                  %{mask: "a!*@1", setter: "op1", set_ts: "111"},
                  %{mask: "b!*@2", setter: "op2", set_ts: "222"}
@@ -946,19 +961,31 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "empty entries → empty list (channel with no bans)" do
-      payload = Wire.banlist_bundle("net", "#empty", %{channel_display: "#empty", entries: []})
+      payload = Wire.banlist_bundle("net", "#empty", "b", %{channel_display: "#empty", entries: []})
 
       assert payload == %{
                kind: :banlist_bundle,
                network: "net",
                channel: "#empty",
+               mode: "b",
                entries: []
              }
     end
 
+    # #1251 — the kind stays `banlist_bundle` (additive-only wire, GH #447);
+    # `mode` is what tells the client WHICH list it got. A bundle that
+    # dropped it would render solanum's quiet list as a ban list.
+    test "carries the queried mode letter verbatim (not always b)" do
+      accum = %{channel_display: "#c", entries: [%{mask: "*!*@muted", setter: "op", set_ts: "1"}]}
+
+      assert Wire.banlist_bundle("libera", "#c", "q", accum).mode == "q"
+      assert Wire.banlist_bundle("azzurra", "#c", "z", accum).mode == "z"
+      assert Wire.banlist_bundle("libera", "#c", "I", accum).mode == "I"
+    end
+
     test "entry with nil setter/set_ts (older ircd) round-trips nils" do
       accum = %{channel_display: "#c", entries: [%{mask: "*!*@h", setter: nil, set_ts: nil}]}
-      payload = Wire.banlist_bundle("net", "#c", accum)
+      payload = Wire.banlist_bundle("net", "#c", "b", accum)
 
       assert payload.entries == [%{mask: "*!*@h", setter: nil, set_ts: nil}]
     end
@@ -1031,7 +1058,7 @@ defmodule Grappa.Session.WireTest do
         Wire.lusers_bundle("net", %{}),
         Wire.whowas_bundle("net", "alice", %{}),
         Wire.whowas_bundle("net", "ghost", %{not_found: true}),
-        Wire.banlist_bundle("net", "#c", %{channel_display: "#c", entries: []}),
+        Wire.banlist_bundle("net", "#c", "b", %{channel_display: "#c", entries: []}),
         Wire.links_bundle("net", %{entries: []}),
         Wire.connection_progress("net", :connecting),
         Wire.connection_progress("net", :connected)

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1424,6 +1424,42 @@ defmodule GrappaWeb.GrappaChannelTest do
       {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "MODE #snap b\r\n"), 1_000)
     end
 
+    # #1251 — the `mode` field is OPTIONAL and additive: absent means `b`
+    # (asserted above, the pre-#1251 client's frame), present means that
+    # letter. `e` is in the pre-005 default type-A seed, so this session
+    # accepts it without a 005.
+    test "banlist: an explicit mode queries THAT list, not the ban list", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref =
+        push(socket, "banlist", %{
+          "network_id" => network.id,
+          "channel" => "#snap",
+          "mode" => "e"
+        })
+
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "MODE #snap e\r\n"), 1_000)
+    end
+
+    # #1251 — SHAPE gate at the web edge: a mode value that is not one ASCII
+    # letter is refused before it can forge MODE arguments upstream.
+    test "banlist: a multi-token mode is rejected with invalid_line", %{
+      socket: socket,
+      network: network
+    } do
+      ref =
+        push(socket, "banlist", %{
+          "network_id" => network.id,
+          "channel" => "#snap",
+          "mode" => "b *!*@forged"
+        })
+
+      assert_reply(ref, :error, %{error: "invalid_line"})
+    end
+
     # #386 — resolve_userhost: on-demand per-nick userhost lookup, the surgical
     # host source the /kb + BanlistModal mask builder consume (cic has no
     # per-member host client-side). Read-only query over Session.lookup_userhost/3.


### PR DESCRIPTION
Only `+b` was reachable. `/banlist` had a complete path — verb, accumulator,
367/368 clauses, modal — and every other type-A channel mode had none of it:
`346/347/348/349/728/729` appeared nowhere in `lib/`. Per the ruling on the
issue this generalises the path rather than adding two letters:

* the query is driven by `ISupport.chanmodes.a` (per-network 005 data),
* the accumulator keys on `{channel, mode}` instead of on channel alone,
* `Grappa.Session.ListModes` holds the numeric-pair table,
* `isupport_changed` publishes `list_modes_queryable` — cic renders exactly
  that set and never derives its own.

Both ircds were read before a line was written, and the issue's own table
turned out to be half right: bahamut (`s_err.c`) and solanum
(`include/messages.h`) both define 728, and they hardcode a DIFFERENT letter
into the format string — `z` (restrict) against `q` (quiet). So `z → 728/729`
is a bahamut fact, not a protocol fact, and the letter is read OFF THE WIRE
for that pair. A hardcoded `z` would have dropped every quiet row on solanum
while looking like a working feature on Azzurra.

The wire kind stays `banlist_bundle` and the `banlist` verb keeps its name:
both gained an additive `mode`, and renaming would be a REMOVAL the wire
contract does not allow. Editing stays `+b`-only on purpose — the other
lists are a viewer and say so.

## Evidence

* `scripts/check.sh` rc=0 — 8 doctests, 59 properties, 5965 tests, 0 failures.
* cic `bun run check` rc=0; `bun run test` 5320/5320.
* e2e `issue1251-list-modes.spec.ts`: 1 passed, then 3/3 under `--repeat-each 3`.
* Mutation-proved, four mutants, each killing a distinct assertion:
  * removing the 005 gate kills only the refusal spec (`unsupported_list_mode`);
  * hardcoding the bundle letter back to `b` kills the `WireTest` pin AND the
    server `z` spec — and, run against the live stack, kills the e2e on the
    restrict mask;
  * removing the `isupport_changed` barrier kills the refusal spec on a
    different assertion (`refute "e" in chanmodes.a`, which then reads the
    pre-005 seed) — the barrier is load-bearing, not decoration.

The e2e's first run was RED and the ircd was right. Its barrier was a joined
peer waiting for the `MODE +z` echo, the shape that works for `+b`. bahamut
writes `b` into both `mbuf` and `stripped_mbuf` but writes case 'z' into
`mbuf` alone, so the echo is routed to chanops only: the restrict list is
op-private on the write side as well as the read side, and a non-op peer
waits forever. The barrier is now the MODE echo as a persisted scrollback
row, which the bouncer (holding op) does see. Nothing in the product was at
fault; details in the decision-log entry.

## Not claimed

The full `scripts/integration.sh` suite has not been run locally — only the
`#1251` spec, scoped. The whole-suite verdict is CI's.