### PR TITLE
Make the video upload duration cap a server setting (#201)

### DIFF
--- a/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
@@ -65,7 +65,10 @@ test.describe("UX-6-B admin Settings tab", () => {
     const admin = getSeededAdmin();
     const res = await request.put("/admin/settings", {
       headers: { authorization: `Bearer ${admin.token}` },
-      data: { upload: { active_host: "embedded" } },
+      // #201 — the duration cap joins active_host in the reset: the
+      // video-upload specs probe a ~1s clip against it, so a lowered
+      // value left behind would refuse every one of them.
+      data: { upload: { active_host: "embedded", video_max_duration_seconds: 120 } },
     });
     expect(res.ok()).toBe(true);
   });
@@ -120,5 +123,47 @@ test.describe("UX-6-B admin Settings tab", () => {
     expect(response.status()).toBe(200);
 
     await expect(page.getByTestId("admin-settings-saved")).toBeVisible({ timeout: 5_000 });
+  });
+
+  // #201 — the video duration ceiling became a server setting. Full
+  // round trip: form → PUT → DB → the operator-facing GET that cic's
+  // upload orchestrator reads its ceiling from. The REFUSAL itself
+  // (an over-long clip rejected with a message naming the new value)
+  // is pinned by vitest, not here: the only committed video fixture,
+  // e2e/fixtures/tiny.mp4, is exactly 1.000s (mvhd timescale 1000 /
+  // duration 1000) and the smallest settable ceiling is 1s, so no
+  // admin value can make it too long.
+  test("video duration cap: form → PUT → /api/server-settings (#201)", async ({
+    page,
+    request,
+  }) => {
+    const admin = getSeededAdmin();
+    await adminFriendlyLogin(page, admin);
+    await openAdminPaneAndSettingsTab(page);
+
+    const duration = page.getByTestId("admin-settings-video-max-duration");
+    await expect(duration).toHaveValue("120");
+
+    await duration.fill("45");
+    await page.getByTestId("admin-settings-save").click();
+    await expect(page.getByTestId("admin-settings-saved")).toBeVisible({ timeout: 5_000 });
+
+    // The value the CLIENT reads — same door cic hydrates from at boot.
+    const res = await request.get("/api/server-settings", {
+      headers: { authorization: `Bearer ${admin.token}` },
+    });
+    expect(res.ok()).toBe(true);
+    expect((await res.json()).upload.video_max_duration_seconds).toBe(45);
+  });
+
+  test("422 invalid_setting flags the video duration field (#201)", async ({ page }) => {
+    await adminFriendlyLogin(page, getSeededAdmin());
+    await openAdminPaneAndSettingsTab(page);
+
+    const duration = page.getByTestId("admin-settings-video-max-duration");
+    await duration.fill("0");
+    await page.getByTestId("admin-settings-save").click();
+
+    await expect(duration).toHaveClass(/admin-settings-field-error/, { timeout: 5_000 });
   });
 });

--- a/cicchetto/src/AdminSettingsTab.tsx
+++ b/cicchetto/src/AdminSettingsTab.tsx
@@ -21,6 +21,10 @@ import { token } from "./lib/auth";
 //   * `upload.global_cap_bytes` — global disk-budget ceiling; uploads
 //     reject with 507 insufficient_storage when total live bytes +
 //     incoming would exceed the cap.
+//   * `upload.video_max_duration_seconds` — video duration ceiling
+//     (#201). Unlike the byte caps this one is enforced CLIENT-side:
+//     duration is probed from the file in the browser, so an over-long
+//     clip is refused before a single byte is POSTed.
 //
 // State model: same shape as `AdminVisitorsTab` (fetch on mount,
 // explicit refresh, splice-on-save). UI units differ from wire:
@@ -64,6 +68,9 @@ const AdminSettingsTab: Component = () => {
   const [documentCapMB, setDocumentCapMB] = createSignal<number>(10);
   const [audioCapMB, setAudioCapMB] = createSignal<number>(25);
   const [globalCapGB, setGlobalCapGB] = createSignal<number>(10);
+  // #201 — seconds on the wire AND in the form: a duration cap has no
+  // unit conversion to hide, unlike the MB/GB byte fields above.
+  const [videoMaxDurationS, setVideoMaxDurationS] = createSignal<number>(120);
 
   const applyView = (view: AdminSettingsView): void => {
     setSettings(view);
@@ -73,6 +80,7 @@ const AdminSettingsTab: Component = () => {
     setDocumentCapMB(view.upload.document_per_file_cap_bytes / MIB);
     setAudioCapMB(view.upload.audio_per_file_cap_bytes / MIB);
     setGlobalCapGB(view.upload.global_cap_bytes / GIB);
+    setVideoMaxDurationS(view.upload.video_max_duration_seconds);
   };
 
   // One row per per-type cap (uploads cluster Task 7) — same markup,
@@ -142,6 +150,7 @@ const AdminSettingsTab: Component = () => {
           document_per_file_cap_bytes: Math.round(documentCapMB() * MIB),
           audio_per_file_cap_bytes: Math.round(audioCapMB() * MIB),
           global_cap_bytes: Math.round(globalCapGB() * GIB),
+          video_max_duration_seconds: Math.round(videoMaxDurationS()),
         },
       });
       applyView(view);
@@ -261,6 +270,31 @@ const AdminSettingsTab: Component = () => {
                     disabled={saving()}
                     classList={{
                       "admin-settings-field-error": fieldError() === "upload.global_cap_bytes",
+                    }}
+                  />
+                </AdminField>
+
+                <AdminField
+                  label="Video max duration (s)"
+                  for="admin-settings-video-max-duration"
+                  error={
+                    fieldError() === "upload.video_max_duration_seconds"
+                      ? "must be positive"
+                      : undefined
+                  }
+                >
+                  <input
+                    id="admin-settings-video-max-duration"
+                    data-testid="admin-settings-video-max-duration"
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={videoMaxDurationS()}
+                    onInput={(e) => setVideoMaxDurationS(Number(e.currentTarget.value))}
+                    disabled={saving()}
+                    classList={{
+                      "admin-settings-field-error":
+                        fieldError() === "upload.video_max_duration_seconds",
                     }}
                   />
                 </AdminField>

--- a/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
@@ -36,6 +36,7 @@ const DEFAULTS: AdminSettingsView = {
     document_per_file_cap_bytes: 10 * 1024 * 1024,
     audio_per_file_cap_bytes: 25 * 1024 * 1024,
     global_cap_bytes: 10 * 1024 * 1024 * 1024,
+    video_max_duration_seconds: 90,
   },
 };
 
