### PR TITLE
session(#1286): name the account in the built-in NickServ identify

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41082,3 +41082,88 @@ an existing one, resist adding a parallel delivery path just because the
 *registration* handshake differs — a discriminator field for display, not a
 branch in the sender, keeps one audited path instead of two half-audited
 ones.
+<!-- entry #1286 -->
+
+---
+
+## 2026-08-13 — #1286: the built-in NickServ IDENTIFY names the account, on the flavours measured to take it
+
+grappa's built-in identify at 001 (`Session.Server.run_perform_and_identify/1`
+→ `maybe_builtin_identify/3`) emitted the one-argument
+`PRIVMSG NickServ :IDENTIFY <password>`. That form names no account, so
+services identify **the nick the session is currently wearing**. When the
+configured nick is taken upstream the session is welcomed under an alt, and
+the identify then addresses the alt rather than the account the credential
+belongs to.
+
+#885 had already fixed the twin site — `$nick` in the perform-list expander
+binds the CONFIGURED nick, not the live one — but only there. A user who typed
+a nick and a password into the web form and never touched the perform list got
+the one-argument form, so **the default path was the broken one**. The fix
+reuses #885's `configured_nick/1`; there is no second derivation of "which
+nick is the account".
+
+### Only one route reaches this, not two
+
+The issue supposed the alt could come either from `Grappa.IRC.AuthFSM`'s 433
+ladder or from `Session.GhostRecovery`. Measured, it is only the latter:
+`auth_fsm.ex:481-492` intercepts 432/433 for `auth_method: :nickserv_identify`
+with `{:cont, state, []}`, and the ladder clause sits AFTER it (`:499-507`),
+deliberately — its own comment says a ladder NICK there would race the GHOST
+sequence off its own nick. Since the built-in identify only exists for
+`:nickserv_identify`, the ladder is unreachable from it. One scenario:
+`server.ex`'s 433 arm arming GhostRecovery's underscore NICK.
+
+### Unconditional within a flavour, not "only when the nicks differ"
+
+Naming an account equal to the live nick is the SAME code path as omitting it
+on both daemons that take the form — azzurra sets `sameNick` through
+`str_equals_nocase`, and atheme's one-argument spelling is literally a shift to
+`si->su->nick`. So a "only when they differ" guard buys no behavioural
+difference, and it would have to read `state.nick` at a moment where its
+equality with the configured nick is an ordering accident rather than a
+contract (the caveat already carried by `configured_nick/1`). One code path.
+
+### The operand order is per-flavour, so the form is too
+
+The two-operand spelling is not universal across the services sets grappa
+targets, so the form is selected from `services_flavor` — the same shape
+`IdentityState.registered_umode/1` already uses for the registered-umode
+letter: a small table of measured divergences plus a conservative default.
+Read off each daemon's own handler:
+
+* `:azzurra` — `azzurra/services@23473ed src/nickserv.c:1659` (`do_identify`)
+  takes `nick` then `pass`; the one-argument spelling is an internal shift
+  (`:1697-98`).
+* `:atheme` — `atheme/atheme modules/nickserv/identify.c:29-30`
+  (`ns_cmd_login`) takes `target = parv[0]`, `password = parv[1]`. There it is
+  not merely accepted but the ONLY form on a `no_nick_ownership`
+  configuration: the one-argument shift at `:46-51` is compiled behind that
+  check.
+* `:oftc` — `oftc/oftc-ircservices modules/nickserv.c:721` (`m_identify`)
+  reads its operands in the OPPOSITE order (its own help:
+  `Usage: IDENTIFY password [nick]`, `languages/nickserv.en.lang:31`) and its
+  two-operand form additionally forces a nick change (`:758`). That is a
+  different verb, not a different spelling of this one, so grappa emits no
+  two-operand identify there.
+
+Everything else — `:unknown`, and an unclassified `nil` — takes the
+one-argument form as well. **The account-naming form goes only where it was
+measured, never by assumption**; the default arm is the conservative one, and
+adding a flavour to the table is a deliberate act with a source citation
+attached.
+
+### What the tests can and cannot observe
+
+On every reachable path the live nick and the configured nick are EQUAL at the
+instant the line is built: `state.nick` has exactly two writers, both in
+`EventRouter` (the 001 reconcile at `:1708`, an observed self-NICK at `:3703`),
+the 001 reconcile is delegated at the very end of Server's 001 arm — after the
+identify — and `pending_password` is one-shot, cleared at the first 001 and
+never re-set, so a second 001 emits no identify at all. A wire-level test
+therefore cannot tell which of the two values the line was built from. The
+suite buys that discrimination with a fake ircd that echoes the rename before
+welcoming the alt, which a real ircd does not do, plus an assertion on the
+pre-state so the test cannot pass for the wrong reason. The realistic
+alt-nick scenario is covered separately through the genuine 433 → GhostRecovery
+path.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4276,10 +4276,64 @@ defmodule Grappa.Session.Server do
   # identify.
   @spec maybe_builtin_identify(t(), String.t() | nil, boolean()) :: t()
   defp maybe_builtin_identify(state, secret, false) when is_binary(secret) and secret != "" do
