### PR TITLE
Union: #359, #201 and #93 replayed onto one base

### DIFF
--- a/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
+++ b/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
@@ -1,0 +1,59 @@
+// GH #359 — Alt+0 jumps to the status/server window (irssi's window 0).
+//
+// Before this, the keyboard could reach channel/query windows (Alt+1..9,
+// index space) and the next unread one (Alt+A), but the status window only
+// with the pointer. Alt+0 is a verb of its own — the status window is NOT in
+// the Alt+1..9 index space — and it resolves to the CURRENT network's status
+// window (`lib/selection.selectStatusWindow`).
+//
+// This spec drives the USER-VISIBLE OUTCOME from inside a channel, with two
+// independent oracles so a sidebar class flipped without the pane following
+// cannot pass:
+//   1. the sidebar selection moves off #bofh onto the `$server` row, and
+//   2. the compose textarea placeholder becomes the server window's
+//      (`message <slug>`, #151) instead of the channel's (`message #bofh`).
+// Both are asserted in their PRE state first, so the gesture is what moves
+// them. On the unfixed code Alt+0 is an unbound key: the channel stays
+// selected and the placeholder never changes — the spec goes RED.
+//
+// Desktop only: the chord needs a physical Alt, and #359 exists precisely
+// because a keyboard-driven operator had no route. The mobile route to the
+// same window is the BottomBar network header, already covered elsewhere
+// (e.g. issue151-server-placeholder).
+
+import { composeTextarea, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#359 — Alt+0 from inside a channel focuses the status/server window", async ({ page }) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+
+  // Barrier: the channel window is really focused (REST page landed + WS
+  // subscribed) before the gesture, so nothing else can be moving focus.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const channelRow = sidebarWindow(page, NETWORK_SLUG, CHANNEL);
+  // `windowName === networkSlug` resolves to the `$server` row.
+  const serverRow = sidebarWindow(page, NETWORK_SLUG, NETWORK_SLUG);
+  const ta = composeTextarea(page);
+
+  // PRE state, both oracles: the channel is selected and the server window
+  // is not. Without this the post-assertions could hold for a run that never
+  // left the status window.
+  await expect(channelRow).toHaveClass(/selected/, { timeout: 10_000 });
+  await expect(serverRow).not.toHaveClass(/selected/);
+  await expect(ta).toHaveAttribute("placeholder", `message ${CHANNEL}`);
+
+  // The gesture. Focus sits in the compose box after selectChannel — the nav
+  // chords deliberately fire regardless of the focus target, as Alt+1..9 do.
+  await page.keyboard.press("Alt+0");
+
+  await expect(serverRow).toHaveClass(/selected/, { timeout: 10_000 });
+  await expect(channelRow).not.toHaveClass(/selected/);
+  // The pane followed, not just the sidebar row: the compose box is now the
+  // server window's (`message <slug>`, the #151 friendly label).
+  await expect(ta).toHaveAttribute("placeholder", `message ${NETWORK_SLUG}`);
+});

--- a/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
@@ -65,7 +65,10 @@ test.describe("UX-6-B admin Settings tab", () => {
     const admin = getSeededAdmin();
     const res = await request.put("/admin/settings", {
       headers: { authorization: `Bearer ${admin.token}` },
-      data: { upload: { active_host: "embedded" } },
+      // #201 — the duration cap joins active_host in the reset: the
+      // video-upload specs probe a ~1s clip against it, so a lowered
+      // value left behind would refuse every one of them.
+      data: { upload: { active_host: "embedded", video_max_duration_seconds: 120 } },
     });
     expect(res.ok()).toBe(true);
   });
@@ -120,5 +123,47 @@ test.describe("UX-6-B admin Settings tab", () => {
     expect(response.status()).toBe(200);
 
     await expect(page.getByTestId("admin-settings-saved")).toBeVisible({ timeout: 5_000 });
+  });
+
+  // #201 — the video duration ceiling became a server setting. Full
+  // round trip: form → PUT → DB → the operator-facing GET that cic's
+  // upload orchestrator reads its ceiling from. The REFUSAL itself
+  // (an over-long clip rejected with a message naming the new value)
+  // is pinned by vitest, not here: the only committed video fixture,
+  // e2e/fixtures/tiny.mp4, is exactly 1.000s (mvhd timescale 1000 /
+  // duration 1000) and the smallest settable ceiling is 1s, so no
+  // admin value can make it too long.
+  test("video duration cap: form → PUT → /api/server-settings (#201)", async ({
+    page,
+    request,
+  }) => {
+    const admin = getSeededAdmin();
+    await adminFriendlyLogin(page, admin);
+    await openAdminPaneAndSettingsTab(page);
+
+    const duration = page.getByTestId("admin-settings-video-max-duration");
+    await expect(duration).toHaveValue("120");
+
+    await duration.fill("45");
+    await page.getByTestId("admin-settings-save").click();
+    await expect(page.getByTestId("admin-settings-saved")).toBeVisible({ timeout: 5_000 });
+
+    // The value the CLIENT reads — same door cic hydrates from at boot.
+    const res = await request.get("/api/server-settings", {
+      headers: { authorization: `Bearer ${admin.token}` },
+    });
+    expect(res.ok()).toBe(true);
+    expect((await res.json()).upload.video_max_duration_seconds).toBe(45);
+  });
+
+  test("422 invalid_setting flags the video duration field (#201)", async ({ page }) => {
+    await adminFriendlyLogin(page, getSeededAdmin());
+    await openAdminPaneAndSettingsTab(page);
+
+    const duration = page.getByTestId("admin-settings-video-max-duration");
+    await duration.fill("0");
+    await page.getByTestId("admin-settings-save").click();
+
+    await expect(duration).toHaveClass(/admin-settings-field-error/, { timeout: 5_000 });
   });
 });

--- a/cicchetto/src/AdminSettingsTab.tsx
+++ b/cicchetto/src/AdminSettingsTab.tsx
@@ -21,6 +21,10 @@ import { token } from "./lib/auth";
 //   * `upload.global_cap_bytes` — global disk-budget ceiling; uploads
 //     reject with 507 insufficient_storage when total live bytes +
 //     incoming would exceed the cap.
+//   * `upload.video_max_duration_seconds` — video duration ceiling
+//     (#201). Unlike the byte caps this one is enforced CLIENT-side:
+//     duration is probed from the file in the browser, so an over-long
+//     clip is refused before a single byte is POSTed.
 //
 // State model: same shape as `AdminVisitorsTab` (fetch on mount,
 // explicit refresh, splice-on-save). UI units differ from wire:
@@ -64,6 +68,9 @@ const AdminSettingsTab: Component = () => {
   const [documentCapMB, setDocumentCapMB] = createSignal<number>(10);
   const [audioCapMB, setAudioCapMB] = createSignal<number>(25);
   const [globalCapGB, setGlobalCapGB] = createSignal<number>(10);
+  // #201 — seconds on the wire AND in the form: a duration cap has no
+  // unit conversion to hide, unlike the MB/GB byte fields above.
+  const [videoMaxDurationS, setVideoMaxDurationS] = createSignal<number>(120);
 
   const applyView = (view: AdminSettingsView): void => {
     setSettings(view);
@@ -73,6 +80,7 @@ const AdminSettingsTab: Component = () => {
     setDocumentCapMB(view.upload.document_per_file_cap_bytes / MIB);
     setAudioCapMB(view.upload.audio_per_file_cap_bytes / MIB);
     setGlobalCapGB(view.upload.global_cap_bytes / GIB);
+    setVideoMaxDurationS(view.upload.video_max_duration_seconds);
   };
 
   // One row per per-type cap (uploads cluster Task 7) — same markup,
@@ -142,6 +150,7 @@ const AdminSettingsTab: Component = () => {
           document_per_file_cap_bytes: Math.round(documentCapMB() * MIB),
           audio_per_file_cap_bytes: Math.round(audioCapMB() * MIB),
           global_cap_bytes: Math.round(globalCapGB() * GIB),
+          video_max_duration_seconds: Math.round(videoMaxDurationS()),
         },
       });
       applyView(view);
@@ -261,6 +270,31 @@ const AdminSettingsTab: Component = () => {
                     disabled={saving()}
                     classList={{
                       "admin-settings-field-error": fieldError() === "upload.global_cap_bytes",
+                    }}
+                  />
+                </AdminField>
+
+                <AdminField
+                  label="Video max duration (s)"
+                  for="admin-settings-video-max-duration"
+                  error={
+                    fieldError() === "upload.video_max_duration_seconds"
+                      ? "must be positive"
+                      : undefined
+                  }
+                >
+                  <input
+                    id="admin-settings-video-max-duration"
+                    data-testid="admin-settings-video-max-duration"
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={videoMaxDurationS()}
+                    onInput={(e) => setVideoMaxDurationS(Number(e.currentTarget.value))}
+                    disabled={saving()}
+                    classList={{
+                      "admin-settings-field-error":
+                        fieldError() === "upload.video_max_duration_seconds",
                     }}
                   />
                 </AdminField>

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -38,7 +38,12 @@ import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/ne
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock, overlayCount } from "./lib/overlayScrollLock";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
-import { closeToPreviousWindow, selectedChannel, setSelectedChannel } from "./lib/selection";
+import {
+  closeToPreviousWindow,
+  selectedChannel,
+  selectStatusWindow,
+  setSelectedChannel,
+} from "./lib/selection";
 import { settingsOpenTick } from "./lib/settingsNav";
 import { isMobile } from "./lib/theme";
 import { bindEdgeGesture } from "./lib/touchGesture";
@@ -371,6 +376,10 @@ const Shell: Component = () => {
       if (target)
         setSelectedChannel({ networkSlug: target.slug, channelName: target.name, kind: "channel" });
     },
+    // GH #359 — Alt+0. The status window is outside the Alt+1..9 index
+    // space, so this is a distinct verb; the selection store owns which
+    // network's status window it resolves to.
+    selectStatusWindow: () => selectStatusWindow(),
     // GH #235 — next/prev unread now route through the shared
     // `activeWindows` ordering (mention/query tier first, chronological
     // within a tier, cycling), the SAME verb the Alt+A keybinding and

--- a/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
@@ -36,6 +36,7 @@ const DEFAULTS: AdminSettingsView = {
     document_per_file_cap_bytes: 10 * 1024 * 1024,
     audio_per_file_cap_bytes: 25 * 1024 * 1024,
     global_cap_bytes: 10 * 1024 * 1024 * 1024,
+    video_max_duration_seconds: 90,
   },
 };
 
