### PR TITLE
union: #1175 + #1277 + #719 + #480, gated once on the v1.1.0 base

### DIFF
--- a/cicchetto/bun.lock
+++ b/cicchetto/bun.lock
@@ -12,7 +12,7 @@
         "uqr": "^0.1.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.6",
+        "@biomejs/biome": "2.5.7",
         "@fontsource/cascadia-code": "^5.3.0",
         "@fontsource/fira-code": "^5.3.0",
         "@fontsource/ibm-plex-mono": "^5.3.0",
@@ -26,7 +26,7 @@
         "jsdom": "^30.0.1",
         "typescript": "^7.0.2",
         "unicode-emoji-json": "^0.9.0",
-        "vite": "^8.2.0",
+        "vite": "^8.2.1",
         "vite-plugin-pwa": "^1.3.0",
         "vite-plugin-solid": "^2.11.14",
         "vitest": "^4.1.10",
@@ -227,23 +227,23 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.7", "@biomejs/cli-darwin-x64": "2.5.7", "@biomejs/cli-linux-arm64": "2.5.7", "@biomejs/cli-linux-arm64-musl": "2.5.7", "@biomejs/cli-linux-x64": "2.5.7", "@biomejs/cli-linux-x64-musl": "2.5.7", "@biomejs/cli-win32-arm64": "2.5.7", "@biomejs/cli-win32-x64": "2.5.7" }, "bin": { "biome": "bin/biome" } }, "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -815,7 +815,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
@@ -849,7 +849,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.24", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
@@ -1019,7 +1019,7 @@
 
     "uqr": ["uqr@0.1.3", "", {}, "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA=="],
 
-    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
+    "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.3.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.1", "workbox-window": "^7.4.1" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A=="],
 
@@ -1133,6 +1133,8 @@
 
     "vitest/vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
