### PR TITLE
union: #1264 addquote sender + #1263 per-worker caches + #1175 css comment, gated together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # ── Elixir / Erlang
 /_build/
+# #1263 — per-worker build caches (GRAPPA_CACHE_ID): one
+# _build/deps/priv/plts triplet per id, opt-in, never shared.
+/.caches/
 /cover/
 /coverage/
 /deps/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,6 +778,13 @@ is due. Don't just look at todo.md.
   a forced rebuild (`scripts/mix.sh --env=dev compile --force`) before you
   believe it, and say in the report which of the two you established. The
   COMPILE lane serialises access; it does NOT make the artefacts yours.
+  **Opt out with `GRAPPA_CACHE_ID=<id>` (#1263):** the three caches then come
+  from `.caches/<id>/` and `MIX_TEST_PARTITION` follows the id, so two ids can
+  run `mix` concurrently. Unset changes nothing. A fresh id is COLD — full
+  compile plus its own dialyzer PLT, nothing seeded (seeding would import the
+  contamination described above). Does NOT isolate the docker stack: compose
+  project and ports are still shared, so `integration.sh` / e2e stay
+  single-occupancy. See `docs/OPERATIONS.md`.
 - **NEVER install hex packages on the host.** Add them to `mix.exs`,
   rebuild the image (`scripts/mix.sh deps.get`).
 - **Don't touch the IRC parser without re-running parser tests.**

--- a/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
+++ b/cicchetto/e2e/tests/issue1107-addquote-menu-item.spec.ts
@@ -1,6 +1,6 @@
-// #1107 — the message menu's `!addquote` item puts `!addquote ` plus the
-// message text into the compose box, with the caret at the end and visible,
-// and sends NOTHING. The command is for whatever bot is in the channel; cic
+// #1107 — the message menu's `!addquote` item puts `!addquote `, the sender's
+// `<nick>` head (#1264) and the message text into the compose box, with the
+// caret at the end and visible, and sends NOTHING. The command is for whatever bot is in the channel; cic
 // only fills the box.
 //
 // Harness + limits:
@@ -96,8 +96,10 @@ test("issue1107 — !addquote fills the compose box with the command and the mes
   await menuItem(page, "!addquote").click();
 
   // The payload ruling, at the only place it is observable end to end: the
-  // command, one space, the body — and no `<nick>` head.
-  await expect(ta).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+  // command, the sender's `<nick>` head, then the body. #1264 reversed #1107's
+  // bare-body shape — what is quoted is what the operator READ, attribution
+  // included. The nick is the spec subject's own, since it posted the line.
+  await expect(ta).toHaveValue(`!addquote <${specNick()}> ${body}`, { timeout: 5_000 });
 });
 
 test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
