### PR TITLE
cic(#1283): ask for the account password before starting a TOTP enrolment

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -934,7 +934,8 @@ export type SettingsSection =
   | "watchlists"
   | "aliases"
   | "perform"
-  | "vhost";
+  | "vhost"
+  | "security";
 
 // Open the settings drawer (viewport-aware) and navigate into `section`'s
 // sub-page, returning the sub-page section locator so callers scope assertions

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -23,7 +23,9 @@
 // read its errors with the dead-token handler ARMED. Sending the password
 // without disarming it would have turned one typo into a logout of every tab
 // sharing the bearer — a regression the fix itself would have introduced.
-// "Still on the security pane, not bounced to /login" is how that is visible.
+// "the refusal is on a pane that is still there" is how that is visible, and
+// it is deliberately ONE assertion rather than two: a separate
+// `pathname !== "/login"` check never fires, because the pane vanishes first.
 //
 // Then the RIGHT password, which has to reach step two: QR and manual key on
 // screen. Enrolment STARTS here and is never confirmed — the returned secret
@@ -59,8 +61,20 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
     await form.getByLabel("Account password").fill("definitely-not-the-password");
     await form.getByRole("button", { name: "enable TOTP" }).click();
 
+    // Two claims in one wait, and the message says so because they fail the
+    // same way. There IS a refusal on the pane — and the pane is still THERE,
+    // which is the survival claim: the door is authenticated, so a wrong
+    // password answers 401, and reading that 401 with the dead-token handler
+    // armed clears the bearer and bounces RequireAuth to /login. Measured:
+    // flipping `readError(res, false)` back to the default kills exactly this
+    // assertion, with the pane gone and nothing to find.
     const alert = pane.getByRole("alert");
-    await expect(alert).toBeVisible();
+    await expect(
+      alert,
+      "no refusal on the TOTP pane — if the pane itself is gone, the 401 was " +
+        "read as a dead bearer and the app logged out (readError must stay " +
+        "disarmed on a re-auth door)",
+    ).toBeVisible();
     // The regression pin. Before the fix EVERY press landed here, whatever
     // was typed, because the request carried no password at all.
     await expect(alert).not.toHaveText(MALFORMED);
@@ -68,11 +82,6 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
 
     // No enrolment was started: no QR, no manual key.
     await expect(pane.getByTestId("totp-enrollment-form")).toHaveCount(0);
-
-    // The 401 must not be read as "this bearer is dead". Still authenticated,
-    // still on the pane.
-    expect(new URL(page.url()).pathname).not.toBe("/login");
-    await expect(pane).toBeVisible();
 
     // The gate clears the field after every attempt, right or wrong, so the
     // next press cannot silently re-send what was just refused.

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -49,7 +49,10 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
   test("a wrong password is refused as a credential, not as a malformed body", async ({ page }) => {
     const user = specUser();
     await loginAs(page, user);
-    const pane = await openSettingsSection(page, "security");
+    const subpage = await openSettingsSection(page, "security");
+    // Scoped to the TOTP section: the passkey section below is a sibling
+    // inside the same subpage and renders its own alert.
+    const pane = subpage.getByTestId("totp-settings");
 
     const form = pane.getByTestId("totp-enable-form");
     await expect(form).toBeVisible();
@@ -79,7 +82,8 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
   test("the right password reaches the QR and the manual key", async ({ page }) => {
     const user = specUser();
     await loginAs(page, user);
-    const pane = await openSettingsSection(page, "security");
+    const subpage = await openSettingsSection(page, "security");
+    const pane = subpage.getByTestId("totp-settings");
 
     const form = pane.getByTestId("totp-enable-form");
     await form.getByLabel("Account password").fill(user.password);

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -1,0 +1,100 @@
+// #1283 — "Enable TOTP" could not work for anybody.
+//
+// `POST /me/totp/enrollment` has required the account password since
+// c1657c3b; cic went on posting a literal `"{}"`, so the controller head
+// never matched, the catch-all answered `bad_request`, and the pane rendered
+// "The request was malformed." on every press. No test caught it because
+// every test that drove the button mocked `lib/api`: the component believed
+// it had asked for an enrolment, and the wire disagreed. This spec is the
+// one that cannot be fooled that way — it drives the real pane against the
+// real endpoint and reads the answer off the screen.
+//
+// ## What it asserts, and why in this order
+//
+// The WRONG password first. A defect that answers `bad_request` to
+// everything looks identical to a working gate if you only check that
+// pressing the button produces an error, so the load-bearing assertion is
+// the NEGATIVE one: the refusal must be the credential refusal, and must NOT
+// be the malformed-body one the defect produced. That single assertion is
+// the regression pin.
+//
+// Still on the wrong-password leg: the session must SURVIVE it. The door is
+// authenticated, so a wrong password answers 401, and this caller used to
+// read its errors with the dead-token handler ARMED. Sending the password
+// without disarming it would have turned one typo into a logout of every tab
+// sharing the bearer — a regression the fix itself would have introduced.
+// "Still on the security pane, not bounced to /login" is how that is visible.
+//
+// Then the RIGHT password, which has to reach step two: QR and manual key on
+// screen. Enrolment STARTS here and is never confirmed — the returned secret
+// stays unarmed, so this spec mutates no account state. Confirming it is
+// what would revoke every other bearer and hand out the recovery codes, and
+// that is deliberately out of scope.
+//
+// The account password is never asserted ON, only typed: it is the per-test
+// subject's throwaway fixture credential, and an assertion that compares it
+// would print it into the report on failure.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: TOTP enrolment
+// is an ACCOUNT verb, not an IRC one. A visitor has no account password and
+// no security pane (the drawer row is gated on `subject.kind === "user"`),
+// so the registered class is the only one this surface has.
+
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import { expect, specUser, test } from "../fixtures/test";
+
+const MALFORMED = /malformed/i;
+
+test.describe("#1283 — TOTP enrolment asks for the account password", () => {
+  test("a wrong password is refused as a credential, not as a malformed body", async ({ page }) => {
+    const user = specUser();
+    await loginAs(page, user);
+    const pane = await openSettingsSection(page, "security");
+
+    const form = pane.getByTestId("totp-enable-form");
+    await expect(form).toBeVisible();
+    await form.getByLabel("Account password").fill("definitely-not-the-password");
+    await form.getByRole("button", { name: "enable TOTP" }).click();
+
+    const alert = pane.getByRole("alert");
+    await expect(alert).toBeVisible();
+    // The regression pin. Before the fix EVERY press landed here, whatever
+    // was typed, because the request carried no password at all.
+    await expect(alert).not.toHaveText(MALFORMED);
+    await expect(alert).toHaveText(/invalid name or password/i);
+
+    // No enrolment was started: no QR, no manual key.
+    await expect(pane.getByTestId("totp-enrollment-form")).toHaveCount(0);
+
+    // The 401 must not be read as "this bearer is dead". Still authenticated,
+    // still on the pane.
+    expect(new URL(page.url()).pathname).not.toBe("/login");
+    await expect(pane).toBeVisible();
+
+    // The gate clears the field after every attempt, right or wrong, so the
+    // next press cannot silently re-send what was just refused.
+    await expect(form.getByLabel("Account password")).toHaveValue("");
+  });
+
+  test("the right password reaches the QR and the manual key", async ({ page }) => {
+    const user = specUser();
+    await loginAs(page, user);
+    const pane = await openSettingsSection(page, "security");
+
+    const form = pane.getByTestId("totp-enable-form");
+    await form.getByLabel("Account password").fill(user.password);
+    await form.getByRole("button", { name: "enable TOTP" }).click();
+
+    const enrollment = pane.getByTestId("totp-enrollment-form");
+    await expect(enrollment).toBeVisible();
+    // Both halves of "scan it or type it" — the QR is an injected svg, the
+    // manual key is the fallback for an unscannable one. Matched as
+    // non-empty rather than compared: the value is enrolment secret material
+    // and a comparison would print it into the report.
+    await expect(enrollment.locator(".qr-frame svg")).toBeVisible();
+    await expect(enrollment.getByLabel("Manual key")).toHaveValue(/.+/);
+
+    // No refusal rode along with the success.
+    await expect(pane.getByRole("alert")).toHaveCount(0);
+  });
+});

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
 import InlineConfirmButton from "./InlineConfirmButton";
+import { withAccountPassword } from "./lib/accountPassword";
 import {
   deletePasskey,
   finishPasskeyModeChange,
@@ -48,36 +49,13 @@ const PasskeySettings: Component = () => {
   };
   onMount(() => void reload().catch((value) => setError(errorMessage(value))));
 
-  // #729 — FIVE privileged actions consume the account password, and only one
-  // of them (add) used to sit inside the form that visually owned the field.
-  // The other four read the signal from elsewhere in the pane with no prompt
-  // of their own, so a user who never filled that form sent `""` and got a
-  // bare 401 back; and a password typed to ADD a passkey stayed live in the
-  // signal, silently re-usable to change how the account authenticates.
-  //
-  // One gate for all five: refuse locally when the field is empty (naming the
-  // blocker instead of spending a doomed request AND a slot in the server's
-  // login-throttle window), and clear the field in the `finally` — on success
-  // AND on failure, so neither a good password nor a wrong one lingers for
-  // the next click to reuse. Re-typing IS the per-action re-confirmation the
-  // pane owes for a change of this weight.
-  const withPassword = async (run: (accountPassword: string) => Promise<void>): Promise<void> => {
-    setError(null);
-    const accountPassword = password();
-    if (accountPassword === "") {
-      setError("Enter your account password to confirm this change.");
-      return;
-    }
-    setBusy(true);
-    try {
-      await run(accountPassword);
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-      setPassword("");
-    }
-  };
+  // #729 — FIVE privileged actions here consume the account password, and
+  // only one of them (add) used to sit inside the form that visually owned
+  // the field. The rationale, and the gate itself, moved to
+  // `lib/accountPassword` when #1283 gave the TOTP section its own consumers.
+  const gate = { password, setPassword, setBusy, setError };
+  const withPassword = (run: (accountPassword: string) => Promise<void>): Promise<void> =>
+    withAccountPassword(gate, run);
 
   const register = async (event: Event): Promise<void> => {
     event.preventDefault();

--- a/cicchetto/src/TotpSettings.tsx
+++ b/cicchetto/src/TotpSettings.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import { withAccountPassword } from "./lib/accountPassword";
 import {
   confirmTotpEnrollment,
   disableTotp,
@@ -41,16 +42,18 @@ const TotpSettings: Component<Props> = (props) => {
       .catch(reportError);
   });
 
-  const beginEnrollment = async (): Promise<void> => {
-    setBusy(true);
-    setError(null);
-    try {
-      setEnrollment(await startTotpEnrollment(currentToken()));
-    } catch (value) {
-      reportError(value);
-    } finally {
-      setBusy(false);
-    }
+  // #1283 — the two account-password consumers in this section go through
+  // the pane-wide gate (`lib/accountPassword`), the same one the passkey
+  // section below uses. Enrolment re-authenticates because confirming it
+  // revokes every other bearer and hands out the recovery codes; disabling
+  // always did.
+  const gate = { password, setPassword, setBusy, setError };
+
+  const beginEnrollment = async (event: Event): Promise<void> => {
+    event.preventDefault();
+    await withAccountPassword(gate, async (accountPassword) => {
+      setEnrollment(await startTotpEnrollment(currentToken(), accountPassword));
+    });
   };
 
   const confirmEnrollment = async (event: Event): Promise<void> => {
@@ -74,18 +77,11 @@ const TotpSettings: Component<Props> = (props) => {
 
   const disable = async (event: Event): Promise<void> => {
     event.preventDefault();
-    setBusy(true);
-    setError(null);
-    try {
-      await disableTotp(currentToken(), password());
+    await withAccountPassword(gate, async (accountPassword) => {
+      await disableTotp(currentToken(), accountPassword);
       setEnabled(false);
-      setPassword("");
       setRecoveryCodes([]);
-    } catch (value) {
-      reportError(value);
-    } finally {
-      setBusy(false);
-    }
+    });
   };
 
   const copyRecoveryCodes = async (): Promise<void> => {
@@ -116,9 +112,24 @@ const TotpSettings: Component<Props> = (props) => {
 
         <Show when={enabled() === false && enrollment() === null && recoveryCodes().length === 0}>
           <p>Protect account login with codes from an authenticator app.</p>
-          <button type="button" disabled={busy()} onClick={() => void beginEnrollment()}>
-            enable TOTP
-          </button>
+          {/* #1283 — no `required` on the field: the gate in
+              `withAccountPassword` is the ONE mechanism that refuses an empty
+              password across this pane, and a native constraint here would
+              make its arm unreachable in a browser while leaving it live in
+              the passkey section. */}
+          <form onSubmit={beginEnrollment} data-testid="totp-enable-form">
+            <label for="totp-enable-password">Account password</label>
+            <input
+              id="totp-enable-password"
+              type="password"
+              autocomplete="current-password"
+              value={password()}
+              onInput={(event) => setPassword(event.currentTarget.value)}
+            />
+            <button type="submit" disabled={busy()}>
+              enable TOTP
+            </button>
+          </form>
         </Show>
 
         <Show when={enrollment()} keyed>
@@ -176,7 +187,6 @@ const TotpSettings: Component<Props> = (props) => {
               autocomplete="current-password"
               value={password()}
               onInput={(event) => setPassword(event.currentTarget.value)}
-              required
             />
             <button type="submit" disabled={busy()}>
               disable TOTP

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -45,7 +45,20 @@ const ENROLLMENT = {
 
 const renderSettings = () => render(() => <TotpSettings onBack={() => undefined} />);
 
+const ACCOUNT_PASSWORD = "test-account-password";
+
+// #1283 — starting an enrolment re-authenticates, so every enrolment
+// journey now begins by typing the account password. Scoped to the enable
+// form: the passkey pane below renders a field with the same label.
+const typeAccountPassword = async (formTestId: string, value: string): Promise<void> => {
+  const form = await screen.findByTestId(formTestId);
+  await fireEvent.input(within(form).getByLabelText("Account password"), {
+    target: { value },
+  });
+};
+
 const beginEnrollment = async (): Promise<void> => {
+  await typeAccountPassword("totp-enable-form", ACCOUNT_PASSWORD);
   await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
   await screen.findByTestId("totp-enrollment-form");
 };
@@ -176,5 +189,72 @@ describe("TotpSettings — enrolment", () => {
     );
     // Still enabled: the pane must not claim a disable that never happened.
     expect(screen.getByTestId("totp-disable-form")).toBeInTheDocument();
+  });
+});
+
+describe("#1283 — starting an enrolment re-authenticates", () => {
+  // `POST /me/totp/enrollment` has demanded the account password since
+  // c1657c3b; the pane went on posting an empty body, so the button could
+  // not work for anyone — every press answered `bad_request`, rendered as
+  // "The request was malformed.". The gate is deliberate (confirming an
+  // enrolment revokes every other bearer and hands out the recovery codes),
+  // so the pane has to ask, exactly as the passkey pane does for its five
+  // privileged verbs and as the disable form already did.
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getTotpStatus.mockResolvedValue({ enabled: false });
+    api.getPasskeyStatus.mockResolvedValue({ mode: "disabled", passkeys: [] });
+    api.startTotpEnrollment.mockResolvedValue(ENROLLMENT);
+  });
+
+  it("passes the typed account password to the enrolment request", async () => {
+    renderSettings();
+    await beginEnrollment();
+
+    expect(api.startTotpEnrollment).toHaveBeenCalledWith("test-token", ACCOUNT_PASSWORD);
+  });
+
+  it("names the empty field as the blocker instead of spending a doomed request", async () => {
+    renderSettings();
+    await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Enter your account password to confirm this change.",
+      ),
+    );
+    expect(api.startTotpEnrollment).not.toHaveBeenCalled();
+  });
+
+  it("clears the field after a refusal so the next press cannot reuse it", async () => {
+    api.startTotpEnrollment.mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    renderSettings();
+    await typeAccountPassword("totp-enable-form", "wrong");
+    await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Invalid name or password.",
+      ),
+    );
+    // The refusal is NOT the malformed-body one the defect produced.
+    expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).not.toHaveTextContent(
+      "The request was malformed.",
+    );
+    // No enrolment was started, and the wrong password does not linger in
+    // the field for the next click to re-send.
+    expect(screen.queryByTestId("totp-enrollment-form")).toBeNull();
+    const form = screen.getByTestId("totp-enable-form");
+    expect((within(form).getByLabelText("Account password") as HTMLInputElement).value).toBe("");
+  });
+
+  it("keeps the field a password field, so it is never rendered in the clear", async () => {
+    renderSettings();
+    const form = await screen.findByTestId("totp-enable-form");
+    const field = within(form).getByLabelText("Account password") as HTMLInputElement;
+
+    expect(field.type).toBe("password");
+    expect(field.autocomplete).toBe("current-password");
   });
 });

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1137,3 +1137,44 @@ describe("api.me single-flight (#394)", () => {
     expect((await retry).badge_count).toBe(2);
   });
 });
+
+describe("#1283 — the enrolment door is password-gated, so cic must knock with one", () => {
+  // `POST /me/totp/enrollment` has required the account password since
+  // c1657c3b; `startTotpEnrollment` kept posting a literal `"{}"`, so the
+  // controller head never matched, the catch-all answered `bad_request` and
+  // the pane rendered "The request was malformed." for every user alive.
+  //
+  // The second test is the half the fix would break if it stopped at the
+  // body. A password-gated door can answer 401 `invalid_credentials`, and
+  // this caller read its errors with the dead-token handler ARMED — the
+  // default. Sending the password without disarming it turns one typo into
+  // a logout of every tab sharing the bearer. `disableTotp` and every
+  // `passkeyRequest` already read theirs disarmed for exactly this reason:
+  // on a re-auth door a 401 means "wrong password", never "dead bearer".
+
+  it("sends the account password in the enrolment request body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ enrollment_token: "t", secret: "s", provisioning_uri: "otpauth://x" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.startTotpEnrollment("bearer", "hunter2");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/totp/enrollment");
+    expect(JSON.parse(init.body as string)).toEqual({ password: "hunter2" });
+  });
+
+  it("a wrong password does not fire the dead-token handler", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "invalid_credentials" });
+    await expect(api.startTotpEnrollment("bearer", "wrong")).rejects.toBeInstanceOf(api.ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ruleBody, themeCss } from "./helpers/themeCss";
 
@@ -77,6 +77,12 @@ describe("#734 TOTP enrolment QR sits in a sized, light-framed box", () => {
     });
 
     render(() => <TotpSettings onBack={() => {}} />);
+    // #1283 — enrolment re-authenticates, so the QR only appears once the
+    // account password has been typed into the enable form.
+    const enable = await screen.findByTestId("totp-enable-form");
+    await fireEvent.input(within(enable).getByLabelText("Account password"), {
+      target: { value: "test-account-password" },
+    });
     await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
 
     const form = await screen.findByTestId("totp-enrollment-form");

--- a/cicchetto/src/lib/accountPassword.ts
+++ b/cicchetto/src/lib/accountPassword.ts
@@ -1,0 +1,54 @@
+import { errorMessage } from "./friendlyApiError";
+
+// The security pane's re-auth gate, shared by every control that spends the
+// account password.
+//
+// #729 wrote it for the passkey pane's five privileged verbs, after four of
+// them read the add-passkey form's field behind the user's back: a user who
+// never filled that form sent `""` and earned a bare 401, and a password
+// typed to ADD a passkey stayed live in the signal, silently re-usable to
+// change how the account authenticates.
+//
+// #1283 gave the TOTP section its second and third consumers (enrolment now
+// re-authenticates too), which is why the gate moved out of the component:
+// two copies of "refuse an empty field, clear it afterwards" would drift,
+// and the refusal a user reads must not depend on which section they are in.
+export const ACCOUNT_PASSWORD_REQUIRED = "Enter your account password to confirm this change.";
+
+// The four signal accessors the gate drives. Each section keeps its own
+// field — one shared field across the pane would let a password typed for
+// one section be spent by another.
+export type AccountPasswordGate = {
+  password: () => string;
+  setPassword: (value: string) => void;
+  setBusy: (value: boolean) => void;
+  setError: (value: string | null) => void;
+};
+
+// Runs `action` with the typed password, or refuses locally when the field
+// is empty — naming the blocker instead of spending a doomed request.
+//
+// The field is cleared in the `finally`: on success AND on failure, so
+// neither a good password nor a wrong one lingers for the next click to
+// reuse. Re-typing IS the per-action re-confirmation a pane that changes how
+// the account authenticates owes its user.
+export async function withAccountPassword(
+  gate: AccountPasswordGate,
+  action: (accountPassword: string) => Promise<void>,
+): Promise<void> {
+  gate.setError(null);
+  const accountPassword = gate.password();
+  if (accountPassword === "") {
+    gate.setError(ACCOUNT_PASSWORD_REQUIRED);
+    return;
+  }
+  gate.setBusy(true);
+  try {
+    await action(accountPassword);
+  } catch (value) {
+    gate.setError(errorMessage(value));
+  } finally {
+    gate.setBusy(false);
+    gate.setPassword("");
+  }
+}

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1552,13 +1552,25 @@ export async function getTotpStatus(token: string): Promise<{ enabled: boolean }
   return (await res.json()) as { enabled: boolean };
 }
 
-export async function startTotpEnrollment(token: string): Promise<TotpEnrollment> {
+// #1283 — the account password is REQUIRED: the door re-authenticates,
+// because confirming the enrolment it opens revokes every other bearer
+// session and hands out the recovery codes.
+//
+// `readError(res, false)` for the same reason `disableTotp` and every
+// `passkeyRequest` use it: on a re-auth door a 401 says "wrong password",
+// not "your bearer is dead". Armed (the default), one typo here would fire
+// the dead-token handler and log out every tab sharing the bearer — the
+// #739 class, arriving through an AUTHENTICATED endpoint.
+export async function startTotpEnrollment(
+  token: string,
+  password: string,
+): Promise<TotpEnrollment> {
   const res = await fetch("/me/totp/enrollment", {
     method: "POST",
     headers: buildHeaders(token),
-    body: "{}",
+    body: JSON.stringify({ password }),
   });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   return (await res.json()) as TotpEnrollment;
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41195,3 +41195,65 @@ exemptions and should not grow any.
 **Apply:** when a limit exists to mirror an external system's limit, key it
 on state that system publishes, and let the letter table say what was READ
 at source rather than what is probably true elsewhere.
+<!-- entry #1283 -->
+
+---
+
+## 2026-08-13 — #1283: the enrolment door asks for a password, so cic knocks with one
+
+`POST /me/totp/enrollment` has demanded the account password since c1657c3b.
+cic kept posting a literal `"{}"`, so the controller head never matched, the
+catch-all answered `bad_request`, and every press of **Enable TOTP** rendered
+"The request was malformed." The button could not work for anyone, on any
+substrate, for anybody's password.
+
+**The gate stays; the client learns to knock.** Re-authenticating before
+arming a second factor is the deliberate posture c1657c3b argued for:
+confirming an enrolment revokes every other bearer session and hands out the
+recovery codes, so a borrowed token alone must not be able to arm a factor
+the real owner does not hold. Weakening the server to admit the client would
+undo the fix the client failed to notice.
+
+**The census, because a gate is a sample and not a list.** Seven
+authenticated endpoints require the account password: `POST
+/me/totp/enrollment`, `DELETE /me/totp`, `POST /me/client-tokens`, `POST
+/me/passkeys/registration/options`, `POST /me/passkeys/mode/options`, `POST
+/me/passkeys/passwordless/recovery`, `DELETE /me/passkeys/:id`. c1657c3b made
+exactly ONE of them newly password-gated — the enrolment start — and moved
+`disable_totp/3` onto the new `Accounts.verify_password/2` without changing
+its contract. Of the seven, six were already answered correctly by cic; the
+`/me/client-tokens` mint has no cic caller at all (the issue's "the way the
+client-token mint flow already must" describes an API-only flow — cic has no
+mint UI, and `client_token` appears in `cicchetto/src` only as error copy).
+So the defect was one caller, and the proven negative on the other six is the
+result, not a shrug.
+
+**The half the body fix would have broken.** A password-gated door answers
+401 `invalid_credentials`, and `startTotpEnrollment` read its errors with the
+dead-token handler ARMED — the `readError` default. Sending the password
+without disarming it turns one typo into a logout of every tab sharing the
+bearer: the #739 class, arriving this time through an AUTHENTICATED endpoint.
+`disableTotp` and every `passkeyRequest` already read theirs disarmed for
+exactly this reason. On a re-auth door a 401 means "wrong password", never
+"dead bearer" — that distinction is now the third member of the #739 rule,
+and the reason it has an e2e assertion of its own rather than a comment.
+
+**One gate for the whole pane.** #729 wrote "refuse an empty field locally,
+clear it in the `finally`" for the passkey section's five verbs. The TOTP
+section now has two consumers of its own, so the gate moved to
+`lib/accountPassword.ts` rather than being copied: two copies of the rule
+would drift, and the refusal a user reads must not depend on which section of
+one pane they are standing in. Each section keeps its OWN field — one shared
+field would let a password typed for one section be spent by another, which
+is the #729 defect at pane scope.
+
+Consequently the disable field loses its `required` attribute. A native
+constraint makes the code gate's arm unreachable in a browser while leaving
+it live in the passkey section: two mechanisms for one rule, and only one of
+them testable. The gate is the mechanism.
+
+**Apply:** when a server-side requirement is added to an endpoint, the
+callers are part of the change. And when the added requirement is a
+credential, check what the endpoint's new failure code does on the way back —
+a 401 that used to be unreachable is not the same 401 the caller was written
+against.


### PR DESCRIPTION
Fixes the **Enable TOTP** button, which could not work for anyone.

`POST /me/totp/enrollment` has required the account password since `c1657c3b`.
`startTotpEnrollment` went on posting a literal `"{}"`, so the controller head
`%{"password" => password}` never matched, the catch-all answered
`bad_request`, and the pane rendered "The request was malformed." on every
press, for every user, on every substrate.

The server gate stays. Re-authenticating before arming a second factor is the
posture `c1657c3b` argued for: confirming an enrolment revokes every other
bearer session and hands out the recovery codes, so a borrowed token alone
must not arm a factor the real owner does not hold. The client learns to
knock.

## The census

The issue asks whether the same gap exists anywhere else `c1657c3b` touched.
It does not — and here is the enumeration behind that negative, because a
gate is a sample and not a list.

Seven authenticated endpoints require the account password:

| Endpoint | Controller | cic caller | Sends the password? |
| --- | --- | --- | --- |
| `POST /me/totp/enrollment` | `TotpController.start_enrollment` | `startTotpEnrollment` | **no — this defect** |
| `DELETE /me/totp` | `TotpController.delete` | `disableTotp` | yes |
| `POST /me/client-tokens` | `ClientTokenController.create` | **none** | n/a |
| `POST /me/passkeys/registration/options` | `PasskeyController.registration_options` | `startPasskeyRegistration` | yes |
| `POST /me/passkeys/mode/options` | `PasskeyController.mode_options` | `startPasskeyModeChange` | yes |
| `POST /me/passkeys/passwordless/recovery` | `PasskeyController.prepare_passwordless` | `preparePasswordless` | yes |
| `DELETE /me/passkeys/:id` | `PasskeyController.delete` | `deletePasskey` | yes |

`c1657c3b` made **exactly one** of them newly password-gated — the enrolment
start. It also moved `disable_totp/3` onto the new `Accounts.verify_password/2`
without changing that endpoint's contract, which is why nothing else moved.

Two things the census turned up that the issue could not:

* **`POST /me/client-tokens` has no cic caller at all.** The issue's fix
  direction says to prompt for the password "the way the client-token mint
  flow already must" — that flow is API-only. `client_token` appears in
  `cicchetto/src` solely as wire-error copy (`friendlyApiError.ts`); there is
  no mint UI to imitate. The real in-cic precedents are #729's passkey section
  and the TOTP disable form, and those are what this follows.
* **The five passkey callers all route through one gate**, `withPassword`
  (#729), which refuses an empty field locally and clears it afterwards. The
  TOTP section needed the same behaviour, so the gate moved to
  `lib/accountPassword.ts` rather than being copied.

## The half a body-only fix would have broken

A password-gated door answers 401 `invalid_credentials`, and this caller read
its errors with the dead-token handler **armed** — `readError`'s default.
Sending the password without disarming it turns one typo into a logout of
every tab sharing the bearer: the #739 class, arriving this time through an
*authenticated* endpoint. `disableTotp` and every `passkeyRequest` already read
theirs disarmed for exactly this reason. On a re-auth door a 401 means "wrong
password", never "dead bearer".

## Also in here

* The disable field loses its `required` attribute, so the code gate is the
  ONE mechanism refusing an empty password across this pane. A native
  constraint makes the gate's arm unreachable in a browser while leaving it
  live in the section next door: two mechanisms for one rule, only one of them
  testable.
* The #729 comment claimed an empty-field request also spends "a slot in the
  server's login-throttle window". Measured, it does not:
  `Grappa.RateLimit.FailureWindow` guards the login, TOTP-login,
  passkey-login-options and passkey-recovery doors, and none of the
  authenticated re-auth doors records a failure there. The claim is dropped
  rather than carried across.

## Tests

Written before the fix; the component and boundary tests were watched red
first (11 failures), and the e2e — which could only be written after — was
proven by measured mutants instead.

* `api.test.ts` — the request body carries the password; a 401 from this door
  does not fire the dead-token handler.
* `TotpSettings.test.tsx` — the typed password reaches the call; an empty
  field is refused locally with no request; the field is cleared after a
  refusal; the field is `type=password` / `autocomplete=current-password`.
* `issue1283-totp-enrolment-password.spec.ts` — real pane, real endpoint. A
  wrong password gets a refusal that is **not** the malformed one, on a pane
  that is still there; the right password reaches the QR and the manual key.
  Enrolment is started and never confirmed, so the spec arms nothing and
  mutates no account state.

Mutants, scoped `--grep "#1283"` on the real stack:

| Mutant | Outcome |
| --- | --- |
| body key `password` → `passwd` (the production defect, in a form that still typechecks) | test 1 dies on `not.toHaveText(/malformed/i)`, `Received string: "The request was malformed."`; test 2 dies with no enrolment form |
| `readError(res, false)` → `readError(res)` | test 1 dies waiting for the alert — the pane is gone, the app logged out; test 2 stays green, correctly, since a right password never reaches a 401 |
| none | 6/6 green under `--repeat-each 3` |

The first mutant is worth a note: reverting the body to the literal `"{}"`
does not reach the browser at all, because `password` then goes unread and
`tsc` fails the bundle build. The mutant had to be re-cut as a wrong KEY to
test what the spec actually watches.

## Gates

* `bun run test` — 5372 passed / 282 files, rc 0
* `bun run check` — biome + `tsc` over `src` and `e2e`, rc 0
* `scripts/design-notes-gate.sh` — rc 0
* `scripts/integration.sh --grep "#1283"` — 2 passed, and 6/6 under
  `--repeat-each 3`

## What is NOT claimed

The **full** integration suite has not been run on this branch — only the
scoped `--grep`. No Elixir gate was run either: the diff touches no `.ex`,
and the only non-cic file is the DESIGN_NOTES entry. The blast radius on the
rest of the e2e suite is a one-line widening of the `SettingsSection` union
in a shared fixture, which no other spec reads.

The sibling issue #1284 is untouched.