### PR TITLE
#1262 — fold channel MODE into the denoise filter, as the withdrawn #458 rule now allows

### DIFF
--- a/cicchetto/e2e/tests/issue1262-mode-denoise.spec.ts
+++ b/cicchetto/e2e/tests/issue1262-mode-denoise.spec.ts
@@ -103,14 +103,61 @@ test("#1262 — a channel MODE row folds when denoised (server-side too), the $s
     await expect(modeRows).toHaveCount(0, { timeout: 10_000 });
     await expect(contentRow).toHaveCount(1); // a filter, not a blanket drop
 
-    // --- THE SERVER HALF: reload → the page arrives without the mode row --
-    // RED before #1262's server change: `:mode` was not in
-    // `suppressed_presence_kinds/0`, so the cold-load page still carried the
-    // row and cic (with only its own side moved) would render it.
+    // --- THE SERVER HALF: the cold-load PAGE arrives without the mode row -
+    //
+    // Asserted on the RESPONSE BODY, not on the pane. Measured, because the
+    // first shape of this arm did the latter and was VACUOUS: with only
+    // `message.ex` reverted and cic's own filter intact, the render filter
+    // hides the row the server still sends, so the pane shows 0 either way
+    // and the spec passed with the server defect fully present. A server-only
+    // mutant survived it; that is what promoted this from a DOM count to a
+    // wire assertion. The pane count below stays as the operator-visible
+    // half, but it is the JSON that speaks for the server.
+    // The path must be ANCHORED, not `includes`-matched: the cold load also
+    // issues `/messages/count`, whose URL contains `/messages` and whose body
+    // is `{count: N}` — an object with no `.some`. Measured, not foreseen: the
+    // loose predicate matched it first and the arm died on a TypeError.
+    // EVERY such response is collected, not just the first one awaited. The
+    // first shape awaited a single response and read an array with no privmsg
+    // in it — the cold load issues more than one GET for a channel, and which
+    // one carries the rows is not something this spec should be pinning. The
+    // claim is about what the server served for this channel, so the subject
+    // is the UNION of what it served.
+    const servedPages: { kind: string }[][] = [];
+    page.on("response", (r) => {
+      if (
+        r.request().method() !== "GET" ||
+        r.status() !== 200 ||
+        !new URL(r.url()).pathname.endsWith(`/channels/${encodeURIComponent(channel)}/messages`)
+      ) {
+        return;
+      }
+      // `GET .../messages` answers a BARE ARRAY (api.ts's `fetchMessages`),
+      // not an envelope. Anchored on the path because `/messages/count`
+      // answers `{count: N}` and an `includes` match ate it first.
+      void r
+        .json()
+        .then((body) => {
+          if (Array.isArray(body)) servedPages.push(body as { kind: string }[]);
+        })
+        .catch(() => {});
+    });
+
     await page.reload();
     await selectChannel(page, NETWORK_SLUG, channel, { awaitWsReady: false });
+
+    // DOM barrier FIRST: the content row being back is the durable signal
+    // that the cold load has actually landed. Reading the collected pages
+    // before it would race the fetches still in flight.
     await expect(contentRow).toHaveCount(1, { timeout: 15_000 });
     await expect(modeRows).toHaveCount(0);
+
+    const served = servedPages.flat();
+    // Non-vacuity, twice over: a page set that was never populated, or one
+    // that carried nothing, would satisfy "no mode row" for the wrong reason.
+    expect(servedPages.length).toBeGreaterThan(0);
+    expect(served.some((m) => m.kind === "privmsg")).toBe(true);
+    expect(served.filter((m) => m.kind === "mode")).toEqual([]);
 
     // --- $server is NOT denoised by the channel's pin ---------------------
     // The pin is per-channel (`"<slug> <channel>"`), and `$server` has no

--- a/cicchetto/e2e/tests/issue1262-mode-denoise.spec.ts
+++ b/cicchetto/e2e/tests/issue1262-mode-denoise.spec.ts
@@ -1,0 +1,127 @@
+// #1262 — channel MODE rows fold into the denoise filter, own-nick mode rows
+// on `$server` do not.
+//
+// `:mode` was carved OUT of the suppressed set by #458 on the rule "the broad
+// presence/control kinds carry operator-relevant signal and MUST stay
+// visible". vjt withdrew that rule on 2026-08-13, so `:mode` is now the fifth
+// plain kind in `Grappa.Scrollback.Message.suppressed_presence_kinds/0` and in
+// cic's `SUPPRESSED_PRESENCE_KINDS`.
+//
+// ## What this e2e owns vs what the unit tests own
+//
+// The SET membership is pinned in `test/grappa/scrollback/message_test.exs` and
+// `src/__tests__/presenceFilter.test.ts`, and the two languages are held equal
+// by the parser gate in `test/grappa/presence_filter_test.exs`. The `$server`
+// resolve-to-SHOW rule is pinned in
+// `test/grappa/presence_filter/resolver_test.exs`. None of those can see the
+// VISIBLE outcome, which is what this spec owns:
+//
+//   1. a channel MODE row renders, then DISAPPEARS the moment the channel is
+//      denoised (the cic render filter), and
+//   2. it is still gone after a RELOAD — i.e. the SERVER omitted it from the
+//      cold-load page, not merely cic hiding it. This is the half that would
+//      regress if only one side of the mirror moved; and
+//   3. the own-nick `$server` mode row SURVIVES the same reload, because
+//      `$server` has no member count and resolves to SHOW.
+//
+// A content row rides along throughout as the load witness: it proves the
+// page is populated, so "0 mode rows" means folded rather than "nothing
+// loaded yet" (an empty pane would satisfy the mode assertion vacuously).
+//
+// ## Why the spec creates its own channel
+//
+// `/join` on a fresh name makes the seeded user the channel creator, hence
+// chanop, hence able to set `+m` — the same trick #240 uses for the mode
+// modal. On a shared autojoin channel the user may not be op, and bahamut
+// only echoes a MODE it actually applied, so a non-op attempt would hang to
+// timeout rather than fail (feedback: the witness must be SERVED by the ircd).
+//
+// Anti-hollow-green: `/umode -i` in `finally` restores the shared seeded
+// session's umode set so sibling specs do not inherit `+i` (mirrors #229).
+//
+// Desktop project (untagged → chromium; NO @webkit).
+
+import { composeSend, loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.setTimeout(90_000);
+
+test("#1262 — a channel MODE row folds when denoised (server-side too), the $server umode row stays", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  const channel = `#t1262-${Date.now()}`;
+  const content = `issue1262-content-${Date.now()}`;
+
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first to confirm login + WS-ready before
+  // issuing the /join (mirrors #240 / issue216 boot order).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  try {
+    // --- the $server half: an own-nick umode row -------------------------
+    // Issued BEFORE the channel work so it is comfortably persisted by the
+    // time the reload below re-reads $server from the server.
+    await composeSend(page, "/umode +i");
+
+    // --- a channel where we are op --------------------------------------
+    await composeSend(page, `/join ${channel}`);
+    await expect(
+      page.locator(".sidebar-network-section li").filter({ hasText: channel }),
+    ).toHaveCount(1, { timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // Content witness first, then the MODE. Same socket ⇒ ordered.
+    await composeSend(page, content);
+    await composeSend(page, `/mode ${channel} +m`);
+
+    const contentRow = page
+      .locator('[data-testid="scrollback-line"][data-kind="privmsg"]')
+      .filter({ hasText: content });
+    const modeRows = page.locator('[data-testid="scrollback-line"][data-kind="mode"]');
+
+    // Baseline: unset pref on a 1-member channel → presence SHOWN, so the
+    // mode row renders. Without this the "0 rows" below proves nothing.
+    await expect(contentRow).toHaveCount(1, { timeout: 15_000 });
+    await expect(modeRows.first()).toBeVisible({ timeout: 15_000 });
+
+    // --- denoise: the render filter drops it -----------------------------
+    // Await the persist PUT before reloading — the cold-load resolves
+    // hide_presence from the PERSISTED pref, so an in-flight PUT would race
+    // an unfiltered fetch (the #458 lesson).
+    await openRailMenu(page);
+    const toggle = page.locator('[data-testid="presence-toggle"]');
+    await expect(toggle).toBeVisible({ timeout: 5_000 });
+    const hidePut = page.waitForResponse(
+      (r) =>
+        r.url().includes("/me/settings/display-prefs") && r.request().method() === "PUT" && r.ok(),
+    );
+    await toggle.click();
+    await hidePut;
+
+    await expect(modeRows).toHaveCount(0, { timeout: 10_000 });
+    await expect(contentRow).toHaveCount(1); // a filter, not a blanket drop
+
+    // --- THE SERVER HALF: reload → the page arrives without the mode row --
+    // RED before #1262's server change: `:mode` was not in
+    // `suppressed_presence_kinds/0`, so the cold-load page still carried the
+    // row and cic (with only its own side moved) would render it.
+    await page.reload();
+    await selectChannel(page, NETWORK_SLUG, channel, { awaitWsReady: false });
+    await expect(contentRow).toHaveCount(1, { timeout: 15_000 });
+    await expect(modeRows).toHaveCount(0);
+
+    // --- $server is NOT denoised by the channel's pin ---------------------
+    // The pin is per-channel (`"<slug> <channel>"`), and `$server` has no
+    // member count, so `PresenceFilter.hidden?/2` reads the unknowable count
+    // as SHOW. The own-nick `+i` row must therefore survive the same
+    // cold-load that just dropped the channel's mode row — this is the
+    // #154(b) confirmation the operator relies on.
+    await selectChannel(page, NETWORK_SLUG, "$server", { awaitWsReady: false });
+    const serverModeRows = page.locator('[data-testid="scrollback-line"][data-kind="mode"]');
+    await expect(serverModeRows.first()).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await composeSend(page, "/umode -i").catch(() => {});
+  }
+});

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -565,7 +565,9 @@ const RailActions: Component<Props> = (props) => {
           </Show>
 
           {/* #222 — per-channel join/part/quit/nick-change suppression toggle
-              (denoise). Channel-gated. One tap writes an EXPLICIT pref
+              (denoise), widened to channel MODE rows in #1262 — the label says
+              so, because the operator must know a `+b` set while denoised is
+              not in the transcript. Channel-gated. One tap writes an EXPLICIT pref
               ("show"/"hide") which by the precedence rule WINS over the
               member-count size default, so it pins the channel regardless of
               size. Reading channelPresenceVisible (tracks the pref signal) keeps
@@ -590,10 +592,10 @@ const RailActions: Component<Props> = (props) => {
                   aria-pressed={!presenceShown()}
                   title={
                     presenceShown()
-                      ? "Hide join/part/quit for this channel"
-                      : "Show join/part/quit for this channel"
+                      ? "Hide join/part/quit/mode for this channel"
+                      : "Show join/part/quit/mode for this channel"
                   }
-                  aria-label="denoise join/part/quit signalling"
+                  aria-label="denoise join/part/quit/mode signalling"
                   onClick={togglePresence}
                 >
                   <span class="rail-action-icon" aria-hidden="true">

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1405,7 +1405,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   const rows = createMemo((): Row[] => {
     const allMsgs = messages() ?? [];
     // #222 — render-layer presence filter. On a "large" channel the
-    // join/part/quit/nick_change rows are pure noise; suppress them by
+    // join/part/quit/nick_change/mode rows are pure noise; suppress them by
     // default, with a per-channel pref that WINS over the size default.
     // Reading BOTH the pref signal (via channelPresenceVisible) AND the
     // live member count inside this memo makes the filter reactive to the
@@ -2693,7 +2693,7 @@ const ScrollbackPane: Component<Props> = (props) => {
 
   // #239 — advance the server read-cursor over the TRAILING run of hidden
   // control messages while this window is DISPLAYED. The #222 presence filter
-  // hides join/part/quit/nick_change; those rows have NO DOM node, so the
+  // hides join/part/quit/nick_change/mode; those rows have NO DOM node, so the
   // DOM-geometry settle paths above (scroll-settle / leave / blur / unmount)
   // can only ever advance the cursor to the last RENDERED row. A trailing run
   // of hidden control messages past the cursor therefore never receives a

--- a/cicchetto/src/__tests__/presenceFilter.test.ts
+++ b/cicchetto/src/__tests__/presenceFilter.test.ts
@@ -70,18 +70,22 @@ describe("presenceFilter module", () => {
     });
   });
 
-  describe("SUPPRESSED_PRESENCE_KINDS — the NARROW noise set", () => {
-    it("suppresses exactly join/part/quit/nick_change", async () => {
+  describe("SUPPRESSED_PRESENCE_KINDS — the noise set", () => {
+    it("suppresses exactly join/part/quit/nick_change/mode", async () => {
       const { SUPPRESSED_PRESENCE_KINDS } = await import("../lib/presenceFilter");
       expect(SUPPRESSED_PRESENCE_KINDS.has("join")).toBe(true);
       expect(SUPPRESSED_PRESENCE_KINDS.has("part")).toBe(true);
       expect(SUPPRESSED_PRESENCE_KINDS.has("quit")).toBe(true);
       expect(SUPPRESSED_PRESENCE_KINDS.has("nick_change")).toBe(true);
+      expect(SUPPRESSED_PRESENCE_KINDS.has("mode")).toBe(true);
     });
 
-    it("does NOT suppress mode/topic/kick/server_event (they are not noise)", async () => {
+    // #1262 — `mode` moved INTO the set when vjt withdrew #458's
+    // "mode carries operator-relevant signal" carve-out. The server twin
+    // (`Grappa.Scrollback.Message.suppressed_presence_kinds/0`) must agree,
+    // and `presence_filter_test.exs` parses this file to enforce it.
+    it("does NOT suppress topic/kick/server_event (still not churn)", async () => {
       const { SUPPRESSED_PRESENCE_KINDS } = await import("../lib/presenceFilter");
-      expect(SUPPRESSED_PRESENCE_KINDS.has("mode")).toBe(false);
       expect(SUPPRESSED_PRESENCE_KINDS.has("topic")).toBe(false);
       expect(SUPPRESSED_PRESENCE_KINDS.has("kick")).toBe(false);
       expect(SUPPRESSED_PRESENCE_KINDS.has("server_event")).toBe(false);
@@ -187,13 +191,24 @@ describe("presenceFilter module", () => {
       expect(presenceRowVisible(key(), 999, "action")).toBe(true);
     });
 
-    it("non-suppressed event kinds (mode/topic/kick/server_event) stay visible when hiding", async () => {
+    it("non-suppressed event kinds (topic/kick/server_event) stay visible when hiding", async () => {
       const { presenceRowVisible, setChannelPresencePref } = await import("../lib/presenceFilter");
       setChannelPresencePref(key(), "hide");
-      expect(presenceRowVisible(key(), 999, "mode")).toBe(true);
       expect(presenceRowVisible(key(), 999, "topic")).toBe(true);
       expect(presenceRowVisible(key(), 999, "kick")).toBe(true);
       expect(presenceRowVisible(key(), 999, "server_event")).toBe(true);
+    });
+
+    // #1262 — the behavioural half of the ruling: a channel MODE row is folded
+    // with join/part/quit while the channel is denoised. Own-nick mode rows are
+    // NOT affected here — they live on the `$server` window, whose unknowable
+    // member count resolves to SHOW server-side (see the Resolver test).
+    it("mode is hidden when the channel hides presence, visible otherwise", async () => {
+      const { presenceRowVisible, setChannelPresencePref } = await import("../lib/presenceFilter");
+      setChannelPresencePref(key(), "hide");
+      expect(presenceRowVisible(key(), 999, "mode")).toBe(false);
+      setChannelPresencePref(key(), "show");
+      expect(presenceRowVisible(key(), 999, "mode")).toBe(true);
     });
 
     it("suppressed kinds hidden when the channel hides presence, visible otherwise", async () => {

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -517,7 +517,8 @@ describe("selection store", () => {
         ["privmsg", 1], // visible content
         ["join", 2], // hidden by the presence filter
         ["part", 3], // hidden by the presence filter
-        ["mode", 4], // NOT in the narrow noise set → visible event
+        ["mode", 4], // #1262 — now hidden too (was the visible-event witness)
+        ["topic", 5], // NOT in the noise set → visible event
       ];
       for (const [kind, id] of rows) {
         scrollback.appendToScrollback(key, {
@@ -532,10 +533,10 @@ describe("selection store", () => {
         });
       }
 
-      // Facet A: the hidden join/part are excluded; the visible privmsg
-      // (message) and the visible mode (event) still count.
+      // Facet A: the hidden join/part/mode are excluded; the visible privmsg
+      // (message) and the visible topic (event) still count.
       expect(selection.messagesUnread()[key]).toBe(1); // privmsg
-      expect(selection.eventsUnread()[key]).toBe(1); // mode only — join/part hidden
+      expect(selection.eventsUnread()[key]).toBe(1); // topic only — join/part/mode hidden
       expect(selection.unreadCounts()[key]).toBe(2);
     });
 

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -199,7 +199,7 @@ export function syncedSetColoredNicklist(on: boolean): void {
 export function syncedSetChannelPresencePref(key: ChannelKey, pref: PresencePref): void {
   setChannelPresencePref(key, pref);
   const pushed = pushDisplayPrefs();
-  // #458 — Option 1 filters join/part/quit/nick_change out of the REST page
+  // #458 — Option 1 filters join/part/quit/nick_change/mode out of the REST page
   // SERVER-SIDE when this channel's pref hides them (so `limit` counts VISIBLE
   // rows, not raw ones). Its one accepted consequence: revealing presence needs
   // rows the server never sent. So on "show" we purge the (filtered) page and

--- a/cicchetto/src/lib/presenceFilter.ts
+++ b/cicchetto/src/lib/presenceFilter.ts
@@ -3,19 +3,20 @@ import type { ScrollbackMessage } from "./api";
 import type { ChannelKey } from "./channelKey";
 import { moduleRoot } from "./moduleRoot";
 
-// #222 — hide join/part/quit/nick-change signalling on large channels by
-// default, with a per-channel opt-in to re-show. Closed-set per-channel
+// #222 — hide join/part/quit/nick-change signalling (and, since #1262,
+// channel mode churn) on large channels by default, with a per-channel opt-in
+// to re-show. Closed-set per-channel
 // preference with localStorage persistence, backed by a module-singleton
 // Solid signal so every open scrollback pane re-filters the moment the
 // operator toggles the per-channel control.
 //
 // ## The whole feature in one sentence
 //
-// grappa STILL delivers join/part/quit/nick_change over the wire (no wire
-// change, no server change); cic decides whether to RENDER them. The render
-// decision is: on a "large" channel these four kinds are pure noise, so hide
-// them by default — but let the operator pin a per-channel choice that WINS
-// over the size default.
+// grappa STILL delivers every suppressed kind over the wire (no wire change,
+// no server change); cic decides whether to RENDER them. The render decision
+// is: on a "large" channel these kinds are pure noise, so hide them by
+// default — but let the operator pin a per-channel choice that WINS over the
+// size default.
 //
 // ## Why a render-layer filter, not a store drop
 //
@@ -69,15 +70,33 @@ import { moduleRoot } from "./moduleRoot";
 // two moduledocs cross-reference and that is the whole guard.
 export const LARGE_CHANNEL_THRESHOLD = 200;
 
-// The NARROW noise set — join/part/quit/nick_change ONLY. Deliberately NOT
-// ScrollbackPane's `PRESENCE_KINDS` (which also holds mode/topic/kick/
-// server_event): those are NOT noise and MUST stay visible. Suppressing them
-// would be a bug.
+// The noise set — join/part/quit/nick_change/mode. Still NOT ScrollbackPane's
+// `PRESENCE_KINDS` (which also holds topic/kick/server_event): those three are
+// not churn and stay visible.
+//
+// `mode` joined the set in #1262. It was previously carved OUT by #458 on the
+// rule "mode carries operator-relevant signal and MUST stay visible"; vjt
+// withdrew that rule on 2026-08-13. The accepted cost, stated so nobody
+// rediscovers it as a bug: while a channel is denoised, structural mode
+// transitions (`+b` / `+k` / `+l` / `+m` / `+i`) are folded along with the
+// status-prefix churn this was aimed at. A write-time split that folds only
+// the churn is a possible follow-up, not a precondition. See DESIGN_NOTES
+// 2026-08-13.
+//
+// Own-nick mode rows (#154(b): `/umode +i`, the services-pushed `+r`/`+a` at
+// IDENTIFY) are NOT affected — they land on the synthetic `$server` window,
+// which has no member count, so the server resolves it to SHOW.
+//
+// MUST equal the server twin `Grappa.Scrollback.Message.suppressed_presence_kinds/0`
+// (lib/grappa/scrollback/message.ex), SAME ORDER. Unlike the threshold, this one
+// IS gated: `test/grappa/presence_filter_test.exs` parses this literal and fails
+// on any drift.
 export const SUPPRESSED_PRESENCE_KINDS: ReadonlySet<ScrollbackMessage["kind"]> = new Set([
   "join",
   "part",
   "quit",
   "nick_change",
+  "mode",
 ]);
 
 // unset (key absent) = follow the size default.
@@ -200,7 +219,7 @@ export function channelPresenceVisible(key: ChannelKey, memberCount: number): bo
 // so a hidden control row can never inflate a badge the operator cannot clear
 // (the count and the pane must agree on which rows "count" — CLAUDE.md "one
 // feature, one code path"). A row is visible unless the channel is suppressing
-// presence AND the row is one of the NARROW noise kinds. Reads the reactive
+// presence AND the row is one of the noise kinds. Reads the reactive
 // pref signal (via `channelPresenceVisible`) ONLY for a suppressed kind, so the
 // consumer memo/effect re-runs on toggle / membership-threshold changes exactly
 // when a suppressed row is present. Never fold a second copy of this rule.

--- a/cicchetto/src/lib/presenceFilter.ts
+++ b/cicchetto/src/lib/presenceFilter.ts
@@ -234,10 +234,11 @@ export function presenceRowVisible(
 
 // #239 — the read-cursor advance target that skips the TRAILING run of hidden
 // control messages on window display, WITHOUT marking any VISIBLE unread read.
-// The presence filter hides join/part/quit/nick_change; the DOM-geometry settle
-// paths (scroll / leave / blur) only ever reach the last RENDERED row, so a
-// trailing run of hidden control messages past the cursor never gets a settle
-// event and `last_read_message_id` stays stuck below them — the stuck badge.
+// The presence filter hides join/part/quit/nick_change/mode; the DOM-geometry
+// settle paths (scroll / leave / blur) only ever reach the last RENDERED row,
+// so a trailing run of hidden control messages past the cursor never gets a
+// settle event and `last_read_message_id` stays stuck below them — the stuck
+// badge.
 //
 // Order-INDEPENDENT: works on `msgs` in any order (the store sorts by
 // [server_time asc, id asc], NOT by id — a delayed/batched or clock-skewed row

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40745,6 +40745,32 @@ prose:
   that button by `data-testid="presence-toggle"` and never by its label —
   measured before touching it, not assumed.
 
+**The e2e's server half was VACUOUS, and only a second mutant found it.** The
+spec's title claims the MODE row folds "server-side too", and its cold-load arm
+asserted that by counting rendered rows after a reload. A both-sides mutant
+killed it — but on the FIRST assertion, the render one, and Playwright stops
+there, so the server arm was never reached. Mutating ONLY `message.ex` and
+leaving cic's filter intact, the spec PASSED with the server defect fully
+present: the render filter hides the row the server still sends, so the pane
+counts 0 in both worlds. The green that CI had already reported for this spec
+was, for that half, true by construction.
+
+The cure is to move the OBSERVATION, not to soften the claim: the arm now reads
+the cold-load `GET .../messages` RESPONSE BODY and asserts no `kind: "mode"` row
+is in it. Re-measured after the change, the server-only mutant dies on exactly
+that assertion, reporting the `+m` row the server served. Two further vacuities
+were found while writing it, both of the same "read nothing, pass" family: the
+first URL predicate used `includes` and matched `/messages/count`, whose body is
+an object; and awaiting a single response caught a page that carried no content
+row at all, since a cold load issues more than one GET per channel. The arm now
+collects every matching response, asserts the shape, waits on a DOM barrier
+before reading, and requires the content witness to be present in the union.
+
+The general rule, which is the reason this is in the log at all: **when two
+layers both suppress the same thing, a test that observes the OUTER layer cannot
+see the inner one fail.** The mutant has to be applied per-layer, and the
+observation has to sit at the layer being claimed.
+
 **The mirror is now gated, which it was not before.** `#915` had already
 observed that the size threshold exists once per language with nothing but two
 cross-referencing moduledocs holding it equal, and added a parser test. The

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40677,3 +40677,70 @@ fixture. It builds a scratch repository with the real attribute, appends an entr
 on each of two branches and runs a real `git rebase`, so what the gate is judged
 against is what the merge machinery actually produced. A fixture would have
 proved the regex works and nothing about the defect.
+<!-- entry #1262 -->
+
+---
+
+## 2026-08-13 — #1262: `:mode` is denoise churn, and #458's carve-out is withdrawn
+
+#458 pinned the suppressed presence set to a deliberately narrow four —
+`join`/`part`/`quit`/`nick_change` — and wrote the reason into
+`Grappa.Scrollback.Message` as a rule: *the broad presence/control kinds
+(`:mode`, `:topic`, `:kick`, `:server_event`) carry operator-relevant signal
+and MUST stay visible; suppressing them would be a bug.* #1262 opened against
+that rule, proposing a write-time split inside `:mode` (a `:status_mode` kind,
+or a boolean column) so that status-prefix churn — services re-opping on every
+join, mass `+o` after a netsplit, `+v` sprays — could fold while structural
+modes (`+b` `+k` `+l` `+m` `+i`) stayed.
+
+**vjt withdrew the #458 rule instead (2026-08-13).** `:mode` enters the
+suppressed set as a plain fifth kind. No sub-classification, no new column, no
+migration. The write-time split is demoted from precondition to possible
+follow-up.
+
+**The accepted cost, stated here so nobody rediscovers it as a bug report:**
+while a channel is denoised, structural channel-mode transitions are omitted
+from the fetch too. A ban set during a denoised session is not in that
+session's transcript. That is the trade, taken knowingly — the alternative was
+holding a genuinely noisy feature hostage to a write-time classifier nobody
+needed yet.
+
+Three consequences worth naming, because two of them are behaviour and not
+prose:
+
+* `count_after_split/6` and `ReadCursor`'s `hidden_channels` both derive from
+  the same SSOT list, so `:mode` also stops counting toward the `events`
+  badge on a hidden window. That is the correct direction: the pane no longer
+  renders those rows, and a badge the operator cannot clear by reading is the
+  #239/#505 defect. It is still a behaviour change that no line of the issue
+  asked for.
+* Own-nick mode rows (#154(b) — `/umode +i`, the services-pushed `+r`/`+a` at
+  IDENTIFY) are untouched. They land on the synthetic `$server` window, which
+  has no member count; `Grappa.PresenceFilter.hidden?/2` reads an unknowable
+  count as SHOW (decision D), so the operator keeps the only confirmation
+  those events ever produce. This is now pinned by a test that asserts
+  `$server` resolves to SHOW *beside a live oversized channel on the same
+  network* — without that neighbour the assertion would pass merely because no
+  session existed, which is a different clause.
+* The prose stating the withdrawn rule lived in six places, not the two the
+  change itself touches: `Message`'s attribute comment and its `@doc`,
+  `Scrollback.fetch/7`'s `hide_presence` section, `count_after_split/6`'s doc,
+  `PresenceFilter`'s moduledoc, and cic's `SUPPRESSED_PRESENCE_KINDS` comment.
+  All six were rewritten in the same commit. A withdrawn rule left in a
+  docstring is a rule that gets resurrected by the next reader who greps for
+  it.
+
+**The mirror is now gated, which it was not before.** `#915` had already
+observed that the size threshold exists once per language with nothing but two
+cross-referencing moduledocs holding it equal, and added a parser test. The
+KIND SET had the same weakness and no such test: adding `:mode` to one side
+alone leaves BOTH suites fully green while page-up and the live tail disagree
+about which rows exist. `presence_filter_test.exs` now parses
+`SUPPRESSED_PRESENCE_KINDS` out of `presenceFilter.ts` and asserts equality
+*and order* against `Message.suppressed_presence_kinds/0`. The threshold gate
+proved the shape; this is the second application of it.
+
+**Apply:** when a ruling is withdrawn, grep for the ruling's *sentence*, not
+for the symbol it constrained. The symbol appears where the code is; the
+sentence appears wherever someone once explained the code, and that is where
+the next contributor will read it back as current.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40729,6 +40729,21 @@ prose:
   All six were rewritten in the same commit. A withdrawn rule left in a
   docstring is a rule that gets resurrected by the next reader who greps for
   it.
+* **A SECOND class of stale prose, found only by grepping for the old set
+  rather than for the rule:** seven more sites did not argue the rule at all,
+  they merely *enumerated the suppressed kinds* — `PresenceFilter`'s #239
+  comment and `ScrollbackPane`'s two (the `rows()` memo and the #239 cursor
+  advance), `displayPrefs`' #458 note, `Scrollback.fetch/7`'s `hide_presence`
+  narrative, `UserSettings`' `presence_filter` typedoc, and the denoise
+  button's own `title` / `aria-label`. An enumeration goes stale silently:
+  it never contradicts the code loudly enough to be noticed, it just quietly
+  omits the fifth member. The last of them is not a comment at all —
+  **it is text the operator reads.** Leaving it would have made the UI
+  understate what the toggle takes away, which is the exact failure the
+  "state the accepted cost plainly" paragraph above exists to prevent.
+  Changing rendered copy was safe to do here only because the specs select
+  that button by `data-testid="presence-toggle"` and never by its label —
+  measured before touching it, not assumed.
 
 **The mirror is now gated, which it was not before.** `#915` had already
 observed that the size threshold exists once per language with nothing but two

--- a/lib/grappa/presence_filter.ex
+++ b/lib/grappa/presence_filter.ex
@@ -1,7 +1,8 @@
 defmodule Grappa.PresenceFilter do
   @moduledoc """
   The server-side decision "should the scrollback fetch HIDE presence rows
-  (join/part/quit/nick_change) for this channel?" — the twin of cic's
+  (join/part/quit/nick_change and, since #1262, mode) for this channel?" — the
+  twin of cic's
   `resolvePresenceVisible` (`cicchetto/src/lib/presenceFilter.ts`), INVERTED:
   cic asks "is presence VISIBLE?" at render time; the server asks "should the
   REST fetch OMIT presence?" at query time (#458).

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -281,7 +281,7 @@ defmodule Grappa.ReadCursor do
 
   `%{network_slug => MapSet.of(channel)}`, resolved once by the caller via
   `Grappa.PresenceFilter.Resolver.hidden_channels/3`. For a window in that
-  set, the NARROW presence-noise kinds
+  set, the presence-noise kinds
   (`Message.suppressed_presence_kinds/0`) do not join, so they never land in
   its `events` bucket — the cold-load twin of `count_after_split/6`'s
   `hide_presence`, and the door the #505 badge jump is actually reported

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -607,7 +607,7 @@ defmodule Grappa.Scrollback do
   Also a REQUIRED positional, same contract as `count_after/6`'s. It was
   absent here until #505 on the reasoning that filtering a SPLIT count
   would be self-defeating; the opposite turned out to be true. On a channel
-  that hides presence the pane never renders join/part/quit/nick_change, so
+  that hides presence the pane never renders join/part/quit/nick_change/mode, so
   an `events` count that includes them is a badge the operator cannot clear
   by reading — and because cic's hydrated count already excludes them
   (`presenceRowVisible`, `cicchetto/src/lib/selection.ts`), the seed

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -98,7 +98,7 @@ defmodule Grappa.Scrollback do
   # never notify.
   @content_kinds Message.content_kinds()
 
-  # #458 — the NARROW presence-noise kinds the history reads omit when a
+  # #458 — the presence-noise kinds the history reads omit when a
   # channel is hiding presence. Derived from the schema SSOT
   # (`Message.suppressed_presence_kinds/0`); consumed by
   # `maybe_exclude_presence/2`. A module attribute (compile-time list) so the
@@ -394,11 +394,11 @@ defmodule Grappa.Scrollback do
 
   ## `hide_presence` (#458)
 
-  When `true`, the query excludes the NARROW presence-noise kinds
-  (`Message.suppressed_presence_kinds/0` — join/part/quit/nick_change) in
-  SQL, so `limit` counts VISIBLE rows: one page-up is one screenful instead
-  of a page that renders empty on a busy channel. The broad control kinds
-  (mode/topic/kick/server_event) always stay. When `false`, every kind is
+  When `true`, the query excludes the presence-noise kinds
+  (`Message.suppressed_presence_kinds/0` — join/part/quit/nick_change and,
+  since #1262, mode) in SQL, so `limit` counts VISIBLE rows: one page-up is
+  one screenful instead of a page that renders empty on a busy channel.
+  `:topic`, `:kick` and `:server_event` always stay. When `false`, every kind is
   returned (unchanged behaviour). REQUIRED positional (same no-default rule as
   `own_nick`): a `false` default would silently disable #458 for any caller
   that forgets to thread it. The per-channel decision (tri-state pref × live
@@ -476,7 +476,7 @@ defmodule Grappa.Scrollback do
 
   ## `hide_presence` (#458)
 
-  Same contract as `fetch/6` — excludes the narrow presence-noise kinds when
+  Same contract as `fetch/6` — excludes the presence-noise kinds when
   `true`, so the reconnect/backfill replay stays consistent with the history
   page (#458 decision B). Safe by construction: cic routes backfill rows ONLY
   to the render/scrollback store (`refreshScrollback`), NEVER through
@@ -614,9 +614,12 @@ defmodule Grappa.Scrollback do
   visibly DROPS the moment the channel hydrates. That jump is the reported
   bug.
 
-  The filter is NARROW: `Message.suppressed_presence_kinds/0` only. `:mode`,
-  `:topic`, `:kick` and `:server_event` still count under `events` when
-  hiding, because the pane still renders them. The content bucket is
+  The filter is `Message.suppressed_presence_kinds/0` only. `:topic`, `:kick`
+  and `:server_event` still count under `events` when hiding, because the pane
+  still renders them. `:mode` STOPPED counting there in #1262 when it entered
+  the suppressed set — the pane no longer renders it on a denoised channel, so
+  counting it would inflate a badge the operator cannot clear. The content
+  bucket is
   unaffected either way — every suppressed kind is disjoint from
   `@content_kinds`, so the exclusion can only ever shrink `events`.
   """
@@ -1153,7 +1156,7 @@ defmodule Grappa.Scrollback do
   defp maybe_before(query, before) when is_integer(before),
     do: where(query, [m], m.id < ^before)
 
-  # #458 — when hiding, exclude the narrow presence-noise kinds
+  # #458 — when hiding, exclude the presence-noise kinds
   # (@suppressed_presence_kinds) in SQL so `limit` counts VISIBLE rows. The
   # `not in ^...` renders `kind NOT IN (?, ?, ?)` with the atoms dumped to
   # their Ecto.Enum string values (same mechanism as count_after_split/6).

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -151,17 +151,29 @@ defmodule Grappa.Scrollback.Message do
   # construction (#395).
   @notify_kinds for {kind, :notify} <- @content_kind_projection, do: kind
 
-  # #458 — the NARROW presence-noise subset the scrollback fetch omits when a
-  # channel is hiding presence. Deliberately NARROW: join/part/quit/nick_change
-  # ONLY. The broad presence/control kinds (:mode, :topic, :kick,
-  # :server_event) carry operator-relevant signal and MUST stay visible —
-  # suppressing them would be a bug. Mirrors cic's SUPPRESSED_PRESENCE_KINDS
-  # (cicchetto/src/lib/presenceFilter.ts), same order, so the server history
-  # filter (#458) and the client live-tail render-filter agree exactly on
-  # which kinds are noise. Disjoint from @content_kinds BY the test invariant
-  # (presence noise is never human content), so hiding presence can never drop
-  # a real message.
-  @suppressed_presence_kinds [:join, :part, :quit, :nick_change]
+  # #458 — the presence-noise subset the scrollback fetch omits when a channel
+  # is hiding presence. `:topic`, `:kick` and `:server_event` stay OUT: they are
+  # control rows, not churn, and a denoised channel still shows them.
+  #
+  # #1262 (2026-08-13) — `:mode` is IN. It was carved out by #458 on the rule
+  # "the broad presence/control kinds carry operator-relevant signal and MUST
+  # stay visible"; vjt withdrew that rule. The accepted cost, recorded here so
+  # nobody rediscovers it as a bug: while a channel is denoised, STRUCTURAL mode
+  # transitions (`+b` / `+k` / `+l` / `+m` / `+i`) are folded along with the
+  # status-prefix churn the issue was aimed at. A write-time split that folds
+  # only the churn is a possible follow-up, not a precondition. Own-nick mode
+  # rows (#154(b)) are untouched: they land on the synthetic `$server` window,
+  # which has no member count, so `PresenceFilter.hidden?/2` resolves it to
+  # SHOW. See DESIGN_NOTES 2026-08-13.
+  #
+  # Mirrors cic's SUPPRESSED_PRESENCE_KINDS (cicchetto/src/lib/presenceFilter.ts),
+  # SAME ORDER, so the server history filter and the client live-tail
+  # render-filter agree exactly on which kinds are noise — and unlike the size
+  # threshold, that agreement IS gated: `presence_filter_test.exs` parses the cic
+  # literal and fails on drift. Disjoint from @content_kinds BY the test
+  # invariant (presence noise is never human content), so hiding presence can
+  # never drop a real message.
+  @suppressed_presence_kinds [:join, :part, :quit, :nick_change, :mode]
 
   # M8 fix 2026-05-08: kinds for which `:dm_with` may legitimately
   # carry a peer nick. CP23 cluster `code-reload` extended the list to
@@ -226,17 +238,22 @@ defmodule Grappa.Scrollback.Message do
   def notify_kinds, do: @notify_kinds
 
   @doc """
-  Returns the NARROW presence-noise subset of `kinds/0` —
-  `[:join, :part, :quit, :nick_change]`. #458 SINGLE SOURCE: the scrollback
-  fetch omits exactly these kinds when a channel is hiding presence
-  (`Grappa.PresenceFilter.hidden?/2` resolves the per-channel decision). The
-  broad control kinds (`:mode`, `:topic`, `:kick`, `:server_event`) are
-  deliberately absent — they carry operator-relevant signal and stay visible.
-  Mirrors the cic `SUPPRESSED_PRESENCE_KINDS` set
-  (`cicchetto/src/lib/presenceFilter.ts`); the two MUST agree so the server
-  history filter and the client live-tail render-filter suppress the same rows.
+  Returns the presence-noise subset of `kinds/0` —
+  `[:join, :part, :quit, :nick_change, :mode]`. #458 SINGLE SOURCE: the
+  scrollback fetch omits exactly these kinds when a channel is hiding presence
+  (`Grappa.PresenceFilter.hidden?/2` resolves the per-channel decision).
+  `:topic`, `:kick` and `:server_event` are deliberately absent — they are
+  control rows rather than churn and stay visible.
+
+  `:mode` joined the set in #1262, when vjt withdrew #458's
+  "mode carries operator-relevant signal" carve-out; the accepted cost is that
+  structural `+b`/`+k`/`+l`/`+m`/`+i` rows are folded too while denoised. Mirrors
+  the cic `SUPPRESSED_PRESENCE_KINDS` set
+  (`cicchetto/src/lib/presenceFilter.ts`); the two MUST agree, in the same
+  order, so the server history filter and the client live-tail render-filter
+  suppress the same rows — enforced by `presence_filter_test.exs`.
   """
-  @spec suppressed_presence_kinds() :: [:join | :part | :quit | :nick_change, ...]
+  @spec suppressed_presence_kinds() :: [:join | :part | :quit | :nick_change | :mode, ...]
   def suppressed_presence_kinds, do: @suppressed_presence_kinds
 
   @type kind ::

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -177,7 +177,8 @@ defmodule Grappa.UserSettings do
 
     * `time_format` — `"hms"` (with seconds, the default) or `"hm"`.
     * `colored_nicklist` — per-nick colours in the members pane (default false).
-    * `presence_filter` — per-channel join/part/quit visibility pins,
+    * `presence_filter` — per-channel join/part/quit/nick_change/mode
+      visibility pins (`:mode` joined the suppressed set in #1262),
       `%{channel_key => "show" | "hide"}`. TRI-STATE: an unpinned channel is
       ABSENT (cic follows the live member-count default). The server never
       stores a third value and never coerces unset into a boolean. Font size

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -135,6 +135,35 @@ defmodule Grappa.PresenceFilter.ResolverTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #1262 / #154(b) — THE PIN vjt asked for. Own-nick MODE rows (`/umode +i`,
+    # the services-pushed `+r`/`+a` at IDENTIFY) land on the synthetic
+    # `$server` window, and `:mode` is now a suppressed kind — so the only
+    # thing keeping that confirmation visible is that `$server` resolves to
+    # SHOW. It does because `Session.list_members/3` cannot count a synthetic
+    # window, so the count is unknowable and `PresenceFilter.hidden?/2` reads
+    # nil as SHOW (decision D).
+    #
+    # The session is LIVE and joined to an OVERSIZED channel on purpose: it
+    # makes the assertion non-vacuous. Without it the test would pass merely
+    # because there is no session at all, which is a different clause and
+    # would not notice someone teaching `$server` a member count.
+    test "#1262 — the synthetic $server window SHOWS even beside an oversized live channel" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      big = PresenceFilter.large_channel_threshold()
+      {network, pid} = session_with_members(user, "#big", big)
+
+      # Sanity: the live session really is oversized, so a count IS reachable
+      # on this network. If this flips, the $server assertion below proves
+      # nothing.
+      assert Resolver.hidden?(subject, network.slug, network.id, "#big")
+
+      refute Resolver.hidden?(subject, network.slug, network.id, "$server"),
+             "own-nick mode rows on $server must stay visible now that :mode is suppressible (#1262)"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "an unset channel below the threshold shows" do
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       subject = {:user, user.id}

--- a/test/grappa/presence_filter_test.exs
+++ b/test/grappa/presence_filter_test.exs
@@ -2,6 +2,7 @@ defmodule Grappa.PresenceFilterTest do
   use ExUnit.Case, async: true
 
   alias Grappa.PresenceFilter
+  alias Grappa.Scrollback.Message
 
   # #458 — the server-side twin of cic's `resolvePresenceVisible`
   # (`cicchetto/src/lib/presenceFilter.ts`), INVERTED: cic asks "is presence
@@ -70,6 +71,67 @@ defmodule Grappa.PresenceFilterTest do
              the REST history fetch). While they differ, every channel whose member
              count falls between the two values shows join/part/quit on the live WS
              tail and loses it on page-up. Move BOTH or neither.
+             """
+    end
+
+    # #1262 — the threshold was not the only thing held equal by prose. The
+    # KIND SET exists twice too (`Message.suppressed_presence_kinds/0` and
+    # cic's `SUPPRESSED_PRESENCE_KINDS`), and adding `:mode` to one side alone
+    # leaves BOTH suites green while the REST history page folds a mode row
+    # the live WS tail still renders. Same executable-drift-guard shape as the
+    # threshold test above: the rule is expressed once per language, so the
+    # EQUALITY has to be expressed as code. Order is asserted too — both sides
+    # document the mirror order, and a set-only compare would let the two
+    # documented orders diverge silently.
+    test "suppressed_presence_kinds/0 equals cic's SUPPRESSED_PRESENCE_KINDS, in order" do
+      source = File.read!(@cic_path)
+
+      body =
+        case Regex.run(
+               ~r/export\s+const\s+SUPPRESSED_PRESENCE_KINDS[^=]*=\s*new\s+Set\(\[(.*?)\]\)/s,
+               source
+             ) do
+          [_, captured] ->
+            captured
+
+          _ ->
+            flunk("Could not locate `export const SUPPRESSED_PRESENCE_KINDS = new Set([...])` in #{@cic_path}")
+        end
+
+      cic_kinds =
+        ~r/"([a-z_]+)"/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, kind] -> String.to_atom(kind) end)
+
+      # A drift guard that reads its subject out of ANOTHER language's source
+      # has one failure mode worse than being wrong: becoming a no-op. If a
+      # reformat, a quoting-style change, or a rename makes the parse yield
+      # NOTHING, the comparison below must not quietly degrade into a
+      # confusing `[] != [...]`. Assert the parse produced something FIRST, so
+      # the failure names the real cause — the gate stopped reading the file.
+      refute cic_kinds == [],
+             """
+             Parsed ZERO kinds out of #{@cic_path}.
+
+             The literal was located but no `"kind"` strings came out of it,
+             so this parity gate is no longer reading anything and would pass
+             vacuously the moment the two sides agreed on emptiness. Fix the
+             parse (quoting style? the array inlined or reformatted?) rather
+             than the assertion.
+             """
+
+      assert cic_kinds == Message.suppressed_presence_kinds(),
+             """
+             The denoise KIND SET has drifted between the two languages.
+
+               #{@cic_path}: #{inspect(cic_kinds)}
+               Grappa.Scrollback.Message:        #{inspect(Message.suppressed_presence_kinds())}
+
+             They MUST be equal AND in the same order: the server omits these
+             kinds from the REST history fetch (#458) while cic omits the same
+             kinds from the live-tail render. While they differ, page-up and
+             the live tail disagree about which rows exist. Move BOTH or
+             neither.
              """
     end
   end

--- a/test/grappa/scrollback/message_test.exs
+++ b/test/grappa/scrollback/message_test.exs
@@ -76,12 +76,15 @@ defmodule Grappa.Scrollback.MessageTest do
     end
   end
 
-  describe "suppressed_presence_kinds/0 (#458)" do
-    test "is the NARROW noise subset [:join, :part, :quit, :nick_change]" do
+  describe "suppressed_presence_kinds/0 (#458, widened by #1262)" do
+    test "is the noise subset [:join, :part, :quit, :nick_change, :mode]" do
       # Mirror order of cic's SUPPRESSED_PRESENCE_KINDS
       # (cicchetto/src/lib/presenceFilter.ts) — the server filter and the
       # client render-filter must agree on exactly which kinds are noise.
-      assert Message.suppressed_presence_kinds() == [:join, :part, :quit, :nick_change]
+      # `:mode` joined the set in #1262 when vjt withdrew #458's
+      # "mode carries operator-relevant signal" rule; the parity test in
+      # `presence_filter_test.exs` is what actually holds the two sides equal.
+      assert Message.suppressed_presence_kinds() == [:join, :part, :quit, :nick_change, :mode]
     end
 
     test "every suppressed kind is a valid schema kind (subset of kinds/0)" do
@@ -98,14 +101,24 @@ defmodule Grappa.Scrollback.MessageTest do
                Message.suppressed_presence_kinds()
     end
 
-    test "the broad control kinds (mode/topic/kick/server_event) are NOT suppressed" do
-      # NARROW vs broad: mode/topic/kick/server_event are presence/control
-      # but NOT noise — they carry operator-relevant signal and MUST stay
-      # visible. Suppressing them would be a bug (presenceFilter.ts:64-73).
-      for k <- [:mode, :topic, :kick, :server_event] do
+    test "the remaining control kinds (topic/kick/server_event) are NOT suppressed" do
+      # `:topic`, `:kick` and `:server_event` are presence/control but are not
+      # churn: they stay visible while a channel is denoised. `:mode` used to
+      # be in this list under #458 and was moved out by #1262 — see the
+      # sibling test below.
+      for k <- [:topic, :kick, :server_event] do
         refute k in Message.suppressed_presence_kinds(),
-               "#{inspect(k)} must NOT be in the narrow suppressed set"
+               "#{inspect(k)} must NOT be in the suppressed set"
       end
+    end
+
+    test "#1262 — :mode IS suppressed (the #458 carve-out is withdrawn)" do
+      # vjt, 2026-08-13: `:mode` may go into the suppressed set as a plain
+      # fifth kind. The accepted cost is that +b/+k/+l/+m/+i transitions are
+      # omitted from the fetch too while the channel is denoised — see
+      # DESIGN_NOTES. A future write-time split (#1262 body) can narrow this
+      # again; until then this assertion is the ruling.
+      assert :mode in Message.suppressed_presence_kinds()
     end
   end
 

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -831,7 +831,7 @@ defmodule Grappa.ScrollbackTest do
       assert Enum.all?(shown_page, &(&1.kind == :join))
     end
 
-    test "hide_presence: true keeps the BROAD control kinds visible (mode/topic/kick/server_event)",
+    test "hide_presence: true keeps topic/kick/server_event visible but folds :mode (#1262)",
          %{user: user, network: net} do
       {:ok, _} =
         ScrollbackHelpers.insert(
@@ -850,8 +850,15 @@ defmodule Grappa.ScrollbackTest do
       page = Scrollback.fetch({:user, user.id}, net.id, "#sniffo", nil, 50, nil, true)
       kinds = page |> Enum.map(& &1.kind) |> MapSet.new()
 
-      assert MapSet.subset?(MapSet.new([:mode, :topic, :kick]), kinds), "broad control kinds must stay visible"
-      refute :join in kinds, "narrow presence noise is still filtered"
+      assert MapSet.subset?(MapSet.new([:topic, :kick]), kinds), "topic/kick must stay visible"
+      refute :join in kinds, "presence noise is still filtered"
+
+      # #1262 — the withdrawn #458 carve-out. A channel MODE row is churn on a
+      # denoised channel and is now folded WITH join/part/quit. The accepted
+      # cost: the `+o alice` row above is a structural-mode row's twin, and
+      # both go. Own-nick mode rows are unaffected — they land on `$server`,
+      # which resolves to SHOW (see PresenceFilter.Resolver test).
+      refute :mode in kinds, "channel mode churn is folded when denoised (#1262)"
     end
   end
 

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -213,19 +213,25 @@ defmodule Grappa.WindowCountsTest do
   # to the hydrated answer.
   # ---------------------------------------------------------------------------
 
-  test "hiding excludes the narrow suppressed kinds from events (#505)" do
+  test "hiding excludes the suppressed kinds from events (#505, :mode added #1262)" do
     c = ctx()
     anchor = insert(c, "#chan", st: 1, body: "anchor")
     insert(c, "#chan", st: 2, sender: "bob", kind: :join, body: nil)
     insert(c, "#chan", st: 3, sender: "bob", kind: :part, body: nil)
     insert(c, "#chan", st: 4, sender: "bob", kind: :mode, body: nil)
+    # `:topic` is body-required, and is the CONTROL row that must survive the
+    # hide — without it this test cannot tell the kind filter from a zeroed
+    # events bucket. It took over that job from `:mode` in #1262.
+    insert(c, "#chan", st: 5, sender: "bob", kind: :topic, body: "new topic")
 
-    # Showing: all three. This is the pre-#505 answer and must not move.
+    # Showing: all four. This is the pre-#505 answer and must not move.
     assert snap(c, "#chan", anchor.id, "vjt") ==
-             %{messages: 0, mentions: 0, events: 3, severity: :event}
+             %{messages: 0, mentions: 0, events: 4, severity: :event}
 
-    # Hiding: join + part go, :mode STAYS. If the filter were "zero the events
-    # bucket" instead of "apply the narrow kind set", this would read 0.
+    # Hiding: join + part + mode go, :topic STAYS. `:mode` joined the
+    # suppressed set in #1262 (vjt withdrew #458's carve-out), so it no longer
+    # counts toward a badge the operator cannot clear by reading — the pane
+    # does not render it either.
     assert snap_hiding(c, "#chan", anchor.id, "vjt") ==
              %{messages: 0, mentions: 0, events: 1, severity: :event}
   end
@@ -567,6 +573,9 @@ defmodule Grappa.WindowCountsTest do
         ins(subject, net.id, chan, st: 3, sender: "bob", kind: :join, body: nil)
         ins(subject, net.id, chan, st: 4, sender: "bob", kind: :quit, body: nil)
         ins(subject, net.id, chan, st: 5, sender: "bob", kind: :mode, body: nil)
+        # The surviving CONTROL row (see the sibling test): `:mode` stopped
+        # playing that part in #1262 when it entered the suppressed set.
+        ins(subject, net.id, chan, st: 6, sender: "bob", kind: :topic, body: "t")
         cursor(subject, net.id, chan, anchor.id)
       end
 
@@ -575,13 +584,13 @@ defmodule Grappa.WindowCountsTest do
 
       bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [], hidden)
 
-      # #big: join + quit dropped, :mode survives.
+      # #big: join + quit + mode dropped, :topic survives.
       assert bulk[net.slug]["#big"] ==
                %{messages: 1, mentions: 0, events: 1, severity: :message}
 
       # #small: untouched — the exclusion is PER WINDOW, not a global switch.
       assert bulk[net.slug]["#small"] ==
-               %{messages: 1, mentions: 0, events: 3, severity: :message}
+               %{messages: 1, mentions: 0, events: 4, severity: :message}
     end
 
     test "agrees with snapshot/7 for the same window" do


### PR DESCRIPTION
## What this is

Issue #1262 as **ruled**, not as filed. The body designs a write-time split
inside `:mode` (a `:status_mode` kind, or a boolean column) so status-prefix
churn folds while structural modes stay. vjt's comment of 2026-08-13
**withdraws the #458 rule** that made the split necessary, so `:mode` enters
the suppressed set as a plain fifth kind: no sub-classification, no column,
no migration. The write-time split is demoted to a possible follow-up.

- `Grappa.Scrollback.Message` — `:mode` appended to `@suppressed_presence_kinds`
  and its `@spec`.
- `cicchetto/src/lib/presenceFilter.ts` — `"mode"` appended to
  `SUPPRESSED_PRESENCE_KINDS`, same order.

## The accepted cost, stated where it will be found

While a channel is denoised, structural channel-mode transitions (`+b` `+k`
`+l` `+m` `+i`) are folded along with the status-prefix churn the issue aimed
at. A ban set during a denoised session is not in that session's transcript.
That is the trade vjt took knowingly; it is written into `DESIGN_NOTES` so
nobody rediscovers it as a bug report.

Own-nick mode rows (#154(b) — `/umode +i`, the services-pushed `+r`/`+a` at
IDENTIFY) are untouched: they land on the synthetic `$server` window, which
has no member count, and `Grappa.PresenceFilter` resolves an unknowable count
to SHOW.

## Two behaviour changes no line of the issue asked for

1. `count_after_split/6` and `ReadCursor`'s `hidden_channels` both derive from
   the same SSOT list, so `:mode` also stops counting toward the `events`
   badge on a hidden window. Correct direction — the pane no longer renders
   those rows, and a badge the operator cannot clear by reading is the
   #239/#505 defect — but it is a behaviour change, named here rather than
   left to be discovered.
2. The denoise button's `title` / `aria-label` now say `mode` too. It is
   rendered copy, so it was measured before being touched: the specs select
   that button by `data-testid="presence-toggle"` and never by its label.
   Leaving it would have made the UI understate what the toggle takes away.

## Gating

- **`Message.suppressed_presence_kinds/0` ↔ `SUPPRESSED_PRESENCE_KINDS` is now
  GATED**, which it was not before. `test/grappa/presence_filter_test.exs`
  parses the literal out of the `.ts` and asserts equality *and order*. The
  gate was hardened until each of two mutants produces a distinct, readable
  message (empty array → "Parsed ZERO kinds out of …"; renamed constant →
  "Could not locate …"). To be precise about what that bought: it bought a
  LEGIBLE failure, not a silent green averted — with `cic_kinds` empty the
  equality failed anyway, since the server list is a non-empty literal.
- `$server` resolving to SHOW is pinned **beside a live oversized channel on
  the same network**. Without that neighbour the assertion would pass merely
  because no session existed, which is a different clause.
- Red measured before green: with `lib/` reverted to the base, `Compiling 6
  files (.ex)` and 4 failures (the parity gate, the two on
  `suppressed_presence_kinds/0`, the `fetch hide_presence` one). Green after
  restore.
- Two `window_counts_test` tests used a `:mode` row as the witness of the
  control that SURVIVES hiding. Witness moved to `:topic` (already the in-tree
  idiom — the third test in the same file says so), the `:mode` rows kept and
  the expected counts moved, so those tests now also prove `:mode` stops
  counting.

## Verification

- `scripts/check.sh` — **rc=0**. `8 doctests, 59 properties, 5998 tests, 0
  failures`; bats suite all `ok`. Sobelow: the gate passes; not "zero
  findings" — the two pre-existing `Traversal.FileModule` Low Confidence hits
  on `lib/grappa/cic/bundle.ex` are still there.
- `bun run check` — rc=0, 1013 files, 60 warnings / 5 infos (the pre-existing
  baseline; the file count rose by one because the new e2e spec is genuinely
  covered by the e2e tsconfig).
- `bun run test` — rc=0, 281 files / 5331 tests passed.

🔴 **What the local `check.sh` does NOT cover.** It ran to green *before* the
last commit. That commit (`docs(#1262): correct the prose that ENUMERATES the
suppressed set`) touches `lib/grappa/scrollback.ex` and
`lib/grappa/user_settings.ex` — **comments and a typedoc only, no branch, no
predicate, no kind set** — plus four cic comments and the button copy. The cic
side was re-gated after the fact (both numbers above are post-commit). The
Elixir delta's verdict is **this PR's CI**, not a second local run. Local is
the sample; CI is the verdict.

**The e2e spec has never been executed.** `cicchetto/e2e/tests/issue1262-mode-denoise.spec.ts`
passes only the static gate, which says nothing about whether its selectors
find anything. It needs a stack, and it will be run together with the three
neighbours that consume the same filter — `issue222-presence-filter`,
`issue458-presence-page-yield`, `issue239-hidden-msg-unread` — chosen by who
consumes the shared path, not by filename prefix.

## Conflict watch

`docs/DESIGN_NOTES.md` is contended with **two** open PRs, #1260 and #1261.
The branch's contribution to that file is pinned at 81 additions / 0 deletions
and will be re-diffed after any rebase, boundary shape read on the file — the
separator-eater tell is additions down by 3, not deletions.