@@ -65,6 +66,7 @@ describe("AdminSettingsTab — initial render", () => {
         document_per_file_cap_bytes: 15 * 1024 * 1024,
         audio_per_file_cap_bytes: 30 * 1024 * 1024,
         global_cap_bytes: 20 * 1024 * 1024 * 1024,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -89,6 +91,12 @@ describe("AdminSettingsTab — initial render", () => {
 
     const global = screen.getByTestId("admin-settings-global-cap") as HTMLInputElement;
     expect(global.value).toBe("20");
+
+    // #201 — seconds straight through, no unit conversion.
+    const videoDuration = screen.getByTestId(
+      "admin-settings-video-max-duration",
+    ) as HTMLInputElement;
+    expect(videoDuration.value).toBe("90");
   });
 
   it("renders an error banner when the initial fetch fails", async () => {
@@ -135,6 +143,11 @@ describe("AdminSettingsTab — save", () => {
     const global = screen.getByTestId("admin-settings-global-cap") as HTMLInputElement;
     fireEvent.input(global, { target: { value: "50" } });
 
+    const videoDuration = screen.getByTestId(
+      "admin-settings-video-max-duration",
+    ) as HTMLInputElement;
+    fireEvent.input(videoDuration, { target: { value: "45" } });
+
     fireEvent.click(screen.getByTestId("admin-settings-save"));
 
     await waitFor(() => {
@@ -146,6 +159,7 @@ describe("AdminSettingsTab — save", () => {
           document_per_file_cap_bytes: 12 * 1024 * 1024,
           audio_per_file_cap_bytes: 20 * 1024 * 1024,
           global_cap_bytes: 50 * 1024 * 1024 * 1024,
+          video_max_duration_seconds: 45,
         },
       });
     });

--- a/cicchetto/src/__tests__/serverSettings.test.ts
+++ b/cicchetto/src/__tests__/serverSettings.test.ts
@@ -15,6 +15,7 @@ const wireUpload = (active_host: ServerSettingsWireUploadView["active_host"]) =>
   document_per_file_cap_bytes: 3,
   audio_per_file_cap_bytes: 5,
   global_cap_bytes: 4,
+  video_max_duration_seconds: 90,
 });
 
 describe("serverSettings() — initial state", () => {
@@ -36,6 +37,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 10_485_760,
         audio_per_file_cap_bytes: 26_214_400,
         global_cap_bytes: 10_737_418_240,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -48,6 +50,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         audio: 26_214_400,
       },
       uploadGlobalCapBytes: 10_737_418_240,
+      uploadVideoMaxDurationSeconds: 90,
       // #324 — absent on the wire → [] (page origin only).
       httpHostAliases: [],
     });
@@ -62,6 +65,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 7_000_000,
         audio_per_file_cap_bytes: 8_000_000,
         global_cap_bytes: 999_999,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -85,6 +89,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 1,
         audio_per_file_cap_bytes: 1,
         global_cap_bytes: 2,
+        video_max_duration_seconds: 90,
       },
     });
     applyServerSettings({
@@ -95,6 +100,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 5,
         audio_per_file_cap_bytes: 7,
         global_cap_bytes: 6,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -102,6 +108,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
       uploadActiveHost: "litterbox",
       uploadPerFileCapBytes: { image: 3, video: 4, document: 5, audio: 7 },
       uploadGlobalCapBytes: 6,
+      uploadVideoMaxDurationSeconds: 90,
       httpHostAliases: [],
     });
   });
@@ -117,6 +124,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 3,
         audio_per_file_cap_bytes: 5,
         global_cap_bytes: 4,
+        video_max_duration_seconds: 90,
       },
       http_host_aliases: ["irc.sindro.me", "irc.sniffo.org"],
     });
@@ -156,6 +164,7 @@ describe("loadServerSettings/0 — REST initial fetch", () => {
             document_per_file_cap_bytes: 9_999_999,
             audio_per_file_cap_bytes: 5_555_555,
             global_cap_bytes: 88_888_888,
+            video_max_duration_seconds: 90,
           },
         }),
     } as unknown as Response);

--- a/cicchetto/src/__tests__/uploadHost.test.ts
+++ b/cicchetto/src/__tests__/uploadHost.test.ts
@@ -31,6 +31,7 @@ const wireUpload = (
   document_per_file_cap_bytes: 10 * 1024 * 1024,
   audio_per_file_cap_bytes: 25 * 1024 * 1024,
   global_cap_bytes: 10 * 1024 * 1024 * 1024,
+  video_max_duration_seconds: 90,
   ...overrides,
 });
 

