### PR TITLE
#1263 — opt-in per-worker build caches so the COMPILE lane can go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # ── Elixir / Erlang
 /_build/
+# #1263 — per-worker build caches (GRAPPA_CACHE_ID): one
+# _build/deps/priv/plts triplet per id, opt-in, never shared.
+/.caches/
 /cover/
 /coverage/
 /deps/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,6 +778,13 @@ is due. Don't just look at todo.md.
   a forced rebuild (`scripts/mix.sh --env=dev compile --force`) before you
   believe it, and say in the report which of the two you established. The
   COMPILE lane serialises access; it does NOT make the artefacts yours.
+  **Opt out with `GRAPPA_CACHE_ID=<id>` (#1263):** the three caches then come
+  from `.caches/<id>/` and `MIX_TEST_PARTITION` follows the id, so two ids can
+  run `mix` concurrently. Unset changes nothing. A fresh id is COLD — full
+  compile plus its own dialyzer PLT, nothing seeded (seeding would import the
+  contamination described above). Does NOT isolate the docker stack: compose
+  project and ports are still shared, so `integration.sh` / e2e stay
+  single-occupancy. See `docs/OPERATIONS.md`.
 - **NEVER install hex packages on the host.** Add them to `mix.exs`,
   rebuild the image (`scripts/mix.sh deps.get`).
 - **Don't touch the IRC parser without re-running parser tests.**

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40725,10 +40725,28 @@ operator may be partitioning for an unrelated reason.
   `cp -c` clone is instant — but those artefacts were compiled from another
   worktree's source, which is precisely the contamination class this issue
   exists to end. A fresh id starts empty and pays a full compile plus its own
-  PLT. Cost measured on this host: ~209M per id (`_build` 148M, `deps` 33M,
-  `priv/plts` 28M), disk that is free at 885G available. The PLT *build time*
-  is the number that would justify revisiting this, and it has not been
-  measured yet.
+  PLT. **The disk cost was over-estimated before it was measured**: reading
+  the shared tree gave ~209M per id, but a real cold `check.sh` produces
+  **113M** — `_build` 70M, `deps` 32M, `priv/plts` 11M. The shared tree is
+  bigger because it also carries `prod` and PLTs left over from older OTP
+  versions; a fresh id builds dev + test and exactly three current PLTs.
+  Free disk on this host is 885G, so the number was never the constraint.
+  The PLT *build time* is the figure that would justify revisiting this, and
+  it is **not** measured: the only window in which two cold gates ran, the
+  whole e2e suite was running beside them, so every wall-clock reading from
+  it is contaminated.
+
+**Acceptance, and the oracle used.** Two `check.sh` runs, in two separate
+worktrees under ids `w2a` and `w2b`, launched two seconds apart and both cold:
+both `rc=0`, `8 doctests, 59 properties, 5995 tests, 0 failures` each, zero
+`not ok` in either bats leg. They overlapped for their whole ~14 minutes and
+finished five seconds apart. That they went green is half the claim; the other
+half is that they went green *without touching the shared cache*, and the
+oracle for that is displacement, not inspection: the shared
+`_build`/`deps`/`priv/plts` were timestamped before the run, and afterwards
+`find -newermt` reported **0** files modified and the file count was unchanged
+at 8261. An assertion about what the runs DID write would have passed even if
+they had also written somewhere they shouldn't; this one cannot.
 
 **Scope held deliberately.** The docker stack — compose project name, host
 ports — is still single-occupancy, so `integration.sh` and e2e remain one

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40677,3 +40677,68 @@ fixture. It builds a scratch repository with the real attribute, appends an entr
 on each of two branches and runs a real `git rebase`, so what the gate is judged
 against is what the merge machinery actually produced. A fixture would have
 proved the regex works and nothing about the defect.
+<!-- entry #1263 -->
+
+---
+
+## 2026-08-13 — #1263: the COMPILE lane was a bind mount, so the cure is one too
+
+Two workers on this host cannot run `mix` at the same time. The orchestrator
+papers over it with an exclusive `COMPILE` lane, which means a worker that is
+otherwise ready sits idle for however long the other one's `check.sh` takes.
+That is real throughput lost every day, and it is not a policy choice — it
+falls out of `scripts/_lib.sh` resolving `REPO_ROOT` through
+`--git-common-dir`, so every worktree binds the MAIN repo's `_build`, `deps`
+and `priv/plts`. The lane is a mutex protecting a shared directory.
+
+**So the fix is at the same layer as the cause.** `GRAPPA_CACHE_ID`, when set,
+binds those three paths from `.caches/<id>/` instead. No new machinery: the
+worktree source overrides already prove that "bind something else over `/app/x`"
+is how this codebase redirects a container path, and the knob reuses that verb
+exactly. Unset, `CACHE_VOLUMES` stays empty and expands to nothing — today's
+invocation, byte for byte, which is the non-negotiable part of the ask.
+
+**What the issue got wrong, measured.** Its point 2 says the test database is
+"already solved upstream — `config/test.exs` builds the path from
+`MIX_TEST_PARTITION`, nothing to change, just set it." Half true, and the
+missing half is the half that matters: the *config* side reads the variable,
+but nothing on the shell side ever set it, and `docker compose run` does not
+inherit host environment. Setting `MIX_TEST_PARTITION` on the host was a
+silent no-op. Two isolated `_build`s would still have fought over one
+`runtime/grappa_test.db`. So the knob derives the partition from the id and
+FORWARDS it with `-e`; an explicitly set partition still wins, because an
+operator may be partitioning for an unrelated reason.
+
+**Two decisions worth the ink:**
+
+* **The knob FORCES a oneshot container.** `in_container_or_oneshot` would
+  otherwise exec into the live container on a main checkout — and a running
+  container cannot be remounted, so the caller would receive the shared cache
+  while believing they had asked for an isolated one. Silent loss of the
+  isolation is the only failure mode this knob must not have, so the exec
+  branch is now conditioned on the knob being unset. It is pinned by a pair of
+  bats cases, not one: the second asserts no exec happens, and the first is the
+  reference box proving the fixture can reach the exec branch at all. Without
+  that pair the "no exec" assertion would hold vacuously.
+* **Nothing is seeded from the shared cache.** Copying the warm `_build` and
+  the PLT into a fresh id would make adoption nearly free — on APFS a
+  `cp -c` clone is instant — but those artefacts were compiled from another
+  worktree's source, which is precisely the contamination class this issue
+  exists to end. A fresh id starts empty and pays a full compile plus its own
+  PLT. Cost measured on this host: ~209M per id (`_build` 148M, `deps` 33M,
+  `priv/plts` 28M), disk that is free at 885G available. The PLT *build time*
+  is the number that would justify revisiting this, and it has not been
+  measured yet.
+
+**Scope held deliberately.** The docker stack — compose project name, host
+ports — is still single-occupancy, so `integration.sh` and e2e remain one
+resource and the `STACK` lane stays. This issue kills one lane, not both.
+
+**A fixture trap worth remembering.** The two main-checkout cases build a
+throwaway repo under `$BATS_TEST_TMPDIR`. On macOS that lives under
+`/var/folders`, a symlink to `/private/var/folders`: `_lib.sh` derives
+`SRC_ROOT` from `pwd` (logical) and `REPO_ROOT` from
+`git rev-parse --path-format=absolute` (resolved), so a logical fixture path
+makes the two differ and the fixture silently becomes a WORKTREE — never
+reaching the branch it was built to exercise. It was passing for the wrong
+reason until the path was taken physical with `pwd -P`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40760,3 +40760,19 @@ throwaway repo under `$BATS_TEST_TMPDIR`. On macOS that lives under
 makes the two differ and the fixture silently becomes a WORKTREE — never
 reaching the branch it was built to exercise. It was passing for the wrong
 reason until the path was taken physical with `pwd -P`.
+
+**And its mirror image, which CI found.** The knob-UNSET case had no fixture
+at all — it ran from the ambient cwd, which on this host is a worktree, so it
+saw the oneshot it asserted. CI checks out a MAIN tree, the stubbed
+`docker compose ps -q` answers with a container id, and
+`in_container_or_oneshot` therefore took the exec branch: `not ok 420`, on a
+branch whose code was right. Unset means "today's invocation", and on a main
+checkout with a live container today's invocation IS the exec — the assertion
+was reading a property of the HOST, not of the knob. It was the only case in
+the suite with that exposure, because every other one sets the knob, and the
+knob forces a oneshot in either layout. The cure is the sibling of the fixture
+above, a real `git worktree add`, so the case states the layout it means; the
+added `-v <root>/lib:/app/lib` assertion doubles as that fixture's own witness,
+since `WORKTREE_VOLUMES` is empty unless `SRC_ROOT != REPO_ROOT`. **General
+rule: a test that asserts a shape chosen by an environment predicate must
+establish that environment itself, or it is measuring the host.**

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -441,9 +441,10 @@ Three things to know before using it:
   shared cache, deliberately: artefacts compiled from another
   worktree's source are the contamination this exists to end. Run
   `GRAPPA_CACHE_ID=<id> scripts/mix.sh deps.get` first, then expect a
-  full compile and a dialyzer PLT build. Measured on this host, the
-  steady-state cost is ~209M of disk per id (`_build` 148M, `deps`
-  33M, `priv/plts` 28M).
+  full compile and a dialyzer PLT build. Measured after a real cold
+  `check.sh`: **113M per id** — `_build` 70M (dev + test; the shared
+  tree is bigger because it also carries `prod`), `deps` 32M,
+  `priv/plts` 11M.
 * **It forces a oneshot container.** A running container cannot be
   remounted, so execing into the live one would silently hand back the
   shared cache. From a main checkout with the stack up, the knob

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -414,6 +414,44 @@ without it the task hits a read-only filesystem, and the default RO
 mount is what protects cic source from accidental container-side
 mutation during ordinary mix tasks.
 
+### `GRAPPA_CACHE_ID` — opt-in per-worker build caches (#1263)
+
+The shared cache above is why two people (or two agents) on one host
+cannot run `mix` at the same time: one `_build`, two concurrent
+compiles, and a red naming a file neither branch touched. Set
+`GRAPPA_CACHE_ID` to buy isolation for one caller:
+
+```sh
+GRAPPA_CACHE_ID=w2 scripts/check.sh
+```
+
+`_build`, `deps` and `priv/plts` are then bound from
+`.caches/<id>/` under the main repo instead of the shared tree, and
+`MIX_TEST_PARTITION` is derived from the id and forwarded into the
+container so the two runs cannot collide on one
+`runtime/grappa_test.db` either. Set `MIX_TEST_PARTITION` explicitly
+and it wins.
+
+**Unset, nothing changes** — that is the point of the knob being
+opt-in, and a bats suite pins it (`test/scripts/cache_id_isolation_test.bats`).
+
+Three things to know before using it:
+
+* **The first run on a new id is cold.** Nothing is seeded from the
+  shared cache, deliberately: artefacts compiled from another
+  worktree's source are the contamination this exists to end. Run
+  `GRAPPA_CACHE_ID=<id> scripts/mix.sh deps.get` first, then expect a
+  full compile and a dialyzer PLT build. Measured on this host, the
+  steady-state cost is ~209M of disk per id (`_build` 148M, `deps`
+  33M, `priv/plts` 28M).
+* **It forces a oneshot container.** A running container cannot be
+  remounted, so execing into the live one would silently hand back the
+  shared cache. From a main checkout with the stack up, the knob
+  therefore costs you the warm-exec path.
+* **It does NOT isolate the docker stack.** Compose project name and
+  host ports are still shared, so `scripts/integration.sh` and the e2e
+  stack remain a single-occupancy resource. That is a separate issue.
+
 **Every root-level file a drift-pin test READS needs its own `-v`
 override, or a worktree can never prove a fix green before merge.**
 Root-level files sit outside the directory mounts above, so a worktree

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -533,6 +533,25 @@ Before adding `config :ex_unit, KEY:` ANYTHING: grep `test/test_helper.exs`
 for `ExUnit.start(...)` opts — opts there silently override config. See
 `feedback_exunit_start_overrides_config`.
 
+## Running two gates at once: `GRAPPA_CACHE_ID` (#1263)
+
+`_build`, `deps` and `priv/plts` are shared by every worktree on a host
+(`scripts/_lib.sh` resolves `REPO_ROOT` through `--git-common-dir`), so
+two concurrent `mix` runs contaminate each other — the class where a red
+names a file your branch never touched. Prefix a gate with a cache id and
+it gets its own triplet, plus a matching `MIX_TEST_PARTITION` so the two
+runs do not share `runtime/grappa_test.db`:
+
+```sh
+GRAPPA_CACHE_ID=w2 scripts/mix.sh deps.get   # once per id — a fresh id is cold
+GRAPPA_CACHE_ID=w2 scripts/check.sh
+```
+
+Unset, everything behaves exactly as before. Full operator notes, the
+first-run cost and what the knob does **not** isolate (the docker stack:
+compose project + ports, so `integration.sh` and e2e are still
+single-occupancy) are in `docs/OPERATIONS.md`.
+
 ## Test-class gotchas (memory pointers)
 
 These bite during cluster work; check the memory before re-investigating.

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -113,6 +113,62 @@ die() {
     exit 1
 }
 
+# GRAPPA_CACHE_ID — opt-in per-worker build caches (#1263).
+#
+# UNSET is today's behaviour, byte for byte: CACHE_VOLUMES stays empty,
+# `"${CACHE_VOLUMES[@]}"` expands to nothing, and `_build`/`deps`/`priv/plts`
+# keep arriving through compose.yaml's `./:/app` bind on the MAIN repo. That
+# sharing is deliberate (see REPO_ROOT above) and is also why two workers on
+# one host cannot compile at the same time — the orchestrator hands out an
+# exclusive COMPILE lane and one of them idles.
+#
+# SET: the three caches are bound to `$REPO_ROOT/.caches/<id>/` instead, so
+# two ids can run `mix` concurrently without meeting in one `_build`. The
+# price, paid once per id: a full first compile, a dialyzer PLT of its own,
+# and ~200M of disk. Nothing is seeded from the shared cache on purpose —
+# artefacts compiled from another worktree's source are the very
+# contamination this exists to end, and a fresh id must not inherit it.
+#
+# This block sits AFTER die() because it calls it: at source time a function
+# defined further down does not exist yet.
+declare -ag CACHE_VOLUMES=()
+declare -ag CACHE_ENV=()
+if [ -n "${GRAPPA_CACHE_ID:-}" ]; then
+    # The id becomes a directory name and reaches a `docker -v` argument.
+    # Anything outside this class — a slash, a `..`, a shell metacharacter,
+    # a leading dot — is refused HERE, before any side effect.
+    case "$GRAPPA_CACHE_ID" in
+        *[!A-Za-z0-9._-]* | .*)
+            die "GRAPPA_CACHE_ID must match [A-Za-z0-9._-]+ and may not start with a dot (got '$GRAPPA_CACHE_ID') — it becomes a directory name and a docker -v argument."
+            ;;
+    esac
+
+    CACHE_ROOT="$REPO_ROOT/.caches/$GRAPPA_CACHE_ID"
+    export CACHE_ROOT
+    # Created host-side on purpose: docker would otherwise materialise a
+    # missing bind source itself, as root on Linux, and the UID-dropped
+    # container could then not write into its own cache.
+    mkdir -p "$CACHE_ROOT/_build" "$CACHE_ROOT/deps" "$CACHE_ROOT/priv/plts"
+    CACHE_VOLUMES=(
+        -v "$CACHE_ROOT/_build:/app/_build"
+        -v "$CACHE_ROOT/deps:/app/deps"
+        -v "$CACHE_ROOT/priv/plts:/app/priv/plts"
+    )
+
+    # The test database is the OTHER shared resource, and it is only
+    # half-solved upstream: config/test.exs builds the sqlite path from
+    # MIX_TEST_PARTITION, but nothing on the shell side ever set it, and
+    # `docker compose run` does not inherit host env — so setting it on the
+    # host was a silent no-op and two isolated caches would still have
+    # fought over one runtime/grappa_test.db. Derive it from the id (one
+    # knob, one isolation identity) and FORWARD it across the boundary. An
+    # explicit MIX_TEST_PARTITION wins: the operator may be partitioning
+    # for a different reason.
+    MIX_TEST_PARTITION="${MIX_TEST_PARTITION:-$GRAPPA_CACHE_ID}"
+    export MIX_TEST_PARTITION
+    CACHE_ENV=(-e "MIX_TEST_PARTITION=$MIX_TEST_PARTITION")
+fi
+
 # Guard: refuse to run from a worktree or a non-main branch. Deploy scripts
 # MUST call this as their FIRST step, before any side effect — in_container's
 # own worktree check fires too late to help. ALLOW_DEPLOY_FROM_BRANCH=1
