### PR TITLE
#1264 — !addquote carries the sender, reversing the #1107 payload ruling

### DIFF
--- a/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
+++ b/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
@@ -1,6 +1,6 @@
-// #1107 — the message menu's `!addquote` item puts `!addquote ` plus the
-// message text into the compose box, with the caret at the end and visible,
-// and sends NOTHING. The command is for whatever bot is in the channel; cic
+// #1107 — the message menu's `!addquote` item puts `!addquote `, the sender's
+// `<nick>` head (#1264) and the message text into the compose box, with the
+// caret at the end and visible, and sends NOTHING. The command is for whatever bot is in the channel; cic
 // only fills the box.
 //
 // Harness + limits:
@@ -96,8 +96,10 @@ test("issue1107 — !addquote fills the compose box with the command and the mes
   await menuItem(page, "!addquote").click();
 
   // The payload ruling, at the only place it is observable end to end: the
-  // command, one space, the body — and no `<nick>` head.
-  await expect(ta).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+  // command, the sender's `<nick>` head, then the body. #1264 reversed #1107's
+  // bare-body shape — what is quoted is what the operator READ, attribution
+  // included. The nick is the spec subject's own, since it posted the line.
+  await expect(ta).toHaveValue(`!addquote <${specNick()}> ${body}`, { timeout: 5_000 });
 });
 
 test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
@@ -110,7 +112,9 @@ test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
   // Barrier first: the compose value settling is the durable state that says
   // the item has fully run. Only then is the absence below an absence rather
   // than a race with an insertion still in flight.
-  await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+  await expect(composeTextarea(page)).toHaveValue(`!addquote <${specNick()}> ${body}`, {
+    timeout: 5_000,
+  });
 
   // The original row is still the ONLY row carrying this text. A sent command
   // would echo back as a second scrollback line containing the same body.
