### PR TITLE
packaging: cd / before handing the release a cwd (#1267)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40935,3 +40935,84 @@ added `-v <root>/lib:/app/lib` assertion doubles as that fixture's own witness,
 since `WORKTREE_VOLUMES` is empty unless `SRC_ROOT != REPO_ROOT`. **General
 rule: a test that asserts a shape chosen by an environment predicate must
 establish that environment itself, or it is measuring the host.**
+<!-- entry #1267 -->
+
+---
+
+## 2026-08-13 — #1267: the same crash signature, a different cause, and the cwd we hand the VM
+
+A self-hoster on Debian 13 (unprivileged LXC, `.deb` 1.0.0) reported that every
+eval-backed verb of `/usr/bin/grappa` — `create-user`, `migrate`,
+`seed-themes`, `rpc`, `remote`, even `eval '1 + 1'` — died during ERTS boot
+with
+
+```
+{badarg,[{persistent_term,get,[code_server],...},{code_server,get_mode,0,...},
+         {code,ensure_loaded,1,...}]}
+```
+
+That is byte-for-byte the signature the packaging README already documents
+under *"Caveat — the migrate/eval proof"*, where it belongs to a **native-Linux
+asdf-built ERTS** and the cure is to avoid the `eval` boot variant. It is not
+that defect. The bundled ERTS is fine, and the report would have been closed as
+a known caveat if the narrowing had stopped at the stack trace.
+
+**The trigger, measured rather than deduced.** Against the published v1.0.0
+image, as the `grappa` user, varying only the mode of the working directory the
+verb is invoked from:
+
+| cwd mode | `other` bits | result |
+|---|---|---|
+| `0700` | `---` | boot dies with the badarg above |
+| `0711` | `--x` | boots |
+| `0555` | `r-x` | boots |
+| `0755` | `rwx` | boots |
+
+So it is precisely the **search (`x`) bit on the cwd for the effective user** —
+not read, not write; `0711` and `0555` both boot clean. And it is bare ERTS:
+the same crash reproduces under `erl -boot .../start_clean` with no grappa
+module loaded at all, so the VM never registers `code_server` and the logger's
+first `code:ensure_loaded/1` blows up. Which inner ERTS path first requires
+that bit was **not** isolated. The table is the boundary that was measured, and
+it is enough to act on — the alternative was filling the gap with supposition.
+
+**Grappa's part is only in handing the VM that cwd.** `runuser -u` — unlike
+`runuser -l` — does not change directory, so the child inherits the caller's
+(`cd /root/secret && runuser -u testu -- pwd` prints `/root/secret`, measured on
+`debian:trixie`). Debian 13 ships `HOME_MODE 0700` in `/etc/login.defs` and
+`/root` is `0700`, which means the operator's own login directory breaks the
+first command in the packaging README. The fix is a `cd /` in
+`infra/packaging/grappa-wrapper.sh` before either exec — `/` being the one
+directory every user can search. The cost accepted is that a relative path in
+`"$@"` now resolves against `/`; in the case this fixes it resolved against a
+directory the VM could not read either way.
+
+**Both branches, and only those two.** The already-unprivileged branch has the
+identical hole the moment someone `su - grappa`s inside a directory another
+user owns, so the `cd` sits before the branch rather than inside the
+privileged one. `infra/release/grappa.sh` execs the boot script with no `cd`
+either and is deliberately left alone: it does not change user, so a cwd it
+could search before it can search after. Symmetry is not a reason to touch it.
+
+**Why no gate ever saw it, which is the part worth generalising.** `dpkg` runs
+maintainer scriptlets with cwd `/`, and the `release.yml` job that installs the
+`.deb` and exercises migrations inherits the same `/`. The packaged path stayed
+green for as long as the interactive path was broken. **A gate that inherits
+its working directory cannot observe a working-directory-shaped defect** — so
+the new suite (`test/infra/packaging_wrapper_cwd_test.bats`) sets the cwd
+deliberately instead, runs the real wrapper from a directory that genuinely
+cannot be searched, and asserts the release is reached from `/`.
+
+**Two things about that suite, stated rather than implied.** It does not boot a
+BEAM: there is no ERTS in the bats environment, so *"the VM survives an
+unsearchable cwd"* stays pinned only by the measurement above, and a
+hypothetical regression inside ERTS would not be caught. What it does pin is
+grappa's own side of the contract, and it was mutation-checked twice: removing
+the `cd` kills both branch cases, and moving it into the `runuser` payload
+alone — the plausible half-fix — kills the unprivileged case and only that one.
+Second, the reproduction upstream used a root-owned `0700` directory entered as
+another user, which an unprivileged test suite cannot construct. It uses mode
+`000` on a directory it owns instead: the kernel's permission check is
+per-class, so denying the owner class the search bit puts the process in the
+same state as denying it to `other`. Ownership was never the variable — the
+effective user's search bit was.

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -224,6 +224,18 @@ whole: they are the FIRST thing a fresh install runs, and on a substrate
 where `eval` is broken they fail the same way `migrate` does, for the
 same reason.
 
+⚠️ **The same badarg has a second, unrelated cause — check this one first
+(#1267).** ERTS dies at kernel start with the *identical*
+`persistent_term`/`code_server` trace when the working directory it is
+launched from lacks the **search (`x`) bit for the effective user**. Measured:
+cwd `0700` dies, `0711` and `0555` boot; it reproduces on bare
+`erl -boot .../start_clean` with no grappa module loaded, and it has nothing to
+do with how the ERTS was built. Debian 13 ships `HOME_MODE 0700` and `/root` is
+`0700`, so it fires from the operator's own login directory. `grappa-wrapper.sh`
+`cd /`s before exec'ing the release since #1267; on an older package the
+operator workaround is `cd /` before any `grappa` subcommand. Do not read a
+`code_server` badarg as the asdf caveat below until the cwd has been ruled out.
+
 R1's job is to prove exactly that on a package built by `build.sh`
 (bundled ERTS, not asdf): install the `.deb` in a clean container, run
 `sudo grappa migrate` against a fresh DB, confirm the service boots and

--- a/infra/packaging/grappa-wrapper.sh
+++ b/infra/packaging/grappa-wrapper.sh
@@ -65,6 +65,21 @@ fi
 # that process's environment, then exec the release bin with our argv.
 run_payload='set -a; . '"$ENV_FILE"'; set +a; exec '"$RELEASE_BIN"' "$@"'
 
+# Hand the VM a working directory it can SEARCH (#1267). ERTS dies during boot
+# on a cwd without the x bit for the effective user — `{badarg, persistent_term
+# get code_server}`, measured on bare `erl -boot start_clean`, so it is upstream
+# behaviour and not ours to fix. Ours is that we hand it that cwd: `runuser -u`,
+# unlike `-l`, does not change directory, and Debian 13 ships HOME_MODE 0700
+# with /root at 0700 — so the operator's own login directory breaks every
+# eval-backed verb. The unprivileged branch below needs it just as much: `su -
+# grappa` inside another user's directory is the same state.
+#
+# Both branches, therefore, and `/` because it is the one directory every user
+# can search. Cost accepted: a RELATIVE path in "$@" now resolves against `/`
+# rather than the caller's cwd — in the case this fixes it resolved against a
+# directory the VM could not read either way.
+cd /
+
 if [ "$(id -u)" -eq 0 ]; then
 	# Drop to the grappa user. runuser ships in util-linux on both the
 	# Debian and RHEL families, so it is a safe common dependency.

--- a/test/infra/packaging_wrapper_cwd_test.bats
+++ b/test/infra/packaging_wrapper_cwd_test.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+#
+# /usr/bin/grappa must hand the release a SEARCHABLE working directory (#1267).
+#
+# Reported by a self-hoster on Debian 13 (unprivileged LXC, .deb 1.0.0): every
+# eval-backed verb — create-user, migrate, seed-themes, rpc, remote — died
+# during ERTS boot with `{badarg,[{persistent_term,get,[code_server]...`. The
+# narrowing upstream varied ONLY the mode of the cwd: 0700 dies, 0711 and 0555
+# boot. So the trigger is precisely the SEARCH (x) bit on the cwd for the
+# EFFECTIVE user — not read, not write. The crash is bare ERTS, reproduced with
+# `erl -boot .../start_clean` and no grappa module loaded; grappa's part is only
+# in HANDING the VM such a cwd. `runuser -u` — unlike `runuser -l` — does not
+# change directory, so the child inherits the caller's cwd, and Debian 13 ships
+# HOME_MODE 0700 with /root at 0700: the first command in the packaging README
+# fails from exactly where the operator's shell puts them.
+#
+# Why nothing caught it: dpkg runs maintainer scriptlets with cwd `/`, and the
+# release.yml job that installs the .deb inherits the same `/`. The packaged
+# path stays green while the interactive one is broken — a suite that does not
+# CONTROL the cwd cannot see this class at all, which is why every case below
+# sets it deliberately.
+#
+# ── WHAT THIS SUITE DOES NOT PROVE ──────────────────────────────────────────
+# It does not boot a BEAM. There is no ERTS here, so "the VM survives an
+# unsearchable cwd" is out of reach and remains pinned only by the measurement
+# in the issue. What is pinned here is grappa's own side of the contract: that
+# BOTH exec branches of the wrapper hand the release a cwd of `/`, when invoked
+# from a directory that genuinely cannot be searched. The mutant that removes
+# the `cd` is killed; a mutant that broke ERTS itself would not be.
+
+load ../bats_helpers
+
+setup() {
+    PKG_SRC="$BATS_TEST_DIRNAME/../../infra/packaging"
+
+    ROOT="$BATS_TEST_TMPDIR/root"
+    mkdir -p "$ROOT/usr/lib/grappa/bin" "$ROOT/etc/grappa"
+
+    CALL_LOG="$BATS_TEST_TMPDIR/calls.log"
+    CWD_LOG="$BATS_TEST_TMPDIR/cwd.log"
+    export CALL_LOG CWD_LOG
+    : > "$CALL_LOG"
+    : > "$CWD_LOG"
+
+    # The mix-release boot script the wrapper execs, as a recorder. It reports
+    # its cwd the way the VM would learn it — a real getcwd, not the inherited
+    # $PWD string, since $PWD is a claim the parent makes and getcwd is the
+    # thing ERTS actually performs. On an unsearchable cwd getcwd FAILS on
+    # darwin and merely returns the path on Linux; either way it is not `/`,
+    # so the assertions below hold on both userlands.
+    cat > "$ROOT/usr/lib/grappa/bin/grappa" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALL_LOG"
+pwd -P >> "$CWD_LOG" 2>/dev/null || printf 'getcwd-failed\n' >> "$CWD_LOG"
+EOF
+    chmod 0755 "$ROOT/usr/lib/grappa/bin/grappa"
+
+    printf 'DATABASE_PATH=%s/db\n' "$ROOT" > "$ROOT/etc/grappa/grappa.env"
+
+    # ── The two root-only externals, stubbed ────────────────────────────────
+    # The privileged branch is unreachable from an unprivileged suite, and it
+    # is the branch the bug report came in on. Both stubs are STRICT: an argv
+    # they do not recognise aborts loudly rather than passing through, so a
+    # future edit to the wrapper's invocation cannot silently start being
+    # measured by a stub that no longer models it.
+    STUB="$BATS_TEST_TMPDIR/stub"
+    mkdir -p "$STUB"
+
+    cat > "$STUB/id" <<'EOF'
+#!/bin/sh
+[ "$1" = "-u" ] || { echo "id stub: unexpected argv: $*" >&2; exit 64; }
+echo 0
+EOF
+
+    # The ONE property of runuser this suite is about: `-u` does not change
+    # directory, so the child inherits the caller's cwd (measured upstream on
+    # debian:trixie — `cd /root/secret && runuser -u testu -- pwd` prints
+    # /root/secret). The identity switch needs real root and is not under test,
+    # so the stub keeps the identity and reproduces only the cwd inheritance.
+    cat > "$STUB/runuser" <<'EOF'
+#!/bin/sh
+[ "$1" = "-u" ] || { echo "runuser stub: expected -u, got: $*" >&2; exit 64; }
+shift 2
+[ "$1" = "--" ] || { echo "runuser stub: expected --, got: $*" >&2; exit 64; }
+shift
+exec "$@"
+EOF
+
+    chmod 0755 "$STUB/id" "$STUB/runuser"
+
+    # The wrapper, re-rooted: it addresses the host by absolute path, and a
+    # leaked one would either abort as non-root or touch the developer's box.
+    WRAPPER="$BATS_TEST_TMPDIR/grappa"
+    sed -e "s#/usr/bin/grappa#$ROOT/usr/bin/grappa#g" \
+        -e "s#/usr/lib/grappa#$ROOT/usr/lib/grappa#g" \
+        -e "s#/usr/share/grappa#$ROOT/usr/share/grappa#g" \
+        -e "s#/etc/grappa#$ROOT/etc/grappa#g" \
+        "$PKG_SRC/grappa-wrapper.sh" > "$WRAPPER"
+    chmod 0755 "$WRAPPER"
+    assert_rerooted "$WRAPPER"
+
+    NOSEARCH="$BATS_TEST_TMPDIR/nosearch"
+    mkdir -p "$NOSEARCH"
+}
+
+teardown() {
+    # Give the bits back or bats cannot clean its own tmpdir.
+    [ -d "$NOSEARCH" ] && chmod 0755 "$NOSEARCH"
+    return 0
+}
+
+# A leaked absolute path means the sandbox is porous and every case below
+# would be measuring something other than the script we ship.
+#
+# The sandbox prefix is neutralised FIRST, and replaced by an alphanumeric
+# sentinel rather than deleted. Both halves are load-bearing: on darwin
+# BATS_TEST_TMPDIR itself lives under /var/folders, so an un-neutralised scan
+# reads every correctly re-rooted path as a leak; and deleting the prefix
+# instead of replacing it would turn `$ROOT/usr/lib/grappa` back into
+# `/usr/lib/grappa`, i.e. into the very thing being looked for.
+assert_rerooted() {
+    local leaked
+    leaked="$(sed "s#$ROOT#SANDBOX#g" "$1" |
+        grep -nE '(^|[^/[:alnum:]_.-])/(usr|etc|var)/[[:alnum:]/._-]*grappa')" \
+        || return 0
+    printf 'absolute host paths survived the re-root:\n%s\n' "$leaked" >&2
+    return 1
+}
+
+# Run a command from a directory the effective user cannot SEARCH.
+#
+# Upstream reproduced the trigger with a root-owned 0700 directory entered as
+# another user. An unprivileged suite cannot own another user's directory, but
+# mode 000 on our OWN denies the owner class the very same bit, and the kernel
+# check is per-class: from the process's point of view the two states are
+# identical. Only root bypasses it, and root is not who runs this.
+#
+# The directory must be ENTERED before the bits go, because afterwards nothing
+# can enter it — which is also why this is done in a subshell.
+from_unsearchable() {
+    ( cd "$NOSEARCH" && chmod 000 . && "$@" )
+}
+
+# The wrapper as the operator invokes it: as root (stubs on PATH, privileged
+# branch) or as the grappa user (no stubs, already-unprivileged branch).
+wrapper_as() {
+    local who="$1"
+    shift
+    if [ "$who" = root ]; then
+        from_unsearchable env "PATH=$STUB:$PATH" "$WRAPPER" "$@"
+    else
+        from_unsearchable "$WRAPPER" "$@"
+    fi
+}
+
+# ── The harness's own oracle ────────────────────────────────────────────────
+
+@test "the harness really hands its child a cwd that is not / (#1267)" {
+    # Without this, every assertion below could hold because the suite runs
+    # from `/` anyway, and the wrapper's `cd` would never be exercised.
+    from_unsearchable "$ROOT/usr/lib/grappa/bin/grappa" probe
+
+    [ "$(cat "$CWD_LOG")" != "/" ]
+}
+
+# ── The fix, on both branches ───────────────────────────────────────────────
+
+@test "as root the release is exec'd from /, not the caller's cwd (#1267)" {
+    # The reported path: `sudo grappa migrate` from a 0700 home. runuser -u
+    # hands the child the caller's cwd, so without a cd in the wrapper the VM
+    # boots on a directory it cannot search and dies in code_server.
+    wrapper_as root migrate
+
+    # Sanity token: an absent cd is indistinguishable from a wrapper that
+    # never reached the release at all.
+    grep -qx 'eval Grappa.Release.migrate()' "$CALL_LOG"
+
+    [ "$(cat "$CWD_LOG")" = "/" ]
+}
+
+@test "as the grappa user the release is exec'd from / too (#1267)" {
+    # The already-unprivileged branch has the same hole the moment someone
+    # `su - grappa`s and cds into a directory another user owns. Fixing only
+    # the branch the report came in on would leave the class open.
+    wrapper_as grappa version
+
+    grep -qx 'version' "$CALL_LOG"
+
+    [ "$(cat "$CWD_LOG")" = "/" ]
+}


### PR DESCRIPTION
Fixes the boot crash reported on #1267 by a self-hoster (Debian 13,
unprivileged LXC, `.deb` 1.0.0) and narrowed in the issue itself. This PR
does not re-derive that narrowing; it implements it and pins it.