@@ -197,7 +253,8 @@ in_container() {
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
 in_oneshot() {
     docker compose "${COMPOSE_ARGS[@]}" -f "$SRC_ROOT/compose.oneshot.yaml" \
-        run --rm --no-deps "${WORKTREE_VOLUMES[@]}" grappa "$@"
+        run --rm --no-deps "${CACHE_ENV[@]}" \
+        "${WORKTREE_VOLUMES[@]}" "${CACHE_VOLUMES[@]}" grappa "$@"
 }
 
 # Prefer exec into the live container when on main and it's up; otherwise
@@ -206,7 +263,12 @@ in_oneshot() {
 #
 # MIX_ENV is NOT injected here; `scripts/mix.sh` is the policy layer.
 in_container_or_oneshot() {
-    if [ "$SRC_ROOT" = "$REPO_ROOT" ]; then
+    # GRAPPA_CACHE_ID forces the oneshot (#1263). An exec enters a container
+    # whose /app/_build is ALREADY bound to the shared tree, and a running
+    # container cannot be remounted — so execing would hand back the shared
+    # cache while the caller believes they asked for an isolated one. Silent
+    # loss of the isolation is the one failure this knob must not have.
+    if [ "$SRC_ROOT" = "$REPO_ROOT" ] && [ -z "${GRAPPA_CACHE_ID:-}" ]; then
         local cid
         cid="$(docker compose "${COMPOSE_ARGS[@]}" ps -q grappa 2>/dev/null || true)"
         if [ -n "$cid" ]; then

--- a/test/scripts/cache_id_isolation_test.bats
+++ b/test/scripts/cache_id_isolation_test.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/_lib.sh — GRAPPA_CACHE_ID, the opt-in per-worker
+# build cache (#1263).
+#
+# WHY THIS EXISTS
+#
+# `_lib.sh` resolves REPO_ROOT through `--git-common-dir`, so every worktree
+# on a host binds the MAIN repo's `_build`, `deps` and `priv/plts`. That
+# sharing is deliberate, and it is also the reason two workers cannot compile
+# at the same time: the orchestrator has to hand out an exclusive COMPILE
+# lane and one worker sits idle. GRAPPA_CACHE_ID buys isolation for whoever
+# asks for it, and changes NOTHING for whoever does not.
+#
+# Scope: asserts the SHAPE of the docker invocation — which host paths get
+# bound over /app/_build, /app/deps, /app/priv/plts, and which env crosses
+# the boundary. Stubs `docker` on PATH so no container is touched. This
+# proves the MAPPING is isolated; it does not prove two real gates run
+# concurrently, which only a live pair of runs can show.
+
+load ../bats_helpers
+
+setup() {
+    MIX_SH="$BATS_TEST_DIRNAME/../../scripts/mix.sh"
+    REPO="$(cd "$BATS_TEST_DIRNAME/../.." && git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Fake `docker` — records every invocation and, for `compose ... ps -q
+    # grappa`, prints a container id so the live-exec branch of
+    # in_container_or_oneshot is REACHABLE. Without that id every call
+    # falls through to oneshot and a test asserting "no exec" would hold
+    # vacuously.
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+for a in "\$@"; do
+    if [ "\$a" = "-q" ]; then
+        printf 'fakecid\n'
+        exit 0
+    fi
+done
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+
+    export PATH="$FAKE_DIR:$PATH"
+    unset GRAPPA_CACHE_ID MIX_TEST_PARTITION
+}
+
+# A throwaway repo shaped like a MAIN checkout: `lib/` plus `.git` as a
+# DIRECTORY (a worktree has `.git` as a FILE — that is the marker _lib.sh
+# disambiguates on). Used by the two tests that need SRC_ROOT == REPO_ROOT,
+# which is the only configuration where the live-exec branch is taken.
+#
+# The path must be PHYSICAL: on macOS $TMPDIR lives under /var/folders, a
+# symlink to /private/var/folders. `pwd` in _lib.sh yields the logical path
+# while `git rev-parse --path-format=absolute` yields the resolved one, so a
+# logical fixture path makes SRC_ROOT != REPO_ROOT and the fixture silently
+# becomes a WORKTREE — never reaching the branch it was built to exercise.
+make_main_checkout() {
+    local root
+    root="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/mainrepo"
+    mkdir -p "$root/lib" "$root/scripts"
+    git -C "$root" init -q
+    cp "$BATS_TEST_DIRNAME/../../scripts/_lib.sh" "$root/scripts/_lib.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/mix.sh" "$root/scripts/mix.sh"
+    chmod +x "$root/scripts/mix.sh"
+    printf '%s' "$root"
+}
+
+@test "unset GRAPPA_CACHE_ID: no cache bind, no partition — today's invocation" {
+    run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    refute grep -q '\.caches' "$ARGV_LOG"
+    refute grep -q 'MIX_TEST_PARTITION' "$ARGV_LOG"
+    # Still a oneshot with the worktree source overrides — unchanged.
+    grep -q 'run --rm --no-deps' "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID binds _build, deps and priv/plts under a per-id root" {
+    GRAPPA_CACHE_ID=w2 run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q -- "-v ${REPO}/.caches/w2/_build:/app/_build" "$ARGV_LOG"
+    grep -q -- "-v ${REPO}/.caches/w2/deps:/app/deps" "$ARGV_LOG"
+    grep -q -- "-v ${REPO}/.caches/w2/priv/plts:/app/priv/plts" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID creates the cache root on the host before binding it" {
+    # Docker would otherwise create the missing path itself — as root on
+    # Linux, which the UID-dropped container then cannot write.
+    GRAPPA_CACHE_ID=mkdirprobe run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    [ -d "$REPO/.caches/mkdirprobe/_build" ]
+    [ -d "$REPO/.caches/mkdirprobe/deps" ]
+    [ -d "$REPO/.caches/mkdirprobe/priv/plts" ]
+    rm -rf "${REPO:?}/.caches/mkdirprobe"
+}
+
+@test "two ids never reach into each other's cache root" {
+    GRAPPA_CACHE_ID=w1 run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q -- "${REPO}/.caches/w1/_build" "$ARGV_LOG"
+    refute grep -q -- "${REPO}/.caches/w2/" "$ARGV_LOG"
+    # And the shared root is no longer what /app/_build resolves to.
+    refute grep -q -- "-v ${REPO}/_build:/app/_build" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID crosses into the container as MIX_TEST_PARTITION" {
+    # config/test.exs builds the sqlite path from MIX_TEST_PARTITION, but
+    # nothing on the shell side ever set or FORWARDED it — so two isolated
+    # caches would still have fought over one runtime/grappa_test.db.
+    GRAPPA_CACHE_ID=w2 run "$MIX_SH" --env=test test
+    [ "$status" -eq 0 ]
+    grep -q -- '-e MIX_TEST_PARTITION=w2' "$ARGV_LOG"
+}
+
+@test "an explicit MIX_TEST_PARTITION wins over the id-derived one" {
+    GRAPPA_CACHE_ID=w2 MIX_TEST_PARTITION=custom run "$MIX_SH" --env=test test
+    [ "$status" -eq 0 ]
+    grep -q -- '-e MIX_TEST_PARTITION=custom' "$ARGV_LOG"
+    refute grep -q -- '-e MIX_TEST_PARTITION=w2' "$ARGV_LOG"
+}
+
+@test "a traversing GRAPPA_CACHE_ID is refused BEFORE docker is invoked" {
+    GRAPPA_CACHE_ID='../../etc' run "$MIX_SH" --env=dev compile
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    # The refusal must precede the side effect, not follow it.
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "a GRAPPA_CACHE_ID with a shell metacharacter is refused" {
+    GRAPPA_CACHE_ID='w2;touch /tmp/pwned' run "$MIX_SH" --env=dev compile
+    [ "$status" -ne 0 ]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "on a MAIN checkout with a live container and NO knob, the container is exec'd" {
+    # The reference box for the next test: proves this fixture DOES reach
+    # the live-exec branch, so "no exec" below is a real observation.
+    root="$(make_main_checkout)"
+    cd "$root"
+    run "$root/scripts/mix.sh" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q 'compose .* exec' "$ARGV_LOG"
+}
+
+@test "on a MAIN checkout with a live container, the knob FORCES a oneshot" {
+    # An exec enters a container whose /app/_build is already bound to the
+    # shared tree; there is no remounting an existing container. Asking for
+    # an isolated cache and silently getting the shared one is the one
+    # failure this knob must never have.
+    root="$(make_main_checkout)"
+    cd "$root"
+    GRAPPA_CACHE_ID=w2 run "$root/scripts/mix.sh" --env=dev compile
+    [ "$status" -eq 0 ]
+    refute grep -q 'compose .* exec' "$ARGV_LOG"
+    grep -q 'run --rm --no-deps' "$ARGV_LOG"
+    grep -q -- "-v ${root}/.caches/w2/_build:/app/_build" "$ARGV_LOG"
+}

--- a/test/scripts/cache_id_isolation_test.bats
+++ b/test/scripts/cache_id_isolation_test.bats
@@ -74,13 +74,49 @@ make_main_checkout() {
     printf '%s' "$root"
 }
 
-@test "unset GRAPPA_CACHE_ID: no cache bind, no partition — today's invocation" {
-    run "$MIX_SH" --env=dev compile
+# A throwaway WORKTREE, the sibling fixture: `lib/` plus `.git` as a FILE,
+# produced by a real `git worktree add` so `--git-common-dir` resolves to the
+# base repo exactly as it does in production. Same physical-path requirement
+# as above, for the same reason.
+make_worktree_checkout() {
+    local base wt
+    base="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/wtbase"
+    wt="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/wtree"
+    mkdir -p "$base/lib" "$base/scripts"
+    : > "$base/lib/.keep"
+    cp "$BATS_TEST_DIRNAME/../../scripts/_lib.sh" "$base/scripts/_lib.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/mix.sh" "$base/scripts/mix.sh"
+    chmod +x "$base/scripts/mix.sh"
+    git -C "$base" init -q
+    git -C "$base" add -A
+    git -C "$base" -c user.email=bats@example.invalid -c user.name=bats commit -q -m fixture
+    git -C "$base" worktree add -q "$wt" -b probe
+    printf '%s' "$wt"
+}
+
+# The knob-unset case is the ONLY one here whose docker branch depends on the
+# checkout it runs FROM: every other case sets the knob, and the knob forces a
+# oneshot in either layout. So this one has to say which layout it means, and
+# it used to run from the ambient cwd instead — green on a worktree host,
+# where `check.sh` runs, and RED in CI, where the checkout is a main tree and
+# the stubbed `docker compose ps -q` hands back a container id, so
+# `in_container_or_oneshot` took the exec branch and never emitted the oneshot
+# form. Nothing was wrong with the code: unset means "today's invocation", and
+# on a main checkout with a live container today's invocation IS the exec. The
+# assertion was reading a property of the host, not of the knob.
+@test "unset GRAPPA_CACHE_ID from a WORKTREE: no cache bind, no partition — today's invocation" {
+    root="$(make_worktree_checkout)"
+    cd "$root"
+    run "$root/scripts/mix.sh" --env=dev compile
     [ "$status" -eq 0 ]
     refute grep -q '\.caches' "$ARGV_LOG"
     refute grep -q 'MIX_TEST_PARTITION' "$ARGV_LOG"
-    # Still a oneshot with the worktree source overrides — unchanged.
+    # Still a oneshot with the worktree source overrides — unchanged. The
+    # second grep is also the fixture's own witness: WORKTREE_VOLUMES is empty
+    # unless SRC_ROOT != REPO_ROOT, so a fixture that silently resolved as a
+    # main checkout would fail here instead of passing for the wrong reason.
     grep -q 'run --rm --no-deps' "$ARGV_LOG"
+    grep -q -- "-v ${root}/lib:/app/lib" "$ARGV_LOG"
 }
 
 @test "GRAPPA_CACHE_ID binds _build, deps and priv/plts under a per-id root" {


### PR DESCRIPTION
## The shape

`GRAPPA_CACHE_ID=<id>` binds `_build`, `deps` and `priv/plts` from
`.caches/<id>/` instead of the shared main-repo tree. Unset, `CACHE_VOLUMES`
stays empty and expands to nothing — today's docker invocation, byte for byte,
which was the non-negotiable part of the ask.

The fix is at the same layer as the cause. The lane exists because `_lib.sh`
resolves `REPO_ROOT` through `--git-common-dir`, so every worktree binds one
`_build`; the lane is a mutex protecting a directory. The worktree source
overrides already establish "bind something else over `/app/x`" as how this
codebase redirects a container path, so the knob reuses that verb rather than
introducing machinery.

## Acceptance: PROVEN, with the oracle stated

Two `check.sh` runs, **two separate worktrees**, ids `w2a` and `w2b`, launched
two seconds apart, **both cold**:

| | run A (`w2a`) | run B (`w2b`) |
|---|---|---|
| exit | `rc=0` | `rc=0` |
| mix | `8 doctests, 59 properties, 5995 tests, 0 failures` | same |
| bats | 0 `not ok` | 0 `not ok` |

They overlapped for their entire run and finished five seconds apart.

Green is only half the claim. The other half — that neither run reached the
shared cache — is asserted by **displacement, not inspection**: the shared
`_build`/`deps`/`priv/plts` were timestamped before launch, and afterwards
`find -newermt` reported **0 files modified**, with the file count unchanged
at **8261**. Asserting what the runs *did* write would have passed even if
they had also written somewhere they should not; this cannot.

🔴 **No wall-clock number is offered, deliberately.** The only window in which
two cold gates ran had the full e2e suite running beside them on the same
host. The isolation claim is structural and survives that; any timing reading
would not. **In particular the dialyzer PLT BUILD TIME — the figure that would
justify a follow-up sharing just the PLT — remains unmeasured.** I am not
estimating it.

## What the issue got wrong, measured

Point 2 says the test DB is already solved — `config/test.exs` builds the
sqlite path from `MIX_TEST_PARTITION`, "nothing to change, just set it."

Half true, and the missing half is the one that matters: the *config* side
reads the variable, but **nothing on the shell side ever set it, and
`docker compose run` does not inherit host environment**. The evidence is a
grep with five hits and no sixth: `MIX_TEST_PARTITION` appears in
`config/test.exs` (twice — the sqlite path and the uploads dir), in
`OPERATIONS.md` and `DESIGN_NOTES.md` as prose, and **nowhere in any `.sh` or
in `compose.yaml`**. Setting it on the host was a silent no-op, and two
isolated `_build` trees would still have fought over one
`runtime/grappa_test.db`. So the knob derives the partition from the id and
forwards it with `-e`. An explicitly set partition still wins.

## Two decisions worth defending

**The knob forces a oneshot.** `in_container_or_oneshot` would otherwise exec
into the live container on a main checkout, and a running container cannot be
remounted — the caller would receive the shared cache while believing they
asked for isolation. Silent loss of the isolation is the one failure this must
not have. (This case sits outside the "a worktree always goes oneshot"
reasoning: it only bites from a *main* checkout with the stack up.)

**Nothing is seeded from the shared cache.** Cloning the warm `_build` and PLT
would make adoption nearly free (APFS `cp -c` is instant), but those artefacts
were compiled from another worktree's source, which is the exact contamination
class this issue exists to end. A fresh id is cold, deliberately.

The id is validated before any side effect — it becomes a directory name and a
`docker -v` argument, so a slash, a `..`, a leading dot or a shell
metacharacter is refused rather than sanitised.

## Cost, measured — and a corrected estimate

**113M per id**: `_build` 70M (dev + test), `deps` 32M, `priv/plts` 11M.

An earlier revision of this branch said ~209M. That number was read off the
*shared* tree, which also carries `prod` and PLTs left over from older OTP
versions — neither of which a fresh id reproduces. The estimate was wrong by
almost half and is corrected in the same docs it was written into.

## Gating

- Two full cold `check.sh` runs, both green (above). They also cover the
  `CLAUDE.md` edit: that commit predates the launch and both trees were clean.
- `scripts/bats.sh` full set on this branch: **rc=0, 458 `ok`, 0 `not ok`**,
  shellcheck gate included.
- Ten new cases in `test/scripts/cache_id_isolation_test.bats`. Red read before
  green: 9 of 10 failed, and the one that passed was the knob-unset invariance
  case, which had to pass before the change.
- The forced oneshot is pinned by a **pair**: one case asserts no exec happens,
  the other is the reference box proving the fixture can reach the exec branch
  at all. It was needed — the fixture initially passed for the wrong reason,
  because on macOS `\$TMPDIR` resolves through a symlink and the fake main
  checkout was silently classified as a worktree.
- The final commit is docs-only (`OPERATIONS.md`, `DESIGN_NOTES.md`) and
  postdates those runs. No test reads either file (checked).

## Scope held

The docker stack — compose project name, host ports — is untouched, so
`integration.sh` and e2e remain single-occupancy and the `STACK` lane survives.
This kills one lane, not both. Concurrent `deps.get` under two ids is also
**not** proven: the hex/rebar caches (`.hex`, `.mix`) stay shared, so the two
were run sequentially during setup.