### PR TITLE
Stop merge=union eating the DESIGN_NOTES separator, and gate it (#1271)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,39 @@
 # DESIGN_NOTES.md is an append-mostly decision log: every PR appends to the
-# tail, so concurrent PRs conflict there constantly. The built-in `union`
-# merge driver keeps lines from BOTH sides of a conflicting hunk (no
-# markers), which auto-resolves the append-vs-append case. Caveat (#114):
-# only safe while the file stays append-mostly — a PR that edits or
-# reorders existing entries can interleave oddly and must be checked by hand.
+# tail, so concurrent PRs conflict there constantly. The built-in `union` merge
+# driver keeps lines from BOTH sides of a conflicting hunk (no markers).
+#
+# What union auto-resolves is the entry BODIES. It does NOT save the boundary
+# between them, and used to destroy it silently (#1271): every entry was
+# appended with the same three leading lines — blank / `---` / blank — so the
+# merge machinery aligned that identical prefix as a COMMON addition and handed
+# only the diverging tails to the driver. Union emitted the shared prefix ONCE
+# and concatenated both bodies after it: one entry kept its separator, the
+# other lost it, with no conflict, no markers, `rc=0` and ZERO deletions. Four
+# occurrences on 2026-08-13 alone, each caught only because a human pinned
+# `git diff --numstat` before the rebase and compared after.
+#
+# 🔴 So an entry MUST open with a UNIQUE marker line, as its FIRST appended
+# line, in exactly this shape:
+#
+#     <!-- entry #1271 -->
+#     <blank>
+#     ---
+#     <blank>
+#     ## 2026-08-13 — #1271: ...
+#
+# Because that line differs between two branches there is no identical prefix
+# left to collapse, the whole block reaches the driver, and both separators
+# survive — measured, with not one line lost. A marker on EITHER side is
+# enough, in both directions, so old entries need no retrofit. Uniqueness is
+# the mechanism and not decoration: two entries sharing a marker restore the
+# collapsible prefix and lose FOUR lines instead of three.
+#
+# `scripts/design-notes-gate.sh` asserts both properties over the entries a
+# branch ADDS, in CI and locally, because a convention nobody enforces depends
+# on somebody remembering it — which is precisely how this survived four times
+# in one day.
+#
+# Caveat (#114), unchanged: union is only safe while the file stays
+# append-mostly. A PR that edits or reorders existing entries can interleave
+# oddly and must be checked by hand.
 docs/DESIGN_NOTES.md merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          # fetch-depth: 0 is a cost this job pays for ONE gate: the
+          # DESIGN_NOTES entry-boundary check (#1271) is diff-scoped, so it
+          # needs `origin/main` and a merge base with it. A shallow checkout
+          # has neither, and the gate FAILS rather than passing vacuously —
+          # so the full history is what keeps it from being a red wall.
+          fetch-depth: 0
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -143,6 +149,16 @@ jobs:
         # laptop and whatever ubuntu-latest ships that month must not
         # disagree about what "clean" means.
         run: scripts/shellcheck.sh
+
+      - name: DESIGN_NOTES entry boundaries (#1271)
+        # `merge=union` auto-resolves concurrent appends to the decision log
+        # and used to eat the separator of the rebased entry — silently, with
+        # rc=0 and zero deletions, four times on 2026-08-13. The only thing
+        # that ever caught it was a human pinning `git diff --numstat` before
+        # the rebase. This is that ritual, automated, and diff-scoped so it
+        # carries no opinion about the 426 headings that predate the
+        # convention. Needs the fetch-depth: 0 above.
+        run: scripts/design-notes-gate.sh
 
       - name: POSIX-parse the shared deploy lib + its sh consumers (#503)
         # A DIFFERENT property from the lint above, with a different tool:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,21 @@ not the surrounding code.**
   the BOUNDARY SHAPE on the real file** (full stop / blank / `---` / blank /
   heading), because an identical numstat proves nothing when the pre-rebase
   state was already broken.
+- **🔴 Open every new DESIGN_NOTES entry with a UNIQUE `<!-- entry #NNNN -->`
+  line, as its FIRST appended line (#1271).** Exact shape: marker / blank /
+  `---` / blank / `## <date> — #NNNN: …`, with NO blank before the marker.
+  **Why: the separator loss above is not bad luck, it is `merge=union` doing
+  what it is told.** Every entry used to be appended with the same three
+  leading lines, so the merge machinery aligned that identical prefix as a
+  COMMON addition and only the diverging tails reached the driver, which
+  emitted the shared prefix once. A marker line differs between branches, so
+  there is no prefix left to collapse and both separators survive — measured,
+  losing not one line, whereas putting a blank ahead of the marker still costs
+  that blank and a duplicated marker costs FOUR lines instead of three. A
+  marker on EITHER side protects the pair, so old entries need no retrofit.
+  Enforced by `scripts/design-notes-gate.sh` over the entries a branch ADDS,
+  in CI and in `scripts/bats.sh`; the same gate treats an added `^## ` as an
+  ENTRY heading, so a subsection inside an entry must be `###` or deeper.
 - **Log honesty**: when a fast path skips work, the log message must
   describe the state it OBSERVED, not the absence of work. Example:
   `bootstrap: no credentials bound — running web-only` lies when N

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40595,3 +40595,85 @@ session, and must keep classifying a notification deep-link with the SPA
 closed. Neither is a per-network IRC fact rendered from a guess; both are
 context-free byte constraints, and they are named in `chantypes.ts` so the next
 reader who greps `#&+!` finds two survivors and knows they were considered.
+<!-- entry #1271 -->
+
+---
+
+## 2026-08-13 — #1271: `merge=union` does not save the separator, and the ritual that caught it is now a gate
+
+`docs/DESIGN_NOTES.md` has carried `merge=union` since #114 (2026-07-22) so
+that concurrent PRs appending entries auto-resolve instead of conflicting by
+hand on every merge. On 2026-08-13 four branches (#1261, #1262, #1263/#1266,
+#1255) came out of a rebase having silently lost the three-line separator block
+that opens their entry: `rc=0`, no conflict, no markers, and **zero deletions**,
+so the additions count of the branch's own contribution simply shrank by three.
+Every one of them was caught only because a human had pinned
+`git diff --numstat` before the rebase and compared after.
+
+**The mechanism, reproduced here rather than inherited from the report.** Every
+entry was appended with the same three leading lines — blank, `---`, blank —
+followed by a unique heading. When two branches append, the merge machinery
+aligns that identical prefix as a *common* addition and hands only the diverging
+tails to the union driver; union emits the shared prefix ONCE and concatenates
+both bodies after it. One entry keeps its separator, the other is glued straight
+onto the previous body. Five variants in a scratch repo, additions before → after
+the rebase:
+
+| setup | rebase | additions | separators |
+|---|---|---|---|
+| union, no marker | rc=0 | 7 → **4** | 2/3, entry glued |
+| no union, `---` | **conflict** | 7 → 7 | 2/3 |
+| union + marker on both sides | rc=0 | 8 → 8 | 3/3 |
+| union + marker on the rebased side only | rc=0 | 8 → 8 | 3/3 |
+| union + marker on the OTHER side only | rc=0 | 7 → 7 | 3/3 |
+
+**Two facts the report did not have.** First, a marker on *either* side is
+enough, in both directions — the pair is protected the moment one of the two
+entries carries one, so adoption is incremental and no old entry needs a
+retrofit. Second, the shape matters: the report measured 9 → 8 for the marker
+variant and read the lost line as a cosmetic blank. That loss is the *leading
+blank*, and it disappears if the marker is the FIRST appended line with no blank
+ahead of it — 8 → 8, nothing lost at all. Worth the pedantry, because a
+convention that routinely shrinks the diff by one line poisons the very numstat
+comparison this whole class is detected by. Conversely a *duplicated* marker is
+worse than none: the identical prefix is back and now includes the marker, so
+the collapse takes FOUR lines. Uniqueness is the mechanism, not decoration.
+
+**The repair sweep in the report was retracted, on measurement.** The claim was
+that entries which already lost their separator are on `main` and want a pass to
+re-insert it. Measured on `efa69e35`: the last fourteen entries are all in the
+canonical shape, and the four losses of 2026-08-13 were each caught before
+landing. Deriving the sweep as written — every `^## ` not preceded by `---` —
+selects **426 of 645** level-2 headings, overwhelmingly entries from before the
+convention existed; the oldest glued one is 2026-05-12, two months before the
+union attribute was added, so it cannot be union damage. And the rule is wrong in
+kind as well as in scale: **12 of those headings are not entry headings** — seven
+are the document's own front-matter sections, and five are mis-levelled
+subsections *inside* the 2026-08-08 #1038 entry. A file-wide "every `##` is
+preceded by `---`" would insert horizontal rules in the middle of an entry.
+Re-levelling the log is a question for its author, and it does not ride a bugfix.
+
+**So the gate is diff-scoped.** `scripts/design-notes-gate.sh` judges only the
+entry headings a branch ADDS relative to its merge base: no opinion about
+history, no exemption list, no false positives to teach people to ignore. It
+asserts the separator (the detector — it sees whatever the merge machinery does
+next, including a mechanism nobody has characterised yet) and the unique marker
+(the prevention). Both, because a convention that is only written down depends
+on somebody remembering it across sessions, which is exactly the property that
+let this happen four times in one day.
+
+Three consequences worth stating. The gate **fails closed**: a base ref it cannot
+resolve is an error, never a skip, because the reachable version of that is a
+shallow CI checkout and a green gate that looked at nothing is the shape of every
+guard that fails open — which is why the CI job now checks out with
+`fetch-depth: 0`, a cost paid for this one gate and declared as such. An added
+`^## ` is treated as an ENTRY heading, so a subsection inside an entry must be
+`###` or deeper; the #1038 entry above is why that constraint is worth having.
+And the gate proves nothing about entries already on `main` — by construction it
+never looks at them.
+
+The suite that proves the gate can fail does not use a hand-written broken
+fixture. It builds a scratch repository with the real attribute, appends an entry
+on each of two branches and runs a real `git rebase`, so what the gate is judged
+against is what the merge machinery actually produced. A fixture would have
+proved the regex works and nothing about the defect.

--- a/scripts/design-notes-gate.sh
+++ b/scripts/design-notes-gate.sh
@@ -107,7 +107,7 @@ separator_findings="$(printf '%s\n' "$findings" | grep -F "	SEPARATOR	" || true)
 if [ -n "$separator_findings" ]; then
 	status=1
 	{
-		printf 'design-notes-gate: entry heading(s) NOT preceded by `---`:\n'
+		printf 'design-notes-gate: entry heading(s) NOT preceded by a --- separator:\n'
 		printf '%s\n' "$separator_findings"
 		printf '\nThis is the #1271 shape. If the rebase reported rc=0 with zero\n'
 		printf 'deletions, the union driver ate the separator: restore it IN the\n'
@@ -121,7 +121,7 @@ marker_findings="$(printf '%s\n' "$findings" | grep -F "	MARKER	" || true)"
 if [ -n "$marker_findings" ]; then
 	status=1
 	{
-		printf 'design-notes-gate: entry heading(s) with no `<!-- entry ... -->` line:\n'
+		printf 'design-notes-gate: entry heading(s) with no <!-- entry ... --> marker line:\n'
 		printf '%s\n' "$marker_findings"
 		printf '\nAn entry must open with a UNIQUE marker line, as the FIRST appended\n'
 		printf 'line, in this exact shape:\n\n'

--- a/scripts/design-notes-gate.sh
+++ b/scripts/design-notes-gate.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# scripts/design-notes-gate.sh — the DESIGN_NOTES entry-boundary gate (#1271).
+#
+# Usage:
+#   scripts/design-notes-gate.sh            # check against origin/main
+#   scripts/design-notes-gate.sh <base-ref> # check against another base
+#
+# WHAT IT GUARDS
+#
+# `docs/DESIGN_NOTES.md` carries `merge=union` (#114) so that concurrent PRs
+# appending entries auto-resolve instead of conflicting by hand. The driver
+# does that for the entry BODIES, and silently mangles the boundary between
+# them: every entry used to be appended with the same three leading lines
+# (blank / `---` / blank), the merge machinery aligns that identical prefix as
+# a COMMON addition, and only the diverging tails reach the union driver. Union
+# emits the shared prefix once and concatenates both bodies after it. One entry
+# keeps its separator, the other loses it — with no conflict, no markers,
+# `rc=0` and ZERO deletions, which is why nothing in the tooling ever flagged
+# it. Four occurrences on 2026-08-13 alone, each caught only because a human
+# pinned `git diff --numstat` before the rebase and compared after.
+#
+# This gate is that ritual, automated. It is DIFF-SCOPED on purpose: it judges
+# only the entry headings the branch ADDS relative to its merge base, so it
+# carries no opinion about the 426 historical headings that predate the
+# convention (measured on efa69e35: 645 level-2 headings, 219 in the canonical
+# shape). A file-wide rule would have had to either rewrite the shape of old
+# entries or carry an exemption list, and would still have been WRONG in kind —
+# 12 of those headings are not entry headings at all (7 document sections, and
+# 5 mis-levelled subsections inside the 2026-08-08 #1038 entry).
+#
+# THE TWO CHECKS, and why both
+#
+#   1. every ADDED `## ` heading is preceded by `---` — the detector. It sees
+#      whatever the merge machinery does next, including a mechanism nobody has
+#      characterised yet.
+#   2. every ADDED entry opens with a UNIQUE `<!-- entry ... -->` marker line —
+#      the prevention. Measured: because that line differs between the two
+#      branches there is no identical prefix left to collapse, and both
+#      separators survive. A marker on EITHER side is enough, in both
+#      directions, so adoption is incremental. Uniqueness is the mechanism, not
+#      decoration: a copy-pasted marker restores the collapsible prefix and the
+#      bug with it, silently.
+#
+# A convention that is only written down depends on somebody remembering it
+# across sessions — which is the very property that made this bug survive four
+# times in one day. So the convention is asserted, not documented.
+#
+# CONSEQUENCE worth knowing: an added `^## ` is treated as an ENTRY heading. A
+# subsection inside an entry must be `###` or deeper. That is a real constraint
+# and a deliberate one — the 2026-08-08 #1038 entry has five `##` subsections
+# and they are why a file-wide separator rule cannot exist.
+#
+# Exit 0 = every added entry is well formed (or the branch adds none).
+# Exit 1 = a finding, or the base ref cannot be resolved. A gate that cannot
+#          reach its base FAILS; it never passes vacuously.
+
+set -euo pipefail
+
+readonly FILE="docs/DESIGN_NOTES.md"
+BASE_REF="${1:-origin/main}"
+
+# The repo we are IN, not the repo this script was copied FROM. The bats suite
+# runs this gate inside a scratch repository that reproduces the union loss for
+# real; deriving the root from BASH_SOURCE would silently point it back at the
+# working checkout and the oracle would measure nothing.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+die() {
+	printf 'design-notes-gate: %s\n' "$*" >&2
+	exit 1
+}
+
+git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null \
+	|| die "base ref '$BASE_REF' does not resolve. In CI this means the checkout is shallow — actions/checkout needs fetch-depth: 0."
+
+base="$(git merge-base "$BASE_REF" HEAD)" \
+	|| die "no merge base between '$BASE_REF' and HEAD"
+
+# The entry headings this branch adds. `+## ` cannot collide with diff's own
+# `+++ ` header line.
+added="$(git diff "$base" HEAD -- "$FILE" | sed -n 's/^+\(## .*\)$/\1/p')"
+
+if [ -z "$added" ]; then
+	printf 'design-notes-gate: this branch adds no %s entry heading — nothing to check.\n' "$FILE"
+	exit 0
+fi
+
+# Locate each added heading in the resulting file and read the four lines above
+# it. Fenced blocks are skipped: a `## ` inside one is shell or markdown sample
+# text, not an entry.
+findings="$(awk '
+NR == FNR { want[$0] = 1; next }
+/^(```|~~~)/ { fence = !fence; p4 = p3; p3 = p2; p2 = p1; p1 = $0; next }
+!fence && /^## / && ($0 in want) {
+    if (!(p1 == "" && p2 == "---"))
+        printf "%d\tSEPARATOR\t%s\n", FNR, $0
+    else if (p3 != "" || p4 !~ /^<!-- entry .+ -->$/)
+        printf "%d\tMARKER\t%s\n", FNR, $0
+}
+{ p4 = p3; p3 = p2; p2 = p1; p1 = $0 }
+' <(printf '%s\n' "$added") "$FILE")"
+
+status=0
+
+separator_findings="$(printf '%s\n' "$findings" | grep -F "	SEPARATOR	" || true)"
+if [ -n "$separator_findings" ]; then
+	status=1
+	{
+		printf 'design-notes-gate: entry heading(s) NOT preceded by `---`:\n'
+		printf '%s\n' "$separator_findings"
+		printf '\nThis is the #1271 shape. If the rebase reported rc=0 with zero\n'
+		printf 'deletions, the union driver ate the separator: restore it IN the\n'
+		printf 'commit that carries the entry, never as a separator-only commit\n'
+		printf '(that one has the same patch-id as three lines already upstream and\n'
+		printf 'gets dropped just as silently).\n'
+	} >&2
+fi
+
+marker_findings="$(printf '%s\n' "$findings" | grep -F "	MARKER	" || true)"
+if [ -n "$marker_findings" ]; then
+	status=1
+	{
+		printf 'design-notes-gate: entry heading(s) with no `<!-- entry ... -->` line:\n'
+		printf '%s\n' "$marker_findings"
+		printf '\nAn entry must open with a UNIQUE marker line, as the FIRST appended\n'
+		printf 'line, in this exact shape:\n\n'
+		printf '    <!-- entry #1271 -->\n    <blank>\n    ---\n    <blank>\n    ## 2026-08-13 — #1271: ...\n\n'
+		printf 'It is what leaves the merge machinery no identical prefix to collapse.\n'
+	} >&2
+fi
+
+# Uniqueness is the mechanism. Two entries carrying the same marker restore the
+# collapsible prefix, and the gate above would still be green.
+duplicates="$(grep -n '^<!-- entry .* -->$' "$FILE" | sed 's/^[0-9]*://' | sort | uniq -d || true)"
+if [ -n "$duplicates" ]; then
+	status=1
+	{
+		printf 'design-notes-gate: duplicate entry marker(s) — each must be unique:\n'
+		printf '%s\n' "$duplicates"
+	} >&2
+fi
+
+if [ "$status" -ne 0 ]; then
+	exit 1
+fi
+
+printf 'design-notes-gate: %s new entry heading(s), separator and marker present.\n' \
+	"$(printf '%s\n' "$added" | wc -l | tr -d ' ')"

--- a/test/scripts/design_notes_gate_test.bats
+++ b/test/scripts/design_notes_gate_test.bats
@@ -160,7 +160,7 @@ contribution() {
     # No rebase: `feat` is well formed apart from the marker.
     run scripts/design-notes-gate.sh main
     [ "$status" -eq 1 ]
-    [[ "$output" == *"no \`<!-- entry ... -->\` line"* ]]
+    [[ "$output" == *"no <!-- entry ... --> marker line"* ]]
     refute grep -q "NOT preceded by" <<<"$output"
 }
 

--- a/test/scripts/design_notes_gate_test.bats
+++ b/test/scripts/design_notes_gate_test.bats
@@ -1,0 +1,250 @@
+#!/usr/bin/env bats
+#
+# scripts/design-notes-gate.sh — the DESIGN_NOTES entry-boundary gate (#1271).
+#
+# `docs/DESIGN_NOTES.md` carries `merge=union` (#114). The driver auto-resolves
+# concurrent appends for the entry BODIES and silently mangles the boundary
+# between them: every entry was appended with the same three leading lines
+# (blank / `---` / blank), the merge machinery aligns that identical prefix as a
+# COMMON addition, union emits it once and concatenates both bodies after it.
+# One entry keeps its separator, the other loses it — no conflict, no markers,
+# `rc=0`, ZERO deletions. Four occurrences on 2026-08-13 alone, every one caught
+# only because a human pinned `git diff --numstat` before the rebase.
+#
+# The gate is that ritual automated, so this suite's job is to prove the gate
+# can FAIL — a guard that cannot fail is not a guard.
+#
+# The oracle is therefore NOT a hand-written broken file. Every case below
+# builds a scratch repository with the real `merge=union` attribute, appends an
+# entry on each of two branches, and runs a real `git rebase`. What the gate is
+# judged against is what the merge machinery actually produced. A synthetic
+# fixture would prove the regex works and nothing about the defect.
+
+load ../bats_helpers
+
+setup() {
+    GATE_SRC="$BATS_TEST_DIRNAME/../../scripts/design-notes-gate.sh"
+    REAL_REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+}
+
+# Append one entry, in the shipped shape. The marker — when present — is the
+# FIRST appended line, with no blank before it: measured, that shape loses
+# nothing at all (8 additions before the rebase, 8 after), whereas putting a
+# blank line ahead of the marker still costs that blank (9 → 8). A convention
+# that routinely shrinks the diff by one line would poison the very numstat
+# comparison this whole class is detected by.
+#
+# The marker tag is separate from the heading tag so a case can hand two
+# entries the SAME marker, which is how the copy-paste is reproduced.
+append_entry() {
+    local tag="$1" marker="$2"
+    if [ "$marker" != no ]; then
+        printf '<!-- entry #%s -->\n' "$marker" >> docs/DESIGN_NOTES.md
+    fi
+    printf '\n---\n\n## 2026-01-02 — entry %s\n\nbody %s\n' "$tag" "$tag" \
+        >> docs/DESIGN_NOTES.md
+}
+
+# A scratch repo with `merge=union` on the log, one entry already in the base,
+# and one appended on each of `main` and `feat`. Leaves `feat` checked out,
+# NOT yet rebased, so each case controls what happens next.
+scratch() {
+    local feat_marker="$1" main_marker="$2"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    rm -rf "$REPO"
+    mkdir -p "$REPO/docs" "$REPO/scripts"
+    cp "$GATE_SRC" "$REPO/scripts/design-notes-gate.sh"
+    chmod 0755 "$REPO/scripts/design-notes-gate.sh"
+
+    cd "$REPO"
+    git -c init.defaultBranch=main init -q .
+    git config user.email bats@example.invalid
+    git config user.name bats
+
+    printf 'INTRO\n\n---\n\n## 2026-01-01 — entry A\n\nbody A\n' > docs/DESIGN_NOTES.md
+    printf 'docs/DESIGN_NOTES.md merge=union\n' > .gitattributes
+    git add -A
+    git commit -qm base
+    git branch feat
+
+    append_entry C "$main_marker"
+    git commit -qam 'main C'
+
+    git checkout -q feat
+    append_entry B "$feat_marker"
+    git commit -qam 'feat B'
+}
+
+# Additions / deletions of the branch's contribution, as the pre-rebase pin.
+contribution() {
+    git diff --numstat main...feat -- docs/DESIGN_NOTES.md | cut -f"$1"
+}
+
+# ── The oracle: the gate fails on what the driver actually produces ──────────
+
+@test "the gate FAILS on a separator the union driver just ate (#1271)" {
+    scratch no no
+
+    local add_before add_after del_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+    del_after="$(contribution 2)"
+
+    # The loss, measured here rather than assumed — and measured as the reason
+    # nothing catches it: exactly the 3-line separator block vanished while the
+    # rebase reported success and deletions stayed at zero.
+    [ "$del_after" -eq 0 ]
+    [ "$add_after" -eq $((add_before - 3)) ]
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"NOT preceded by"* ]]
+    [[ "$output" == *"entry B"* ]]
+}
+
+@test "with a marker on both sides, nothing is eaten and the gate passes (#1271)" {
+    scratch B C
+
+    local add_before add_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+
+    # Not one line lost — the marker leaves no identical prefix to collapse.
+    [ "$add_after" -eq "$add_before" ]
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+}
+
+@test "the OTHER side's marker alone already saves the separator (#1271)" {
+    # Adoption is therefore incremental: the pair is protected the moment
+    # EITHER entry carries a marker, so no flag day and no sweep of old
+    # entries. Measured on the side that would otherwise lose its separator —
+    # `feat` here carries none.
+    scratch no C
+
+    local add_before add_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+    [ "$add_after" -eq "$add_before" ]
+
+    # The gate still fails this branch, and on the OTHER finding: `feat`'s own
+    # entry has no marker. What must not appear is the #1271 one — the
+    # separator survived, and saying otherwise would send the next reader
+    # hunting a merge that behaved.
+    run scripts/design-notes-gate.sh main
+    refute grep -q "NOT preceded by" <<<"$output"
+}
+
+# ── The second failure mode, kept separate from the first ───────────────────
+
+@test "a separator with no marker is its own finding, not the #1271 one" {
+    # Two causes, two messages: an eaten separator is the merge machinery, a
+    # missing marker is an author who did not know the convention. Reporting
+    # them as one would send the next reader looking for a rebase that never
+    # happened.
+    scratch no no
+
+    # No rebase: `feat` is well formed apart from the marker.
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no \`<!-- entry ... -->\` line"* ]]
+    refute grep -q "NOT preceded by" <<<"$output"
+}
+
+@test "a DUPLICATED marker reinstates the collapse — uniqueness IS the mechanism" {
+    # Both entries carry `#C`, so the identical prefix is back and so is the
+    # bug — one line WORSE than before, because the marker collapses with the
+    # separator block it was added to protect. Measured, not assumed: this is
+    # why the gate has to check uniqueness and not merely presence.
+    scratch C C
+
+    local add_before add_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+    [ "$add_after" -eq $((add_before - 4)) ]
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"NOT preceded by"* ]]
+}
+
+@test "the same marker twice in one file is rejected before a merge can use it" {
+    # The reachable way to get there: an author copies the previous entry's
+    # block as a template and keeps its marker. No merge is involved yet, both
+    # entries are perfectly well formed, and the NEXT concurrent rebase is the
+    # one that pays. This is the only case that isolates the uniqueness check —
+    # once the collapse has happened there is a single marker left to count.
+    scratch B C
+    printf '<!-- entry #B -->\n\n---\n\n## 2026-01-03 — entry D\n\nbody D\n' \
+        >> docs/DESIGN_NOTES.md
+    git commit -qam 'feat D, template copied from B'
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate entry marker"* ]]
+    refute grep -q "NOT preceded by" <<<"$output"
+}
+
+# ── Fail-closed, and the fast path that must stay honest ────────────────────
+
+@test "an unresolvable base ref FAILS the gate, it does not skip it" {
+    # The reachable version of this is a shallow CI checkout, where origin/main
+    # simply is not there. Passing would report a green gate that looked at
+    # nothing — the exact shape of every guard that fails open.
+    scratch B C
+
+    run scripts/design-notes-gate.sh no/such/ref
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not resolve"* ]]
+    [[ "$output" == *"fetch-depth"* ]]
+}
+
+@test "a branch that adds no entry says so, rather than claiming a check" {
+    scratch B C
+    git checkout -q main
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"adds no"* ]]
+}
+
+@test "a '## ' line inside a fenced block is sample text, not an entry" {
+    # Entries quote shell and markdown constantly. Reading a fenced `## ` as a
+    # heading would fail a perfectly well-formed entry and teach the next
+    # author to stop quoting.
+    scratch B C
+    printf '\n```\n## 2026-01-02 — entry B\n```\n' >> docs/DESIGN_NOTES.md
+    git commit -qam 'feat B gains a fenced sample of its own heading'
+    git rebase -q main
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+}
+
+# ── The gate against the file it actually ships to guard ────────────────────
+
+@test "the real docs/DESIGN_NOTES.md passes the gate on this branch" {
+    # Self-referential on purpose: this branch appends an entry of its own, so
+    # this case is the gate running for real against its first client.
+    cd "$REAL_REPO"
+
+    run scripts/design-notes-gate.sh
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
`docs/DESIGN_NOTES.md` carries `merge=union` (#114) so concurrent PRs
appending entries auto-resolve instead of conflicting by hand. The driver does
that for the entry BODIES and destroys the boundary between them, silently.
Four occurrences on 2026-08-13 alone.

## The mechanism, reproduced here

Not taken from the issue — re-measured in a scratch repo, five variants,
additions of the branch's contribution before → after the rebase:

| setup | rebase | additions | separators |
|---|---|---|---|
| union, no marker | rc=0 | 7 → **4** | 2/3, entry glued |
| no union, `---` | **conflict** | 7 → 7 | 2/3 |
| union + marker both sides | rc=0 | 8 → 8 | 3/3 |
| union + marker on the rebased side only | rc=0 | 8 → 8 | 3/3 |
| union + marker on the OTHER side only | rc=0 | 7 → 7 | 3/3 |

Every entry was appended with the same three leading lines (blank / `---` /
blank). The merge machinery aligns that identical prefix as a COMMON addition
and hands only the diverging tails to the driver; union emits the shared prefix
once and concatenates both bodies after it. rc=0, no conflict, **zero
deletions** — which is why nothing in the tooling ever flagged it.

**Two facts the issue does not have.** A marker on *either* side is enough, in
both directions, so **adoption is incremental** — no flag day, no retrofit of
old entries. And the single line the issue saw the marker variant lose (9 → 8)
is the *leading blank*: put the marker first with no blank ahead of it and
nothing is lost at all. Worth the pedantry, because a convention that routinely
shrinks the diff by one line poisons the very numstat comparison this class is
detected by. Conversely a **duplicated** marker is worse than none — the
identical prefix is back and now includes the marker, so the collapse takes
four lines.

## What changed

- **`.gitattributes` + `CLAUDE.md`** — the ruling comment claimed union
  "auto-resolves the append-vs-append case". True of the bodies, false of the
  shared separator. Both now carry the mechanism and the convention: an entry
  opens with a unique `<!-- entry #NNNN -->` line, as its FIRST appended line.
- **`scripts/design-notes-gate.sh`** — the manual `git diff --numstat` ritual,
  automated. Diff-scoped.
- **`.github/workflows/ci.yml`** — runs the gate, and checks out with
  `fetch-depth: 0`. **That is a declared cost**, paid by one job for this one
  gate: a diff-scoped check needs `origin/main` and a merge base with it, and
  the gate fails rather than skipping when it cannot resolve them.

## Why diff-scoped, and the sweep that is NOT here

The issue asked for a sweep re-inserting the separators already lost on `main`.
Measured on `efa69e35`, **it has no object**: the last fourteen entries are all
well formed and the four losses of 2026-08-13 were each caught before landing.

Deriving the sweep as written — every `^## ` not preceded by `---` — selects
**426 of 645** level-2 headings. Those are entries from before the convention
existed; the oldest glued one is 2026-05-12, two months before the union
attribute was added, so it cannot be union damage. The rule is also wrong in
kind: **12 of those headings are not entry headings** — seven are the
document's front-matter sections and five are mis-levelled subsections *inside*
the 2026-08-08 #1038 entry. A file-wide rule would insert horizontal rules in
the middle of an entry. Re-levelling the log is a question for its author and
does not ride a bugfix.

So the gate judges only what a branch ADDS: no opinion about history, no
exemption list, no false positive to teach people to ignore.

## The gate, and the proof it can fail

Two assertions with distinct messages, because they have distinct causes: the
separator is the **detector** (it sees whatever the merge machinery does next),
the unique marker is the **prevention**. Uniqueness is checked because a
copy-pasted marker restores the collapsible prefix while both entries still
look well formed.

The suite uses **no hand-written broken fixture**. Every case builds a scratch
repo with the real `merge=union` attribute, appends an entry on each of two
branches and runs a real `git rebase`, so the gate is judged against what the
merge machinery actually produced:

| case | proves |
|---|---|
| separator eaten by a real rebase | gate exits 1, names the heading — **the oracle** |
| marker both sides | nothing eaten, gate exits 0 |
| marker on the other side only | separator survives, no #1271 finding |
| `---` present, marker absent | the second finding, not the first |
| duplicated marker | the collapse is back, four lines instead of three |
| same marker twice, no merge yet | the uniqueness check, isolated |
| unresolvable base ref | exits 1 — fails closed, never skips |
| branch adds no entry | exits 0, and says that is what it observed |
| `## ` inside a fenced block | not read as a heading |
| the real `docs/DESIGN_NOTES.md` | the gate against its first client |

## Beyond the letter of the brief, named so it can be dropped

The ruling asked for the marker as a **convention** and the separator as the
**gate**. The marker is asserted too, in the same gate. A convention that is
only written down depends on somebody remembering it across sessions, which is
precisely the property that let this survive four times in one day. Drop the
two marker checks and the separator detector still stands on its own.

One real constraint this introduces: an added `^## ` is treated as an ENTRY
heading, so a subsection inside an entry must be `###` or deeper. The #1038
entry is why that is worth having rather than a cost.

## Scope

Repo hygiene and CI only. No runtime code, no deploy.

## Gates run locally

- `scripts/bats.sh` (full set): 458 ok, 0 not ok, rc=0
- `scripts/shellcheck.sh` (pinned container, 74 derived scripts): rc=0
- `scripts/design-notes-gate.sh` against `origin/main`: rc=0
- `scripts/check.sh` not run — no Elixir touched, and it wants a lane.