## The defect

Every eval-backed verb of the packaged `/usr/bin/grappa` — `create-user`,
`migrate`, `seed-themes`, `rpc`, `remote`, even `eval '1 + 1'` — dies during
ERTS boot with a `{badarg,[{persistent_term,get,[code_server]...}` trace when
invoked from a working directory the effective user cannot **search**. The
measured table in the issue: `0700` dies, `0711` and `0555` boot. Not read,
not write — the `x` bit.

It is not grappa code: the same crash reproduces under
`erl -boot .../start_clean` with no grappa module loaded. Grappa's part is
only in *handing* the VM such a cwd — `runuser -u`, unlike `runuser -l`, does
not change directory, and Debian 13 ships `HOME_MODE 0700` with `/root` at
`0700`, so the first command in the packaging README fails from where the
operator's shell puts them.

## The change

- `cd /` in `infra/packaging/grappa-wrapper.sh`, before the branch, so it
  covers **both** exec paths. The already-unprivileged one has the same hole
  the moment someone `su - grappa`s inside another user's directory.
- `infra/release/grappa.sh` deliberately **untouched**: it also execs with no
  `cd`, but it does not change user, so a cwd it could search before it can
  search after. Symmetry is not a reason.
- Cost accepted and written down: a relative path in `"$@"` now resolves
  against `/`. In the case this fixes, it resolved against a directory the VM
  could not read either way.