--- a/cicchetto/src/__tests__/uploadOrchestrator.test.ts
+++ b/cicchetto/src/__tests__/uploadOrchestrator.test.ts
@@ -42,6 +42,7 @@ const vt = vi.hoisted(() => ({
   transcodes: [] as Array<{
     file: File;
     capBytes: number;
+    maxDurationSeconds: number;
     onProgress: (fraction: number) => void;
     signal: AbortSignal;
     resolve: (
@@ -62,15 +63,22 @@ vi.mock("../lib/videoPolicy", async () => {
 
 vi.mock("../lib/videoTranscode", () => ({
   transcodeVideo: vi.fn(
-    (file: File, capBytes: number, onProgress: (fraction: number) => void, signal: AbortSignal) =>
+    (
+      file: File,
+      capBytes: number,
+      maxDurationSeconds: number,
+      onProgress: (fraction: number) => void,
+      signal: AbortSignal,
+    ) =>
       new Promise((resolve) => {
-        vt.transcodes.push({ file, capBytes, onProgress, signal, resolve });
+        vt.transcodes.push({ file, capBytes, maxDurationSeconds, onProgress, signal, resolve });
       }),
   ),
 }));
 
 import { channelKey } from "../lib/channelKey";
 import { sendMessage } from "../lib/scrollback";
+import { setServerSettings } from "../lib/serverSettings";
 import { activeHost, type UploadHost } from "../lib/uploadHost";
 import {
   acknowledgePrivacy,
@@ -710,6 +718,73 @@ describe("video transcode branch", () => {
 
   afterEach(() => {
     warnSpy.mockRestore();
+    setServerSettings(null);
+  });
+
+  // #201 — the duration ceiling is a server setting. These pin the
+  // three things that broke when it was a compile-time const: the
+  // value handed to the transcoder, the value the reject GATE uses on
+  // the capability-fallback path, and the value the operator READS in
+  // the error copy.
+  const settingsWithVideoDuration = (seconds: number): void => {
+    setServerSettings({
+      uploadActiveHost: "embedded",
+      uploadPerFileCapBytes: { image: 1, video: 5 * 1024 * 1024, document: 1, audio: 1 },
+      uploadGlobalCapBytes: 1,
+      uploadVideoMaxDurationSeconds: seconds,
+      httpHostAliases: [],
+    });
+  };
+
+  it("#201: the live server ceiling is what reaches transcodeVideo", async () => {
+    settingsWithVideoDuration(45);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    expect(vt.transcodes[0]?.maxDurationSeconds).toBe(45);
+  });
+
+  it("#201: with no settings snapshot yet, the 120s fallback reaches transcodeVideo", async () => {
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    expect(vt.transcodes[0]?.maxDurationSeconds).toBe(120);
+  });
+
+  it("#201: the too-long copy names the LIVE ceiling, not the constant", async () => {
+    settingsWithVideoDuration(45);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "too_long", durationSeconds: 90 } });
+
+    await vi.waitFor(() =>
+      expect(uploadState(key)?.error).toBe("Video too long (max 45 seconds)."),
+    );
+  });
+
+  it("#201: a whole-minute ceiling still reads in minutes", async () => {
+    settingsWithVideoDuration(60);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "too_long", durationSeconds: 90 } });
+
+    await vi.waitFor(() => expect(uploadState(key)?.error).toBe("Video too long (max 1 minute)."));
+  });
+
+  it("#201: the capability-fallback gate rejects against the LIVE ceiling", async () => {
+    // 90s is under the 120s fallback constant, so only the admin-set
+    // 60s ceiling can reject it on the fallback path.
+    settingsWithVideoDuration(60);
+    triggerUpload(key, slug, channel, videoClip());
+
+    vt.probeDuration.mockResolvedValue(90);
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "failed", message: "encoder blew up" } });
+
+    await vi.waitFor(() => expect(uploadState(key)?.error).toBe("Video too long (max 1 minute)."));
+    expect(pendingResolvers.length).toBe(0);
   });
 
   it("happy path: transcoding phase first, host receives the TRANSCODED file, 🎬 PRIVMSG", async () => {

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1134,6 +1134,80 @@ describe("userTopic", () => {
     });
   });
 
+  // #201 — the duration ceiling rides the existing settings push. The
+  // narrowing for it is deliberately LENIENT (degrade, don't drop)
+  // while the byte caps stay strict; these pin both halves.
+  describe("server_settings_changed arm — video duration cap (#201)", () => {
+    const uploadWire = (extra: Record<string, unknown>): Record<string, unknown> => ({
+      active_host: "embedded",
+      image_per_file_cap_bytes: 1,
+      video_per_file_cap_bytes: 2,
+      document_per_file_cap_bytes: 3,
+      audio_per_file_cap_bytes: 4,
+      global_cap_bytes: 5,
+      ...extra,
+    });
+
+    afterEach(async () => {
+      const ss = await import("../lib/serverSettings");
+      ss.setServerSettings(null);
+    });
+
+    it("carries the server's value into the store", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 45 }),
+        http_host_aliases: [],
+      });
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+    });
+
+    it("degrades an ABSENT value to the 120s fallback and still applies the rest", async () => {
+      // A pre-#201 server omits the field. Dropping the push here would
+      // strand the byte caps too — the additive-only wire contract.
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({}),
+        http_host_aliases: [],
+      });
+      const view = ss.serverSettings();
+      expect(view?.uploadVideoMaxDurationSeconds).toBe(120);
+      expect(view?.uploadPerFileCapBytes.video).toBe(2);
+    });
+
+    it("degrades a malformed value to the fallback, still applying the rest", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: -5 }),
+        http_host_aliases: [],
+      });
+      const view = ss.serverSettings();
+      expect(view?.uploadVideoMaxDurationSeconds).toBe(120);
+      expect(view?.uploadPerFileCapBytes.video).toBe(2);
+    });
+
+    it("a malformed BYTE cap still drops the whole push (strictness unchanged)", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 45 }),
+        http_host_aliases: [],
+      });
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 99, global_cap_bytes: 0 }),
+        http_host_aliases: [],
+      });
+      // Dropped: the store still holds the previous, valid push.
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+    });
+  });
+
   // P-0b — peer_away dispatch.
   describe("peer_away arm", () => {
     it("calls setPeerAway with (network, peer, message)", async () => {

--- a/cicchetto/src/lib/__tests__/videoTranscode.test.ts
+++ b/cicchetto/src/lib/__tests__/videoTranscode.test.ts
@@ -234,7 +234,13 @@ describe("transcodeVideo", () => {
     const controller = new AbortController();
     controller.abort();
 
-    const result = await transcodeVideo(sampleClip(), cap, noProgress, controller.signal);
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      controller.signal,
+    );
 
     expect(result).toEqual({ error: { kind: "failed", message: "aborted" } });
     expect(h.conversionInit).not.toHaveBeenCalled();
@@ -248,6 +254,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -256,10 +263,46 @@ describe("transcodeVideo", () => {
     expect(h.conversionInit).not.toHaveBeenCalled();
   });
 
+  it("#201: the ceiling is the CALLER's value — a lowered cap rejects a clip the fallback allows", async () => {
+    stubWebCodecs();
+    __setProbeDurationForTests(async () => 90);
+
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      60,
+      noProgress,
+      new AbortController().signal,
+    );
+
+    // 90s is comfortably under the 120s fallback constant; only an
+    // admin-lowered 60s ceiling can reject it.
+    expect(result).toEqual({ error: { kind: "too_long", durationSeconds: 90 } });
+    expect(h.conversionInit).not.toHaveBeenCalled();
+  });
+
+  it("#201: a raised ceiling lets a clip past the 120s fallback", async () => {
+    stubWebCodecs();
+    __setProbeDurationForTests(async () => 300);
+
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      600,
+      noProgress,
+      new AbortController().signal,
+    );
+
+    // Same 300s clip the test above rejects at 120 — the only
+    // difference is the ceiling the caller handed down.
+    expect("ok" in result).toBe(true);
+  });
+
   it("gate closed (no WebCodecs) with a legal duration → unsupported, encoder detail", async () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -277,6 +320,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -292,6 +336,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -323,6 +368,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -347,7 +393,13 @@ describe("transcodeVideo", () => {
     });
     const seen: number[] = [];
 
-    await transcodeVideo(sampleClip(), cap, (f) => seen.push(f), new AbortController().signal);
+    await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      (f) => seen.push(f),
+      new AbortController().signal,
+    );
 
     expect(seen).toEqual([0.5]);
   });
@@ -369,6 +421,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -396,6 +449,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -421,6 +475,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -446,7 +501,13 @@ describe("transcodeVideo", () => {
     });
 
     const controller = new AbortController();
-    const pending = transcodeVideo(sampleClip(), cap, noProgress, controller.signal);
+    const pending = transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      controller.signal,
+    );
     await vi.waitFor(() => expect(execute).toHaveBeenCalled());
     controller.abort();
 
@@ -455,7 +516,10 @@ describe("transcodeVideo", () => {
     expect(result).toEqual({ error: { kind: "failed", message: "conversion canceled" } });
   });
 
-  it("MAX_DURATION_SECONDS is the spec'd 120s policy ceiling", () => {
+  // #201 — the constant is the FALLBACK now (pre-snapshot / pre-#201
+  // server); the live ceiling is `upload.video_max_duration_seconds`.
+  // It must keep mirroring the server-side default, so the pin stays.
+  it("MAX_DURATION_SECONDS is the 120s fallback ceiling", () => {
     expect(MAX_DURATION_SECONDS).toBe(120);
   });
 });
@@ -481,7 +545,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     const file = mp4Clip(16);
 
