### PR TITLE
cic(#359): Alt+0 jumps to the status window

### DIFF
--- a/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
+++ b/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
@@ -1,0 +1,59 @@
+// GH #359 — Alt+0 jumps to the status/server window (irssi's window 0).
+//
+// Before this, the keyboard could reach channel/query windows (Alt+1..9,
+// index space) and the next unread one (Alt+A), but the status window only
+// with the pointer. Alt+0 is a verb of its own — the status window is NOT in
+// the Alt+1..9 index space — and it resolves to the CURRENT network's status
+// window (`lib/selection.selectStatusWindow`).
+//
+// This spec drives the USER-VISIBLE OUTCOME from inside a channel, with two
+// independent oracles so a sidebar class flipped without the pane following
+// cannot pass:
+//   1. the sidebar selection moves off #bofh onto the `$server` row, and
+//   2. the compose textarea placeholder becomes the server window's
+//      (`message <slug>`, #151) instead of the channel's (`message #bofh`).
+// Both are asserted in their PRE state first, so the gesture is what moves
+// them. On the unfixed code Alt+0 is an unbound key: the channel stays
+// selected and the placeholder never changes — the spec goes RED.
+//
+// Desktop only: the chord needs a physical Alt, and #359 exists precisely
+// because a keyboard-driven operator had no route. The mobile route to the
+// same window is the BottomBar network header, already covered elsewhere
+// (e.g. issue151-server-placeholder).
+
+import { composeTextarea, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#359 — Alt+0 from inside a channel focuses the status/server window", async ({ page }) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+
+  // Barrier: the channel window is really focused (REST page landed + WS
+  // subscribed) before the gesture, so nothing else can be moving focus.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const channelRow = sidebarWindow(page, NETWORK_SLUG, CHANNEL);
+  // `windowName === networkSlug` resolves to the `$server` row.
+  const serverRow = sidebarWindow(page, NETWORK_SLUG, NETWORK_SLUG);
+  const ta = composeTextarea(page);
+
+  // PRE state, both oracles: the channel is selected and the server window
+  // is not. Without this the post-assertions could hold for a run that never
+  // left the status window.
+  await expect(channelRow).toHaveClass(/selected/, { timeout: 10_000 });
+  await expect(serverRow).not.toHaveClass(/selected/);
+  await expect(ta).toHaveAttribute("placeholder", `message ${CHANNEL}`);
+
+  // The gesture. Focus sits in the compose box after selectChannel — the nav
+  // chords deliberately fire regardless of the focus target, as Alt+1..9 do.
+  await page.keyboard.press("Alt+0");
+
+  await expect(serverRow).toHaveClass(/selected/, { timeout: 10_000 });
+  await expect(channelRow).not.toHaveClass(/selected/);
+  // The pane followed, not just the sidebar row: the compose box is now the
+  // server window's (`message <slug>`, the #151 friendly label).
+  await expect(ta).toHaveAttribute("placeholder", `message ${NETWORK_SLUG}`);
+});

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -38,7 +38,12 @@ import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/ne
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock, overlayCount } from "./lib/overlayScrollLock";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
-import { closeToPreviousWindow, selectedChannel, setSelectedChannel } from "./lib/selection";
+import {
+  closeToPreviousWindow,
+  selectedChannel,
+  selectStatusWindow,
+  setSelectedChannel,
+} from "./lib/selection";
 import { settingsOpenTick } from "./lib/settingsNav";
 import { isMobile } from "./lib/theme";
 import { bindEdgeGesture } from "./lib/touchGesture";
@@ -371,6 +376,10 @@ const Shell: Component = () => {
       if (target)
         setSelectedChannel({ networkSlug: target.slug, channelName: target.name, kind: "channel" });
     },
