### PR TITLE
cic(#719): correlate every CTCP verb, not just PING

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -775,9 +775,16 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // body is the raw \x01VERB [args]\x01 frame, classified ONCE on the server
       // (SSOT Grappa.IRC.CTCP.verb_args/1) into typed meta.ctcp_verb /
       // meta.ctcp_args. A CORRELATED /ping reply is consumed upstream
-      // (subscribe.ts maybeConsumePingReply) and never reaches here; an
-      // UNCORRELATED CTCP reply (a stray VERSION/TIME, or a token-less PING that
-      // matched no pending /ping) does. Before this arm it fell through to the
+      // (subscribe.ts maybeConsumeCtcpReply) and never reaches here, because that
+      // gate SYNTHESIZES an RTT line and strips the meta. Everything else does
+      // reach here: an UNCORRELATED reply (a stray VERSION/TIME, or a token-less
+      // PING that matched no pending /ping) in its `$server` routing, and — since
+      // #719 — a CORRELATED non-PING reply too, re-keyed to the window the query
+      // was sent from with its meta deliberately INTACT so this arm can draw it.
+      // That is why the gate must not strip meta on the #719 branch: doing so
+      // would drop the row into the generic body render below and leak raw \x01,
+      // which is the very thing this arm exists to prevent.
+      // Before this arm it fell through to the
       // generic body render below and leaked the raw \x01 into the DOM. Render a
       // human INBOUND line from the TYPED meta instead — cic NEVER parses \x01
       // (the "one IRC parser, on the server" invariant). This is the notice twin

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -660,8 +660,9 @@ describe("ScrollbackPane", () => {
 
   it("renders an uncorrelated inbound CTCP notice from typed meta, never raw \\x01 — #641", () => {
     // #641 — an inbound CTCP reply (a NOTICE carrying \x01VERB [args]\x01) that
-    // matches no pending /ping is NOT consumed by subscribe.ts's
-    // maybeConsumePingReply (that swallows only CORRELATED PING replies). It
+    // matches no pending query is NOT consumed by subscribe.ts's
+    // maybeConsumeCtcpReply (which only claims a reply some outstanding question
+    // of ours can account for). It
     // reaches this render, where — before the fix — the notice arm fell through
     // to the generic body render and leaked the raw \x01 delimiters into the DOM
     // (`-NickServ- ^APING^A`), breaking the "cic NEVER shows \x01" invariant that
@@ -674,8 +675,11 @@ describe("ScrollbackPane", () => {
     //
     // TRAP (#638): /ping NickServ now CORRELATES (token-less service PING replies
     // resolve), so a PING fixture would be consumed upstream and never reach this
-    // render — green for the WRONG reason. VERSION/TIME have NO correlation
-    // machinery: they are the genuinely uncorrelated class this fix must cover.
+    // render — green for the WRONG reason. #719 extended correlation to every
+    // verb, so VERSION/TIME are no longer uncorrelatABLE either — what keeps this
+    // fixture honest is that it seeds the store DIRECTLY, with no pending query
+    // anywhere, which is exactly the unsolicited-probe-answer case. A correlated
+    // non-PING reply reaches this same arm; it just arrives re-keyed.
     const ctcpNotice: ScrollbackMessage[] = [
       {
         id: 1,

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -140,12 +140,17 @@ vi.mock("../lib/scrollback", () => ({
   sendMessage: vi.fn(),
 }));
 
-// #591 — /ping registers a pending correlation entry; spy it so the test can
-// assert the (networkId, nick, token, sourceKey, sourceChannel, sentAtMs) tuple
-// without exercising the real store.
+// #591/#719 — a CTCP query registers a pending correlation entry (PING in the
+// token table, every other verb in the verb table); spy both so the test can
+// assert the (networkId, nick, token-or-verb, sourceKey, sourceChannel,
+// sentAtMs) tuple without exercising the real store. The whole module is
+// replaced, so a register the seam calls but this mock omits is not a silent
+// no-op — it throws and takes the send with it.
 vi.mock("../lib/pingCorrelation", () => ({
   registerPing: vi.fn(),
   resolvePing: vi.fn(),
+  registerCtcpQuery: vi.fn(),
+  resolveCtcpReply: vi.fn(),
 }));
 
 vi.mock("../lib/members", () => ({
@@ -1343,7 +1348,7 @@ describe("compose submit — slash command dispatch", () => {
   // awaited. `sendPrivmsg` is a REST POST; on a slow/loaded runner its ack can
   // resolve AFTER the peer's CTCP PING reply has already been processed on the
   // (separate, already-open) WS. If registration waited on the send,
-  // `maybeConsumePingReply → resolvePing` would find no pending entry and drop
+  // `maybeConsumeCtcpReply → resolvePing` would find no pending entry and drop
   // the RTT line — the #600 CI timeout (deterministic on the slow CI runner,
   // invisible on a fast local box). Model the slow send with a deferred promise
   // and assert registerPing already fired while the send is still pending.

--- a/cicchetto/src/__tests__/ctcpQuery.test.ts
+++ b/cicchetto/src/__tests__/ctcpQuery.test.ts
@@ -4,7 +4,8 @@ import { channelKey } from "../lib/channelKey";
 // Boundary stubs. The seam's whole job is WHICH two calls it makes and in WHAT
 // ORDER, so both collaborators are spies: the send door (scrollback.sendMessage,
 // whose own REST plumbing is pinned in scrollback.test.ts) and the correlation
-// store (pingCorrelation.registerPing, whose RTT arithmetic is pinned in
+// store (pingCorrelation's two registers — the token-keyed one for PING and the
+// verb-keyed one for everything else — whose matching rules are pinned in
 // pingCorrelation.test.ts).
 vi.mock("../lib/scrollback", () => ({
   sendMessage: vi.fn(),
@@ -13,6 +14,8 @@ vi.mock("../lib/scrollback", () => ({
 vi.mock("../lib/pingCorrelation", () => ({
   registerPing: vi.fn(),
   resolvePing: vi.fn(),
+  registerCtcpQuery: vi.fn(),
+  resolveCtcpReply: vi.fn(),
 }));
 
 // The invariant fields of a dispatch. `verb` / `args` are supplied per test —
@@ -47,10 +50,11 @@ describe("sendCtcpQuery — #1192", () => {
     });
   });
 
-  // Verb-agnostic means verb-agnostic: PING is the ONLY verb the seam correlates,
-  // and every other one is fire-and-forget. A seam that registered for everything
-  // would leak a pending entry per menu click that can never resolve.
-  it("registers no correlation for a non-PING verb", async () => {
+  // #719 — a non-PING verb registers too, in the VERB-keyed table, against the
+  // SOURCE window. Without this the question echoed in one window and the answer
+  // rendered in $server. The ping table must stay out of it: its key is a token,
+  // and a verb landing there would be claimable by any reply echoing that string.
+  it("registers a non-PING verb in the VERB table, keyed on the source window", async () => {
     const sb = await import("../lib/scrollback");
     vi.mocked(sb.sendMessage).mockResolvedValue();
     const pc = await import("../lib/pingCorrelation");
@@ -58,7 +62,55 @@ describe("sendCtcpQuery — #1192", () => {
 
     await sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
 
+    expect(pc.registerCtcpQuery).toHaveBeenCalledWith(
+      1,
+      "bob",
+      "VERSION",
+      channelKey("freenode", "#a"),
+      "#a",
+      1706743200000,
+    );
     expect(pc.registerPing).not.toHaveBeenCalled();
+  });
+
+  // The converse: PING keys on its token and must NOT also take a verb entry, or
+  // a peer's PING reply could be claimed twice — once for the RTT, once as a
+  // plain re-keyed row.
+  it("registers a PING in the token table only, never the verb table", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "PING", args: "tok-719" });
+
+    expect(pc.registerPing).toHaveBeenCalled();
+    expect(pc.registerCtcpQuery).not.toHaveBeenCalled();
+  });
+
+  // #600's ordering is the seam's whole reason to exist, and it now has to hold
+  // on the branch #719 added — not just on the PING branch it was written for.
+  // A VERSION reply comes back on the already-open WS just as readily.
+  it("registers a non-PING verb BEFORE the send resolves", async () => {
+    const sb = await import("../lib/scrollback");
+    const pc = await import("../lib/pingCorrelation");
+    let releaseSend!: () => void;
+    vi.mocked(sb.sendMessage).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      }),
+    );
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    const inFlight = sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sb.sendMessage).toHaveBeenCalled();
+    expect(pc.registerCtcpQuery).toHaveBeenCalled();
+
+    releaseSend();
+    await inFlight;
   });
 
   // Args are the caller's bytes, passed through untouched — the seam is not a
@@ -147,7 +199,7 @@ describe("sendCtcpQuery — #1192", () => {
   //
   // `sendMessage` is a REST POST. Its ack can resolve AFTER the peer's CTCP PING
   // reply has already been processed on the separate, already-open WS. If the
-  // registration waited on the send, `maybeConsumePingReply → resolvePing` would
+  // registration waited on the send, `maybeConsumeCtcpReply → resolvePing` would
   // find no pending entry and drop the RTT — the deterministic CI timeout #600
   // diagnosed, invisible on a fast local box. compose.ts got this right by hand;
   // a second caller (the #1192 nick menu) is exactly how a hand-held invariant

--- a/cicchetto/src/__tests__/pingCorrelation.test.ts
+++ b/cicchetto/src/__tests__/pingCorrelation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { channelKey } from "../lib/channelKey";
-import { PENDING_TTL_MS, registerPing, resolvePing } from "../lib/pingCorrelation";
+import {
+  PENDING_TTL_MS,
+  registerCtcpQuery,
+  registerPing,
+  resolveCtcpReply,
+  resolvePing,
+} from "../lib/pingCorrelation";
 
 // #591 — the /ping reply-correlation table. Pure register/resolve with time
 // passed in explicitly (sentAtMs at register, nowMs at resolve) so the RTT
@@ -135,5 +141,119 @@ describe("pingCorrelation", () => {
     );
 
     expect(resolvePing(1, "grace", "tok-g1", 6000 + PENDING_TTL_MS)).not.toBeNull();
+  });
+});
+
+// #719 — the VERB-keyed sibling table. A non-PING CTCP reply echoes no token,
+// so the only thing that can attribute it back to the question is the verb the
+// question asked. Same store, same TTL, same one-shot resolve; it returns no
+// RTT because there is no token to time against and the reply renders as the
+// answer it is, not as a round trip.
+describe("pingCorrelation — CTCP query correlation (#719)", () => {
+  it("resolves a non-PING reply to the window the query was sent from", () => {
+    registerCtcpQuery(1, "bob", "VERSION", channelKey("freenode", "#chan"), "#chan", 1000);
+
+    expect(resolveCtcpReply(1, "bob", "VERSION")).toEqual({
+      sourceKey: channelKey("freenode", "#chan"),
+      sourceChannel: "#chan",
+    });
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolveCtcpReply(1, "nobody", "VERSION")).toBeNull();
+  });
+
+  it("folds the nick (CASEMAPPING=ascii) — ask Bob, resolve bob", () => {
+    registerCtcpQuery(1, "Bob", "TIME", channelKey("freenode", "#room"), "#room", 2000);
+
+    expect(resolveCtcpReply(1, "bob", "TIME")).toEqual({
+      sourceKey: channelKey("freenode", "#room"),
+      sourceChannel: "#room",
+    });
+  });
+
+  // The verb reaches the table from two directions — a parser that upper-cases
+  // and a menu literal on the way in, a peer's own spelling on the way back.
+  // Neither end controls the other's case, so both fold.
+  it("folds the verb — register lower-case, resolve upper-case and back", () => {
+    registerCtcpQuery(1, "carol", "version", channelKey("freenode", "carol"), "carol", 3000);
+    expect(resolveCtcpReply(1, "carol", "VERSION")).not.toBeNull();
+
+    registerCtcpQuery(1, "carol", "USERINFO", channelKey("freenode", "carol"), "carol", 3100);
+    expect(resolveCtcpReply(1, "carol", "userinfo")).not.toBeNull();
+  });
+
+  it("is one-shot: a second reply to the same query is null", () => {
+    registerCtcpQuery(1, "dave", "SOURCE", channelKey("freenode", "dave"), "dave", 4000);
+
+    expect(resolveCtcpReply(1, "dave", "SOURCE")).not.toBeNull();
+    expect(resolveCtcpReply(1, "dave", "SOURCE")).toBeNull();
+  });
+
+  // The whole point of keying on the verb: a peer answering a question we did
+  // not ask must not be able to claim a window. Otherwise an unsolicited probe
+  // reply would be filed into whatever conversation happened to have an entry.
+  it("does not match across networks, nicks, or verbs", () => {
+    registerCtcpQuery(1, "eve", "CLIENTINFO", channelKey("freenode", "#ops"), "#ops", 5000);
+
+    expect(resolveCtcpReply(2, "eve", "CLIENTINFO")).toBeNull();
+    expect(resolveCtcpReply(1, "mallory", "CLIENTINFO")).toBeNull();
+    expect(resolveCtcpReply(1, "eve", "TIME")).toBeNull();
+    expect(resolveCtcpReply(1, "eve", "CLIENTINFO")).not.toBeNull();
+  });
+
+  // Two tables, not one map with a three-part key: a PING token is opaque
+  // operator-supplied text and could BE a verb. Sharing one map would let
+  // `/ping frank VERSION` be claimed by frank's VERSION reply, filing an RTT
+  // question's answer under the wrong entry. Pinned in both directions.
+  it("cannot cross-claim between the token table and the verb table", () => {
+    registerPing(1, "frank", "VERSION", channelKey("freenode", "#a"), "#a", 6000);
+    registerCtcpQuery(1, "grace", "TIME", channelKey("freenode", "#b"), "#b", 6000);
+
+    // A VERSION reply must not eat frank's pending ping whose TOKEN is "VERSION".
+    expect(resolveCtcpReply(1, "frank", "VERSION")).toBeNull();
+    // A PING reply carrying the token "TIME" must not eat grace's TIME query.
+    expect(resolvePing(1, "grace", "TIME", 6050)).toBeNull();
+    // Both originals survive untouched.
+    expect(resolvePing(1, "frank", "VERSION", 6050)).not.toBeNull();
+    expect(resolveCtcpReply(1, "grace", "TIME")).not.toBeNull();
+  });
+
+  // Same leak guard as the ping table, and it must work ACROSS the two: a
+  // session that only ever runs /ctcp would otherwise never sweep the ping
+  // table, and vice versa. The bound is "queries issued in the last TTL",
+  // whichever door they came through.
+  it("sweeps stale entries in BOTH tables on either register (leak guard)", () => {
+    registerPing(1, "ivan", "tok-i", channelKey("freenode", "ivan"), "ivan", 7000);
+    registerCtcpQuery(1, "judy", "FINGER", channelKey("freenode", "judy"), "judy", 7000);
+
+    // A CTCP query at the horizon must evict the stale entry in EITHER table.
+    registerCtcpQuery(
+      1,
+      "ken",
+      "TIME",
+      channelKey("freenode", "ken"),
+      "ken",
+      7000 + PENDING_TTL_MS,
+    );
+
+    expect(resolvePing(1, "ivan", "tok-i", 7000 + PENDING_TTL_MS + 10)).toBeNull();
+    expect(resolveCtcpReply(1, "judy", "FINGER")).toBeNull();
+    expect(resolveCtcpReply(1, "ken", "TIME")).not.toBeNull();
+  });
+
+  it("keeps an entry still within the TTL horizon on a later register", () => {
+    registerCtcpQuery(1, "laura", "SOURCE", channelKey("freenode", "laura"), "laura", 8000);
+
+    registerCtcpQuery(
+      1,
+      "mike",
+      "TIME",
+      channelKey("freenode", "mike"),
+      "mike",
+      8000 + PENDING_TTL_MS - 1,
+    );
+
+    expect(resolveCtcpReply(1, "laura", "SOURCE")).not.toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1860,7 +1860,7 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
   // #637 — a service's CTCP PING reply is CTCP-framed, so the server routes it to
   // the synthetic `$server` window (event_router route_non_channel_notice,
   // 86416a21); cic subscribes to `$server` via installChannelHandler, whose
-  // `routeMessage` runs the `maybeConsumePingReply` gate. THE BUG: Azzurra
+  // `routeMessage` runs the `maybeConsumeCtcpReply` gate. THE BUG: Azzurra
   // services (NickServ) echo a CTCP PING as a BARE `\x01PING\x01` — token
   // STRIPPED — so grappa hands cic an EMPTY `ctcp_args`. Before #637 that missed
   // the token-keyed pending entry and rendered raw in $server (while /ping a
@@ -2007,6 +2007,141 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
     expect(store.scrollbackByChannel()[channelKey("freenode", "vjt")]?.map((m) => m.body)).toEqual([
       "\x01PING stray-token\x01",
     ]);
+  });
+
+  // #719 — the bug this pins. `/ctcp bob VERSION` from a query window echoed the
+  // QUESTION there (#640) but its ANSWER rendered in $server, because PING was
+  // the only verb anything registered for: the server routes every CTCP-framed
+  // NOTICE to $server by design (#591 route_non_channel_notice, which must NOT
+  // change or it re-mints the control-character query window), so the client is
+  // the only half that can attribute the reply back. Pre-fix this lands in
+  // $server and the source window stays empty.
+  it("#719 — a non-PING CTCP reply claiming a pending query renders in the SOURCE window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerCtcpQuery } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // Operator typed `/ctcp vjt VERSION` in the #grappa window.
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerCtcpQuery(1, "vjt", "VERSION", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    // Handler index 2 is the $server handler (channels, dm-listener, $server).
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 800,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        body: "\x01VERSION irssi 1.4.5\x01",
+        meta: { ctcp_verb: "VERSION", ctcp_args: "irssi 1.4.5" },
+      },
+    });
+    // The answer joined its question: the row moved to the SOURCE window.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "\x01VERSION irssi 1.4.5\x01",
+    ]);
+    // ...and it KEEPS its typed meta, unlike the PING arm which synthesizes its
+    // own RTT body. This row is still the raw reply, so ScrollbackPane's notice
+    // CTCP arm must be able to draw "← CTCP VERSION reply from vjt: irssi 1.4.5"
+    // from meta. Strip it and the generic body render leaks raw \x01 (#641).
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_verb).toBe("VERSION");
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_args).toBe("irssi 1.4.5");
+    // $server did NOT also get a copy — the reply moved, it was not duplicated.
+    expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
+  });
+
+  // The other half of the #719 rule, and a hard constraint from the issue: a
+  // reply we never asked for must keep falling back to $server. Losing it would
+  // hide the fact that somebody answered a question nobody here asked.
+  it("#719 — a non-PING CTCP reply claiming NOTHING stays in $server", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerCtcpQuery } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // A pending query exists, but for a DIFFERENT verb — so the TIME reply below
+    // has an entry to be tempted by and must still refuse it.
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerCtcpQuery(1, "mallory", "VERSION", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 801,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "mallory",
+        body: "\x01TIME Sat Aug 02 2026\x01",
+        meta: { ctcp_verb: "TIME", ctcp_args: "Sat Aug 02 2026" },
+      },
+    });
+    expect(
+      store.scrollbackByChannel()[channelKey("freenode", "$server")]?.map((m) => m.body),
+    ).toEqual(["\x01TIME Sat Aug 02 2026\x01"]);
+    expect(store.scrollbackByChannel()[sourceKey]).toBeUndefined();
+  });
+
+  // #719 — the verb folds on the way back too. The SEND side already folded
+  // (`sendCtcpQuery` compares `verb.toUpperCase()`), so a peer answering `ping`
+  // in lower case used to miss the token table it had a perfectly good entry in
+  // and render raw in $server. One fold, both ends — otherwise the pair of
+  // compares disagree about what a PING is.
+  it("#719 — a lower-cased PING reply still claims its pending /ping", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerPing } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerPing(1, "vjt", "tok-719", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 802,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        body: "\x01ping tok-719\x01",
+        meta: { ctcp_verb: "ping", ctcp_args: "tok-719" },
+      },
+    });
+    nowSpy.mockRestore();
+    // Correlated as a PING: the synthesized RTT line, not a re-keyed raw row.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "CTCP PING reply from vjt: 42 ms",
+    ]);
+    expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
   });
 
   // Self-echo guard: own outbound NOTICEs (server fans out to the

