### PR TITLE
#1249 — CHANMODES type-A list modes must not enter the channel mode set

### DIFF
--- a/cicchetto/e2e/tests/issue1249-typea-not-a-channel-flag.spec.ts
+++ b/cicchetto/e2e/tests/issue1249-typea-not-a-channel-flag.spec.ts
@@ -42,11 +42,16 @@ test("#1249 — +b does not join the channel mode string, and its mask does not 
     ).toHaveCount(1, { timeout: 15_000 });
     await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
 
-    // PRE-STATE — the indicator is live and already carries the ircd's own
-    // fresh-channel flags. Without this the post-gesture `not.toContainText`
-    // could pass on an indicator that never rendered at all.
+    // PRE-STATE — established, not assumed. This bahamut creates a channel
+    // with NO modes at all (measured: on a fresh channel the indicator never
+    // renders, because it is shown only for a non-empty set), so waiting for
+    // the ircd's own flags waits forever. Set one plain flag and watch it
+    // land: that proves the indicator is live and tracking THIS channel
+    // before any ban exists, which is what makes the absence asserted below
+    // a change rather than an element that was never there.
+    await composeSend(page, `/mode ${channel} +t`);
     const modeIndicator = page.locator(".topic-bar-modes");
-    await expect(modeIndicator).toBeVisible({ timeout: 15_000 });
+    await expect(modeIndicator).toContainText("t", { timeout: 15_000 });
     await expect(modeIndicator).not.toContainText("b");
     await expect(modeIndicator).not.toContainText("k");
 