-    send_perform_line(state, "PRIVMSG NickServ :IDENTIFY #{secret}")
+    send_perform_line(state, builtin_identify_line(state, secret))
   end
 
   defp maybe_builtin_identify(state, _, _), do: state
+
+  # GH #1286 — which OPERANDS the built-in identify carries. The
+  # one-argument `IDENTIFY <password>` names no account, so services
+  # identify whatever nick the session is WEARING; land on an alt (the
+  # `Session.GhostRecovery` underscore, the only reachable route here —
+  # `Grappa.IRC.AuthFSM`'s ladder deliberately skips `:nickserv_identify`)
+  # and that is the alt, not the account the credential belongs to. Naming
+  # the account fixes it — the built-in twin of #885's `$nick`, and it
+  # reuses the same `configured_nick/1`, never a second derivation.
+  #
+  # UNCONDITIONAL within a flavour: on both daemons below, naming an
+  # account equal to the live nick is the same code path as omitting it
+  # (azzurra sets `sameNick` via `str_equals_nocase`; atheme's one-argument
+  # form is literally a shift to `si->su->nick`), so a "only when they
+  # differ" guard would buy nothing and would have to read `state.nick` at a
+  # point where its equality with the configured nick is an ordering
+  # accident (see `configured_nick/1`).
+  #
+  # The operand ORDER is not universal, so the form is per-flavour. Read off
+  # each daemon's own handler, not inferred:
+  #
+  #   * `:azzurra` — `azzurra/services@23473ed src/nickserv.c:1659`
+  #     (`do_identify`): `nick = strtok(...)` then `pass = strtok(...)`, and
+  #     the one-argument spelling is an internal shift (`:1697-98`).
+  #   * `:atheme` — `atheme/atheme modules/nickserv/identify.c:29-30`
+  #     (`ns_cmd_login`): `target = parv[0]`, `password = parv[1]`. Naming
+  #     the account is not merely accepted there, it is the ONLY form on a
+  #     `no_nick_ownership` configuration — the one-argument shift at
+  #     `:46-51` is compiled behind that very check.
+  #
+  # Every other flavour keeps the one-argument form, INCLUDING `:unknown`
+  # and an unclassified `nil`: the account-naming form goes only where it
+  # was measured, never by assumption. `:oftc` is a DELIBERATE exclusion
+  # rather than an omission — `oftc/oftc-ircservices modules/nickserv.c:721`
+  # (`m_identify`) reads its operands in the opposite order (its own help
+  # says `Usage: IDENTIFY password [nick]`,
+  # `languages/nickserv.en.lang:31`) and its two-operand form additionally
+  # forces a nick change (`:758`). That is a different verb, not a different
+  # spelling of this one, so grappa does not emit a two-operand identify
+  # there at all.
+  #
+  # `Map.get` for #229 hot-reload safety, mirroring `IdentityState`'s read
+  # of the same field: a process predating `:services_flavor` takes the
+  # conservative arm instead of raising on its next 001.
+  @account_first_identify_flavors [:azzurra, :atheme]
+
+  @spec builtin_identify_line(t(), String.t()) :: String.t()
+  defp builtin_identify_line(state, secret) do
+    if Map.get(state, :services_flavor) in @account_first_identify_flavors do
+      "PRIVMSG NickServ :IDENTIFY #{configured_nick(state)} #{secret}"
+    else
+      "PRIVMSG NickServ :IDENTIFY #{secret}"
+    end
+  end
 
   # Cancel-and-arm the timed `pending_auth` rendezvous slot. Latest-wins
   # serialization for concurrent IDENTIFYs is automatic via Session.Server

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1744,7 +1744,7 @@ defmodule Grappa.Session.ServerTest do
     # on the first NICK, `001 <nick>_` on the second. That IS the #1286
     # scenario — the session is welcomed under an alt.
     defp flavoured_session(port, flavor) do