@@ -110,7 +112,9 @@ test("issue1107 — picking !addquote sends nothing", async ({ page }) => {
   // Barrier first: the compose value settling is the durable state that says
   // the item has fully run. Only then is the absence below an absence rather
   // than a race with an insertion still in flight.
-  await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+  await expect(composeTextarea(page)).toHaveValue(`!addquote <${specNick()}> ${body}`, {
+    timeout: 5_000,
+  });
 
   // The original row is still the ONLY row carrying this text. A sent command
   // would echo back as a second scrollback line containing the same body.
@@ -153,7 +157,9 @@ test.describe("the caret, where the overflow is real", () => {
 
     await openMenuOnRow(page, body);
     await menuItem(page, "!addquote").click();
-    await expect(composeTextarea(page)).toHaveValue(`!addquote ${body}`, { timeout: 5_000 });
+    await expect(composeTextarea(page)).toHaveValue(`!addquote <${specNick()}> ${body}`, {
+      timeout: 5_000,
+    });
 
     // The #1105/#1113 dependency the issue names, on the real engine jsdom
     // cannot stand in for. The oracle's own overflow guard is what makes this

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -150,12 +150,12 @@ describe("the !addquote item", () => {
     expect(labels()).toEqual(["Copy", "Reply", "!addquote", "Select…"]);
   });
 
-  it("drops the command plus the message text into the compose box", () => {
+  it("drops the command, the sender and the message text into the compose box", () => {
     mountCompose();
     render(() => <MessageContextMenu />);
     openOver(scrollbackRow("12:34 <vjt> ciao"), { body: "ciao mondo" });
     fireEvent.click(screen.getByText("!addquote"));
-    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 
   // Disabled but VISIBLE, the posture Reply already takes: the menu's shape

--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -4,15 +4,19 @@ import { addQuoteCommand, addQuoteToCompose } from "../lib/addQuote";
 import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
+import { replyQuote } from "../lib/replyQuote";
 
 // #1107 — the `!addquote` menu item: it drops `!addquote ` plus the message
 // text into the compose box and stops there. cic never sends it and never
 // interprets it; whatever bot sits in the channel does.
 //
-// THE PAYLOAD IS THE BARE BODY — no `<nick>` head, no `<< ` tail. That is the
-// issue's open question, ruled on the requester's literal words ("mette nel
-// composebox '!addquote' e poi il messaggio"). The rule is pinned by its own
-// assertion below so a later reshaping cannot take it silently.
+// THE PAYLOAD CARRIES THE SENDER, in the form the scrollback rendered — #1264
+// reverses #1107's bare-body ruling. `<nick> body` for speech, `* nick body`
+// for an action: what gets quoted is what the operator READ. There is still no
+// `<< ` tail, which belongs to Reply and not to an archive.
+//
+// The reversed rule is pinned by its own assertion below, as the old one was,
+// so the next reshaping has to trip over it rather than reword a string.
 
 const NET = "azzurra";
 const CHAN = "#grappa";
@@ -47,23 +51,41 @@ beforeEach(() => {
 });
 
 describe("addQuoteCommand", () => {
-  it("prefixes the message text with the bot command", () => {
-    expect(addQuoteCommand(msg({}))).toBe("!addquote ciao mondo");
+  it("prefixes the bot command and the sender's nick", () => {
+    expect(addQuoteCommand(msg({}))).toBe("!addquote <vjt> ciao mondo");
   });
 
-  // The ruling, pinned on its own. Co-killed with the shape assertion above by
-  // a "carry the nick" implementation, and kept anyway: it is the answer to the
-  // issue's open question, and a future reshaping of the payload must trip over
-  // it explicitly rather than quietly reword the string above.
-  it("carries no nick — the payload is the bare body", () => {
-    expect(addQuoteCommand(msg({ sender: "vjt", body: "ciao mondo" }))).not.toContain("vjt");
+  // #1264's ruling, pinned on its own — the inverse of the assertion #1107 put
+  // here. Co-killed with the shape above by a bare-body implementation, and
+  // kept for the same reason the old one was: the attribution is the POINT of
+  // the payload, not an incidental part of the string.
+  it("carries the sender — the payload is never the bare body", () => {
+    expect(addQuoteCommand(msg({ sender: "vjt", body: "ciao mondo" }))).toContain("vjt");
+  });
+
+  // The two kinds differ in the HEAD, and both heads are the ones the
+  // scrollback renders — that equivalence is the whole ruling, so it is
+  // asserted against `replyQuote`'s head rather than against a literal that
+  // could drift away from it silently.
+  it("gives an action the rendered `* nick` head, not `<nick>`", () => {
+    expect(
+      addQuoteCommand(msg({ kind: "action", body: "\x01ACTION pees over the fence\x01" })),
+    ).toBe("!addquote * vjt pees over the fence");
+  });
+
+  it("heads the payload exactly as Reply heads its quote", () => {
+    for (const kind of ["privmsg", "notice", "action"] as const) {
+      const body = kind === "action" ? "\x01ACTION waves\x01" : "waves";
+      const head = replyQuote(msg({ kind, body }))?.split(" waves")[0];
+      expect(addQuoteCommand(msg({ kind, body }))).toBe(`!addquote ${head} waves`);
+    }
   });
 
   // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
   // operator is quoting what they SEE, and a control byte round-tripped through
   // compose would be re-sent as formatting they never chose.
   it("strips mIRC control codes out of the quoted body", () => {
-    expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote bold plain");
+    expect(addQuoteCommand(msg({ body: "\x02bold\x02 plain" }))).toBe("!addquote <vjt> bold plain");
   });
 
   it("refuses a presence row", () => {
@@ -92,7 +114,7 @@ describe("addQuoteCommand", () => {
   });
 
   it("quotes a notice like speech — it has an author and a body", () => {
-    expect(addQuoteCommand(msg({ kind: "notice" }))).toBe("!addquote ciao mondo");
+    expect(addQuoteCommand(msg({ kind: "notice" }))).toBe("!addquote <vjt> ciao mondo");
   });
 
   // An action's stored body is the raw `\x01ACTION …\x01` wire form (the
@@ -101,7 +123,7 @@ describe("addQuoteCommand", () => {
   // the compose box — the #1126 defect, at a second door.
   it("unwraps a CTCP action down to its text", () => {
     expect(addQuoteCommand(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
-      "!addquote si dà alla fuga",
+      "!addquote * vjt si dà alla fuga",
     );
   });
 
@@ -124,7 +146,7 @@ describe("addQuoteCommand", () => {
   // attribute someone else's line to this sender forever.
   it("drops a previous reply-quote out of the body", () => {
     expect(addQuoteCommand(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
-      "!addquote answer",
+      "!addquote <alice> answer",
     );
   });
 
@@ -135,7 +157,7 @@ describe("addQuoteCommand", () => {
   // `<<` is ordinary text and must not be mistaken for a quote tail.
   it("leaves a shift expression alone", () => {
     expect(addQuoteCommand(msg({ body: "shift << 2 gives four" }))).toBe(
-      "!addquote shift << 2 gives four",
+      "!addquote <vjt> shift << 2 gives four",
     );
   });
 });
@@ -144,7 +166,7 @@ describe("addQuoteToCompose", () => {
   it("fills an empty compose with exactly the command", () => {
     mountCompose();
     addQuoteToCompose(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("!addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 
   // Never destroy work in progress: the command lands AFTER what is already
@@ -153,7 +175,7 @@ describe("addQuoteToCompose", () => {
     mountCompose();
     setDraft(KEY, "bozza ");
     addQuoteToCompose(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("bozza !addquote ciao mondo");
+    expect(getDraft(KEY)).toBe("bozza !addquote <vjt> ciao mondo");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -1,31 +1,37 @@
 import type { ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
-import { quotableBody } from "./quotableBody";
+import { attributionHead, quotableBody } from "./quotableBody";
 
 // #1107 — the `!addquote` verb behind the message menu's fourth item. It fills
 // the compose box and stops: nothing is sent, and cic does not know or care
 // what `!addquote` means. Whatever bot sits in the channel interprets it, and
 // the operator gets to read the line before pressing enter.
 //
-// THE PAYLOAD IS THE BARE BODY. The issue leaves that open ("whether the
-// payload is the bare body or carries the nick") because bots differ; it is
-// ruled on the requester's literal words — `!addquote` and then the message.
-// A wrapper is one line away in either direction, and guessing WIDER is the
-// worse guess: a bot that wants attribution can read the nick off the channel,
-// while a bot that stores its input verbatim would put `<vjt>` inside every
-// stored quote with no way for the operator to know until it is recalled.
+// THE PAYLOAD CARRIES THE SENDER (#1264, reversing #1107). It used to be the
+// bare body, on the reasoning that a bot storing its input verbatim would bake
+// `<vjt>` into every stored quote; vjt ruled the other way, and the new rule is
+// the sharper one: **what gets quoted is what the operator READ**. The line in
+// the compose box is the line as the scrollback rendered it, attribution
+// included, so the operator can see before pressing enter exactly what the
+// archive will hold. A bot that wants the nick can no longer only "read it off
+// the channel" — by the time a quote is recalled, that context is gone.
+//
+// There is still no `<< ` tail: that is Reply's, and an archive is not a reply.
 export const ADDQUOTE_COMMAND = "!addquote ";
 
 // The command line for a message, or null when the row has nothing to quote —
 // the same refusals Reply makes, because they are the same question ("did
 // somebody say something here?") and `quotableBody` is where they live.
 //
-// An ACTION contributes its text without the `* nick` form Reply gives it: the
-// payload carries no attribution at all, so half of one for one kind would be
-// a shape the operator cannot predict from the menu.
+// An ACTION keeps the `* nick` form, exactly as Reply gives it (#1264 closed
+// the issue's open question this way). The two kinds therefore head the payload
+// DIFFERENTLY — `<vjt> ciao mondo` against `* vjt pees over the fence` — and
+// that is the predictable shape, not the exception to it: each is the line the
+// scrollback showed. `attributionHead` is shared with `replyQuote` so the two
+// doors cannot drift.
 export function addQuoteCommand(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
-  return body === null ? null : `${ADDQUOTE_COMMAND}${body}`;
+  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg)} ${body}`;
 }
 
 // Drop the command into the window's compose box with the caret at the end and

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -12,7 +12,9 @@ import { mircPlainText } from "./mircFormat";
 // worth of history and would let the two doors drift apart on the next one.
 //
 // The WRAPPER is the caller's business — `replyQuote` puts a `<nick> …<< `
-// around this, `addQuoteCommand` puts `!addquote ` in front of it.
+// around this, `addQuoteCommand` puts `!addquote ` in front of it. The
+// ATTRIBUTION is not: since #1264 both doors head the quote the same way, so
+// `attributionHead` lives here with the body it heads.
 
 // #1123 — the nick charset, mirrored from the server's
 // `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
@@ -61,4 +63,17 @@ export function quotableBody(msg: ScrollbackMessage): string | null {
   // quote said nothing to quote back.
   const body = withoutPreviousQuote(mircPlainText(raw).trim());
   return body === "" ? null : body;
+}
+
+// How the row names its sender, in the form the SCROLLBACK RENDERS it: `<nick>`
+// for speech, `* nick` for an action.
+//
+// #1126 ruled it for Reply — quoting `* vjt waves` as `<vjt> waves` puts a
+// sentence in someone's mouth they never said. #1264 gave `!addquote` the same
+// heads, on the same principle stated from the other side: what gets quoted is
+// what the operator READ. Shared rather than written twice because the two
+// doors are now one rule, and a copy would let the next kind be added to one of
+// them only.
+export function attributionHead(msg: ScrollbackMessage): string {
+  return msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
 }

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,6 +1,6 @@
 import type { ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
-import { quotableBody } from "./quotableBody";
+import { attributionHead, quotableBody } from "./quotableBody";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
 // the long-press menu's Reply item. Both doors, one code path.
@@ -47,12 +47,8 @@ function capQuotedBody(body: string): string {
 export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
-  // #1126 — an action is NOT speech. Quoting `* vjt waves` as `<vjt> waves`
-  // puts a sentence in someone's mouth that they never said, so the quote keeps
-  // the `* nick …` form the scrollback renders. Ruled on the least-surprise
-  // tiebreak; privmsg/notice keep the `<nick> …` shape unchanged.
-  const head = msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
-  return `${head} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
+  // #1126's heads, shared with `!addquote` since #1264 — see `attributionHead`.
+  return `${attributionHead(msg)} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10916,8 +10916,9 @@ html.resize-dragging * {
   overflow: hidden;
   border-radius: 1.25rem; /* overscan rounded corners */
   background: radial-gradient(ellipse at center, #04140b 0%, #020a06 70%, #000 100%);
+  /* phosphor bloom, then inner vignette */
   box-shadow:
-    0 0 1.5rem rgba(51, 255, 136, 0.18), /* phosphor bloom */
+    0 0 1.5rem rgba(51, 255, 136, 0.18),
     inset 0 0 4rem rgba(0, 0, 0, 0.9);
   animation: crt-flicker 4.5s infinite steps(60);
   will-change: opacity;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40884,10 +40884,28 @@ operator may be partitioning for an unrelated reason.
   `cp -c` clone is instant — but those artefacts were compiled from another
   worktree's source, which is precisely the contamination class this issue
   exists to end. A fresh id starts empty and pays a full compile plus its own
-  PLT. Cost measured on this host: ~209M per id (`_build` 148M, `deps` 33M,
-  `priv/plts` 28M), disk that is free at 885G available. The PLT *build time*
-  is the number that would justify revisiting this, and it has not been
-  measured yet.
+  PLT. **The disk cost was over-estimated before it was measured**: reading
+  the shared tree gave ~209M per id, but a real cold `check.sh` produces
+  **113M** — `_build` 70M, `deps` 32M, `priv/plts` 11M. The shared tree is
+  bigger because it also carries `prod` and PLTs left over from older OTP
+  versions; a fresh id builds dev + test and exactly three current PLTs.
+  Free disk on this host is 885G, so the number was never the constraint.
+  The PLT *build time* is the figure that would justify revisiting this, and
+  it is **not** measured: the only window in which two cold gates ran, the
+  whole e2e suite was running beside them, so every wall-clock reading from
+  it is contaminated.
+
+**Acceptance, and the oracle used.** Two `check.sh` runs, in two separate
+worktrees under ids `w2a` and `w2b`, launched two seconds apart and both cold:
+both `rc=0`, `8 doctests, 59 properties, 5995 tests, 0 failures` each, zero
+`not ok` in either bats leg. They overlapped for their whole ~14 minutes and
+finished five seconds apart. That they went green is half the claim; the other
+half is that they went green *without touching the shared cache*, and the
+oracle for that is displacement, not inspection: the shared
+`_build`/`deps`/`priv/plts` were timestamped before the run, and afterwards
+`find -newermt` reported **0** files modified and the file count was unchanged
+at 8261. An assertion about what the runs DID write would have passed even if
+they had also written somewhere they shouldn't; this one cannot.
 
 **Scope held deliberately.** The docker stack — compose project name, host
 ports — is still single-occupancy, so `integration.sh` and e2e remain one

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40836,3 +40836,68 @@ the 12 that passed were the refusal gates, which the change does not touch.
 `quotableBody` itself is untouched: the gate ("did somebody say something
 here?"), the CTCP unwrap, the mIRC strip and #1123's nesting cut all still
 answer the same. Only the wrapper moved.
+<!-- entry #1263 -->
+
+---
+
+## 2026-08-13 — #1263: the COMPILE lane was a bind mount, so the cure is one too
+
+Two workers on this host cannot run `mix` at the same time. The orchestrator
+papers over it with an exclusive `COMPILE` lane, which means a worker that is
+otherwise ready sits idle for however long the other one's `check.sh` takes.
+That is real throughput lost every day, and it is not a policy choice — it
+falls out of `scripts/_lib.sh` resolving `REPO_ROOT` through
+`--git-common-dir`, so every worktree binds the MAIN repo's `_build`, `deps`
+and `priv/plts`. The lane is a mutex protecting a shared directory.
+
+**So the fix is at the same layer as the cause.** `GRAPPA_CACHE_ID`, when set,
+binds those three paths from `.caches/<id>/` instead. No new machinery: the
+worktree source overrides already prove that "bind something else over `/app/x`"
+is how this codebase redirects a container path, and the knob reuses that verb
+exactly. Unset, `CACHE_VOLUMES` stays empty and expands to nothing — today's
+invocation, byte for byte, which is the non-negotiable part of the ask.
+
+**What the issue got wrong, measured.** Its point 2 says the test database is
+"already solved upstream — `config/test.exs` builds the path from
+`MIX_TEST_PARTITION`, nothing to change, just set it." Half true, and the
+missing half is the half that matters: the *config* side reads the variable,
+but nothing on the shell side ever set it, and `docker compose run` does not
+inherit host environment. Setting `MIX_TEST_PARTITION` on the host was a
+silent no-op. Two isolated `_build`s would still have fought over one
+`runtime/grappa_test.db`. So the knob derives the partition from the id and
+FORWARDS it with `-e`; an explicitly set partition still wins, because an
+operator may be partitioning for an unrelated reason.
+
+**Two decisions worth the ink:**
+
+* **The knob FORCES a oneshot container.** `in_container_or_oneshot` would
+  otherwise exec into the live container on a main checkout — and a running
+  container cannot be remounted, so the caller would receive the shared cache
+  while believing they had asked for an isolated one. Silent loss of the
+  isolation is the only failure mode this knob must not have, so the exec
+  branch is now conditioned on the knob being unset. It is pinned by a pair of
+  bats cases, not one: the second asserts no exec happens, and the first is the
+  reference box proving the fixture can reach the exec branch at all. Without
+  that pair the "no exec" assertion would hold vacuously.
+* **Nothing is seeded from the shared cache.** Copying the warm `_build` and
+  the PLT into a fresh id would make adoption nearly free — on APFS a
+  `cp -c` clone is instant — but those artefacts were compiled from another
+  worktree's source, which is precisely the contamination class this issue
+  exists to end. A fresh id starts empty and pays a full compile plus its own
+  PLT. Cost measured on this host: ~209M per id (`_build` 148M, `deps` 33M,
+  `priv/plts` 28M), disk that is free at 885G available. The PLT *build time*
+  is the number that would justify revisiting this, and it has not been
+  measured yet.
+
+**Scope held deliberately.** The docker stack — compose project name, host
+ports — is still single-occupancy, so `integration.sh` and e2e remain one
+resource and the `STACK` lane stays. This issue kills one lane, not both.
+
+**A fixture trap worth remembering.** The two main-checkout cases build a
+throwaway repo under `$BATS_TEST_TMPDIR`. On macOS that lives under
+`/var/folders`, a symlink to `/private/var/folders`: `_lib.sh` derives
+`SRC_ROOT` from `pwd` (logical) and `REPO_ROOT` from
+`git rev-parse --path-format=absolute` (resolved), so a logical fixture path
+makes the two differ and the fixture silently becomes a WORKTREE — never
+reaching the branch it was built to exercise. It was passing for the wrong
+reason until the path was taken physical with `pwd -P`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40919,3 +40919,19 @@ throwaway repo under `$BATS_TEST_TMPDIR`. On macOS that lives under
 makes the two differ and the fixture silently becomes a WORKTREE — never
 reaching the branch it was built to exercise. It was passing for the wrong
 reason until the path was taken physical with `pwd -P`.
+
+**And its mirror image, which CI found.** The knob-UNSET case had no fixture
+at all — it ran from the ambient cwd, which on this host is a worktree, so it
+saw the oneshot it asserted. CI checks out a MAIN tree, the stubbed
+`docker compose ps -q` answers with a container id, and
+`in_container_or_oneshot` therefore took the exec branch: `not ok 420`, on a
+branch whose code was right. Unset means "today's invocation", and on a main
+checkout with a live container today's invocation IS the exec — the assertion
+was reading a property of the HOST, not of the knob. It was the only case in
+the suite with that exposure, because every other one sets the knob, and the
+knob forces a oneshot in either layout. The cure is the sibling of the fixture
+above, a real `git worktree add`, so the case states the layout it means; the
+added `-v <root>/lib:/app/lib` assertion doubles as that fixture's own witness,
+since `WORKTREE_VOLUMES` is empty unless `SRC_ROOT != REPO_ROOT`. **General
+rule: a test that asserts a shape chosen by an environment predicate must
+establish that environment itself, or it is measuring the host.**

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -40785,3 +40785,54 @@ proved the shape; this is the second application of it.
 for the symbol it constrained. The symbol appears where the code is; the
 sentence appears wherever someone once explained the code, and that is where
 the next contributor will read it back as current.
+<!-- entry #1264 -->
+
+---
+
+## 2026-08-13 — #1264: `!addquote` carries the sender, reversing #1107 three days later
+
+#1107 ruled the payload was the bare body and wrote the reasoning down: the two
+guesses are not symmetric, a bot that wants attribution can read the nick off
+the channel, a bot that stores its input verbatim would bake `<vjt>` into every
+stored quote. It also pinned the rule with an assertion of its own so a later
+reshaping could not take it silently.
+
+**vjt reversed it, and the reversal comes with a sharper rule than the one it
+replaces: what gets quoted is what the operator READ.** The compose box now
+shows the line as the scrollback rendered it, attribution included, which is
+precisely what makes it reviewable before enter is pressed. The old tiebreak
+underweighted the recall side — "the bot can read the nick off the channel"
+holds at the moment the command arrives and not one second later, and a quote
+is a thing you recall months afterwards, when that context is gone.
+
+So the open question the issue left about ACTION rows is closed the same way:
+
+* PRIVMSG / NOTICE → `!addquote <vjt> ciao mondo`
+* ACTION → `!addquote * vjt pees over the fence`
+
+The two heads DIFFER, and under the new rule that is the predictable shape
+rather than the exception to it — #1107 read a difference between kinds as
+unpredictability, but each of these is the line its own row showed. #1126 had
+already ruled the same way for Reply, from the other side: rendering
+`* vjt waves` as `<vjt> waves` puts a sentence in someone's mouth.
+
+**The head became shared, because the two doors are now one rule.**
+`attributionHead` sits in `lib/quotableBody.ts` next to the body it heads, and
+`replyQuote` lost its inline copy. This is the #1107 argument applied one level
+up: that module exists because copying the quotable-body clauses would have let
+the two doors drift on the next ruling, and the head is now in exactly that
+position. Left duplicated, the next kind would have been taught to one door
+only. `replyQuote`'s output is unchanged, which its own suite still asserts.
+
+**The reversal was carried into the pin, not around it.** #1107's
+`carries no nick — the payload is the bare body` assertion is gone, replaced by
+its inverse rather than deleted: a rule with no pin is a rule the next
+reshaping takes silently, which is the thing #1107 was right about. The two
+comment blocks stating the withdrawn reasoning were rewritten in place, in the
+module and in the test — the #1262 lesson, applied on purpose. Red measured
+before green: 12 assertions across two suites failed on the payload shape, and
+the 12 that passed were the refusal gates, which the change does not touch.
+
+`quotableBody` itself is untouched: the gate ("did somebody say something
+here?"), the CTCP unwrap, the mIRC strip and #1123's nesting cut all still
+answer the same. Only the wrapper moved.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -441,9 +441,10 @@ Three things to know before using it:
   shared cache, deliberately: artefacts compiled from another
   worktree's source are the contamination this exists to end. Run
   `GRAPPA_CACHE_ID=<id> scripts/mix.sh deps.get` first, then expect a
-  full compile and a dialyzer PLT build. Measured on this host, the
-  steady-state cost is ~209M of disk per id (`_build` 148M, `deps`
-  33M, `priv/plts` 28M).
+  full compile and a dialyzer PLT build. Measured after a real cold
+  `check.sh`: **113M per id** — `_build` 70M (dev + test; the shared
+  tree is bigger because it also carries `prod`), `deps` 32M,
+  `priv/plts` 11M.
 * **It forces a oneshot container.** A running container cannot be
   remounted, so execing into the live one would silently hand back the
   shared cache. From a main checkout with the stack up, the knob

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -414,6 +414,44 @@ without it the task hits a read-only filesystem, and the default RO
 mount is what protects cic source from accidental container-side
 mutation during ordinary mix tasks.
 
+### `GRAPPA_CACHE_ID` — opt-in per-worker build caches (#1263)
+
+The shared cache above is why two people (or two agents) on one host
+cannot run `mix` at the same time: one `_build`, two concurrent
+compiles, and a red naming a file neither branch touched. Set
+`GRAPPA_CACHE_ID` to buy isolation for one caller:
+
+```sh
+GRAPPA_CACHE_ID=w2 scripts/check.sh
+```
+
+`_build`, `deps` and `priv/plts` are then bound from
+`.caches/<id>/` under the main repo instead of the shared tree, and
+`MIX_TEST_PARTITION` is derived from the id and forwarded into the
+container so the two runs cannot collide on one
+`runtime/grappa_test.db` either. Set `MIX_TEST_PARTITION` explicitly
+and it wins.
+
+**Unset, nothing changes** — that is the point of the knob being
+opt-in, and a bats suite pins it (`test/scripts/cache_id_isolation_test.bats`).
+
+Three things to know before using it:
+
+* **The first run on a new id is cold.** Nothing is seeded from the
+  shared cache, deliberately: artefacts compiled from another
+  worktree's source are the contamination this exists to end. Run
+  `GRAPPA_CACHE_ID=<id> scripts/mix.sh deps.get` first, then expect a
+  full compile and a dialyzer PLT build. Measured on this host, the
+  steady-state cost is ~209M of disk per id (`_build` 148M, `deps`
+  33M, `priv/plts` 28M).
+* **It forces a oneshot container.** A running container cannot be
+  remounted, so execing into the live one would silently hand back the
+  shared cache. From a main checkout with the stack up, the knob
+  therefore costs you the warm-exec path.
+* **It does NOT isolate the docker stack.** Compose project name and
+  host ports are still shared, so `scripts/integration.sh` and the e2e
+  stack remain a single-occupancy resource. That is a separate issue.
+
 **Every root-level file a drift-pin test READS needs its own `-v`
 override, or a worktree can never prove a fix green before merge.**
 Root-level files sit outside the directory mounts above, so a worktree

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -533,6 +533,25 @@ Before adding `config :ex_unit, KEY:` ANYTHING: grep `test/test_helper.exs`
 for `ExUnit.start(...)` opts — opts there silently override config. See
 `feedback_exunit_start_overrides_config`.
 
+## Running two gates at once: `GRAPPA_CACHE_ID` (#1263)
+
+`_build`, `deps` and `priv/plts` are shared by every worktree on a host
+(`scripts/_lib.sh` resolves `REPO_ROOT` through `--git-common-dir`), so
+two concurrent `mix` runs contaminate each other — the class where a red
+names a file your branch never touched. Prefix a gate with a cache id and
+it gets its own triplet, plus a matching `MIX_TEST_PARTITION` so the two
+runs do not share `runtime/grappa_test.db`:
+
+```sh
+GRAPPA_CACHE_ID=w2 scripts/mix.sh deps.get   # once per id — a fresh id is cold
+GRAPPA_CACHE_ID=w2 scripts/check.sh
+```
+
+Unset, everything behaves exactly as before. Full operator notes, the
+first-run cost and what the knob does **not** isolate (the docker stack:
+compose project + ports, so `integration.sh` and e2e are still
+single-occupancy) are in `docs/OPERATIONS.md`.
+
 ## Test-class gotchas (memory pointers)
 
 These bite during cluster work; check the memory before re-investigating.

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -113,6 +113,62 @@ die() {
     exit 1
 }
 
+# GRAPPA_CACHE_ID — opt-in per-worker build caches (#1263).
+#
+# UNSET is today's behaviour, byte for byte: CACHE_VOLUMES stays empty,
+# `"${CACHE_VOLUMES[@]}"` expands to nothing, and `_build`/`deps`/`priv/plts`
+# keep arriving through compose.yaml's `./:/app` bind on the MAIN repo. That
+# sharing is deliberate (see REPO_ROOT above) and is also why two workers on
+# one host cannot compile at the same time — the orchestrator hands out an
+# exclusive COMPILE lane and one of them idles.
+#
+# SET: the three caches are bound to `$REPO_ROOT/.caches/<id>/` instead, so
+# two ids can run `mix` concurrently without meeting in one `_build`. The
+# price, paid once per id: a full first compile, a dialyzer PLT of its own,
+# and ~200M of disk. Nothing is seeded from the shared cache on purpose —
+# artefacts compiled from another worktree's source are the very
+# contamination this exists to end, and a fresh id must not inherit it.
+#
+# This block sits AFTER die() because it calls it: at source time a function
+# defined further down does not exist yet.
+declare -ag CACHE_VOLUMES=()
+declare -ag CACHE_ENV=()
+if [ -n "${GRAPPA_CACHE_ID:-}" ]; then
+    # The id becomes a directory name and reaches a `docker -v` argument.
+    # Anything outside this class — a slash, a `..`, a shell metacharacter,
+    # a leading dot — is refused HERE, before any side effect.
+    case "$GRAPPA_CACHE_ID" in
+        *[!A-Za-z0-9._-]* | .*)
+            die "GRAPPA_CACHE_ID must match [A-Za-z0-9._-]+ and may not start with a dot (got '$GRAPPA_CACHE_ID') — it becomes a directory name and a docker -v argument."
+            ;;
+    esac
+
+    CACHE_ROOT="$REPO_ROOT/.caches/$GRAPPA_CACHE_ID"
+    export CACHE_ROOT
+    # Created host-side on purpose: docker would otherwise materialise a
+    # missing bind source itself, as root on Linux, and the UID-dropped
+    # container could then not write into its own cache.
+    mkdir -p "$CACHE_ROOT/_build" "$CACHE_ROOT/deps" "$CACHE_ROOT/priv/plts"
+    CACHE_VOLUMES=(
+        -v "$CACHE_ROOT/_build:/app/_build"
+        -v "$CACHE_ROOT/deps:/app/deps"
+        -v "$CACHE_ROOT/priv/plts:/app/priv/plts"
+    )
+
+    # The test database is the OTHER shared resource, and it is only
+    # half-solved upstream: config/test.exs builds the sqlite path from
+    # MIX_TEST_PARTITION, but nothing on the shell side ever set it, and
+    # `docker compose run` does not inherit host env — so setting it on the
+    # host was a silent no-op and two isolated caches would still have
+    # fought over one runtime/grappa_test.db. Derive it from the id (one
+    # knob, one isolation identity) and FORWARD it across the boundary. An
+    # explicit MIX_TEST_PARTITION wins: the operator may be partitioning
+    # for a different reason.
+    MIX_TEST_PARTITION="${MIX_TEST_PARTITION:-$GRAPPA_CACHE_ID}"
+    export MIX_TEST_PARTITION
+    CACHE_ENV=(-e "MIX_TEST_PARTITION=$MIX_TEST_PARTITION")
+fi
+
 # Guard: refuse to run from a worktree or a non-main branch. Deploy scripts
 # MUST call this as their FIRST step, before any side effect — in_container's
 # own worktree check fires too late to help. ALLOW_DEPLOY_FROM_BRANCH=1
@@ -197,7 +253,8 @@ in_container() {
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
 in_oneshot() {
     docker compose "${COMPOSE_ARGS[@]}" -f "$SRC_ROOT/compose.oneshot.yaml" \
-        run --rm --no-deps "${WORKTREE_VOLUMES[@]}" grappa "$@"
+        run --rm --no-deps "${CACHE_ENV[@]}" \
+        "${WORKTREE_VOLUMES[@]}" "${CACHE_VOLUMES[@]}" grappa "$@"
 }
 
 # Prefer exec into the live container when on main and it's up; otherwise
@@ -206,7 +263,12 @@ in_oneshot() {
 #
 # MIX_ENV is NOT injected here; `scripts/mix.sh` is the policy layer.
 in_container_or_oneshot() {
-    if [ "$SRC_ROOT" = "$REPO_ROOT" ]; then
+    # GRAPPA_CACHE_ID forces the oneshot (#1263). An exec enters a container
+    # whose /app/_build is ALREADY bound to the shared tree, and a running
+    # container cannot be remounted — so execing would hand back the shared
+    # cache while the caller believes they asked for an isolated one. Silent
+    # loss of the isolation is the one failure this knob must not have.
+    if [ "$SRC_ROOT" = "$REPO_ROOT" ] && [ -z "${GRAPPA_CACHE_ID:-}" ]; then
         local cid
         cid="$(docker compose "${COMPOSE_ARGS[@]}" ps -q grappa 2>/dev/null || true)"
         if [ -n "$cid" ]; then

--- a/test/scripts/cache_id_isolation_test.bats
+++ b/test/scripts/cache_id_isolation_test.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/_lib.sh — GRAPPA_CACHE_ID, the opt-in per-worker
+# build cache (#1263).
+#
+# WHY THIS EXISTS
+#
+# `_lib.sh` resolves REPO_ROOT through `--git-common-dir`, so every worktree
+# on a host binds the MAIN repo's `_build`, `deps` and `priv/plts`. That
+# sharing is deliberate, and it is also the reason two workers cannot compile
+# at the same time: the orchestrator has to hand out an exclusive COMPILE
+# lane and one worker sits idle. GRAPPA_CACHE_ID buys isolation for whoever
+# asks for it, and changes NOTHING for whoever does not.
+#
+# Scope: asserts the SHAPE of the docker invocation — which host paths get
+# bound over /app/_build, /app/deps, /app/priv/plts, and which env crosses
+# the boundary. Stubs `docker` on PATH so no container is touched. This
+# proves the MAPPING is isolated; it does not prove two real gates run
+# concurrently, which only a live pair of runs can show.
+
+load ../bats_helpers
+
+setup() {
+    MIX_SH="$BATS_TEST_DIRNAME/../../scripts/mix.sh"
+    REPO="$(cd "$BATS_TEST_DIRNAME/../.." && git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Fake `docker` — records every invocation and, for `compose ... ps -q
+    # grappa`, prints a container id so the live-exec branch of
+    # in_container_or_oneshot is REACHABLE. Without that id every call
+    # falls through to oneshot and a test asserting "no exec" would hold
+    # vacuously.
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+for a in "\$@"; do
+    if [ "\$a" = "-q" ]; then
+        printf 'fakecid\n'
+        exit 0
+    fi
+done
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+
+    export PATH="$FAKE_DIR:$PATH"
+    unset GRAPPA_CACHE_ID MIX_TEST_PARTITION
+}
+
+# A throwaway repo shaped like a MAIN checkout: `lib/` plus `.git` as a
+# DIRECTORY (a worktree has `.git` as a FILE — that is the marker _lib.sh
+# disambiguates on). Used by the two tests that need SRC_ROOT == REPO_ROOT,
+# which is the only configuration where the live-exec branch is taken.
+#
+# The path must be PHYSICAL: on macOS $TMPDIR lives under /var/folders, a
+# symlink to /private/var/folders. `pwd` in _lib.sh yields the logical path
+# while `git rev-parse --path-format=absolute` yields the resolved one, so a
+# logical fixture path makes SRC_ROOT != REPO_ROOT and the fixture silently
+# becomes a WORKTREE — never reaching the branch it was built to exercise.
+make_main_checkout() {
+    local root
+    root="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/mainrepo"
+    mkdir -p "$root/lib" "$root/scripts"
+    git -C "$root" init -q
+    cp "$BATS_TEST_DIRNAME/../../scripts/_lib.sh" "$root/scripts/_lib.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/mix.sh" "$root/scripts/mix.sh"
+    chmod +x "$root/scripts/mix.sh"
+    printf '%s' "$root"
+}
+
+@test "unset GRAPPA_CACHE_ID: no cache bind, no partition — today's invocation" {
+    run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    refute grep -q '\.caches' "$ARGV_LOG"
+    refute grep -q 'MIX_TEST_PARTITION' "$ARGV_LOG"
+    # Still a oneshot with the worktree source overrides — unchanged.
+    grep -q 'run --rm --no-deps' "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID binds _build, deps and priv/plts under a per-id root" {
+    GRAPPA_CACHE_ID=w2 run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q -- "-v ${REPO}/.caches/w2/_build:/app/_build" "$ARGV_LOG"
+    grep -q -- "-v ${REPO}/.caches/w2/deps:/app/deps" "$ARGV_LOG"
+    grep -q -- "-v ${REPO}/.caches/w2/priv/plts:/app/priv/plts" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID creates the cache root on the host before binding it" {
+    # Docker would otherwise create the missing path itself — as root on
+    # Linux, which the UID-dropped container then cannot write.
+    GRAPPA_CACHE_ID=mkdirprobe run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    [ -d "$REPO/.caches/mkdirprobe/_build" ]
+    [ -d "$REPO/.caches/mkdirprobe/deps" ]
+    [ -d "$REPO/.caches/mkdirprobe/priv/plts" ]
+    rm -rf "${REPO:?}/.caches/mkdirprobe"
+}
+
+@test "two ids never reach into each other's cache root" {
+    GRAPPA_CACHE_ID=w1 run "$MIX_SH" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q -- "${REPO}/.caches/w1/_build" "$ARGV_LOG"
+    refute grep -q -- "${REPO}/.caches/w2/" "$ARGV_LOG"
+    # And the shared root is no longer what /app/_build resolves to.
+    refute grep -q -- "-v ${REPO}/_build:/app/_build" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID crosses into the container as MIX_TEST_PARTITION" {
+    # config/test.exs builds the sqlite path from MIX_TEST_PARTITION, but
+    # nothing on the shell side ever set or FORWARDED it — so two isolated
+    # caches would still have fought over one runtime/grappa_test.db.
+    GRAPPA_CACHE_ID=w2 run "$MIX_SH" --env=test test
+    [ "$status" -eq 0 ]
+    grep -q -- '-e MIX_TEST_PARTITION=w2' "$ARGV_LOG"
+}
+
+@test "an explicit MIX_TEST_PARTITION wins over the id-derived one" {
+    GRAPPA_CACHE_ID=w2 MIX_TEST_PARTITION=custom run "$MIX_SH" --env=test test
+    [ "$status" -eq 0 ]
+    grep -q -- '-e MIX_TEST_PARTITION=custom' "$ARGV_LOG"
+    refute grep -q -- '-e MIX_TEST_PARTITION=w2' "$ARGV_LOG"
+}
+
+@test "a traversing GRAPPA_CACHE_ID is refused BEFORE docker is invoked" {
+    GRAPPA_CACHE_ID='../../etc' run "$MIX_SH" --env=dev compile
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    # The refusal must precede the side effect, not follow it.
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "a GRAPPA_CACHE_ID with a shell metacharacter is refused" {
+    GRAPPA_CACHE_ID='w2;touch /tmp/pwned' run "$MIX_SH" --env=dev compile
+    [ "$status" -ne 0 ]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "on a MAIN checkout with a live container and NO knob, the container is exec'd" {
+    # The reference box for the next test: proves this fixture DOES reach
+    # the live-exec branch, so "no exec" below is a real observation.
+    root="$(make_main_checkout)"
+    cd "$root"
+    run "$root/scripts/mix.sh" --env=dev compile
+    [ "$status" -eq 0 ]
+    grep -q 'compose .* exec' "$ARGV_LOG"
+}
+
+@test "on a MAIN checkout with a live container, the knob FORCES a oneshot" {
+    # An exec enters a container whose /app/_build is already bound to the
+    # shared tree; there is no remounting an existing container. Asking for
+    # an isolated cache and silently getting the shared one is the one
+    # failure this knob must never have.
+    root="$(make_main_checkout)"
+    cd "$root"
+    GRAPPA_CACHE_ID=w2 run "$root/scripts/mix.sh" --env=dev compile
+    [ "$status" -eq 0 ]
+    refute grep -q 'compose .* exec' "$ARGV_LOG"
+    grep -q 'run --rm --no-deps' "$ARGV_LOG"
+    grep -q -- "-v ${root}/.caches/w2/_build:/app/_build" "$ARGV_LOG"
+}

--- a/test/scripts/cache_id_isolation_test.bats
+++ b/test/scripts/cache_id_isolation_test.bats
@@ -74,13 +74,49 @@ make_main_checkout() {
     printf '%s' "$root"
 }
 
-@test "unset GRAPPA_CACHE_ID: no cache bind, no partition — today's invocation" {
-    run "$MIX_SH" --env=dev compile
+# A throwaway WORKTREE, the sibling fixture: `lib/` plus `.git` as a FILE,
+# produced by a real `git worktree add` so `--git-common-dir` resolves to the
+# base repo exactly as it does in production. Same physical-path requirement
+# as above, for the same reason.
+make_worktree_checkout() {
+    local base wt
+    base="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/wtbase"
+    wt="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/wtree"
+    mkdir -p "$base/lib" "$base/scripts"
+    : > "$base/lib/.keep"
+    cp "$BATS_TEST_DIRNAME/../../scripts/_lib.sh" "$base/scripts/_lib.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/mix.sh" "$base/scripts/mix.sh"
+    chmod +x "$base/scripts/mix.sh"
+    git -C "$base" init -q
+    git -C "$base" add -A
+    git -C "$base" -c user.email=bats@example.invalid -c user.name=bats commit -q -m fixture
+    git -C "$base" worktree add -q "$wt" -b probe
+    printf '%s' "$wt"
+}
+
+# The knob-unset case is the ONLY one here whose docker branch depends on the
+# checkout it runs FROM: every other case sets the knob, and the knob forces a
+# oneshot in either layout. So this one has to say which layout it means, and
+# it used to run from the ambient cwd instead — green on a worktree host,
+# where `check.sh` runs, and RED in CI, where the checkout is a main tree and
+# the stubbed `docker compose ps -q` hands back a container id, so
+# `in_container_or_oneshot` took the exec branch and never emitted the oneshot
+# form. Nothing was wrong with the code: unset means "today's invocation", and
+# on a main checkout with a live container today's invocation IS the exec. The
+# assertion was reading a property of the host, not of the knob.
+@test "unset GRAPPA_CACHE_ID from a WORKTREE: no cache bind, no partition — today's invocation" {
+    root="$(make_worktree_checkout)"
+    cd "$root"
+    run "$root/scripts/mix.sh" --env=dev compile
     [ "$status" -eq 0 ]
     refute grep -q '\.caches' "$ARGV_LOG"
     refute grep -q 'MIX_TEST_PARTITION' "$ARGV_LOG"
-    # Still a oneshot with the worktree source overrides — unchanged.
+    # Still a oneshot with the worktree source overrides — unchanged. The
+    # second grep is also the fixture's own witness: WORKTREE_VOLUMES is empty
+    # unless SRC_ROOT != REPO_ROOT, so a fixture that silently resolved as a
+    # main checkout would fail here instead of passing for the wrong reason.
     grep -q 'run --rm --no-deps' "$ARGV_LOG"
+    grep -q -- "-v ${root}/lib:/app/lib" "$ARGV_LOG"
 }
 
 @test "GRAPPA_CACHE_ID binds _build, deps and priv/plts under a per-id root" {


### PR DESCRIPTION
## Union branch — one gate, one merge

This branch carries three independent changes that were each green
against `9e5457c1`, i.e. against a base that no longer exists: #1262
has since landed and `main` is now `07a98238`.

A green check attests `branch + base`. It never attests
`branch + the other branches`. Merging three separately-green PRs one
after another therefore ships a combination that nothing has ever
gated — and re-basing them one at a time costs three full CI rounds,
each one re-staling the other two. So the three are cherry-picked onto
current `main` here and gated **once, together**.

### What it carries

| Issue | Original PR | Commits | Area |
|-------|-------------|---------|------|
| #1264 | #1269 | 1 | `!addquote` carries the sender, reversing #1107 |
| #1263 | #1266 | 4 | opt-in per-worker build caches (`GRAPPA_CACHE_ID`) |
| #1175 | #1273 | 1 | hoist the CRT box-shadow comment out of the value list |

The commits are unchanged in content; only their SHAs differ, because
they were cherry-picked onto a newer base.

### Why the combination is safe to gate as one

The three touch **fifteen distinct files with zero overlap**: #1264 is
in `cicchetto/src/lib/` and its tests, #1263 is in `scripts/_lib.sh`
plus a new bats file and the docs, #1175 is one CSS declaration. The
only shared file is `docs/DESIGN_NOTES.md`, where the two entries
append at the same point.

The per-PR contribution was pinned by `--numstat` before the union and
the union was verified to be the exact per-file sum, so nothing was
dropped or double-applied in the cherry-pick. On `DESIGN_NOTES.md` that
sum is 150 additions / 0 deletions (51 + 99), which is the measure that
detects the `merge=union` separator-eater: it removes three lines
(blank / `---` / blank) without ever showing up as a deletion.
`scripts/design-notes-gate.sh` passes, and the two entry markers
(`<!-- entry #1264 -->`, `<!-- entry #1263 -->`) are distinct and
unique file-wide.