+    "vitest/vite/postcss": ["postcss@8.5.24", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw=="],
+
     "vitest/vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -1158,6 +1160,8 @@
     "vitest/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "vitest/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "vitest/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 

--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -45,14 +45,16 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // already wraps and already hides the caret. This body is far past it, so the
 // ROW wraps and the quote it produces is a capped one, while staying well
 // inside one PRIVMSG so the server-side split budget (#246) never turns it
-// into two scrollback rows.
+// into two scrollback rows. #1277 raised the cap to 100 and left the filler
+// alone: the posted body runs 161 code points with the timestamp, still 61
+// past the cap, and the overflow below was measured rather than assumed.
 const FILLER =
   "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
   "quindi il caret finisce sotto la piega e non si vede piu' nulla";
 
-// #1235 capped the quoted body at 42 characters plus a literal `...`, so a
-// single reply can no longer BE six wrapped lines: the longest quote the
-// gesture can now produce is `<nick> ` + 45 + ` << `, about two. The overflow
+// #1235 capped the quoted body plus a literal `...`, so a single reply can no
+// longer BE six wrapped lines: the longest quote the gesture can produce is
+// `<nick> ` + 103 + ` << ` since #1277 raised the cap to 100. The overflow
 // this spec needs is therefore built the way an operator builds it — the reply
 // verb APPENDS, so three replies to the same row stack into a draft that wraps
 // well past the fold, with the caret at the very end of the third. What is
@@ -61,7 +63,7 @@ const FILLER =
 // Hardcoded in lockstep with `REPLY_QUOTE_BODY_LIMIT` / `REPLY_QUOTE_ELLIPSIS`
 // in `src/lib/replyQuote.ts` — the e2e package does not import from `src`, and
 // the house convention here is a mirrored constant with a lockstep comment.
-const QUOTED_BODY_LIMIT = 42;
+const QUOTED_BODY_LIMIT = 100;
 const QUOTED_ELLIPSIS = "...";
 const REPLIES = 3;
 
@@ -79,10 +81,11 @@ function uniqueBody(): string {
   return `issue1105 ${Date.now()} ${FILLER}`;
 }
 
-// Six-ish wrapped lines minus generous slack — three stacked quotes come to
-// about what the single uncapped one used to be. Its job is to fail loudly if
-// the fixture ever stops overflowing, because then "the caret is in view" would
-// be true for the wrong reason.
+// Generous slack under what the fixture actually produces: three stacked
+// quotes measure scrollHeight 269 against clientHeight 42 at this viewport,
+// so 227px of overflow (it was 109px under the 42-char cap). Its job is to
+// fail loudly if the fixture ever stops overflowing, because then "the caret
+// is in view" would be true for the wrong reason.
 const MIN_OVERFLOW_PX = 40;
 
 // A left→right drag on the message row whose text contains `body`. Touch

--- a/cicchetto/package.json
+++ b/cicchetto/package.json
@@ -22,7 +22,7 @@
     "uqr": "^0.1.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.6",
+    "@biomejs/biome": "2.5.7",
     "@fontsource/cascadia-code": "^5.3.0",
     "@fontsource/fira-code": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
@@ -36,7 +36,7 @@
     "jsdom": "^30.0.1",
     "typescript": "^7.0.2",
     "unicode-emoji-json": "^0.9.0",
-    "vite": "^8.2.0",
+    "vite": "^8.2.1",
     "vite-plugin-pwa": "^1.3.0",
     "vite-plugin-solid": "^2.11.14",
     "vitest": "^4.1.10",

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -775,9 +775,16 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // body is the raw \x01VERB [args]\x01 frame, classified ONCE on the server
       // (SSOT Grappa.IRC.CTCP.verb_args/1) into typed meta.ctcp_verb /
       // meta.ctcp_args. A CORRELATED /ping reply is consumed upstream
-      // (subscribe.ts maybeConsumePingReply) and never reaches here; an
-      // UNCORRELATED CTCP reply (a stray VERSION/TIME, or a token-less PING that
-      // matched no pending /ping) does. Before this arm it fell through to the
+      // (subscribe.ts maybeConsumeCtcpReply) and never reaches here, because that
+      // gate SYNTHESIZES an RTT line and strips the meta. Everything else does
+      // reach here: an UNCORRELATED reply (a stray VERSION/TIME, or a token-less
+      // PING that matched no pending /ping) in its `$server` routing, and — since
+      // #719 — a CORRELATED non-PING reply too, re-keyed to the window the query
+      // was sent from with its meta deliberately INTACT so this arm can draw it.
+      // That is why the gate must not strip meta on the #719 branch: doing so
+      // would drop the row into the generic body render below and leak raw \x01,
+      // which is the very thing this arm exists to prevent.
+      // Before this arm it fell through to the
       // generic body render below and leaked the raw \x01 into the DOM. Render a
       // human INBOUND line from the TYPED meta instead — cic NEVER parses \x01
       // (the "one IRC parser, on the server" invariant). This is the notice twin

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -660,8 +660,9 @@ describe("ScrollbackPane", () => {
 
   it("renders an uncorrelated inbound CTCP notice from typed meta, never raw \\x01 — #641", () => {
     // #641 — an inbound CTCP reply (a NOTICE carrying \x01VERB [args]\x01) that
-    // matches no pending /ping is NOT consumed by subscribe.ts's
-    // maybeConsumePingReply (that swallows only CORRELATED PING replies). It
+    // matches no pending query is NOT consumed by subscribe.ts's
+    // maybeConsumeCtcpReply (which only claims a reply some outstanding question
+    // of ours can account for). It
     // reaches this render, where — before the fix — the notice arm fell through
     // to the generic body render and leaked the raw \x01 delimiters into the DOM
     // (`-NickServ- ^APING^A`), breaking the "cic NEVER shows \x01" invariant that
@@ -674,8 +675,11 @@ describe("ScrollbackPane", () => {
     //
     // TRAP (#638): /ping NickServ now CORRELATES (token-less service PING replies
     // resolve), so a PING fixture would be consumed upstream and never reach this
-    // render — green for the WRONG reason. VERSION/TIME have NO correlation
-    // machinery: they are the genuinely uncorrelated class this fix must cover.
+    // render — green for the WRONG reason. #719 extended correlation to every
+    // verb, so VERSION/TIME are no longer uncorrelatABLE either — what keeps this
+    // fixture honest is that it seeds the store DIRECTLY, with no pending query
+    // anywhere, which is exactly the unsolicited-probe-answer case. A correlated
+    // non-PING reply reaches this same arm; it just arrives re-keyed.
     const ctcpNotice: ScrollbackMessage[] = [
       {
         id: 1,

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -140,12 +140,17 @@ vi.mock("../lib/scrollback", () => ({
   sendMessage: vi.fn(),
 }));
 
-// #591 — /ping registers a pending correlation entry; spy it so the test can
-// assert the (networkId, nick, token, sourceKey, sourceChannel, sentAtMs) tuple
-// without exercising the real store.
+// #591/#719 — a CTCP query registers a pending correlation entry (PING in the
+// token table, every other verb in the verb table); spy both so the test can
+// assert the (networkId, nick, token-or-verb, sourceKey, sourceChannel,
+// sentAtMs) tuple without exercising the real store. The whole module is
+// replaced, so a register the seam calls but this mock omits is not a silent
+// no-op — it throws and takes the send with it.
 vi.mock("../lib/pingCorrelation", () => ({
   registerPing: vi.fn(),
   resolvePing: vi.fn(),
+  registerCtcpQuery: vi.fn(),
+  resolveCtcpReply: vi.fn(),
 }));
 
 vi.mock("../lib/members", () => ({
@@ -1343,7 +1348,7 @@ describe("compose submit — slash command dispatch", () => {
   // awaited. `sendPrivmsg` is a REST POST; on a slow/loaded runner its ack can
   // resolve AFTER the peer's CTCP PING reply has already been processed on the
   // (separate, already-open) WS. If registration waited on the send,
-  // `maybeConsumePingReply → resolvePing` would find no pending entry and drop
+  // `maybeConsumeCtcpReply → resolvePing` would find no pending entry and drop
   // the RTT line — the #600 CI timeout (deterministic on the slow CI runner,
   // invisible on a fast local box). Model the slow send with a deferred promise
   // and assert registerPing already fired while the send is still pending.

--- a/cicchetto/src/__tests__/ctcpQuery.test.ts
+++ b/cicchetto/src/__tests__/ctcpQuery.test.ts
@@ -4,7 +4,8 @@ import { channelKey } from "../lib/channelKey";
 // Boundary stubs. The seam's whole job is WHICH two calls it makes and in WHAT
 // ORDER, so both collaborators are spies: the send door (scrollback.sendMessage,
 // whose own REST plumbing is pinned in scrollback.test.ts) and the correlation
-// store (pingCorrelation.registerPing, whose RTT arithmetic is pinned in
+// store (pingCorrelation's two registers — the token-keyed one for PING and the
+// verb-keyed one for everything else — whose matching rules are pinned in
 // pingCorrelation.test.ts).
 vi.mock("../lib/scrollback", () => ({
   sendMessage: vi.fn(),
@@ -13,6 +14,8 @@ vi.mock("../lib/scrollback", () => ({
 vi.mock("../lib/pingCorrelation", () => ({
   registerPing: vi.fn(),
   resolvePing: vi.fn(),
+  registerCtcpQuery: vi.fn(),
+  resolveCtcpReply: vi.fn(),
 }));
 
 // The invariant fields of a dispatch. `verb` / `args` are supplied per test —
@@ -47,10 +50,11 @@ describe("sendCtcpQuery — #1192", () => {
     });
   });
 
-  // Verb-agnostic means verb-agnostic: PING is the ONLY verb the seam correlates,
-  // and every other one is fire-and-forget. A seam that registered for everything
-  // would leak a pending entry per menu click that can never resolve.
-  it("registers no correlation for a non-PING verb", async () => {
+  // #719 — a non-PING verb registers too, in the VERB-keyed table, against the
+  // SOURCE window. Without this the question echoed in one window and the answer
+  // rendered in $server. The ping table must stay out of it: its key is a token,
+  // and a verb landing there would be claimable by any reply echoing that string.
+  it("registers a non-PING verb in the VERB table, keyed on the source window", async () => {
     const sb = await import("../lib/scrollback");
     vi.mocked(sb.sendMessage).mockResolvedValue();
     const pc = await import("../lib/pingCorrelation");
@@ -58,7 +62,55 @@ describe("sendCtcpQuery — #1192", () => {
 
     await sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
 
+    expect(pc.registerCtcpQuery).toHaveBeenCalledWith(
+      1,
+      "bob",
+      "VERSION",
+      channelKey("freenode", "#a"),
+      "#a",
+      1706743200000,
+    );
     expect(pc.registerPing).not.toHaveBeenCalled();
+  });
+
+  // The converse: PING keys on its token and must NOT also take a verb entry, or
+  // a peer's PING reply could be claimed twice — once for the RTT, once as a
+  // plain re-keyed row.
+  it("registers a PING in the token table only, never the verb table", async () => {
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    await sendCtcpQuery({ ...QUERY, verb: "PING", args: "tok-719" });
+
+    expect(pc.registerPing).toHaveBeenCalled();
+    expect(pc.registerCtcpQuery).not.toHaveBeenCalled();
+  });
+
+  // #600's ordering is the seam's whole reason to exist, and it now has to hold
+  // on the branch #719 added — not just on the PING branch it was written for.
+  // A VERSION reply comes back on the already-open WS just as readily.
+  it("registers a non-PING verb BEFORE the send resolves", async () => {
+    const sb = await import("../lib/scrollback");
+    const pc = await import("../lib/pingCorrelation");
+    let releaseSend!: () => void;
+    vi.mocked(sb.sendMessage).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      }),
+    );
+    const { sendCtcpQuery } = await import("../lib/ctcpQuery");
+
+    const inFlight = sendCtcpQuery({ ...QUERY, verb: "VERSION", args: "" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sb.sendMessage).toHaveBeenCalled();
+    expect(pc.registerCtcpQuery).toHaveBeenCalled();
+
+    releaseSend();
+    await inFlight;
   });
 
   // Args are the caller's bytes, passed through untouched — the seam is not a
@@ -147,7 +199,7 @@ describe("sendCtcpQuery — #1192", () => {
   //
   // `sendMessage` is a REST POST. Its ack can resolve AFTER the peer's CTCP PING
   // reply has already been processed on the separate, already-open WS. If the
-  // registration waited on the send, `maybeConsumePingReply → resolvePing` would
+  // registration waited on the send, `maybeConsumeCtcpReply → resolvePing` would
   // find no pending entry and drop the RTT — the deterministic CI timeout #600
   // diagnosed, invisible on a fast local box. compose.ts got this right by hand;
   // a second caller (the #1192 nick menu) is exactly how a hand-held invariant

--- a/cicchetto/src/__tests__/pingCorrelation.test.ts
+++ b/cicchetto/src/__tests__/pingCorrelation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { channelKey } from "../lib/channelKey";
-import { PENDING_TTL_MS, registerPing, resolvePing } from "../lib/pingCorrelation";
+import {
+  PENDING_TTL_MS,
+  registerCtcpQuery,
+  registerPing,
+  resolveCtcpReply,
+  resolvePing,
+} from "../lib/pingCorrelation";
 
 // #591 — the /ping reply-correlation table. Pure register/resolve with time
 // passed in explicitly (sentAtMs at register, nowMs at resolve) so the RTT
@@ -135,5 +141,119 @@ describe("pingCorrelation", () => {
     );
 
     expect(resolvePing(1, "grace", "tok-g1", 6000 + PENDING_TTL_MS)).not.toBeNull();
+  });
+});
+
+// #719 — the VERB-keyed sibling table. A non-PING CTCP reply echoes no token,
+// so the only thing that can attribute it back to the question is the verb the
+// question asked. Same store, same TTL, same one-shot resolve; it returns no
+// RTT because there is no token to time against and the reply renders as the
+// answer it is, not as a round trip.
+describe("pingCorrelation — CTCP query correlation (#719)", () => {
+  it("resolves a non-PING reply to the window the query was sent from", () => {
+    registerCtcpQuery(1, "bob", "VERSION", channelKey("freenode", "#chan"), "#chan", 1000);
+
+    expect(resolveCtcpReply(1, "bob", "VERSION")).toEqual({
+      sourceKey: channelKey("freenode", "#chan"),
+      sourceChannel: "#chan",
+    });
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolveCtcpReply(1, "nobody", "VERSION")).toBeNull();
+  });
+
+  it("folds the nick (CASEMAPPING=ascii) — ask Bob, resolve bob", () => {
+    registerCtcpQuery(1, "Bob", "TIME", channelKey("freenode", "#room"), "#room", 2000);
+
+    expect(resolveCtcpReply(1, "bob", "TIME")).toEqual({
+      sourceKey: channelKey("freenode", "#room"),
+      sourceChannel: "#room",
+    });
+  });
+
+  // The verb reaches the table from two directions — a parser that upper-cases
+  // and a menu literal on the way in, a peer's own spelling on the way back.
+  // Neither end controls the other's case, so both fold.
+  it("folds the verb — register lower-case, resolve upper-case and back", () => {
+    registerCtcpQuery(1, "carol", "version", channelKey("freenode", "carol"), "carol", 3000);
+    expect(resolveCtcpReply(1, "carol", "VERSION")).not.toBeNull();
+
+    registerCtcpQuery(1, "carol", "USERINFO", channelKey("freenode", "carol"), "carol", 3100);
+    expect(resolveCtcpReply(1, "carol", "userinfo")).not.toBeNull();
+  });
+
+  it("is one-shot: a second reply to the same query is null", () => {
+    registerCtcpQuery(1, "dave", "SOURCE", channelKey("freenode", "dave"), "dave", 4000);
+
+    expect(resolveCtcpReply(1, "dave", "SOURCE")).not.toBeNull();
+    expect(resolveCtcpReply(1, "dave", "SOURCE")).toBeNull();
+  });
+
+  // The whole point of keying on the verb: a peer answering a question we did
+  // not ask must not be able to claim a window. Otherwise an unsolicited probe
+  // reply would be filed into whatever conversation happened to have an entry.
+  it("does not match across networks, nicks, or verbs", () => {
+    registerCtcpQuery(1, "eve", "CLIENTINFO", channelKey("freenode", "#ops"), "#ops", 5000);
+
+    expect(resolveCtcpReply(2, "eve", "CLIENTINFO")).toBeNull();
+    expect(resolveCtcpReply(1, "mallory", "CLIENTINFO")).toBeNull();
+    expect(resolveCtcpReply(1, "eve", "TIME")).toBeNull();
+    expect(resolveCtcpReply(1, "eve", "CLIENTINFO")).not.toBeNull();
+  });
+
+  // Two tables, not one map with a three-part key: a PING token is opaque
+  // operator-supplied text and could BE a verb. Sharing one map would let
+  // `/ping frank VERSION` be claimed by frank's VERSION reply, filing an RTT
+  // question's answer under the wrong entry. Pinned in both directions.
+  it("cannot cross-claim between the token table and the verb table", () => {
+    registerPing(1, "frank", "VERSION", channelKey("freenode", "#a"), "#a", 6000);
+    registerCtcpQuery(1, "grace", "TIME", channelKey("freenode", "#b"), "#b", 6000);
+
+    // A VERSION reply must not eat frank's pending ping whose TOKEN is "VERSION".
+    expect(resolveCtcpReply(1, "frank", "VERSION")).toBeNull();
+    // A PING reply carrying the token "TIME" must not eat grace's TIME query.
+    expect(resolvePing(1, "grace", "TIME", 6050)).toBeNull();
+    // Both originals survive untouched.
+    expect(resolvePing(1, "frank", "VERSION", 6050)).not.toBeNull();
+    expect(resolveCtcpReply(1, "grace", "TIME")).not.toBeNull();
+  });
+
+  // Same leak guard as the ping table, and it must work ACROSS the two: a
+  // session that only ever runs /ctcp would otherwise never sweep the ping
+  // table, and vice versa. The bound is "queries issued in the last TTL",
+  // whichever door they came through.
+  it("sweeps stale entries in BOTH tables on either register (leak guard)", () => {
+    registerPing(1, "ivan", "tok-i", channelKey("freenode", "ivan"), "ivan", 7000);
+    registerCtcpQuery(1, "judy", "FINGER", channelKey("freenode", "judy"), "judy", 7000);
+
+    // A CTCP query at the horizon must evict the stale entry in EITHER table.
+    registerCtcpQuery(
+      1,
+      "ken",
+      "TIME",
+      channelKey("freenode", "ken"),
+      "ken",
+      7000 + PENDING_TTL_MS,
+    );
+
+    expect(resolvePing(1, "ivan", "tok-i", 7000 + PENDING_TTL_MS + 10)).toBeNull();
+    expect(resolveCtcpReply(1, "judy", "FINGER")).toBeNull();
+    expect(resolveCtcpReply(1, "ken", "TIME")).not.toBeNull();
+  });
+
+  it("keeps an entry still within the TTL horizon on a later register", () => {
+    registerCtcpQuery(1, "laura", "SOURCE", channelKey("freenode", "laura"), "laura", 8000);
+
+    registerCtcpQuery(
+      1,
+      "mike",
+      "TIME",
+      channelKey("freenode", "mike"),
+      "mike",
+      8000 + PENDING_TTL_MS - 1,
+    );
+
+    expect(resolveCtcpReply(1, "laura", "SOURCE")).not.toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -217,10 +217,12 @@ describe("replyQuote — what must NOT be mistaken for a quote (#1123)", () => {
 
 // #1235 — vjt: "sul reply limitiamo a 42 i caratteri di cui facciamo reply, se
 // sforano mettiamo un ellipsis `...`, e poi mettiamo sempre uno spazio prima
-// del `<<` finale". The cap lives in the WRAPPER, never in `quotableBody`:
-// that helper is shared with `!addquote` (#1107), which archives the line and
-// must keep it whole. `addQuote.test.ts` is the control group for that.
-describe("replyQuote — the quoted body is capped (#1235)", () => {
+// del `<<` finale". #1277 raised that 42 to 100 — the number moved, every
+// reading below did not. The cap lives in the WRAPPER, never in
+// `quotableBody`: that helper is shared with `!addquote` (#1107), which
+// archives the line and must keep it whole. `addQuote.test.ts` is the control
+// group for that.
+describe("replyQuote — the quoted body is capped (#1235, #1277)", () => {
   const AT_LIMIT = "a".repeat(REPLY_QUOTE_BODY_LIMIT);
 
   it("leaves a body at the limit whole, with no ellipsis", () => {
@@ -228,14 +230,14 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
   });
 
   // The first body over the limit is where an off-by-one shows: one way it
-  // clips a body that fits, the other it lets a 43rd character through.
+  // clips a body that fits, the other it lets a 101st character through.
   it("caps the first body that overflows", () => {
     expect(replyQuote(msg({ body: `${AT_LIMIT}b` }))).toBe(`<vjt> ${AT_LIMIT}... << `);
   });
 
-  // The 42 counts BODY characters and the ellipsis is ADDED past them — the
-  // quoted run is 45, not 42 with three of them spent on dots.
-  it("keeps a full 42 characters and adds the ellipsis after them", () => {
+  // The 100 counts BODY characters and the ellipsis is ADDED past them — the
+  // quoted run is 103, not 100 with three of them spent on dots.
+  it("keeps a full 100 characters and adds the ellipsis after them", () => {
     const quote = replyQuote(msg({ body: "x".repeat(200) })) ?? "";
     const quoted = quote.slice("<vjt> ".length, -REPLY_QUOTE_TAIL.length);
     expect(quoted).toBe(`${"x".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}`);
@@ -251,13 +253,15 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
     expect(quote).not.toContain("…");
   });
 
-  // A flat cut, with no backing off to the last word boundary: that is
-  // "limitiamo a 42 i caratteri" read literally, and a word-boundary rule would
-  // make the quote length depend on where the spaces happen to fall.
+  // A flat cut, with no backing off to the last word boundary: that is the
+  // request read literally, and a word-boundary rule would make the quote
+  // length depend on where the spaces happen to fall. The body is sized by
+  // hand against 100 so the cut lands INSIDE the last word — a body that
+  // happened to end on a space would pass under either rule.
   it("cuts flat at the limit, mid-word", () => {
-    const body = `${"parola ".repeat(5)}spezzata`;
-    expect(body).toHaveLength(43);
-    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(5)}spezzat... << `);
+    const body = `${"parola ".repeat(14)}spezzata`;
+    expect(body).toHaveLength(106);
+    expect(replyQuote(msg({ body }))).toBe(`<vjt> ${"parola ".repeat(14)}sp... << `);
   });
 
   // The cap is on the BODY: a long nick does not eat into what the sender said.
@@ -274,12 +278,14 @@ describe("replyQuote — the quoted body is capped (#1235)", () => {
     expect(replyQuote(msg({ sender: "alice", body }))).toBe("<alice> breve << ");
   });
 
-  // A UTF-16 slice at 42 can land between the halves of a surrogate pair and
+  // A UTF-16 slice at 100 can land between the halves of a surrogate pair and
   // emit a lone surrogate — an unpaired code unit in the compose box, and from
-  // there onto the wire. The cut counts code points.
+  // there onto the wire. The cut counts code points: the emoji is the 100th of
+  // them but sits at UTF-16 indices 99 and 100, so a unit-wise `slice(0, 100)`
+  // would keep its high surrogate alone.
   it("does not cut an astral character in half", () => {
-    const quote = replyQuote(msg({ body: `${"a".repeat(41)}🍺x` })) ?? "";
-    expect(quote).toBe(`<vjt> ${"a".repeat(41)}🍺... << `);
+    const quote = replyQuote(msg({ body: `${"a".repeat(99)}🍺x` })) ?? "";
+    expect(quote).toBe(`<vjt> ${"a".repeat(99)}🍺... << `);
     expect(quote.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "")).not.toMatch(/[\uD800-\uDFFF]/);
   });
 });

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1860,7 +1860,7 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
   // #637 — a service's CTCP PING reply is CTCP-framed, so the server routes it to
   // the synthetic `$server` window (event_router route_non_channel_notice,
   // 86416a21); cic subscribes to `$server` via installChannelHandler, whose
-  // `routeMessage` runs the `maybeConsumePingReply` gate. THE BUG: Azzurra
+  // `routeMessage` runs the `maybeConsumeCtcpReply` gate. THE BUG: Azzurra
   // services (NickServ) echo a CTCP PING as a BARE `\x01PING\x01` — token
   // STRIPPED — so grappa hands cic an EMPTY `ctcp_args`. Before #637 that missed
   // the token-keyed pending entry and rendered raw in $server (while /ping a
@@ -2007,6 +2007,141 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
     expect(store.scrollbackByChannel()[channelKey("freenode", "vjt")]?.map((m) => m.body)).toEqual([
       "\x01PING stray-token\x01",
     ]);
+  });
+
+  // #719 — the bug this pins. `/ctcp bob VERSION` from a query window echoed the
+  // QUESTION there (#640) but its ANSWER rendered in $server, because PING was
+  // the only verb anything registered for: the server routes every CTCP-framed
+  // NOTICE to $server by design (#591 route_non_channel_notice, which must NOT
+  // change or it re-mints the control-character query window), so the client is
+  // the only half that can attribute the reply back. Pre-fix this lands in
+  // $server and the source window stays empty.
+  it("#719 — a non-PING CTCP reply claiming a pending query renders in the SOURCE window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerCtcpQuery } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // Operator typed `/ctcp vjt VERSION` in the #grappa window.
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerCtcpQuery(1, "vjt", "VERSION", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    // Handler index 2 is the $server handler (channels, dm-listener, $server).
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 800,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        body: "\x01VERSION irssi 1.4.5\x01",
+        meta: { ctcp_verb: "VERSION", ctcp_args: "irssi 1.4.5" },
+      },
+    });
+    // The answer joined its question: the row moved to the SOURCE window.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "\x01VERSION irssi 1.4.5\x01",
+    ]);
+    // ...and it KEEPS its typed meta, unlike the PING arm which synthesizes its
+    // own RTT body. This row is still the raw reply, so ScrollbackPane's notice
+    // CTCP arm must be able to draw "← CTCP VERSION reply from vjt: irssi 1.4.5"
+    // from meta. Strip it and the generic body render leaks raw \x01 (#641).
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_verb).toBe("VERSION");
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_args).toBe("irssi 1.4.5");
+    // $server did NOT also get a copy — the reply moved, it was not duplicated.
+    expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
+  });
+
+  // The other half of the #719 rule, and a hard constraint from the issue: a
+  // reply we never asked for must keep falling back to $server. Losing it would
+  // hide the fact that somebody answered a question nobody here asked.
+  it("#719 — a non-PING CTCP reply claiming NOTHING stays in $server", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerCtcpQuery } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // A pending query exists, but for a DIFFERENT verb — so the TIME reply below
+    // has an entry to be tempted by and must still refuse it.
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerCtcpQuery(1, "mallory", "VERSION", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 801,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "mallory",
+        body: "\x01TIME Sat Aug 02 2026\x01",
+        meta: { ctcp_verb: "TIME", ctcp_args: "Sat Aug 02 2026" },
+      },
+    });
+    expect(
+      store.scrollbackByChannel()[channelKey("freenode", "$server")]?.map((m) => m.body),
+    ).toEqual(["\x01TIME Sat Aug 02 2026\x01"]);
+    expect(store.scrollbackByChannel()[sourceKey]).toBeUndefined();
+  });
+
+  // #719 — the verb folds on the way back too. The SEND side already folded
+  // (`sendCtcpQuery` compares `verb.toUpperCase()`), so a peer answering `ping`
+  // in lower case used to miss the token table it had a perfectly good entry in
+  // and render raw in $server. One fold, both ends — otherwise the pair of
+  // compares disagree about what a PING is.
+  it("#719 — a lower-cased PING reply still claims its pending /ping", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const { registerPing } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerPing(1, "vjt", "tok-719", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 802,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        body: "\x01ping tok-719\x01",
+        meta: { ctcp_verb: "ping", ctcp_args: "tok-719" },
+      },
+    });
+    nowSpy.mockRestore();
+    // Correlated as a PING: the synthesized RTT line, not a re-keyed raw row.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "CTCP PING reply from vjt: 42 ms",
+    ]);
+    expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
   });
 
   // Self-echo guard: own outbound NOTICEs (server fans out to the

--- a/cicchetto/src/lib/ctcpQuery.ts
+++ b/cicchetto/src/lib/ctcpQuery.ts
@@ -1,6 +1,6 @@
 import { channelKey } from "./channelKey";
 import { ctcpFrame } from "./ctcpAction";
-import { registerPing } from "./pingCorrelation";
+import { registerCtcpQuery, registerPing } from "./pingCorrelation";
 import { sendMessage } from "./scrollback";
 
 // #1192 — the ONE door an outbound CTCP query goes through.
@@ -12,11 +12,11 @@ import { sendMessage } from "./scrollback";
 //      is looking at), with the wire recipient travelling in `ctcpTarget`. Send
 //      it to the recipient's window instead and a probe mints a phantom query
 //      tab for somebody the operator never talked to.
-//   2. #600 — a PING's pending correlation entry MUST be registered BEFORE the
+//   2. #600 — the pending correlation entry MUST be registered BEFORE the
 //      send is awaited. `sendMessage` is a REST POST; on a loaded runner its ack
 //      resolves AFTER the peer's reply has already been processed on the
 //      separate, already-open WS. Register behind the await and
-//      `maybeConsumePingReply → resolvePing` finds nothing, the RTT line never
+//      `maybeConsumeCtcpReply → resolvePing` finds nothing, the RTT line never
 //      renders, and the failure is deterministic on CI and invisible locally.
 //
 // compose.ts held both by hand while `/ping` and `/ctcp` were the only callers.
@@ -54,17 +54,36 @@ type CtcpQuery = {
 };
 
 export const sendCtcpQuery = async (query: CtcpQuery): Promise<void> => {
-  // PING is the one verb whose reply cic can attribute back to the question, so
-  // it is the one verb that registers. Everything else is fire-and-forget: its
-  // reply is an asynchronous NOTICE the server routes to `$server`, and a
-  // pending entry for it could only ever leak. Folded because the verb reaches
-  // here from a parser that upper-cases AND from a menu that passes a literal.
+  // EVERY verb registers (#719). PING keys on its token, because that is what
+  // buys the RTT and what disambiguates two pings to one nick; every other verb
+  // keys on the verb itself, because a non-PING reply echoes no token at all.
+  //
+  // This used to be PING-only, on the grounds that a pending entry for anything
+  // else "could only ever leak". The leak was real but the conclusion was too
+  // strong: what bounds the table is the #637 TTL sweep, not the choice of verb,
+  // and the price of not registering was that `/ctcp bob VERSION` asked its
+  // question in one window and got its answer in another. Both tables are swept
+  // by the same horizon, so an unanswered VERSION costs exactly what an
+  // unanswered PING already did.
+  //
+  // Folded because the verb reaches here from a parser that upper-cases AND
+  // from a menu that passes a literal.
+  const sourceKey = channelKey(query.networkSlug, query.sourceChannel);
   if (query.verb.toUpperCase() === "PING") {
     registerPing(
       query.networkId,
       query.targetNick,
       query.args,
-      channelKey(query.networkSlug, query.sourceChannel),
+      sourceKey,
+      query.sourceChannel,
+      query.sentAtMs,
+    );
+  } else {
+    registerCtcpQuery(
+      query.networkId,
+      query.targetNick,
+      query.verb,
+      sourceKey,
       query.sourceChannel,
       query.sentAtMs,
     );

--- a/cicchetto/src/lib/pingCorrelation.ts
+++ b/cicchetto/src/lib/pingCorrelation.ts
@@ -27,9 +27,27 @@ import { asciiFold } from "./nickEquals";
 // the table is bounded by the pings issued within the last PENDING_TTL_MS.
 // A reply that arrives past the horizon simply isn't correlated (it renders in
 // its normal $server routing) — a CTCP round-trip that slow is not worth an RTT.
+//
+// #719 — the same story for every OTHER CTCP verb. `/ctcp bob VERSION` echoed
+// its question in the source window (#640) but its answer rendered in `$server`,
+// because PING was the only verb anything registered for. The two halves of one
+// round trip landed in two different places.
+//
+// The reply cannot be keyed on a token — only PING echoes one — so the generic
+// table keys on the VERB the question asked, in a table of its OWN. One map with
+// a three-part key would let the two collide: a PING token is opaque
+// operator-supplied text and could BE a verb, so `/ping frank VERSION` and a
+// VERSION reply from frank would fight over one entry.
+//
+// Everything else is deliberately identical to the ping table — the same
+// identity-scoped store, the same TTL horizon, the same one-shot resolve, and a
+// sweep that runs over BOTH maps from EITHER register (a session that only ever
+// ran /ctcp would otherwise never sweep the ping side). What it does NOT return
+// is an RTT: with no token there is nothing to time against, and a non-PING
+// reply renders as the answer it is rather than as a round trip.
 export const PENDING_TTL_MS = 60_000;
 
-type PendingPing = {
+type Pending = {
   sourceKey: ChannelKey;
   sourceChannel: string;
   sentAtMs: number;
@@ -41,9 +59,36 @@ type PendingPing = {
 const pendingKey = (networkId: number, nick: string, token: string): string =>
   `${networkId}\x00${asciiFold(nick)}\x00${token}`;
 
+// #719 — the verb-keyed twin. The nick folds the same way; the VERB folds to
+// upper case because neither end owns the other's spelling — the question comes
+// from a parser that upper-cases OR a menu literal, the answer carries whatever
+// the peer chose to send.
+const queryKey = (networkId: number, nick: string, verb: string): string =>
+  `${networkId}\x00${asciiFold(nick)}\x00${verb.toUpperCase()}`;
+
 const exports_ = identityScopedStore((onIdentityChange) => {
-  const pending = new Map<string, PendingPing>();
-  onIdentityChange(() => pending.clear());
+  const pending = new Map<string, Pending>();
+  const pendingQueries = new Map<string, Pending>();
+  onIdentityChange(() => {
+    pending.clear();
+    pendingQueries.clear();
+  });
+
+  // #637 leak guard — evict entries older than the TTL horizon before
+  // inserting. The horizon is measured against the REGISTERING caller's
+  // sentAtMs, keeping the module wall-clock-free (spec). Bounds the tables to
+  // the queries issued within the last PENDING_TTL_MS, so a run of unmatched
+  // probes can no longer accumulate until logout. Both maps are swept from
+  // either door: the bound is "queries issued in the last TTL", whichever verb
+  // they carried.
+  const sweep = (sentAtMs: number): void => {
+    const horizon = sentAtMs - PENDING_TTL_MS;
+    for (const map of [pending, pendingQueries]) {
+      for (const [key, entry] of map) {
+        if (entry.sentAtMs <= horizon) map.delete(key);
+      }
+    }
+  };
 
   const registerPing = (
     networkId: number,
@@ -53,16 +98,40 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     sourceChannel: string,
     sentAtMs: number,
   ): void => {
-    // #637 leak guard — evict entries older than the TTL horizon before
-    // inserting. The horizon is measured against THIS register's sentAtMs (the
-    // caller's clock), keeping the module wall-clock-free (spec). Bounds the
-    // table to the pings issued within the last PENDING_TTL_MS, so a run of
-    // unmatched /pings can no longer accumulate until logout.
-    const horizon = sentAtMs - PENDING_TTL_MS;
-    for (const [key, entry] of pending) {
-      if (entry.sentAtMs <= horizon) pending.delete(key);
-    }
+    sweep(sentAtMs);
     pending.set(pendingKey(networkId, nick, token), { sourceKey, sourceChannel, sentAtMs });
+  };
+
+  // #719 — register a non-PING CTCP query so its reply can be attributed back
+  // to the window it was asked from.
+  const registerCtcpQuery = (
+    networkId: number,
+    nick: string,
+    verb: string,
+    sourceKey: ChannelKey,
+    sourceChannel: string,
+    sentAtMs: number,
+  ): void => {
+    sweep(sentAtMs);
+    pendingQueries.set(queryKey(networkId, nick, verb), { sourceKey, sourceChannel, sentAtMs });
+  };
+
+  // #719 — the source window for a reply that CLAIMS a pending query, deleting
+  // it (one-shot). Null for a reply matching nothing, which is what keeps an
+  // UNSOLICITED probe answer falling back to `$server`: losing it would hide
+  // the fact that somebody answered a question we never asked. Takes no clock,
+  // unlike its ping twin — there is no RTT to compute, and the TTL horizon is
+  // enforced at register by the sweep, not here.
+  const resolveCtcpReply = (
+    networkId: number,
+    nick: string,
+    verb: string,
+  ): { sourceKey: ChannelKey; sourceChannel: string } | null => {
+    const key = queryKey(networkId, nick, verb);
+    const entry = pendingQueries.get(key);
+    if (entry === undefined) return null;
+    pendingQueries.delete(key);
+    return { sourceKey: entry.sourceKey, sourceChannel: entry.sourceChannel };
   };
 
   // Returns the source window + RTT for a reply that CLAIMS a pending entry,
@@ -74,7 +143,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     token: string,
     nowMs: number,
   ): { sourceKey: ChannelKey; sourceChannel: string; rttMs: number } | null => {
-    const resolve = (key: string, entry: PendingPing) => {
+    const resolve = (key: string, entry: Pending) => {
       pending.delete(key);
       return {
         sourceKey: entry.sourceKey,
@@ -101,7 +170,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     if (token !== "") return null;
     const nickPrefix = `${networkId}\x00${asciiFold(nick)}\x00`;
     let bestKey: string | undefined;
-    let best: PendingPing | undefined;
+    let best: Pending | undefined;
     for (const [key, entry] of pending) {
       if (!key.startsWith(nickPrefix)) continue;
       if (best === undefined || entry.sentAtMs > best.sentAtMs) {
@@ -113,8 +182,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     return resolve(bestKey, best);
   };
 
-  return { registerPing, resolvePing };
+  return { registerPing, resolvePing, registerCtcpQuery, resolveCtcpReply };
 });
 
 export const registerPing = exports_.registerPing;
 export const resolvePing = exports_.resolvePing;
+export const registerCtcpQuery = exports_.registerCtcpQuery;
+export const resolveCtcpReply = exports_.resolveCtcpReply;

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -17,16 +17,17 @@ export const REPLY_QUOTE_TAIL = " << ";
 // #1235 — how much of the quoted line comes along. Without a cap, replying to a
 // long message drags the whole thing into the compose box and buries the answer.
 //
-// Four readings of "limitiamo a 42 i caratteri" are all defensible; these are
-// the ones ruled on, deliberately kept to one constant plus one function so a
-// change of mind is a one-line edit:
-//   - 42 counts BODY characters and the ellipsis is ADDED past them (45 quoted,
-//     not 42 with three spent on dots);
+// #1277 raised the number to 100: 42 was the original ask ("limitiamo a 42 i
+// caratteri") and read too tight in practice. The four readings ruled on in
+// #1235 stand unchanged, and they are still deliberately kept to one constant
+// plus one function, which is what made raising the number a one-line edit:
+//   - 100 counts BODY characters and the ellipsis is ADDED past them (103
+//     quoted, not 100 with three spent on dots);
 //   - the marker is the literal `...` the request spells, not `…` U+2026;
-//   - the cut is flat at 42, with no backing off to a word boundary;
+//   - the cut is flat at 100, with no backing off to a word boundary;
 //   - the head (`<nick> ` / `* nick `) is outside the count — the nick is not
 //     what overflows.
-export const REPLY_QUOTE_BODY_LIMIT = 42;
+export const REPLY_QUOTE_BODY_LIMIT = 100;
 export const REPLY_QUOTE_ELLIPSIS = "...";
 
 // The quoted body, cut to the limit. Counted in CODE POINTS: a UTF-16 slice can

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -24,7 +24,7 @@ import { nickEquals } from "./nickEquals";
 import { notificationPrefs } from "./notificationPrefs";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
-import { resolvePing } from "./pingCorrelation";
+import { resolveCtcpReply, resolvePing } from "./pingCorrelation";
 import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
@@ -205,12 +205,37 @@ moduleRoot(() => {
   // from the #546/#548 CTCP-routing work). The RTT body is a cic-owned display
   // string (the server sends structured data only), keyed on the correlation's
   // resolved source window, never the peer's.
-  const maybeConsumePingReply = (slug: string, message: ChannelEvent["message"]): boolean => {
-    if (message.kind !== "notice" || message.meta.ctcp_verb !== "PING") return false;
-    const token = message.meta.ctcp_args;
-    if (typeof token !== "string") return false;
+  // #719 — every OTHER verb gets the same treatment, keyed on the VERB rather
+  // than a token (only PING echoes one). A claim MOVES the row to the source
+  // window; no claim leaves it exactly where it was, which is what keeps an
+  // unsolicited probe answer visible on `$server` instead of vanishing.
+  //
+  // The verb folds on BOTH branches. The register side already folded
+  // (`sendCtcpQuery`'s `verb.toUpperCase() === "PING"`), so a case-sensitive
+  // compare here was an asymmetry: a peer answering `ping` in lower case missed
+  // the token table it had a perfectly good entry in. One rule, both ends.
+  const maybeConsumeCtcpReply = (slug: string, message: ChannelEvent["message"]): boolean => {
+    if (message.kind !== "notice") return false;
+    const verb = message.meta.ctcp_verb;
+    if (typeof verb !== "string") return false;
     const networkId = networkIdBySlug(slug);
     if (networkId === undefined) return false;
+
+    if (verb.toUpperCase() !== "PING") {
+      const claim = resolveCtcpReply(networkId, message.sender, verb);
+      if (claim === null) return false;
+      // Re-keyed, NOT rewritten: the row keeps its body and its typed ctcp meta
+      // so ScrollbackPane's notice arm draws "← CTCP VERSION reply from <peer>"
+      // in the source window. Stripping the meta the way the PING arm does would
+      // drop it into the generic body render and leak raw \x01 into the DOM
+      // (#641). The PING arm can strip because it SYNTHESIZES a human body; here
+      // there is nothing to synthesize — the reply already is the answer.
+      appendToScrollback(claim.sourceKey, { ...message, channel: claim.sourceChannel });
+      return true;
+    }
+
+    const token = message.meta.ctcp_args;
+    if (typeof token !== "string") return false;
     const hit = resolvePing(networkId, message.sender, token, Date.now());
     if (hit === null) return false;
     appendToScrollback(hit.sourceKey, {
@@ -234,10 +259,10 @@ moduleRoot(() => {
     message: ChannelEvent["message"],
     ownNick: string | null,
   ): void => {
-    // #591 — swallow a matched CTCP PING reply before it renders raw in this
+    // #591/#719 — claim a matched CTCP reply before it renders raw in this
     // window. Catches every routing path (channel/query/DM-listener); the
     // DM-listener notice arm ALSO gates earlier to suppress its pre-route beep.
-    if (maybeConsumePingReply(slug, message)) return;
+    if (maybeConsumeCtcpReply(slug, message)) return;
     appendToScrollback(key, message);
     // Message-replay-on-reconnect cluster — track high-water mark per
     // topic so the backfill on the NEXT reconnect knows where to
@@ -737,11 +762,11 @@ moduleRoot(() => {
             // NOTICEs (NickServ etc.) never hit this branch — our server
             // routes those to "$server" not the own-nick channel.
             //
-            // #591 — a peer's CTCP PING reply is DM-shaped (lands here at
+            // #591/#719 — a peer's CTCP reply is DM-shaped (lands here at
             // channel == ownNick). Consume a matched one BEFORE the beep below:
             // routeMessage's own gate swallows the raw render, but this arm
             // beeps PRE-route, so the suppression must happen here too.
-            if (maybeConsumePingReply(slug, message)) return;
+            if (maybeConsumeCtcpReply(slug, message)) return;
             // #372: canonical peer re-key — see the PRIVMSG/ACTION arm.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);

--- a/config/config.exs
+++ b/config/config.exs
@@ -140,9 +140,23 @@ config :grappa, :busy_retry,
 #   * capacity — burst allowance (5, per bahamut's flood burst).
 #   * refill_per_sec — sustained rate: 1 token every 2s = 0.5/s (bahamut's
 #     ~2s-per-line drip once the burst is spent).
+#
+# GH #480 — the oper pair. On a connection the ircd meters on its OPER
+# path the ordinary numbers stop mirroring anything and start being the
+# binding constraint, refusing a line bahamut would have carried. These
+# are NOT read off the source: `parse.c` / `s_bsd.c` describe a PATH (the
+# penalty accrues on a fraction of messages; the RecvQ check is skipped),
+# never a magnitude. 10x the ordinary pair is a CHOSEN headroom — wide
+# enough that grappa stops being the ceiling, still a bucket rather than
+# an open door, and still a config knob for the operator who measures
+# their own network. `Grappa.Session.FloodAllowance` decides which
+# session gets them; a session the upstream throttles not at all skips
+# the bucket entirely.
 config :grappa, :send_throttle,
   capacity: 5,
-  refill_per_sec: 0.5
+  refill_per_sec: 0.5,
+  oper_capacity: 50,
+  oper_refill_per_sec: 5.0
 
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,7 +58,14 @@ config :grappa, :admission, default_max_per_ip_per_network: 10
 # GrappaWeb.MessagesControllerOutboundTest); dev/e2e drive real users, not
 # a flood, so the throttle is effectively off here. Mirror of the
 # :admission relaxation above.
-config :grappa, :send_throttle, capacity: 1_000, refill_per_sec: 1_000
+# #480 — the oper pair rides the same relaxation. Left at the production
+# numbers it would be TIGHTER than the ordinary one here, so an oper'd dev
+# session would get less headroom than a plain one: the mirror inverted.
+config :grappa, :send_throttle,
+  capacity: 1_000,
+  refill_per_sec: 1_000,
+  oper_capacity: 1_000,
+  oper_refill_per_sec: 1_000
 
 # GH #630 — coarse per-subject request budget (see config.exs). Dev/e2e
 # headroom is set HIGH enough that a normal user (and every non-flood e2e

--- a/config/test.exs
+++ b/config/test.exs
@@ -220,9 +220,18 @@ config :grappa, :busy_retry,
 # refills between the sequential POSTs of a single test (deterministic
 # burst→429 without a wall-clock sleep; refill-over-time is proven
 # deterministically at the `TokenBucket` unit level via its now_ms seam).
+#
+# #480 — the oper pair is deliberately DISTINCT on both axes: a wider
+# burst (6 vs 3) so a test can prove the oper branch is the one being
+# used, and a slower refill (0.25 vs 0.5) so the `retry-after` it emits
+# cannot be confused with the ordinary one. Slower, never faster: a
+# refill fast enough to top the bucket up mid-test would turn the
+# expected 429 into a wall-clock race.
 config :grappa, :send_throttle,
   capacity: 3,
-  refill_per_sec: 0.5
+  refill_per_sec: 0.5,
+  oper_capacity: 6,
+  oper_refill_per_sec: 0.25
 
 # GH #630 — the request budget is effectively OFF by default in test:
 # it now meters EVERY WS handle_in verb AND every REST write, so a low

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,48 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #719 -->
+
+---
+
+## 2026-08-13 — #719: a CTCP reply belongs to the window that asked, and shottino does not agree
+
+`/ctcp <nick> VERSION` echoed its question in the source window (#640) and
+rendered its answer in `$server`. `/ping` did not, because PING was the only
+verb anything registered a correlation entry for. The fix extends the
+correlation table to every verb, client-side; the mechanics live in
+`pingCorrelation.ts` and `ctcpQuery.ts`.
+
+Two things worth keeping that the code cannot say on its own.
+
+**The routing decision stays on the client, deliberately.** The server routes
+every CTCP-framed NOTICE to `$server` (`route_non_channel_notice/3`) and must
+keep doing so: that predicate is #591, and before it a CTCP reply took the
+regular-nick branch and `maybe_open_query_window/2` minted a tab full of
+control characters. Attributing a reply to a window is something only the half
+that ASKED can do, and that half is the client.
+
+**cic and shottino now follow different rules, and this was measured, not
+assumed.** `event_router.ex:2745` says shottino "renders it as a card in the
+window the question was asked from". It does not. `card()`
+(`frontends/shottino/shottino.c:7429`) files a row under the window that has
+FOCUS when the answer arrives, falling back to that network's `$server` when
+the focused window belongs to another network — and it does this for every
+verb uniformly. Its `(network, nick, stamp)` ping table carries no source
+window at all; `ping_claim` returns a bool, and all it decides is whether to
+print an RTT and whether to stay quiet on a backfill. The card block's own
+comment (`:7410`) is accurate where the event_router one is not: "the window
+that had focus when the answer arrived".
+
+So the two clients coincide in the common case — ask, and stay where you are —
+and diverge the moment the operator switches windows while a reply is in
+flight: cic files it where the question was asked, shottino where the operator
+is looking. cic's rule is source-at-send because that is what its correlation
+table already expressed for PING, and because it makes both halves of a round
+trip land together no matter where attention went. shottino's is a TUI
+affordance for a client whose reply cards all follow focus.
+
+**Apply:** the `event_router.ex:2745` sentence is wrong and stayed wrong here
+(a server-tree comment fix is not in a cic PR's scope). Before quoting a
+comment about a SIBLING component's behaviour, read that component — this one
+had been repeated into an issue as a design constraint.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41127,3 +41127,71 @@ affordance for a client whose reply cards all follow focus.
 (a server-tree comment fix is not in a cic PR's scope). Before quoting a
 comment about a SIBLING component's behaviour, read that component — this one
 had been repeated into an issue as a design constraint.
+<!-- entry #480 -->
+
+---
+
+## 2026-08-13 — #480: the send throttle mirrors the ircd, so it reads the ircd
+
+The inbound send throttle (#340) is a shock absorber: it 429s a flooding
+client *before* bahamut k-lines the connection, and its numbers — burst 5,
+one line per two seconds — were read off the flood allowance bahamut
+applies to an **ordinary** client. Sonic hit the corollary as an
+admin+ircop: on a connection the ircd meters on its oper path, that same
+bucket stops mirroring anything and becomes the binding constraint,
+refusing a line the upstream would have carried.
+
+**The axis is upstream state, not a grappa-side tier.** The tempting shape
+— a "trusted user" flag, an admin bit, an account role — answers a
+different question ("who deserves more?") and drifts from the thing being
+mirrored the moment the ircd changes its mind. What decides the allowance
+is the ircd, so what the throttle reads is what the ircd published about
+this connection: the per-session umode set #229 already tracks.
+`Grappa.Session.FloodAllowance` folds that into `:exempt | :oper |
+:ordinary`, `Session.get_flood_allowance/2` serves it, and the controller
+picks bucket parameters from the class without ever seeing a mode letter.
+The cost is one extra serialized call per POST, on the session that is
+about to handle the send anyway; the alternative — mirroring umodes into an
+ETS table the web edge could read lock-free — duplicates state that already
+exists, and every parallel structure needs housekeeping that will drift.
+
+**Two letters, two different kinds of knowledge.** `+o` is read
+flavour-independently: RFC 1459 fixes it and every ircd in reach spells the
+operator flag that way. The no-throttle letter is not portable at all —
+bahamut's is `F` (`OFLAG_UMODEF`), solanum assigns no `F` in core, and
+nothing was verified for hybrid — so it lives in the per-flavour table
+`IdentityState.registered_umode/1` established for exactly this shape.
+`supported_umodes` (#249) was considered and rejected as the source: 004
+param 3 is a signless concatenation of letters parsed with no meaning
+attached, so it can say `F` EXISTS on this ircd and never that `F` means
+NoMsgThrottle.
+
+**The default is the opposite of #388's, deliberately.** `IdentityState`
+defaults an unclassified network to the bahamut letter to preserve
+pre-#388 behaviour; here there is no prior behaviour to preserve, and the
+two error directions are not symmetric. A withheld exemption costs an oper
+some headroom they still largely get from the `:oper` tier; a wrongly
+granted one switches the throttle off for a connection the upstream is
+still metering, which is precisely the k-line #340 was built to prevent. So
+an unclassified network gets no exempt letter, and **an operator who wants
+the exemption on their bahamut network classifies it
+`services_flavor: :azzurra`** through the admin surface #349 already ships.
+The exemption also requires `+o` alongside the letter: free where the
+letter is an oper flag, and the bound on the damage where it is not.
+
+**The oper numbers are chosen, not measured.** 10x the ordinary pair. The
+issue's citations (`config.h:510`, `parse.c:225-236`, `s_bsd.c:1791-1795`)
+establish that the oper path is qualitatively different — the penalty
+accrues on a fraction of messages, the RecvQ check is skipped — which is a
+PATH, not a magnitude. Nothing here was measured against a live bahamut,
+which is why the pair stays a config knob and why this note says so.
+
+**Not moved:** the whole `send_throttle` block stays `Application.compile_env`.
+The issue floats moving it to runtime config "in the same change"; that is a
+second change with its own risk surface, and the oper axis does not depend
+on it. **Not touched:** the admission per-IP clone cap, which has no tier
+exemptions and should not grow any.
+
+**Apply:** when a limit exists to mirror an external system's limit, key it
+on state that system publishes, and let the letter table say what was READ
+at source rather than what is probably true elsewhere.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -80,7 +80,7 @@ defmodule Grappa.Session do
     exports: [Backoff, NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
-  alias Grappa.Session.Server
+  alias Grappa.Session.{FloodAllowance, Server}
 
   require Logger
 
@@ -1474,6 +1474,27 @@ defmodule Grappa.Session do
   def get_umodes(subject, network_id)
       when is_subject(subject) and is_integer(network_id) do
     call_session(subject, network_id, :get_umodes)
+  end
+
+  @doc """
+  Returns the UPSTREAM flood allowance this session's connection has (#480).
+
+  The inbound send throttle (#340) is a mirror of what the ircd itself
+  allows, so it asks the session — the only party holding the upstream's
+  own answer — rather than keying on a grappa-side identity tier. The
+  classes and the umode letters behind them are
+  `Grappa.Session.FloodAllowance`'s contract; a caller picks bucket
+  parameters from the class and never reads a mode letter.
+
+  Always succeeds for a live session (`:ordinary` before the 221 arrives);
+  `{:error, :no_session}` when none is registered for
+  `(subject, network_id)`.
+  """
+  @spec get_flood_allowance(subject(), integer()) ::
+          {:ok, FloodAllowance.t()} | {:error, :no_session}
+  def get_flood_allowance(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :get_flood_allowance)
   end
 
   @doc """

--- a/lib/grappa/session/flood_allowance.ex
+++ b/lib/grappa/session/flood_allowance.ex
@@ -1,0 +1,137 @@
+defmodule Grappa.Session.FloodAllowance do
+  @moduledoc """
+  The single source of truth for one question (GH #480): **how much flood
+  allowance does this session's UPSTREAM connection have?**
+
+  grappa's inbound send throttle (#340) exists to 429 a flooding client
+  *before* the ircd k-lines it. Its numbers were read off the allowance
+  bahamut applies to an ORDINARY client, so on a connection the ircd
+  meters far more generously grappa stops being the shock absorber and
+  becomes the binding constraint — it refuses a line the upstream would
+  have carried.
+
+  ## Why this reads upstream state and not an identity tier
+
+  The throttle is not an authorization gate. "Trusted user", an admin
+  flag, or an account role would all answer a DIFFERENT question — who
+  deserves more? — and would drift from the thing being mirrored the
+  moment the ircd changed its mind. What decides the allowance is the
+  ircd, so what this reads is the state the ircd published about the
+  connection: the per-session umode set (#229, seeded by the 221
+  RPL_UMODEIS reply grappa solicits at 001 and kept current from `:mode`
+  events on `$server`).
+
+  ## The three classes
+
+    * `:exempt` — the upstream applies no message throttle at all, so
+      grappa mirrors nothing and the bucket is skipped.
+    * `:oper` — the upstream meters this connection on the oper path,
+      which is qualitatively looser; grappa keeps a bucket, with its own
+      wider pair of numbers.
+    * `:ordinary` — today's behaviour, unchanged.
+
+  ## Which letters, and why they are NOT the same question
+
+  `+o` is the one letter RFC 1459 fixes (§4.1.5) and every ircd in reach
+  spells the operator flag with it, so it is read flavour-independently.
+
+  The no-throttle letter is not portable at all. On bahamut it is `F`
+  (`OFLAG_UMODEF`, NoMsgThrottle — the umode the issue's `parse.c`
+  reading names), and that is the ONE flavour whose mode table was read
+  at source. solanum assigns no `F` in core (`user_modes[256]` is
+  `D/Q/S/Z/a/i/o/s/w/z`) and nothing was verified for hybrid, so those
+  flavours — and an unclassified network — get NO exempt letter and their
+  opers land on `:oper`. This is deliberately the opposite default from
+  `Grappa.Session.IdentityState.registered_umode/1`, which defaults to
+  the bahamut answer to preserve pre-#388 behaviour: there is no prior
+  behaviour to preserve here, and the two directions are not symmetric —
+  a missing exemption costs an oper some headroom they still largely get
+  from `:oper`, while a wrongly granted one switches the throttle off for
+  a connection the upstream is still metering, which is the k-line #340
+  was built to prevent. **An operator whose bahamut network wants the
+  exemption classifies it `services_flavor: :azzurra`** (the admin PATCH
+  surface #349 already ships).
+
+  `supported_umodes` (#249, 004 RPL_MYINFO param 3) deliberately does not
+  feed this: it is a signless concatenation of letters the server
+  advertises, parsed with no meaning attached, so it can say `F` EXISTS
+  here and never that `F` means NoMsgThrottle.
+
+  ## Why the exemption also requires `+o`
+
+  bahamut's `F` is an oper flag, so demanding `+o` alongside it changes
+  nothing on the flavour that has one. Off that flavour it is what keeps
+  a letter that means something else entirely from switching the throttle
+  off for a plain user.
+
+  ## Shape
+
+  Pure functions over the session-state map, storing nothing — the
+  `IdentityState` shape, for the same reason: the facts already live on
+  `Grappa.Session.Server`'s state (`:umodes`, `:services_flavor`) and are
+  read with `Map.get` defaults, so a hot-reloaded process whose state
+  predates a field answers `:ordinary` (the safe direction) instead of
+  `KeyError`-crashing (the #216 contract).
+  """
+
+  @typedoc """
+  The upstream allowance this session's throttle mirrors.
+  """
+  @type t :: :exempt | :oper | :ordinary
+
+  @typedoc """
+  The operator-set services flavour, mirroring
+  `Grappa.Networks.Network.services_flavor/0`. Declared as a plain
+  `atom()` for the same reason `IdentityState` does: `Networks` already
+  depends on `Session`, so naming the type there would close a cycle.
+  """
+  @type flavor :: atom() | nil
+
+  @typedoc """
+  The session-state slice this reads. Every key optional: a hot-reloaded
+  state predating one of them must degrade, not crash.
+  """
+  @type facts :: %{
+          optional(:umodes) => [String.t()],
+          optional(:services_flavor) => flavor(),
+          optional(atom()) => term()
+        }
+
+  # RFC 1459 §4.1.5 — the operator flag, the one umode letter that is fixed
+  # across ircds. Not per-flavour, unlike the letter below.
+  @oper_umode "o"
+
+  # Flavours whose mode table was READ, not guessed. Absent ⇒ no exemption.
+  @no_throttle_umode_by_flavor %{azzurra: "F"}
+
+  @doc """
+  The umode letter meaning "the upstream applies no message throttle" on
+  the given services flavour, or `nil` where no letter has been verified.
+  """
+  @spec no_throttle_umode(flavor()) :: String.t() | nil
+  def no_throttle_umode(flavor) do
+    Map.get(@no_throttle_umode_by_flavor, flavor)
+  end
+
+  @doc """
+  The allowance class for a session, from its own upstream umode set.
+  """
+  @spec classify(facts()) :: t()
+  def classify(facts) when is_map(facts) do
+    umodes = Map.get(facts, :umodes, [])
+
+    cond do
+      @oper_umode not in umodes -> :ordinary
+      exempt?(umodes, Map.get(facts, :services_flavor)) -> :exempt
+      true -> :oper
+    end
+  end
+
+  @spec exempt?([String.t()], flavor()) :: boolean()
+  defp exempt?(umodes, flavor) do
+    case no_throttle_umode(flavor) do
+      nil -> false
+      letter -> letter in umodes
+    end
+  end
+end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -101,6 +101,7 @@ defmodule Grappa.Session.Server do
     Backoff,
     Broadcaster,
     EventRouter,
+    FloodAllowance,
     GhostRecovery,
     IdentityState,
     ISupport,
@@ -2621,6 +2622,17 @@ defmodule Grappa.Session.Server do
   # reaches here). See #229 umode hot-reload safety test.
   def handle_call(:get_umodes, _, state) do
     {:reply, {:ok, Map.get(state, :umodes, [])}, state}
+  end
+
+  # #480: returns the UPSTREAM flood allowance this connection has — the
+  # class the inbound send throttle mirrors, derived from the umode set the
+  # session already tracks plus the network's services flavour. Always
+  # succeeds (`:ordinary` before the 221 arrives). `FloodAllowance.classify/1`
+  # reads both facts with `Map.get` defaults, so a live proc whose state
+  # predates either field answers `:ordinary` instead of KeyError-crashing —
+  # and this one is reached on EVERY send, not just an after-join snapshot.
+  def handle_call(:get_flood_allowance, _, state) do
+    {:reply, {:ok, FloodAllowance.classify(state)}, state}
   end
 
   # #249: returns the per-session SUPPORTED umode set (004 RPL_MYINFO). Always

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -63,6 +63,7 @@ defmodule GrappaWeb.MessagesController do
   alias Grappa.PresenceFilter.Resolver
   alias Grappa.RateLimit.TokenBucket
   alias Grappa.{Scrollback, Session}
+  alias Grappa.Session.FloodAllowance
   alias GrappaWeb.{BodyLimit, Subject}
 
   @default_limit 50
@@ -90,6 +91,22 @@ defmodule GrappaWeb.MessagesController do
   # `max(1, _)` guards a sub-second config from flooring to 0. HTTP Retry-After
   # is integer seconds (RFC 7231 §7.1.3) — coarse but honest for this bucket.
   @send_throttle_retry_after_seconds max(1, ceil(1.0 / @send_throttle_refill_per_sec))
+
+  # #480 — the pair for a connection the upstream meters on its OPER path.
+  # Same bucket, same key, wider numbers: a session that gains (or loses)
+  # `+o` mid-burst simply has its stored level re-capped on the next take,
+  # which is the honest reading of "the allowance changed".
+  @send_throttle_oper_capacity Application.compile_env(
+                                 :grappa,
+                                 [:send_throttle, :oper_capacity],
+                                 50
+                               )
+  @send_throttle_oper_refill_per_sec Application.compile_env(
+                                       :grappa,
+                                       [:send_throttle, :oper_refill_per_sec],
+                                       5.0
+                                     )
+  @send_throttle_oper_retry_after_seconds max(1, ceil(1.0 / @send_throttle_oper_refill_per_sec))
 
   @doc """
   `GET /networks/:network_id/channels/:channel_id/messages` —
@@ -318,17 +335,69 @@ defmodule GrappaWeb.MessagesController do
   # lines of a multi-line paste against the bucket that actually refused —
   # NOT the coarse #630 budget. The bare `:rate_limited` atom stays reserved
   # for the #75 themes daily quota (no meaningful seconds hint).
+  # #480 — WHICH numbers is asked of the session, because the throttle is a
+  # mirror of the allowance the UPSTREAM applies to this connection and the
+  # session is the only party holding that. `:exempt` skips the bucket (there
+  # is nothing to mirror); the outer #630 request budget still meters the
+  # door, so this is not an unmetered path. A session that is gone answers
+  # `:no_session` and takes today's numbers — the send right behind this will
+  # 404 anyway, and guessing generous on the way to a 404 would be the wrong
+  # direction.
+  #
+  # Both this and `take_token/5` carry the `PresenceFilter` treatment for a
+  # config-derived constant: the retry hints come from module attributes, so
+  # Dialyzer narrows the success typing to those literals and reads the
+  # honest `pos_integer()` as a supertype. The general spec is the contract
+  # (the seconds are a tunable, not a promise of the number); the narrow one
+  # would have to be rewritten every time an operator retunes the config.
+  @dialyzer {:nowarn_function, take_send_token: 2}
   @spec take_send_token(Session.subject(), integer()) ::
           :ok | {:error, {:rate_limited, pos_integer()}}
   defp take_send_token(subject, network_id) do
+    case flood_allowance(subject, network_id) do
+      :exempt ->
+        :ok
+
+      :oper ->
+        take_token(
+          subject,
+          network_id,
+          @send_throttle_oper_capacity,
+          @send_throttle_oper_refill_per_sec,
+          @send_throttle_oper_retry_after_seconds
+        )
+
+      :ordinary ->
+        take_token(
+          subject,
+          network_id,
+          @send_throttle_capacity,
+          @send_throttle_refill_per_sec,
+          @send_throttle_retry_after_seconds
+        )
+    end
+  end
+
+  @spec flood_allowance(Session.subject(), integer()) :: FloodAllowance.t()
+  defp flood_allowance(subject, network_id) do
+    case Session.get_flood_allowance(subject, network_id) do
+      {:ok, allowance} -> allowance
+      {:error, :no_session} -> :ordinary
+    end
+  end
+
+  @dialyzer {:nowarn_function, take_token: 5}
+  @spec take_token(Session.subject(), integer(), pos_integer(), number(), pos_integer()) ::
+          :ok | {:error, {:rate_limited, pos_integer()}}
+  defp take_token(subject, network_id, capacity, refill_per_sec, retry_after_seconds) do
     case TokenBucket.take(
            @send_throttle_bucket,
            {subject, network_id},
-           @send_throttle_capacity,
-           @send_throttle_refill_per_sec
+           capacity,
+           refill_per_sec
          ) do
       :ok -> :ok
-      {:error, :rate_limited} -> {:error, {:rate_limited, @send_throttle_retry_after_seconds}}
+      {:error, :rate_limited} -> {:error, {:rate_limited, retry_after_seconds}}
     end
   end
 

--- a/test/grappa/session/flood_allowance_test.exs
+++ b/test/grappa/session/flood_allowance_test.exs
@@ -1,0 +1,71 @@
+defmodule Grappa.Session.FloodAllowanceTest do
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.FloodAllowance
+
+  describe "no_throttle_umode/1 — the per-flavour exempt letter" do
+    test "is F on bahamut/Azzurra, the only flavour where the letter was read at source" do
+      assert FloodAllowance.no_throttle_umode(:azzurra) == "F"
+    end
+
+    test "is absent on every flavour whose letter table we have NOT read" do
+      # solanum core assigns no F (`user_modes[256]` is D/Q/S/Z/a/i/o/s/w/z),
+      # and nothing was verified for hybrid. An unclassified network gets no
+      # letter either: honouring one would be assuming an ircd, and the cost
+      # of assuming wrong is a throttle switched OFF for a connection the
+      # upstream still meters.
+      assert FloodAllowance.no_throttle_umode(:atheme) == nil
+      assert FloodAllowance.no_throttle_umode(:oftc) == nil
+      assert FloodAllowance.no_throttle_umode(:unknown) == nil
+      assert FloodAllowance.no_throttle_umode(nil) == nil
+      assert FloodAllowance.no_throttle_umode(:some_future_ircd) == nil
+    end
+  end
+
+  describe "classify/1 — the upstream allowance this session mirrors" do
+    test "no facts at all reads as ordinary" do
+      # The #216 hot-reload contract: a live proc whose state predates the
+      # fields must answer the SAFE direction, not KeyError-crash.
+      assert FloodAllowance.classify(%{}) == :ordinary
+    end
+
+    test "a session with no oper umode is ordinary" do
+      assert FloodAllowance.classify(%{umodes: ["i", "w"], services_flavor: :azzurra}) ==
+               :ordinary
+    end
+
+    test "an oper'd session gets the oper allowance" do
+      assert FloodAllowance.classify(%{umodes: ["i", "o"], services_flavor: :azzurra}) == :oper
+    end
+
+    test "an oper carrying the flavour's no-throttle letter is exempt" do
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: :azzurra}) == :exempt
+    end
+
+    test "the exempt letter alone, without oper, is NOT exempt" do
+      # bahamut's `F` is an oper flag (OFLAG_UMODEF), so requiring `+o`
+      # alongside costs nothing there. Off bahamut it is the guard that
+      # keeps an unrelated `F` from switching the throttle off for a plain
+      # user we have no reason to trust.
+      assert FloodAllowance.classify(%{umodes: ["F"], services_flavor: :azzurra}) == :ordinary
+    end
+
+    test "the exempt letter is per-flavour: F on a flavour without one is just an oper" do
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: :atheme}) == :oper
+      assert FloodAllowance.classify(%{umodes: ["F", "o"], services_flavor: nil}) == :oper
+    end
+
+    test "the oper letter is o everywhere — it is the one RFC 1459 fixes" do
+      for flavor <- [:azzurra, :atheme, :oftc, :unknown, nil] do
+        assert FloodAllowance.classify(%{umodes: ["o"], services_flavor: flavor}) == :oper
+      end
+    end
+
+    test "an uppercase O is not the oper umode" do
+      # Some ircds spell a local/global distinction with `O`; the letter this
+      # reads is the RFC one, and inventing a union would be the same mistake
+      # #388 refused for the registered letter.
+      assert FloodAllowance.classify(%{umodes: ["O"], services_flavor: :azzurra}) == :ordinary
+    end
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -4877,6 +4877,133 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #480 — the send throttle mirrors the UPSTREAM flood allowance, so the
+  # session answers what that allowance is from the umode set it already
+  # tracks. The letters and their per-flavour table are
+  # `Grappa.Session.FloodAllowance`'s unit contract; what is proven here is
+  # that the live session reads its OWN state and answers over the facade.
+  describe "#480 — upstream flood allowance" do
+    # `welcome_handler/0` is defined further down this module and shared:
+    # `defp` is module-wide, and a second copy here would be the duplicate
+    # the compiler warns about.
+    defp await_umodes(modes) do
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :umode_changed, modes: ^modes}
+                     },
+                     1_000
+
+      :ok
+    end
+
+    test "a session with no oper umode is :ordinary" do
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # Before any 221 the set is empty — the safe direction, not a crash.
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +iw\r\n")
+      :ok = await_umodes(["i", "w"])
+
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper'd session is :oper" do
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # The broadcast is the barrier: the fold has landed before we ask.
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +io\r\n")
+      :ok = await_umodes(["i", "o"])
+
+      assert {:ok, :oper} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper with the flavour's no-throttle umode is :exempt" do
+      {server, port} = start_server(welcome_handler())
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+      {network, _} =
+        network_with_server(
+          port: port,
+          slug: "test-#{System.unique_integer([:positive])}",
+          services_flavor: :azzurra
+        )
+
+      _ = credential_fixture(user, network, %{})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
+      :ok = await_umodes(["F", "o"])
+
+      assert {:ok, :exempt} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the SAME umodes on an unclassified network stop at :oper" do
+      # The exempt letter is per-flavour and only bahamut's was read at
+      # source. `setup_user_and_network` leaves services_flavor nil, which
+      # is what an operator who never classified the network has.
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
+      :ok = await_umodes(["F", "o"])
+
+      assert {:ok, :oper} = Session.get_flood_allowance({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "hot-reload safety: a live proc whose state predates :umodes answers :ordinary" do
+      # Same #216 contract the get_umodes reader carries: a plain hot module
+      # reload does not rewrite live process state, and the throttle asks
+      # this on EVERY send — a KeyError here would crash-wave the sessions
+      # under load rather than degrade to today's numbers.
+      {server, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
+
+      assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "no live session for (subject, network) is :no_session, not a class" do
+      {_, port} = start_server(welcome_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      assert {:error, :no_session} =
+               Session.get_flood_allowance({:user, user.id}, network.id)
+    end
+  end
+
   describe "#249 — supported umodes (server-advertised umode set from 004)" do
     test "004 RPL_MYINFO stores supported umodes + broadcasts on Topic.user" do
       # 004 advertises the server's supported usermode set (param index 3).

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -44,7 +44,11 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   end
 
   defp setup_network(vjt, port, slug \\ "azzurra") do
-    {network, _} = network_with_server(port: port, slug: slug)
+    setup_network(vjt, port, slug, nil)
+  end
+
+  defp setup_network(vjt, port, slug, services_flavor) do
+    {network, _} = network_with_server(port: port, slug: slug, services_flavor: services_flavor)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
     network
   end
@@ -696,6 +700,128 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
       :ok = GenServer.stop(pid1, :normal, 1_000)
       :ok = GenServer.stop(pid2, :normal, 1_000)
+    end
+  end
+
+  # #480 — the throttle mirrors the UPSTREAM allowance, so the numbers it
+  # applies depend on what the ircd published about THIS connection, never
+  # on a grappa-side identity tier. Test config: ordinary burst 3, oper
+  # burst 6, oper refill 0.25/s (`config/test.exs`). The classification
+  # itself is `Grappa.Session.FloodAllowance`'s unit contract; what these
+  # prove is that the send door reaches for a different pair of numbers.
+  describe "POST send throttle — the upstream allowance decides the pair (#480)" do
+    setup do
+      :ets.delete_all_objects(TokenBucket.table_name())
+      :ok
+    end
+
+    # The session must have FOLDED the umode set before the first POST, or
+    # the test races its own fixture: a PING answered is proof the session
+    # processed everything fed before it.
+    defp feed_umodes(server, modes) do
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test #{modes}\r\n")
+      IRCServer.feed(server, "PING :umodes\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :umodes\r\n"), 1_000)
+      :ok
+    end
+
+    test "an oper'd session rides the WIDER burst, and still lands on a 429 at its own ceiling",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+io")
+
+      # Sends 4, 5 and 6 are the discriminating ones: under the ordinary
+      # pair the bucket was empty after 3.
+      for n <- 1..6 do
+        assert json_response(post_body(conn, network, "oper line #{n}"), 201)
+      end
+
+      # Still a bucket, not an open door — the oper allowance is wider,
+      # not absent.
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "oper flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the oper 429 carries the OPER refill interval, not the ordinary one",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+io")
+
+      for n <- 1..6, do: assert(json_response(post_body(conn, network, "oper #{n}"), 201))
+      throttled = post_body(conn, network, "oper flood")
+      assert %{"error" => "rate_limited"} = json_response(throttled, 429)
+
+      # Derived from config, like the #666 ordinary assertion, so the test
+      # tracks the wire contract rather than a magic constant — and the two
+      # intervals are distinct on purpose (4 vs 2).
+      throttle = Application.get_env(:grappa, :send_throttle)
+      expected = Integer.to_string(max(1, ceil(1.0 / throttle[:oper_refill_per_sec])))
+      ordinary = Integer.to_string(max(1, ceil(1.0 / throttle[:refill_per_sec])))
+      refute expected == ordinary
+      assert [^expected] = get_resp_header(throttled, "retry-after")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an oper carrying the network's no-throttle umode is not metered at all",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      # The exempt letter is per-flavour; bahamut's is the one that was read
+      # at source, so the network has to say it is one.
+      network = setup_network(vjt, port, "azzurra", :azzurra)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+Fio")
+
+      # Well past BOTH ceilings (3 ordinary, 6 oper): there is no upstream
+      # throttle to mirror, so grappa mirrors none.
+      for n <- 1..10 do
+        assert json_response(post_body(conn, network, "exempt line #{n}"), 201)
+      end
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the same +F on an unclassified network is metered on the oper pair",
+         %{conn: conn, vjt: vjt} do
+      # No services_flavor: grappa has not been told which ircd this is, so
+      # `F` carries no verified meaning and the exemption is withheld. The
+      # oper tier still applies — the degradation is graceful.
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+Fio")
+
+      for n <- 1..6, do: assert(json_response(post_body(conn, network, "unclassified #{n}"), 201))
+
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "unclassified flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a plain user is metered on today's numbers, unchanged", %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+      :ok = feed_umodes(server, "+iw")
+
+      for n <- 1..3, do: assert(json_response(post_body(conn, network, "plain #{n}"), 201))
+
+      assert %{"error" => "rate_limited"} =
+               json_response(post_body(conn, network, "plain flood"), 429)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
     end
   end
 

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -153,7 +153,11 @@ defmodule Grappa.AuthFixtures do
     visitor_enabled = Keyword.get(attrs, :visitor_enabled, false)
 
     {:ok, network} =
-      Networks.find_or_create_network(%{slug: slug, visitor_enabled: visitor_enabled})
+      Networks.find_or_create_network(%{
+        slug: slug,
+        visitor_enabled: visitor_enabled,
+        services_flavor: Keyword.get(attrs, :services_flavor)
+      })
 
     {:ok, server} =
       Servers.add_server(network, %{


### PR DESCRIPTION
This is a UNION branch: four open PRs, cherry-picked onto `main` unchanged and
gated once, together.

## Why

Each of the four was gated green against a different base, and `main` has since
moved (the `VERSION` bump for the v1.1.0 cut, `4879785c`). Merging them in
sequence on those older greens is the batch-merge fallacy: nothing would have
proven the four green *together*, and every merge would have re-staled the
three behind it. Four rebase-and-re-gate rounds cost roughly the same wall
clock as this one branch, and leave three PRs stale again at the end. One
branch, one gate, one merge.

No commit was edited, squashed or reordered. Each was cherry-picked from its
own merge-base with `main`, in ascending order of blast radius, so a red can be
peeled off the top.

| Issue | Source PR | Source head at pick time | Commits taken | Replayed here as | Brings |
| --- | --- | --- | --- | --- | --- |
| — | #1175 | `a59181a94d80db291b18e2d24d4a3ce80437d185` | `a59181a9` | `c4a1d97e` | dependabot: bump the cic tooling group (2 dev deps) |
| #1277 | #1278 | `cf260e3b8f00ad911f9354d052449f9644debe52` | `cf260e3b` | `275950d1` | reply quote cap 42 → 100 |
| #719 | #1279 | `71ffa4bcb3f5a85fd4f774684dbe24fb8e4be5db` | `81fd3b83`, `71ffa4bc` | `6a0b6a1b`, `ea7cdf7d` | correlate every CTCP verb, not just PING |
| #480 | #1280 | `3600c0b97550a3662be00cd1ac7163085ba6fb3b` | `3390396e`, `3600c0b9` | `65f0b970`, `d76145ed` | send throttle mirrors the upstream oper allowance |

Cherry-picking rewrites the SHAs, so GitHub will not close the four source PRs
on its own and this branch deliberately carries no `Closes` keyword: the source
heads above are the trace for closing them by content, naming this union.

The four touch disjoint files apart from `docs/DESIGN_NOTES.md`, where #719 and
#480 each append one entry; every cherry-pick applied without a conflict.

## What was verified about the assembly itself

- **Per-file numstat is the exact sum of the four contributions**, measured
  before assembly and recomputed after — additions AND deletions, all 26 files,
  1273 / 111 in total.
- **`docs/DESIGN_NOTES.md` is 113 additions / 0 deletions** (45 from #719 + 68
  from #480). The additions count is the tell: the union-merge separator eater
  removes three lines while leaving deletions at zero, so 110/0 would have been
  the failure and it did not happen.
- **Both entry boundaries read correctly on the file**, not just in the diff:
  previous entry's last line, then `<!-- entry #NNN -->` with no blank ahead of
  it, then blank / `---` / blank / heading.
- **Marker census, file-wide:** 8 markers, no duplicates; the two this branch
  adds (`#719`, `#480`) are distinct from each other and from every existing
  one.
- `scripts/design-notes-gate.sh` RC 0 — 2 new entry headings, separator and
  marker present.

## Test plan

- [x] `bun run check` RC 0 — biome + tsc over `src` and `e2e`
- [x] `bun run test` — 282 files / 5366 tests green (5352 before #719's)
- [ ] Elixir gate (`scripts/check.sh`) — needs the COMPILE lane
- [ ] CI