@@ -65,6 +66,7 @@ describe("AdminSettingsTab — initial render", () => {
         document_per_file_cap_bytes: 15 * 1024 * 1024,
         audio_per_file_cap_bytes: 30 * 1024 * 1024,
         global_cap_bytes: 20 * 1024 * 1024 * 1024,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -89,6 +91,12 @@ describe("AdminSettingsTab — initial render", () => {
 
     const global = screen.getByTestId("admin-settings-global-cap") as HTMLInputElement;
     expect(global.value).toBe("20");
+
+    // #201 — seconds straight through, no unit conversion.
+    const videoDuration = screen.getByTestId(
+      "admin-settings-video-max-duration",
+    ) as HTMLInputElement;
+    expect(videoDuration.value).toBe("90");
   });
 
   it("renders an error banner when the initial fetch fails", async () => {
@@ -135,6 +143,11 @@ describe("AdminSettingsTab — save", () => {
     const global = screen.getByTestId("admin-settings-global-cap") as HTMLInputElement;
     fireEvent.input(global, { target: { value: "50" } });
 
+    const videoDuration = screen.getByTestId(
+      "admin-settings-video-max-duration",
+    ) as HTMLInputElement;
+    fireEvent.input(videoDuration, { target: { value: "45" } });
+
     fireEvent.click(screen.getByTestId("admin-settings-save"));
 
     await waitFor(() => {
@@ -146,6 +159,7 @@ describe("AdminSettingsTab — save", () => {
           document_per_file_cap_bytes: 12 * 1024 * 1024,
           audio_per_file_cap_bytes: 20 * 1024 * 1024,
           global_cap_bytes: 50 * 1024 * 1024 * 1024,
+          video_max_duration_seconds: 45,
         },
       });
     });

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -141,6 +141,7 @@ let handlers: KeybindingHandlers;
 beforeEach(() => {
   handlers = {
     selectChannelByIndex: vi.fn(),
+    selectStatusWindow: vi.fn(),
     nextUnread: vi.fn(),
     prevUnread: vi.fn(),
     insertIntoCompose: vi.fn(),

--- a/cicchetto/src/__tests__/keybindings.test.ts
+++ b/cicchetto/src/__tests__/keybindings.test.ts
@@ -14,6 +14,7 @@ let handlers: KeybindingHandlers;
 beforeEach(() => {
   handlers = {
     selectChannelByIndex: vi.fn(),
+    selectStatusWindow: vi.fn(),
     nextUnread: vi.fn(),
     prevUnread: vi.fn(),
     insertIntoCompose: vi.fn(),
@@ -39,6 +40,24 @@ describe("keybindings", () => {
 
     dispatch({ key: "9", altKey: true });
     expect(handlers.selectChannelByIndex).toHaveBeenCalledWith(8);
+  });
+
+  it("Alt+0 dispatches selectStatusWindow (GH #359 jump to the status window)", () => {
+    // Matched on `e.code`, like the Alt+A sibling: on a macOS US layout
+    // Option+0 composes `e.key` into "º", so a key-based match would miss
+    // the chord on exactly the platform this session runs on.
+    dispatch({ code: "Digit0", key: "º", altKey: true });
+    expect(handlers.selectStatusWindow).toHaveBeenCalledTimes(1);
+    // It is NOT an index jump: the status window is outside the Alt+1..9
+    // index space (channels/queries only).
+    expect(handlers.selectChannelByIndex).not.toHaveBeenCalled();
+    // ...and it must not leak into the compose auto-focus path.
+    expect(handlers.insertIntoCompose).not.toHaveBeenCalled();
+  });
+
+  it("Digit0 without Alt does NOT dispatch selectStatusWindow", () => {
+    dispatch({ code: "Digit0", key: "0" });
+    expect(handlers.selectStatusWindow).not.toHaveBeenCalled();
   });
 
   it("Ctrl+N dispatches nextUnread", () => {

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -1855,6 +1855,95 @@ describe("selection store", () => {
     });
   });
 
+  // #359 — Alt+0 jumps to the status/server window. The verb resolves WHICH
+  // network's status window purely from live state (the selection's own
+  // network, else the first one in the sidebar's order) — no parallel
+  // "current network" store to drift.
+  describe("selectStatusWindow (#359)", () => {
+    const net = (id: number, slug: string) => ({
+      kind: "user" as const,
+      id,
+      slug,
+      nick: "alice",
+      connection_state: "connected" as const,
+      connection_state_reason: null,
+      connection_state_changed_at: null,
+      inserted_at: "",
+      updated_at: "",
+    });
+
+    it("selects the CURRENT network's server window, not the first network's", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([net(1, "freenode"), net(2, "azzurra")]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359a");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(2));
+
+      selection.setSelectedChannel({
+        networkSlug: "azzurra",
+        channelName: "#italia",
+        kind: "channel",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()).toEqual({
+        networkSlug: "azzurra",
+        channelName: "$server",
+        kind: "server",
+      });
+    });
+
+    it("falls back to the first network when the selection has no network (home)", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([net(1, "freenode"), net(2, "azzurra")]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359b");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(2));
+
+      selection.setSelectedChannel({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()).toEqual({
+        networkSlug: "freenode",
+        channelName: "$server",
+        kind: "server",
+      });
+    });
+
+    it("is a no-op when no network is bound", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok359c");
+      await vi.waitFor(() => expect(networks.networks()?.length).toBe(0));
+
+      selection.setSelectedChannel({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+      selection.selectStatusWindow();
+
+      expect(selection.selectedChannel()?.kind).toBe("home");
+    });
+  });
+
   describe("followQueryNick (#373 — focus follows a peer NICK)", () => {
     it("migrates the selection when the exact query window is focused", async () => {
       localStorage.setItem("grappa-token", "tok");

--- a/cicchetto/src/__tests__/serverSettings.test.ts
+++ b/cicchetto/src/__tests__/serverSettings.test.ts
@@ -15,6 +15,7 @@ const wireUpload = (active_host: ServerSettingsWireUploadView["active_host"]) =>
   document_per_file_cap_bytes: 3,
   audio_per_file_cap_bytes: 5,
   global_cap_bytes: 4,
+  video_max_duration_seconds: 90,
 });
 
 describe("serverSettings() — initial state", () => {
@@ -36,6 +37,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 10_485_760,
         audio_per_file_cap_bytes: 26_214_400,
         global_cap_bytes: 10_737_418_240,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -48,6 +50,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         audio: 26_214_400,
       },
       uploadGlobalCapBytes: 10_737_418_240,
+      uploadVideoMaxDurationSeconds: 90,
       // #324 — absent on the wire → [] (page origin only).
       httpHostAliases: [],
     });
@@ -62,6 +65,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 7_000_000,
         audio_per_file_cap_bytes: 8_000_000,
         global_cap_bytes: 999_999,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -85,6 +89,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 1,
         audio_per_file_cap_bytes: 1,
         global_cap_bytes: 2,
+        video_max_duration_seconds: 90,
       },
     });
     applyServerSettings({
@@ -95,6 +100,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 5,
         audio_per_file_cap_bytes: 7,
         global_cap_bytes: 6,
+        video_max_duration_seconds: 90,
       },
     });
 
@@ -102,6 +108,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
       uploadActiveHost: "litterbox",
       uploadPerFileCapBytes: { image: 3, video: 4, document: 5, audio: 7 },
       uploadGlobalCapBytes: 6,
+      uploadVideoMaxDurationSeconds: 90,
       httpHostAliases: [],
     });
   });
@@ -117,6 +124,7 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         document_per_file_cap_bytes: 3,
         audio_per_file_cap_bytes: 5,
         global_cap_bytes: 4,
+        video_max_duration_seconds: 90,
       },
       http_host_aliases: ["irc.sindro.me", "irc.sniffo.org"],
     });
@@ -156,6 +164,7 @@ describe("loadServerSettings/0 — REST initial fetch", () => {
             document_per_file_cap_bytes: 9_999_999,
             audio_per_file_cap_bytes: 5_555_555,
             global_cap_bytes: 88_888_888,
+            video_max_duration_seconds: 90,
           },
         }),
     } as unknown as Response);

--- a/cicchetto/src/__tests__/uploadHost.test.ts
+++ b/cicchetto/src/__tests__/uploadHost.test.ts
@@ -31,6 +31,7 @@ const wireUpload = (
   document_per_file_cap_bytes: 10 * 1024 * 1024,
   audio_per_file_cap_bytes: 25 * 1024 * 1024,
   global_cap_bytes: 10 * 1024 * 1024 * 1024,
+  video_max_duration_seconds: 90,
   ...overrides,
 });
 

