### PR TITLE
send: mirror the upstream oper flood allowance in the send throttle

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -140,9 +140,23 @@ config :grappa, :busy_retry,
 #   * capacity — burst allowance (5, per bahamut's flood burst).
 #   * refill_per_sec — sustained rate: 1 token every 2s = 0.5/s (bahamut's
 #     ~2s-per-line drip once the burst is spent).
+#
+# GH #480 — the oper pair. On a connection the ircd meters on its OPER
+# path the ordinary numbers stop mirroring anything and start being the
+# binding constraint, refusing a line bahamut would have carried. These
+# are NOT read off the source: `parse.c` / `s_bsd.c` describe a PATH (the
+# penalty accrues on a fraction of messages; the RecvQ check is skipped),
+# never a magnitude. 10x the ordinary pair is a CHOSEN headroom — wide
+# enough that grappa stops being the ceiling, still a bucket rather than
+# an open door, and still a config knob for the operator who measures
+# their own network. `Grappa.Session.FloodAllowance` decides which
+# session gets them; a session the upstream throttles not at all skips
+# the bucket entirely.
 config :grappa, :send_throttle,
   capacity: 5,
-  refill_per_sec: 0.5
+  refill_per_sec: 0.5,
+  oper_capacity: 50,
+  oper_refill_per_sec: 5.0
 
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,7 +58,14 @@ config :grappa, :admission, default_max_per_ip_per_network: 10
 # GrappaWeb.MessagesControllerOutboundTest); dev/e2e drive real users, not
 # a flood, so the throttle is effectively off here. Mirror of the
 # :admission relaxation above.
-config :grappa, :send_throttle, capacity: 1_000, refill_per_sec: 1_000
+# #480 — the oper pair rides the same relaxation. Left at the production
+# numbers it would be TIGHTER than the ordinary one here, so an oper'd dev
+# session would get less headroom than a plain one: the mirror inverted.
+config :grappa, :send_throttle,
+  capacity: 1_000,
+  refill_per_sec: 1_000,
+  oper_capacity: 1_000,
+  oper_refill_per_sec: 1_000
 
 # GH #630 — coarse per-subject request budget (see config.exs). Dev/e2e
 # headroom is set HIGH enough that a normal user (and every non-flood e2e

--- a/config/test.exs
+++ b/config/test.exs
@@ -220,9 +220,18 @@ config :grappa, :busy_retry,
 # refills between the sequential POSTs of a single test (deterministic
 # burst→429 without a wall-clock sleep; refill-over-time is proven
 # deterministically at the `TokenBucket` unit level via its now_ms seam).
+#
+# #480 — the oper pair is deliberately DISTINCT on both axes: a wider
+# burst (6 vs 3) so a test can prove the oper branch is the one being
+# used, and a slower refill (0.25 vs 0.5) so the `retry-after` it emits
+# cannot be confused with the ordinary one. Slower, never faster: a
+# refill fast enough to top the bucket up mid-test would turn the
+# expected 429 into a wall-clock race.
 config :grappa, :send_throttle,
   capacity: 3,
