### PR TITLE
cic(#1277): raise the reply quote cap from 42 to 100

### DIFF
--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -45,14 +45,16 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // already wraps and already hides the caret. This body is far past it, so the
 // ROW wraps and the quote it produces is a capped one, while staying well
 // inside one PRIVMSG so the server-side split budget (#246) never turns it
-// into two scrollback rows.
+// into two scrollback rows. #1277 raised the cap to 100 and left the filler
+// alone: the posted body runs 161 code points with the timestamp, still 61
+// past the cap, and the overflow below was measured rather than assumed.
 const FILLER =
   "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
   "quindi il caret finisce sotto la piega e non si vede piu' nulla";
 
-// #1235 capped the quoted body at 42 characters plus a literal `...`, so a
-// single reply can no longer BE six wrapped lines: the longest quote the
-// gesture can now produce is `<nick> ` + 45 + ` << `, about two. The overflow
+// #1235 capped the quoted body plus a literal `...`, so a single reply can no
+// longer BE six wrapped lines: the longest quote the gesture can produce is
+// `<nick> ` + 103 + ` << ` since #1277 raised the cap to 100. The overflow
 // this spec needs is therefore built the way an operator builds it — the reply
 // verb APPENDS, so three replies to the same row stack into a draft that wraps
 // well past the fold, with the caret at the very end of the third. What is
@@ -61,7 +63,7 @@ const FILLER =
 // Hardcoded in lockstep with `REPLY_QUOTE_BODY_LIMIT` / `REPLY_QUOTE_ELLIPSIS`
 // in `src/lib/replyQuote.ts` — the e2e package does not import from `src`, and
 // the house convention here is a mirrored constant with a lockstep comment.
-const QUOTED_BODY_LIMIT = 42;
+const QUOTED_BODY_LIMIT = 100;
 const QUOTED_ELLIPSIS = "...";
 const REPLIES = 3;
 
@@ -79,10 +81,11 @@ function uniqueBody(): string {
   return `issue1105 ${Date.now()} ${FILLER}`;
 }
 
-// Six-ish wrapped lines minus generous slack — three stacked quotes come to
-// about what the single uncapped one used to be. Its job is to fail loudly if
-// the fixture ever stops overflowing, because then "the caret is in view" would
-// be true for the wrong reason.
+// Generous slack under what the fixture actually produces: three stacked
+// quotes measure scrollHeight 269 against clientHeight 42 at this viewport,
+// so 227px of overflow (it was 109px under the 42-char cap). Its job is to
+// fail loudly if the fixture ever stops overflowing, because then "the caret
+// is in view" would be true for the wrong reason.
 const MIN_OVERFLOW_PX = 40;
 
 // A left→right drag on the message row whose text contains `body`. Touch

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -217,10 +217,12 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
 
 // #1235 — vjt: "sul reply limitiamo a 42 i caratteri di cui facciamo reply, se
 // sforano mettiamo un ellipsis `...`, e poi mettiamo sempre uno spazio prima
-// del `<<` finale". The cap lives in the WRAPPER, never in `quotableBody`:
-// that helper is shared with `!addquote` (#1107), which archives the line and
-// must keep it whole. `addQuote.test.ts` is the control group for that.
-describe("replyQuote — the quoted body is capped (#1235)", () => {
+// del `<<` finale". #1277 raised that 42 to 100 — the number moved, every
+// reading below did not. The cap lives in the WRAPPER, never in
+// `quotableBody`: that helper is shared with `!addquote` (#1107), which
+// archives the line and must keep it whole. `addQuote.test.ts` is the control
+// group for that.
+describe("replyQuote — the quoted body is capped (#1235, #1277)", () => {
   const AT_LIMIT = "a".repeat(REPLY_QUOTE_BODY_LIMIT);
 
   it("leaves a body at the limit whole, with no ellipsis", () => {
@@ -228,14 +230,14 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
   });
 
   // The first body over the limit is where an off-by-one shows: one way it
-  // clips a body that fits, the other it lets a 43rd character through.
+  // clips a body that fits, the other it lets a 101st character through.
   it("caps the first body that overflows", () => {
     expect(replyQuote(msg({ body: `${AT_LIMIT}b` }))).toBe(`<vjt> ${AT_LIMIT}... << `);
   });
 
-  // The 42 counts BODY characters and the ellipsis is ADDED past them — the
-  // quoted run is 45, not 42 with three of them spent on dots.
-  it("keeps a full 42 characters and adds the ellipsis after them", () => {
+  // The 100 counts BODY characters and the ellipsis is ADDED past them — the
+  // quoted run is 103, not 100 with three of them spent on dots.
+  it("keeps a full 100 characters and adds the ellipsis after them", () => {
     const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
     const quoted = quote.slice("<vjt> ".length, -REPLY_QUOTE_TAIL.length);
     expect(quoted).toBe(`${"x".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}`);
@@ -251,13 +253,15 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
     expect(quote).not.toContain("…");
   });
 
-  // A flat cut, with no backing off to the last word boundary: that is
-  // "limitiamo a 42 i caratteri" read literally, and a word-boundary rule would
-  // make the quote length depend on where the spaces happen to fall.
+  // A flat cut, with no backing off to the last word boundary: that is the
+  // request read literally, and a word-boundary rule would make the quote
+  // length depend on where the spaces happen to fall. The body is sized by
+  // hand against 100 so the cut lands INSIDE the last word — a body that
+  // happened to end on a space would pass under either rule.
   it("cuts flat at the limit, mid-word", () => {
-    const body = `${"parola ".repeat(5)}spezzata`;
-    expect(body).toHaveLength(43);
-    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(5)}spezzat... << `);
+    const body = `${"parola ".repeat(14)}spezzata`;
+    expect(body).toHaveLength(106);
+    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(14)}sp... << `);
   });
 
   // The cap is on the BODY: a long nick does not eat into what the sender said.
@@ -274,12 +278,14 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
     expect(replyQuote(msg({ sender: "alice", body }))).toBe("<alice> breve << ");
   });
 
-  // A UTF-16 slice at 42 can land between the halves of a surrogate pair and
+  // A UTF-16 slice at 100 can land between the halves of a surrogate pair and
   // emit a lone surrogate — an unpaired code unit in the compose box, and from
-  // there onto the wire. The cut counts code points.
+  // there onto the wire. The cut counts code points: the emoji is the 100th of
+  // them but sits at UTF-16 indices 99 and 100, so a unit-wise `slice(0, 100)`
+  // would keep its high surrogate alone.
   it("does not cut an astral character in half", () => {
-    const quote = replyQuote(msg({ body: `${"a".repeat(41)}🍺x` })) ?? "";
-    expect(quote).toBe(`<vjt> ${"a".repeat(41)}🍺... << `);
+    const quote = replyQuote(msg({ body: `${"a".repeat(99)}🍺x` })) ?? "";
+    expect(quote).toBe(`<vjt> ${"a".repeat(99)}🍺... << `);
     expect(quote.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "")).not.toMatch(/[\uD800-\uDFFF]/);
   });
 });

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -17,16 +17,17 @@ export const REPLY_QUOTE_TAIL = " << ";
 // #1235 — how much of the quoted line comes along. Without a cap, replying to a
 // long message drags the whole thing into the compose box and buries the answer.
 //