--- a/cicchetto/src/__tests__/uploadOrchestrator.test.ts
+++ b/cicchetto/src/__tests__/uploadOrchestrator.test.ts
@@ -42,6 +42,7 @@ const vt = vi.hoisted(() => ({
   transcodes: [] as Array<{
     file: File;
     capBytes: number;
+    maxDurationSeconds: number;
     onProgress: (fraction: number) => void;
     signal: AbortSignal;
     resolve: (
@@ -62,15 +63,22 @@ vi.mock("../lib/videoPolicy", async () => {
 
 vi.mock("../lib/videoTranscode", () => ({
   transcodeVideo: vi.fn(
-    (file: File, capBytes: number, onProgress: (fraction: number) => void, signal: AbortSignal) =>
+    (
+      file: File,
+      capBytes: number,
+      maxDurationSeconds: number,
+      onProgress: (fraction: number) => void,
+      signal: AbortSignal,
+    ) =>
       new Promise((resolve) => {
-        vt.transcodes.push({ file, capBytes, onProgress, signal, resolve });
+        vt.transcodes.push({ file, capBytes, maxDurationSeconds, onProgress, signal, resolve });
       }),
   ),
 }));
 
 import { channelKey } from "../lib/channelKey";
 import { sendMessage } from "../lib/scrollback";
+import { setServerSettings } from "../lib/serverSettings";
 import { activeHost, type UploadHost } from "../lib/uploadHost";
 import {
   acknowledgePrivacy,
@@ -710,6 +718,73 @@ describe("video transcode branch", () => {
 
   afterEach(() => {
     warnSpy.mockRestore();
+    setServerSettings(null);
+  });
+
+  // #201 — the duration ceiling is a server setting. These pin the
+  // three things that broke when it was a compile-time const: the
+  // value handed to the transcoder, the value the reject GATE uses on
+  // the capability-fallback path, and the value the operator READS in
+  // the error copy.
+  const settingsWithVideoDuration = (seconds: number): void => {
+    setServerSettings({
+      uploadActiveHost: "embedded",
+      uploadPerFileCapBytes: { image: 1, video: 5 * 1024 * 1024, document: 1, audio: 1 },
+      uploadGlobalCapBytes: 1,
+      uploadVideoMaxDurationSeconds: seconds,
+      httpHostAliases: [],
+    });
+  };
+
+  it("#201: the live server ceiling is what reaches transcodeVideo", async () => {
+    settingsWithVideoDuration(45);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    expect(vt.transcodes[0]?.maxDurationSeconds).toBe(45);
+  });
+
+  it("#201: with no settings snapshot yet, the 120s fallback reaches transcodeVideo", async () => {
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    expect(vt.transcodes[0]?.maxDurationSeconds).toBe(120);
+  });
+
+  it("#201: the too-long copy names the LIVE ceiling, not the constant", async () => {
+    settingsWithVideoDuration(45);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "too_long", durationSeconds: 90 } });
+
+    await vi.waitFor(() =>
+      expect(uploadState(key)?.error).toBe("Video too long (max 45 seconds)."),
+    );
+  });
+
+  it("#201: a whole-minute ceiling still reads in minutes", async () => {
+    settingsWithVideoDuration(60);
+    triggerUpload(key, slug, channel, videoClip());
+
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "too_long", durationSeconds: 90 } });
+
+    await vi.waitFor(() => expect(uploadState(key)?.error).toBe("Video too long (max 1 minute)."));
+  });
+
+  it("#201: the capability-fallback gate rejects against the LIVE ceiling", async () => {
+    // 90s is under the 120s fallback constant, so only the admin-set
+    // 60s ceiling can reject it on the fallback path.
+    settingsWithVideoDuration(60);
+    triggerUpload(key, slug, channel, videoClip());
+
+    vt.probeDuration.mockResolvedValue(90);
+    await awaitTranscodeStart(1);
+    vt.transcodes[0]?.resolve({ error: { kind: "failed", message: "encoder blew up" } });
+
+    await vi.waitFor(() => expect(uploadState(key)?.error).toBe("Video too long (max 1 minute)."));
+    expect(pendingResolvers.length).toBe(0);
   });
 
   it("happy path: transcoding phase first, host receives the TRANSCODED file, 🎬 PRIVMSG", async () => {

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1134,6 +1134,80 @@ describe("userTopic", () => {
     });
   });
 
+  // #201 — the duration ceiling rides the existing settings push. The
+  // narrowing for it is deliberately LENIENT (degrade, don't drop)
+  // while the byte caps stay strict; these pin both halves.
+  describe("server_settings_changed arm — video duration cap (#201)", () => {
+    const uploadWire = (extra: Record<string, unknown>): Record<string, unknown> => ({
+      active_host: "embedded",
+      image_per_file_cap_bytes: 1,
+      video_per_file_cap_bytes: 2,
+      document_per_file_cap_bytes: 3,
+      audio_per_file_cap_bytes: 4,
+      global_cap_bytes: 5,
+      ...extra,
+    });
+
+    afterEach(async () => {
+      const ss = await import("../lib/serverSettings");
+      ss.setServerSettings(null);
+    });
+
+    it("carries the server's value into the store", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 45 }),
+        http_host_aliases: [],
+      });
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+    });
+
+    it("degrades an ABSENT value to the 120s fallback and still applies the rest", async () => {
+      // A pre-#201 server omits the field. Dropping the push here would
+      // strand the byte caps too — the additive-only wire contract.
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({}),
+        http_host_aliases: [],
+      });
+      const view = ss.serverSettings();
+      expect(view?.uploadVideoMaxDurationSeconds).toBe(120);
+      expect(view?.uploadPerFileCapBytes.video).toBe(2);
+    });
+
+    it("degrades a malformed value to the fallback, still applying the rest", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: -5 }),
+        http_host_aliases: [],
+      });
+      const view = ss.serverSettings();
+      expect(view?.uploadVideoMaxDurationSeconds).toBe(120);
+      expect(view?.uploadPerFileCapBytes.video).toBe(2);
+    });
+
+    it("a malformed BYTE cap still drops the whole push (strictness unchanged)", async () => {
+      const ss = await import("../lib/serverSettings");
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 45 }),
+        http_host_aliases: [],
+      });
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+
+      channelMock.fireEvent({
+        kind: "server_settings_changed",
+        upload: uploadWire({ video_max_duration_seconds: 99, global_cap_bytes: 0 }),
+        http_host_aliases: [],
+      });
+      // Dropped: the store still holds the previous, valid push.
+      expect(ss.serverSettings()?.uploadVideoMaxDurationSeconds).toBe(45);
+    });
+  });
+
   // P-0b — peer_away dispatch.
   describe("peer_away arm", () => {
     it("calls setPeerAway with (network, peer, message)", async () => {

--- a/cicchetto/src/lib/__tests__/videoTranscode.test.ts
+++ b/cicchetto/src/lib/__tests__/videoTranscode.test.ts
@@ -234,7 +234,13 @@ describe("transcodeVideo", () => {
     const controller = new AbortController();
     controller.abort();
 
-    const result = await transcodeVideo(sampleClip(), cap, noProgress, controller.signal);
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      controller.signal,
+    );
 
     expect(result).toEqual({ error: { kind: "failed", message: "aborted" } });
     expect(h.conversionInit).not.toHaveBeenCalled();
@@ -248,6 +254,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -256,10 +263,46 @@ describe("transcodeVideo", () => {
     expect(h.conversionInit).not.toHaveBeenCalled();
   });
 
+  it("#201: the ceiling is the CALLER's value — a lowered cap rejects a clip the fallback allows", async () => {
+    stubWebCodecs();
+    __setProbeDurationForTests(async () => 90);
+
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      60,
+      noProgress,
+      new AbortController().signal,
+    );
+
+    // 90s is comfortably under the 120s fallback constant; only an
+    // admin-lowered 60s ceiling can reject it.
+    expect(result).toEqual({ error: { kind: "too_long", durationSeconds: 90 } });
+    expect(h.conversionInit).not.toHaveBeenCalled();
+  });
+
+  it("#201: a raised ceiling lets a clip past the 120s fallback", async () => {
+    stubWebCodecs();
+    __setProbeDurationForTests(async () => 300);
+
+    const result = await transcodeVideo(
+      sampleClip(),
+      cap,
+      600,
+      noProgress,
+      new AbortController().signal,
+    );
+
+    // Same 300s clip the test above rejects at 120 — the only
+    // difference is the ceiling the caller handed down.
+    expect("ok" in result).toBe(true);
+  });
+
   it("gate closed (no WebCodecs) with a legal duration → unsupported, encoder detail", async () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -277,6 +320,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -292,6 +336,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -323,6 +368,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -347,7 +393,13 @@ describe("transcodeVideo", () => {
     });
     const seen: number[] = [];
 
-    await transcodeVideo(sampleClip(), cap, (f) => seen.push(f), new AbortController().signal);
+    await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      (f) => seen.push(f),
+      new AbortController().signal,
+    );
 
     expect(seen).toEqual([0.5]);
   });
@@ -369,6 +421,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -396,6 +449,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -421,6 +475,7 @@ describe("transcodeVideo", () => {
     const result = await transcodeVideo(
       sampleClip(),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -446,7 +501,13 @@ describe("transcodeVideo", () => {
     });
 
     const controller = new AbortController();
-    const pending = transcodeVideo(sampleClip(), cap, noProgress, controller.signal);
+    const pending = transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      controller.signal,
+    );
     await vi.waitFor(() => expect(execute).toHaveBeenCalled());
     controller.abort();
 
@@ -455,7 +516,10 @@ describe("transcodeVideo", () => {
     expect(result).toEqual({ error: { kind: "failed", message: "conversion canceled" } });
   });
 
-  it("MAX_DURATION_SECONDS is the spec'd 120s policy ceiling", () => {
+  // #201 — the constant is the FALLBACK now (pre-snapshot / pre-#201
+  // server); the live ceiling is `upload.video_max_duration_seconds`.
+  // It must keep mirroring the server-side default, so the pin stays.
+  it("MAX_DURATION_SECONDS is the 120s fallback ceiling", () => {
     expect(MAX_DURATION_SECONDS).toBe(120);
   });
 });
@@ -481,7 +545,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     const file = mp4Clip(16);
 
-    const result = await transcodeVideo(file, cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      file,
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     if (!("ok" in result)) throw new Error(`expected ok, got ${JSON.stringify(result)}`);
     expect(result.ok).toBe(file); // same File identity — untouched
@@ -492,7 +562,13 @@ describe("transcodeVideo skip-gate", () => {
     stubWebCodecs();
     h.format = "mov";
 
-    const result = await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect("ok" in result).toBe(true);
     expect(h.conversionInit).toHaveBeenCalled();
@@ -504,7 +580,13 @@ describe("transcodeVideo skip-gate", () => {
     // sampleClip declares video/quicktime; the demuxed container says
     // mp4. The upload would ride the declared type, so the gate must
     // refuse and let the transcode rename it .mp4/video/mp4.
-    await transcodeVideo(sampleClip(), cap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      sampleClip(),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -514,7 +596,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     h.codec = "vp9";
 
-    await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -527,6 +615,7 @@ describe("transcodeVideo skip-gate", () => {
     const result = await transcodeVideo(
       mp4Clip(16 * MiB),
       cap,
+      MAX_DURATION_SECONDS,
       noProgress,
       new AbortController().signal,
     );
@@ -543,7 +632,13 @@ describe("transcodeVideo skip-gate", () => {
     // 2MiB file — pins condition 4 independently of condition 3.
     const smallCap = 1 * MiB;
 
-    await transcodeVideo(mp4Clip(2 * MiB), smallCap, noProgress, new AbortController().signal);
+    await transcodeVideo(
+      mp4Clip(2 * MiB),
+      smallCap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect(h.conversionInit).toHaveBeenCalled();
   });
@@ -553,7 +648,13 @@ describe("transcodeVideo skip-gate", () => {
     h.format = "mp4";
     h.getFormatThrows = true;
 
-    const result = await transcodeVideo(mp4Clip(16), cap, noProgress, new AbortController().signal);
+    const result = await transcodeVideo(
+      mp4Clip(16),
+      cap,
+      MAX_DURATION_SECONDS,
+      noProgress,
+      new AbortController().signal,
+    );
 
     expect("ok" in result).toBe(true);
     expect(h.conversionInit).toHaveBeenCalled();

--- a/cicchetto/src/lib/keybindings.ts
+++ b/cicchetto/src/lib/keybindings.ts
@@ -23,6 +23,7 @@ import { runTopmostOverlayEscape } from "./overlayScrollLock";
 
 export type KeybindingHandlers = {
   selectChannelByIndex: (idx: number) => void; // Alt+1..9 → idx 0..8
+  selectStatusWindow: () => void; // Alt+0
   nextUnread: () => void; // Ctrl+N
   prevUnread: () => void; // Ctrl+P
   insertIntoCompose: (char: string) => void; // any printable key off-compose
@@ -78,6 +79,18 @@ function onKeydown(e: KeyboardEvent): void {
   if (e.altKey && /^[1-9]$/.test(e.key)) {
     e.preventDefault();
     handlers.selectChannelByIndex(Number(e.key) - 1);
+    return;
+  }
+
+  // GH #359 — Alt+0 jumps to the status/server window (irssi's window 0).
+  // A verb of its own, NOT index 0 of the chord above: that index space is
+  // channels/queries only, the status window is outside it. Matched on
+  // `e.code` for the same reason as the Alt+A chord below — a macOS
+  // Option+digit composes `e.key` (US layout: Option+0 → "º"), so a
+  // key-based match would miss the chord there.
+  if (e.altKey && e.code === "Digit0") {
+    e.preventDefault();
+    handlers.selectStatusWindow();
     return;
   }
 

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -850,6 +850,31 @@ const exports = identityScopedStore((onIdentityChange) => {
     });
   });
 
+  // #359 — jump to the status/server window (irssi's window 0). The status
+  // window IS an ordinary selection target ({slug, $server, kind: "server"});
+  // what it is NOT is part of the Alt+1..9 index space, which walks
+  // channels/queries only — hence a verb of its own rather than an index.
+  // WHICH network's status window is DERIVED, never stored: the selection's
+  // own network when it has one (channel/query/server/list all carry a real
+  // slug), else the first network in the sidebar's order. The identity-scoped
+  // home/admin windows carry a `$`-sentinel slug that `networkBySlug` does not
+  // know, which is exactly the "no network in focus" signal. No-op when no
+  // network is bound at all.
+  const selectStatusWindow = (): void => {
+    untrack(() => {
+      const sel = selectedChannel();
+      const inFocus =
+        sel !== null && networkBySlug(sel.networkSlug) !== undefined ? sel.networkSlug : undefined;
+      const slug = inFocus ?? (networks() ?? [])[0]?.slug;
+      if (slug === undefined) return;
+      setSelectedChannel({
+        networkSlug: slug,
+        channelName: SERVER_WINDOW_NAME,
+        kind: "server",
+      });
+    });
+  };
+
   // #373 — a query window's peer renamed (observed via a per-channel
   // NICK). If THIS device has that exact query window focused, follow the
   // rename so the focused window keeps routing to the live nick — an
@@ -881,6 +906,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     setSelectedChannel,
     isActiveSelection,
     closeToPreviousWindow,
+    selectStatusWindow,
     setServerSeedCount,
     applySeedEnvelope,
     setCursorIfAdvances,
@@ -896,6 +922,7 @@ export const selectedChannel = exports.selectedChannel;
 export const setSelectedChannel = exports.setSelectedChannel;
 export const isActiveSelection = exports.isActiveSelection;
 export const closeToPreviousWindow = exports.closeToPreviousWindow;
+export const selectStatusWindow = exports.selectStatusWindow;
 export const setServerSeedCount = exports.setServerSeedCount;
 export const applySeedEnvelope = exports.applySeedEnvelope;
 export const setCursorIfAdvances = exports.setCursorIfAdvances;

--- a/cicchetto/src/lib/serverSettings.ts
+++ b/cicchetto/src/lib/serverSettings.ts
@@ -64,6 +64,13 @@ export type ServerSettingsView = {
   uploadActiveHost: ServerSettingsWireUploadView["active_host"];
   uploadPerFileCapBytes: Record<UploadCategory, number>;
   uploadGlobalCapBytes: number;
+  // #201 — the video duration ceiling, formerly videoPolicy's
+  // compile-time `MAX_DURATION_SECONDS`. Copied raw like the byte caps:
+  // consumers read it through an optional chain
+  // (`serverSettings()?.…  ?? MAX_DURATION_SECONDS`), which covers BOTH
+  // the pre-snapshot null view and a pre-#201 server that omits the
+  // field on the REST blind-cast path.
+  uploadVideoMaxDurationSeconds: number;
   // #324 — the deployment's HTTP host aliases (bare lowercased
   // hostnames the server advertised). `mediaLink.ts` admits an upload
   // link on ANY of them (they share the /uploads store). Always an
@@ -106,6 +113,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         audio: raw.upload.audio_per_file_cap_bytes,
       },
       uploadGlobalCapBytes: raw.upload.global_cap_bytes,
+      uploadVideoMaxDurationSeconds: raw.upload.video_max_duration_seconds,
       // #324 — absent (old server / pre-snapshot / REST blind-cast) → []
       // so mediaLink admits the page origin only (pre-#324 behaviour).
       httpHostAliases: raw.http_host_aliases ?? [],

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import type { ChannelKey } from "./channelKey";
 import { formatBytes } from "./formatBytes";
 import { sendMessage } from "./scrollback";
+import { serverSettings } from "./serverSettings";
 import {
   baseMime,
   categoryOf,
@@ -474,7 +475,29 @@ async function dispatchUpload(
     });
 }
 
-const VIDEO_TOO_LONG_MESSAGE = `Video too long (max ${MAX_DURATION_SECONDS / 60} minutes).`;
+// #201 — the ceiling is a server setting now; MAX_DURATION_SECONDS is
+// only the fallback for the window before the first settings snapshot
+// (and for a pre-#201 server). Read at each gate, never captured in a
+// module const: an admin can move it mid-session and the WS push
+// updates the signal without a reload.
+function videoMaxDurationSeconds(): number {
+  return serverSettings()?.uploadVideoMaxDurationSeconds ?? MAX_DURATION_SECONDS;
+}
+
+// Deliberately NOT `formatDuration` from duration.ts: that one floors
+// (90s → "1m"), which would UNDERSTATE a ceiling and tell the operator
+// a 75s clip was over a "1m" limit. A cap has to name itself exactly.
+function durationLabel(seconds: number): string {
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
+function videoTooLongMessage(maxSeconds: number): string {
+  return `Video too long (max ${durationLabel(maxSeconds)}).`;
+}
 
 // Video transform — Task 6 (2026-06-09). Returns the file to upload
 // (transcoded mp4, or the ORIGINAL on a capability fallback), or null
@@ -510,9 +533,14 @@ async function prepareVideo(
   // size the transcode for the embedded default (50MiB) and let the
   // host's actual limit reject the upload if it disagrees.
   const capBytes = host.maxFileSizeBytes("video") ?? 50 * 1024 * 1024;
+  // Read ONCE per attempt so the gate inside transcodeVideo and the
+  // fallback gate below cannot straddle an admin change mid-upload and
+  // reject against a value the message never named.
+  const maxDurationSeconds = videoMaxDurationSeconds();
   const result = await transcodeVideo(
     file,
     capBytes,
+    maxDurationSeconds,
     (fraction) => {
       if (inflight.get(key)?.controller !== controller) return;
       setEntry(key, { filename: file.name, loaded: fraction, total: 1, phase: "transcoding" });
@@ -530,7 +558,7 @@ async function prepareVideo(
       loaded: 0,
       total: 0,
       phase: "transcoding",
-      error: VIDEO_TOO_LONG_MESSAGE,
+      error: videoTooLongMessage(maxDurationSeconds),
     });
     return null;
   }
@@ -539,14 +567,14 @@ async function prepareVideo(
   console.warn("video transcode unavailable, uploading original:", result.error);
   const durationSeconds = await probeDuration(file);
   if (inflight.get(key)?.controller !== controller) return null; // cancelled
-  if (durationSeconds !== null && durationSeconds > MAX_DURATION_SECONDS) {
+  if (durationSeconds !== null && durationSeconds > maxDurationSeconds) {
     inflight.delete(key);
     setEntry(key, {
       filename: file.name,
       loaded: 0,
       total: 0,
       phase: "transcoding",
-      error: VIDEO_TOO_LONG_MESSAGE,
+      error: videoTooLongMessage(maxDurationSeconds),
     });
     return null;
   }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -54,6 +54,7 @@ import { applyServerSettings } from "./serverSettings";
 import { joinUser } from "./socket";
 import { seedSupportedUmodes } from "./supportedUmodes";
 import { seedUmodes } from "./umodes";
+import { MAX_DURATION_SECONDS } from "./videoPolicy";
 import { setWhoisBundle } from "./whoisCard";
 import { setWhoReply } from "./whoModal";
 import { setWhowasBundle } from "./whowasCard";
@@ -770,6 +771,16 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         !posInt(u.global_cap_bytes)
       )
         return null;
+      // #201 — LENIENT, unlike the caps above: a pre-#201 server omits
+      // the field entirely, and the additive-only wire contract says a
+      // client must not choke on a shape it half-recognises. Hard-
+      // narrowing it here would drop the WHOLE settings push against an
+      // older server and strand the byte caps too. Absent / malformed →
+      // the compile-time default, same degrade-don't-drop posture as
+      // `http_host_aliases` below.
+      const videoMaxDurationSeconds = posInt(u.video_max_duration_seconds)
+        ? u.video_max_duration_seconds
+        : MAX_DURATION_SECONDS;
       // #324 — deployment HTTP host aliases. Lenient: a malformed /
       // absent value degrades to [] (page origin only) rather than
       // dropping the whole settings push (which would strand the upload
@@ -787,6 +798,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
           document_per_file_cap_bytes: u.document_per_file_cap_bytes,
           audio_per_file_cap_bytes: u.audio_per_file_cap_bytes,
           global_cap_bytes: u.global_cap_bytes,
+          video_max_duration_seconds: videoMaxDurationSeconds,
         },
         http_host_aliases: httpHostAliases,
       };

--- a/cicchetto/src/lib/videoPolicy.ts
+++ b/cicchetto/src/lib/videoPolicy.ts
@@ -13,13 +13,20 @@
 //
 // Policy vs capability split (the orchestrator's fallback contract):
 // - `too_long` is POLICY — duration is read via a <video> element's
-//   loadedmetadata, which works WITHOUT WebCodecs, so the 2-minute
+//   loadedmetadata, which works WITHOUT WebCodecs, so the duration
 //   ceiling binds on the no-transcode fallback path too.
 // - capability (WebCodecs presence, codec support) is videoTranscode's
 //   business; see that module.
 //
 // Spec: docs/superpowers/specs/2026-06-09-video-doc-uploads-design.md
 
+// FALLBACK ONLY since #201. The live ceiling is the server setting
+// `upload.video_max_duration_seconds`, which reaches cic on the
+// server-settings snapshot/push; uploadOrchestrator resolves it per
+// attempt and passes it down. This constant is what applies before the
+// first snapshot lands (and against a pre-#201 server), and it mirrors
+// `Grappa.ServerSettings` `@default_upload_video_max_duration_seconds`
+// — the two must move together.
 export const MAX_DURATION_SECONDS = 120;
 const RESOLUTION_THRESHOLD_BPS = 2_000_000;
 // Exported for videoTranscode's skip-gate: a source file's OVERALL

--- a/cicchetto/src/lib/videoTranscode.ts
+++ b/cicchetto/src/lib/videoTranscode.ts
@@ -37,8 +37,8 @@
 // 128kbps audio reserve; a comfortable budget (≥ 2 Mbps) gets 720p,
 // a starved one 480p. Never upscale — mediabunny scales to the
 // requested box unconditionally, so the target is clamped to the
-// source track's display height. The budget math + duration ceiling +
-// probe live in videoPolicy.ts (mediabunny-free) so the orchestrator
+// source track's display height. The budget math + duration-ceiling
+// fallback + probe live in videoPolicy.ts (mediabunny-free) so the orchestrator
 // can import them statically while THIS module — the only mediabunny
 // importer — stays behind a dynamic import() in a lazy chunk (Task 6
 // quality-review follow-up, landed with Task 7, 2026-06-09).
@@ -58,7 +58,6 @@ import {
 } from "mediabunny";
 import {
   AUDIO_BUDGET_BPS,
-  MAX_DURATION_SECONDS,
   pickEncodeBitrate,
   pickTargetHeight,
   probeDuration,
@@ -108,7 +107,7 @@ export function __resetVideoTranscodeSupportForTests(): void {
 //      meaningfully shrink it;
 //   4. size within the cap (an over-cap original MUST transcode —
 //      shrinking is the point).
-// Duration policy (≤ MAX_DURATION_SECONDS) is enforced by the caller
+// Duration policy (≤ maxDurationSeconds) is enforced by the caller
 // before this probe runs. Probe failures return false: an unreadable
 // container falls through to the normal transcode/capability path,
 // which owns the diagnostics.
@@ -149,13 +148,19 @@ async function alreadyTargetShape(
 // --------------------------------------------------------------------
 
 /** Transcode `file` to an adaptive-resolution H.264 mp4 sized for
- *  `capBytes`. Resolves `{ok}` with a fresh `<basename>.mp4` File, or
+ *  `capBytes`, rejecting anything longer than `maxDurationSeconds`.
+ *  Resolves `{ok}` with a fresh `<basename>.mp4` File, or
  *  `{error}` per the policy/capability split in the moduledoc. Honors
  *  `signal`: pre-aborted → immediate failed; mid-flight abort cancels
- *  the conversion. */
+ *  the conversion.
+ *
+ *  Both policy numbers arrive as PARAMETERS (#201): the caller reads
+ *  the live server settings once per attempt, exactly as it already
+ *  did for `capBytes`. This module stays free of the settings signal. */
 export async function transcodeVideo(
   file: File,
   capBytes: number,
+  maxDurationSeconds: number,
   onProgress: (fraction: number) => void,
   signal: AbortSignal,
 ): Promise<{ ok: File } | { error: TranscodeError }> {
@@ -163,7 +168,7 @@ export async function transcodeVideo(
 
   // Policy gate FIRST — binds even when the capability gate is closed.
   const durationSeconds = await probeDuration(file);
-  if (durationSeconds !== null && durationSeconds > MAX_DURATION_SECONDS) {
+  if (durationSeconds !== null && durationSeconds > maxDurationSeconds) {
     return { error: { kind: "too_long", durationSeconds } };
   }
 

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -861,6 +861,7 @@ export const S_ServerSettingsWireUploadView = {
     document_per_file_cap_bytes: "i",
     audio_per_file_cap_bytes: "i",
     global_cap_bytes: "i",
+    video_max_duration_seconds: "i",
   },
 } as const;
 

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -846,6 +846,7 @@ export type ServerSettingsWireUploadView = {
   document_per_file_cap_bytes: number;
   audio_per_file_cap_bytes: number;
   global_cap_bytes: number;
+  video_max_duration_seconds: number;
 };
 
 export type ServerSettingsWireChangedPayload = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41306,3 +41306,77 @@ is not available here. The refusal and its copy are pinned by vitest
 through the existing `__setProbeDurationForTests` seam; the e2e covers the
 admin form -> PUT -> `GET /api/server-settings` round trip, which is the
 door cic hydrates from.
+<!-- entry #93 -->
+
+---
+
+## 2026-08-13 — #93: the outer fail-over loop was already running, it just never advanced
+
+`network_servers` has carried irssi's `(host, port, tls, priority, enabled)`
+shape since the Phase 2 schema, and for just as long only ever the head of
+that list was dialled. A network whose preferred endpoint went down parked
+every session on that endpoint until an operator intervened, however many
+working rows sat behind it. #271 folded this together with its own problem
+into one two-level machine — server as the outer loop, resolved leaf as the
+inner one — and shipped the inner half: `Grappa.IRC.Client` resolves the full
+RR set itself, shuffles it, and rotates across leaves before giving up.
+
+The 2026-08-06 stale-premise audit on the issue called the remainder PARTIAL,
+on the grounds that the backoff half was already shipped (`Session.Backoff`
+plus #100's `@connection_stable_ms` reset gate) and only the server-index
+advance was left. Re-verified a week and a great many commits later against
+`origin/main` `45e88c5e`: still accurate. `pick_server!/1` still took the head
+of `filter(&enabled) |> sort_by({priority, id})`, and `git grep -E
+'failover|next_server'` over `lib` still returned nothing.
+
+What the audit could not see from a cold repo is that **the outer loop needs
+no loop**. The iteration was already running, once per failure, spread across
+process lifetimes: `do_connect/5` fails, the Client stops, the linked
+`Session.Server` exits abnormally, `terminate/2` calls
+`Backoff.record_failure/2` — synchronously, and the docstring says why: so the
+count is visible to the NEXT `init/1` — and the `:transient` supervisor
+restarts the child, whose `init/1` calls the plan's `refresh_plan` closure.
+Every element of `for server in servers_by_priority(enabled)` was in place
+except the part where the body picks a different server. So the fix is to
+resolve at `pick_server!(network, attempt)` with `attempt` read from the
+counter that already exists, and the ring position becomes DERIVED rather than
+tracked: no per-server row of state, nothing to keep in sync, nothing to
+garbage-collect when a server is deleted from under a live session.
+
+The two resolver doors are deliberately NOT the same. `resolve/1` — Bootstrap,
+the `/connect` verb through `SpawnOrchestrator`, `Operator` — stays pinned to
+position 0. That is not a convenience default: those doors mean "start this
+session now" and clear the ladder before spawning, so the preferred endpoint
+is the correct one to try, and reading the counter there would additionally
+race, because `Backoff.reset/2` is a `cast` and a resolve immediately behind
+it can still observe the pre-reset count. The respawn door runs at the one
+moment the counter is authoritative, and it is the only one that walks the
+ring. `pick_server!/2` therefore takes no default argument — a caller that
+does not say which position it wants is a caller that has not decided which
+door it is.
+
+One consequence worth stating plainly, because it is a property of the
+derivation rather than of the original sketch: the exponential ladder remains
+keyed on `(subject, network)`, so it is shared across the whole ring instead
+of one ladder per server row. With three dead endpoints the exponent grows
+1, 2, 3, … across them rather than restarting at the base for each. That is
+the intended reading of "derive instead of duplicate", and it preserves the
+property the ladder exists for — the rate at which we approach an upstream is
+identical to today's whatever the server count, which matters because that
+rate is what got the bouncer's IP k-lined by Azzurra in the first place. A
+single-server network is byte-for-byte unchanged, every attempt folding back
+onto position 0.
+
+Not measured, and not claimed: the wall-clock interval between one endpoint
+and the next. `@connect_failure_sleep_ms` (30s) and the ladder's 5s base are
+source reads, not observations; no stack was stood up for this and no
+end-to-end fail-over was timed. The tests likewise stop at the plan boundary —
+they assert that the respawn door resolves the next endpoint, not that a real
+refused connect reaches that door. That chain is pre-existing behaviour and
+this change does not touch it.
+
+**Apply:** before adding state to advance a retry policy, check whether the
+retry is already counted somewhere that survives the restart — a failure
+counter kept for backoff is usually also the attempt ordinal, and deriving the
+second use from it costs one argument instead of one more thing to keep in
+sync.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41239,3 +41239,70 @@ wants its own issue and its own test, and folding it in would have made this
 change a two-verb refactor. Recorded so the split reads as a decision rather
 than as an oversight — and so the next reader does not "restore consistency"
 by moving the new chord onto the broken side.
+
+<!-- entry #201 -->
+
+---
+
+## 2026-08-13 — #201: the video duration ceiling becomes a server setting
+
+cic refused videos longer than two minutes because `videoPolicy.ts` said
+`export const MAX_DURATION_SECONDS = 120`. Moving that to
+`upload.video_max_duration_seconds` (pos_integer, default 120) was a
+straight ride down the rails the BYTE cap `upload.video_per_file_cap_bytes`
+already laid: `ServerSettings` accessor pair -> `public_view/0` ->
+`ServerSettings.Wire.upload_view/1` -> the WS snapshot/push and both REST
+doors -> `serverSettings()` -> an admin field. No new mechanism, no
+migration (settings are key/value rows whose defaults live in code, like
+the audio cap before it). Four decisions are worth keeping.
+
+**It is enforced CLIENT-side, and that is not a gap to close.** Duration is
+not a property of the bytes the way size is: reading it means decoding the
+container, and the whole point of the ceiling is to refuse the clip BEFORE
+it is uploaded. So the server publishes the number and cic enforces it,
+while the byte caps stay enforced at `POST /api/uploads` (413) as they
+always were. A hostile client can ignore the duration ceiling; it cannot
+ignore the per-file and global byte caps, and those are what actually bound
+disk. Reading this setting as a security control would be a mistake — it is
+a policy the server states and the client applies.
+
+**The value travels as a PARAMETER, not as a signal read deep in the
+stack.** `transcodeVideo/5` now takes `maxDurationSeconds` next to the
+`capBytes` it already took, and `uploadOrchestrator` resolves both once per
+attempt. The tempting alternative — have `videoPolicy.ts` read
+`serverSettings()` itself — would have put a solid-js store import into the
+one module that is deliberately dependency-free so it can be imported
+statically while its mediabunny-laden sibling stays behind a dynamic
+`import()`. Reading once per attempt also means the gate inside the
+transcoder and the capability-fallback gate in the orchestrator cannot
+straddle an admin change mid-upload and reject against a number the error
+message never named.
+
+**The client narrowing for this field is LENIENT while the byte caps stay
+strict.** `userTopic.ts` hard-rejects a `server_settings_changed` push whose
+byte caps are malformed. Applying that treatment to the new field would
+have meant a cic built with #201 dropping EVERY settings push from a
+pre-#201 server — stranding the byte caps too — which is exactly the
+failure the additive-only wire contract exists to prevent. Absent or
+malformed duration degrades to the compile-time fallback and the rest of
+the push applies, the same degrade-don't-drop posture `http_host_aliases`
+took in #324. `MAX_DURATION_SECONDS` survives as that fallback and must
+keep mirroring `@default_upload_video_max_duration_seconds`.
+
+**The error copy formats the cap exactly, and does not reuse
+`formatDuration`.** That helper floors (90s -> "1m") because it describes
+elapsed spans, where losing the remainder is harmless. A ceiling that
+understates itself tells the operator a 75-second clip exceeded a "1m"
+limit. So the message says "2 minutes" on whole minutes and "45 seconds"
+otherwise.
+
+**What the tests do NOT prove.** There is no end-to-end Playwright run in
+which a real over-long video is refused with a message naming an
+admin-lowered value. The only committed video fixture,
+`cicchetto/e2e/fixtures/tiny.mp4`, is exactly 1.000s (mvhd timescale 1000,
+duration 1000) and the smallest settable ceiling is 1 second, so no admin
+value can make it too long; producing a longer fixture needs ffmpeg, which
+is not available here. The refusal and its copy are pinned by vitest
+through the existing `__setProbeDurationForTests` seam; the e2e covers the
+admin form -> PUT -> `GET /api/server-settings` round trip, which is the
+door cic hydrates from.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41195,3 +41195,47 @@ exemptions and should not grow any.
 **Apply:** when a limit exists to mirror an external system's limit, key it
 on state that system publishes, and let the letter table say what was READ
 at source rather than what is probably true elsewhere.
+<!-- entry #359 -->
+
+---
+
+## 2026-08-13 — #359: the status window was never unaddressable, it was just outside the index space
+
+`Alt+1..9` selected windows by index and `Alt+A` jumped to the next unread
+one, but nothing on the keyboard reached the per-network status window. #359
+filed that gap together with a diagnosis: the status window "is not part of
+the `ActiveWindow` model", so the plumbing to make it selectable at all is
+the real work. Measured, the second half is wrong in a way worth writing
+down, because it is the kind of wrong that grows a parallel window model.
+
+`ActiveWindow` (`activeWindows.ts`) is the ACTIVITY ordering — the tier list
+`Alt+A` walks, and it deliberately excludes server buffers because server
+noise is not activity worth being sent to. `SelectedChannel`
+(`selection.ts`) is the FOCUS model, and there the status window has been an
+ordinary target since UX-4 bucket C: `{slug, "$server", kind: "server"}`, the
+exact tuple the sidebar's network-header row sets on click, backed by real
+`NumericRouter` scrollback. Two models, two jobs. The index space
+`selectChannelByIndex` walks is channels+queries, so the status window is
+genuinely NOT reachable as "index 0" — but that is a statement about one
+verb's domain, not about the window's addressability. The fix is therefore a
+sibling verb (`selectStatusWindow`), not a representation.
+
+Which network's status window is DERIVED at call time, never stored: the
+selection's own network when it has one, else the first network in the
+sidebar's order, else nothing happens. The `$`-sentinel slugs that `home` and
+`admin` carry are unknown to `networkBySlug`, which makes "no network in
+focus" fall out of the existing lookup instead of needing a kind check per
+identity-scoped window — a new one inherits the fallback for free. A stored
+"current network" would have been a second copy of what the selection
+already says, with the usual drift bill.
+
+The chord matches `e.code === "Digit0"`, not `e.key`. #235 already recorded
+why for `Alt+A` — a macOS Option+letter composes `e.key` ("å") — and the
+same holds for Option+digit on a US layout (`Option+0` → "º"). **Known
+divergence, deliberately not widened here: `Alt+1..9` still matches
+`/^[1-9]$/` against `e.key`, so those chords are the ones that would miss on
+macOS.** That is a pre-existing defect in a verb #359 does not touch, it
+wants its own issue and its own test, and folding it in would have made this
+change a two-verb refactor. Recorded so the split reads as a decision rather
+than as an oversight — and so the next reader does not "restore consistency"
+by moving the new chord onto the broken side.

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -12,7 +12,7 @@ defmodule Grappa.Networks do
     * `Grappa.Networks` (this module) — network slug CRUD +
       T32 connection-state transitions.
     * `Grappa.Networks.Servers` — server-endpoint CRUD + selection
-      policy (`add_server/2`, `list_servers/1`, `pick_server!/1`,
+      policy (`add_server/2`, `list_servers/1`, `pick_server!/2`,
       `remove_server/3`).
     * `Grappa.Networks.Credentials` — per-(user, network) credential
       lifecycle; `unbind_credential/2` detaches a credential + stops the
@@ -193,12 +193,12 @@ defmodule Grappa.Networks do
   ## Why it refuses on `:no_enabled_server`
 
   A user plus a credential still cannot connect: `SessionPlan.resolve/1`
-  picks a server with `Servers.pick_server!/1`, which raises
+  picks a server with `Servers.pick_server!/2`, which raises
   `NoServerError` when the network owns none that is enabled. Binding
   anyway produces a row that READS as access in every listing and
   fails only at spawn time — so the check happens here, at the
   boundary, and no half-access is ever written. The dialability test is
-  `pick_server!/1` itself, not a re-derived predicate, so the two
+  `pick_server!/2` itself, not a re-derived predicate, so the two
   cannot drift apart.
 
   Not atomic across the three writes, and deliberately so: a network
@@ -239,7 +239,7 @@ defmodule Grappa.Networks do
 
   defp ensure_dialable(%Network{} = network) do
     network = Repo.preload(network, :servers, force: true)
-    _ = Servers.pick_server!(network)
+    _ = Servers.pick_server!(network, 0)
     {:ok, network}
   rescue
     NoServerError -> {:error, :no_enabled_server}

--- a/lib/grappa/networks/no_server_error.ex
+++ b/lib/grappa/networks/no_server_error.ex
@@ -1,6 +1,6 @@
 defmodule Grappa.Networks.NoServerError do
   @moduledoc """
-  Raised by `Grappa.Networks.Servers.pick_server!/1` when a network
+  Raised by `Grappa.Networks.Servers.pick_server!/2` when a network
   resolves to zero enabled server endpoints.
 
   Lives in the `Networks` boundary because the policy is operator-side

--- a/lib/grappa/networks/servers.ex
+++ b/lib/grappa/networks/servers.ex
@@ -72,24 +72,43 @@ defmodule Grappa.Networks.Servers do
   end
 
   @doc """
-  Picks the lowest-priority enabled server for a `network` whose
-  `:servers` association is preloaded. Tie-broken by row id
-  (insertion order) to match `list_servers/1`. Raises
-  `Grappa.Networks.NoServerError` when every server is disabled OR
-  the network has none — operator misconfiguration is loud, never
-  silent.
+  Picks the enabled server at ring position `attempt` for a `network`
+  whose `:servers` association is preloaded. The ring is ordered by
+  `(priority asc, id asc)` — same order `list_servers/1` returns — so
+  `attempt` 0 is the lowest-priority endpoint, 1 the next one, and the
+  ring wraps. Raises `Grappa.Networks.NoServerError` when every server
+  is disabled OR the network has none — operator misconfiguration is
+  loud, never silent.
 
   Pre-A2/A10 this lived in `Grappa.Session.Server`; the cycle
   inversion lifts the policy where it belongs (Networks owns
   server-list semantics, Session just consumes the picked endpoint).
-  Phase 5 fail-over across the rest of the list is the natural
-  evolution from here.
+
+  ## `attempt` is the caller's, and only two values are meaningful (#93)
+
+  This function is pure policy — it owns "which endpoint sits at
+  position N", nothing else. WHO supplies N is the fail-over machine's
+  outer loop, and there are exactly two kinds of caller:
+
+    * a spawn door (Bootstrap, `SpawnOrchestrator`, the `/connect`
+      verb, the `add_network/3` dialability check) passes `0`. Those
+      doors mean "start this session now" and clear the failure ladder
+      first, so the preferred endpoint is the right one to try.
+    * the respawn door — the `refresh_plan` closure both SessionPlans
+      inject — passes `Grappa.Session.Backoff.failure_count/2`. That
+      counter is bumped once per abnormal session exit and survives the
+      `:transient` restart, so it IS the connect-attempt ordinal with no
+      second structure to keep in sync.
+
+  No default argument on purpose: a caller that does not say which
+  position it wants is a caller that has not decided which door it is.
   """
-  @spec pick_server!(Network.t()) :: Server.t()
-  def pick_server!(%Network{servers: servers, id: nid, slug: slug}) when is_list(servers) do
+  @spec pick_server!(Network.t(), non_neg_integer()) :: Server.t()
+  def pick_server!(%Network{servers: servers, id: nid, slug: slug}, attempt)
+      when is_list(servers) and is_integer(attempt) and attempt >= 0 do
     case servers |> Enum.filter(& &1.enabled) |> Enum.sort_by(&{&1.priority, &1.id}) do
-      [server | _] -> server
       [] -> raise NoServerError, network_id: nid, network_slug: slug
+      ring -> Enum.at(ring, rem(attempt, length(ring)))
     end
   end
 

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -3,7 +3,7 @@ defmodule Grappa.Networks.SessionPlan do
   Pure resolver: credential → primitive `t:Grappa.Session.start_opts/0`.
 
   Reads from `Accounts` for the user name, picks the lowest-priority
-  enabled server via `Grappa.Networks.Servers.pick_server!/1`, and
+  enabled server via `Grappa.Networks.Servers.pick_server!/2`, and
   copies the Cloak-decrypted upstream password into the resulting
   primitive opts map. The output carries no `Credential` / `Network` /
   `Server` / `User` struct refs, so the Session boundary stays
@@ -21,6 +21,7 @@ defmodule Grappa.Networks.SessionPlan do
   alias Grappa.IRC.{Identifier, Identity}
   alias Grappa.Networks.{Credential, Credentials, Network, NoServerError, Server, Servers}
   alias Grappa.Repo
+  alias Grappa.Session.Backoff
 
   @doc """
   Resolves `credential` into the fully-flat opts map that
@@ -36,7 +37,7 @@ defmodule Grappa.Networks.SessionPlan do
 
   Two reachable error tags:
 
-    * `{:error, :no_server}` — `Servers.pick_server!/1` raised; the
+    * `{:error, :no_server}` — `Servers.pick_server!/2` raised; the
       network has zero enabled endpoints. Operator action:
       `mix grappa.add_server`.
     * `{:error, :user_not_found}` — `Accounts.get_user!/1` raised;
@@ -53,7 +54,27 @@ defmodule Grappa.Networks.SessionPlan do
   """
   @spec resolve(Credential.t()) ::
           {:ok, Session.start_opts()} | {:error, :no_server | :user_not_found}
-  def resolve(%Credential{} = credential) do
+  def resolve(%Credential{} = credential), do: resolve_attempt(credential, 0)
+
+  # #93 — the ring-aware resolver behind `resolve/1`. `attempt` is the
+  # connect-attempt ordinal `Servers.pick_server!/2` indexes the enabled
+  # endpoint ring with.
+  #
+  # `resolve/1` pins it to 0 and that is not a default argument in
+  # disguise: its callers are the SPAWN doors (Bootstrap, the `/connect`
+  # verb via `SpawnOrchestrator`, `Operator`), which mean "start this
+  # session now" and clear the failure ladder before spawning. Starting
+  # them anywhere but the preferred endpoint would be wrong, and reading
+  # the counter there would additionally race — `Backoff.reset/2` is a
+  # cast, so a resolve immediately after it can still observe the old
+  # count. The RESPAWN door (`refresh_plan` below) is the one that walks
+  # the ring, and it runs at the only moment the counter is authoritative:
+  # `Backoff.record_failure/2` is a synchronous call from the dying
+  # session's `terminate/2`, so the bump has landed before the supervisor's
+  # restart reaches `Session.Server.init/1`.
+  @spec resolve_attempt(Credential.t(), non_neg_integer()) ::
+          {:ok, Session.start_opts()} | {:error, :no_server | :user_not_found}
+  defp resolve_attempt(%Credential{} = credential, attempt) do
     # Caller may pass a credential straight from
     # `Credentials.list_credentials_for_all_users/0` (network preloaded
     # already) or one fresh from `Credentials.get_credential!/2` (assoc
@@ -61,7 +82,7 @@ defmodule Grappa.Networks.SessionPlan do
     # already-loaded assocs, so no extra query for the Bootstrap path.
     credential = Repo.preload(credential, network: :servers)
     user = Accounts.get_user!(credential.user_id)
-    server = Servers.pick_server!(credential.network)
+    server = Servers.pick_server!(credential.network, attempt)
 
     {:ok, build_plan(user, credential.network, credential, server)}
   rescue
@@ -151,10 +172,22 @@ defmodule Grappa.Networks.SessionPlan do
       # returns `:ignore` and the supervisor drops the child
       # permanently. Operator re-spawns once the underlying config
       # is fixed.
+      #
+      # #93 — this is ALSO the outer loop of the two-level fail-over machine
+      # (#271 shipped the inner, per-leaf one inside `Grappa.IRC.Client`).
+      # There is no loop to write: a connect failure kills the Client, the
+      # linked Session.Server exits abnormally, `terminate/2` bumps
+      # `Backoff`, and the `:transient` supervisor lands us right here. So
+      # the endpoint advances by resolving at the failure count — attempt 0
+      # is the preferred server, attempt 1 the next enabled one, wrapping.
+      # The counter is cleared by the #100 sustained-connection gate, so a
+      # session that stays up returns the ring to the preferred endpoint.
       refresh_plan: fn ->
         case Credentials.get_credential_by_ids(user.id, cred.network_id) do
           {:ok, fresh_cred} ->
-            case resolve(fresh_cred) do
+            attempt = Backoff.failure_count({:user, user.id}, cred.network_id)
+
+            case resolve_attempt(fresh_cred, attempt) do
               {:ok, _} = ok -> ok
               {:error, _} -> {:error, :not_found}
             end

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -19,6 +19,7 @@ defmodule Grappa.ServerSettings do
   | `"upload.document_per_file_cap_bytes"`  | `pos_integer()`            | 10_485_760 (10MB)| UX-6-B |
   | `"upload.audio_per_file_cap_bytes"`     | `pos_integer()`            | 26_214_400 (25MB)| audio-uploads |
   | `"upload.global_cap_bytes"`             | `pos_integer()`            | 10_737_418_240 (10GB) | UX-6-B |
+  | `"upload.video_max_duration_seconds"`   | `pos_integer()`            | 120              | #201 |
   | `"addressing.mode"`                     | `:pool_with_reservations \\| :static_mapping_with_reservations` | `:pool_with_reservations` | #543 |
   | `"addressing.static_mapping_prefix"`    | `String.t()` (v6 CIDR) \\| `nil` | `nil`       | #543 |
 
@@ -30,7 +31,7 @@ defmodule Grappa.ServerSettings do
 
   Returns the operator-visible subset for `GET /api/server-settings`:
   the upload block (active_host + the per-category per-file caps +
-  global_cap_bytes) plus `http_host_aliases` — the deployment's HTTP
+  global_cap_bytes + the #201 video duration ceiling) plus `http_host_aliases` — the deployment's HTTP
   host aliases (#324, from `Grappa.HttpHosts`, config-derived not
   DB-backed) that cic's media-link classifier admits. Admin-only
   settings (when added) stay out of this view.
@@ -87,6 +88,7 @@ defmodule Grappa.ServerSettings do
   @key_upload_document_per_file_cap_bytes "upload.document_per_file_cap_bytes"
   @key_upload_audio_per_file_cap_bytes "upload.audio_per_file_cap_bytes"
   @key_upload_global_cap_bytes "upload.global_cap_bytes"
+  @key_upload_video_max_duration_seconds "upload.video_max_duration_seconds"
 
   # Defaults
   @default_upload_active_host :embedded
@@ -99,6 +101,10 @@ defmodule Grappa.ServerSettings do
   # 20260609204800_rename_per_file_cap_setting_to_image.exs).
   @default_upload_audio_per_file_cap_bytes 25 * 1024 * 1024
   @default_upload_global_cap_bytes 10 * 1024 * 1024 * 1024
+  # #201 — the client-side video duration ceiling, formerly cic's
+  # compile-time `MAX_DURATION_SECONDS`. Same 2 minutes it always was;
+  # what changes is that an operator can now move it without a rebuild.
+  @default_upload_video_max_duration_seconds 120
 
   # #543 outbound addressing mode (admin-only — NOT in public_view/0).
   @key_addressing_mode "addressing.mode"
@@ -127,7 +133,8 @@ defmodule Grappa.ServerSettings do
             video_per_file_cap_bytes: pos_integer(),
             document_per_file_cap_bytes: pos_integer(),
             audio_per_file_cap_bytes: pos_integer(),
-            global_cap_bytes: pos_integer()
+            global_cap_bytes: pos_integer(),
+            video_max_duration_seconds: pos_integer()
           },
           http_host_aliases: [String.t()]
         }
@@ -216,6 +223,33 @@ defmodule Grappa.ServerSettings do
   end
 
   def put_upload_global_cap_bytes(_), do: {:error, :invalid_value}
+
+  # ---- upload.video_max_duration_seconds (#201) --------------------
+
+  @doc """
+  Returns the video-upload duration ceiling in seconds (default 120).
+
+  Enforced client-side by cic's upload orchestrator (the duration probe
+  needs the file, which never leaves the browser when the clip is over
+  the ceiling); this setting is what makes that ceiling operator-tunable
+  instead of a compile-time constant.
+  """
+  @spec get_upload_video_max_duration_seconds() :: pos_integer()
+  def get_upload_video_max_duration_seconds do
+    read_cap(
+      @key_upload_video_max_duration_seconds,
+      @default_upload_video_max_duration_seconds
+    )
+  end
+
+  @doc "Pins the video-upload duration ceiling. Positive integer seconds only."
+  @spec put_upload_video_max_duration_seconds(pos_integer()) ::
+          :ok | {:error, :invalid_value | :db_unavailable}
+  def put_upload_video_max_duration_seconds(n) when is_integer(n) and n > 0 do
+    put_raw(@key_upload_video_max_duration_seconds, Integer.to_string(n))
+  end
+
+  def put_upload_video_max_duration_seconds(_), do: {:error, :invalid_value}
 
   # ---- addressing.mode (#543) --------------------------------------
 
@@ -310,7 +344,8 @@ defmodule Grappa.ServerSettings do
         video_per_file_cap_bytes: get_upload_per_file_cap_bytes(:video),
         document_per_file_cap_bytes: get_upload_per_file_cap_bytes(:document),
         audio_per_file_cap_bytes: get_upload_per_file_cap_bytes(:audio),
-        global_cap_bytes: get_upload_global_cap_bytes()
+        global_cap_bytes: get_upload_global_cap_bytes(),
+        video_max_duration_seconds: get_upload_video_max_duration_seconds()
       },
       # #324 — deployment HTTP host aliases (config, not DB): boot-derived
       # in config/runtime.exs, stashed via Grappa.HttpHosts. cic's media-

--- a/lib/grappa/server_settings/wire.ex
+++ b/lib/grappa/server_settings/wire.ex
@@ -71,7 +71,8 @@ defmodule Grappa.ServerSettings.Wire do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          video_max_duration_seconds: pos_integer()
         }
 
   @typedoc """
@@ -96,7 +97,8 @@ defmodule Grappa.ServerSettings.Wire do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          video_max_duration_seconds: pos_integer()
         }) :: upload_view()
   def upload_view(%{} = upload) do
     %{
@@ -105,7 +107,11 @@ defmodule Grappa.ServerSettings.Wire do
       video_per_file_cap_bytes: upload.video_per_file_cap_bytes,
       document_per_file_cap_bytes: upload.document_per_file_cap_bytes,
       audio_per_file_cap_bytes: upload.audio_per_file_cap_bytes,
-      global_cap_bytes: upload.global_cap_bytes
+      global_cap_bytes: upload.global_cap_bytes,
+      # #201 — the video duration ceiling cic enforces client-side. A
+      # duration, not a byte count: it rides the upload subtree because
+      # that is where every other upload policy knob already lives.
+      video_max_duration_seconds: upload.video_max_duration_seconds
     }
   end
 

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -36,6 +36,7 @@ defmodule Grappa.Visitors.SessionPlan do
   alias Grappa.{Networks, Repo, Session, Visitors}
   alias Grappa.Networks.{Credential, Credentials, NoServerError, Servers}
   alias Grappa.Networks.SessionPlan, as: NetworksSessionPlan
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors.Visitor
 
   @doc """
@@ -54,12 +55,23 @@ defmodule Grappa.Visitors.SessionPlan do
   """
   @spec resolve(Visitor.t(), Networks.Network.t()) ::
           {:ok, Session.start_opts()} | {:error, :network_unconfigured | :no_server}
-  def resolve(%Visitor{} = visitor, %Networks.Network{} = network) do
+  def resolve(%Visitor{} = visitor, %Networks.Network{} = network),
+    do: resolve_attempt(visitor, network, 0)
+
+  # #93 — the ring-aware resolver behind `resolve/2`, mirroring
+  # `Grappa.Networks.SessionPlan.resolve_attempt/2` field for field:
+  # `attempt` indexes the enabled endpoint ring, `resolve/2` pins it to 0
+  # because its callers are the spawn doors (Bootstrap, `Visitors.Login`,
+  # `Operator`) which clear the failure ladder before spawning, and only
+  # the `refresh_plan` closure below — the respawn door — walks it.
+  @spec resolve_attempt(Visitor.t(), Networks.Network.t(), non_neg_integer()) ::
+          {:ok, Session.start_opts()} | {:error, :network_unconfigured | :no_server}
+  defp resolve_attempt(%Visitor{} = visitor, %Networks.Network{} = network, attempt) do
     with {:ok, credential} <- fetch_credential(visitor, network) do
       network = Repo.preload(network, :servers)
 
       try do
-        server = Servers.pick_server!(network)
+        server = Servers.pick_server!(network, attempt)
         {:ok, build_plan(visitor, credential, network, server)}
       rescue
         NoServerError -> {:error, :no_server}
@@ -267,7 +279,13 @@ defmodule Grappa.Visitors.SessionPlan do
                 {:error, :not_found}
 
               %Networks.Network{} = fresh_network ->
-                case resolve(fresh, fresh_network) do
+                # #93 — the respawn door walks the endpoint ring. Same
+                # derivation as the user side: the `:transient` restart that
+                # lands here has already had its failure recorded, so the
+                # counter IS the connect-attempt ordinal.
+                attempt = Backoff.failure_count({:visitor, visitor.id}, network.id)
+
+                case resolve_attempt(fresh, fresh_network, attempt) do
                   {:ok, _} = ok -> ok
                   {:error, _} -> {:error, :not_found}
                 end

--- a/lib/grappa_web/controllers/admin/servers_controller.ex
+++ b/lib/grappa_web/controllers/admin/servers_controller.ex
@@ -18,7 +18,7 @@ defmodule GrappaWeb.Admin.ServersController do
 
   ## Session lifecycle on delete (A-6)
 
-  `DELETE` leaves any live `Session.Server` alone — `Servers.pick_server!/1`
+  `DELETE` leaves any live `Session.Server` alone — `Servers.pick_server!/2`
   is only consulted on (re)connect. Live sockets stay open against
   their current host:port regardless of the DB row. Response body
   surfaces `network_session_count: N` (total live sessions on the

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -20,7 +20,9 @@ defmodule GrappaWeb.Admin.SettingsController do
             image_per_file_cap_bytes: pos_integer(),
             video_per_file_cap_bytes: pos_integer(),
             document_per_file_cap_bytes: pos_integer(),
-            global_cap_bytes: pos_integer()
+            audio_per_file_cap_bytes: pos_integer(),
+            global_cap_bytes: pos_integer(),
+            video_max_duration_seconds: pos_integer()
           },
           addressing: %{
             mode: "pool_with_reservations" | "static_mapping_with_reservations",
@@ -39,7 +41,9 @@ defmodule GrappaWeb.Admin.SettingsController do
           "image_per_file_cap_bytes" => pos_integer(),
           "video_per_file_cap_bytes" => pos_integer(),
           "document_per_file_cap_bytes" => pos_integer(),
-          "global_cap_bytes" => pos_integer()
+          "audio_per_file_cap_bytes" => pos_integer(),
+          "global_cap_bytes" => pos_integer(),
+          "video_max_duration_seconds" => pos_integer()
         },
         "addressing" => %{
           "mode" => "pool_with_reservations" | "static_mapping_with_reservations",
@@ -186,6 +190,12 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   defp apply_upload_key("global_cap_bytes", _),
     do: {:error, {:invalid_setting, "upload.global_cap_bytes"}}
+
+  defp apply_upload_key("video_max_duration_seconds", n) when is_integer(n) and n > 0,
+    do: ServerSettings.put_upload_video_max_duration_seconds(n)
+
+  defp apply_upload_key("video_max_duration_seconds", _),
+    do: {:error, {:invalid_setting, "upload.video_max_duration_seconds"}}
 
   # Unknown key — ignore but log at warning level. Tolerant of
   # forward-compat shapes cic might send when an admin opens an

--- a/lib/grappa_web/controllers/server_settings_controller.ex
+++ b/lib/grappa_web/controllers/server_settings_controller.ex
@@ -19,7 +19,9 @@ defmodule GrappaWeb.ServerSettingsController do
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
           audio_per_file_cap_bytes: pos_integer(),
-          global_cap_bytes: pos_integer()
+          global_cap_bytes: pos_integer(),
+          # #201 — video duration ceiling cic enforces before upload.
+          video_max_duration_seconds: pos_integer()
         },
         # #324 — the deployment's HTTP host aliases; cic's media-link
         # classifier admits an upload link on ANY of them. No `kind`

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -29,6 +29,7 @@ defmodule Grappa.NetworksTest do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.{Credential, Credentials, Network, Server, Servers, SessionPlan}
   alias Grappa.PubSub.Topic
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors.Visitor
 
   defp user_fixture(name \\ nil) do
@@ -41,6 +42,24 @@ defmodule Grappa.NetworksTest do
     slug = slug || "net-#{System.unique_integer([:positive])}"
     {:ok, network} = Networks.find_or_create_network(%{slug: slug})
     network
+  end
+
+  # #93 — builds the `{host, enabled}` list as an ascending-priority ring,
+  # binds `user` to it and resolves the spawn-door plan.
+  defp bind_ring(user, net, hosts) do
+    Enum.each(Enum.with_index(hosts, 1), fn {{host, enabled}, priority} ->
+      {:ok, _} =
+        Servers.add_server(net, %{host: host, port: 6667, priority: priority, enabled: enabled})
+    end)
+
+    {:ok, _} =
+      Credentials.bind_credential(user, net, %{
+        nick: "vjt",
+        auth_method: :none,
+        autojoin_channels: []
+      })
+
+    user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
   end
 
   describe "find_or_create_network/1" do
@@ -1738,6 +1757,84 @@ defmodule Grappa.NetworksTest do
       # false branch — same semantics, strictly more informative shape).
       :ok = Credentials.unbind_credential(user, net)
       assert plan.refresh_plan.() == {:error, :not_found}
+    end
+  end
+
+  # #93 — the OUTER loop of the two-level fail-over machine (#271 shipped
+  # the inner, per-leaf one inside `Grappa.IRC.Client`). The iteration
+  # mechanism is the existing `:transient` respawn: every abnormal exit
+  # bumps `Session.Backoff`, the supervisor restarts the session, and
+  # `Session.Server.init/1` calls `refresh_plan`. So the ring position is
+  # DERIVED from the failure counter that already exists — no parallel
+  # per-server state to keep in sync.
+  describe "SessionPlan fail-over ring (#93)" do
+    setup do
+      user = user_fixture()
+      net = network_fixture()
+      on_exit(fn -> Backoff.forget({:user, user.id}) end)
+
+      {:ok, user: user, net: net}
+    end
+
+    test "each recorded failure advances the plan to the next enabled server", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+      assert plan.host == "primary"
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
+    end
+
+    test "the ring wraps back to the primary after the last enabled server", ctx do
+      %{user: user, net: net} = ctx
+
+      assert {:ok, plan} =
+               bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      for expected <- ["secondary", "tertiary", "primary", "secondary"] do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+        assert {:ok, fresh} = plan.refresh_plan.()
+        assert fresh.host == expected
+      end
+    end
+
+    test "a disabled server is not a ring position", ctx do
+      %{user: user, net: net} = ctx
+
+      assert {:ok, plan} =
+               bind_ring(user, net, [{"primary", true}, {"off", false}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
+    end
+
+    test "clearing the failure history puts the ring back on the primary", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      assert {:ok, %{host: "secondary"}} = plan.refresh_plan.()
+
+      :ok = Backoff.forget({:user, user.id})
+      assert {:ok, back} = plan.refresh_plan.()
+      assert back.host == "primary"
+    end
+
+    # The spawn doors (Bootstrap, SpawnOrchestrator, the /connect verb) mean
+    # "start this session now", and they reset the ladder before spawning —
+    # so `resolve/1` is pinned to the primary and never reads the counter.
+    # Only the respawn door walks the ring.
+    test "resolve/1 stays on the primary whatever the failure history says", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, _} = bind_ring(user, net, [{"primary", true}, {"secondary", true}])
+
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+      :ok = Backoff.record_failure({:user, user.id}, net.id)
+
+      assert {:ok, plan} = user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
+      assert plan.host == "primary"
     end
   end
 

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -419,7 +419,7 @@ defmodule Grappa.NetworksTest do
   # #1158 — the operator-facing verb pair. `bind_credential/3` writes ONE row
   # and is the internal primitive; a user holding only that row still cannot
   # connect, because `SessionPlan.resolve/1` needs the network to own an
-  # ENABLED server (`pick_server!/1` raises otherwise). `add_network/3` is the
+  # ENABLED server (`pick_server!/2` raises otherwise). `add_network/3` is the
   # composition that makes the access real, and every assertion here uses
   # `SessionPlan.resolve/1` as the oracle rather than counting rows: "the
   # credential exists" is exactly the half-truth the verb was introduced to
@@ -1555,7 +1555,7 @@ defmodule Grappa.NetworksTest do
     end
   end
 
-  describe "pick_server!/1 (A2/A10 — lifted from Session.Server)" do
+  describe "pick_server!/2 (A2/A10 — lifted from Session.Server)" do
     test "returns the lowest-priority enabled server, ties broken by id" do
       net = network_fixture()
       {:ok, _} = Servers.add_server(net, %{host: "h1", port: 6667, priority: 5})
@@ -1563,7 +1563,7 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "h3", port: 6667, priority: 1})
 
       preloaded = Repo.preload(net, :servers)
-      assert %Server{host: "h2"} = Servers.pick_server!(preloaded)
+      assert %Server{host: "h2"} = Servers.pick_server!(preloaded, 0)
     end
 
     test "skips disabled servers even when priority would prefer them" do
@@ -1572,7 +1572,7 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "enabled", port: 6667, priority: 5})
 
       preloaded = Repo.preload(net, :servers)
-      assert %Server{host: "enabled"} = Servers.pick_server!(preloaded)
+      assert %Server{host: "enabled"} = Servers.pick_server!(preloaded, 0)
     end
 
     test "raises NoServerError when every server is disabled" do
@@ -1580,13 +1580,73 @@ defmodule Grappa.NetworksTest do
       {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, enabled: false})
       preloaded = Repo.preload(net, :servers)
 
-      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded) end
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 0) end
     end
 
     test "raises NoServerError when the network has zero servers" do
       net = network_fixture()
       preloaded = Repo.preload(net, :servers)
-      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded) end
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 0) end
+    end
+
+    # #93 — `attempt` indexes the same `(priority, id)` order `list_servers/1`
+    # returns, so the ring the fail-over machine walks and the list an
+    # operator reads are the same object seen twice.
+    test "attempt indexes the enabled ring in (priority, id) order" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "third", port: 6667, priority: 9})
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 5})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 0)
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 1)
+      assert %Server{host: "third"} = Servers.pick_server!(preloaded, 2)
+    end
+
+    test "attempt wraps around the ring instead of running off its end" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 2})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 2)
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 3)
+      # The counter is unbounded (`Backoff` never caps the count, only the
+      # wait it computes), so a long-dead network keeps indexing safely.
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 1_000_000)
+    end
+
+    test "a disabled server occupies no ring position" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "first", port: 6667, priority: 1})
+      {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, priority: 2, enabled: false})
+      {:ok, _} = Servers.add_server(net, %{host: "second", port: 6667, priority: 3})
+
+      preloaded = Repo.preload(net, :servers)
+
+      assert %Server{host: "second"} = Servers.pick_server!(preloaded, 1)
+      assert %Server{host: "first"} = Servers.pick_server!(preloaded, 2)
+    end
+
+    test "a single enabled server is every ring position" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "only", port: 6667, priority: 1})
+      preloaded = Repo.preload(net, :servers)
+
+      for attempt <- 0..3 do
+        assert %Server{host: "only"} = Servers.pick_server!(preloaded, attempt)
+      end
+    end
+
+    test "raises NoServerError at any ring position when none is enabled" do
+      net = network_fixture()
+      {:ok, _} = Servers.add_server(net, %{host: "off", port: 6667, enabled: false})
+      preloaded = Repo.preload(net, :servers)
+
+      assert_raise Networks.NoServerError, fn -> Servers.pick_server!(preloaded, 7) end
     end
   end
 