-      {user, network, _credential} =
+      {user, network, _} =
         setup_user_and_network(port, %{
           nick: "grappa-test",
           auth_method: :nickserv_identify,
@@ -1790,23 +1790,20 @@ defmodule Grappa.Session.ServerTest do
 
       fn state, line ->
         if String.starts_with?(line, "NICK ") do
-          n = :counters.get(counter, 1)
-          :counters.add(counter, 1, 1)
-
-          reply =
-            case n do
-              0 ->
-                ":server 433 * #{nick} :Nickname is already in use.\r\n"
-
-              _ ->
-                ":#{nick}!u@h NICK :#{nick}_\r\n" <>
-                  ":server 001 #{nick}_ :Welcome\r\n"
-            end
-
-          {:reply, reply, state}
+          {:reply, alt_nick_echo_response(counter, nick), state}
         else
           {:reply, nil, state}
         end
+      end
+    end
+
+    defp alt_nick_echo_response(counter, nick) do
+      n = :counters.get(counter, 1)
+      :counters.add(counter, 1, 1)
+
+      case n do
+        0 -> ":server 433 * #{nick} :Nickname is already in use.\r\n"
+        _ -> ":#{nick}!u@h NICK :#{nick}_\r\n:server 001 #{nick}_ :Welcome\r\n"
       end
     end
 
@@ -1918,7 +1915,7 @@ defmodule Grappa.Session.ServerTest do
       # captured the nick instead would stage — and on +r commit — the account
       # name as if it were the secret.
       state = SessionStateHelpers.fetch(pid)
-      assert {"s3cr3t-identify", _deadline} = SessionStateHelpers.pending_auth(state)
+      assert {"s3cr3t-identify", _} = SessionStateHelpers.pending_auth(state)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1728,6 +1728,202 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "built-in identify operand form per services flavour (#1286)" do
+    # The built-in identify at 001 used to be the one-argument
+    # `IDENTIFY <password>`, which names no account — so services identify
+    # whatever nick the session happens to be WEARING. Land on an alt after a
+    # 433 and that is the alt, not the account the credential belongs to.
+    #
+    # #885 already fixed the perform-list twin (`$nick` binds the CONFIGURED
+    # nick); this pins the same account-naming form on the built-in site, and
+    # pins the flavours that do NOT get it. The form is chosen per
+    # `services_flavor` because the operand order is not universal — see
+    # `maybe_builtin_identify/3`'s table for the per-daemon sources.
+    #
+    # Reuses `ghost_handler/1` (defined with the GhostRecovery describe): 433
+    # on the first NICK, `001 <nick>_` on the second. That IS the #1286
+    # scenario — the session is welcomed under an alt.
+    defp flavoured_session(port, flavor) do
+      {user, network, _credential} =
+        setup_user_and_network(port, %{
+          nick: "grappa-test",
+          auth_method: :nickserv_identify,
+          password: "s3cr3t-identify",
+          autojoin_channels: []
+        })
+
+      {:ok, _} = Grappa.Networks.update_network_settings(network, %{services_flavor: flavor})
+
+      # Re-read the credential so `SessionPlan.resolve/1` preloads the network
+      # FRESH — the fixture's struct carries the pre-update association, and a
+      # stale flavour here would silently test the default arm every time.
+      {user, network, Credentials.get_credential!(user, network)}
+    end
+
+    # 433 on the first NICK, then the ircd ECHOES the rename before welcoming
+    # the alt.
+    #
+    # 🔴 A REAL ircd does not send this. The echo exists to make observable a
+    # divergence that on the real path originates from `Session.GhostRecovery`
+    # — and which is otherwise unobservable at the only moment that matters.
+    # Measured, not assumed:
+    #
+    #   * `state.nick` has exactly two writers, both in `EventRouter`: the 001
+    #     reconcile (`event_router.ex:1708`) and an OBSERVED self-NICK
+    #     (`:3703`). `Session.Server` never writes it.
+    #   * The 001 reconcile is reached through `delegate/2` at the very END of
+    #     Server's 001 arm (`server.ex:3228`), i.e. strictly AFTER
+    #     `run_perform_and_identify/1` — so it cannot have moved the nick by
+    #     the time the identify line is built.
+    #   * `pending_password` is one-shot: set at init (`server.ex:1233`),
+    #     cleared at the first 001 (`:4218`), never re-set. So a SECOND 001 —
+    #     the only other way to reach the identify with a diverged nick —
+    #     emits no identify at all.
+    #
+    # Net: on every reachable path the live and configured nicks are EQUAL at
+    # the instant the line is built, which is exactly the "ordering accident"
+    # `configured_nick/1` is commented against (`server.ex:4241-48`). Without
+    # this handler the assertion below would pass no matter which of the two
+    # the line was built from.
+    defp alt_nick_echo_handler(nick) do
+      counter = :counters.new(1, [])
+
+      fn state, line ->
+        if String.starts_with?(line, "NICK ") do
+          n = :counters.get(counter, 1)
+          :counters.add(counter, 1, 1)
+
+          reply =
+            case n do
+              0 ->
+                ":server 433 * #{nick} :Nickname is already in use.\r\n"
+
+              _ ->
+                ":#{nick}!u@h NICK :#{nick}_\r\n" <>
+                  ":server 001 #{nick}_ :Welcome\r\n"
+            end
+
+          {:reply, reply, state}
+        else
+          {:reply, nil, state}
+        end
+      end
+    end
+
+    test "azzurra: the identify names the configured nick while the session wears an alt" do
+      {server, port} = start_server(ghost_handler("grappa-test"))
+      {user, network, credential} = flavoured_session(port, :azzurra)
+
+      pid = nickserv_plan(user, network, credential, 60_000)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY grappa-test s3cr3t-identify\r\n"),
+          2_000
+        )
+
+      # …and the account-blind form is not ALSO emitted.
+      refute "PRIVMSG NickServ :IDENTIFY s3cr3t-identify\r\n" in IRCServer.sent_lines(server)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "atheme: the identify names the configured nick" do
+      {server, port} = start_server()
+      {user, network, credential} = flavoured_session(port, :atheme)
+
+      pid = nickserv_plan(user, network, credential, 60_000)
+
+      :ok = await_handshake(server)
+      IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY grappa-test s3cr3t-identify\r\n"),
+          1_000
+        )
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The account-naming form must never leak onto a flavour that was not
+    # measured to take it, and an unclassified network must take the same
+    # conservative arm as a known-divergent one.
+    for flavor <- [:oftc, :unknown, nil] do
+      test "#{inspect(flavor)}: the identify keeps the account-blind one-argument form" do
+        {server, port} = start_server()
+        {user, network, credential} = flavoured_session(port, unquote(flavor))
+
+        pid = nickserv_plan(user, network, credential, 60_000)
+
+        :ok = await_handshake(server)
+        IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+        {:ok, _} =
+          IRCServer.wait_for_line(
+            server,
+            &(&1 == "PRIVMSG NickServ :IDENTIFY s3cr3t-identify\r\n"),
+            1_000
+          )
+
+        refute Enum.any?(
+                 IRCServer.sent_lines(server),
+                 &String.starts_with?(&1, "PRIVMSG NickServ :IDENTIFY grappa-test ")
+               )
+
+        :ok = GenServer.stop(pid, :normal, 1_000)
+      end
+    end
+
+    test "the identify names the CONFIGURED nick, not the live one, once the two diverge" do
+      {server, port} = start_server(alt_nick_echo_handler("grappa-test"))
+      {user, network, credential} = flavoured_session(port, :azzurra)
+
+      pid = nickserv_plan(user, network, credential, 60_000)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY grappa-test s3cr3t-identify\r\n"),
+          2_000
+        )
+
+      # The premise the assertion above rests on: the live nick really had
+      # moved off the configured one by the time the line went out. Without
+      # this the test passes for the wrong reason.
+      assert SessionStateHelpers.fetch(pid).nick == "grappa-test_"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the account-naming identify still stages the PASSWORD for the +r rendezvous" do
+      {server, port} = start_server()
+      {user, network, credential} = flavoured_session(port, :azzurra)
+
+      pid = nickserv_plan(user, network, credential, 60_000)
+
+      :ok = await_handshake(server)
+      IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY grappa-test s3cr3t-identify\r\n"),
+          1_000
+        )
+
+      # The outbound choke point lifts the LAST token. A second operand that
+      # captured the nick instead would stage — and on +r commit — the account
+      # name as if it were the secret.
+      state = SessionStateHelpers.fetch(pid)
+      assert {"s3cr3t-identify", _deadline} = SessionStateHelpers.pending_auth(state)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "$nickserv_pass resolves from the credential password (#124, retiring #509)" do
     # #509 gave the credential a SECOND NickServ secret that WON over
     # `password_encrypted` and worked on ANY auth method. #124 retired it: one


