### PR TITLE
cic: hoist the CRT box-shadow comment so biome 2.5.7 stops rewriting it

### DIFF
--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10916,8 +10916,9 @@ html.resize-dragging * {
   overflow: hidden;
   border-radius: 1.25rem; /* overscan rounded corners */
   background: radial-gradient(ellipse at center, #04140b 0%, #020a06 70%, #000 100%);
+  /* phosphor bloom, then inner vignette */
   box-shadow:
-    0 0 1.5rem rgba(51, 255, 136, 0.18), /* phosphor bloom */
+    0 0 1.5rem rgba(51, 255, 136, 0.18),
     inset 0 0 4rem rgba(0, 0, 0, 0.9);
   animation: crt-flicker 4.5s infinite steps(60);
   will-change: opacity;


### PR DESCRIPTION
Two lines in `cicchetto/src/themes/default.css`. This is the whole of
the red `cicchetto (types + lint + unit)` job on dependabot PR #1175.

## What breaks

`@biomejs/biome` 2.5.7 formats a trailing comment inside a multi-value
`box-shadow` differently from 2.5.6 — it moves the comment to the head
of the *next* line:

```
-    0 0 1.5rem rgba(51, 255, 136, 0.18), /* phosphor bloom */
-    inset 0 0 4rem rgba(0, 0, 0, 0.9);
+    0 0 1.5rem rgba(51, 255, 136, 0.18),
+    /* phosphor bloom */ inset 0 0 4rem rgba(0, 0, 0, 0.9);
```

That output is what biome wants, but it makes the comment annotate the
inset vignette instead of the bloom it names. So this PR takes the
third option: hoist the comment onto its own line above the property,
where it names both values truthfully.

Measured: `biome check` is clean under **both** 2.5.6 (main's current
pin) and 2.5.7. The fix is version-agnostic, lands ahead of any bump,
and does not come back at the next one.

## Why this file, and why now — the measurement

Diagnosed by displacement, in a scratch worktree off `origin/main`
(`9e5457c1`), running the gate in the container image at the **same
digest CI uses** (`oven/bun:1@sha256:e105…`), one factor at a time:

| tree (same worktree)                    | `bun run check` |
|-----------------------------------------|-----------------|
| `origin/main` bare                      | **RC=0**, 0 errors, 60 warnings |
| \+ the two dependabot files             | **RC=1**, 1 error |
| \+ `$schema` aligned to 2.5.7 as well   | RC=1, 1 error (so: not the schema) |
| vite 8.2.1 only, biome pinned to 2.5.6  | **RC=0** |
| biome 2.5.7 only                        | RC=1, the formatter error |

So the red is biome alone, not a stale base and not vite. Nothing else
on that PR is broken: `tsc --noEmit` and `tsc --noEmit -p
e2e/tsconfig.json` both return 0 under the bumped deps, and `vitest
run` is green there too (282 files, 5349 tests) — CI never got to
either, because `bun run check` is a `&&` chain and biome is the first
link.

## Two traps worth writing down

**The CI log never shows the actual error.** biome truncates to 20
diagnostics (`Diagnostics not shown: 48`) and the single error-level
one falls outside the window; the log ends at a bare `Found 1 error.`
Re-run with `--diagnostic-level=error` to see it.

**`biome.json`'s `$schema` pin is a decoy.** It is the first thing the
log prints (`The configuration schema version does not match the CLI
version 2.5.7`) and it looks like the cause. It is info-level: aligning
it changes nothing but the info count. The second `biome.json`
diagnostic (`recommended` is DEPRECATED) is already present on green
main. Both are left alone here — the `$schema` bump belongs to whoever
takes the biome bump, not to this PR.

## Expected effect on #1175

With this on main, #1175 is *expected* to go green on its next run.
That is an expectation, not a measurement — it has not been re-run, and
this PR does not touch the dependabot branch.

## Gates

`bun.sh run check` RC=0 and `bun.sh run test` RC=0 (282 files, 5349
tests) on this branch with main's pinned biome 2.5.6; `biome check`
RC=0 on this branch under 2.5.7. No Elixir touched.

No DESIGN_NOTES entry: a two-line comment placement is not a design
decision, and the reasoning that outlives it is in the commit message.