### PR TITLE
shottino: publish the rtc_stub payload before the count that names it

### DIFF
--- a/frontends/shottino/tests/rtc_stub.c
+++ b/frontends/shottino/tests/rtc_stub.c
@@ -16,9 +16,15 @@
  *
  * Ids are two disjoint ranges so a peer-connection id used where a track id
  * belongs lands in bad_calls instead of quietly addressing something.
+ *
+ * The send record is the one part of this stub that is read from a DIFFERENT
+ * thread than the one that writes it: the pump thread sends, the test's main
+ * thread waits on the count and then reads the payload. So sent_count is not
+ * a statistic, it is a HANDSHAKE — see send_lock below.
  */
 #include "rtc_stub.h"
 
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,6 +54,19 @@ struct stub_track {
 static struct stub_pc *pcs[STUB_MAX_PCS];
 static struct stub_track *tracks[STUB_MAX_TRACKS];
 
+/* Guards the send record — sent_count, last_sent, last_sent_size — because
+ * a sender and a reader on two threads have to agree on WHICH send the
+ * count names. A reader waits for the count to reach N and then asks for
+ * the payload, so the count must not become N until the payload of send N
+ * is in place: the three fields move together, under this lock, or a reader
+ * that wakes mid-write is handed the packet before the one it waited for.
+ *
+ * A mutex rather than release/acquire atomics on the counter: this is
+ * test-only code, the lock is uncontended (one pump thread), and one lock
+ * around all three fields says "these are a set" in a way that a reviewer
+ * does not have to reconstruct from memory orders. */
+static pthread_mutex_t send_lock = PTHREAD_MUTEX_INITIALIZER;
+
 static int pcs_created, pcs_deleted, tracks_added, cleanups, bad_calls;
 static bool fail_next_create;
 static int fail_track_at, track_attempts;
@@ -72,6 +91,18 @@ static void track_free(int index) {
     free(t->last_sent);
     free(t);
     tracks[index] = NULL;
+}
+
+/* Hand a finished payload to the readers. The counter moves LAST and inside
+ * the lock, so "the count says N" and "the payload is send N's" are the same
+ * observation — which is the whole contract a waiter relies on. */
+static void publish_send(struct stub_track *t, char *payload, int size) {
+    pthread_mutex_lock(&send_lock);
+    free(t->last_sent);
+    t->last_sent = payload;
+    t->last_sent_size = size;
+    t->sent_count++;
+    pthread_mutex_unlock(&send_lock);
 }
 
 void rtc_stub_reset(void) {
@@ -106,14 +137,21 @@ bool rtc_stub_track(int track, struct rtc_stub_track *out) {
 
 int rtc_stub_sent_count(int track) {
     struct stub_track *t = track_at(track);
-    return t ? t->sent_count : -1;
+    if (!t) return -1;
+    pthread_mutex_lock(&send_lock);
+    int count = t->sent_count;
+    pthread_mutex_unlock(&send_lock);
+    return count;
 }
 
 const char *rtc_stub_last_sent(int track, int *size) {
     struct stub_track *t = track_at(track);
     if (!t) return NULL;
+    pthread_mutex_lock(&send_lock);
+    const char *payload = t->last_sent;
     if (size) *size = t->last_sent_size;
-    return t->last_sent;
+    pthread_mutex_unlock(&send_lock);
+    return payload;
 }
 
 const char *rtc_stub_remote_description(int pc) {
@@ -328,15 +366,19 @@ int rtcSendMessage(int id, const char *data, int size) {
         bad_calls++;
         return RTC_ERR_INVALID;
     }
-    t->sent_count++;
-    free(t->last_sent);
-    t->last_sent = NULL;
-    t->last_sent_size = size;
-    if (!data || size <= 0) return RTC_ERR_SUCCESS;
+    if (!data || size <= 0) {
+        publish_send(t, NULL, 0);
+        return RTC_ERR_SUCCESS;
+    }
     /* The copy IS the check: `size` bytes are read from the caller's
-     * buffer, so a length the caller does not have is a read past it. */
-    t->last_sent = malloc((size_t)size);
-    if (t->last_sent) memcpy(t->last_sent, data, (size_t)size);
+     * buffer, so a length the caller does not have is a read past it.
+     * It happens before the lock because allocation is not what needs
+     * serialising — publication is. */
+    char *copy = malloc((size_t)size);
+    if (copy) memcpy(copy, data, (size_t)size);
+    /* A failed malloc publishes NULL AND zero: a size that describes no
+     * buffer is worse than no record, because the reader believes it. */
+    publish_send(t, copy, copy ? size : 0);
     return size;
 }
 


### PR DESCRIPTION
Fixes the race behind #1275. Test-harness only —
`frontends/shottino/tests/rtc_stub.c`, which is linked by exactly one
target (`tests/test_callmain`, Makefile:137). No production path moves.

## The defect

`rtcSendMessage` incremented `sent_count` first and wrote `last_sent` /
`last_sent_size` afterwards. The pump thread runs that; the test's main
thread waits on the counter and then reads the payload. A reader that
woke inside the gap got the PREVIOUS packet — a plausible number, not
garbage, which is why the failure reads as a real assertion:
`expected 32, got 2048` at `test_callmain.c:866`.

Second defect at the same call: `last_sent_size` was assigned before
the `malloc` that backs it, so a failed allocation left a size that
described no buffer.

## The fix

The three fields become one set, published under `send_lock` with the
counter moving LAST; both accessors take the same lock. The copy stays
outside the lock (allocation is not what needs serialising), and a
failed copy publishes NULL **and** zero.

A mutex rather than release/acquire atomics on the counter: test-only
code, uncontended (one pump thread), and one lock around all three
fields states the invariant without a reviewer reconstructing it from
memory orders. Atomics on the counter alone would still leave the
buffer and its length as plain cross-thread writes.

## Red first, and the issue undersells the blast radius

A race that passes nearly always is not proven by a green suite, so the
window was widened — a 50 ms sleep injected immediately after
`sent_count++`, filtered to one payload size at a time so each reader
site could be attributed on its own. Every run is `tests/test_callmain`
(242 checks), ubuntu:24.04, ASan+UBSan, the same `make` the CI job runs:

| delayed send | before | after |
|---|---|---|
| 1400 B | FAIL `:814` `sent && memcmp(sent, big, …)` | 242/242 |
| 2048 B | FAIL `:813` `expected 2048, got 1400`, then **ASan heap-buffer-overflow** at `:814` and abort | 242/242 |
| 120 B  | FAIL `:824` `expected 120, got 0` | 242/242 |
| 32 B   | FAIL `:866` `expected 32, got 2048` — the CI symptom, 1/242 | 242/242 |

Two corrections to the issue text, both measured:

- It says the other three `rtc_stub_last_sent()` sites are invisible
  because the predecessor happens to have a matching size. That holds
  for `:799` only. At `:812` the predecessor is 1400 against an expected
  2048, and at `:823` there is no predecessor at all (first send on the
  video track), so the stale read is `0`. Both fail loudly.
- The stale read is not always a wrong number. At `:812` the following
  `memcmp` walks 2048 bytes over the stale 1400-byte buffer, which ASan
  reports as a heap-buffer-overflow and the process aborts — no check
  summary, no `expected/got`. CI lost the coin flip at the one site
  where nothing dereferences the pointer; the same window can take the
  job down with a sanitizer report instead.

## Out of scope, found while measuring — not fixed here

- **`rtc_stub_last_sent()` returns a pointer the sender may free.** The
  lock ends at the return, so the buffer's LIFETIME is still unguarded;
  closing it means a copy-out accessor and a new contract for all four
  call sites. Latent today: at every assertion the test controls the
  sends and none is in flight.
- **The self-view echo is not covered by the `sent_count` handshake.**
  Delaying the pump BEFORE it records anything fails `:827` and `:855`
  (`recv(self_sink, …, MSG_DONTWAIT)`), and that reproduces identically
  on the unfixed stub, so it is neither this race nor a regression from
  this change — a separate latent timing assumption in the same test.

## Gates

Full `make -C frontends/shottino check` on the fixed tree: **RC=0, 19
suites, 9703 checks, zero failures**, `tests/test_callmain` 242/242.
Run in an ubuntu:24.04 container because the suite does not build on
darwin (`_POSIX_C_SOURCE=200809L` hides `INADDR_LOOPBACK` and
`MSG_DONTWAIT` there); the committed `config.mk` is used as-is, so
`./configure` never ran and the file is untouched.

`call-compile` — the target that compiles this stub against the REAL
`<rtc/rtc.h>` — could not run: `vendor/libdatachannel` is not
initialised in this worktree. CI runs it with `submodules: recursive`.
The change adds `#include <pthread.h>` and no new declaration, and the
test build is warning-clean under `-Wall -Wextra -Wpedantic`.

No DESIGN_NOTES entry: a lock in a test stub is not a design decision,
and the reasoning that outlives it is in the file, next to the lock.