--- a/test/grappa/server_settings/wire_test.exs
+++ b/test/grappa/server_settings/wire_test.exs
@@ -14,7 +14,8 @@ defmodule Grappa.ServerSettings.WireTest do
         video_per_file_cap_bytes: 52_428_800,
         document_per_file_cap_bytes: 10_485_760,
         audio_per_file_cap_bytes: 26_214_400,
-        global_cap_bytes: 10_737_418_240
+        global_cap_bytes: 10_737_418_240,
+        video_max_duration_seconds: 120
       },
       http_host_aliases: aliases
     }
@@ -34,6 +35,7 @@ defmodule Grappa.ServerSettings.WireTest do
       assert payload.upload.document_per_file_cap_bytes == 10_485_760
       assert payload.upload.audio_per_file_cap_bytes == 26_214_400
       assert payload.upload.global_cap_bytes == 10_737_418_240
+      assert payload.upload.video_max_duration_seconds == 120
     end
 
     test "passes litterbox host atom through" do
@@ -61,6 +63,7 @@ defmodule Grappa.ServerSettings.WireTest do
       assert decoded["kind"] == "server_settings_changed"
       assert decoded["upload"]["active_host"] == "embedded"
       assert decoded["upload"]["audio_per_file_cap_bytes"] == 26_214_400