--- a/cicchetto/src/lib/ctcpQuery.ts
+++ b/cicchetto/src/lib/ctcpQuery.ts
@@ -1,6 +1,6 @@
 import { channelKey } from "./channelKey";
 import { ctcpFrame } from "./ctcpAction";
-import { registerPing } from "./pingCorrelation";
+import { registerCtcpQuery, registerPing } from "./pingCorrelation";
 import { sendMessage } from "./scrollback";
 
 // #1192 — the ONE door an outbound CTCP query goes through.
@@ -12,11 +12,11 @@ import { sendMessage } from "./scrollback";
 //      is looking at), with the wire recipient travelling in `ctcpTarget`. Send
 //      it to the recipient's window instead and a probe mints a phantom query
 //      tab for somebody the operator never talked to.
-//   2. #600 — a PING's pending correlation entry MUST be registered BEFORE the
+//   2. #600 — the pending correlation entry MUST be registered BEFORE the
 //      send is awaited. `sendMessage` is a REST POST; on a loaded runner its ack
 //      resolves AFTER the peer's reply has already been processed on the
 //      separate, already-open WS. Register behind the await and
-//      `maybeConsumePingReply → resolvePing` finds nothing, the RTT line never
+//      `maybeConsumeCtcpReply → resolvePing` finds nothing, the RTT line never
 //      renders, and the failure is deterministic on CI and invisible locally.
 //
 // compose.ts held both by hand while `/ping` and `/ctcp` were the only callers.