### PR DESCRIPTION
## What this fixes

The built-in NickServ identify at 001 (`Session.Server.run_perform_and_identify/1`
→ `maybe_builtin_identify/3`) emitted the one-argument
`PRIVMSG NickServ :IDENTIFY <password>`. That form names no account, so services
identify **the nick the session is currently wearing**. When the configured nick
is taken upstream the session is welcomed under an alt, and the identify then
addresses the alt rather than the account the credential belongs to.

#885 had already fixed the twin site — `$nick` in the perform-list expander binds
the CONFIGURED nick — but only there. A user who typed a nick and a password into
the web form and never touched the perform list got the one-argument form, so the
**default path was the broken one**. This reuses the same `configured_nick/1`;
there is no second derivation of "which nick is the account".

## Correction to the issue's premise: one route, not two

The issue supposed the alt nick could arrive either from `Grappa.IRC.AuthFSM`'s
433 ladder or from `Session.GhostRecovery`. Measured, only the latter is
reachable here: `auth_fsm.ex:481-492` intercepts 432/433 for
`auth_method: :nickserv_identify` with `{:cont, state, []}`, and the ladder clause
sits **after** it (`:499-507`) deliberately — its own comment says a ladder NICK
there would race the GHOST sequence off its own nick. The built-in identify only
exists for `:nickserv_identify`, so the ladder cannot be its source. That is the
difference between a fix with one scenario and a fix with two.