-    const result = await transcodeVideo(file, cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      file,
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     if (!("ok" in result)) throw new Error(`expected ok, got ${JSON.stringify(result)}`);
     expect(result.ok).toBe(file); // same File identity — untouched
@@ -492,7 +562,13 @@ describe("transcodeVideo skip-gate", () => {
     stubWebCodecs();
     h.format = "mov";
 
-    const result = await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect("ok" in result).toBe(true);
     expect(h.conversionInit).toHaveBeenCalled();
@@ -504,7 +580,13 @@ describe("transcodeVideo skip-gate", () => {
     // sampleClip declares video/quicktime; the demuxed container says
     // mp4. The upload would ride the declared type, so the gate must
     // refuse and let the transcode rename it .mp4/video/mp4.
-    await transcodeVideo(sampleClip(), cap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -514,7 +596,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     h.codec = "vp9";
 
-    await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -527,6 +615,7 @@ describe("transcodeVideo skip-gate", () => {
     const result = await transcodeVideo(
       mp4Clip(16 * MiB),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -543,7 +632,13 @@ describe("transcodeVideo skip-gate", () => {
     // 2MiB file — pins condition 4 independently of condition 3.
     const smallCap = 1 * MiB;
 
-    await transcodeVideo(mp4Clip(2 * MiB), smallCap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      mp4Clip(2 * MiB),
+      smallCap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -553,7 +648,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     h.getFormatThrows = true;
 
-    const result = await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect("ok" in result).toBe(true);
     expect(h.conversionInit).toHaveBeenCalled();

--- a/cicchetto/src/lib/serverSettings.ts
+++ b/cicchetto/src/lib/serverSettings.ts
@@ -64,6 +64,13 @@ export type ServerSettingsView = {
   uploadActiveHost: ServerSettingsWireUploadView["active_host"];
   uploadPerFileCapBytes: Record<UploadCategory, number>;
   uploadGlobalCapBytes: number;
+  // #201 — the video duration ceiling, formerly videoPolicy's
+  // compile-time `MAX_DURATION_SECONDS`. Copied raw like the byte caps:
+  // consumers read it through an optional chain
+  // (`serverSettings()?.…  ?? MAX_DURATION_SECONDS`), which covers BOTH
+  // the pre-snapshot null view and a pre-#201 server that omits the
+  // field on the REST blind-cast path.
+  uploadVideoMaxDurationSeconds: number;
   // #324 — the deployment's HTTP host aliases (bare lowercased
   // hostnames the server advertised). `mediaLink.ts` admits an upload
   // link on ANY of them (they share the /uploads store). Always an
@@ -106,6 +113,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         audio: raw.upload.audio_per_file_cap_bytes,
       },
       uploadGlobalCapBytes: raw.upload.global_cap_bytes,
+      uploadVideoMaxDurationSeconds: raw.upload.video_max_duration_seconds,
       // #324 — absent (old server / pre-snapshot / REST blind-cast) → []
       // so mediaLink admits the page origin only (pre-#324 behaviour).
       httpHostAliases: raw.http_host_aliases ?? [],

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import type { ChannelKey } from "./channelKey";
 import { formatBytes } from "./formatBytes";
 import { sendMessage } from "./scrollback";
+import { serverSettings } from "./serverSettings";
 import {
   baseMime,
   categoryOf,
@@ -474,7 +475,29 @@ async function dispatchUpload(
     });
 }
 
-const VIDEO_TOO_LONG_MESSAGE = `Video too long (max ${MAX_DURATION_SECONDS / 60} minutes).`;
+// #201 — the ceiling is a server setting now; MAX_DURATION_SECONDS is
+// only the fallback for the window before the first settings snapshot
+// (and for a pre-#201 server). Read at each gate, never captured in a
+// module const: an admin can move it mid-session and the WS push
+// updates the signal without a reload.
+function videoMaxDurationSeconds(): number {
+  return serverSettings()?.uploadVideoMaxDurationSeconds ?? MAX_DURATION_SECONDS;
+}
+
+// Deliberately NOT `formatDuration` from duration.ts: that one floors
+// (90s → "1m"), which would UNDERSTATE a ceiling and tell the operator
+// a 75s clip was over a "1m" limit. A cap has to name itself exactly.
+function durationLabel(seconds: number): string {
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
+function videoTooLongMessage(maxSeconds: number): string {
+  return `Video too long (max ${durationLabel(maxSeconds)}).`;
+}
 
 // Video transform — Task 6 (2026-06-09). Returns the file to upload
 // (transcoded mp4, or the ORIGINAL on a capability fallback), or null
@@ -510,9 +533,14 @@ async function prepareVideo(
   // size the transcode for the embedded default (50MiB) and let the
   // host's actual limit reject the upload if it disagrees.
   const capBytes = host.maxFileSizeBytes("video") ?? 50 * 1024 * 1024;
+  // Read ONCE per attempt so the gate inside transcodeVideo and the
+  // fallback gate below cannot straddle an admin change mid-upload and
+  // reject against a value the message never named.
+  const maxDurationSeconds = videoMaxDurationSeconds();
   const result = await transcodeVideo(
     file,
     capBytes,
+    maxDurationSeconds,
     (fraction) => {
       if (inflight.get(key)?.controller !== controller) return;
       setEntry(key, { filename: file.name, loaded: fraction, total: 1, phase: "transcoding" });
@@ -530,7 +558,7 @@ async function prepareVideo(
       loaded: 0,
       total: 0,
       phase: "transcoding",
-      error: VIDEO_TOO_LONG_MESSAGE,
+      error: videoTooLongMessage(maxDurationSeconds),
     });
     return null;
   }
@@ -539,14 +567,14 @@ async function prepareVideo(
   console.warn("video transcode unavailable, uploading original:", result.error);
   const durationSeconds = await probeDuration(file);
   if (inflight.get(key)?.controller !== controller) return null; // cancelled
-  if (durationSeconds !== null && durationSeconds > MAX_DURATION_SECONDS) {
+  if (durationSeconds !== null && durationSeconds > maxDurationSeconds) {
     inflight.delete(key);
     setEntry(key, {
       filename: file.name,
       loaded: 0,
       total: 0,
       phase: "transcoding",
-      error: VIDEO_TOO_LONG_MESSAGE,
+      error: videoTooLongMessage(maxDurationSeconds),
     });
     return null;
   }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -54,6 +54,7 @@ import { applyServerSettings } from "./serverSettings";
 import { joinUser } from "./socket";
 import { seedSupportedUmodes } from "./supportedUmodes";
 import { seedUmodes } from "./umodes";
+import { MAX_DURATION_SECONDS } from "./videoPolicy";
 import { setWhoisBundle } from "./whoisCard";
 import { setWhoReply } from "./whoModal";
 import { setWhowasBundle } from "./whowasCard";
@@ -770,6 +771,16 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         !posInt(u.global_cap_bytes)
       )
         return null;
+      // #201 — LENIENT, unlike the caps above: a pre-#201 server omits
+      // the field entirely, and the additive-only wire contract says a
+      // client must not choke on a shape it half-recognises. Hard-
+      // narrowing it here would drop the WHOLE settings push against an
+      // older server and strand the byte caps too. Absent / malformed →
+      // the compile-time default, same degrade-don't-drop posture as
+      // `http_host_aliases` below.
+      const videoMaxDurationSeconds = posInt(u.video_max_duration_seconds)
+        ? u.video_max_duration_seconds
+        : MAX_DURATION_SECONDS;
       // #324 — deployment HTTP host aliases. Lenient: a malformed /
       // absent value degrades to [] (page origin only) rather than
       // dropping the whole settings push (which would strand the upload
@@ -787,6 +798,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
           document_per_file_cap_bytes: u.document_per_file_cap_bytes,
           audio_per_file_cap_bytes: u.audio_per_file_cap_bytes,
           global_cap_bytes: u.global_cap_bytes,
+          video_max_duration_seconds: videoMaxDurationSeconds,
         },
         http_host_aliases: httpHostAliases,
       };

--- a/cicchetto/src/lib/videoPolicy.ts
+++ b/cicchetto/src/lib/videoPolicy.ts
@@ -13,13 +13,20 @@
 //
 // Policy vs capability split (the orchestrator's fallback contract):
 // - `too_long` is POLICY — duration is read via a <video> element's
-//   loadedmetadata, which works WITHOUT WebCodecs, so the 2-minute
+//   loadedmetadata, which works WITHOUT WebCodecs, so the duration
 //   ceiling binds on the no-transcode fallback path too.
 // - capability (WebCodecs presence, codec support) is videoTranscode's
 //   business; see that module.
 //
 // Spec: docs/superpowers/specs/2026-06-09-video-doc-uploads-design.md
 
+// FALLBACK ONLY since #201. The live ceiling is the server setting
+// `upload.video_max_duration_seconds`, which reaches cic on the
+// server-settings snapshot/push; uploadOrchestrator resolves it per
+// attempt and passes it down. This constant is what applies before the
+// first snapshot lands (and against a pre-#201 server), and it mirrors
+// `Grappa.ServerSettings` `@default_upload_video_max_duration_seconds`
+// — the two must move together.
 export const MAX_DURATION_SECONDS = 120;
 const RESOLUTION_THRESHOLD_BPS = 2_000_000;
 // Exported for videoTranscode's skip-gate: a source file's OVERALL

--- a/cicchetto/src/lib/videoTranscode.ts
+++ b/cicchetto/src/lib/videoTranscode.ts
@@ -37,8 +37,8 @@
 // 128kbps audio reserve; a comfortable budget (≥ 2 Mbps) gets 720p,
 // a starved one 480p. Never upscale — mediabunny scales to the
 // requested box unconditionally, so the target is clamped to the
-// source track's display height. The budget math + duration ceiling +
-// probe live in videoPolicy.ts (mediabunny-free) so the orchestrator
+// source track's display height. The budget math + duration-ceiling
+// fallback + probe live in videoPolicy.ts (mediabunny-free) so the orchestrator
 // can import them statically while THIS module — the only mediabunny
 // importer — stays behind a dynamic import() in a lazy chunk (Task 6
 // quality-review follow-up, landed with Task 7, 2026-06-09).
@@ -58,7 +58,6 @@ import {
 } from "mediabunny";
 import {
   AUDIO_BUDGET_BPS,
-  MAX_DURATION_SECONDS,
   pickEncodeBitrate,
   pickTargetHeight,
   probeDuration,
@@ -108,7 +107,7 @@ export function __resetVideoTranscodeSupportForTests(): void {
 //      meaningfully shrink it;
 //   4. size within the cap (an over-cap original MUST transcode —
 //      shrinking is the point).
-// Duration policy (≤ MAX_DURATION_SECONDS) is enforced by the caller
+// Duration policy (≤ maxDurationSeconds) is enforced by the caller
 // before this probe runs. Probe failures return false: an unreadable
 // container falls through to the normal transcode/capability path,
 // which owns the diagnostics.
@@ -149,13 +148,19 @@ async function alreadyTargetShape(
 // --------------------------------------------------------------------
 
 /** Transcode `file` to an adaptive-resolution H.264 mp4 sized for
- *  `capBytes`. Resolves `{ok}` with a fresh `<basename>.mp4` File, or
+ *  `capBytes`, rejecting anything longer than `maxDurationSeconds`.
+ *  Resolves `{ok}` with a fresh `<basename>.mp4` File, or
  *  `{error}` per the policy/capability split in the moduledoc. Honors
  *  `signal`: pre-aborted → immediate failed; mid-flight abort cancels
- *  the conversion. */
+ *  the conversion.
+ *
+ *  Both policy numbers arrive as PARAMETERS (#201): the caller reads
+ *  the live server settings once per attempt, exactly as it already
+ *  did for `capBytes`. This module stays free of the settings signal. */
 export async function transcodeVideo(
   file: File,
   capBytes: number,
+  maxDurationSeconds: number,
   onProgress: (fraction: number) => void,
   signal: AbortSignal,
 ): Promise<{ ok: File } | { error: TranscodeError }> {
@@ -163,7 +168,7 @@ export async function transcodeVideo(
 
   // Policy gate FIRST — binds even when the capability gate is closed.
   const durationSeconds = await probeDuration(file);
-  if (durationSeconds !== null && durationSeconds > MAX_DURATION_SECONDS) {
+  if (durationSeconds !== null && durationSeconds > maxDurationSeconds) {
     return { error: { kind: "too_long", durationSeconds } };
   }
 

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -861,6 +861,7 @@ export const S_ServerSettingsWireUploadView = {
     document_per_file_cap_bytes: "i",
     audio_per_file_cap_bytes: "i",
     global_cap_bytes: "i",
+    video_max_duration_seconds: "i",
   },
 } as const;
 

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -846,6 +846,7 @@ export type ServerSettingsWireUploadView = {
   document_per_file_cap_bytes: number;
   audio_per_file_cap_bytes: number;
   global_cap_bytes: number;
+  video_max_duration_seconds: number;
 };
 
 export type ServerSettingsWireChangedPayload = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,70 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+
+<!-- entry #201 -->
+
+---
+
+## 2026-08-13 — #201: the video duration ceiling becomes a server setting
+
+cic refused videos longer than two minutes because `videoPolicy.ts` said
+`export const MAX_DURATION_SECONDS = 120`. Moving that to
+`upload.video_max_duration_seconds` (pos_integer, default 120) was a
+straight ride down the rails the BYTE cap `upload.video_per_file_cap_bytes`
+already laid: `ServerSettings` accessor pair -> `public_view/0` ->
+`ServerSettings.Wire.upload_view/1` -> the WS snapshot/push and both REST
+doors -> `serverSettings()` -> an admin field. No new mechanism, no
+migration (settings are key/value rows whose defaults live in code, like
+the audio cap before it). Four decisions are worth keeping.
+
+**It is enforced CLIENT-side, and that is not a gap to close.** Duration is
+not a property of the bytes the way size is: reading it means decoding the
+container, and the whole point of the ceiling is to refuse the clip BEFORE
+it is uploaded. So the server publishes the number and cic enforces it,
+while the byte caps stay enforced at `POST /api/uploads` (413) as they
+always were. A hostile client can ignore the duration ceiling; it cannot
+ignore the per-file and global byte caps, and those are what actually bound
+disk. Reading this setting as a security control would be a mistake — it is
+a policy the server states and the client applies.
+
+**The value travels as a PARAMETER, not as a signal read deep in the
+stack.** `transcodeVideo/5` now takes `maxDurationSeconds` next to the
+`capBytes` it already took, and `uploadOrchestrator` resolves both once per
+attempt. The tempting alternative — have `videoPolicy.ts` read
+`serverSettings()` itself — would have put a solid-js store import into the
+one module that is deliberately dependency-free so it can be imported
+statically while its mediabunny-laden sibling stays behind a dynamic
+`import()`. Reading once per attempt also means the gate inside the
+transcoder and the capability-fallback gate in the orchestrator cannot
+straddle an admin change mid-upload and reject against a number the error
+message never named.
+
+**The client narrowing for this field is LENIENT while the byte caps stay
+strict.** `userTopic.ts` hard-rejects a `server_settings_changed` push whose
+byte caps are malformed. Applying that treatment to the new field would
+have meant a cic built with #201 dropping EVERY settings push from a
+pre-#201 server — stranding the byte caps too — which is exactly the
+failure the additive-only wire contract exists to prevent. Absent or
+malformed duration degrades to the compile-time fallback and the rest of
+the push applies, the same degrade-don't-drop posture `http_host_aliases`
+took in #324. `MAX_DURATION_SECONDS` survives as that fallback and must
+keep mirroring `@default_upload_video_max_duration_seconds`.
+
+**The error copy formats the cap exactly, and does not reuse
+`formatDuration`.** That helper floors (90s -> "1m") because it describes
+elapsed spans, where losing the remainder is harmless. A ceiling that
+understates itself tells the operator a 75-second clip exceeded a "1m"
+limit. So the message says "2 minutes" on whole minutes and "45 seconds"
+otherwise.
+
+**What the tests do NOT prove.** There is no end-to-end Playwright run in
+which a real over-long video is refused with a message naming an
+admin-lowered value. The only committed video fixture,
+`cicchetto/e2e/fixtures/tiny.mp4`, is exactly 1.000s (mvhd timescale 1000,
+duration 1000) and the smallest settable ceiling is 1 second, so no admin
+value can make it too long; producing a longer fixture needs ffmpeg, which
+is not available here. The refusal and its copy are pinned by vitest
+through the existing `__setProbeDurationForTests` seam; the e2e covers the
+admin form -> PUT -> `GET /api/server-settings` round trip, which is the
+door cic hydrates from.

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -19,6 +19,7 @@ defmodule Grappa.ServerSettings do
   | `"upload.document_per_file_cap_bytes"`  | `pos_integer()`            | 10_485_760 (10MB)| UX-6-B |
   | `"upload.audio_per_file_cap_bytes"`     | `pos_integer()`            | 26_214_400 (25MB)| audio-uploads |
   | `"upload.global_cap_bytes"`             | `pos_integer()`            | 10_737_418_240 (10GB) | UX-6-B |
+  | `"upload.video_max_duration_seconds"`   | `pos_integer()`            | 120              | #201 |
   | `"addressing.mode"`                     | `:pool_with_reservations \\| :static_mapping_with_reservations` | `:pool_with_reservations` | #543 |
   | `"addressing.static_mapping_prefix"`    | `String.t()` (v6 CIDR) \\| `nil` | `nil`       | #543 |
 
@@ -30,7 +31,7 @@ defmodule Grappa.ServerSettings do
 
   Returns the operator-visible subset for `GET /api/server-settings`:
   the upload block (active_host + the per-category per-file caps +
-  global_cap_bytes) plus `http_host_aliases` — the deployment's HTTP
+  global_cap_bytes + the #201 video duration ceiling) plus `http_host_aliases` — the deployment's HTTP
   host aliases (#324, from `Grappa.HttpHosts`, config-derived not
   DB-backed) that cic's media-link classifier admits. Admin-only
   settings (when added) stay out of this view.
@@ -87,6 +88,7 @@ defmodule Grappa.ServerSettings do
   @key_upload_document_per_file_cap_bytes "upload.document_per_file_cap_bytes"
   @key_upload_audio_per_file_cap_bytes "upload.audio_per_file_cap_bytes"
   @key_upload_global_cap_bytes "upload.global_cap_bytes"
+  @key_upload_video_max_duration_seconds "upload.video_max_duration_seconds"
 
   # Defaults
   @default_upload_active_host :embedded
@@ -99,6 +101,10 @@ defmodule Grappa.ServerSettings do
   # 20260609204800_rename_per_file_cap_setting_to_image.exs).
   @default_upload_audio_per_file_cap_bytes 25 * 1024 * 1024
   @default_upload_global_cap_bytes 10 * 1024 * 1024 * 1024
+  # #201 — the client-side video duration ceiling, formerly cic's
+  # compile-time `MAX_DURATION_SECONDS`. Same 2 minutes it always was;
+  # what changes is that an operator can now move it without a rebuild.
+  @default_upload_video_max_duration_seconds 120
 
   # #543 outbound addressing mode (admin-only — NOT in public_view/0).
   @key_addressing_mode "addressing.mode"
@@ -127,7 +133,8 @@ defmodule Grappa.ServerSettings do
             video_per_file_cap_bytes: pos_integer(),
             document_per_file_cap_bytes: pos_integer(),
             audio_per_file_cap_bytes: pos_integer(),
-            global_cap_bytes: pos_integer()
+            global_cap_bytes: pos_integer(),
+            video_max_duration_seconds: pos_integer()
           },
           http_host_aliases: [String.t()]
         }
@@ -216,6 +223,33 @@ defmodule Grappa.ServerSettings do
   end
 
   def put_upload_global_cap_bytes(_), do: {:error, :invalid_value}
+
+  # ---- upload.video_max_duration_seconds (#201) --------------------
+
+  @doc """
+  Returns the video-upload duration ceiling in seconds (default 120).
+
+  Enforced client-side by cic's upload orchestrator (the duration probe
+  needs the file, which never leaves the browser when the clip is over
+  the ceiling); this setting is what makes that ceiling operator-tunable
+  instead of a compile-time constant.
+  """
+  @spec get_upload_video_max_duration_seconds() :: pos_integer()
+  def get_upload_video_max_duration_seconds do
+    read_cap(
+      @key_upload_video_max_duration_seconds,
+      @default_upload_video_max_duration_seconds
+    )
+  end
+
+  @doc "Pins the video-upload duration ceiling. Positive integer seconds only."
+  @spec put_upload_video_max_duration_seconds(pos_integer()) ::
+          :ok | {:error, :invalid_value | :db_unavailable}
+  def put_upload_video_max_duration_seconds(n) when is_integer(n) and n > 0 do
+    put_raw(@key_upload_video_max_duration_seconds, Integer.to_string(n))
+  end
+
+  def put_upload_video_max_duration_seconds(_), do: {:error, :invalid_value}
 
   # ---- addressing.mode (#543) --------------------------------------
 
@@ -310,7 +344,8 @@ defmodule Grappa.ServerSettings do
         video_per_file_cap_bytes: get_upload_per_file_cap_bytes(:video),
         document_per_file_cap_bytes: get_upload_per_file_cap_bytes(:document),
         audio_per_file_cap_bytes: get_upload_per_file_cap_bytes(:audio),
-        global_cap_bytes: get_upload_global_cap_bytes()
+        global_cap_bytes: get_upload_global_cap_bytes(),
+        video_max_duration_seconds: get_upload_video_max_duration_seconds()
       },
       # #324 — deployment HTTP host aliases (config, not DB): boot-derived
       # in config/runtime.exs, stashed via Grappa.HttpHosts. cic's media-

--- a/lib/grappa/server_settings/wire.ex
+++ b/lib/grappa/server_settings/wire.ex
@@ -71,7 +71,8 @@ defmodule Grappa.ServerSettings.Wire do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          video_max_duration_seconds: pos_integer()
         }
 
   @typedoc """
@@ -96,7 +97,8 @@ defmodule Grappa.ServerSettings.Wire do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          video_max_duration_seconds: pos_integer()
         }) :: upload_view()
   def upload_view(%{} = upload) do
     %{
@@ -105,7 +107,11 @@ defmodule Grappa.ServerSettings.Wire do
       video_per_file_cap_bytes: upload.video_per_file_cap_bytes,
       document_per_file_cap_bytes: upload.document_per_file_cap_bytes,
       audio_per_file_cap_bytes: upload.audio_per_file_cap_bytes,
-      global_cap_bytes: upload.global_cap_bytes
+      global_cap_bytes: upload.global_cap_bytes,
+      # #201 — the video duration ceiling cic enforces client-side. A
+      # duration, not a byte count: it rides the upload subtree because
+      # that is where every other upload policy knob already lives.
+      video_max_duration_seconds: upload.video_max_duration_seconds
     }
   end
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -20,7 +20,9 @@ defmodule GrappaWeb.Admin.SettingsController do
             image_per_file_cap_bytes: pos_integer(),
             video_per_file_cap_bytes: pos_integer(),
             document_per_file_cap_bytes: pos_integer(),
-            global_cap_bytes: pos_integer()
+            audio_per_file_cap_bytes: pos_integer(),
+            global_cap_bytes: pos_integer(),
+            video_max_duration_seconds: pos_integer()
           },
           addressing: %{
             mode: "pool_with_reservations" | "static_mapping_with_reservations",
@@ -39,7 +41,9 @@ defmodule GrappaWeb.Admin.SettingsController do
           "image_per_file_cap_bytes" => pos_integer(),
           "video_per_file_cap_bytes" => pos_integer(),
           "document_per_file_cap_bytes" => pos_integer(),
-          "global_cap_bytes" => pos_integer()
+          "audio_per_file_cap_bytes" => pos_integer(),
+          "global_cap_bytes" => pos_integer(),
+          "video_max_duration_seconds" => pos_integer()
         },
         "addressing" => %{
           "mode" => "pool_with_reservations" | "static_mapping_with_reservations",
@@ -186,6 +190,12 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   defp apply_upload_key("global_cap_bytes", _),
     do: {:error, {:invalid_setting, "upload.global_cap_bytes"}}
+
+  defp apply_upload_key("video_max_duration_seconds", n) when is_integer(n) and n > 0,
+    do: ServerSettings.put_upload_video_max_duration_seconds(n)
+
+  defp apply_upload_key("video_max_duration_seconds", _),
+    do: {:error, {:invalid_setting, "upload.video_max_duration_seconds"}}
 
   # Unknown key — ignore but log at warning level. Tolerant of
   # forward-compat shapes cic might send when an admin opens an

--- a/lib/grappa_web/controllers/server_settings_controller.ex
+++ b/lib/grappa_web/controllers/server_settings_controller.ex
@@ -19,7 +19,9 @@ defmodule GrappaWeb.ServerSettingsController do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          # #201 — video duration ceiling cic enforces before upload.
+          video_max_duration_seconds: pos_integer()
         },
         # #324 — the deployment's HTTP host aliases; cic's media-link
         # classifier admits an upload link on ANY of them. No `kind`

--- a/test/grappa/server_settings/wire_test.exs
+++ b/test/grappa/server_settings/wire_test.exs
@@ -14,7 +14,8 @@ defmodule Grappa.ServerSettings.WireTest do
         video_per_file_cap_bytes: 52_428_800,
         document_per_file_cap_bytes: 10_485_760,
         audio_per_file_cap_bytes: 26_214_400,
-        global_cap_bytes: 10_737_418_240
+        global_cap_bytes: 10_737_418_240,
+        video_max_duration_seconds: 120
       },
       http_host_aliases: aliases
     }
@@ -34,6 +35,7 @@ defmodule Grappa.ServerSettings.WireTest do
       assert payload.upload.document_per_file_cap_bytes == 10_485_760
       assert payload.upload.audio_per_file_cap_bytes == 26_214_400
       assert payload.upload.global_cap_bytes == 10_737_418_240
+      assert payload.upload.video_max_duration_seconds == 120
     end
 
     test "passes litterbox host atom through" do
@@ -61,6 +63,7 @@ defmodule Grappa.ServerSettings.WireTest do
       assert decoded["kind"] == "server_settings_changed"
       assert decoded["upload"]["active_host"] == "embedded"
       assert decoded["upload"]["audio_per_file_cap_bytes"] == 26_214_400
+      assert decoded["upload"]["video_max_duration_seconds"] == 120
       assert decoded["http_host_aliases"] == ["irc.sindro.me"]
     end
 
@@ -78,7 +81,8 @@ defmodule Grappa.ServerSettings.WireTest do
                video_per_file_cap_bytes: 52_428_800,
                document_per_file_cap_bytes: 10_485_760,
                audio_per_file_cap_bytes: 26_214_400,
-               global_cap_bytes: 10_737_418_240
+               global_cap_bytes: 10_737_418_240,
+               video_max_duration_seconds: 120
              } =
                Wire.upload_view(%{
                  active_host: :embedded,
@@ -86,7 +90,8 @@ defmodule Grappa.ServerSettings.WireTest do
                  video_per_file_cap_bytes: 52_428_800,
                  document_per_file_cap_bytes: 10_485_760,
                  audio_per_file_cap_bytes: 26_214_400,
-                 global_cap_bytes: 10_737_418_240
+                 global_cap_bytes: 10_737_418_240,
+                 video_max_duration_seconds: 120
                })
     end
 
@@ -98,7 +103,8 @@ defmodule Grappa.ServerSettings.WireTest do
                  video_per_file_cap_bytes: 2,
                  document_per_file_cap_bytes: 3,
                  audio_per_file_cap_bytes: 5,
-                 global_cap_bytes: 4
+                 global_cap_bytes: 4,
+                 video_max_duration_seconds: 6
                })
     end
 

--- a/test/grappa/server_settings_test.exs
+++ b/test/grappa/server_settings_test.exs
@@ -13,6 +13,10 @@ defmodule Grappa.ServerSettingsTest do
       assert ServerSettings.get_upload_global_cap_bytes() == 10 * 1024 * 1024 * 1024
     end
 
+    test "get_upload_video_max_duration_seconds/0 defaults to 120s" do
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 120
+    end
+
     test "public_view/0 returns defaults under :upload" do
       view = ServerSettings.public_view()
       assert view.upload.active_host == :embedded
@@ -20,6 +24,7 @@ defmodule Grappa.ServerSettingsTest do
       assert view.upload.video_per_file_cap_bytes == 50 * 1024 * 1024
       assert view.upload.document_per_file_cap_bytes == 10 * 1024 * 1024
       assert view.upload.global_cap_bytes == 10 * 1024 * 1024 * 1024
+      assert view.upload.video_max_duration_seconds == 120
       # #324 — the deployment HTTP host alias set is always present (a
       # list; empty when no PHX_HOST is configured, as in test env).
       assert is_list(view.http_host_aliases)
@@ -138,6 +143,30 @@ defmodule Grappa.ServerSettingsTest do
     end
   end
 
+  describe "put_upload_video_max_duration_seconds/1 (#201)" do
+    test "accepts positive integer" do
+      assert :ok = ServerSettings.put_upload_video_max_duration_seconds(45)
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 45
+    end
+
+    test "rejects zero" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds(0)
+    end
+
+    test "rejects negative" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds(-1)
+    end
+
+    test "rejects a non-integer" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds("90")
+    end
+
+    test "a stored non-positive value falls back to the default" do
+      Repo.insert!(%Setting{key: "upload.video_max_duration_seconds", value: "0"})
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 120
+    end
+  end
+
   describe "PubSub broadcast on change" do
     setup do
       Phoenix.PubSub.subscribe(Grappa.PubSub, ServerSettings.topic())
@@ -162,6 +191,15 @@ defmodule Grappa.ServerSettingsTest do
           kind: :server_settings_changed,
           upload: %{video_per_file_cap_bytes: 7_777_777}
         }
+      }
+    end
+
+    test "broadcasts server_settings_changed on put_upload_video_max_duration_seconds" do
+      :ok = ServerSettings.put_upload_video_max_duration_seconds(30)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "event",
+        payload: %{kind: :server_settings_changed, upload: %{video_max_duration_seconds: 30}}
       }
     end
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1240,7 +1240,8 @@ defmodule GrappaWeb.GrappaChannelTest do
           video_per_file_cap_bytes: video_cap,
           document_per_file_cap_bytes: document_cap,
           audio_per_file_cap_bytes: audio_cap,
-          global_cap_bytes: global_cap_bytes
+          global_cap_bytes: global_cap_bytes,
+          video_max_duration_seconds: video_max_duration
         }
       })
 
@@ -1250,6 +1251,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert is_integer(document_cap) and document_cap > 0
       assert is_integer(audio_cap) and audio_cap > 0
       assert is_integer(global_cap_bytes) and global_cap_bytes > 0
+      assert is_integer(video_max_duration) and video_max_duration > 0
     end
 
     test "after-join snapshot: pushes server_settings_changed for visitor socket" do

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -52,6 +52,7 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert upload["document_per_file_cap_bytes"] == 10 * 1024 * 1024
       assert upload["audio_per_file_cap_bytes"] == 25 * 1024 * 1024
       assert upload["global_cap_bytes"] == 10 * 1024 * 1024 * 1024
+      assert upload["video_max_duration_seconds"] == 120
     end
   end
 
@@ -95,6 +96,18 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
                json_response(conn, 200)
 
       assert ServerSettings.get_upload_per_file_cap_bytes(:video) == 25_000_000
+    end
+
+    test "updates video_max_duration_seconds (#201)", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"upload" => %{"video_max_duration_seconds" => 45}})
+
+      assert %{"settings" => %{"upload" => %{"video_max_duration_seconds" => 45}}} =
+               json_response(conn, 200)
+
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 45
     end
 
     test "updates document_per_file_cap_bytes", %{conn: conn, session: session} do
@@ -191,6 +204,21 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert json_response(conn, 422) == %{
                "error" => "invalid_setting",
                "field" => "upload.video_per_file_cap_bytes"
+             }
+    end
+
+    test "422 invalid_setting for zero video_max_duration_seconds (#201)", %{
+      conn: conn,
+      session: session
+    } do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"upload" => %{"video_max_duration_seconds" => 0}})
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "upload.video_max_duration_seconds"
              }
     end
 

--- a/test/grappa_web/controllers/server_settings_controller_test.exs
+++ b/test/grappa_web/controllers/server_settings_controller_test.exs
@@ -23,6 +23,16 @@ defmodule GrappaWeb.ServerSettingsControllerTest do
       assert upload["document_per_file_cap_bytes"] == 10 * 1024 * 1024
       assert upload["audio_per_file_cap_bytes"] == 25 * 1024 * 1024
       assert upload["global_cap_bytes"] == 10 * 1024 * 1024 * 1024
+      assert upload["video_max_duration_seconds"] == 120
+    end
+
+    test "an admin-tuned video duration cap reaches the operator view (#201)", %{conn: conn} do
+      :ok = ServerSettings.put_upload_video_max_duration_seconds(45)
+
+      {_, session} = user_and_session([])
+      conn = conn |> put_bearer(session.id) |> get("/api/server-settings")
+      assert %{"upload" => upload} = json_response(conn, 200)
+      assert upload["video_max_duration_seconds"] == 45
     end
 
     test "response carries the deployment HTTP host aliases (#324)", %{conn: conn} do


### PR DESCRIPTION
## What

The video-upload duration ceiling was a compile-time constant in cic
(`videoPolicy.ts` — `export const MAX_DURATION_SECONDS = 120`), so moving it
meant a rebuild and a redeploy. It becomes the server setting
`upload.video_max_duration_seconds` (pos_integer, default 120), admin-tunable
like every other upload knob.

The change rides the rails the BYTE cap `upload.video_per_file_cap_bytes`
already laid — accessor pair on `Grappa.ServerSettings` → `public_view/0` →
`ServerSettings.Wire.upload_view/1` (one edit feeds the WS snapshot/push AND
both REST doors) → `serverSettings()` → an admin field. No new mechanism.

**No migration.** Settings are key/value rows whose defaults live in code; the
audio cap set that precedent (`@default_upload_audio_per_file_cap_bytes`, no
seed row).

## Corrections to the issue text

The issue's structure holds; several of its line numbers had drifted, and one
call is wrong in kind. Recorded here so #201 stops misleading the next reader:

- `uploadOrchestrator.ts` — import is at `:18` (issue says `:16`),
  `VIDEO_TOO_LONG_MESSAGE` at `:477` (`:409`), the fallback reject gate at
  `:542` (`:474`).
- `AdminSettingsTab.tsx` — `videoCapMB` is at `:63` (`:59`).
- **`videoTranscode.ts:166` is the PRIMARY duration gate, not "an import".**
  The issue lists `videoTranscode.ts:61` only as an import site. That gate runs
  BEFORE the capability gate — it is the one that binds on the WebCodecs-less
  fallback path — so it, not the orchestrator's, is the main enforcement point.
  Both are converted.

## Design calls worth reviewing

**⚠️ This ceiling is NOT an enforced limit — it is enforced client-side only.**
Worth stating plainly, because an operator reading "video max duration" in an
admin panel next to four byte caps will reasonably assume all five behave the
same way, and they do not:

| Setting | Where enforced | What happens if the client ignores it |
|---|---|---|
| `*_per_file_cap_bytes`, `global_cap_bytes` | server, `POST /api/uploads` | rejected — 413 / 507 |
| `video_max_duration_seconds` | **cic only** | the upload proceeds |

The reason is not an oversight to fix later: reading a duration means decoding
the container, and the whole point of the ceiling is to refuse the clip BEFORE
it is uploaded, while the file is still in the browser. So the server publishes
the number and cic applies it. What actually bounds disk is the byte caps,
which are unaffected. The accessor's `@doc` says this too, so the next reader
of `Grappa.ServerSettings` does not mistake it for a control.

**The value travels as a parameter.** `transcodeVideo/5` takes
`maxDurationSeconds` alongside the `capBytes` it already took;
`uploadOrchestrator` resolves both once per attempt. Letting `videoPolicy.ts`
read `serverSettings()` itself would have put a solid-js store import into the
one module kept dependency-free so it can be imported statically while its
mediabunny-laden sibling stays behind a dynamic `import()`. Reading once per
attempt also keeps the transcoder gate and the fallback gate from straddling an
admin change mid-upload and rejecting against a number the message never named.

**The new field's narrowing in `userTopic.ts` is LENIENT while the byte caps
stay strict.** Hard-narrowing it would make a cic built with #201 drop EVERY
settings push from a pre-#201 server — stranding the byte caps too. Absent or
malformed degrades to the fallback and the rest of the push applies: the
additive-only wire contract, same posture `http_host_aliases` took in #324.

**The copy formats the cap exactly instead of reusing `formatDuration`.** That
helper floors (90s → "1m") because it describes elapsed spans; a ceiling that
understates itself tells the operator a 75-second clip exceeded a "1m" limit.
So: "2 minutes" on whole minutes, "45 seconds" otherwise.

## Tests — what they cover, and what they cannot

Covered:

- ExUnit — default, put/get round trip, rejection of zero/negative/non-integer,
  a stored non-positive falling back to the default, the PubSub broadcast, the
  after-join snapshot, both REST doors, and the 422 `invalid_setting` field.
- vitest — the ceiling handed to the transcoder is the live one (and the 120s
  fallback with no snapshot); both reject gates fire against the live value; the
  error copy names it; the lenient-vs-strict narrowing split, including that a
  malformed BYTE cap still drops the whole push.
- e2e (`ux-6-b-admin-settings.spec.ts`) — admin form → PUT →
  `GET /api/server-settings`, the door cic hydrates from, plus the 422 field
  highlight. Run locally, scoped: `Running 2 tests using 1 worker` → `2 passed`
  (the same grep selects 0 tests on the merge base, so the suite gains 2).

**NOT covered, and why:** there is no end-to-end run in which a real over-long
video is refused with a message naming an admin-lowered value. The only
committed video fixture, `cicchetto/e2e/fixtures/tiny.mp4`, is **exactly
1.000s** (mvhd timescale 1000, duration 1000) and the smallest settable ceiling
is 1 second — so no admin value can make it too long. Producing a longer
fixture needs ffmpeg, which is not available in this environment. Rather than
commit a generated video or lower the minimum below 1s, the refusal and its copy
are pinned by vitest through the pre-existing `__setProbeDurationForTests` seam
(introduced in `b760d8df`, five call sites before this branch), and the e2e
covers the round trip.