@@ -57,7 +62,10 @@ test("#1249 — +b does not join the channel mode string, and its mask does not 
     await expect(modeIndicator).toContainText("k", { timeout: 15_000 });
 
     // THE CLAIM — the ban is a list, not a flag: no `b` in the mode string.
+    // The `t` from the pre-state is still there, so this is the same live
+    // indicator, not a re-rendered empty one.
     await expect(modeIndicator).not.toContainText("b");
+    await expect(modeIndicator).toContainText("t");
 
     // ARG ALIGNMENT — the key is the KEY, not the ban mask.
     await composeSend(page, `/mode ${channel}`);

--- a/cicchetto/e2e/tests/issue1249-typea-not-a-channel-flag.spec.ts
+++ b/cicchetto/e2e/tests/issue1249-typea-not-a-channel-flag.spec.ts
@@ -1,0 +1,76 @@
+// #1249 — a ban (CHANMODES type A) must never enter the channel's mode
+// string. Setting `+b` used to grow the header indicator a `b`: a channel
+// that is really `+nt` rendered as `+bnt`, because the server-side
+// `channel_modes` cache treated every non-membership letter as a channel
+// flag. The header is the user-visible face of that cache, so the fix is
+// only proven here.
+//
+// The gesture is ONE token, `+bk <mask> <key>`, and that is deliberate:
+//   - the `k` landing in the header is the barrier that the ircd accepted
+//     and echoed the WHOLE token — without it, "no b in the header" would
+//     also pass if the MODE had simply never arrived;
+//   - the key reflected in the modal proves the dropped `b` still CONSUMED
+//     its mask, so the arg list stayed aligned. A fix that skips the pop
+//     keys the channel to `*!*@…` instead, and this is where that shows.
+//
+// vjt creates a fresh per-run channel (→ sole op, so the MODE is accepted
+// and no peer is needed) and PARTs it in `finally`. jsdom/vitest cannot do
+// this — it needs the live ircd MODE round-trip.
+
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test("#1249 — +b does not join the channel mode string, and its mask does not steal +k's param", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  const channel = `#t1249-${Date.now()}`;
+  const mask = `*!*@t1249-${Date.now() % 100000}.example.org`;
+  const key = `s3cr3t${Date.now() % 100000}`;
+
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first to confirm login + WS-ready before
+  // issuing the /join (mirrors the issue240 boot order).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  try {
+    // vjt creates the channel → becomes op → the ircd accepts his MODE.
+    await composeSend(page, `/join ${channel}`);
+    await expect(
+      page.locator(".sidebar-network-section li").filter({ hasText: channel }),
+    ).toHaveCount(1, { timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // PRE-STATE — the indicator is live and already carries the ircd's own
+    // fresh-channel flags. Without this the post-gesture `not.toContainText`
+    // could pass on an indicator that never rendered at all.
+    const modeIndicator = page.locator(".topic-bar-modes");
+    await expect(modeIndicator).toBeVisible({ timeout: 15_000 });
+    await expect(modeIndicator).not.toContainText("b");
+    await expect(modeIndicator).not.toContainText("k");
+
+    // GESTURE — one token, a list mode followed by a param mode.
+    await composeSend(page, `/mode ${channel} +bk ${mask} ${key}`);
+
+    // BARRIER — the `k` arrived, so the whole token was accepted and echoed.
+    await expect(modeIndicator).toContainText("k", { timeout: 15_000 });
+
+    // THE CLAIM — the ban is a list, not a flag: no `b` in the mode string.
+    await expect(modeIndicator).not.toContainText("b");
+
+    // ARG ALIGNMENT — the key is the KEY, not the ban mask.
+    await composeSend(page, `/mode ${channel}`);
+    const modal = page.getByTestId("mode-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    const keyRow = modal.getByTestId("mode-param-row-k");
+    await expect(keyRow).toHaveClass(/mode-modal-param-row-active/, { timeout: 15_000 });
+    await expect(keyRow).toContainText(key);
+
+    await modal.getByLabel("close modes").click();
+    await expect(modal).toBeHidden({ timeout: 2_000 });
+  } finally {
+    await composeSend(page, `/part ${channel}`).catch(() => {});
+  }
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40402,8 +40402,8 @@ pop keys the channel to `*!*@…`, which is why the witness token is `+bk <mask>
 where the `k` landing in the header is also the barrier proving the ircd
 accepted and echoed the whole token.
 
-**Two predicates over `chanmodes.a`, deliberately.** #1251, in flight
-alongside this, adds `ListModes.queryable/1` — the type-A letters grappa may
+**Two predicates over `chanmodes.a`, deliberately.** #1251, which landed just
+before this, adds `ListModes.queryable/1` — the type-A letters grappa may
 *ask* for, i.e. those
 it also knows a terminating numeric pair for. This walk needs
 `ISupport.list_mode?/2` — pure class membership. They diverge on exactly one
@@ -40428,3 +40428,9 @@ BEFORE any ban exists, and re-asserting the `t` after the gesture shows the
 absent `b` is the same live indicator rather than a re-rendered empty one.
 Anyone writing the next channel-mode witness should establish the pre-state
 the same way instead of waiting for flags the server never sets.
+
+The witness was then mutation-checked, because an e2e that would pass without
+the fix proves nothing: with the class branch reverted the spec dies on the
+claim, reporting the header as `+kbt` — the reported bug, reproduced in a
+browser. The barrier before it passed, so what the mutant killed is the fix,
+not the arrival of the MODE.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40360,6 +40360,9 @@ under a windows-1252 misread. Server-side, the red was measured before the fix
 existed: five of the six new controller assertions failed with
 `unsupported_media_type`, and the sixth — the mirror-image guard — passed, as
 it had to.
+
+---
+
 ## 2026-08-13 — #1249: a list is not a flag, and arity is not class
 
 A single `MODE #chan +b <mask>` made the channel header read `+blrnt`. The
@@ -40412,3 +40415,16 @@ here would have re-introduced the phantom flag for precisely the letters
 nobody has taught us about yet. One notion of "type A" — `chanmodes.a`, read
 per-network, never a hardcoded `["b","e","I"]`, because bahamut advertises
 `bz` and has no `+e`/`+I` at all — two questions asked of it.
+
+**The witness had to build its own pre-state, and that is a fact about the
+ircd worth writing down.** The e2e first asserted the mode indicator was
+visible on the freshly created channel, on the assumption that an ircd stamps
+its own flags at channel creation. The testnet bahamut does not: a channel
+comes up with an EMPTY mode set, cic renders the indicator only for a
+non-empty one, and the wait could only time out. So the spec now sets a plain
+`+t` first and watches it land — which is strictly better than the assumption
+it replaces, because it proves the indicator is live and bound to THIS channel
+BEFORE any ban exists, and re-asserting the `t` after the gesture shows the
+absent `b` is the same live indicator rather than a re-rendered empty one.
+Anyone writing the next channel-mode witness should establish the pre-state
+the same way instead of waiting for flags the server never sets.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40360,3 +40360,55 @@ under a windows-1252 misread. Server-side, the red was measured before the fix
 existed: five of the six new controller assertions failed with
 `unsupported_media_type`, and the sixth — the mirror-image guard — passed, as
 it had to.
+## 2026-08-13 — #1249: a list is not a flag, and arity is not class
+
+A single `MODE #chan +b <mask>` made the channel header read `+blrnt`. The
+server-side `channel_modes` cache is what the header renders, and its walker
+(`EventRouter.walk_channel_modes/5`) had exactly two categories: a membership
+mode from `PREFIX` (skipped — it belongs to the roster) and *everything else*,
+recorded as a channel flag. CHANMODES type A — bans and the exception lists —
+fell in the second bucket.
+
+The classifier already knew better. `ISupport.takes_param?/3` reads the same
+005 table and says "type A takes a param on both signs", which is why the mask
+was consumed and the arg list stayed aligned; the walk just never asked what
+CLASS the letter was, only whether it had an argument. **Arity and class are
+two different questions about one table, and consulting only the first is what
+turned a list into a flag.**
+
+Four consequences, and the fourth is the one that makes it a correctness bug
+rather than a cosmetic one: the phantom letter; one `params` slot holding the
+*last* mask of an N-entry list; an unban of a different mask clearing the flag
+while two bans are still in force; and a disagreement with the ircd itself —
+324 RPL_CHANNELMODEIS never carries list modes, so a rejoin silently deletes
+the phantom, and two clients on the same channel show different mode strings
+depending on who watched the `+b` go by. The banlist is untouched by any of
+this: it is served by the 367/368 query path (#536), which never enters this
+cache.
+
+cic had already drawn the line the server had not: `availableModes/1` builds
+the modal's toggle list from `b ∪ c ∪ d`, so a type-A letter is excluded by
+construction and no `+b` row has ever existed there. The header renders the
+raw `modes` list instead, which is why the phantom surfaced there and only
+there — and why the client needed no change.
+
+The fix asks the class question after the arity one: consume the argument,
+then drop the letter on **both** signs. Order matters — a fix that skips the
+pop keys the channel to `*!*@…`, which is why the witness token is `+bk <mask>
+<key>` rather than a lone `+b`, at every level: the unit test, and the e2e
+where the `k` landing in the header is also the barrier proving the ircd
+accepted and echoed the whole token.
+
+**Two predicates over `chanmodes.a`, deliberately.** #1251, in flight
+alongside this, adds `ListModes.queryable/1` — the type-A letters grappa may
+*ask* for, i.e. those
+it also knows a terminating numeric pair for. This walk needs
+`ISupport.list_mode?/2` — pure class membership. They diverge on exactly one
+input: a letter the network advertises as type A that our numeric table does
+not know. `queryable/1` must exclude it (a `MODE #chan X` we cannot terminate
+is a request that hangs); `list_mode?/2` must include it (it is still a list,
+so it still must not be rendered as a flag). Reusing the query-side predicate
+here would have re-introduced the phantom flag for precisely the letters
+nobody has taught us about yet. One notion of "type A" — `chanmodes.a`, read
+per-network, never a hardcoded `["b","e","I"]`, because bahamut advertises
+`bz` and has no `+e`/`+I` at all — two questions asked of it.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -165,6 +165,12 @@ defmodule Grappa.Session.EventRouter do
   modes that carry args (e.g. `%{"k" => "secret", "l" => "42"}`).
   Modes without args are absent from `params`. Stored case-preserved;
   lookup normalises to downcase.
+
+  CHANMODES **type-A** letters never appear here (#1249). They address a
+  per-channel LIST (bans, ban/invite exceptions), not the channel's mode
+  state — an ircd never reports them in 324 RPL_CHANNELMODEIS either, and
+  one `params` slot could hold only the last mask of an N-entry list. They
+  are served by the 367/368 query path (#536) instead.
   """
   @type channel_mode_entry :: %{
           modes: [String.t()],
@@ -3571,7 +3577,20 @@ defmodule Grappa.Session.EventRouter do
         # param modes like k or l.
         takes_param = ISupport.takes_param?(isupport, mode, direction)
         {arg, remaining} = if takes_param, do: pop_arg(args), else: {nil, args}
-        entry = toggle_channel_mode(entry, mode, arg, direction)
+
+        # #1249 — then branch on the CLASS, not just the arity. A type-A
+        # letter addresses a LIST (bans, exceptions): it consumes its
+        # argument, keeping the arg list aligned for a following `+k`/`+l`,
+        # and is dropped on BOTH signs. Recording it would publish a mode
+        # the channel does not have, keep only the LAST mask of an N-entry
+        # list in `params`, let an unban of a different mask clear the
+        # flag, and disagree with the next 324 snapshot (which never
+        # carries list modes). Types B/C/D are channel state and toggle.
+        entry =
+          if ISupport.list_mode?(isupport, mode),
+            do: entry,
+            else: toggle_channel_mode(entry, mode, arg, direction)
+
         walk_channel_modes(entry, rest, remaining, direction, isupport)
     end
   end

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -192,6 +192,24 @@ defmodule Grappa.Session.ISupport do
   end
 
   @doc """
+  Whether channel mode `mode` is CHANMODES **type A** — a per-channel LIST
+  (bans, ban/invite exceptions, quiets) rather than a channel flag. Sign
+  independent: a list letter is a list letter on `+` and on `-`.
+
+  RFC 2811 §4.3 / the `CHANMODES=A,B,C,D` contract: a type-A letter
+  addresses a list the ircd keeps beside the channel's mode state, is never
+  part of that state, and never appears in 324 RPL_CHANNELMODEIS. It is the
+  CLASS twin of `takes_param?/3` (which reads the same table for ARITY):
+  the mode-set walkers need both — consume the argument, drop the letter
+  (#1249).
+
+  The letter set is per-network, never a constant: bahamut/Azzurra
+  advertises `bz` (no `+e`/`+I`, plus a restrict list), solanum `eIbq`.
+  """
+  @spec list_mode?(t(), String.t()) :: boolean()
+  def list_mode?(%{chanmodes: cm}, mode) when is_binary(mode), do: mode in cm.a
+
+  @doc """
   Resolves a membership mode letter to its rendered sigil, or `:error`
   when `mode` is not a membership (per-user) mode for this network.
   Mirrors the old `Map.fetch(@user_mode_prefixes, mode)` call the walkers

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -2456,7 +2456,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg(:mode, ["#italia", "-b+k", "*!*@spammer.net", "s3cret"], {:nick, "op", "u", "h"})
 
-      assert {:cont, new_state, _effects} = EventRouter.route(m, state)
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
 
       entry = new_state.channel_modes["#italia"]
       refute "b" in entry.modes
@@ -2479,7 +2479,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg(:mode, ["#italia", "+zt", "*!*@lamer.net"], {:nick, "op", "u", "h"})
 
-      assert {:cont, new_state, _effects} = EventRouter.route(m, state)
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
 
       entry = new_state.channel_modes["#italia"]
       refute "z" in entry.modes

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -2389,27 +2389,101 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.meta == %{modes: "+ovo", args: ["a", "b", "c"]}
     end
 
-    test "MODE +b (channel-level, not user mode) emits :persist + :channel_modes_changed, no member mutation" do
+    test "MODE +b emits :persist, mutates no member and does NOT enter the channel mode set" do
+      # #1249 — +b is a ban: CHANMODES type A, a per-channel LIST. It is not
+      # a channel flag, so it must leave `channel_modes` untouched — and with
+      # nothing changed there is no `:channel_modes_changed` delta to emit.
+      # (The ban itself is served by the 367/368 query path, #536.)
       state = base_state(%{members: %{"#italia" => %{"alice" => []}}})
 
-      # +b is a ban — not in our user-mode prefix table; channel-level only.
       m = msg(:mode, ["#italia", "+b", "*!*@spammer.net"], {:nick, "op", "u", "h"})
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
 
       # alice mode list unchanged — +b doesn't apply to a member's modes
       assert new_state.members["#italia"] == %{"alice" => []}
-      # channel_modes cache updated with ban
-      assert "b" in new_state.channel_modes["#italia"].modes
+
+      entry = new_state.channel_modes["#italia"]
+      refute "b" in entry.modes
+      refute Map.has_key?(entry.params, "b")
 
       persist = Enum.find(effects, fn {tag, _, _} -> tag == :persist end)
       assert {:persist, :mode, attrs} = persist
       assert attrs.meta == %{modes: "+b", args: ["*!*@spammer.net"]}
 
-      assert Enum.any?(effects, fn
-               {:channel_modes_changed, "#italia", _} -> true
+      refute Enum.any?(effects, fn
+               {:channel_modes_changed, _, _} -> true
                _ -> false
              end)
+    end
+
+    test "MODE +bk mask key drops the ban but lands the key with its own param" do
+      # #1249 arg alignment: the dropped type-A letter still CONSUMES its
+      # mask, so the following type-B `k` must pair with "key", not "mask".
+      # A fix that skipped the pop would silently key the channel to the
+      # ban mask.
+      state = base_state(%{members: %{"#italia" => %{"alice" => []}}})
+
+      m = msg(:mode, ["#italia", "+bk", "*!*@spammer.net", "s3cret"], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      entry = new_state.channel_modes["#italia"]
+      refute "b" in entry.modes
+      assert "k" in entry.modes
+      assert entry.params == %{"k" => "s3cret"}
+
+      # The `k` IS a real change, so the delta is emitted — the entry it
+      # carries is the ban-free one.
+      assert Enum.any?(effects, fn
+               {:channel_modes_changed, "#italia", ^entry} -> true
+               _ -> false
+             end)
+    end
+
+    test "MODE -bk mask key consumes the ban mask on the remove sign too" do
+      # #1249 both signs: type A takes a param on `-` as well, so `-b` must
+      # pop the mask or the `-k` clause would swallow it and leave the key
+      # standing.
+      state =
+        base_state(%{
+          members: %{"#italia" => %{"alice" => []}},
+          channel_modes: %{
+            "#italia" => %{modes: ["k", "n"], params: %{"k" => "s3cret"}}
+          }
+        })
+
+      m = msg(:mode, ["#italia", "-bk", "*!*@spammer.net", "s3cret"], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, _effects} = EventRouter.route(m, state)
+
+      entry = new_state.channel_modes["#italia"]
+      refute "k" in entry.modes
+      assert "n" in entry.modes
+      assert entry.params == %{}
+    end
+
+    test "the type-A letter set comes from the advertised CHANMODES, not a constant" do
+      # #1249 per-network: a network whose type-A class carries `z` (bahamut
+      # restrict list) must have `+z` dropped as well — a hardcoded
+      # ["b","e","I"] would render it as a channel flag.
+      isupport =
+        ISupport.merge_isupport(
+          ["s", "PREFIX=(ohv)@%+", "CHANMODES=bz,k,l,imnpst"],
+          ISupport.default()
+        )
+
+      state = base_state(%{members: %{"#italia" => %{"alice" => []}}, isupport: isupport})
+
+      m = msg(:mode, ["#italia", "+zt", "*!*@lamer.net"], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, _effects} = EventRouter.route(m, state)
+
+      entry = new_state.channel_modes["#italia"]
+      refute "z" in entry.modes
+      refute Map.has_key?(entry.params, "z")
+      # `t` still lands: the token was walked, not rejected.
+      assert "t" in entry.modes
     end
 
     test "membership modes come from state.isupport PREFIX, not a hardcoded table" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -2441,26 +2441,28 @@ defmodule Grappa.Session.EventRouterTest do
              end)
     end
 
-    test "MODE -bk mask key consumes the ban mask on the remove sign too" do
-      # #1249 both signs: type A takes a param on `-` as well, so `-b` must
-      # pop the mask or the `-k` clause would swallow it and leave the key
-      # standing.
+    test "MODE -b+k mask key consumes the ban mask on the remove sign too" do
+      # #1249 both signs: type A takes a param on `-` as well. The witness
+      # has to be a mode that KEEPS its param — `-b-k mask key` cannot fail
+      # visibly, because a removal discards the argument it popped, so a
+      # mask swallowed by the `-k` leaves no trace. Flipping the sign back
+      # makes the misalignment observable: if `-b` does not pop, the key
+      # this channel gets is the ban mask.
       state =
         base_state(%{
           members: %{"#italia" => %{"alice" => []}},
-          channel_modes: %{
-            "#italia" => %{modes: ["k", "n"], params: %{"k" => "s3cret"}}
-          }
+          channel_modes: %{"#italia" => %{modes: ["n"], params: %{}}}
         })
 
-      m = msg(:mode, ["#italia", "-bk", "*!*@spammer.net", "s3cret"], {:nick, "op", "u", "h"})
+      m = msg(:mode, ["#italia", "-b+k", "*!*@spammer.net", "s3cret"], {:nick, "op", "u", "h"})
 
       assert {:cont, new_state, _effects} = EventRouter.route(m, state)
 
       entry = new_state.channel_modes["#italia"]
-      refute "k" in entry.modes
+      refute "b" in entry.modes
+      assert "k" in entry.modes
       assert "n" in entry.modes
-      assert entry.params == %{}
+      assert entry.params == %{"k" => "s3cret"}
     end
 
     test "the type-A letter set comes from the advertised CHANMODES, not a constant" do

--- a/test/grappa/session/isupport_test.exs
+++ b/test/grappa/session/isupport_test.exs
@@ -13,6 +13,9 @@ defmodule Grappa.Session.ISupportTest do
   - `takes_param?/3` — whether a channel mode consumes an argument when
     applied with the given sign (RFC 2811 type A/B always; type C on +
     only; type D never).
+  - `list_mode?/2` (#1249) — whether a channel mode is CHANMODES type A
+    (a per-channel list: bans, exceptions), which the mode-set walkers
+    must consume the param of but never record as a channel flag.
   - `user_prefix/2` — mode letter → sigil for per-user (membership)
     modes, or `:error` for channel-level modes.
   - `presence_mechanism/1` (#247) — MONITOR=/WATCH= token capture and
@@ -110,6 +113,49 @@ defmodule Grappa.Session.ISupportTest do
       d = ISupport.default()
       assert ISupport.takes_param?(d, "l", :add)
       refute ISupport.takes_param?(d, "l", :remove)
+    end
+  end
+
+  # #1249 — CHANMODES type A is a per-channel LIST (bans, exceptions), not a
+  # channel flag: the letter never belongs in the channel's mode set and an
+  # ircd never reports it in 324 RPL_CHANNELMODEIS. `takes_param?/3` already
+  # reads the same table for ARITY; this is the CLASS question, and the
+  # walkers need it to drop the letter while still consuming its argument.
+  describe "list_mode?/2 (#1249)" do
+    test "the default table classifies b/e/I as list modes and flags as not" do
+      d = ISupport.default()
+
+      for mode <- ["b", "e", "I"] do
+        assert ISupport.list_mode?(d, mode), "expected #{mode} to be a type-A list mode"
+      end
+
+      # Type B/C/D are channel state, not lists — including `k`, which takes
+      # a param on both signs exactly like a type A does.
+      for mode <- ["k", "l", "n", "t", "m", "s", "i"] do
+        refute ISupport.list_mode?(d, mode), "expected #{mode} NOT to be a type-A list mode"
+      end
+    end
+
+    test "the type-A letter set is per-network, read from the advertised CHANMODES" do
+      # bahamut/Azzurra has no +e/+I and does have a `z` restrict list;
+      # solanum advertises `q`. A hardcoded ["b","e","I"] would mis-class
+      # both networks — the answer must come from the 005 table.
+      bahamut =
+        ISupport.merge_isupport(["s", "CHANMODES=bz,k,l,imnpst"], ISupport.default())
+
+      assert ISupport.list_mode?(bahamut, "b")
+      assert ISupport.list_mode?(bahamut, "z")
+      refute ISupport.list_mode?(bahamut, "e")
+      refute ISupport.list_mode?(bahamut, "I")
+
+      solanum =
+        ISupport.merge_isupport(["s", "CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz"], ISupport.default())
+
+      for mode <- ["e", "I", "b", "q"] do
+        assert ISupport.list_mode?(solanum, mode)
+      end
+
+      refute ISupport.list_mode?(solanum, "z")
     end
   end
 


### PR DESCRIPTION
A single `MODE #chan +b <mask>` made the channel header read `+blrnt`. Fixes the server-side `channel_modes` cache that the header renders.

## The bug

`EventRouter.walk_channel_modes/5` had two categories: a membership mode from `PREFIX` (skipped, it belongs to the roster) and *everything else*, recorded as a channel flag. CHANMODES type A — a per-channel LIST — fell in the second bucket.

The table already knew better. `ISupport.takes_param?/3` reads the same 005 data and correctly says type A carries a param on both signs, which is why the mask was consumed and the arg list stayed aligned. Only the CLASS question was never asked. **Arity and class are two questions about one table; asking only the first is what turned a list into a flag.**

Beyond the phantom letter: one `params` slot holding the last mask of an N-entry list; an unban of a different mask clearing the flag while bans are still in force; and disagreement with 324 RPL_CHANNELMODEIS, which never carries list modes — so a rejoin silently deleted the phantom and two clients showed different mode strings.

## The fix

`ISupport.list_mode?/2` — pure class membership over `chanmodes.a`, per-network (bahamut advertises `bz` and has no `+e`/`+I`; solanum `eIbq` — never a hardcoded `["b","e","I"]`). The walk consumes the argument FIRST, then drops the letter on both signs.

### Two predicates over the same class, deliberately

#1251 (landed just before this) adds `ListModes.queryable/1` — the type-A letters we may *ask* for, i.e. those we also know a terminating numeric pair for. They diverge on exactly one input: a letter the network advertises as type A that our numeric table does not know. `queryable/1` must exclude it (a query we cannot terminate hangs); `list_mode?/2` must include it (still a list, so still not a flag). Reusing the query-side predicate here would have re-introduced the phantom for precisely the letters nobody has taught us yet. Re-checked against the MERGED `queryable/1`, not the branch it was written on.

### Measured, not assumed

- **The banlist is untouched**: it lives in `state.banlist_pending`, fed by 367/368 (#536), sharing nothing with this cache. No reader of `params["b"]` exists in `lib/` or `cicchetto/src`.
- **cic needed no change**: `availableModes/1` builds the modal's toggles from `b ∪ c ∪ d`, so a `+b` row never existed. The header renders the raw `modes` list, which is why the phantom surfaced there and only there.

## Evidence

| step | result |
|---|---|
| red, implementation removed | rc=3, 5 failures — 2 `UndefinedFunctionError` on `list_mode?/2`, 3 refutes falling on `["b"]`, `["k","b"]`, `["t","z"]` |
| green, implementation restored | rc=0 |
| unit mutant "type A drops the letter but skips the pop" | kills `+bk` and `-b+k`; the channel is keyed to `*!*@spammer.net` |
| **e2e**, chromium | green (8.4s) |
| **e2e mutant**, class branch reverted | **red — header reads `+kbt`**, the reported bug reproduced in a browser. The barrier before the claim still passes, so what dies is the fix and not the arrival of the MODE echo |
| `scripts/check.sh` on the rebased base | rc=0 — 8 doctests, 59 properties, 6000 tests, 0 failures; sobelow `Total errors: 0`; dialyzer `done (passed successfully)`; working tree clean before AND after |

Two corrections worth reading, both of which came from mutants rather than from review:

**The first remove-sign unit test could not fail.** `-bk mask key` asserted the right end state, but a removal discards the argument it popped, so a swallowed mask leaves no trace when nothing follows. Rewritten as `-b+k mask key` — flip the sign and the mode that KEEPS its param reports which token it got.

**The first e2e waited for a pre-state the ircd never creates.** It asserted the mode indicator was visible on a freshly created channel. Measured against the testnet bahamut: a channel comes up with an EMPTY mode set and cic renders the indicator only for a non-empty one, so the wait could only time out — which is exactly how CI reported it (`element(s) not found`). The spec now sets a plain `+t` and watches it land, which is strictly stronger: the indicator is proven live and bound to that channel BEFORE any ban exists, and the `t` re-asserted after the gesture shows the absent `b` is the same live indicator, not a re-rendered empty one.