-  refill_per_sec: 0.5
+  refill_per_sec: 0.5,
+  oper_capacity: 6,
+  oper_refill_per_sec: 0.25
 
 # GH #630 — the request budget is effectively OFF by default in test:
 # it now meters EVERY WS handle_in verb AND every REST write, so a low

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,71 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #480 -->
+
+---
+
+## 2026-08-13 — #480: the send throttle mirrors the ircd, so it reads the ircd
+
+The inbound send throttle (#340) is a shock absorber: it 429s a flooding
+client *before* bahamut k-lines the connection, and its numbers — burst 5,
+one line per two seconds — were read off the flood allowance bahamut
+applies to an **ordinary** client. Sonic hit the corollary as an
+admin+ircop: on a connection the ircd meters on its oper path, that same
+bucket stops mirroring anything and becomes the binding constraint,
+refusing a line the upstream would have carried.
+
+**The axis is upstream state, not a grappa-side tier.** The tempting shape
+— a "trusted user" flag, an admin bit, an account role — answers a
+different question ("who deserves more?") and drifts from the thing being
+mirrored the moment the ircd changes its mind. What decides the allowance
+is the ircd, so what the throttle reads is what the ircd published about
+this connection: the per-session umode set #229 already tracks.
+`Grappa.Session.FloodAllowance` folds that into `:exempt | :oper |
+:ordinary`, `Session.get_flood_allowance/2` serves it, and the controller
+picks bucket parameters from the class without ever seeing a mode letter.
+The cost is one extra serialized call per POST, on the session that is
+about to handle the send anyway; the alternative — mirroring umodes into an
+ETS table the web edge could read lock-free — duplicates state that already
+exists, and every parallel structure needs housekeeping that will drift.
+
+**Two letters, two different kinds of knowledge.** `+o` is read
+flavour-independently: RFC 1459 fixes it and every ircd in reach spells the
+operator flag that way. The no-throttle letter is not portable at all —
+bahamut's is `F` (`OFLAG_UMODEF`), solanum assigns no `F` in core, and
+nothing was verified for hybrid — so it lives in the per-flavour table
+`IdentityState.registered_umode/1` established for exactly this shape.
+`supported_umodes` (#249) was considered and rejected as the source: 004
+param 3 is a signless concatenation of letters parsed with no meaning
+attached, so it can say `F` EXISTS on this ircd and never that `F` means
+NoMsgThrottle.
+
+**The default is the opposite of #388's, deliberately.** `IdentityState`
+defaults an unclassified network to the bahamut letter to preserve
+pre-#388 behaviour; here there is no prior behaviour to preserve, and the
+two error directions are not symmetric. A withheld exemption costs an oper
+some headroom they still largely get from the `:oper` tier; a wrongly
+granted one switches the throttle off for a connection the upstream is
+still metering, which is precisely the k-line #340 was built to prevent. So
+an unclassified network gets no exempt letter, and **an operator who wants
+the exemption on their bahamut network classifies it
+`services_flavor: :azzurra`** through the admin surface #349 already ships.
+The exemption also requires `+o` alongside the letter: free where the
+letter is an oper flag, and the bound on the damage where it is not.
+
+**The oper numbers are chosen, not measured.** 10x the ordinary pair. The
+issue's citations (`config.h:510`, `parse.c:225-236`, `s_bsd.c:1791-1795`)
+establish that the oper path is qualitatively different — the penalty
+accrues on a fraction of messages, the RecvQ check is skipped — which is a
+PATH, not a magnitude. Nothing here was measured against a live bahamut,
+which is why the pair stays a config knob and why this note says so.
+
+**Not moved:** the whole `send_throttle` block stays `Application.compile_env`.
+The issue floats moving it to runtime config "in the same change"; that is a
+second change with its own risk surface, and the oper axis does not depend
+on it. **Not touched:** the admission per-IP clone cap, which has no tier
+exemptions and should not grow any.
+
+**Apply:** when a limit exists to mirror an external system's limit, key it
+on state that system publishes, and let the letter table say what was READ
+at source rather than what is probably true elsewhere.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -80,7 +80,7 @@ defmodule Grappa.Session do
     exports: [Backoff, NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
-  alias Grappa.Session.Server
+  alias Grappa.Session.{FloodAllowance, Server}
 
   require Logger
 
@@ -1474,6 +1474,27 @@ defmodule Grappa.Session do
   def get_umodes(subject, network_id)
       when is_subject(subject) and is_integer(network_id) do
     call_session(subject, network_id, :get_umodes)
+  end
+
+  @doc """
+  Returns the UPSTREAM flood allowance this session's connection has (#480).
+
+  The inbound send throttle (#340) is a mirror of what the ircd itself
+  allows, so it asks the session — the only party holding the upstream's
+  own answer — rather than keying on a grappa-side identity tier. The
+  classes and the umode letters behind them are
+  `Grappa.Session.FloodAllowance`'s contract; a caller picks bucket
+  parameters from the class and never reads a mode letter.
+
+  Always succeeds for a live session (`:ordinary` before the 221 arrives);
+  `{:error, :no_session}` when none is registered for
+  `(subject, network_id)`.
+  """
+  @spec get_flood_allowance(subject(), integer()) ::
+          {:ok, FloodAllowance.t()} | {:error, :no_session}
+  def get_flood_allowance(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :get_flood_allowance)
   end
 
   @doc """

--- a/lib/grappa/session/flood_allowance.ex
+++ b/lib/grappa/session/flood_allowance.ex
@@ -1,0 +1,137 @@
+defmodule Grappa.Session.FloodAllowance do
+  @moduledoc """
+  The single source of truth for one question (GH #480): **how much flood
+  allowance does this session's UPSTREAM connection have?**
+
+  grappa's inbound send throttle (#340) exists to 429 a flooding client
+  *before* the ircd k-lines it. Its numbers were read off the allowance
+  bahamut applies to an ORDINARY client, so on a connection the ircd
+  meters far more generously grappa stops being the shock absorber and
+  becomes the binding constraint — it refuses a line the upstream would
+  have carried.
+
+  ## Why this reads upstream state and not an identity tier
+
+  The throttle is not an authorization gate. "Trusted user", an admin
+  flag, or an account role would all answer a DIFFERENT question — who
+  deserves more? — and would drift from the thing being mirrored the
+  moment the ircd changed its mind. What decides the allowance is the
+  ircd, so what this reads is the state the ircd published about the
+  connection: the per-session umode set (#229, seeded by the 221
+  RPL_UMODEIS reply grappa solicits at 001 and kept current from `:mode`
+  events on `$server`).
+
+  ## The three classes
+
+    * `:exempt` — the upstream applies no message throttle at all, so
+      grappa mirrors nothing and the bucket is skipped.
+    * `:oper` — the upstream meters this connection on the oper path,
+      which is qualitatively looser; grappa keeps a bucket, with its own
+      wider pair of numbers.
+    * `:ordinary` — today's behaviour, unchanged.
+
+  ## Which letters, and why they are NOT the same question
+
+  `+o` is the one letter RFC 1459 fixes (§4.1.5) and every ircd in reach
+  spells the operator flag with it, so it is read flavour-independently.
+
+  The no-throttle letter is not portable at all. On bahamut it is `F`
+  (`OFLAG_UMODEF`, NoMsgThrottle — the umode the issue's `parse.c`
+  reading names), and that is the ONE flavour whose mode table was read
+  at source. solanum assigns no `F` in core (`user_modes[256]` is
+  `D/Q/S/Z/a/i/o/s/w/z`) and nothing was verified for hybrid, so those
+  flavours — and an unclassified network — get NO exempt letter and their
+  opers land on `:oper`. This is deliberately the opposite default from
+  `Grappa.Session.IdentityState.registered_umode/1`, which defaults to
+  the bahamut answer to preserve pre-#388 behaviour: there is no prior
+  behaviour to preserve here, and the two directions are not symmetric —
+  a missing exemption costs an oper some headroom they still largely get
+  from `:oper`, while a wrongly granted one switches the throttle off for
+  a connection the upstream is still metering, which is the k-line #340
+  was built to prevent. **An operator whose bahamut network wants the
+  exemption classifies it `services_flavor: :azzurra`** (the admin PATCH
+  surface #349 already ships).
+
+  `supported_umodes` (#249, 004 RPL_MYINFO param 3) deliberately does not
+  feed this: it is a signless concatenation of letters the server
+  advertises, parsed with no meaning attached, so it can say `F` EXISTS
+  here and never that `F` means NoMsgThrottle.
+
+  ## Why the exemption also requires `+o`
+
+  bahamut's `F` is an oper flag, so demanding `+o` alongside it changes
+  nothing on the flavour that has one. Off that flavour it is what keeps
+  a letter that means something else entirely from switching the throttle
+  off for a plain user.
+
+  ## Shape
+
+  Pure functions over the session-state map, storing nothing — the
+  `IdentityState` shape, for the same reason: the facts already live on
+  `Grappa.Session.Server`'s state (`:umodes`, `:services_flavor`) and are
+  read with `Map.get` defaults, so a hot-reloaded process whose state
+  predates a field answers `:ordinary` (the safe direction) instead of
+  `KeyError`-crashing (the #216 contract).
+  """
+
+  @typedoc """
+  The upstream allowance this session's throttle mirrors.
+  """
+  @type t :: :exempt | :oper | :ordinary
+
+  @typedoc """
+  The operator-set services flavour, mirroring
+  `Grappa.Networks.Network.services_flavor/0`. Declared as a plain
+  `atom()` for the same reason `IdentityState` does: `Networks` already
+  depends on `Session`, so naming the type there would close a cycle.
+  """
+  @type flavor :: atom() | nil
+
+  @typedoc """
+  The session-state slice this reads. Every key optional: a hot-reloaded
+  state predating one of them must degrade, not crash.
+  """
+  @type facts :: %{
+          optional(:umodes) => [String.t()],
+          optional(:services_flavor) => flavor(),
+          optional(atom()) => term()
+        }
+
+  # RFC 1459 §4.1.5 — the operator flag, the one umode letter that is fixed
+  # across ircds. Not per-flavour, unlike the letter below.
+  @oper_umode "o"
+
+  # Flavours whose mode table was READ, not guessed. Absent ⇒ no exemption.
+  @no_throttle_umode_by_flavor %{azzurra: "F"}
+
+  @doc """
+  The umode letter meaning "the upstream applies no message throttle" on
+  the given services flavour, or `nil` where no letter has been verified.
+  """
+  @spec no_throttle_umode(flavor()) :: String.t() | nil
+  def no_throttle_umode(flavor) do
+    Map.get(@no_throttle_umode_by_flavor, flavor)
+  end
+
+  @doc """
+  The allowance class for a session, from its own upstream umode set.
+  """
+  @spec classify(facts()) :: t()
+  def classify(facts) when is_map(facts) do
+    umodes = Map.get(facts, :umodes, [])
+
+    cond do
+      @oper_umode not in umodes -> :ordinary
+      exempt?(umodes, Map.get(facts, :services_flavor)) -> :exempt
+      true -> :oper
+    end
+  end
+
+  @spec exempt?([String.t()], flavor()) :: boolean()
+  defp exempt?(umodes, flavor) do
+    case no_throttle_umode(flavor) do
+      nil -> false
+      letter -> letter in umodes
+    end
+  end
+end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -101,6 +101,7 @@ defmodule Grappa.Session.Server do
     Backoff,
     Broadcaster,
     EventRouter,
+    FloodAllowance,
     GhostRecovery,
     IdentityState,
     ISupport,
@@ -2621,6 +2622,17 @@ defmodule Grappa.Session.Server do
   # reaches here). See #229 umode hot-reload safety test.
   def handle_call(:get_umodes, _, state) do
     {:reply, {:ok, Map.get(state, :umodes, [])}, state}
+  end
+
+  # #480: returns the UPSTREAM flood allowance this connection has — the
+  # class the inbound send throttle mirrors, derived from the umode set the
+  # session already tracks plus the network's services flavour. Always
+  # succeeds (`:ordinary` before the 221 arrives). `FloodAllowance.classify/1`
+  # reads both facts with `Map.get` defaults, so a live proc whose state
+  # predates either field answers `:ordinary` instead of KeyError-crashing —
+  # and this one is reached on EVERY send, not just an after-join snapshot.
+  def handle_call(:get_flood_allowance, _, state) do
+    {:reply, {:ok, FloodAllowance.classify(state)}, state}
   end
 
   # #249: returns the per-session SUPPORTED umode set (004 RPL_MYINFO). Always

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -63,6 +63,7 @@ defmodule GrappaWeb.MessagesController do
   alias Grappa.PresenceFilter.Resolver
   alias Grappa.RateLimit.TokenBucket
   alias Grappa.{Scrollback, Session}
+  alias Grappa.Session.FloodAllowance
   alias GrappaWeb.{BodyLimit, Subject}
 
   @default_limit 50
@@ -90,6 +91,22 @@ defmodule GrappaWeb.MessagesController do
   # `max(1, _)` guards a sub-second config from flooring to 0. HTTP Retry-After
   # is integer seconds (RFC 7231 §7.1.3) — coarse but honest for this bucket.
   @send_throttle_retry_after_seconds max(1, ceil(1.0 / @send_throttle_refill_per_sec))
+
+  # #480 — the pair for a connection the upstream meters on its OPER path.
+  # Same bucket, same key, wider numbers: a session that gains (or loses)
+  # `+o` mid-burst simply has its stored level re-capped on the next take,
+  # which is the honest reading of "the allowance changed".
+  @send_throttle_oper_capacity Application.compile_env(
+                                 :grappa,
+                                 [:send_throttle, :oper_capacity],
+                                 50
+                               )
+  @send_throttle_oper_refill_per_sec Application.compile_env(
+                                       :grappa,
+                                       [:send_throttle, :oper_refill_per_sec],
+                                       5.0
+                                     )
+  @send_throttle_oper_retry_after_seconds max(1, ceil(1.0 / @send_throttle_oper_refill_per_sec))
 
   @doc """
   `GET /networks/:network_id/channels/:channel_id/messages` —
@@ -318,17 +335,69 @@ defmodule GrappaWeb.MessagesController do
   # lines of a multi-line paste against the bucket that actually refused —
   # NOT the coarse #630 budget. The bare `:rate_limited` atom stays reserved
   # for the #75 themes daily quota (no meaningful seconds hint).
+  # #480 — WHICH numbers is asked of the session, because the throttle is a
+  # mirror of the allowance the UPSTREAM applies to this connection and the
+  # session is the only party holding that. `:exempt` skips the bucket (there
+  # is nothing to mirror); the outer #630 request budget still meters the
+  # door, so this is not an unmetered path. A session that is gone answers
+  # `:no_session` and takes today's numbers — the send right behind this will
+  # 404 anyway, and guessing generous on the way to a 404 would be the wrong
+  # direction.
+  #
+  # Both this and `take_token/5` carry the `PresenceFilter` treatment for a
+  # config-derived constant: the retry hints come from module attributes, so
+  # Dialyzer narrows the success typing to those literals and reads the
+  # honest `pos_integer()` as a supertype. The general spec is the contract
+  # (the seconds are a tunable, not a promise of the number); the narrow one
+  # would have to be rewritten every time an operator retunes the config.
+  @dialyzer {:nowarn_function, take_send_token: 2}
   @spec take_send_token(Session.subject(), integer()) ::
           :ok | {:error, {:rate_limited, pos_integer()}}
   defp take_send_token(subject, network_id) do
+    case flood_allowance(subject, network_id) do
+      :exempt ->
+        :ok
+
+      :oper ->
+        take_token(
+          subject,
+          network_id,
+          @send_throttle_oper_capacity,
+          @send_throttle_oper_refill_per_sec,
+          @send_throttle_oper_retry_after_seconds
+        )
+
+      :ordinary ->
+        take_token(
+          subject,
+          network_id,
+          @send_throttle_capacity,
+          @send_throttle_refill_per_sec,
+          @send_throttle_retry_after_seconds
+        )
+    end
+  end
+
+  @spec flood_allowance(Session.subject(), integer()) :: FloodAllowance.t()
+  defp flood_allowance(subject, network_id) do
+    case Session.get_flood_allowance(subject, network_id) do
+      {:ok, allowance} -> allowance
+      {:error, :no_session} -> :ordinary
+    end
+  end
+
+  @dialyzer {:nowarn_function, take_token: 5}
+  @spec take_token(Session.subject(), integer(), pos_integer(), number(), pos_integer()) ::
+          :ok | {:error, {:rate_limited, pos_integer()}}
+  defp take_token(subject, network_id, capacity, refill_per_sec, retry_after_seconds) do
     case TokenBucket.take(
            @send_throttle_bucket,
            {subject, network_id},
-           @send_throttle_capacity,
-           @send_throttle_refill_per_sec
+           capacity,
+           refill_per_sec
          ) do
       :ok -> :ok
-      {:error, :rate_limited} -> {:error, {:rate_limited, @send_throttle_retry_after_seconds}}
+      {:error, :rate_limited} -> {:error, {:rate_limited, retry_after_seconds}}
     end
   end
 

--- a/test/grappa/session/flood_allowance_test.exs
+++ b/test/grappa/session/flood_allowance_test.exs
@@ -1,0 +1,71 @@
+defmodule Grappa.Session.FloodAllowanceTest do
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.FloodAllowance
+
+  describe "no_throttle_umode/1 — the per-flavour exempt letter" do
+    test "is F on bahamut/Azzurra, the only flavour where the letter was read at source" do
+      assert FloodAllowance.no_throttle_umode(:azzurra) == "F"
+    end
+
+    test "is absent on every flavour whose letter table we have NOT read" do
+      # solanum core assigns no F (`user_modes[256]` is D/Q/S/Z/a/i/o/s/w/z),
+      # and nothing was verified for hybrid. An unclassified network gets no
+      # letter either: honouring one would be assuming an ircd, and the cost
+      # of assuming wrong is a throttle switched OFF for a connection the
+      # upstream still meters.
+      assert FloodAllowance.no_throttle_umode(:atheme) == nil
+      assert FloodAllowance.no_throttle_umode(:oftc) == nil
+      assert FloodAllowance.no_throttle_umode(:unknown) == nil
+      assert FloodAllowance.no_throttle_umode(nil) == nil
+      assert FloodAllowance.no_throttle_umode(:some_future_ircd) == nil
+    end
+  end
+
+  describe "classify/1 — the upstream allowance this session mirrors" do
+    test "no facts at all reads as ordinary" do
+      # The #216 hot-reload contract: a live proc whose state predates the
+      # fields must answer the SAFE direction, not KeyError-crash.
+      assert FloodAllowance.classify(%{}) == :ordinary
+    end
+
+    test "a session with no oper umode is ordinary" do
+      assert FloodAllowance.classify(%{umodes: ["i", "w"], services_flavor: :azzurra}) ==
+               :ordinary
+    end
+
+    test "an oper'd session gets the oper allowance" do
+      assert FloodAllowance.classify(%{umodes: ["i", "o"], services_flavor: :azzurra}) == :oper
+    end
+
+    test "an oper carrying the flavour's no-throttle letter is exempt" do
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: :azzurra}) == :exempt
+    end
+
+    test "the exempt letter alone, without oper, is NOT exempt" do
+      # bahamut's `F` is an oper flag (OFLAG_UMODEF), so requiring `+o`
+      # alongside costs nothing there. Off bahamut it is the guard that
+      # keeps an unrelated `F` from switching the throttle off for a plain
+      # user we have no reason to trust.
+      assert FloodAllowance.classify(%{umodes: ["F"], services_flavor: :azzurra}) == :ordinary
+    end
+
+    test "the exempt letter is per-flavour: F on a flavour without one is just an oper" do
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: :atheme}) == :oper
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: nil}) == :oper
+    end
+
+    test "the oper letter is o everywhere — it is the one RFC 1459 fixes" do
+      for flavor <- [:azzurra, :atheme, :oftc, :unknown, nil] do
+        assert FloodAllowance.classify(%{umodes: ["o"], services_flavor: flavor}) == :oper
+      end
+    end
+
+    test "an uppercase O is not the oper umode" do
+      # Some ircds spell a local/global distinction with `O`; the letter this
+      # reads is the RFC one, and inventing a union would be the same mistake
+      # #388 refused for the registered letter.
+      assert FloodAllowance.classify(%{umodes: ["O"], services_flavor: :azzurra}) == :ordinary
+    end
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -4877,6 +4877,133 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #480 — the send throttle mirrors the UPSTREAM flood allowance, so the
+  # session answers what that allowance is from the umode set it already
+  # tracks. The letters and their per-flavour table are
+  # `Grappa.Session.FloodAllowance`'s unit contract; what is proven here is
+  # that the live session reads its OWN state and answers over the facade.
+  describe "#480 — upstream flood allowance" do
+    # `welcome_handler/0` is defined further down this module and shared:
+    # `defp` is module-wide, and a second copy here would be the duplicate
+    # the compiler warns about.
+    defp await_umodes(modes) do
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :umode_changed, modes: ^modes}
+                     },
+                     1_000
+
+      :ok
+    end
+
+    test "a session with no oper umode is :ordinary" do
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # Before any 221 the set is empty — the safe direction, not a crash.
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +iw\r\n")
+      :ok = await_umodes(["i", "w"])
+
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper'd session is :oper" do
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # The broadcast is the barrier: the fold has landed before we ask.
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +io\r\n")
+      :ok = await_umodes(["i", "o"])
+
+      assert {:ok, :oper} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper with the flavour's no-throttle umode is :exempt" do
+      {server, port} = start_server(welcome_handler())
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+      {network, _} =
+        network_with_server(
+          port: port,
+          slug: "test-#{System.unique_integer([:positive])}",
+          services_flavor: :azzurra
+        )
+
+      _ = credential_fixture(user, network, %{})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
+      :ok = await_umodes(["F", "o"])
+
+      assert {:ok, :exempt} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the SAME umodes on an unclassified network stop at :oper" do
+      # The exempt letter is per-flavour and only bahamut's was read at
+      # source. `setup_user_and_network` leaves services_flavor nil, which
+      # is what an operator who never classified the network has.
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
+      :ok = await_umodes(["F", "o"])
+
+      assert {:ok, :oper} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "hot-reload safety: a live proc whose state predates :umodes answers :ordinary" do
+      # Same #216 contract the get_umodes reader carries: a plain hot module
+      # reload does not rewrite live process state, and the throttle asks
+      # this on EVERY send — a KeyError here would crash-wave the sessions
+      # under load rather than degrade to today's numbers.
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
+
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "no live session for (subject, network) is :no_session, not a class" do
+      {_, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      assert {:error, :no_session} =
+               Session.get_flood_allowance({:user, user.id}, network.id)
+    end
+  end
+
   describe "#249 — supported umodes (server-advertised umode set from 004)" do
     test "004 RPL_MYINFO stores supported umodes + broadcasts on Topic.user" do
       # 004 advertises the server's supported usermode set (param index 3).

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -44,7 +44,11 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   end
 
   defp setup_network(vjt, port, slug \\ "azzurra") do
-    {network, _} = network_with_server(port: port, slug: slug)
+    setup_network(vjt, port, slug, nil)
+  end
+
+  defp setup_network(vjt, port, slug, services_flavor) do
+    {network, _} = network_with_server(port: port, slug: slug, services_flavor: services_flavor)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
     network
   end
@@ -696,6 +700,128 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
       :ok = GenServer.stop(pid1, :normal, 1_000)
       :ok = GenServer.stop(pid2, :normal, 1_000)
+    end
+  end
+
+  # #480 — the throttle mirrors the UPSTREAM allowance, so the numbers it
+  # applies depend on what the ircd published about THIS connection, never
+  # on a grappa-side identity tier. Test config: ordinary burst 3, oper
+  # burst 6, oper refill 0.25/s (`config/test.exs`). The classification
+  # itself is `Grappa.Session.FloodAllowance`'s unit contract; what these
+  # prove is that the send door reaches for a different pair of numbers.
+  describe "POST send throttle — the upstream allowance decides the pair (#480)" do
+    setup do
+      :ets.delete_all_objects(TokenBucket.table_name())
+      :ok
+    end
+
+    # The session must have FOLDED the umode set before the first POST, or
+    # the test races its own fixture: a PING answered is proof the session
+    # processed everything fed before it.
+    defp feed_umodes(server, modes) do
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test #{modes}\r\n")
+      IRCServer.feed(server, "PING :umodes\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :umodes\r\n"), 1_000)
+      :ok
+    end
+
+    test "an oper'd session rides the WIDER burst, and still lands on a 429 at its own ceiling",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+io")
+
+      # Sends 4, 5 and 6 are the discriminating ones: under the ordinary
+      # pair the bucket was empty after 3.
+      for n <- 1..6 do
+        assert json_response(post_body(conn, network, "oper line #{n}"), 201)
+      end
+
+      # Still a bucket, not an open door — the oper allowance is wider,
+      # not absent.
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "oper flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the oper 429 carries the OPER refill interval, not the ordinary one",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+io")
+
+      for n <- 1..6, do: assert(json_response(post_body(conn, network, "oper #{n}"), 201))
+      throttled = post_body(conn, network, "oper flood")
+      assert %{"error" => "rate_limited"} = json_response(throttled, 429)
+
+      # Derived from config, like the #666 ordinary assertion, so the test
+      # tracks the wire contract rather than a magic constant — and the two
+      # intervals are distinct on purpose (4 vs 2).
+      throttle = Application.get_env(:grappa, :send_throttle)
+      expected = Integer.to_string(max(1, ceil(1.0 / throttle[:oper_refill_per_sec])))
+      ordinary = Integer.to_string(max(1, ceil(1.0 / throttle[:refill_per_sec])))
+      refute expected == ordinary
+      assert [^expected] = get_resp_header(throttled, "retry-after")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper carrying the network's no-throttle umode is not metered at all",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      # The exempt letter is per-flavour; bahamut's is the one that was read
+      # at source, so the network has to say it is one.
+      network = setup_network(vjt, port, "azzurra", :azzurra)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+Fio")
+
+      # Well past BOTH ceilings (3 ordinary, 6 oper): there is no upstream
+      # throttle to mirror, so grappa mirrors none.
+      for n <- 1..10 do
+        assert json_response(post_body(conn, network, "exempt line #{n}"), 201)
+      end
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the same +F on an unclassified network is metered on the oper pair",
+         %{conn: conn, vjt: vjt} do
+      # No services_flavor: grappa has not been told which ircd this is, so
+      # `F` carries no verified meaning and the exemption is withheld. The
+      # oper tier still applies — the degradation is graceful.
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+Fio")
+
+      for n <- 1..6, do: assert(json_response(post_body(conn, network, "unclassified #{n}"), 201))
+
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "unclassified flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a plain user is metered on today's numbers, unchanged", %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+iw")
+
+      for n <- 1..3, do: assert(json_response(post_body(conn, network, "plain #{n}"), 201))
+
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "plain flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
     end
   end
 

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -153,7 +153,11 @@ defmodule Grappa.AuthFixtures do
     visitor_enabled = Keyword.get(attrs, :visitor_enabled, false)
 
     {:ok, network} =