+      assert decoded["upload"]["video_max_duration_seconds"] == 120
       assert decoded["http_host_aliases"] == ["irc.sindro.me"]
     end
 
@@ -78,7 +81,8 @@ defmodule Grappa.ServerSettings.WireTest do
                video_per_file_cap_bytes: 52_428_800,
                document_per_file_cap_bytes: 10_485_760,
                audio_per_file_cap_bytes: 26_214_400,
-               global_cap_bytes: 10_737_418_240
+               global_cap_bytes: 10_737_418_240,
+               video_max_duration_seconds: 120
              } =
                Wire.upload_view(%{
                  active_host: :embedded,
@@ -86,7 +90,8 @@ defmodule Grappa.ServerSettings.WireTest do
                  video_per_file_cap_bytes: 52_428_800,
                  document_per_file_cap_bytes: 10_485_760,
                  audio_per_file_cap_bytes: 26_214_400,
-                 global_cap_bytes: 10_737_418_240
+                 global_cap_bytes: 10_737_418_240,
+                 video_max_duration_seconds: 120
                })
     end
 
@@ -98,7 +103,8 @@ defmodule Grappa.ServerSettings.WireTest do
                  video_per_file_cap_bytes: 2,
                  document_per_file_cap_bytes: 3,
                  audio_per_file_cap_bytes: 5,
