### PR TITLE
#93: walk the server list on the backoff ladder

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,77 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #93 -->
+
+---
+
+## 2026-08-13 — #93: the outer fail-over loop was already running, it just never advanced
+
+`network_servers` has carried irssi's `(host, port, tls, priority, enabled)`
+shape since the Phase 2 schema, and for just as long only ever the head of
+that list was dialled. A network whose preferred endpoint went down parked
+every session on that endpoint until an operator intervened, however many
+working rows sat behind it. #271 folded this together with its own problem
+into one two-level machine — server as the outer loop, resolved leaf as the
+inner one — and shipped the inner half: `Grappa.IRC.Client` resolves the full
+RR set itself, shuffles it, and rotates across leaves before giving up.
+
+The 2026-08-06 stale-premise audit on the issue called the remainder PARTIAL,
+on the grounds that the backoff half was already shipped (`Session.Backoff`
+plus #100's `@connection_stable_ms` reset gate) and only the server-index
+advance was left. Re-verified a week and a great many commits later against
+`origin/main` `45e88c5e`: still accurate. `pick_server!/1` still took the head
+of `filter(&enabled) |> sort_by({priority, id})`, and `git grep -E
+'failover|next_server'` over `lib` still returned nothing.
+
+What the audit could not see from a cold repo is that **the outer loop needs
+no loop**. The iteration was already running, once per failure, spread across
+process lifetimes: `do_connect/5` fails, the Client stops, the linked
+`Session.Server` exits abnormally, `terminate/2` calls
+`Backoff.record_failure/2` — synchronously, and the docstring says why: so the
+count is visible to the NEXT `init/1` — and the `:transient` supervisor
+restarts the child, whose `init/1` calls the plan's `refresh_plan` closure.
+Every element of `for server in servers_by_priority(enabled)` was in place
+except the part where the body picks a different server. So the fix is to
+resolve at `pick_server!(network, attempt)` with `attempt` read from the
+counter that already exists, and the ring position becomes DERIVED rather than
+tracked: no per-server row of state, nothing to keep in sync, nothing to
+garbage-collect when a server is deleted from under a live session.
+
+The two resolver doors are deliberately NOT the same. `resolve/1` — Bootstrap,
+the `/connect` verb through `SpawnOrchestrator`, `Operator` — stays pinned to
+position 0. That is not a convenience default: those doors mean "start this
+session now" and clear the ladder before spawning, so the preferred endpoint
+is the correct one to try, and reading the counter there would additionally
+race, because `Backoff.reset/2` is a `cast` and a resolve immediately behind
+it can still observe the pre-reset count. The respawn door runs at the one
+moment the counter is authoritative, and it is the only one that walks the
+ring. `pick_server!/2` therefore takes no default argument — a caller that
+does not say which position it wants is a caller that has not decided which
+door it is.
+
+One consequence worth stating plainly, because it is a property of the
+derivation rather than of the original sketch: the exponential ladder remains
+keyed on `(subject, network)`, so it is shared across the whole ring instead
+of one ladder per server row. With three dead endpoints the exponent grows
+1, 2, 3, … across them rather than restarting at the base for each. That is
+the intended reading of "derive instead of duplicate", and it preserves the
+property the ladder exists for — the rate at which we approach an upstream is
+identical to today's whatever the server count, which matters because that
+rate is what got the bouncer's IP k-lined by Azzurra in the first place. A
+single-server network is byte-for-byte unchanged, every attempt folding back
+onto position 0.
+
+Not measured, and not claimed: the wall-clock interval between one endpoint
+and the next. `@connect_failure_sleep_ms` (30s) and the ladder's 5s base are
+source reads, not observations; no stack was stood up for this and no
+end-to-end fail-over was timed. The tests likewise stop at the plan boundary —
+they assert that the respawn door resolves the next endpoint, not that a real
+refused connect reaches that door. That chain is pre-existing behaviour and
+this change does not touch it.
+
+**Apply:** before adding state to advance a retry policy, check whether the
+retry is already counted somewhere that survives the restart — a failure
+counter kept for backoff is usually also the attempt ordinal, and deriving the
+second use from it costs one argument instead of one more thing to keep in
+sync.

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -12,7 +12,7 @@ defmodule Grappa.Networks do
     * `Grappa.Networks` (this module) — network slug CRUD +
       T32 connection-state transitions.
     * `Grappa.Networks.Servers` — server-endpoint CRUD + selection
-      policy (`add_server/2`, `list_servers/1`, `pick_server!/1`,
+      policy (`add_server/2`, `list_servers/1`, `pick_server!/2`,
       `remove_server/3`).
     * `Grappa.Networks.Credentials` — per-(user, network) credential
       lifecycle; `unbind_credential/2` detaches a credential + stops the
@@ -193,12 +193,12 @@ defmodule Grappa.Networks do
   ## Why it refuses on `:no_enabled_server`
 
   A user plus a credential still cannot connect: `SessionPlan.resolve/1`
-  picks a server with `Servers.pick_server!/1`, which raises
+  picks a server with `Servers.pick_server!/2`, which raises
   `NoServerError` when the network owns none that is enabled. Binding
   anyway produces a row that READS as access in every listing and
   fails only at spawn time — so the check happens here, at the
   boundary, and no half-access is ever written. The dialability test is
-  `pick_server!/1` itself, not a re-derived predicate, so the two
+  `pick_server!/2` itself, not a re-derived predicate, so the two
   cannot drift apart.
 
   Not atomic across the three writes, and deliberately so: a network
@@ -239,7 +239,7 @@ defmodule Grappa.Networks do
 
   defp ensure_dialable(%Network{} = network) do
     network = Repo.preload(network, :servers, force: true)
-    _ = Servers.pick_server!(network)
+    _ = Servers.pick_server!(network, 0)
     {:ok, network}
   rescue
     NoServerError -> {:error, :no_enabled_server}

--- a/lib/grappa/networks/no_server_error.ex
+++ b/lib/grappa/networks/no_server_error.ex
@@ -1,6 +1,6 @@
 defmodule Grappa.Networks.NoServerError do
   @moduledoc """
-  Raised by `Grappa.Networks.Servers.pick_server!/1` when a network
+  Raised by `Grappa.Networks.Servers.pick_server!/2` when a network
   resolves to zero enabled server endpoints.
 
   Lives in the `Networks` boundary because the policy is operator-side

--- a/lib/grappa/networks/servers.ex
+++ b/lib/grappa/networks/servers.ex
@@ -72,24 +72,43 @@ defmodule Grappa.Networks.Servers do
   end
 
   @doc """
-  Picks the lowest-priority enabled server for a `network` whose
-  `:servers` association is preloaded. Tie-broken by row id
-  (insertion order) to match `list_servers/1`. Raises
-  `Grappa.Networks.NoServerError` when every server is disabled OR
-  the network has none — operator misconfiguration is loud, never
-  silent.
+  Picks the enabled server at ring position `attempt` for a `network`
+  whose `:servers` association is preloaded. The ring is ordered by
+  `(priority asc, id asc)` — same order `list_servers/1` returns — so
+  `attempt` 0 is the lowest-priority endpoint, 1 the next one, and the
+  ring wraps. Raises `Grappa.Networks.NoServerError` when every server
+  is disabled OR the network has none — operator misconfiguration is
+  loud, never silent.
 
   Pre-A2/A10 this lived in `Grappa.Session.Server`; the cycle
   inversion lifts the policy where it belongs (Networks owns
   server-list semantics, Session just consumes the picked endpoint).
-  Phase 5 fail-over across the rest of the list is the natural
-  evolution from here.
+
+  ## `attempt` is the caller's, and only two values are meaningful (#93)
+
+  This function is pure policy — it owns "which endpoint sits at
+  position N", nothing else. WHO supplies N is the fail-over machine's
+  outer loop, and there are exactly two kinds of caller:
+
+    * a spawn door (Bootstrap, `SpawnOrchestrator`, the `/connect`
+      verb, the `add_network/3` dialability check) passes `0`. Those
+      doors mean "start this session now" and clear the failure ladder
+      first, so the preferred endpoint is the right one to try.
+    * the respawn door — the `refresh_plan` closure both SessionPlans
+      inject — passes `Grappa.Session.Backoff.failure_count/2`. That
+      counter is bumped once per abnormal session exit and survives the
+      `:transient` restart, so it IS the connect-attempt ordinal with no
+      second structure to keep in sync.
+
+  No default argument on purpose: a caller that does not say which
+  position it wants is a caller that has not decided which door it is.
   """
-  @spec pick_server!(Network.t()) :: Server.t()
-  def pick_server!(%Network{servers: servers, id: nid, slug: slug}) when is_list(servers) do
+  @spec pick_server!(Network.t(), non_neg_integer()) :: Server.t()
+  def pick_server!(%Network{servers: servers, id: nid, slug: slug}, attempt)
+      when is_list(servers) and is_integer(attempt) and attempt >= 0 do
     case servers |> Enum.filter(& &1.enabled) |> Enum.sort_by(&{&1.priority, &1.id}) do
-      [server | _] -> server
       [] -> raise NoServerError, network_id: nid, network_slug: slug
+      ring -> Enum.at(ring, rem(attempt, length(ring)))
     end
   end
 

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -3,7 +3,7 @@ defmodule Grappa.Networks.SessionPlan do
   Pure resolver: credential → primitive `t:Grappa.Session.start_opts/0`.
 
   Reads from `Accounts` for the user name, picks the lowest-priority
-  enabled server via `Grappa.Networks.Servers.pick_server!/1`, and
+  enabled server via `Grappa.Networks.Servers.pick_server!/2`, and
   copies the Cloak-decrypted upstream password into the resulting
   primitive opts map. The output carries no `Credential` / `Network` /
   `Server` / `User` struct refs, so the Session boundary stays
@@ -21,6 +21,7 @@ defmodule Grappa.Networks.SessionPlan do
   alias Grappa.IRC.{Identifier, Identity}
   alias Grappa.Networks.{Credential, Credentials, Network, NoServerError, Server, Servers}
   alias Grappa.Repo
+  alias Grappa.Session.Backoff
 
   @doc """
   Resolves `credential` into the fully-flat opts map that
@@ -36,7 +37,7 @@ defmodule Grappa.Networks.SessionPlan do
 
   Two reachable error tags:
 
-    * `{:error, :no_server}` — `Servers.pick_server!/1` raised; the
+    * `{:error, :no_server}` — `Servers.pick_server!/2` raised; the
       network has zero enabled endpoints. Operator action:
       `mix grappa.add_server`.
     * `{:error, :user_not_found}` — `Accounts.get_user!/1` raised;
@@ -53,7 +54,27 @@ defmodule Grappa.Networks.SessionPlan do
   """
   @spec resolve(Credential.t()) ::
           {:ok, Session.start_opts()} | {:error, :no_server | :user_not_found}
-  def resolve(%Credential{} = credential) do
+  def resolve(%Credential{} = credential), do: resolve_attempt(credential, 0)
+
+  # #93 — the ring-aware resolver behind `resolve/1`. `attempt` is the
+  # connect-attempt ordinal `Servers.pick_server!/2` indexes the enabled
+  # endpoint ring with.
+  #
+  # `resolve/1` pins it to 0 and that is not a default argument in
+  # disguise: its callers are the SPAWN doors (Bootstrap, the `/connect`
+  # verb via `SpawnOrchestrator`, `Operator`), which mean "start this
+  # session now" and clear the failure ladder before spawning. Starting
+  # them anywhere but the preferred endpoint would be wrong, and reading
+  # the counter there would additionally race — `Backoff.reset/2` is a
+  # cast, so a resolve immediately after it can still observe the old
+  # count. The RESPAWN door (`refresh_plan` below) is the one that walks
+  # the ring, and it runs at the only moment the counter is authoritative:
+  # `Backoff.record_failure/2` is a synchronous call from the dying
+  # session's `terminate/2`, so the bump has landed before the supervisor's
+  # restart reaches `Session.Server.init/1`.
+  @spec resolve_attempt(Credential.t(), non_neg_integer()) ::
+          {:ok, Session.start_opts()} | {:error, :no_server | :user_not_found}
+  defp resolve_attempt(%Credential{} = credential, attempt) do
     # Caller may pass a credential straight from
     # `Credentials.list_credentials_for_all_users/0` (network preloaded
     # already) or one fresh from `Credentials.get_credential!/2` (assoc
@@ -61,7 +82,7 @@ defmodule Grappa.Networks.SessionPlan do
     # already-loaded assocs, so no extra query for the Bootstrap path.
     credential = Repo.preload(credential, network: :servers)
     user = Accounts.get_user!(credential.user_id)
-    server = Servers.pick_server!(credential.network)
+    server = Servers.pick_server!(credential.network, attempt)
 
     {:ok, build_plan(user, credential.network, credential, server)}
   rescue
@@ -151,10 +172,22 @@ defmodule Grappa.Networks.SessionPlan do
       # returns `:ignore` and the supervisor drops the child
       # permanently. Operator re-spawns once the underlying config
       # is fixed.
+      #
+      # #93 — this is ALSO the outer loop of the two-level fail-over machine
+      # (#271 shipped the inner, per-leaf one inside `Grappa.IRC.Client`).
+      # There is no loop to write: a connect failure kills the Client, the
+      # linked Session.Server exits abnormally, `terminate/2` bumps
+      # `Backoff`, and the `:transient` supervisor lands us right here. So
+      # the endpoint advances by resolving at the failure count — attempt 0
+      # is the preferred server, attempt 1 the next enabled one, wrapping.
+      # The counter is cleared by the #100 sustained-connection gate, so a
+      # session that stays up returns the ring to the preferred endpoint.
       refresh_plan: fn ->
         case Credentials.get_credential_by_ids(user.id, cred.network_id) do
           {:ok, fresh_cred} ->
-            case resolve(fresh_cred) do
+            attempt = Backoff.failure_count({:user, user.id}, cred.network_id)
+
+            case resolve_attempt(fresh_cred, attempt) do
               {:ok, _} = ok -> ok
               {:error, _} -> {:error, :not_found}
             end

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -36,6 +36,7 @@ defmodule Grappa.Visitors.SessionPlan do
   alias Grappa.{Networks, Repo, Session, Visitors}
   alias Grappa.Networks.{Credential, Credentials, NoServerError, Servers}
   alias Grappa.Networks.SessionPlan, as: NetworksSessionPlan
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors.Visitor
 
   @doc """
@@ -54,12 +55,23 @@ defmodule Grappa.Visitors.SessionPlan do
   """
   @spec resolve(Visitor.t(), Networks.Network.t()) ::
           {:ok, Session.start_opts()} | {:error, :network_unconfigured | :no_server}
-  def resolve(%Visitor{} = visitor, %Networks.Network{} = network) do
+  def resolve(%Visitor{} = visitor, %Networks.Network{} = network),
+    do: resolve_attempt(visitor, network, 0)
+
+  # #93 — the ring-aware resolver behind `resolve/2`, mirroring
+  # `Grappa.Networks.SessionPlan.resolve_attempt/2` field for field:
+  # `attempt` indexes the enabled endpoint ring, `resolve/2` pins it to 0
+  # because its callers are the spawn doors (Bootstrap, `Visitors.Login`,
+  # `Operator`) which clear the failure ladder before spawning, and only
+  # the `refresh_plan` closure below — the respawn door — walks it.
+  @spec resolve_attempt(Visitor.t(), Networks.Network.t(), non_neg_integer()) ::
+          {:ok, Session.start_opts()} | {:error, :network_unconfigured | :no_server}
+  defp resolve_attempt(%Visitor{} = visitor, %Networks.Network{} = network, attempt) do
     with {:ok, credential} <- fetch_credential(visitor, network) do
       network = Repo.preload(network, :servers)
 
       try do
-        server = Servers.pick_server!(network)
+        server = Servers.pick_server!(network, attempt)
         {:ok, build_plan(visitor, credential, network, server)}
       rescue
         NoServerError -> {:error, :no_server}
@@ -267,7 +279,13 @@ defmodule Grappa.Visitors.SessionPlan do
                 {:error, :not_found}
 
               %Networks.Network{} = fresh_network ->
-                case resolve(fresh, fresh_network) do
+                # #93 — the respawn door walks the endpoint ring. Same
+                # derivation as the user side: the `:transient` restart that
+                # lands here has already had its failure recorded, so the
+                # counter IS the connect-attempt ordinal.
+                attempt = Backoff.failure_count({:visitor, visitor.id}, network.id)
+
+                case resolve_attempt(fresh, fresh_network, attempt) do
                   {:ok, _} = ok -> ok
                   {:error, _} -> {:error, :not_found}
                 end

--- a/lib/grappa_web/controllers/admin/servers_controller.ex
+++ b/lib/grappa_web/controllers/admin/servers_controller.ex
@@ -18,7 +18,7 @@ defmodule GrappaWeb.Admin.ServersController do
 
   ## Session lifecycle on delete (A-6)
 
-  `DELETE` leaves any live `Session.Server` alone — `Servers.pick_server!/1`
+  `DELETE` leaves any live `Session.Server` alone — `Servers.pick_server!/2`
   is only consulted on (re)connect. Live sockets stay open against
   their current host:port regardless of the DB row. Response body
   surfaces `network_session_count: N` (total live sessions on the

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -29,6 +29,7 @@ defmodule Grappa.NetworksTest do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.{Credential, Credentials, Network, Server, Servers, SessionPlan}
   alias Grappa.PubSub.Topic
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors.Visitor
 
   defp user_fixture(name \\ nil) do
@@ -41,6 +42,24 @@ defmodule Grappa.NetworksTest do
     slug = slug || "net-#{System.unique_integer([:positive])}"
     {:ok, network} = Networks.find_or_create_network(%{slug: slug})
     network
+  end
+
+  # #93 — builds the `{host, enabled}` list as an ascending-priority ring,
+  # binds `user` to it and resolves the spawn-door plan.
+  defp bind_ring(user, net, hosts) do
+    Enum.each(Enum.with_index(hosts, 1), fn {{host, enabled}, priority} ->
+      {:ok, _} =
+        Servers.add_server(net, %{host: host, port: 6667, priority: priority, enabled: enabled})
+    end)
+
+    {:ok, _} =
+      Credentials.bind_credential(user, net, %{
+        nick: "vjt",
+        auth_method: :none,
+        autojoin_channels: []
+      })
+
+    user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
   end
 
   describe "find_or_create_network/1" do
@@ -1738,6 +1757,84 @@ defmodule Grappa.NetworksTest do
       # false branch — same semantics, strictly more informative shape).
       :ok = Credentials.unbind_credential(user, net)
       assert plan.refresh_plan.() == {:error, :not_found}
+    end
+  end
+
+  # #93 — the OUTER loop of the two-level fail-over machine (#271 shipped
+  # the inner, per-leaf one inside `Grappa.IRC.Client`). The iteration
+  # mechanism is the existing `:transient` respawn: every abnormal exit
+  # bumps `Session.Backoff`, the supervisor restarts the session, and
+  # `Session.Server.init/1` calls `refresh_plan`. So the ring position is
+  # DERIVED from the failure counter that already exists — no parallel
+  # per-server state to keep in sync.
+  describe "SessionPlan fail-over ring (#93)" do
+    setup do
+      user = user_fixture()
+      net = network_fixture()
+      on_exit(fn -> Backoff.forget({:user, user.id}) end)
+
+      {:ok, user: user, net: net}
+    end
+
+    test "each recorded failure advances the plan to the next enabled server", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+      assert plan.host == "primary"
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
+    end
+
+    test "the ring wraps back to the primary after the last enabled server", ctx do
+      %{user: user, net: net} = ctx
+
+      assert {:ok, plan} =
+               bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      for expected <- ["secondary", "tertiary", "primary", "secondary"] do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+        assert {:ok, fresh} = plan.refresh_plan.()
+        assert fresh.host == expected
+      end
+    end
+
+    test "a disabled server is not a ring position", ctx do
+      %{user: user, net: net} = ctx
+
+      assert {:ok, plan} =
+               bind_ring(user, net, [{"primary", true}, {"off", false}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
+    end
+
+    test "clearing the failure history puts the ring back on the primary", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, %{host: "secondary"}} = plan.refresh_plan.()
+
+      :ok = Backoff.forget({:user, user.id})
+      assert {:ok, back} = plan.refresh_plan.()
+      assert back.host == "primary"
+    end
+
+    # The spawn doors (Bootstrap, SpawnOrchestrator, the /connect verb) mean
+    # "start this session now", and they reset the ladder before spawning —
+    # so `resolve/1` is pinned to the primary and never reads the counter.
+    # Only the respawn door walks the ring.
+    test "resolve/1 stays on the primary whatever the failure history says", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, _} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+
+      assert {:ok, plan} = user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
+      assert plan.host == "primary"
     end
   end
 

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -419,7 +419,7 @@ defmodule Grappa.NetworksTest do
   # #1158 — the operator-facing verb pair. `bind_credential/3` writes ONE row
   # and is the internal primitive; a user holding only that row still cannot
   # connect, because `SessionPlan.resolve/1` needs the network to own an
-  # ENABLED server (`pick_server!/1` raises otherwise). `add_network/3` is the
+  # ENABLED server (`pick_server!/2` raises otherwise). `add_network/3` is the
   # composition that makes the access real, and every assertion here uses
   # `SessionPlan.resolve/1` as the oracle rather than counting rows: "the
   # credential exists" is exactly the half-truth the verb was introduced to
@@ -1555,7 +1555,7 @@ defmodule Grappa.NetworksTest do
     end
   end
 
-  describe "pick_server!/1 (A2/A10 — lifted from Session.Server)" do
+  describe "pick_server!/2 (A2/A10 — lifted from Session.Server)" do
     test "returns the lowest-priority enabled server, ties broken by id" do
       net = network_fixture()
       {:ok, _} = Servers.add_server(net, %{host: "h1", port: 6667, priority: 5})
@@ -1563,7 +1563,7 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "h3", port: 6667, priority: 1})
 
       preloaded = Repo.preload(net, :servers)
-      assert %Server{host: "h2"} = Servers.pick_server!(preloaded)
+      assert %Server{host: "h2"} = Servers.pick_server!(preloaded, 0)
     end
 
     test "skips disabled servers even when priority would prefer them" do
@@ -1572,7 +1572,7 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "enabled", port: 6667, priority: 5})
 
       preloaded = Repo.preload(net, :servers)
-      assert %Server{host: "enabled"} = Servers.pick_server!(preloaded)
+      assert %Server{host: "enabled"} = Servers.pick_server!(preloaded, 0)
     end
 
     test "raises NoServerError when every server is disabled" do
@@ -1580,13 +1580,73 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, enabled: false})
       preloaded = Repo.preload(net, :servers)
 
-      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded) end
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 0) end
     end
 
     test "raises NoServerError when the network has zero servers" do
       net = network_fixture()
       preloaded = Repo.preload(net, :servers)
-      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded) end
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 0) end
+    end
+
+    # #93 — `attempt` indexes the same `(priority, id)` order `list_servers/1`
+    # returns, so the ring the fail-over machine walks and the list an
+    # operator reads are the same object seen twice.
+    test "attempt indexes the enabled ring in (priority, id) order" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "third", port: 6667, priority: 9})
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 5})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 0)
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 1)
+      assert %Server{host: "third"} = Servers.pick_server!(preloaded, 2)
+    end
+
+    test "attempt wraps around the ring instead of running off its end" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 2})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 2)
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 3)
+      # The counter is unbounded (`Backoff` never caps the count, only the
+      # wait it computes), so a long-dead network keeps indexing safely.
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 1_000_000)
+    end
+
+    test "a disabled server occupies no ring position" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, priority: 2, enabled: false})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 3})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 1)
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 2)
+    end
+
+    test "a single enabled server is every ring position" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "only", port: 6667, priority: 1})
+      preloaded = Repo.preload(net, :servers)
+
+      for attempt <- 0..3 do
+        assert %Server{host: "only"} = Servers.pick_server!(preloaded, attempt)
+      end
+    end
+
+    test "raises NoServerError at any ring position when none is enabled" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, enabled: false})
+      preloaded = Repo.preload(net, :servers)
+
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 7) end
     end
   end
 

--- a/test/grappa/visitors/session_plan_test.exs
+++ b/test/grappa/visitors/session_plan_test.exs
@@ -7,7 +7,8 @@ defmodule Grappa.Visitors.SessionPlanTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Networks.Credentials
+  alias Grappa.Networks.{Credentials, Servers}
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors
   alias Grappa.Visitors.SessionPlan
 
@@ -89,6 +90,25 @@ defmodule Grappa.Visitors.SessionPlanTest do
       {:ok, visitor} = Visitors.find_or_provision_anon("vjt", other.slug, "1.2.3.4")
 
       assert {:error, :network_unconfigured} = SessionPlan.resolve(visitor, network)
+    end
+
+    # #93 — the visitor half of the outer fail-over loop. Same derivation as
+    # the user side (`Grappa.Networks.SessionPlan`): the respawn door reads
+    # the `Session.Backoff` counter the `:transient` cycle already maintains,
+    # so a dead endpoint rolls to the next enabled one instead of parking the
+    # visitor on it forever.
+    test "refresh_plan walks the enabled server ring as failures accrue (#93)" do
+      {network, _} = network_with_server(slug: "azzurra", port: 6667, host: "primary")
+      {:ok, _} = Servers.add_server(network, %{host: "secondary", port: 6667, priority: 9})
+      {:ok, visitor} = Visitors.find_or_provision_anon("vjt-ring", "azzurra", "1.2.3.4")
+      on_exit(fn -> Backoff.forget({:visitor, visitor.id}) end)
+
+      assert {:ok, plan} = SessionPlan.resolve(visitor, network)
+      assert plan.host == "primary"
+
+      :ok = Backoff.record_failure({:visitor, visitor.id}, network.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
     end
 
     # CP24 bucket E lifecycle/S1: visitor plans carry a `credential_failer`


### PR DESCRIPTION
## What

`network_servers` has carried irssi's `(host, port, tls, priority, enabled)`
shape since the Phase 2 schema, but only ever the head of that list was
dialled. A network whose preferred endpoint went down parked every session on
it until an operator intervened, however many working rows sat behind it.

This is the outer loop of the two-level fail-over machine agreed on #271 —
server as outer, resolved leaf as inner. The inner half shipped with #271
(`Grappa.IRC.Client` resolves the RR set itself, shuffles, and rotates across
leaves).

## The finding: the outer loop needed no loop

The iteration was already running, once per failure, spread across process
lifetimes:

`do_connect/5` fails → the Client stops → the linked `Session.Server` exits
abnormally → `terminate/2` calls `Backoff.record_failure/2` **synchronously**
(its docstring says why: so the count is visible to the next `init/1`) → the
`:transient` supervisor restarts the child → `init/1` calls the plan's
`refresh_plan` closure.

Every element of `for server in servers_by_priority(enabled)` was in place
except the part where the body picks a different server: the closure
re-resolved the same head forever. So the endpoint is now
`pick_server!(network, attempt)` with `attempt` read from the counter that
already exists. The ring position is **derived**, not tracked — no per-server
row of state, nothing to keep in sync, nothing to collect when a server row is
deleted under a live session.

No change to `lib/grappa/irc/client.ex`. It was not needed.

## Two doors, deliberately different

`resolve/1` — Bootstrap, the `/connect` verb via `SpawnOrchestrator`,
`Operator` — stays pinned to ring position 0. Not a convenience default: those
doors mean "start this session now" and clear the ladder before spawning, and
reading the counter there would additionally **race**, because
`Backoff.reset/2` is a `cast` and a resolve immediately behind it can still
observe the pre-reset count. The respawn door runs at the one moment the
counter is authoritative, and it is the only one that walks the ring.

`pick_server!/2` takes no default argument (CLAUDE.md): a caller that does not
say which position it wants is a caller that has not decided which door it is.

## Consequence worth stating

The exponential ladder stays keyed on `(subject, network)`, so it is shared
across the ring rather than one ladder per server row — with three dead
endpoints the exponent grows 1, 2, 3, … across them instead of restarting at
the base for each. That is the intended reading of "derive instead of
duplicate", and it preserves the property the ladder exists for: the rate at
which we approach an upstream is identical to today's whatever the server
count. A single-server network is byte-for-byte unchanged, every attempt
folding back onto position 0.

## Evidence

Red first: the plan-level tests were committed before the implementation and
failed with real assertion diffs (`left: "primary"`, `right: "secondary"`),
RC=2, 5 failures.

Green: `scripts/check.sh` RC=0 — credo `5761 mods/funs, found no issues`,
sobelow `No vulnerabilities found`, doctor passed, `8 doctests, 59 properties,
6062 tests, 0 failures`, dialyzer `Total errors: 0 … done (passed
successfully)`, bats 471 tests with zero `not ok`.

Mutation: 5 mutants injected, 5 killed, attributed so that policy and
plumbing are proven separately (one mutant covering both sides would be
vacuous).

| mutant | injection | killed |
|---|---|---|
| m1 | `Enum.at(ring, 0)` — `attempt` ignored | 8 (3 pure ring units, 4 plan, 1 visitor) |
| m2 | `rem(attempt + 1, …)` | 10, including the "spawn door stays on the primary" guard |
| m3 | `enabled` filter dropped | 7, of which 4 pre-existing (`no_server`, `add_network/3` refusal) |
| m4 | user respawn door → `resolve_attempt(cred, 0)` | **only** the 4 user-plan tests |
| m5 | visitor respawn door → `…, 0` | **exactly 1**, the visitor test |

m4/m5 are the load-bearing ones: each side's wiring is covered independently
of the policy in `pick_server!/2`, and the visitor side is not passing in the
user side's wake. m2 is what keeps the primary-pinning guard from being
decorative — no other mutant touched it.

## Not measured, not claimed

No wall-clock magnitude for fail-over. `@connect_failure_sleep_ms` (30s) and
the ladder's 5s base are source reads, not observations; no stack was stood up
and no end-to-end fail-over was timed.

The tests also stop at the plan boundary: they assert that the respawn door
resolves the next endpoint, not that a real refused connect reaches that door.
That chain is pre-existing behaviour and this change does not touch it — but
it is not re-proven here either.