+    // GH #359 — Alt+0. The status window is outside the Alt+1..9 index
+    // space, so this is a distinct verb; the selection store owns which
+    // network's status window it resolves to.
+    selectStatusWindow: () => selectStatusWindow(),
     // GH #235 — next/prev unread now route through the shared
     // `activeWindows` ordering (mention/query tier first, chronological
     // within a tier, cycling), the SAME verb the Alt+A keybinding and

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -141,6 +141,7 @@ let handlers: KeybindingHandlers;
 beforeEach(() => {
   handlers = {
     selectChannelByIndex: vi.fn(),
+    selectStatusWindow: vi.fn(),
     nextUnread: vi.fn(),
     prevUnread: vi.fn(),
     insertIntoCompose: vi.fn(),

--- a/cicchetto/src/__tests__/keybindings.test.ts
+++ b/cicchetto/src/__tests__/keybindings.test.ts
@@ -14,6 +14,7 @@ let handlers: KeybindingHandlers;
 beforeEach(() => {
   handlers = {
     selectChannelByIndex: vi.fn(),
+    selectStatusWindow: vi.fn(),
     nextUnread: vi.fn(),
     prevUnread: vi.fn(),
     insertIntoCompose: vi.fn(),
@@ -39,6 +40,24 @@ describe("keybindings", () => {
 
     dispatch({ key: "9", altKey: true });
     expect(handlers.selectChannelByIndex).toHaveBeenCalledWith(8);
+  });
+
+  it("Alt+0 dispatches selectStatusWindow (GH #359 jump to the status window)", () => {
+    // Matched on `e.code`, like the Alt+A sibling: on a macOS US layout
+    // Option+0 composes `e.key` into "º", so a key-based match would miss
+    // the chord on exactly the platform this session runs on.
+    dispatch({ code: "Digit0", key: "º", altKey: true });
+    expect(handlers.selectStatusWindow).toHaveBeenCalledTimes(1);
+    // It is NOT an index jump: the status window is outside the Alt+1..9
+    // index space (channels/queries only).
+    expect(handlers.selectChannelByIndex).not.toHaveBeenCalled();
+    // ...and it must not leak into the compose auto-focus path.
+    expect(handlers.insertIntoCompose).not.toHaveBeenCalled();
+  });
+
+  it("Digit0 without Alt does NOT dispatch selectStatusWindow", () => {
+    dispatch({ code: "Digit0", key: "0" });
+    expect(handlers.selectStatusWindow).not.toHaveBeenCalled();
   });
 
   it("Ctrl+N dispatches nextUnread", () => {

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -1855,6 +1855,95 @@ describe("selection store", () => {
     });
   });
 
+  // #359 — Alt+0 jumps to the status/server window. The verb resolves WHICH
+  // network's status window purely from live state (the selection's own
+  // network, else the first one in the sidebar's order) — no parallel
+  // "current network" store to drift.
+  describe("selectStatusWindow (#359)", () => {
+    const net = (id: number, slug: string) => ({
+      kind: "user" as const,
+      id,
+      slug,
+      nick: "alice",
+      connection_state: "connected" as const,
+      connection_state_reason: null,
+      connection_state_changed_at: null,
+      inserted_at: "",
+      updated_at: "",
+    });
+
+    it("selects the CURRENT network's server window, not the first network's", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([net(1, "freenode"), net(2, "azzurra")]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359a");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(2));
+
+      selection.setSelectedChannel({
+        networkSlug: "azzurra",
+        channelName: "#italia",
+        kind: "channel",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()).toEqual({
+        networkSlug: "azzurra",
+        channelName: "$server",
+        kind: "server",
+      });
+    });
+
+    it("falls back to the first network when the selection has no network (home)", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([net(1, "freenode"), net(2, "azzurra")]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359b");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(2));
+
+      selection.setSelectedChannel({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()).toEqual({
+        networkSlug: "freenode",
+        channelName: "$server",
+        kind: "server",
+      });
+    });
+
+    it("is a no-op when no network is bound", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359c");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(0));
+
+      selection.setSelectedChannel({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()?.kind).toBe("home");
+    });
+  });
+
   describe("followQueryNick (#373 — focus follows a peer NICK)", () => {
     it("migrates the selection when the exact query window is focused", async () => {
       localStorage.setItem("grappa-token", "tok");

--- a/cicchetto/src/lib/keybindings.ts
+++ b/cicchetto/src/lib/keybindings.ts
@@ -23,6 +23,7 @@ import { runTopmostOverlayEscape } from "./overlayScrollLock";
 
 export type KeybindingHandlers = {
   selectChannelByIndex: (idx: number) => void; // Alt+1..9 → idx 0..8
+  selectStatusWindow: () => void; // Alt+0
   nextUnread: () => void; // Ctrl+N
   prevUnread: () => void; // Ctrl+P
   insertIntoCompose: (char: string) => void; // any printable key off-compose
@@ -78,6 +79,18 @@ function onKeydown(e: KeyboardEvent): void {
   if (e.altKey && /^[1-9]$/.test(e.key)) {
     e.preventDefault();
     handlers.selectChannelByIndex(Number(e.key) - 1);
+    return;
+  }
+
+  // GH #359 — Alt+0 jumps to the status/server window (irssi's window 0).
+  // A verb of its own, NOT index 0 of the chord above: that index space is
+  // channels/queries only, the status window is outside it. Matched on
+  // `e.code` for the same reason as the Alt+A chord below — a macOS
+  // Option+digit composes `e.key` (US layout: Option+0 → "º"), so a
+  // key-based match would miss the chord there.
+  if (e.altKey && e.code === "Digit0") {
+    e.preventDefault();
+    handlers.selectStatusWindow();
     return;
   }
 

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -850,6 +850,31 @@ const exports = identityScopedStore((onIdentityChange) => {
     });
   });
 
+  // #359 — jump to the status/server window (irssi's window 0). The status
+  // window IS an ordinary selection target ({slug, $server, kind: "server"});
+  // what it is NOT is part of the Alt+1..9 index space, which walks
+  // channels/queries only — hence a verb of its own rather than an index.
+  // WHICH network's status window is DERIVED, never stored: the selection's
+  // own network when it has one (channel/query/server/list all carry a real
+  // slug), else the first network in the sidebar's order. The identity-scoped
+  // home/admin windows carry a `$`-sentinel slug that `networkBySlug` does not
+  // know, which is exactly the "no network in focus" signal. No-op when no
+  // network is bound at all.
+  const selectStatusWindow = (): void => {
+    untrack(() => {
+      const sel = selectedChannel();
+      const inFocus =
+        sel !== null && networkBySlug(sel.networkSlug) !== undefined ? sel.networkSlug : undefined;
+      const slug = inFocus ?? (networks() ?? [])[0]?.slug;
+      if (slug === undefined) return;
+      setSelectedChannel({
+        networkSlug: slug,
+        channelName: SERVER_WINDOW_NAME,
+        kind: "server",
+      });
+    });
+  };
+
   // #373 — a query window's peer renamed (observed via a per-channel
   // NICK). If THIS device has that exact query window focused, follow the
   // rename so the focused window keeps routing to the live nick — an
@@ -881,6 +906,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     setSelectedChannel,
     isActiveSelection,
     closeToPreviousWindow,
+    selectStatusWindow,
     setServerSeedCount,
     applySeedEnvelope,
     setCursorIfAdvances,
@@ -896,6 +922,7 @@ export const selectedChannel = exports.selectedChannel;
 export const setSelectedChannel = exports.setSelectedChannel;
 export const isActiveSelection = exports.isActiveSelection;
 export const closeToPreviousWindow = exports.closeToPreviousWindow;
+export const selectStatusWindow = exports.selectStatusWindow;
 export const setServerSeedCount = exports.setServerSeedCount;
 export const applySeedEnvelope = exports.applySeedEnvelope;
 export const setCursorIfAdvances = exports.setCursorIfAdvances;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,47 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #359 -->
+
+---
+
+## 2026-08-13 — #359: the status window was never unaddressable, it was just outside the index space
+
+`Alt+1..9` selected windows by index and `Alt+A` jumped to the next unread
+one, but nothing on the keyboard reached the per-network status window. #359
+filed that gap together with a diagnosis: the status window "is not part of
+the `ActiveWindow` model", so the plumbing to make it selectable at all is
+the real work. Measured, the second half is wrong in a way worth writing
+down, because it is the kind of wrong that grows a parallel window model.
+
+`ActiveWindow` (`activeWindows.ts`) is the ACTIVITY ordering — the tier list
+`Alt+A` walks, and it deliberately excludes server buffers because server
+noise is not activity worth being sent to. `SelectedChannel`
+(`selection.ts`) is the FOCUS model, and there the status window has been an
+ordinary target since UX-4 bucket C: `{slug, "$server", kind: "server"}`, the
+exact tuple the sidebar's network-header row sets on click, backed by real
+`NumericRouter` scrollback. Two models, two jobs. The index space
+`selectChannelByIndex` walks is channels+queries, so the status window is
+genuinely NOT reachable as "index 0" — but that is a statement about one
+verb's domain, not about the window's addressability. The fix is therefore a
+sibling verb (`selectStatusWindow`), not a representation.
+
+Which network's status window is DERIVED at call time, never stored: the
+selection's own network when it has one, else the first network in the
+sidebar's order, else nothing happens. The `$`-sentinel slugs that `home` and
+`admin` carry are unknown to `networkBySlug`, which makes "no network in
+focus" fall out of the existing lookup instead of needing a kind check per
+identity-scoped window — a new one inherits the fallback for free. A stored
+"current network" would have been a second copy of what the selection
+already says, with the usual drift bill.
+
+The chord matches `e.code === "Digit0"`, not `e.key`. #235 already recorded
+why for `Alt+A` — a macOS Option+letter composes `e.key` ("å") — and the
+same holds for Option+digit on a US layout (`Option+0` → "º"). **Known
+divergence, deliberately not widened here: `Alt+1..9` still matches
+`/^[1-9]$/` against `e.key`, so those chords are the ones that would miss on
+macOS.** That is a pre-existing defect in a verb #359 does not touch, it
+wants its own issue and its own test, and folding it in would have made this
+change a two-verb refactor. Recorded so the split reads as a decision rather
+than as an oversight — and so the next reader does not "restore consistency"
+by moving the new chord onto the broken side.


### PR DESCRIPTION
## What

`Alt+0` jumps to the current network's status/server window (irssi's window 0).
Before this, the keyboard reached channel/query windows (`Alt+1..9`) and the
next unread one (`Alt+A`), but the status window only with the pointer — so a
keyboard-driven operator, or one on a viewport where the sidebar is a drawer,
had no route back to server notices.

## The issue's diagnosis was wrong, and that shaped the fix

#359 reads the gap as *"the status window is not part of the `ActiveWindow`
model … that plumbing is the real work"*. Measured on the code, it is not:

* `ActiveWindow` (`lib/activeWindows.ts`) is the **activity** ordering — the
  tier list `Alt+A` walks. It excludes server buffers deliberately (server
  noise is not activity worth being sent to).
* `SelectedChannel` (`lib/selection.ts`) is the **focus** model, and there the
  status window has been an ordinary target since UX-4 bucket C:
  `{slug, "$server", kind: "server"}` — the exact tuple the sidebar's
  network-header row sets on click, backed by real `NumericRouter` scrollback.

What the status window *is* outside of is the index space
`selectChannelByIndex` walks (channels + queries). That is a statement about
one verb's domain, not about the window's addressability — so this adds a
**sibling verb**, not a new representation. No parallel window model, nothing
originated client-side.

## How

* `lib/selection.ts` — `selectStatusWindow()`, next to the other selection
  verbs. Which network it means is **derived** at call time: the selection's
  own network when it has one, else the first network in the sidebar's order,
  else no-op. The `$`-sentinel slugs `home`/`admin` carry are unknown to
  `networkBySlug`, so "no network in focus" falls out of the existing lookup
  instead of a per-kind check — a future identity-scoped window inherits the
  fallback for free. No stored "current network" to drift.
* `lib/keybindings.ts` — the `Alt+0` branch, matched on **`e.code ===
  "Digit0"`**, like the `Alt+A` sibling and for the same reason #235 recorded:
  a macOS Option+digit composes `e.key` (US layout `Option+0` → `º`).
* `Shell.tsx` — wires the handler.

## Tests

* `keybindings.test.ts` — `Alt+0` dispatches `selectStatusWindow` and neither
  `selectChannelByIndex` nor the compose auto-focus path; the dispatch carries
  `key: "º"`, so a key-based match fails the test. Plus `Digit0` without Alt is
  a no-op.
* `selection.test.ts` — the verb picks the **current** network's status window
  (not the first one), falls back to the first network from `home`, and no-ops
  with no network bound.
* `e2e/tests/issue359-alt0-status-window.spec.ts` — from inside `#bofh`,
  `Alt+0` focuses the status window. Two independent oracles, both asserted in
  their **pre** state first: the sidebar selection class moves onto the
  `$server` row, and the compose placeholder becomes `message <slug>` (#151) —
  so a sidebar class flipped without the pane following cannot pass.

## Not claimed

* **Not measured on a real macOS browser.** Playwright's `Alt+0` sends
  `key: "0"` + `code: "Digit0"`, so the e2e cannot distinguish the two
  implementations; the `e.code` choice rests on the precedent #235 documented,
  not on a measurement of mine.
* `Alt+1..9` still match on `e.key`, so **those** chords are the ones that
  would miss on macOS. Pre-existing defect in a verb this change does not
  touch — deliberately not widened here, recorded in DESIGN_NOTES so the
  divergence reads as a decision, and worth its own issue.