## Why the form is chosen per services flavour

The two-operand spelling is not universal across the services sets grappa targets,
so the form is selected from `services_flavor` — the same shape
`IdentityState.registered_umode/1` already uses: a table of measured divergences
plus a conservative default. Each entry is read off that daemon's own handler and
cited in the code:

* `:azzurra` — `azzurra/services@23473ed src/nickserv.c:1659` (`do_identify`):
  `nick` then `pass`; the one-argument spelling is an internal shift (`:1697-98`).
* `:atheme` — `atheme/atheme modules/nickserv/identify.c:29-30` (`ns_cmd_login`):
  `target = parv[0]`, `password = parv[1]`. Not merely accepted — it is the ONLY
  form on a `no_nick_ownership` configuration, where the one-argument shift
  (`:46-51`) is compiled out.
* `:oftc` — `oftc/oftc-ircservices modules/nickserv.c:721` (`m_identify`) reads
  the operands in the opposite order (its own help says
  `Usage: IDENTIFY password [nick]`, `languages/nickserv.en.lang:31`) and its
  two-operand form additionally forces a nick change (`:758`). A different verb,
  not a different spelling — so no two-operand identify is emitted there.

`:unknown` and an unclassified `nil` take the one-argument form too. The
account-naming form goes **only where it was measured**; the default arm is the
conservative one, and adding a flavour is a deliberate act with a citation.