@@ -54,17 +54,36 @@ type CtcpQuery = {
 };
 
 export const sendCtcpQuery = async (query: CtcpQuery): Promise<void> => {
-  // PING is the one verb whose reply cic can attribute back to the question, so
-  // it is the one verb that registers. Everything else is fire-and-forget: its
-  // reply is an asynchronous NOTICE the server routes to `$server`, and a
-  // pending entry for it could only ever leak. Folded because the verb reaches
-  // here from a parser that upper-cases AND from a menu that passes a literal.
+  // EVERY verb registers (#719). PING keys on its token, because that is what
+  // buys the RTT and what disambiguates two pings to one nick; every other verb
+  // keys on the verb itself, because a non-PING reply echoes no token at all.
+  //
+  // This used to be PING-only, on the grounds that a pending entry for anything
+  // else "could only ever leak". The leak was real but the conclusion was too
+  // strong: what bounds the table is the #637 TTL sweep, not the choice of verb,
+  // and the price of not registering was that `/ctcp bob VERSION` asked its
+  // question in one window and got its answer in another. Both tables are swept
+  // by the same horizon, so an unanswered VERSION costs exactly what an
+  // unanswered PING already did.
+  //
+  // Folded because the verb reaches here from a parser that upper-cases AND
+  // from a menu that passes a literal.
+  const sourceKey = channelKey(query.networkSlug, query.sourceChannel);
   if (query.verb.toUpperCase() === "PING") {
     registerPing(
       query.networkId,
       query.targetNick,
       query.args,
-      channelKey(query.networkSlug, query.sourceChannel),
+      sourceKey,
+      query.sourceChannel,
+      query.sentAtMs,
+    );
+  } else {
+    registerCtcpQuery(
+      query.networkId,
+      query.targetNick,
+      query.verb,
+      sourceKey,
       query.sourceChannel,
       query.sentAtMs,
     );

--- a/cicchetto/src/lib/pingCorrelation.ts
+++ b/cicchetto/src/lib/pingCorrelation.ts
@@ -27,9 +27,27 @@ import { asciiFold } from "./nickEquals";
 // the table is bounded by the pings issued within the last PENDING_TTL_MS.
 // A reply that arrives past the horizon simply isn't correlated (it renders in
 // its normal $server routing) — a CTCP round-trip that slow is not worth an RTT.
+//
+// #719 — the same story for every OTHER CTCP verb. `/ctcp bob VERSION` echoed
+// its question in the source window (#640) but its answer rendered in `$server`,
+// because PING was the only verb anything registered for. The two halves of one
+// round trip landed in two different places.
+//
+// The reply cannot be keyed on a token — only PING echoes one — so the generic
+// table keys on the VERB the question asked, in a table of its OWN. One map with
+// a three-part key would let the two collide: a PING token is opaque
+// operator-supplied text and could BE a verb, so `/ping frank VERSION` and a
+// VERSION reply from frank would fight over one entry.
+//
+// Everything else is deliberately identical to the ping table — the same
+// identity-scoped store, the same TTL horizon, the same one-shot resolve, and a
+// sweep that runs over BOTH maps from EITHER register (a session that only ever
+// ran /ctcp would otherwise never sweep the ping side). What it does NOT return
+// is an RTT: with no token there is nothing to time against, and a non-PING
+// reply renders as the answer it is rather than as a round trip.
 export const PENDING_TTL_MS = 60_000;
 
-type PendingPing = {
+type Pending = {
   sourceKey: ChannelKey;
   sourceChannel: string;
   sentAtMs: number;
@@ -41,9 +59,36 @@ type PendingPing = {
 const pendingKey = (networkId: number, nick: string, token: string): string =>
   `${networkId}\x00${asciiFold(nick)}\x00${token}`;
 
+// #719 — the verb-keyed twin. The nick folds the same way; the VERB folds to
+// upper case because neither end owns the other's spelling — the question comes
+// from a parser that upper-cases OR a menu literal, the answer carries whatever
+// the peer chose to send.
+const queryKey = (networkId: number, nick: string, verb: string): string =>
+  `${networkId}\x00${asciiFold(nick)}\x00${verb.toUpperCase()}`;
+
 const exports_ = identityScopedStore((onIdentityChange) => {
-  const pending = new Map<string, PendingPing>();
-  onIdentityChange(() => pending.clear());
+  const pending = new Map<string, Pending>();
+  const pendingQueries = new Map<string, Pending>();
+  onIdentityChange(() => {
+    pending.clear();
+    pendingQueries.clear();
+  });
+
+  // #637 leak guard — evict entries older than the TTL horizon before
+  // inserting. The horizon is measured against the REGISTERING caller's
+  // sentAtMs, keeping the module wall-clock-free (spec). Bounds the tables to
+  // the queries issued within the last PENDING_TTL_MS, so a run of unmatched
+  // probes can no longer accumulate until logout. Both maps are swept from
+  // either door: the bound is "queries issued in the last TTL", whichever verb
+  // they carried.
+  const sweep = (sentAtMs: number): void => {
+    const horizon = sentAtMs - PENDING_TTL_MS;
+    for (const map of [pending, pendingQueries]) {
+      for (const [key, entry] of map) {
+        if (entry.sentAtMs <= horizon) map.delete(key);
+      }
+    }
+  };
 
   const registerPing = (
     networkId: number,
@@ -53,16 +98,40 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     sourceChannel: string,
     sentAtMs: number,
   ): void => {
-    // #637 leak guard — evict entries older than the TTL horizon before
-    // inserting. The horizon is measured against THIS register's sentAtMs (the
-    // caller's clock), keeping the module wall-clock-free (spec). Bounds the
-    // table to the pings issued within the last PENDING_TTL_MS, so a run of
-    // unmatched /pings can no longer accumulate until logout.
-    const horizon = sentAtMs - PENDING_TTL_MS;
-    for (const [key, entry] of pending) {
-      if (entry.sentAtMs <= horizon) pending.delete(key);
-    }
+    sweep(sentAtMs);
     pending.set(pendingKey(networkId, nick, token), { sourceKey, sourceChannel, sentAtMs });
+  };
+
+  // #719 — register a non-PING CTCP query so its reply can be attributed back
+  // to the window it was asked from.
+  const registerCtcpQuery = (
+    networkId: number,
+    nick: string,
+    verb: string,
+    sourceKey: ChannelKey,
+    sourceChannel: string,
+    sentAtMs: number,
+  ): void => {
+    sweep(sentAtMs);
+    pendingQueries.set(queryKey(networkId, nick, verb), { sourceKey, sourceChannel, sentAtMs });
+  };
+
+  // #719 — the source window for a reply that CLAIMS a pending query, deleting
+  // it (one-shot). Null for a reply matching nothing, which is what keeps an
+  // UNSOLICITED probe answer falling back to `$server`: losing it would hide
+  // the fact that somebody answered a question we never asked. Takes no clock,
+  // unlike its ping twin — there is no RTT to compute, and the TTL horizon is
+  // enforced at register by the sweep, not here.
+  const resolveCtcpReply = (
+    networkId: number,
+    nick: string,
+    verb: string,
+  ): { sourceKey: ChannelKey; sourceChannel: string } | null => {
+    const key = queryKey(networkId, nick, verb);
+    const entry = pendingQueries.get(key);
+    if (entry === undefined) return null;
+    pendingQueries.delete(key);
+    return { sourceKey: entry.sourceKey, sourceChannel: entry.sourceChannel };
   };
 
   // Returns the source window + RTT for a reply that CLAIMS a pending entry,
@@ -74,7 +143,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     token: string,
     nowMs: number,
   ): { sourceKey: ChannelKey; sourceChannel: string; rttMs: number } | null => {
-    const resolve = (key: string, entry: PendingPing) => {
+    const resolve = (key: string, entry: Pending) => {
       pending.delete(key);
       return {
         sourceKey: entry.sourceKey,
@@ -101,7 +170,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     if (token !== "") return null;
     const nickPrefix = `${networkId}\x00${asciiFold(nick)}\x00`;
     let bestKey: string | undefined;
-    let best: PendingPing | undefined;
+    let best: Pending | undefined;
     for (const [key, entry] of pending) {
       if (!key.startsWith(nickPrefix)) continue;
       if (best === undefined || entry.sentAtMs > best.sentAtMs) {
@@ -113,8 +182,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     return resolve(bestKey, best);
   };
 
-  return { registerPing, resolvePing };
+  return { registerPing, resolvePing, registerCtcpQuery, resolveCtcpReply };
 });
 
 export const registerPing = exports_.registerPing;
 export const resolvePing = exports_.resolvePing;
+export const registerCtcpQuery = exports_.registerCtcpQuery;
+export const resolveCtcpReply = exports_.resolveCtcpReply;

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -24,7 +24,7 @@ import { nickEquals } from "./nickEquals";
 import { notificationPrefs } from "./notificationPrefs";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
-import { resolvePing } from "./pingCorrelation";
+import { resolveCtcpReply, resolvePing } from "./pingCorrelation";
 import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
@@ -205,12 +205,37 @@ moduleRoot(() => {
   // from the #546/#548 CTCP-routing work). The RTT body is a cic-owned display
   // string (the server sends structured data only), keyed on the correlation's
   // resolved source window, never the peer's.
-  const maybeConsumePingReply = (slug: string, message: ChannelEvent["message"]): boolean => {
-    if (message.kind !== "notice" || message.meta.ctcp_verb !== "PING") return false;
-    const token = message.meta.ctcp_args;
-    if (typeof token !== "string") return false;
+  // #719 — every OTHER verb gets the same treatment, keyed on the VERB rather
+  // than a token (only PING echoes one). A claim MOVES the row to the source
+  // window; no claim leaves it exactly where it was, which is what keeps an
+  // unsolicited probe answer visible on `$server` instead of vanishing.
+  //
+  // The verb folds on BOTH branches. The register side already folded
+  // (`sendCtcpQuery`'s `verb.toUpperCase() === "PING"`), so a case-sensitive
+  // compare here was an asymmetry: a peer answering `ping` in lower case missed
+  // the token table it had a perfectly good entry in. One rule, both ends.
+  const maybeConsumeCtcpReply = (slug: string, message: ChannelEvent["message"]): boolean => {
+    if (message.kind !== "notice") return false;
+    const verb = message.meta.ctcp_verb;
+    if (typeof verb !== "string") return false;
     const networkId = networkIdBySlug(slug);
     if (networkId === undefined) return false;
+
+    if (verb.toUpperCase() !== "PING") {
+      const claim = resolveCtcpReply(networkId, message.sender, verb);
+      if (claim === null) return false;
+      // Re-keyed, NOT rewritten: the row keeps its body and its typed ctcp meta
+      // so ScrollbackPane's notice arm draws "← CTCP VERSION reply from <peer>"
+      // in the source window. Stripping the meta the way the PING arm does would
+      // drop it into the generic body render and leak raw \x01 into the DOM
+      // (#641). The PING arm can strip because it SYNTHESIZES a human body; here
+      // there is nothing to synthesize — the reply already is the answer.
+      appendToScrollback(claim.sourceKey, { ...message, channel: claim.sourceChannel });
+      return true;
+    }
+
+    const token = message.meta.ctcp_args;
+    if (typeof token !== "string") return false;
     const hit = resolvePing(networkId, message.sender, token, Date.now());
     if (hit === null) return false;
     appendToScrollback(hit.sourceKey, {
@@ -234,10 +259,10 @@ moduleRoot(() => {
     message: ChannelEvent["message"],
     ownNick: string | null,
   ): void => {
-    // #591 — swallow a matched CTCP PING reply before it renders raw in this
+    // #591/#719 — claim a matched CTCP reply before it renders raw in this
     // window. Catches every routing path (channel/query/DM-listener); the
     // DM-listener notice arm ALSO gates earlier to suppress its pre-route beep.
-    if (maybeConsumePingReply(slug, message)) return;
+    if (maybeConsumeCtcpReply(slug, message)) return;
     appendToScrollback(key, message);
     // Message-replay-on-reconnect cluster — track high-water mark per
     // topic so the backfill on the NEXT reconnect knows where to
@@ -737,11 +762,11 @@ moduleRoot(() => {
             // NOTICEs (NickServ etc.) never hit this branch — our server
             // routes those to "$server" not the own-nick channel.
             //
-            // #591 — a peer's CTCP PING reply is DM-shaped (lands here at
+            // #591/#719 — a peer's CTCP reply is DM-shaped (lands here at
             // channel == ownNick). Consume a matched one BEFORE the beep below:
             // routeMessage's own gate swallows the raw render, but this arm
             // beeps PRE-route, so the suppression must happen here too.
-            if (maybeConsumePingReply(slug, message)) return;
+            if (maybeConsumeCtcpReply(slug, message)) return;
             // #372: canonical peer re-key — see the PRIVMSG/ACTION arm.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,48 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #719 -->
+
+---
+
+## 2026-08-13 — #719: a CTCP reply belongs to the window that asked, and shottino does not agree
+
+`/ctcp <nick> VERSION` echoed its question in the source window (#640) and
+rendered its answer in `$server`. `/ping` did not, because PING was the only
+verb anything registered a correlation entry for. The fix extends the
+correlation table to every verb, client-side; the mechanics live in
+`pingCorrelation.ts` and `ctcpQuery.ts`.
+
+Two things worth keeping that the code cannot say on its own.
+
+**The routing decision stays on the client, deliberately.** The server routes
+every CTCP-framed NOTICE to `$server` (`route_non_channel_notice/3`) and must
+keep doing so: that predicate is #591, and before it a CTCP reply took the
+regular-nick branch and `maybe_open_query_window/2` minted a tab full of
+control characters. Attributing a reply to a window is something only the half
+that ASKED can do, and that half is the client.
+
+**cic and shottino now follow different rules, and this was measured, not
+assumed.** `event_router.ex:2745` says shottino "renders it as a card in the
+window the question was asked from". It does not. `card()`
+(`frontends/shottino/shottino.c:7429`) files a row under the window that has
+FOCUS when the answer arrives, falling back to that network's `$server` when
+the focused window belongs to another network — and it does this for every
+verb uniformly. Its `(network, nick, stamp)` ping table carries no source
+window at all; `ping_claim` returns a bool, and all it decides is whether to
+print an RTT and whether to stay quiet on a backfill. The card block's own
+comment (`:7410`) is accurate where the event_router one is not: "the window
+that had focus when the answer arrived".
+
+So the two clients coincide in the common case — ask, and stay where you are —
+and diverge the moment the operator switches windows while a reply is in
+flight: cic files it where the question was asked, shottino where the operator
+is looking. cic's rule is source-at-send because that is what its correlation
+table already expressed for PING, and because it makes both halves of a round
+trip land together no matter where attention went. shottino's is a TUI
+affordance for a client whose reply cards all follow focus.
+
+**Apply:** the `event_router.ex:2745` sentence is wrong and stayed wrong here
+(a server-tree comment fix is not in a cic PR's scope). Before quoting a
+comment about a SIBLING component's behaviour, read that component — this one
+had been repeated into an issue as a design constraint.


### PR DESCRIPTION
## What

`/ctcp <nick> VERSION` (or TIME, or anything that is not PING) sent from a
query window echoed its **question** in that window (#640) and rendered its
**answer** in `$server`. `/ping` did not, because PING was the only verb
anything registered a correlation entry for.

The correlation table now covers every verb. The reply lands in the window the
query was sent from; an uncorrelated reply keeps falling back to `$server`.

## The issue's premise had moved — two corrections

**1. The fix does not belong where the issue says.** #719 was traced at
`42ee2013` and states that `compose.ts` `case "ctcp"` "registers nothing".
That is no longer the shape of the code: #1192 moved `/ctcp`, `/ping` *and*
the nick context menu's CTCP submenu onto one seam, `sendCtcpQuery`
(`lib/ctcpQuery.ts`), which owns the #600 register-before-send ordering — and
registers PING only. Registering in `compose.ts` as written would have missed
the menu caller entirely, so the branch went in the seam.

**2. shottino does not do what the issue says it does.** The Notes cite
`event_router.ex:2745` — "shottino renders it as a card in the window the
question was asked from" — and use it to argue the clients would agree. That
sentence is wrong, measured:

- `card()` (`frontends/shottino/shottino.c:7429`) files a row under the window
  that has **FOCUS when the answer arrives**, falling back to that network's
  `$server` when the focused window belongs to another network.
- It does this for **every verb uniformly** (`render_ctcp_reply`, `:3645`
  claimed-PING, `:3656` uncorrelated-PING, `:3660`/`:3661` any other verb).
- Its `(network, nick, stamp)` table holds **no source window**: `ping_claim`
  (`:3455`) returns a bool, and all it decides is RTT-vs-plain-line and
  backfill suppression.
- The card block's own comment (`:7410`) is accurate where the event_router one
  is not: *"the window that had focus when the answer arrived"*.

So the two clients now follow different rules. They coincide in the common case
(ask, stay put) and diverge when the operator switches windows while a reply is
in flight: cic files it where the question was asked, shottino where the
operator is looking. Recorded in DESIGN_NOTES rather than papered over. **The
`event_router.ex:2745` sentence is left wrong on purpose** — a server-tree
comment fix is not this PR's business, and it needs a compile lane.

## Shape

- `pingCorrelation.ts` — a second map keyed `(network, ASCII-folded nick,
  upper-cased VERB)`. Two maps, not one three-part key: a PING token is opaque
  operator text and could *be* a verb, so `/ping frank VERSION` and a VERSION
  reply from frank would otherwise fight over one entry (pinned in both
  directions). Same identity-scoped store, same #637 TTL sweep — now run over
  both maps from either register, so a session that only ever runs `/ctcp`
  still bounds the ping side. No RTT: there is no token to time against.
- `ctcpQuery.ts` — PING keeps its token entry, every other verb takes a verb
  entry, both before the send is awaited (#600).
- `subscribe.ts` — `maybeConsumePingReply` becomes `maybeConsumeCtcpReply`. A
  claimed non-PING reply is **re-keyed, not rewritten**: it keeps its body and
  its typed ctcp meta so `ScrollbackPane`'s notice arm draws
  `← CTCP VERSION reply from <peer>` in the source window. The PING arm strips
  meta because it *synthesizes* an RTT body; stripping here would drop the row
  into the generic body render and leak raw `\x01` (#641).

Design constraints from the issue, all held: the routing decision stays
client-side (`route_non_channel_notice/3` untouched, #591 intact); an
uncorrelated reply still falls back to `$server`; PING's token entry is
unchanged; same shape and TTL sweep as `registerPing`.

## One deliberate consequence beyond the report

The verb now folds on the **resolve** side too. The send side already folded
(`sendCtcpQuery` compares `verb.toUpperCase()`), so a case-sensitive compare on
the way back was a standing asymmetry: a peer answering `ping` in lower case
missed a token-table entry it had every right to. One fold, both ends —
covered by its own test.

## Test plan

- [x] Load-bearing red first: `#719 — a non-PING CTCP reply claiming a pending
  query renders in the SOURCE window` failed with the source window `undefined`
  before the fix, while its sibling (`...claiming NOTHING stays in $server`)
  passed pre-fix — the fallback is preserved behaviour, not new behaviour.
- [x] Three mutants, each killing exactly one test and no others: drop the verb
  fold → only the lower-cased-PING test dies; strip meta on the claimed branch
  → only the source-window test dies; claim every reply regardless → only the
  `$server`-fallback test dies. Source restored green after each.
- [x] `scripts/bun.sh run check` — RC=0 (biome + `tsc --noEmit` + the e2e
  tsconfig; 60 warnings, all pre-existing, none on a touched file).
- [x] `scripts/bun.sh run test` — RC=0, 282 files / 5366 tests. The full suite
  caught a regression the scoped run could not: `compose.test.ts` replaces the
  whole `pingCorrelation` module, so its mock had to learn the new register or
  the seam threw and took the send with it.
- [x] `scripts/design-notes-gate.sh` — RC=0, "1 new entry heading(s), separator
  and marker present" (run against committed state; it reports "nothing to
  check" on an uncommitted tree).
- [ ] No e2e written. The visible outcome is which window a row renders in,
  which the subscribe-level tests assert against the real store; an e2e would
  need a peer that answers CTCP VERSION, and bahamut does not.

## Not verified

- No compile or stack lane was used, so nothing server-side was exercised. The
  shottino findings are from reading its source, not from running it.