-                 global_cap_bytes: 4
+                 global_cap_bytes: 4,
+                 video_max_duration_seconds: 6
                })
     end
 

--- a/test/grappa/server_settings_test.exs
+++ b/test/grappa/server_settings_test.exs
@@ -13,6 +13,10 @@ defmodule Grappa.ServerSettingsTest do
       assert ServerSettings.get_upload_global_cap_bytes() == 10 * 1024 * 1024 * 1024
     end
 
+    test "get_upload_video_max_duration_seconds/0 defaults to 120s" do
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 120
+    end
+
     test "public_view/0 returns defaults under :upload" do
       view = ServerSettings.public_view()
       assert view.upload.active_host == :embedded
@@ -20,6 +24,7 @@ defmodule Grappa.ServerSettingsTest do
       assert view.upload.video_per_file_cap_bytes == 50 * 1024 * 1024
       assert view.upload.document_per_file_cap_bytes == 10 * 1024 * 1024
       assert view.upload.global_cap_bytes == 10 * 1024 * 1024 * 1024
+      assert view.upload.video_max_duration_seconds == 120
       # #324 — the deployment HTTP host alias set is always present (a
       # list; empty when no PHX_HOST is configured, as in test env).
       assert is_list(view.http_host_aliases)
@@ -138,6 +143,30 @@ defmodule Grappa.ServerSettingsTest do
     end
   end
 
