### PR TITLE
uploads: declare the charset of uploaded text instead of guessing it (#1256)

### DIFF
--- a/cicchetto/e2e/tests/issue1256-upload-charset.spec.ts
+++ b/cicchetto/e2e/tests/issue1256-upload-charset.spec.ts
@@ -1,0 +1,125 @@
+// #1256 — an uploaded UTF-8 paste must RENDER as the text that was
+// pasted, not as mojibake.
+//
+// `GET /uploads/:slug` used to serve `text/plain` with no charset, so a
+// browser had no declared encoding and fell back to its locale default
+// (windows-1252 in a Western locale): `è` painted as `Ã¨`, `—` as
+// `â€”`. The bytes on disk were always fine — the DECLARATION was
+// missing, and it could not get in either, because the upload
+// allowlist matched the client-declared content type by whole-string
+// equality. A client labelling its encoding honestly
+// (`text/plain; charset=utf-8`) was the one earning a 415.
+//
+// The fix is two-sided and this spec is the only gate that sees both
+// halves at once: cic labels the File it builds from a JS string
+// (pasteRoute.ts — UTF-8 by File-constructor spec, a fact and not a
+// guess), and the server splits the parameter off the type before
+// matching its allowlist, persists the charset in a closed set, and
+// rebuilds the response header from it (Grappa.Uploads.ContentType).
+//
+// The oracle is deliberately the RENDERED text, read out of a real
+// navigation to the upload URL — the response header is asserted too,
+// but a header assertion alone would not prove the browser stopped
+// guessing. Server-side unit coverage (uploads_controller_test.exs)
+// pins the header matrix; vitest pins the File's label; only a real
+// browser can show the accents surviving the trip.
+
+import type { Page } from "@playwright/test";
+import {
+  composeTextarea,
+  confirmModal,
+  confirmModalYes,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Every line carries bytes that differ between UTF-8 and windows-1252:
+// accented vowels (2 bytes) and an em dash (3 bytes). Six lines — one
+// past the paste hard cap of five — so the guard's affirmative IS the
+// upload door (#816).
+const LINES = 6;
+const accentedBlock = (tag: string): string =>
+  Array.from(
+    { length: LINES },
+    (_, i) => `${tag} riga ${i} — perché è così, più o meno: àèìòù`,
+  ).join("\n");
+
+// Same paste driver as issue80-paste-flood-guard: a real ClipboardEvent
+// with a real DataTransfer, so the production onPaste handler runs.
+async function pasteText(page: Page, text: string): Promise<void> {
+  await composeTextarea(page).evaluate((el, t) => {
+    const dt = new DataTransfer();
+    dt.setData("text/plain", t);
+    el.dispatchEvent(
+      new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+    );
+  }, text);
+}
+
+test("#1256 — a pasted UTF-8 block uploads labelled and renders with its accents intact", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "shares the upload plumbing the uploads specs gate to chromium",
+  );
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // Pre-ack the embedded-host privacy modal so the upload runs
+  // unattended (that flow is covered by ux-6-b-embedded-upload).
+  await page.evaluate(() =>
+    localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
+  );
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+
+  const tag = crypto.randomUUID().slice(0, 8);
+  const block = accentedBlock(tag);
+
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+
+  // Over the cap the upload IS the affirmative. Race the click against
+  // the POST so the 201 is pinned before we chase the served bytes.
+  const [uploadRes] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes("/api/uploads") && r.request().method() === "POST",
+      { timeout: 20_000 },
+    ),
+    confirmModalYes(page),
+  ]);
+
+  // Pre-fix this is a 415: the labelled File was refused at the door.
+  expect(uploadRes.status()).toBe(201);
+  const { url } = (await uploadRes.json()) as { slug: string; url: string };
+
+  // Navigate the way a recipient clicking the link does. Path-only, so
+  // the assertion does not depend on Endpoint.url() matching the
+  // browser's origin in this stack.
+  const path = new URL(url).pathname;
+  const served = await page.goto(path);
+
+  expect(served?.status()).toBe(200);
+  expect(served?.headers()["content-type"]).toBe("text/plain; charset=utf-8");
+
+  // The visible outcome. Unlabelled, this body reads `perchÃ©` /
+  // `Ã¨` / `â€”` in a Western-locale browser.
+  const rendered = await page.locator("body").innerText();
+  expect(rendered).toContain("perché è così, più o meno: àèìòù");
+  expect(rendered).toContain("—");
+  expect(rendered).toContain(`${tag} riga ${LINES - 1}`);
+  // Negative control: no windows-1252 misread survived anywhere in the
+  // document. `Ã` cannot occur in the pasted text, so its presence
+  // means exactly one thing.
+  expect(rendered).not.toContain("Ã");
+});

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1644,7 +1644,8 @@ describe("ComposeBox", () => {
         expect(orch.triggerUploads).toHaveBeenCalledTimes(1);
         const files = vi.mocked(orch.triggerUploads).mock.calls[0]?.[3] as File[];
         expect(files).toHaveLength(1);
-        expect(files[0]?.type).toBe("text/plain");
+        // #1256 — the File declares the encoding it is built with.
+        expect(files[0]?.type).toBe("text/plain; charset=utf-8");
         // The bytes are the paste itself — an upload that dropped or mangled
         // the text would still satisfy "a file was uploaded".
         await expect(files[0]?.text()).resolves.toBe(FOUR_LINES);
@@ -1708,7 +1709,8 @@ describe("ComposeBox", () => {
         expect(orch.triggerUploads).toHaveBeenCalledTimes(1);
         const files = vi.mocked(orch.triggerUploads).mock.calls[0]?.[3] as File[];
         expect(files).toHaveLength(1);
-        expect(files[0]?.type).toBe("text/plain");
+        // #1256 — the File declares the encoding it is built with.
+        expect(files[0]?.type).toBe("text/plain; charset=utf-8");
         // The bytes are the paste itself — an upload that dropped or mangled
         // the text would still satisfy "a file was uploaded".
         await expect(files[0]?.text()).resolves.toBe(OVER_CAP);

--- a/cicchetto/src/__tests__/pasteRoute.test.ts
+++ b/cicchetto/src/__tests__/pasteRoute.test.ts
@@ -30,7 +30,12 @@ vi.mock("../lib/dropUpload", () => ({
 import { setDraft } from "../lib/compose";
 import { requestConfirm } from "../lib/confirmDialog";
 import { dropUpload } from "../lib/dropUpload";
-import { routeClipboardPaste, routePastedInput } from "../lib/pasteRoute";
+import {
+  PASTE_UPLOAD_FILENAME,
+  routeClipboardPaste,
+  routePastedInput,
+  uploadPastedText,
+} from "../lib/pasteRoute";
 
 type ClipItem = { kind: string; type: string; getAsFile: () => File | null };
 
@@ -315,5 +320,29 @@ describe("pasteRoute — one gesture cannot ask twice (#1250)", () => {
     expect(setDraft).not.toHaveBeenCalled();
     expect(pastePrevented).not.toHaveBeenCalled();
     expect(inputPrevented).not.toHaveBeenCalled();
+  });
+});
+
+// #1256 — the paste-as-.txt File must DECLARE utf-8. The bytes are ours
+// (File encodes a USVString part as UTF-8 by spec), and a server that
+// stores no charset serves no charset, which a Western-locale browser
+// then decodes as windows-1252 — every accent becomes mojibake.
+describe("uploadPastedText — the File declares its encoding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hands dropUpload a text/plain File labelled utf-8", async () => {
+    uploadPastedText("perché è così", "freenode", "#a");
+
+    expect(dropUpload).toHaveBeenCalledTimes(1);
+    const [[files, slug, channel]] = vi.mocked(dropUpload).mock.calls;
+    expect(slug).toBe("freenode");
+    expect(channel).toBe("#a");
+    const file = files?.[0] as File;
+    expect(file.name).toBe(PASTE_UPLOAD_FILENAME);
+    expect(file.type).toBe("text/plain; charset=utf-8");
+    // And the label is true: the bytes really are UTF-8.
+    expect(await file.text()).toBe("perché è così");
   });
 });

--- a/cicchetto/src/__tests__/pasteRoute.test.ts
+++ b/cicchetto/src/__tests__/pasteRoute.test.ts
@@ -336,7 +336,7 @@ describe("uploadPastedText — the File declares its encoding", () => {
     uploadPastedText("perché è così", "freenode", "#a");
 
     expect(dropUpload).toHaveBeenCalledTimes(1);
-    const [[files, slug, channel]] = vi.mocked(dropUpload).mock.calls;
+    const [files, slug, channel] = vi.mocked(dropUpload).mock.calls[0] ?? [];
     expect(slug).toBe("freenode");
     expect(channel).toBe("#a");
     const file = files?.[0] as File;

--- a/cicchetto/src/lib/__tests__/uploadCategory.test.ts
+++ b/cicchetto/src/lib/__tests__/uploadCategory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  baseMime,
   categoryOf,
   DOCUMENT_MIMES_OFFICE,
   DOCUMENT_MIMES_PORTABLE,
@@ -35,7 +36,17 @@ describe("categoryOf — full MIME matrix", () => {
 // constructor encodes as UTF-8 by spec). An exact-string gate dropped
 // exactly that correctly-labelled File, client-side, before it could
 // reach the upload — the mirror of the server's 415.
-describe("categoryOf — parameter tolerance", () => {
+describe("baseMime — parameter tolerance", () => {
+  it.each([
+    ["text/plain", "text/plain"],
+    ["text/plain; charset=utf-8", "text/plain"],
+    ["text/plain;charset=utf-8", "text/plain"],
+    [" TEXT/Plain ; Charset=UTF-8", "text/plain"],
+    ["", ""],
+  ])("%j → %j", (mime, expected) => {
+    expect(baseMime(mime)).toBe(expected);
+  });
+
   it("a labelled paste File still categorises as a document", () => {
     expect(categoryOf("text/plain; charset=utf-8")).toBe("document");
   });

--- a/cicchetto/src/lib/__tests__/uploadCategory.test.ts
+++ b/cicchetto/src/lib/__tests__/uploadCategory.test.ts
@@ -30,6 +30,21 @@ describe("categoryOf — full MIME matrix", () => {
   });
 });
 
+// #1256 — a File may carry a charset the sender knows for certain (the
+// paste-as-.txt path builds its File from a JS string, which the File
+// constructor encodes as UTF-8 by spec). An exact-string gate dropped
+// exactly that correctly-labelled File, client-side, before it could
+// reach the upload — the mirror of the server's 415.
+describe("categoryOf — parameter tolerance", () => {
+  it("a labelled paste File still categorises as a document", () => {
+    expect(categoryOf("text/plain; charset=utf-8")).toBe("document");
+  });
+
+  it("a parameter cannot smuggle an unlisted type past the gate", () => {
+    expect(categoryOf("text/html; charset=utf-8")).toBeNull();
+  });
+});
+
 describe("categoryOf — boundary rejection", () => {
   it.each([
     "image/svg+xml",

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -78,8 +78,18 @@ export function insertPastedText(
 export const PASTE_UPLOAD_FILENAME = "paste.txt";
 export const PASTE_UPLOAD_LABEL = "Upload as .txt";
 
+// #1256 — declare the encoding. `text` is a JS string and the File
+// constructor encodes USVString parts as UTF-8 by specification, so this
+// is a fact about the bytes, not a guess: these bytes are OURS. Without
+// the label the server stores a bare `text/plain` and serves it
+// unlabelled, and a Western-locale browser paints every accented
+// character as mojibake. The server splits the parameter off the type
+// before matching its allowlist (Grappa.Uploads.ContentType) and
+// re-emits the charset on GET.
 export function uploadPastedText(text: string, networkSlug: string, channelName: string): void {
-  const file = new File([text], PASTE_UPLOAD_FILENAME, { type: "text/plain" });
+  const file = new File([text], PASTE_UPLOAD_FILENAME, {
+    type: "text/plain; charset=utf-8",
+  });
   dropUpload([file], networkSlug, channelName);
 }
 

--- a/cicchetto/src/lib/uploadCategory.ts
+++ b/cicchetto/src/lib/uploadCategory.ts
@@ -58,9 +58,23 @@ const MIME_CATEGORIES: Record<string, UploadCategory> = Object.fromEntries([
   ...AUDIO_MIMES.map((m) => [m, "audio"] as const),
 ]);
 
-/** Single MIME→category map. null = not uploadable, reject at boundary. */
+/**
+ * Strip the parameter run off a content type, leaving `type/subtype`
+ * lowercased — the form every gate and accept-list in cic compares
+ * against. Mirrors the server's `Grappa.Uploads.ContentType.parse/1`
+ * (#1256): a File may legitimately carry `text/plain; charset=utf-8`
+ * (the paste-as-.txt path knows its encoding for certain), and an
+ * exact-string gate would drop it before it ever reached the upload.
+ */
+export function baseMime(mime: string): string {
+  return (mime.split(";")[0] ?? "").trim().toLowerCase();
+}
+
+/** Single MIME→category map. null = not uploadable, reject at boundary.
+ *  Parameter-tolerant: the category is a property of the type, not of
+ *  the charset the client declared alongside it. */
 export function categoryOf(mime: string): UploadCategory | null {
-  return MIME_CATEGORIES[mime] ?? null;
+  return MIME_CATEGORIES[baseMime(mime)] ?? null;
 }
 
 // Audio extension → canonical MIME — 1:1 mirror of the server's

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -3,6 +3,7 @@ import type { ChannelKey } from "./channelKey";
 import { formatBytes } from "./formatBytes";
 import { sendMessage } from "./scrollback";
 import {
+  baseMime,
   categoryOf,
   mimeExtLabel,
   normalizeUploadFile,
@@ -363,8 +364,11 @@ async function dispatchUpload(
   // box shows, and a new selection always replaces a rejected one.
   lastAttempt.set(key, { file, networkSlug, channelName });
 
-  const category = categoryOf(file.type);
-  if (category === null || !host.acceptedMimeTypes[category].includes(file.type)) {
+  // #1256: gate on the TYPE. `file.type` may carry a charset the paste
+  // path declares truthfully, and the host accept-lists are bare types.
+  const mime = baseMime(file.type);
+  const category = categoryOf(mime);
+  if (category === null || !host.acceptedMimeTypes[category].includes(mime)) {
     setEntry(key, {
       filename: file.name,
       loaded: 0,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40289,3 +40289,74 @@ a modal that keeps saying "Loading". Pre-#1251 this could not happen, because
 both ircds let anyone read the ban list; it becomes reachable exactly because
 the other lists are now reachable. A server-side watchdog that flushed a
 `timed_out` bundle is the obvious cure and is deliberately not in this change.
+
+---
+
+## 2026-08-13 — #1256: the label follows what the uploader declared, never what we assume
+
+`GET /uploads/:slug` served `text/plain` with no charset, so a browser had no
+declared encoding and fell back to its locale default — windows-1252 in a
+Western locale. Every accented paste rendered as mojibake: `è` as `Ã¨`, `—` as
+`â€”`. The bytes on disk were always valid UTF-8; `curl` proved it. Only the
+declaration was missing.
+
+**The charset could not get in either, and that is the more interesting half.**
+`validate_mime/1` matched the whole client-declared content type against the
+closed MIME allowlist with `Map.fetch`, which quietly made that allowlist a
+closed *parameter* allowlist too. `text/plain; charset=utf-8` missed, fell into
+the audio extension rescue, and came back 415. The client labelling its
+encoding honestly was the one being refused, and the one saying nothing was
+stored unlabelled — the failure was symmetric and the correct behaviour was
+unreachable from either side.
+
+**Two directions were on the table; vjt picked the one that never guesses.**
+Sniffing the bytes for UTF-8 validity at upload time would have worked for the
+reported case and broken its mirror: a genuinely Latin-1 `.txt` uploaded by
+hand renders correctly *today* precisely because nothing is declared, and most
+short Latin-1 files also happen to be valid UTF-8. The alternative labels only
+where the bytes are ours. `cicchetto/src/lib/pasteRoute.ts` builds its paste
+File from a JS string, and the File constructor encodes a USVString part as
+UTF-8 **by specification** — so for the path that produces this bug the charset
+is a fact, not an estimate. The rule that falls out generalises past the paste
+path: the label follows what the uploader declared, never what we assume.
+
+**The parse and the emit had to move together, and the emit is the security
+half.** Accepting parameters turns `row.mime` into client-controlled text one
+hop from a response header, and the `x-content-type-options: nosniff` at
+`show/2` only pins the browser to whatever *we* declare — so storing the raw
+parameter run would have traded mojibake for content-type confusion and
+undercut the exact protection that makes serving user bytes inline defensible.
+`Grappa.Uploads.ContentType.parse/1` therefore reduces the declared charset to
+an ATOM from a closed set and `header/2` re-spells it from a canonical map:
+there is no path by which a byte the client wrote reaches the header. The
+column is an `Ecto.Enum` fed from that same map, so a charset the header
+builder cannot spell cannot be persisted in the first place.
+
+**An unrecognised charset is DROPPED, not rejected.** `charset=iso-8859-1`
+still lands a 201 and is served unlabelled — which is both the pre-#1256
+behaviour and the correct one, since unlabelled is what the browser's locale
+default already handles. Refusing it would have regressed the mirror-image case
+into a 415 to protect it from a display bug. A charset is read only off a
+`text/*` type, derived from the type rather than kept as a second allowlist
+beside `@mime_categories`, because a second list is a second thing to drift.
+
+**The column is nullable with no backfill.** NULL is not missing data here: it
+is the truthful record that those clients declared nothing. Stamping `utf-8`
+across the existing rows would have been the sniffing direction wearing a
+migration's clothes.
+
+**cic could not simply start labelling.** `categoryOf` was an exact-string gate
+mirroring the server's, so the moment the paste File carried
+`type: "text/plain; charset=utf-8"` it would have been dropped *client-side*,
+before it could even earn the 415 — the same bug, one layer earlier. `baseMime`
+makes the gates parameter-tolerant: the category is a property of the type, not
+of the charset declared alongside it.
+
+**The oracle is the rendered text.** A header assertion proves what the server
+said, not that the browser stopped guessing, so the e2e navigates to the upload
+URL for real and reads the accents back out of the document, with `Ã` as a
+negative control — a byte that cannot occur in the pasted text and appears only
+under a windows-1252 misread. Server-side, the red was measured before the fix
+existed: five of the six new controller assertions failed with
+`unsupported_media_type`, and the sixth — the mirror-image guard — passed, as
+it had to.

--- a/lib/grappa/uploads.ex
+++ b/lib/grappa/uploads.ex
@@ -20,7 +20,8 @@ defmodule Grappa.Uploads do
     * `create/3` — accepts `{file_bytes, attrs, opts}`, strips
       image/video metadata (`MetadataStrip` — fail-closed, #39),
       writes to disk, inserts row. `attrs` carries the subject (XOR
-      user/visitor FK), `mime`, optional `original_filename`,
+      user/visitor FK), `mime`, optional `charset`, optional
+      `original_filename`,
       optional `expires_at`. `opts` carries `:storage_root` (DI for
       tests) + the random-slug + clock injection seams.
     * `get_by_slug/1` — slug → `{:ok, %Upload{}} | {:error, :not_found}`.
@@ -79,7 +80,7 @@ defmodule Grappa.Uploads do
   import Ecto.Query
 
   alias Grappa.{Repo, Subject}
-  alias Grappa.Uploads.{MetadataStrip, Upload}
+  alias Grappa.Uploads.{ContentType, MetadataStrip, Upload}
 
   @slug_byte_size 16
   @slug_regex ~r/\A[a-z2-7]{26}\z/
@@ -111,6 +112,7 @@ defmodule Grappa.Uploads do
   @type create_attrs :: %{
           required(:subject) => Subject.t(),
           required(:mime) => String.t(),
+          optional(:charset) => ContentType.charset() | nil,
           optional(:bytes) => non_neg_integer(),
           optional(:original_filename) => String.t() | nil,
           optional(:expires_at) => DateTime.t() | nil
@@ -151,6 +153,24 @@ defmodule Grappa.Uploads do
   """
   @spec ext_for(term()) :: {:ok, String.t()} | :error
   defdelegate ext_for(mime), to: __MODULE__.MimeExt
+
+  @doc """
+  Split a client-declared content type into `{mime, charset}`, the
+  charset reduced to a closed set of atoms (`nil` when absent or
+  unrecognised). The upload boundary matches `mime` against its
+  allowlist and persists `charset` beside it. Single source of truth:
+  `Grappa.Uploads.ContentType`.
+  """
+  @spec parse_content_type(String.t()) :: {String.t(), ContentType.charset() | nil}
+  defdelegate parse_content_type(raw), to: __MODULE__.ContentType, as: :parse
+
+  @doc """
+  Rebuild a `content-type` header value from a stored `{mime, charset}`
+  pair, re-spelling the charset canonically. The client's own parameter
+  run is never stored and never echoed (#1256).
+  """
+  @spec content_type_header(String.t(), ContentType.charset() | nil) :: String.t()
+  defdelegate content_type_header(mime, charset), to: __MODULE__.ContentType, as: :header
 
   @doc """
   Compose the on-disk path for a slug. Validates the slug shape at

--- a/lib/grappa/uploads/content_type.ex
+++ b/lib/grappa/uploads/content_type.ex
@@ -1,0 +1,105 @@
+defmodule Grappa.Uploads.ContentType do
+  @moduledoc """
+  Content-Type parsing + rebuilding for uploads (GH #1256).
+
+  ## Why this exists
+
+  `GET /uploads/:slug` echoed the stored MIME verbatim, and the stored
+  MIME was a bare `text/plain` — no `charset`. A browser given
+  unlabelled text falls back to its locale default (windows-1252 in
+  Western locales), so a UTF-8 paste rendered as mojibake even though
+  the bytes on disk were fine.
+
+  The charset could not get in either: the upload allowlist matched the
+  client-declared type by whole-string equality, which made a closed
+  MIME allowlist accidentally a closed *parameter* allowlist. A client
+  labelling its encoding correctly (`text/plain; charset=utf-8`) was
+  exactly the one getting 415.
+
+  ## The shape
+
+  `parse/1` splits `type/subtype` from the parameter run so the caller
+  can match the type against its allowlist, and returns the charset as
+  an ATOM from a closed set — never the client's string.
+  `header/2` rebuilds the response header from that atom.
+
+  That asymmetry is the security property. Once parameters are
+  accepted, the raw parameter run is client-controlled text on its way
+  into a response header, and `x-content-type-options: nosniff`
+  (`UploadsController.show/2`) only pins the browser to whatever we
+  declare. So the parameter run is never stored and never echoed: an
+  unrecognised charset is DROPPED and the upload is still accepted,
+  which also leaves the mirror-image case intact — a genuinely Latin-1
+  `.txt` uploaded by hand stays unlabelled and keeps rendering under
+  the browser's locale default, as it did before #1256.
+
+  A charset is only meaningful for text, so it is read only off a
+  `text/*` type. That is derived from the type itself rather than kept
+  as a second allowlist beside `@mime_categories`.
+  """
+
+  @typedoc "The closed set of charsets grappa will label bytes with."
+  @type charset :: :utf8
+
+  # charset atom → the ONLY spelling that may reach a response header.
+  @wire %{utf8: "utf-8"}
+
+  # Accepted client spellings → charset atom. Compared after trimming,
+  # unquoting and ASCII-downcasing (RFC 2045: parameter names and the
+  # charset value are case-insensitive, values may be quoted strings).
+  # `utf8` is not the registered name but is a common client spelling,
+  # and a client that sends it means the same thing — accepting it
+  # costs nothing, because the OUTPUT is rebuilt from `@wire` either
+  # way.
+  @accepted %{"utf-8" => :utf8, "utf8" => :utf8}
+
+  @doc """
+  Split a client-declared content type into its `type/subtype` and the
+  charset it declared, if that charset is one grappa will label bytes
+  with. Total: an absent, malformed or unrecognised parameter run
+  yields `nil`, never an error.
+  """
+  @spec parse(String.t()) :: {String.t(), charset() | nil}
+  def parse(raw) when is_binary(raw) do
+    [type | params] = String.split(raw, ";")
+    mime = normalise(type)
+    {mime, charset_of(mime, params)}
+  end
+
+  @doc """
+  Rebuild a `content-type` header value from a stored MIME and a
+  stored charset. The charset is re-spelled from `@wire`, so no
+  client-supplied byte can reach the header through this function.
+  """
+  @spec header(String.t(), charset() | nil) :: String.t()
+  def header(mime, nil) when is_binary(mime), do: mime
+
+  def header(mime, charset) when is_binary(mime) and is_map_key(@wire, charset),
+    do: mime <> "; charset=" <> Map.fetch!(@wire, charset)
+
+  @doc """
+  The charset atoms this module can store and re-emit. Feeds the
+  `Ecto.Enum` on `Grappa.Uploads.Upload.charset`, so the column and
+  the header builder cannot drift apart.
+  """
+  @spec charsets() :: [charset()]
+  def charsets, do: Map.keys(@wire)
+
+  defp charset_of("text/" <> _, params), do: Enum.find_value(params, &charset_param/1)
+  defp charset_of(_, _), do: nil
+
+  defp charset_param(param) do
+    case String.split(param, "=", parts: 2) do
+      [name, value] -> accepted(normalise(name), value)
+      _ -> nil
+    end
+  end
+
+  defp accepted("charset", value) do
+    Map.get(@accepted, value |> String.trim() |> String.trim("\"") |> normalise())
+  end
+
+  defp accepted(_, _), do: nil
+
+  defp normalise(s), do: s |> String.trim() |> String.downcase(:ascii)
+end

--- a/lib/grappa/uploads/upload.ex
+++ b/lib/grappa/uploads/upload.ex
@@ -27,9 +27,15 @@ defmodule Grappa.Uploads.Upload do
     races the Reaper between unlink + soft-delete sees the row
     live + ENOENT on disk and returns 404.
 
-  ## Why `mime` + `bytes` + `original_filename` are stored
+  ## Why `mime` + `charset` + `bytes` + `original_filename` are stored
 
   - `mime` — served back as `Content-Type` on download.
+  - `charset` — the encoding the UPLOADER declared, reduced to a closed
+    set of atoms by `Grappa.Uploads.ContentType` (GH #1256). NULL means
+    unlabelled, which is what every client that declares no encoding
+    gets — the browser then falls back to its locale default, as it did
+    before the column existed. Never the client's raw parameter run:
+    the value is re-spelled from the atom when the header is rebuilt.
   - `bytes` — summed for the global-cap check on POST.
   - `original_filename` — best-effort, populates
     `Content-Disposition: inline; filename="..."` if present.
@@ -40,6 +46,7 @@ defmodule Grappa.Uploads.Upload do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Uploads.ContentType
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -50,6 +57,7 @@ defmodule Grappa.Uploads.Upload do
           visitor_id: Ecto.UUID.t() | nil,
           visitor: Visitor.t() | Ecto.Association.NotLoaded.t() | nil,
           mime: String.t() | nil,
+          charset: ContentType.charset() | nil,
           bytes: non_neg_integer() | nil,
           original_filename: String.t() | nil,
           expires_at: DateTime.t() | nil,
@@ -68,6 +76,9 @@ defmodule Grappa.Uploads.Upload do
     belongs_to :visitor, Visitor
 
     field :mime, :string
+    # Closed set fed from ContentType, so the column cannot accept a
+    # charset the header builder has no canonical spelling for.
+    field :charset, Ecto.Enum, values: ContentType.charsets()
     field :bytes, :integer
     field :original_filename, :string
 
@@ -89,6 +100,7 @@ defmodule Grappa.Uploads.Upload do
       :user_id,
       :visitor_id,
       :mime,
+      :charset,
       :bytes,
       :original_filename,
       :expires_at

--- a/lib/grappa_web/controllers/uploads_controller.ex
+++ b/lib/grappa_web/controllers/uploads_controller.ex
@@ -18,8 +18,16 @@ defmodule GrappaWeb.UploadsController do
   Boundary checks (in order — fail fast on the cheapest):
 
     1. Multipart shape — missing `file` → 400 bad_request.
-    2. MIME — must be a key of `@mime_categories` (image / video /
-       document / audio allowlists) → 415 unsupported. The category is
+    2. MIME — the client-declared content type is split into
+       `type/subtype` + charset (`Grappa.Uploads.ContentType`, #1256)
+       and the TYPE must be a key of `@mime_categories` (image / video /
+       document / audio allowlists) → 415 unsupported. Matching the
+       whole declared string made the closed MIME allowlist an
+       accidental closed PARAMETER allowlist, so a client labelling its
+       encoding honestly (`text/plain; charset=utf-8`) was the one
+       getting 415. The charset is persisted beside the MIME and
+       re-emitted by `show/2`; anything outside the closed charset set
+       is dropped, never stored. The category is
        DERIVED from the MIME at request time, never stored — no
        schema change. Audio uploads the OS labels
        `application/octet-stream` (common for .m4a/.flac) are rescued
@@ -41,6 +49,12 @@ defmodule GrappaWeb.UploadsController do
   so the cic viewer reads the type from the URL, not a message-body emoji.
 
   ## GET /uploads/:slug[.ext] (public, NO auth)
+
+  Content-Type is REBUILT from the stored `{mime, charset}` pair
+  (`Uploads.content_type_header/2`), never echoed from a client string
+  — with parameters accepted at upload time, echoing the raw run would
+  trade #1256's mojibake for content-type confusion and undercut the
+  `nosniff` below.
 
   Streams the file via `Plug.Conn.send_file/5`. Validates slug shape
   + row + on-disk file. Any failure → 404 with no oracle. The optional
@@ -154,13 +168,15 @@ defmodule GrappaWeb.UploadsController do
 
     with {:ok, upload} <- extract_upload_field(params),
          {:ok, ttl_seconds} <- parse_ttl(params),
-         {:ok, mime, category} <- validate_mime(upload),
+         {:ok, mime, charset, category} <- validate_mime(upload),
          :ok <- check_per_file_cap(upload, category),
          {:ok, bytes} <- read_file(upload),
          :ok <-
            Uploads.check_global_cap(byte_size(bytes), ServerSettings.get_upload_global_cap_bytes()),
          {:ok, row} <-
-           Uploads.create(bytes, build_attrs(subject, mime, upload, ttl_seconds), storage_root: storage_root()) do
+           Uploads.create(bytes, build_attrs(subject, {mime, charset}, upload, ttl_seconds),
+             storage_root: storage_root()
+           ) do
       conn
       |> put_status(:created)
       |> json(%{
@@ -182,7 +198,7 @@ defmodule GrappaWeb.UploadsController do
          path = Uploads.storage_path(storage_root(), row.slug),
          {:ok, %File.Stat{size: size}} <- File.stat(path) do
       conn
-      |> put_resp_header("content-type", row.mime)
+      |> put_resp_header("content-type", Uploads.content_type_header(row.mime, row.charset))
       |> put_resp_header("content-disposition", disposition_header(row))
       # S5: user bytes are served inline from the SAME origin as cic and
       # text/plain is in the accept allowlist, so uploaded text carrying
@@ -274,10 +290,16 @@ defmodule GrappaWeb.UploadsController do
   defp parse_ttl(%{"expire" => _}), do: {:error, :bad_request}
   defp parse_ttl(_), do: {:ok, @default_ttl_seconds}
 
+  # #1256: match the TYPE, keep the charset. `ContentType.parse/1`
+  # yields the declared charset as an atom from a closed set (nil when
+  # absent or unrecognised) — the client's parameter run stops here and
+  # never reaches storage or a header.
   defp validate_mime(%Plug.Upload{content_type: ct, filename: filename}) when is_binary(ct) do
-    case Map.fetch(@mime_categories, ct) do
-      {:ok, category} -> {:ok, ct, category}
-      :error -> sniff_audio(ct, filename)
+    {mime, charset} = Uploads.parse_content_type(ct)
+
+    case Map.fetch(@mime_categories, mime) do
+      {:ok, category} -> {:ok, mime, charset, category}
+      :error -> sniff_audio(mime, filename)
     end
   end
 
@@ -293,7 +315,10 @@ defmodule GrappaWeb.UploadsController do
     ext = filename |> Path.extname() |> String.downcase() |> String.trim_leading(".")
 
     case Map.fetch(@audio_ext_canonical_mime, ext) do
-      {:ok, mime} -> {:ok, mime, :audio}
+      # No charset: the rescue MINTS the type from the extension, so
+      # there is nothing the uploader declared to carry through — and
+      # audio is not text.
+      {:ok, mime} -> {:ok, mime, nil, :audio}
       :error -> {:error, :unsupported_media_type}
     end
   end
@@ -334,7 +359,7 @@ defmodule GrappaWeb.UploadsController do
     end
   end
 
-  defp build_attrs(subject, mime, %Plug.Upload{filename: filename}, ttl_seconds) do
+  defp build_attrs(subject, {mime, charset}, %Plug.Upload{filename: filename}, ttl_seconds) do
     now = DateTime.utc_now()
 
     # `:bytes` is set inside `Uploads.create/3` from the actual
@@ -343,6 +368,7 @@ defmodule GrappaWeb.UploadsController do
     %{
       subject: subject,
       mime: mime,
+      charset: charset,
       original_filename: filename,
       expires_at: DateTime.add(now, ttl_seconds, :second)
     }

--- a/priv/repo/migrations/20260812220753_add_charset_to_uploads.exs
+++ b/priv/repo/migrations/20260812220753_add_charset_to_uploads.exs
@@ -1,0 +1,22 @@
+defmodule Grappa.Repo.Migrations.AddCharsetToUploads do
+  use Ecto.Migration
+
+  # #1256 — the encoding the UPLOADER declared, stored beside the MIME so
+  # `GET /uploads/:slug` can re-emit it instead of leaving the browser to
+  # guess (and paint UTF-8 text as windows-1252 mojibake).
+  #
+  # Nullable, no backfill, no default: NULL means unlabelled, which is
+  # exactly what every existing row is — we know what those clients
+  # declared, and it was nothing. Guessing UTF-8 for them would break the
+  # mirror-image case, a genuinely Latin-1 .txt that renders correctly
+  # today precisely because nothing is declared.
+  #
+  # The column is not free-text: `Grappa.Uploads.Upload` maps it through an
+  # `Ecto.Enum` fed by `Grappa.Uploads.ContentType`, so the only values
+  # that can land here are ones the header builder can spell canonically.
+  def change do
+    alter table(:uploads) do
+      add :charset, :string, null: true
+    end
+  end
+end

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -1209,6 +1209,7 @@ defmodule Grappa.Deploy.PreflightTest do
       20260802190000_add_user_totp
       20260805100000_add_old_nick_to_session_log_events
       20260810120000_add_client_tokens_to_sessions
+      20260812220753_add_charset_to_uploads
     )
 
     test "every migration on disk classifies, and the HOT set is exactly the pinned one" do

--- a/test/grappa/uploads/content_type_test.exs
+++ b/test/grappa/uploads/content_type_test.exs
@@ -1,0 +1,94 @@
+defmodule Grappa.Uploads.ContentTypeTest do
+  use ExUnit.Case, async: true
+
+  alias Grappa.Uploads.ContentType
+
+  describe "parse/1 — type/subtype" do
+    test "a bare type is returned unchanged, with no charset" do
+      assert ContentType.parse("text/plain") == {"text/plain", nil}
+    end
+
+    test "the parameter run is split off so the allowlist can match the type" do
+      assert {"text/plain", _} = ContentType.parse("text/plain; charset=utf-8")
+    end
+
+    test "type is trimmed and ASCII-downcased so a lax client still matches" do
+      assert {"text/plain", :utf8} = ContentType.parse(" TEXT/Plain ; Charset=UTF-8")
+    end
+  end
+
+  describe "parse/1 — charset, closed set" do
+    test "utf-8 is recognised" do
+      assert {_, :utf8} = ContentType.parse("text/plain; charset=utf-8")
+    end
+
+    test "the undashed spelling is accepted as the same charset" do
+      assert {_, :utf8} = ContentType.parse("text/plain; charset=utf8")
+    end
+
+    test "a quoted value is unquoted" do
+      assert {_, :utf8} = ContentType.parse(~s|text/plain; charset="utf-8"|)
+    end
+
+    test "a charset we do not label with is dropped, not surfaced" do
+      assert ContentType.parse("text/plain; charset=iso-8859-1") == {"text/plain", nil}
+    end
+
+    test "a non-charset parameter is ignored" do
+      assert ContentType.parse("text/plain; format=flowed") == {"text/plain", nil}
+    end
+
+    test "charset is read past other parameters" do
+      assert {_, :utf8} = ContentType.parse("text/plain; format=flowed; charset=utf-8")
+    end
+
+    test "a malformed parameter run does not raise" do
+      assert ContentType.parse("text/plain;;;charset") == {"text/plain", nil}
+    end
+
+    test "charset is only read off a text type" do
+      assert ContentType.parse("application/pdf; charset=utf-8") == {"application/pdf", nil}
+      assert ContentType.parse("image/png; charset=utf-8") == {"image/png", nil}
+    end
+  end
+
+  describe "header/2" do
+    test "no charset → the bare MIME, byte for byte" do
+      assert ContentType.header("text/plain", nil) == "text/plain"
+    end
+
+    test "a stored charset is re-spelled canonically" do
+      assert ContentType.header("text/plain", :utf8) == "text/plain; charset=utf-8"
+    end
+  end
+
+  describe "the client's parameter run never reaches the header" do
+    # Once parameters are accepted, the declared type is client-
+    # controlled text one hop from a response header, and `nosniff`
+    # only pins the browser to what we declare. parse/1 must reduce it
+    # to an atom, and header/2 must rebuild from that atom — so a
+    # smuggled second type cannot ride through.
+    test "a second type smuggled in the parameter run is dropped" do
+      injected = ~s|text/plain; charset="utf-8"; x=1, text/html|
+      {mime, charset} = ContentType.parse(injected)
+
+      refute ContentType.header(mime, charset) =~ "text/html"
+      assert ContentType.header(mime, charset) == "text/plain; charset=utf-8"
+    end
+
+    test "an unrecognised charset value is not echoed in the header" do
+      {mime, charset} = ContentType.parse(~s|text/plain; charset=utf-8@evil|)
+
+      assert ContentType.header(mime, charset) == "text/plain"
+    end
+  end
+
+  describe "charsets/0" do
+    test "every advertised charset round-trips through header/2" do
+      for charset <- ContentType.charsets() do
+        assert {_, ^charset} =
+                 ContentType.parse(ContentType.header("text/plain", charset))
+      end
+    end
+  end
+end

--- a/test/grappa_web/controllers/uploads_controller_test.exs
+++ b/test/grappa_web/controllers/uploads_controller_test.exs
@@ -481,6 +481,103 @@ defmodule GrappaWeb.UploadsControllerTest do
     end
   end
 
+  describe "charset round-trip (#1256)" do
+    # `è` as UTF-8. Served unlabelled, a Western-locale browser decodes
+    # it as windows-1252 and paints `Ã¨` — the bug. The bytes are never
+    # in question; the DECLARATION is.
+    @utf8_bytes "perché è così"
+
+    test "a client declaring utf-8 is accepted — it used to be the one getting 415",
+         %{conn: conn} do
+      {_, session} = user_and_session([])
+
+      upload = upload_fixture("paste.txt", "text/plain; charset=utf-8", @utf8_bytes)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/api/uploads", %{"file" => upload})
+
+      assert %{"slug" => slug} = json_response(conn, 201)
+      assert Uploads.valid_slug?(slug)
+    end
+
+    test "GET re-emits the declared charset, so the browser stops guessing" do
+      slug =
+        uploaded_slug(
+          Phoenix.ConnTest.build_conn(),
+          "paste.txt",
+          "text/plain; charset=utf-8",
+          @utf8_bytes
+        )
+
+      get_conn = get(Phoenix.ConnTest.build_conn(), "/uploads/" <> slug)
+
+      assert response(get_conn, 200) == @utf8_bytes
+      assert get_resp_header(get_conn, "content-type") == ["text/plain; charset=utf-8"]
+      # The declaration is the fix; sniffing stays off.
+      assert get_resp_header(get_conn, "x-content-type-options") == ["nosniff"]
+    end
+
+    test "an upload that declares no charset stays unlabelled" do
+      # The mirror-image case: a genuinely Latin-1 .txt uploaded by hand
+      # renders correctly today only because nothing is declared. The
+      # label follows what the uploader said, never what we assume.
+      slug =
+        uploaded_slug(Phoenix.ConnTest.build_conn(), "hand.txt", "text/plain", "plain text body")
+
+      get_conn = get(Phoenix.ConnTest.build_conn(), "/uploads/" <> slug)
+
+      assert get_resp_header(get_conn, "content-type") == ["text/plain"]
+    end
+
+    test "a charset outside the closed set is dropped, and the upload still lands" do
+      slug =
+        uploaded_slug(
+          Phoenix.ConnTest.build_conn(),
+          "legacy.txt",
+          "text/plain; charset=iso-8859-1",
+          "caff\xE8"
+        )
+
+      get_conn = get(Phoenix.ConnTest.build_conn(), "/uploads/" <> slug)
+
+      assert get_resp_header(get_conn, "content-type") == ["text/plain"]
+    end
+
+    test "the client's parameter run never reaches the response header" do
+      # With parameters accepted, the declared type is client-controlled
+      # text one hop from a response header. It is reduced to an atom at
+      # the door and the header is rebuilt — otherwise this trades
+      # mojibake for content-type confusion and undercuts nosniff.
+      slug =
+        uploaded_slug(
+          Phoenix.ConnTest.build_conn(),
+          "smuggle.txt",
+          ~s|text/plain; charset="utf-8"; x=1, text/html|,
+          "<script>1</script>"
+        )
+
+      get_conn = get(Phoenix.ConnTest.build_conn(), "/uploads/" <> slug)
+
+      assert get_resp_header(get_conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+
+    test "a non-text type keeps its parameters off the header" do
+      slug =
+        uploaded_slug(
+          Phoenix.ConnTest.build_conn(),
+          "doc.pdf",
+          "application/pdf; charset=utf-8",
+          "%PDF-FAKE"
+        )
+
+      get_conn = get(Phoenix.ConnTest.build_conn(), "/uploads/" <> slug)
+
+      assert get_resp_header(get_conn, "content-type") == ["application/pdf"]
+    end
+  end
+
   describe "GET /uploads/:slug — Range requests (iOS video playback needs 206)" do
     # 16 known bytes so content-range arithmetic is assertable by eye.
     # text/plain: Range serving is mime-agnostic (send_file on stored


### PR DESCRIPTION
## What

`GET /uploads/:slug` served `text/plain` with no charset, so a browser had no declared encoding and fell back to its locale default (windows-1252 in a Western locale). A UTF-8 paste rendered as mojibake — `è` as `Ã¨`, `—` as `â€”` — while the bytes on disk were valid the whole time.

The charset could not get in either. `validate_mime/1` matched the whole client-declared content type against the closed MIME allowlist, which made that allowlist accidentally a closed *parameter* allowlist: `text/plain; charset=utf-8` missed, fell into the audio extension rescue, and earned a 415. The client labelling its encoding honestly was the one being refused.

Per vjt's ruling on the issue, the fix labels only where the bytes are ours, server first.

## How

- **`Grappa.Uploads.ContentType`** — `parse/1` splits `type/subtype` from the parameter run and reduces the declared charset to an ATOM from a closed set; `header/2` rebuilds the response header by re-spelling that atom. Reached through the context (`Uploads.parse_content_type/1`, `Uploads.content_type_header/2`), following the `MimeExt` precedent.
- **`uploads.charset`** — new nullable column, no backfill, no default. NULL is not missing data: it is the record that those clients declared nothing. Mapped through an `Ecto.Enum` fed from `ContentType`, so a charset the header builder cannot spell canonically cannot be persisted. The migration is additive-nullable and classifies HOT, so it joins the preflight's pinned HOT set.
- **`UploadsController`** — matches the type, persists the charset beside the MIME, and rebuilds the `content-type` on `show/2`. `nosniff` unchanged.
- **cic** — `baseMime` makes the upload gates parameter-tolerant (an exact-string `categoryOf` would have dropped a correctly-labelled File client-side, before it could even reach the 415), and the paste-as-`.txt` File declares `charset=utf-8` — a fact for that path, since the File constructor encodes a USVString part as UTF-8 by specification.

## Decisions worth reviewing

- **The rebuild is the security half.** Accepting parameters turns the declared type into client-controlled text one hop from a response header, and `nosniff` only pins the browser to whatever we declare. Storing the raw parameter run would trade mojibake for content-type confusion and undercut the protection at `show/2`. Nothing the client wrote reaches the header.
- **An unrecognised charset is dropped, not rejected.** `charset=iso-8859-1` still lands a 201 and is served unlabelled — the pre-fix behaviour, deliberately preserved. Refusing it would regress the mirror-image case (a genuinely Latin-1 `.txt`, correct today because nothing is declared) into a 415 to protect it from a display bug.
- **A charset is read only off a `text/*` type**, derived from the type rather than kept as a second allowlist beside `@mime_categories`.

## Test plan

- [x] Red measured before the fix: 5 of the 6 new controller assertions failed with `unsupported_media_type`; the sixth — the mirror-image guard — passed, as it had to. On cic, `categoryOf("text/plain; charset=utf-8")` answered `null` and the paste File's type read bare `text/plain`.
- [x] `scripts/check.sh` green: 8 doctests, 59 properties, 5961 tests, 0 failures; Credo 5713 mods/funs no issues; Dialyzer `Total errors: 0`; Sobelow no medium-or-above; bats green.
- [x] `bun run test` 281 files / 5315 tests, `bun run check` clean.
- [ ] e2e `issue1256-upload-charset.spec.ts` — pastes an accented block, uploads it, navigates to the served URL and asserts the RENDERED text (with `Ã` as a negative control, a byte that can only appear under a windows-1252 misread). Not yet run: the stack lane was held elsewhere. To be measured before merge.

## Notes

- Not for the 1.0.0 cut, per vjt on the issue.
- The wire contract is untouched; the admin uploads listing is unchanged.