@@ -153,7 +157,9 @@ test.describe("the caret, where the overflow is real", () => {
 
     await openMenuOnRow(page, body);
     await menuItem(page, "!addquote").click();
-    await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+    await expect(composeTextarea(page)).toHaveValue(`!addquote <${specNick()}> ${body}`, {
+      timeout: 5_000,
+    });
 
     // The #1105/#1113 dependency the issue names, on the real engine jsdom
     // cannot stand in for. The oracle's own overflow guard is what makes this

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -150,12 +150,12 @@ describe("the !addquote item", () => {
     expect(labels()).toEqual(["Copy", "Reply", "!addquote", "Select…"]);
   });
 
-  it("drops the command plus the message text into the compose box", () => {
+  it("drops the command, the sender and the message text into the compose box", () => {
     mountCompose();
     render(() => <MessageContextMenu />);
     openOver(scrollbackRow("12:34 <vjt> ciao"), { body: "ciao mondo" });
     fireEvent.click(screen.getByText("!addquote"));
-    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 
   // Disabled but VISIBLE, the posture Reply already takes: the menu's shape

--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -4,15 +4,19 @@ import { addQuoteCommand, addQuoteToCompose } from "../lib/addQuote";
 import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
+import { replyQuote } from "../lib/replyQuote";
 
 // #1107 — the `!addquote` menu item: it drops `!addquote ` plus the message
 // text into the compose box and stops there. cic never sends it and never
 // interprets it; whatever bot sits in the channel does.
 //
-// THE PAYLOAD IS THE BARE BODY — no `<nick>` head, no `<< ` tail. That is the
-// issue's open question, ruled on the requester's literal words ("mette nel
-// composebox '!addquote' e poi il messaggio"). The rule is pinned by its own
-// assertion below so a later reshaping cannot take it silently.
+// THE PAYLOAD CARRIES THE SENDER, in the form the scrollback rendered — #1264
+// reverses #1107's bare-body ruling. `<nick> body` for speech, `* nick body`
+// for an action: what gets quoted is what the operator READ. There is still no
+// `<< ` tail, which belongs to Reply and not to an archive.
+//
+// The reversed rule is pinned by its own assertion below, as the old one was,
+// so the next reshaping has to trip over it rather than reword a string.
 
 const NET = "azzurra";
 const CHAN = "#grappa";
@@ -47,23 +51,41 @@ beforeEach(() => {
 });
 
 describe("addQuoteCommand", () => {
-  it("prefixes the message text with the bot command", () => {
-    expect(addQuoteCommand(msg({}))).toBe("!addquote ciao mondo");
+  it("prefixes the bot command and the sender's nick", () => {
+    expect(addQuoteCommand(msg({}))).toBe("!addquote <vjt> ciao mondo");
   });
 
-  // The ruling, pinned on its own. Co-killed with the shape assertion above by
-  // a "carry the nick" implementation, and kept anyway: it is the answer to the
-  // issue's open question, and a future reshaping of the payload must trip over
-  // it explicitly rather than quietly reword the string above.
-  it("carries no nick — the payload is the bare body", () => {
-    expect(addQuoteCommand(msg({ sender: "vjt", body: "ciao mondo" }))).not.toContain("vjt");
+  // #1264's ruling, pinned on its own — the inverse of the assertion #1107 put
+  // here. Co-killed with the shape above by a bare-body implementation, and
+  // kept for the same reason the old one was: the attribution is the POINT of
+  // the payload, not an incidental part of the string.
+  it("carries the sender — the payload is never the bare body", () => {
+    expect(addQuoteCommand(msg({ sender: "vjt", body: "ciao mondo" }))).toContain("vjt");
+  });
+
+  // The two kinds differ in the HEAD, and both heads are the ones the
+  // scrollback renders — that equivalence is the whole ruling, so it is
+  // asserted against `replyQuote`'s head rather than against a literal that
+  // could drift away from it silently.
+  it("gives an action the rendered `* nick` head, not `<nick>`", () => {
+    expect(
+      addQuoteCommand(msg({ kind: "action", body: "\x01ACTION pees over the fence\x01" })),
+    ).toBe("!addquote * vjt pees over the fence");
+  });
+
+  it("heads the payload exactly as Reply heads its quote", () => {
+    for (const kind of ["privmsg", "notice", "action"] as const) {
+      const body = kind === "action" ? "\x01ACTION waves\x01" : "waves";
+      const head = replyQuote(msg({ kind, body }))?.split(" waves")[0];
+      expect(addQuoteCommand(msg({ kind, body }))).toBe(`!addquote ${head} waves`);
+    }
   });
 
   // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
   // operator is quoting what they SEE, and a control byte round-tripped through
   // compose would be re-sent as formatting they never chose.
   it("strips mIRC control codes out of the quoted body", () => {
-    expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote bold plain");
+    expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote <vjt> bold plain");
   });
 
   it("refuses a presence row", () => {
@@ -92,7 +114,7 @@ describe("addQuoteCommand", () => {
   });
 
   it("quotes a notice like speech — it has an author and a body", () => {
-    expect(addQuoteCommand(msg({ kind: "notice" }))).toBe("!addquote ciao mondo");
+    expect(addQuoteCommand(msg({ kind: "notice" }))).toBe("!addquote <vjt> ciao mondo");
   });
 
   // An action's stored body is the raw `\x01ACTION …\x01` wire form (the
@@ -101,7 +123,7 @@ describe("addQuoteCommand", () => {
   // the compose box — the #1126 defect, at a second door.
   it("unwraps a CTCP action down to its text", () => {
     expect(addQuoteCommand(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
-      "!addquote si dà alla fuga",
+      "!addquote * vjt si dà alla fuga",
     );
   });
 
@@ -124,7 +146,7 @@ describe("addQuoteCommand", () => {
   // attribute someone else's line to this sender forever.
   it("drops a previous reply-quote out of the body", () => {
     expect(addQuoteCommand(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
-      "!addquote answer",
+      "!addquote <alice> answer",
     );
   });
 
@@ -135,7 +157,7 @@ describe("addQuoteCommand", () => {
   // `<<` is ordinary text and must not be mistaken for a quote tail.
   it("leaves a shift expression alone", () => {
     expect(addQuoteCommand(msg({ body: "shift << 2 gives four" }))).toBe(
-      "!addquote shift << 2 gives four",
+      "!addquote <vjt> shift << 2 gives four",
     );
   });
 });
@@ -144,7 +166,7 @@ describe("addQuoteToCompose", () => {
   it("fills an empty compose with exactly the command", () => {
     mountCompose();
     addQuoteToCompose(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 
   // Never destroy work in progress: the command lands AFTER what is already
@@ -153,7 +175,7 @@ describe("addQuoteToCompose", () => {
     mountCompose();
     setDraft(KEY, "bozza ");
     addQuoteToCompose(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("bozza !addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("bozza !addquote <vjt> ciao mondo");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -1,31 +1,37 @@
 import type { ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
-import { quotableBody } from "./quotableBody";
+import { attributionHead, quotableBody } from "./quotableBody";
 
 // #1107 — the `!addquote` verb behind the message menu's fourth item. It fills
 // the compose box and stops: nothing is sent, and cic does not know or care
 // what `!addquote` means. Whatever bot sits in the channel interprets it, and
 // the operator gets to read the line before pressing enter.
 //
-// THE PAYLOAD IS THE BARE BODY. The issue leaves that open ("whether the
-// payload is the bare body or carries the nick") because bots differ; it is
-// ruled on the requester's literal words — `!addquote` and then the message.
-// A wrapper is one line away in either direction, and guessing WIDER is the
-// worse guess: a bot that wants attribution can read the nick off the channel,
-// while a bot that stores its input verbatim would put `<vjt>` inside every
-// stored quote with no way for the operator to know until it is recalled.
+// THE PAYLOAD CARRIES THE SENDER (#1264, reversing #1107). It used to be the
+// bare body, on the reasoning that a bot storing its input verbatim would bake
+// `<vjt>` into every stored quote; vjt ruled the other way, and the new rule is
+// the sharper one: **what gets quoted is what the operator READ**. The line in
+// the compose box is the line as the scrollback rendered it, attribution
+// included, so the operator can see before pressing enter exactly what the
+// archive will hold. A bot that wants the nick can no longer only "read it off
+// the channel" — by the time a quote is recalled, that context is gone.
+//
+// There is still no `<< ` tail: that is Reply's, and an archive is not a reply.
 export const ADDQUOTE_COMMAND = "!addquote ";
 
 // The command line for a message, or null when the row has nothing to quote —
 // the same refusals Reply makes, because they are the same question ("did
 // somebody say something here?") and `quotableBody` is where they live.
 //
-// An ACTION contributes its text without the `* nick` form Reply gives it: the
-// payload carries no attribution at all, so half of one for one kind would be
-// a shape the operator cannot predict from the menu.
+// An ACTION keeps the `* nick` form, exactly as Reply gives it (#1264 closed
+// the issue's open question this way). The two kinds therefore head the payload
+// DIFFERENTLY — `<vjt> ciao mondo` against `* vjt pees over the fence` — and
+// that is the predictable shape, not the exception to it: each is the line the
+// scrollback showed. `attributionHead` is shared with `replyQuote` so the two
+// doors cannot drift.
 export function addQuoteCommand(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
-  return body === null ? null : `${ADDQUOTE_COMMAND}${body}`;
+  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg)} ${body}`;
 }
 
 // Drop the command into the window's compose box with the caret at the end and

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -12,7 +12,9 @@ import { mircPlainText } from "./mircFormat";
 // worth of history and would let the two doors drift apart on the next one.
 //
 // The WRAPPER is the caller's business — `replyQuote` puts a `<nick> …<< `
-// around this, `addQuoteCommand` puts `!addquote ` in front of it.
+// around this, `addQuoteCommand` puts `!addquote ` in front of it. The
+// ATTRIBUTION is not: since #1264 both doors head the quote the same way, so
+// `attributionHead` lives here with the body it heads.
 
 // #1123 — the nick charset, mirrored from the server's
 // `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
@@ -61,4 +63,17 @@ export function quotableBody(msg: ScrollbackMessage): string | null {
   // quote said nothing to quote back.
   const body = withoutPreviousQuote(mircPlainText(raw).trim());
   return body === "" ? null : body;
+}
+
+// How the row names its sender, in the form the SCROLLBACK RENDERS it: `<nick>`
+// for speech, `* nick` for an action.
+//
+// #1126 ruled it for Reply — quoting `* vjt waves` as `<vjt> waves` puts a
+// sentence in someone's mouth they never said. #1264 gave `!addquote` the same
+// heads, on the same principle stated from the other side: what gets quoted is
+// what the operator READ. Shared rather than written twice because the two
+// doors are now one rule, and a copy would let the next kind be added to one of
+// them only.
+export function attributionHead(msg: ScrollbackMessage): string {
+  return msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
 }

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,6 +1,6 @@
 import type { ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
-import { quotableBody } from "./quotableBody";
+import { attributionHead, quotableBody } from "./quotableBody";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
 // the long-press menu's Reply item. Both doors, one code path.
@@ -47,12 +47,8 @@ function capQuotedBody(body: string): string {
 export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
-  // #1126 — an action is NOT speech. Quoting `* vjt waves` as `<vjt> waves`
-  // puts a sentence in someone's mouth that they never said, so the quote keeps
-  // the `* nick …` form the scrollback renders. Ruled on the least-surprise
-  // tiebreak; privmsg/notice keep the `<nick> …` shape unchanged.
-  const head = msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
-  return `${head} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
+  // #1126's heads, shared with `!addquote` since #1264 — see `attributionHead`.
+  return `${attributionHead(msg)} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40677,3 +40677,54 @@ fixture. It builds a scratch repository with the real attribute, appends an entr
 on each of two branches and runs a real `git rebase`, so what the gate is judged
 against is what the merge machinery actually produced. A fixture would have
 proved the regex works and nothing about the defect.
+<!-- entry #1264 -->
+
+---
+
+## 2026-08-13 — #1264: `!addquote` carries the sender, reversing #1107 three days later
+
+#1107 ruled the payload was the bare body and wrote the reasoning down: the two
+guesses are not symmetric, a bot that wants attribution can read the nick off
+the channel, a bot that stores its input verbatim would bake `<vjt>` into every
+stored quote. It also pinned the rule with an assertion of its own so a later
+reshaping could not take it silently.
+
+**vjt reversed it, and the reversal comes with a sharper rule than the one it
+replaces: what gets quoted is what the operator READ.** The compose box now
+shows the line as the scrollback rendered it, attribution included, which is
+precisely what makes it reviewable before enter is pressed. The old tiebreak
+underweighted the recall side — "the bot can read the nick off the channel"
+holds at the moment the command arrives and not one second later, and a quote
+is a thing you recall months afterwards, when that context is gone.
+
+So the open question the issue left about ACTION rows is closed the same way:
+
+* PRIVMSG / NOTICE → `!addquote <vjt> ciao mondo`
+* ACTION → `!addquote * vjt pees over the fence`
+
+The two heads DIFFER, and under the new rule that is the predictable shape
+rather than the exception to it — #1107 read a difference between kinds as
+unpredictability, but each of these is the line its own row showed. #1126 had
+already ruled the same way for Reply, from the other side: rendering
+`* vjt waves` as `<vjt> waves` puts a sentence in someone's mouth.
+
+**The head became shared, because the two doors are now one rule.**
+`attributionHead` sits in `lib/quotableBody.ts` next to the body it heads, and
+`replyQuote` lost its inline copy. This is the #1107 argument applied one level
+up: that module exists because copying the quotable-body clauses would have let
+the two doors drift on the next ruling, and the head is now in exactly that
+position. Left duplicated, the next kind would have been taught to one door
+only. `replyQuote`'s output is unchanged, which its own suite still asserts.
+
+**The reversal was carried into the pin, not around it.** #1107's
+`carries no nick — the payload is the bare body` assertion is gone, replaced by
+its inverse rather than deleted: a rule with no pin is a rule the next
+reshaping takes silently, which is the thing #1107 was right about. The two
+comment blocks stating the withdrawn reasoning were rewritten in place, in the
+module and in the test — the #1262 lesson, applied on purpose. Red measured
+before green: 12 assertions across two suites failed on the payload shape, and
+the 12 that passed were the refusal gates, which the change does not touch.
+
+`quotableBody` itself is untouched: the gate ("did somebody say something
+here?"), the CTCP unwrap, the mIRC strip and #1123's nesting cut all still
+answer the same. Only the wrapper moved.


### PR DESCRIPTION
## The shape, as ruled

* PRIVMSG / NOTICE → `!addquote <vjt> ciao mondo`
* ACTION → `!addquote * vjt pees over the fence`

vjt's comment on the issue closes the open question about ACTION rows: an action
keeps its rendered form. The heads therefore **differ between kinds**, and under
the new rule that is the predictable shape rather than an exception to it —
#1107 read a difference between kinds as unpredictability, but each of these is
the line its own row showed. #1126 had already ruled identically for Reply, from
the other side: rendering `* vjt waves` as `<vjt> waves` puts a sentence in
someone's mouth.

## The reversal went through the pin, not around it

#1107 did not just implement the bare body, it argued for it in a comment block
and pinned it with `carries no nick — the payload is the bare body`. Both are
part of the change:

- the assertion is **replaced by its inverse**, not deleted — a rule with no pin
  is a rule the next reshaping takes silently, which is the part #1107 got right;
- the comment blocks in `addQuote.ts` and at the head of its test are **rewritten
  in place**, so the next reader finds the current rule where the withdrawn one
  used to be, rather than a gap.

The new reasoning, stated so it can be argued with later: the old tiebreak was
"a bot that wants attribution can read the nick off the channel". That holds at
the moment the command arrives and not one second afterwards — and a quote is a
thing you recall months later, when that context is gone.

## One refactor, and why it is not scope creep

`attributionHead` moves into `lib/quotableBody.ts` and `replyQuote` loses its
inline copy. That module exists **because** #1107 argued that duplicating quote
rules would let the two doors drift on the next ruling — and the head has just
become one of those rules, identical on both sides. Left duplicated, the next
kind gets taught to one door only. `replyQuote`'s output is unchanged, and its
own suite still asserts it.

One of the new tests asserts the two doors agree by comparing against
`replyQuote`'s head rather than against a literal, so a future divergence fails
instead of quietly passing on both sides.

## Gating

- Red read before green: **12 assertions failed** across `addQuote.test.ts` and
  `MessageContextMenu.test.tsx`, all of them payload-shape. The 12 that passed
  were the refusal gates (`quotableBody`), which this change does not touch —
  the failure set matching the blast radius is itself the check that the change
  is where I think it is.
- `bun run test`: **rc=0, 281 files / 5332 tests passed**.
- `bun run check`: **rc=0**, 1013 files, 60 warnings / 5 infos — the unchanged
  pre-existing baseline, 0 `error TS`.
- No lane used: this is cic-only.

## The e2e — extended, NOT run

`cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts` had three assertions
of the old bare-body payload. A spec asserting the withdrawn world is rewritten
onto the decided behaviour, not left to fail and not softened: all three now
expect `!addquote <${specNick()}> ${body}`, and the spec's header comment says
why.

🔴 **I have not executed it.** It passes the static gate only, and a static gate
says nothing about whether the assertion holds in a browser. No new e2e was
added — this is a string-shape change on an existing feature whose outcome is
the compose box's contents, which the component tests already observe; a new
spec would have claimed a stack for a string.

One risk I am naming rather than hiding: the expected nick is `specNick()`. That
is sound here because #1078 gives every spec its own subject, derived from a
sha1 of the title path, and a collision fails loudly at provision rather than
silently renaming — but the assertion does now depend on the live nick matching
the provisioned one, which it did not before.