+  describe "put_upload_video_max_duration_seconds/1 (#201)" do
+    test "accepts positive integer" do
+      assert :ok = ServerSettings.put_upload_video_max_duration_seconds(45)
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 45
+    end
+
+    test "rejects zero" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds(0)
+    end
+
+    test "rejects negative" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds(-1)
+    end
+
+    test "rejects a non-integer" do
+      assert {:error, :invalid_value} = ServerSettings.put_upload_video_max_duration_seconds("90")
+    end
+
+    test "a stored non-positive value falls back to the default" do
+      Repo.insert!(%Setting{key: "upload.video_max_duration_seconds", value: "0"})
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 120
+    end
+  end
+
   describe "PubSub broadcast on change" do
     setup do
       Phoenix.PubSub.subscribe(Grappa.PubSub, ServerSettings.topic())
@@ -162,6 +191,15 @@ defmodule Grappa.ServerSettingsTest do
           kind: :server_settings_changed,
           upload: %{video_per_file_cap_bytes: 7_777_777}
         }
+      }
+    end
+
+    test "broadcasts server_settings_changed on put_upload_video_max_duration_seconds" do
+      :ok = ServerSettings.put_upload_video_max_duration_seconds(30)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "event",
+        payload: %{kind: :server_settings_changed, upload: %{video_max_duration_seconds: 30}}
       }
     end
 

