### PR TITLE
auth(#1284): stop the other-sessions sweep from killing client tokens

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -356,9 +356,12 @@ Three properties worth designing around:
   may also skip `/auth/login` entirely and present it directly as
   `Authorization: Bearer <token>` / the WS bearer subprotocol (§3a).
 - **It does not expire while idle.** A browser session dies after seven
-  days of silence; a client token does not. Revocation by its owner is
-  the only thing that ends it — expect a `401`, and surface it as "this
-  token was revoked", not as a transient network error.
+  days of silence; a client token does not. Only revocation ends it —
+  by its owner, or by an operator resetting the account's factors or
+  rotating its password. Its owner arming, disarming or changing a
+  second factor does NOT (#1284), so minting the token first and arming
+  the factor afterwards is a safe order. Expect a `401`, and surface it
+  as "this token was revoked", not as a transient network error.
 - **It is scoped.** A client token can read and send as the account, and
   that is all. The account's own credential surfaces — `/admin/*`,
   `/me/totp*`, `/me/passkeys*`, `DELETE /me`, and the token routes

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41195,3 +41195,54 @@ exemptions and should not grow any.
 **Apply:** when a limit exists to mirror an external system's limit, key it
 on state that system publishes, and let the letter table say what was READ
 at source rather than what is probably true elsewhere.
+<!-- entry #1284 -->
+
+---
+
+## 2026-08-13 — #1284: who is at the door decides whether a client token dies
+
+`revoke_other_sessions_for_user!/2` swept an account's live bearers by
+`user_id` alone. A per-client token (#1196) is a `Session` row like any
+other, so arming TOTP revoked the exact credential the feature exists to
+provide — and the order `CLIENT_PROTOCOL.md` §7 puts an operator on (mint
+the token, hand it to the headless client, then arm the factor) was the
+order that broke. Silently: the enrolment succeeds, the recovery codes
+print, and the bridge starts answering `401 invalid_credentials`,
+indistinguishable from a wrong password.
+
+**Ruled: exclude.** The sweep now carries `s.kind != :client`, on all
+three of its call-sites — TOTP enrolment (`accounts.ex`), TOTP disable
+(same), and the passkey mode transaction (`webauthn.ex`). The first was
+the reported one; the other two were censused and ruled together, because
+they are one class rather than three cases.
+
+**The line is WHO is at the door, not WHICH factor moved.** All three
+call-sites are reached by an account holder who has just proven they hold
+the account — a password, a TOTP code, a passkey assertion — and who is
+changing their factors precisely so the headless credential keeps working.
+Operator recovery (`reset_totp` / `reset_passkeys`) and admin password
+rotation are the opposite: nobody proved anything, and burning every
+derived credential is the defensible blast radius. Those doors were
+already a DIFFERENT function — `revoke_sessions_for_user!/1`, the
+whole-account sweep with no `other` and no `kind` filter — so the fix
+needed nothing added there, only a test pinning that the filter did not
+leak into it.
+
+**Why a filter in the function and not a flag on the call.** An opt-out
+argument would put the security posture at three call-sites where it can
+drift, and a default argument would make the safe answer the one nobody
+typed (house rule). One function, one behaviour, and the docstring states
+what it no longer revokes; a caller that wants everything gone asks for
+the whole-account sweep by name.
+
+`!= :client` rather than `== :web`, so a future third kind is swept until
+someone rules otherwise — fail-closed is the right default for a revoke,
+and `:client` is the only kind with an argument for surviving.
+
+**Apply:** when a sweep exists to protect an account, ask what the door
+PROVED before deciding how wide it reaches. And a credential whose whole
+purpose is to outlive a change must be tested against the change itself,
+not only against its own kill switch — the `Accounts` moduledoc had
+asserted in prose that the sweeps deliberately did not special-case it,
+which is how a documented non-decision outlived the feature that
+contradicted it.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -62,13 +62,20 @@ defmodule Grappa.Accounts do
       `GrappaWeb.Plugs.RequireFullSession`, so it can read and send but
       cannot administer, re-credential, or re-mint.
 
-  What is deliberately NOT special-cased: the revoke sweeps. Every
-  credential-material change that already evicts an account's other
-  sessions (`revoke_other_sessions_for_user!/2`, reached from TOTP
-  enrolment / disable; `revoke_sessions_for_user/1`, reached from the
-  operator resets) evicts its client tokens along with them. That is the
-  fail-closed direction and it costs no branch: arming or resetting a
-  second factor is exactly the moment a re-issue is wanted.
+  The third difference is which revoke sweep reaches it (GH #1284), and
+  the line is WHO is at the door:
+
+    * a sweep the account holder triggered, having just proven they hold
+      the account — arming or disarming TOTP, changing passkey mode —
+      spares them (`revoke_other_sessions_for_user!/2`). The point of the
+      credential is to outlive a change to the account's factors; revoking
+      it there made the documented order (mint, then arm) lock the client
+      out at the moment the factor was confirmed;
+    * a sweep nobody proved they hold the account to reach — operator
+      recovery, admin password rotation — takes them
+      (`revoke_sessions_for_user/1` and its `!` twin, no `kind` filter).
+
+  A token's own kill switch is `revoke_client_token/2`.
   """
   use Boundary,
     top_level?: true,
@@ -844,7 +851,19 @@ defmodule Grappa.Accounts do
   end
 
   @doc """
-  Revokes every live bearer for `user` except the current session.
+  Revokes every live WEB bearer for `user` except the current session.
+
+  It does NOT revoke the account's `:client` tokens (GH #1284). Every
+  caller here is a door the account holder has just proven they hold —
+  arming TOTP, disarming it under password, changing passkey mode — and a
+  client token is the credential #1196 exists to keep alive ACROSS such a
+  change. Sweeping by `user_id` alone made the documented order (mint the
+  token, then arm the factor) lock the client out at the moment the factor
+  was confirmed, with a `401` the operator could not tell from a wrong
+  password. The kill switch for a token is `revoke_client_token/2`, and
+  operator recovery still burns everything through the whole-account
+  `revoke_sessions_for_user!/1` — which is a different function, and
+  deliberately carries no `kind` filter.
 
   In-transaction only — every caller (TOTP enrolment/disable, the passkey
   mode transaction) already runs inside a
@@ -857,9 +876,14 @@ defmodule Grappa.Accounts do
   @spec revoke_other_sessions_for_user!(User.t(), Ecto.UUID.t()) :: :ok
   def revoke_other_sessions_for_user!(%User{id: user_id, name: name}, current_session_id)
       when is_binary(current_session_id) do
+    # `!= :client` rather than `== :web`: a future third kind is swept until
+    # someone rules otherwise, which is the fail-closed direction for a
+    # revoke. Only `:client` has an argument for surviving, and it is above.
     query =
       from(s in Session,
-        where: s.user_id == ^user_id and s.id != ^current_session_id and is_nil(s.revoked_at)
+        where:
+          s.user_id == ^user_id and s.id != ^current_session_id and is_nil(s.revoked_at) and
+            s.kind != :client
       )
 
     Repo.update_all(query, set: [revoked_at: DateTime.utc_now()])

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -150,7 +150,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       now = 1_700_000_000
       {:ok, code} = TOTP.code_at(@rfc_secret, now)
 
-      assert {:ok, _codes} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
+      assert {:ok, _} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
 
       assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
       assert {:error, :revoked} = Accounts.authenticate(other.id)
@@ -164,7 +164,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       other = session_fixture(armed)
       token = client_token(armed, "bicchierino bridge")
 
-      assert {:ok, _user} = Accounts.disable_totp(armed, current.id, password)
+      assert {:ok, _} = Accounts.disable_totp(armed, current.id, password)
 
       assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
       assert {:error, :revoked} = Accounts.authenticate(other.id)
@@ -191,7 +191,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       armed = arm(user)
       token = client_token(armed, "bicchierino bridge")
 
-      assert {:ok, _user} = Accounts.reset_totp(armed.name)
+      assert {:ok, _} = Accounts.reset_totp(armed.name)
 
       assert {:error, :revoked} = Accounts.authenticate(token.id)
     end
@@ -200,7 +200,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
   defp arm(user) do
     now = 1_700_000_000
     {:ok, code} = TOTP.code_at(@rfc_secret, now)
-    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    {:ok, _} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
     Accounts.get_user!(user.id)
   end
 

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -8,9 +8,10 @@ defmodule Grappa.Accounts.ClientTokenTest do
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, Repo}
-  alias Grappa.Accounts.{Session, Wire}
+  alias Grappa.Accounts.{Session, TOTP, WebAuthn, Wire}
 
   @thirty_days 30 * 24 * 3600
+  @rfc_secret "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
 
   defp idle_for(%Session{} = session, seconds) do
     session
@@ -120,10 +121,11 @@ defmodule Grappa.Accounts.ClientTokenTest do
       assert Accounts.list_client_tokens(user) == []
     end
 
-    test "a credential-material sweep takes the client tokens with it" do
-      # Not a special case in the code, and this arm is what keeps it from
-      # becoming one: arming or resetting a second factor evicts an
-      # account's other sessions, and a client token is one of them.
+    test "a whole-account sweep takes the client tokens with it" do
+      # The revoke-EVERY-session door (admin password rotation, operator
+      # recovery) draws no line at `kind`: nobody proved they hold the
+      # account, so every derived credential goes. Contrast the
+      # revoke-every-OTHER-session door below, which spares them.
       user = user_fixture()
       token = client_token(user, "issued before the reset")
 
@@ -131,6 +133,75 @@ defmodule Grappa.Accounts.ClientTokenTest do
 
       assert {:error, :revoked} = Accounts.authenticate(token.id)
     end
+  end
+
+  # GH #1284. `revoke_other_sessions_for_user!/2` swept by `user_id` alone,
+  # so arming TOTP killed the very credential #1196 exists to keep alive —
+  # silently, with a 401 the operator could not tell from a wrong password.
+  # Each test pins BOTH halves: the token survives AND the browser bearer
+  # still dies, because a filter that revoked nothing would pass on the
+  # first assertion alone.
+  describe "the revoke-other-sessions sweep spares client tokens" do
+    test "arming TOTP" do
+      user = user_fixture()
+      current = session_fixture(user)
+      other = session_fixture(user)
+      token = client_token(user, "bicchierino bridge")
+      now = 1_700_000_000
+      {:ok, code} = TOTP.code_at(@rfc_secret, now)
+
+      assert {:ok, _codes} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+      assert {:ok, %Session{}} = Accounts.authenticate(current.id)
+    end
+
+    test "disabling TOTP" do
+      {user, password} = user_fixture_with_password()
+      armed = arm(user)
+      current = session_fixture(armed)
+      other = session_fixture(armed)
+      token = client_token(armed, "bicchierino bridge")
+
+      assert {:ok, _user} = Accounts.disable_totp(armed, current.id, password)
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+    end
+
+    test "changing passkey mode" do
+      user = user_fixture()
+      current = session_fixture(user)
+      other = session_fixture(user)
+      token = client_token(user, "bicchierino bridge")
+
+      assert {:ok, :second_factor} = WebAuthn.set_mode(user, :second_factor, current.id, [])
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+    end
+
+    # The other side of the ruling: the recovery door is reached by an
+    # operator, not by a proven account holder, so it keeps burning every
+    # credential. It is a DIFFERENT function (`revoke_sessions_for_user!/1`,
+    # no `other`) and the `kind` filter must not reach it.
+    test "but operator recovery still burns them" do
+      user = user_fixture()
+      armed = arm(user)
+      token = client_token(armed, "bicchierino bridge")
+
+      assert {:ok, _user} = Accounts.reset_totp(armed.name)
+
+      assert {:error, :revoked} = Accounts.authenticate(token.id)
+    end
+  end
+
+  defp arm(user) do
+    now = 1_700_000_000
+    {:ok, code} = TOTP.code_at(@rfc_secret, now)
+    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    Accounts.get_user!(user.id)
   end
 
   describe "authenticate_client_token/5" do


### PR DESCRIPTION
Refs #1284. Ruling: **exclude** (vjt, on #grappa 2026-08-13 18:37), extended to all three call-sites (19:18).

## The defect

`revoke_other_sessions_for_user!/2` swept an account's live bearers by `user_id` alone. A per-client token (#1196) is a `Session` row like any other, so arming TOTP revoked the exact credential the feature exists to provide — and the order `CLIENT_PROTOCOL.md` §7 puts an operator on (mint the token, hand it to the headless client, then arm the factor) was the order that broke. Silently: the enrolment succeeds, the recovery codes print, and the bridge starts answering a `401` indistinguishable from a wrong password.

## The fix

The sweep now carries `s.kind != :client`. The filter lives in the function, not at the call-sites: an opt-out argument would put a security posture in three places where it can drift, and a default argument would make the safe answer the one nobody typed.

`!= :client` rather than `== :web` so a future third kind is still swept — fail-closed is the right default for a revoke, and `:client` is the only kind with an argument for surviving.

## Census

Three call-sites, all covered, because they are one class rather than three cases — each is reached by an account holder who has just proven they hold the account and is changing their factors precisely so the headless credential keeps working:

| call-site | door |
|---|---|
| `accounts.ex` `confirm_totp_transaction` | `POST /me/totp/enrollment/confirm` |
| `accounts.ex` `disable_totp_transaction` | `DELETE /me/totp`, under password |
| `webauthn.ex` `set_mode_transaction` | `POST /me/passkeys/mode`, under assertion |

Operator recovery (`reset_totp` / `reset_passkeys`) and admin password rotation are the opposite door — nobody proved anything there — and they already go through a **different** function, `revoke_sessions_for_user!/1`: whole-account, no `other`, no `kind` filter. Untouched, and a test pins that the filter did not leak into it.

The census also covers the write side, not only the call side: four sites in `lib` write `revoked_at`, and the other three (`revoke_session/1`, `revoke_sessions_for_visitor/1`, `revoke_sessions_for_user!/1`) are all correct as they stand.

## Evidence

Red before green, then each assertion bought with a measured mutant:

| mutant | kills |
|---|---|
| no `kind` filter (the pre-fix code) | `the token survives` — 3 failures |
| filter that matches nothing | `the browser bearer still dies` — 3 failures |
| `kind` filter leaked into `revoke_sessions_for_user!/1` | the two recovery-side guards — 2 failures |

One mutant, one assertion: none of them is decorative.

`scripts/check.sh` green on this tip — 8 doctests, 59 properties, 6076 tests, 0 failures; Sobelow `Total errors: 0`; Credo clean; `design-notes-gate.sh` reports the entry's separator and marker present.

## Docs

- `docs/DESIGN_NOTES.md` — entry `#1284`, separator and marker in the same commit.
- `docs/CLIENT_PROTOCOL.md` §7 — the paragraph the issue names said revocation by the owner was "the only thing that ends it", which was false before this change and still not exhaustive after it. It now names the operator doors and states that arming a factor does not revoke the token, so the mint-then-arm order is documented as safe.
- `docs/OPERATIONS.md` needed no edit: its client-token paragraph already claimed arming a factor "does not have to lock shottino out any more", which this change makes true rather than aspirational, and its "the two reset verbs revoke client tokens along with everything else" is unaffected.

No wire change, no `cicchetto/` file touched, no e2e spec covers this surface.