-      Networks.find_or_create_network(%{slug: slug, visitor_enabled: visitor_enabled})
+      Networks.find_or_create_network(%{
+        slug: slug,
+        visitor_enabled: visitor_enabled,
+        services_flavor: Keyword.get(attrs, :services_flavor)
+      })
 
     {:ok, server} =
       Servers.add_server(network, %{


### PR DESCRIPTION
Refs #480.

The inbound send throttle (#340) 429s a flooding client before the ircd k-lines
it, and its numbers were read off the allowance bahamut applies to an
**ordinary** client. On a connection the ircd meters on its oper path the same
bucket stops mirroring anything and becomes the binding constraint, refusing a
line the upstream would have carried.

## The axis

Upstream state, not a grappa-side identity tier — the throttle is not an
authorization gate. `Grappa.Session.FloodAllowance` (pure, the
`IdentityState` shape) folds the per-session umode set #229 already tracks
plus the network's services flavour into `:exempt | :oper | :ordinary`;
`Session.get_flood_allowance/2` serves it; `MessagesController` picks bucket
parameters from the class and never sees a mode letter.

- `:exempt` — skip the bucket. The outer #630 request budget still meters the
  door, so this is not an unmetered path.
- `:oper` — the same bucket and key with a wider pair (`oper_capacity` /
  `oper_refill_per_sec`), and its own `retry-after`.
- `:ordinary` — today's numbers, unchanged.

Cost: one extra serialized call per POST, to the session that is about to
handle the send anyway. Mirroring umodes into ETS for a lock-free read would
duplicate state that already exists.

## The two decisions the issue asked for

**Where the numbers live.** Still `Application.compile_env`, like the existing
pair. Moving the whole `send_throttle` block to runtime config is a second
change with its own risk surface and the oper axis does not depend on it.

**Which letter means oper.** `+o`, read flavour-independently — RFC 1459 fixes
it. `supported_umodes` cannot answer this: 004 param 3 is a signless
concatenation of letters parsed with no meaning attached, so it says `F`
EXISTS on this ircd, never that `F` means NoMsgThrottle. The per-flavour table
is `IdentityState.registered_umode/1`'s precedent.

## Two calls worth reviewing

**An unclassified network gets no exemption.** bahamut's `F` (`OFLAG_UMODEF`)
is the one letter read at source; solanum assigns no `F` in core and nothing
was verified for hybrid. This is the OPPOSITE default from #388, deliberately:
there is no prior behaviour to preserve here, and the directions are not
symmetric — a withheld exemption costs an oper headroom the `:oper` tier
mostly gives back, a wrongly granted one switches the throttle off for a
connection the upstream still meters. An operator who wants it sets
`services_flavor: :azzurra` via the admin surface #349 ships. The exemption
also requires `+o`: free where the letter is an oper flag, a bound on the
damage where it is not.

**The oper numbers are chosen, not measured.** 10x the ordinary pair. The
issue's source citations establish that the oper path is qualitatively
different (penalty on a fraction of messages, RecvQ check skipped) — a PATH,
not a magnitude. Nothing was measured against a live bahamut; the pair stays a
config knob and the DESIGN_NOTES entry says so.

Out of scope, as the issue states: the `Grappa.Admission` per-IP clone cap is
untouched.

## Test plan

- [x] `scripts/check.sh` RC 0 on a clean tree — 8 doctests, 59 properties,
      6072 tests, 0 failures; dialyzer 0; credo strict 0; bats green
- [x] a failing-then-passing test per branch: exempt, oper, ordinary, plus the
      withheld-exemption case and the `:no_session` fallback
- [x] five mutants, each killed by the intended tests and only those:
      oper capacity 6→3 (3 controller tests), oper refill 0.25→0.5 (only the
      retry-after test), `:exempt` taking the oper bucket (only the exempt
      test), unverified flavours defaulting to `F` (2 unit + 1 controller +
      1 session), the exemption no longer requiring `+o` (1 unit)
- [x] `scripts/design-notes-gate.sh` RC 0
- [ ] CI