--- a/test/grappa/visitors/session_plan_test.exs
+++ b/test/grappa/visitors/session_plan_test.exs
@@ -7,7 +7,8 @@ defmodule Grappa.Visitors.SessionPlanTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Networks.Credentials
+  alias Grappa.Networks.{Credentials, Servers}
+  alias Grappa.Session.Backoff
   alias Grappa.Visitors
   alias Grappa.Visitors.SessionPlan
 
@@ -89,6 +90,25 @@ defmodule Grappa.Visitors.SessionPlanTest do
       {:ok, visitor} = Visitors.find_or_provision_anon("vjt", other.slug, "1.2.3.4")
 
       assert {:error, :network_unconfigured} = SessionPlan.resolve(visitor, network)
+    end
+
+    # #93 — the visitor half of the outer fail-over loop. Same derivation as
+    # the user side (`Grappa.Networks.SessionPlan`): the respawn door reads
+    # the `Session.Backoff` counter the `:transient` cycle already maintains,
+    # so a dead endpoint rolls to the next enabled one instead of parking the
+    # visitor on it forever.
+    test "refresh_plan walks the enabled server ring as failures accrue (#93)" do
+      {network, _} = network_with_server(slug: "azzurra", port: 6667, host: "primary")
+      {:ok, _} = Servers.add_server(network, %{host: "secondary", port: 6667, priority: 9})
+      {:ok, visitor} = Visitors.find_or_provision_anon("vjt-ring", "azzurra", "1.2.3.4")
+      on_exit(fn -> Backoff.forget({:visitor, visitor.id}) end)
+
+      assert {:ok, plan} = SessionPlan.resolve(visitor, network)
+      assert plan.host == "primary"
+
+      :ok = Backoff.record_failure({:visitor, visitor.id}, network.id)
+      assert {:ok, second} = plan.refresh_plan.()
+      assert second.host == "secondary"
     end
 
     # CP24 bucket E lifecycle/S1: visitor plans carry a `credential_failer`

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1240,7 +1240,8 @@ defmodule GrappaWeb.GrappaChannelTest do
           video_per_file_cap_bytes: video_cap,
           document_per_file_cap_bytes: document_cap,
           audio_per_file_cap_bytes: audio_cap,
-          global_cap_bytes: global_cap_bytes
+          global_cap_bytes: global_cap_bytes,
+          video_max_duration_seconds: video_max_duration
         }
       })
 
@@ -1250,6 +1251,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert is_integer(document_cap) and document_cap > 0
       assert is_integer(audio_cap) and audio_cap > 0
       assert is_integer(global_cap_bytes) and global_cap_bytes > 0
+      assert is_integer(video_max_duration) and video_max_duration > 0
     end
 
     test "after-join snapshot: pushes server_settings_changed for visitor socket" do

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -52,6 +52,7 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert upload["document_per_file_cap_bytes"] == 10 * 1024 * 1024
       assert upload["audio_per_file_cap_bytes"] == 25 * 1024 * 1024
       assert upload["global_cap_bytes"] == 10 * 1024 * 1024 * 1024
+      assert upload["video_max_duration_seconds"] == 120
     end
   end
 
@@ -95,6 +96,18 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
                json_response(conn, 200)
 
       assert ServerSettings.get_upload_per_file_cap_bytes(:video) == 25_000_000
+    end
+
+    test "updates video_max_duration_seconds (#201)", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"upload" => %{"video_max_duration_seconds" => 45}})
+
+      assert %{"settings" => %{"upload" => %{"video_max_duration_seconds" => 45}}} =
+               json_response(conn, 200)
+
+      assert ServerSettings.get_upload_video_max_duration_seconds() == 45
     end
 
     test "updates document_per_file_cap_bytes", %{conn: conn, session: session} do
@@ -191,6 +204,21 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert json_response(conn, 422) == %{
                "error" => "invalid_setting",
                "field" => "upload.video_per_file_cap_bytes"
+             }
+    end
+
+    test "422 invalid_setting for zero video_max_duration_seconds (#201)", %{
+      conn: conn,
+      session: session
+    } do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"upload" => %{"video_max_duration_seconds" => 0}})
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "upload.video_max_duration_seconds"
              }
     end
 

--- a/test/grappa_web/controllers/server_settings_controller_test.exs
+++ b/test/grappa_web/controllers/server_settings_controller_test.exs
@@ -23,6 +23,16 @@ defmodule GrappaWeb.ServerSettingsControllerTest do
       assert upload["document_per_file_cap_bytes"] == 10 * 1024 * 1024
       assert upload["audio_per_file_cap_bytes"] == 25 * 1024 * 1024
       assert upload["global_cap_bytes"] == 10 * 1024 * 1024 * 1024
+      assert upload["video_max_duration_seconds"] == 120
+    end
+
+    test "an admin-tuned video duration cap reaches the operator view (#201)", %{conn: conn} do
+      :ok = ServerSettings.put_upload_video_max_duration_seconds(45)
+
+      {_, session} = user_and_session([])
+      conn = conn |> put_bearer(session.id) |> get("/api/server-settings")
+      assert %{"upload" => upload} = json_response(conn, 200)
+      assert upload["video_max_duration_seconds"] == 45
     end
 
     test "response carries the deployment HTTP host aliases (#324)", %{conn: conn} do


### PR DESCRIPTION
## Union branch — three reviewed PRs replayed onto one base

`main` moved to `d76145ed` underneath all three source PRs. Three greens against
three older bases do not compose: a green attests `branch + base`, never
`branch + the other branches about to land beside it`. This branch replays all
six commits onto the current `origin/main` so that **one** CI run gates the
**union** rather than the parts.

Cherry-picked in order, least to most invasive (pure cic → server+cic setting →
core session/respawn), so a red gate can be peeled off the top.

| Source PR | Issue | Source branch | Merge-base | Original head sha |
|-----------|-------|---------------|------------|-------------------|
| #1285 | #359 | `w1/359-alt0-status` | `4879785c` | `f1b17419416a1cda5422200fe2361329458339bd` |
| #1289 | #201 | `w2/201-video-duration-cap` | `4879785c` | `e8eeb2ec278b65b7c1adc3d09778d5299ae0023c` |
| #1282 | #93 | `issue93-server-failover` | `45e88c5e` | `6a152012da8d8a824638e833e633c155e2298ae2` |

The cherry-pick rewrites the shas, so GitHub will not close the source PRs from
this branch; they are closed by content, by hand.

### What lands

- **#359 — Alt+0 jumps to the status window.** The status window was never
  unaddressable; it sat outside the `1..9` index space the digit chords address.
  Alt+0 gives it a chord of its own. Pure cic.
- **#201 — the video duration ceiling becomes a server setting.** The transcode
  ceiling was a client-side constant; it is now an admin-editable server setting
  that cic reads over the wire instead of hardcoding. Server + cic.
- **#93 — the fail-over ring actually advances.** The outer fail-over loop was
  already running, it just never advanced past the first server. It now walks
  the server list on the backoff ladder. Core session/respawn.

### Integrity of the replay

Each PR's `git diff --numstat` contribution was pinned **before** the
cherry-picks and re-diffed **after**; all three are identical byte-for-byte,
including the three `docs/DESIGN_NOTES.md` blocks at 44 / 67 / 74 additions and
zero deletions. No separator was eaten at the append boundary. The eleven
`<!-- entry #... -->` markers in the file are unique, and
`scripts/design-notes-gate.sh` reports `3 new entry heading(s)`.

### Gates

- `scripts/design-notes-gate.sh` — exit 0, `3 new entry heading(s)`
- `scripts/bun.sh run check` — exit 0 over the whole `biome check && tsc --noEmit
  && tsc --noEmit -p e2e/tsconfig.json` chain
- `scripts/bun.sh run test` — exit 0, 282 files / 5382 tests
- `scripts/check.sh` — exit 0. Credo `found no issues` (5778 mods/funs),
  `mix deps.audit` `No vulnerabilities found`, `mix test` 6093 tests /
  59 properties / 8 doctests, 0 failures, Dialyzer `Total errors: 0`, bats
  471/471. The cowboy/cowlib lines are `mix hex.audit`, advisory-only by the
  standing #147/#149 posture, not a gate.
- `scripts/integration.sh` (full suite) — **737 passed, 1 failed**.

### The one e2e red, and why it is not this branch

`media-link-cross-host-modal.spec.ts:138` (#1240, chromium) fails: the
cross-host `<video>` never decodes, the viewer falls into its
*"failed to load"* branch.

It is **pre-existing on this host**, established by displacement rather than by
argument — the same command, `--project chromium --grep "cross-host https video
link" --repeat-each 3`, was run on both sides:

| side | result |
|------|--------|
| this branch | 3/3 red |
| pristine `d76145ed` (detached worktree) | 3/3 red |

Both sides fail on the same two asserts (`:155` when the element is already
gone, `:159` when the poll wins the race to it) — one mechanism, not two bugs.
The verdict was written down before either run.

Supporting evidence that the branch cannot reach it: the **image** twin at `:95`
— same foreign host, same `page.route` stub, same real served CSP — passes; no
`securitypolicyviolation` is logged anywhere; `fixtures/tiny.mp4` is untouched
and valid; `MediaViewerModal.tsx` is not touched by this branch and imports only
`mediaViewer`, `overlayScrollLock`, `pinchZoom`, `platform`, none of which are
touched. #201's `videoPolicy.ts` / `videoTranscode.ts` sit on the upload path,
not the viewer's. The likely mechanism — a runner chromium without an H.264
decoder — is **not** diagnosed here; it belongs to whoever owns that spec.