-// Four readings of "limitiamo a 42 i caratteri" are all defensible; these are
-// the ones ruled on, deliberately kept to one constant plus one function so a
-// change of mind is a one-line edit:
-//   - 42 counts BODY characters and the ellipsis is ADDED past them (45 quoted,
-//     not 42 with three spent on dots);
+// #1277 raised the number to 100: 42 was the original ask ("limitiamo a 42 i
+// caratteri") and read too tight in practice. The four readings ruled on in
+// #1235 stand unchanged, and they are still deliberately kept to one constant
+// plus one function, which is what made raising the number a one-line edit:
+//   - 100 counts BODY characters and the ellipsis is ADDED past them (103
+//     quoted, not 100 with three spent on dots);
 //   - the marker is the literal `...` the request spells, not `…` U+2026;
-//   - the cut is flat at 42, with no backing off to a word boundary;
+//   - the cut is flat at 100, with no backing off to a word boundary;
 //   - the head (`<nick> ` / `* nick `) is outside the count — the nick is not
 //     what overflows.
-export const REPLY_QUOTE_BODY_LIMIT = 42;
+export const REPLY_QUOTE_BODY_LIMIT = 100;
 export const REPLY_QUOTE_ELLIPSIS = "...";
 
 // The quoted body, cut to the limit. Counted in CODE POINTS: a UTF-16 slice can


### PR DESCRIPTION
Raises `REPLY_QUOTE_BODY_LIMIT` from 42 to 100. Refs #1277.

Only the number moves. Every reading ruled on in #1235 stands: 100 counts BODY
code points and the ellipsis is added past them (a capped quote runs 103), the
marker stays the literal `...`, the cut stays flat at the limit with no backing
off to a word boundary, and the head (`<nick> ` / `* nick `) stays outside the
count. Prose was rewritten wherever it argued for 42, in the source comment and
in both test files.

## Sites

- `src/lib/replyQuote.ts` — the constant plus its comment block.
- `e2e/tests/issue1105-reply-quote-caret-visible.spec.ts` — the deliberate
  mirrored constant (the e2e package does not import from `src`) and its
  lockstep prose, same commit.
- `src/__tests__/replyQuote.test.ts` — prose, plus two tests that build their
  bodies against the number rather than the constant.

## Measured, not assumed

- **The two hardcoded tests really do break.** Kept at their 42-sized bodies
  they go red against a 100 cap (2 failed / 38 passed) rather than passing
  vacuously; re-sized against 100 and run with a deliberate 99 cap, they are the
  exactly two tests that fail. The issue's site list expected only prose here.
- **The e2e fixture is left alone.** `FILLER` clears the new cap by ~37
  characters where it cleared the old one by ~95, so the run answered instead of
  the arithmetic: three stacked quotes measure `scrollHeight` 269 against
  `clientHeight` 42 at the 390px viewport — 227px of overflow against the spec's
  `MIN_OVERFLOW_PX` guard of 40, where the 42-char cap produced 109px. The guard
  does not fire, so nothing was lengthened; lengthening would also have pushed
  the posted body toward the #246 split budget for no gain.
- **Compose room at 390px.** One quote now occupies three wrapped lines of the
  `rows=1` box (`scrollHeight` 112) where it occupied two (73). The caret stays
  in view — that is what the spec asserts — but the quote is one line taller
  than before per reply.

## Test plan

- [x] `bun run test` — 282 files / 5352 tests green
- [x] `bun run check` — biome + tsc over `src` and `e2e`, RC 0
- [x] `scripts/integration.sh --grep issue1105` — passes on the committed state
- [ ] full integration suite in CI