## Unconditional within a flavour

Rather than "only when the live nick differs": on both daemons that take the form,
naming an account equal to the live nick is the same code path as omitting it
(azzurra sets `sameNick` via `str_equals_nocase`; atheme's one-argument form is
literally a shift to `si->su->nick`). The guard would buy no behavioural
difference and would have to read `state.nick` at a point where its equality with
the configured nick is an ordering accident, not a contract — the caveat
`configured_nick/1` already carries.

## Why one test is built on a synthetic wire

🔴 **One test drives a fake ircd that ECHOES the rename before welcoming the alt.
A real ircd does not send that.** It exists to make observable a divergence that
on the real path originates from `Session.GhostRecovery`, and it is called out in
a comment on the helper itself as well as here.

It is there because the divergence is otherwise unobservable at the only moment
that matters. Measured:

1. `state.nick` has exactly two writers, both in `EventRouter`: the 001 reconcile
   (`event_router.ex:1708`) and an OBSERVED self-NICK (`:3703`). `Session.Server`
   never writes it.
2. The 001 reconcile is reached through `delegate/2` at the very end of Server's
   001 arm (`server.ex:3228`) — strictly **after** `run_perform_and_identify/1`,
   so it cannot have moved the nick by the time the line is built.
3. `pending_password` is one-shot: set at init (`server.ex:1233`), cleared at the
   first 001 (`:4218`), never re-set. A second 001 — the only other way to reach
   the identify with a diverged nick — emits no identify at all.

So on every reachable path the live and configured nicks are **equal** when the
line is built, and a wire-level assertion cannot tell which one it came from. The
synthetic echo buys that discrimination; an assertion on the pre-state
(`state.nick == "grappa-test_"`) keeps the test from passing for the wrong reason.
The realistic alt-nick scenario is covered separately, through the genuine
433 → GhostRecovery path.

## Tests

Six, in `test/grappa/session/server_test.exs`:

* `:azzurra` under a real alt nick, via the existing `ghost_handler/1` (433 on the
  first NICK, `001 <nick>_` on the second) — the actual reported scenario.
* `:atheme` names the configured nick.
* `:oftc`, `:unknown` and `nil` keep the one-argument line, as a comprehension —
  regression pins, and these three passed **before** the change, which is the
  point of them.
* the configured-vs-live discriminator described above.
* the account-naming identify still stages the **password** for the `+r`
  rendezvous — if the outbound choke point lifted the wrong token it would commit
  the account name as the secret on `+r`, a silent and persistent corruption.

Red first: 4 failures out of 406, all of them the new behavioural tests, no
pre-existing failures. Green after: 406/0. `scripts/check.sh` clean.