## The test, and what it does not cover

`dpkg` runs maintainer scriptlets with cwd `/`, and the `release.yml` job that
installs the `.deb` inherits the same `/` — the packaged path stayed green for
as long as the interactive path was broken. **A gate that inherits its working
directory cannot observe a working-directory-shaped defect**, so
`test/infra/packaging_wrapper_cwd_test.bats` sets the cwd deliberately: it runs
the real wrapper (re-rooted into a sandbox) from a directory that genuinely
cannot be searched, and asserts the release is reached from `/` — on both
branches, with the two root-only externals (`id`, `runuser`) stubbed strictly.

Mutation-checked, twice:

| mutant | result |
|---|---|
| remove `cd /` | both branch cases die |
| move `cd /` into the `runuser` payload only (the plausible half-fix) | the unprivileged case dies, and only that one |

**It does not boot a BEAM.** There is no ERTS in the bats environment, so *"the
VM survives an unsearchable cwd"* stays pinned only by the measurement in the
issue; a regression inside ERTS would not be caught here. What is pinned is
grappa's own side of the contract.

The upstream reproduction used a root-owned `0700` directory entered as another
user, which an unprivileged suite cannot construct. The suite uses mode `000`
on a directory it owns: the kernel's permission check is per-class, so denying
the owner class the search bit is the same state as denying it to `other`.
Ownership was never the variable.

## Docs

The packaging README already documented this exact badarg trace, attributed to
a native-Linux **asdf-built** ERTS. Same signature, unrelated cause — the
report reads as a known caveat and would have been closed as one. A warning
now sits above that caveat telling the reader to rule out the cwd first. The
decision log records the measurements, the limit that was deliberately left
unfilled (which inner ERTS path first needs the bit), and the generalisable
lesson about inherited cwd in gates.

## Scope

Touches `infra/packaging/` only — the `.deb`/`.rpm`/Arch path, i.e. self
hosters. **No deploy of ours is needed**: prod is the m42 FreeBSD jail, which
does not go through this wrapper.

## Gates run locally

- `scripts/bats.sh` (full set): 451 ok, 0 not ok, rc=0
- new suite x3 consecutive: 3 ok each, rc=0
- `scripts/shellcheck.sh` (pinned container, 73 derived scripts): rc=0
- `scripts/check.sh` not run — no Elixir touched, and it wants a lane.