### PR TITLE
cic(#1288): ingest a catch-up page in one store write, not two hundred

### DIFF
--- a/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
@@ -1,0 +1,347 @@
+import { createEffect, createRoot, on } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+
+// #1288 — the COST of ingesting a catch-up page, and the invariants that cost
+// is not allowed to buy.
+//
+// `refreshScrollback` used to ingest its REST page one `appendToScrollback`
+// per row. Each of those is a duplicate SCAN over everything the pane already
+// holds, a copy of the whole row array, a copy of the channel map, and its own
+// Solid signal write — so a 200-row page ran the pane's reactive graph 200
+// times and did O(page x pane) work. A reporter's Firefox Profiler trace put
+// 1917 of 2002 cicchetto samples under that verb, ~1 s of saturated main
+// thread per burst.
+//
+// Two oracles here, both DELIBERATELY host-independent — a wall-clock
+// threshold in a shared-runner suite goes red on load rather than on a
+// regression, so the committed guard measures WORK, not time:
+//
+//   * reactive passes — an effect on the store signal counts one tick per
+//     store write. The honest user-visible unit: each pass is a render the
+//     browser pays for. 200 -> 1.
+//   * id reads — every row is handed to the store with `id` behind a getter
+//     that counts. The dedupe scan reads every loaded row's id once per
+//     ARRIVING row in the per-row shape (O(P*N)) and once in total in the
+//     batched one (O(P+N)). The number is exact, reproducible and moves with
+//     the mutation: restore the loop and it goes back up by two orders of
+//     magnitude on a full page.
+//
+// Both are asserted with DISPLACEMENT — the same measurement at several page
+// and pane sizes — because a single before/after pair cannot tell a constant
+// factor from a changed complexity class.
+//
+// The third block asserts what the fix must NOT cost. The issue proposed
+// reusing `mergeIntoScrollback` (already batched, in this same module); it is
+// NOT the same verb. It deliberately applies no S20 ring cap (a scroll-up
+// prepend must not be truncated mid-scroll) and so never invalidates the
+// loadMore exhausted latch either. Swapping it in would have removed the ring
+// cap from the reconnect path — the very path S20's own comment names — with
+// every existing cap test still green, because they all drive
+// `appendToScrollback` directly.
+
+vi.mock("../lib/api", () => ({
+  listMessages: vi.fn(),
+  listMessagesAfter: vi.fn(),
+  countMessagesAfter: vi.fn(),
+  sendMessage: vi.fn(),
+  isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
+  isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+}));
+
+const mockGetResumeCursor = vi.fn<(slug: string, chan: string) => number | null>(() => null);
+vi.mock("../lib/reconnectBackfill", () => ({
+  getResumeCursor: (slug: string, chan: string) => mockGetResumeCursor(slug, chan),
+  recordSeen: vi.fn(),
+}));
+
+const mockGetReadCursor = vi.fn<(slug: string, chan: string) => number | null>(() => null);
+vi.mock("../lib/readCursor", () => ({
+  getReadCursor: (slug: string, chan: string) => mockGetReadCursor(slug, chan),
+  setReadCursor: vi.fn(),
+}));
+
+const SLUG = "freenode";
+const CHAN = "#grappa";
+const KEY = channelKey(SLUG, CHAN);
+
+// Row whose `id` is a counting getter. Every read the store performs — the
+// dedupe scan, the tail comparison, the ring-cap protection scan, a sort — is
+// one tick. `counter` is a shared box so a whole page reports into one number.
+const countingRow = (id: number, counter: { reads: number }): ScrollbackMessage => {
+  const row = {
+    network: SLUG,
+    channel: CHAN,
+    server_time: id * 1000,
+    kind: "privmsg" as const,
+    sender: "alice",
+    body: `line ${id}`,
+    meta: {},
+  };
+  Object.defineProperty(row, "id", {
+    get() {
+      counter.reads++;
+      return id;
+    },
+    enumerable: true,
+  });
+  return row as ScrollbackMessage;
+};
+
+const plainRow = (id: number): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: CHAN,
+  server_time: id * 1000,
+  kind: "privmsg",
+  sender: "alice",
+  body: `line ${id}`,
+  meta: {},
+});
+
+// Fill a pane with `n` rows through the LIVE path. The seeded rows count
+// their id reads too — they are what the dedupe scan walks, so leaving them
+// plain would under-report the quadratic term by half.
+const seedPane = (
+  scrollback: typeof import("../lib/scrollback"),
+  n: number,
+  counter: { reads: number },
+): void => {
+  for (let i = 1; i <= n; i++) scrollback.appendToScrollback(KEY, countingRow(i, counter));
+};
+
+// Drive ONE catch-up page of `pageSize` rows through refreshScrollback and
+// report both oracles. The counter is zeroed after seeding, so only the
+// catch-up page is measured.
+const ingestPage = async (
+  scrollback: typeof import("../lib/scrollback"),
+  api: typeof import("../lib/api"),
+  paneSize: number,
+  pageSize: number,
+  counter: { reads: number },
+): Promise<{ reads: number; passes: number }> => {
+  const page = Array.from({ length: pageSize }, (_, i) => countingRow(paneSize + 1 + i, counter));
+  mockGetResumeCursor.mockReturnValue(paneSize);
+  vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+
+  let passes = 0;
+  const dispose = createRoot((d) => {
+    // `defer: true` so subscribing does not count as a pass.
+    createEffect(on(scrollback.scrollbackByChannel, () => void passes++, { defer: true }));
+    return d;
+  });
+  counter.reads = 0;
+
+  await scrollback.refreshScrollback(SLUG, CHAN);
+  await new Promise((r) => queueMicrotask(() => r(undefined)));
+  dispose();
+  return { reads: counter.reads, passes };
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  localStorage.setItem("grappa-token", "tok");
+  mockGetReadCursor.mockReturnValue(null);
+  mockGetResumeCursor.mockReturnValue(null);
+});
+
+describe("#1288 — a catch-up page costs ONE reactive pass", () => {
+  it("runs the pane's reactive graph once per PAGE, at every page size", async () => {
+    // Displacement on the page axis: the per-row shape scales this number
+    // linearly with the page (1 / 50 / 200); one write per page pins it at 1.
+    for (const pageSize of [1, 50, 200]) {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      const scrollback = await import("../lib/scrollback");
+      const counter = { reads: 0 };
+      seedPane(scrollback, 100, counter);
+      const { passes } = await ingestPage(scrollback, api, 100, pageSize, counter);
+      expect({ pageSize, passes }).toEqual({ pageSize, passes: 1 });
+    }
+  });
+
+  it("writes nothing at all when every row of the page is already loaded", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    seedPane(scrollback, 50, { reads: 0 });
+    // The page repeats rows 41..50, all of which the pane already holds: a
+    // wholly-duplicate page must not re-render the pane.
+    const page = Array.from({ length: 10 }, (_, i) => plainRow(41 + i));
+    mockGetResumeCursor.mockReturnValue(40);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+
+    let passes = 0;
+    const dispose = createRoot((d) => {
+      createEffect(on(scrollback.scrollbackByChannel, () => void passes++, { defer: true }));
+      return d;
+    });
+    await scrollback.refreshScrollback(SLUG, CHAN);
+    await new Promise((r) => queueMicrotask(() => r(undefined)));
+    dispose();
+
+    expect(passes).toBe(0);
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).length).toBe(50);
+  });
+});
+
+// The PAGE axis is the discriminating one, and it is the only one asserted
+// here. A displacement on the PANE axis was written first and DELETED: both
+// shapes are linear in the pane (the loop scans it P times, the batch indexes
+// it once), so quadrupling the pane moves both numbers and the ratios sit
+// 2.86 vs 2.67 — measured, not reasoned. Worse, the S20 ring cap pins the pane
+// at 1000, so a "4x pane" is not one. It passed against the unfixed code, which
+// is the definition of an assertion that is scenery rather than coverage.
+describe("#1288 — ingest work is O(page + pane), not O(page x pane)", () => {
+  it("reads each loaded row's id a bounded number of times per page", async () => {
+    const paneSize = 500;
+    const pageSize = 200;
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const counter = { reads: 0 };
+    seedPane(scrollback, paneSize, counter);
+    const { reads } = await ingestPage(scrollback, api, paneSize, pageSize, counter);
+    // Linear: one index build over the pane plus a constant number of reads
+    // per arriving row. The per-row loop reads ~paneSize ids for EVERY row of
+    // the page (~240_000 here, measured); the bound below is ~85x under that,
+    // so it cannot be met by a constant-factor tweak of the quadratic shape.
+    expect(reads).toBeLessThan(4 * (paneSize + pageSize));
+  });
+
+  it("scales linearly in the page (displacement on the page axis)", async () => {
+    const measure = async (pageSize: number): Promise<number> => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      const scrollback = await import("../lib/scrollback");
+      const counter = { reads: 0 };
+      seedPane(scrollback, 500, counter);
+      const { reads } = await ingestPage(scrollback, api, 500, pageSize, counter);
+      return reads;
+    };
+    // Quadrupling the page against a fixed pane multiplies the per-row scan by
+    // 4 in the quadratic shape (measured: 5.09x, super-linear because each
+    // ingested row joins the pane the next row must scan). Batched, the pane
+    // index is built once and only the per-row constant grows, so the ratio
+    // stays near 1.
+    const small = await measure(50);
+    const large = await measure(200);
+    expect(large / small).toBeLessThan(2);
+  });
+});
+
+describe("#1288 — the batched ingest keeps every per-row invariant", () => {
+  it("applies the S20 ring cap to a catch-up page (mergeIntoScrollback would not)", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    mockGetReadCursor.mockReturnValue(null); // no divider → free eviction
+    seedPane(scrollback, cap, { reads: 0 });
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).length).toBe(cap);
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    // A full page also triggers the #693 gap probe; answer "nothing more" so
+    // the ingest is the only thing under test.
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.length).toBe(cap);
+    expect(rows[0]?.id).toBe(201);
+    expect(rows[rows.length - 1]?.id).toBe(cap + 200);
+  });
+
+  it("never evicts a row at/after the read cursor when ingesting a page", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    const cursor = 5;
+    mockGetReadCursor.mockReturnValue(cursor);
+    seedPane(scrollback, cap, { reads: 0 });
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const ids = (scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id);
+    // The divider anchor and every unread row survive, above the cap.
+    for (let i = cursor; i <= cap + 200; i++) expect(ids).toContain(i);
+    // Only the read rows below the cursor were evictable.
+    expect(ids).not.toContain(cursor - 1);
+  });
+
+  it("resets the loadMore exhausted latch when a page evicts older history", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    mockGetReadCursor.mockReturnValue(null);
+    seedPane(scrollback, cap, { reads: 0 });
+
+    // Latch loadMore as exhausted, then prove a page-driven eviction clears it.
+    vi.mocked(api.listMessages).mockResolvedValueOnce([]);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(1);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(1);
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+    expect(scrollback.scrollbackByChannel()[KEY]?.some((m) => m.id === 1)).toBe(false);
+
+    vi.mocked(api.listMessages).mockResolvedValueOnce([]);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-sorts a page that interleaves with rows already at the tail (#423)", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    // A live WS row landed at the tail during the await; the REST gap page
+    // sorts BEFORE it. Store order IS display order, so the result must be
+    // canonical, not arrival-ordered.
+    scrollback.appendToScrollback(KEY, plainRow(9));
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([plainRow(6), plainRow(7), plainRow(8)]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id)).toEqual([6, 7, 8, 9]);
+  });
+
+  it("keeps first-write-wins on a row the pane already holds", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    scrollback.appendToScrollback(KEY, { ...plainRow(6), body: "live" });
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([
+      { ...plainRow(6), body: "fetched-dupe" },
+      { ...plainRow(7), body: "fresh" },
+    ]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.map((m) => m.body)).toEqual(["live", "fresh"]);
+  });
+
+  it("drops an id repeated WITHIN one page, as the per-row loop did", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([
+      { ...plainRow(6), body: "first" },
+      { ...plainRow(6), body: "second" },
+      { ...plainRow(7), body: "next" },
+    ]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.map((m) => m.body)).toEqual(["first", "next"]);
+  });
+});

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -129,6 +129,43 @@ const byServerTimeThenId = (a: ScrollbackMessage, b: ScrollbackMessage): number 
   return a.id - b.id;
 };
 
+// #1288 — the rows of `page` the pane does not already hold, in arrival order.
+// First-write-wins, including WITHIN the page: an id repeated twice in one
+// page yields the first occurrence, which is what the per-row loop this
+// replaced did by deduping against a list it was growing as it went.
+//
+// One row SCANS and a page INDEXES, deliberately. The live WS append is the
+// hot path and arrives one row at a time; it pays a single O(n) comparison
+// pass and allocates nothing, where building a Set of every loaded id would
+// cost it two allocations per message on a busy channel — more GC churn, which
+// is the thing the profile complained about. A page cannot afford the scan:
+// doing it P times IS the O(P*n) this exists to remove.
+const freshRows = (
+  existing: ScrollbackMessage[],
+  page: ScrollbackMessage[],
+): ScrollbackMessage[] => {
+  const only = page.length === 1 ? page[0] : undefined;
+  if (only !== undefined) return existing.some((m) => m.id === only.id) ? [] : page;
+  const ids = new Set<number>();
+  for (const m of existing) ids.add(m.id);
+  return page.filter((m) => {
+    if (ids.has(m.id)) return false;
+    ids.add(m.id);
+    return true;
+  });
+};
+
+// Are these rows already in the order the store keeps them? Gates the
+// append-without-sorting fast path below.
+const isCanonicallyOrdered = (rows: ScrollbackMessage[]): boolean => {
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1];
+    const cur = rows[i];
+    if (prev !== undefined && cur !== undefined && byServerTimeThenId(prev, cur) > 0) return false;
+  }
+  return true;
+};
+
 // Trim `rows` (ASC by id) to the ring cap by dropping the OLDEST, but NEVER a
 // row at/after the read cursor: the in-pane `── XX unread ──` divider anchors
 // on the cursor and its unread rows (CLAUDE.md "Read state is server-owned"),
@@ -369,25 +406,61 @@ const exports = identityScopedStore((onIdentityChange) => {
   // no re-sort), so push only when the row is at/after the tail; otherwise
   // re-sort it into position. Costs one comparison against the tail on the hot
   // path and a re-sort only on the rare out-of-order row.
-  const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {
+  //
+  // #1288 — this is the PAGE-shaped verb, and `appendToScrollback` below is
+  // its P=1 case. The live WS handler ingests one row; `refreshScrollback`
+  // ingests a whole REST catch-up page, and used to do it by calling the
+  // single-row verb once per row. That cost O(page * pane) array work and —
+  // the part that reaches the DOM — one Solid signal write, hence one reactive
+  // pass, PER MESSAGE. A reporter's Firefox Profiler trace (desktop, 9 s
+  // capture) put 1917 of 2002 cicchetto samples under `refreshScrollback`, in
+  // 21 bursts of 20-180 ms, with DOM construction/teardown and cycle
+  // collection as the native leaves. One write per page collapses that to
+  // O(page + pane) and a single pass.
+  //
+  // Why NOT `mergeIntoScrollback`, which is already batched and sits right
+  // below: it is a different verb, not a faster spelling of this one. It
+  // applies no S20 ring cap — deliberately, so a scroll-up prepend is not
+  // truncated mid-scroll — and therefore never invalidates the loadMore
+  // exhausted latch an eviction implies. Reusing it here would have silently
+  // dropped the cap from the reconnect catch-up path, which is one of the two
+  // paths S20 was written for.
+  //
+  // The cap is applied ONCE over the union instead of after every row. Same
+  // result on every ordinary ingest: eviction only ever drops from the head,
+  // the protected suffix is decided by the same read cursor either way, and
+  // the arithmetic (drop min(surplus, unprotected-prefix)) does not care
+  // whether the surplus arrived in one step or P. The two differ only when a
+  // page carries rows OLDER than what the cap is evicting, where the batch
+  // keeps the newest CAP rows of the union and the loop could keep a late
+  // arrival while having already dropped a newer row.
+  const appendPageToScrollback = (key: ChannelKey, page: ScrollbackMessage[]): void => {
+    if (page.length === 0) return;
     // S20: track whether the ring cap evicted older rows so we can reset the
     // loadMore exhausted latch below. Computed inside the pure updater,
     // consumed after it runs (Solid calls a plain-signal updater exactly once,
     // synchronously) — keeps the setter body free of the Set side-effect.
     let evicted = false;
     setScrollbackByChannel((prev) => {
-      const existing = prev[key];
-      if (existing?.some((m) => m.id === msg.id)) return prev;
-      let next: ScrollbackMessage[];
-      if (!existing || existing.length === 0) {
-        next = [msg];
-      } else {
-        const tail = existing[existing.length - 1];
-        next =
-          tail && byServerTimeThenId(msg, tail) < 0
-            ? [...existing, msg].sort(byServerTimeThenId)
-            : [...existing, msg];
-      }
+      const existing = prev[key] ?? [];
+      const fresh = freshRows(existing, page);
+      // Nothing new: return the SAME object so Solid's equality check skips
+      // the write entirely. A wholly-duplicate page (every row already live)
+      // must not re-render the pane.
+      if (fresh.length === 0) return prev;
+      const tail = existing[existing.length - 1];
+      const head = fresh[0];
+      // #423 order-safe insert, generalised from one row to a page: append
+      // without sorting when the arriving rows are themselves in canonical
+      // order AND start at/after the current tail — true of every live append
+      // and of every ASC catch-up page. Re-sort only when they interleave with
+      // rows the pane already holds.
+      const next =
+        head !== undefined &&
+        (tail === undefined || byServerTimeThenId(head, tail) >= 0) &&
+        isCanonicallyOrdered(fresh)
+          ? [...existing, ...fresh]
+          : [...existing, ...fresh].sort(byServerTimeThenId);
       const capped = capScrollbackRing(key, next);
       evicted = capped.length < next.length;
       return { ...prev, [key]: capped };
@@ -396,6 +469,10 @@ const exports = identityScopedStore((onIdentityChange) => {
     // is now stale: the server DOES have rows older than the new oldest. Clear
     // it so a scroll-to-top re-pages the evicted region.
     if (evicted) loadMoreExhausted.delete(key);
+  };
+
+  const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {
+    appendPageToScrollback(key, [msg]);
   };
 
   // Merge a freshly-fetched REST page into the per-channel list. Server
@@ -1074,13 +1151,14 @@ const exports = identityScopedStore((onIdentityChange) => {
       // api.ts helper signature.
       const page = await listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT);
       if (identityMoved(t)) return;
-      for (const msg of page) {
-        appendToScrollback(key, msg);
-        // Roll the high-water mark forward as we ingest so a second
-        // disconnect mid-refresh resumes from the new highest id
-        // rather than the original cursor.
-        recordSeen(key, msg);
-      }
+      // #1288 — ONE store write for the whole page (see
+      // `appendPageToScrollback`). `recordSeen` still walks it row by row: it
+      // is a plain Map high-water mark with no reactive surface, so iterating
+      // it costs nothing the profile can see, and no await separates it from
+      // the ingest — the "second disconnect mid-refresh" its roll-forward
+      // exists for cannot land between the two.
+      appendPageToScrollback(key, page);
+      for (const msg of page) recordSeen(key, msg);
       // #161: a FULL-cap refresh page means the server tail may be further
       // ahead than what we just appended (a >200-message reconnect re-opens
       // the forward gap). Invalidate the forward-tail latch so the next

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41380,3 +41380,82 @@ retry is already counted somewhere that survives the restart — a failure
 counter kept for backoff is usually also the attempt ordinal, and deriving the
 second use from it costs one argument instead of one more thing to keep in
 sync.
+<!-- entry #1288 -->
+
+---
+
+## 2026-08-13 — #1288: a catch-up page is one store write, not two hundred
+
+`refreshScrollback` fetches up to `PAGE_LIMIT = 200` rows on every WS
+join-ok and used to ingest them one `appendToScrollback` per row. Each of
+those calls scans the whole pane for a duplicate id, copies the row array,
+copies the channel map, and writes the Solid signal — so a full page did
+O(page × pane) array work and ran the pane's reactive graph **200 times**.
+A reporter's Firefox Profiler trace (desktop, full JS stacks, the
+granularity #408 lacked) put 1917 of 2002 cicchetto samples under that one
+verb, in 21 bursts of 20–180 ms, with DOM construction/teardown and cycle
+collection as the native leaves. It now ingests the page in ONE store write.
+
+**The batched shape already in this module is not the same verb.** The
+issue proposed reusing `mergeIntoScrollback`, and it does dedupe by Set and
+write once — but it deliberately applies no S20 ring cap (a scroll-up
+prepend must not be truncated mid-scroll) and so never invalidates the
+`loadMoreExhausted` latch an eviction implies. Swapping it in was measured
+against the new specs: it passes both cost oracles and breaks four
+invariants — the pane grows to 1200 rows and stays there, no row is ever
+evicted, the latch survives, and an id repeated within one page lands
+twice. It would have removed the ring cap from the reconnect catch-up path,
+which is one of the two paths S20 names, and **every pre-existing cap test
+would have stayed green**, because they all drive `appendToScrollback`
+directly. So `appendPageToScrollback` is the page-shaped verb and
+`appendToScrollback` is now its P=1 case: one implementation, both arities.
+
+**One row scans, a page indexes.** The live WS append pays a single O(n)
+comparison pass and allocates nothing; building a Set of every loaded id
+would cost it two allocations per message on a busy channel, which is more
+of the GC churn the profile complains about. A page cannot afford the scan
+— doing it P times IS the cost being removed.
+
+**The cap is applied once over the union**, not after every row. Identical
+on every ordinary ingest: eviction only drops from the head and the
+protected suffix is decided by the same read cursor, so `min(surplus,
+unprotected-prefix)` does not care whether the surplus arrived in one step
+or in P. The two differ only when a page carries rows OLDER than what is
+being evicted, where the batch keeps the newest CAP rows of the union and
+the loop could keep a late arrival having already dropped a newer row.
+
+**Measured, both sides, same harness** (`scrollbackIngestCost.test.ts`,
+jsdom) — reactive passes / id reads / ms, before → after:
+
+| pane | page | passes | id reads | ms |
+|---|---|---|---|---|
+| 200 | 200 | 200 → 1 | 119 801 → 601 | 0.47 → 0.10 |
+| 500 | 200 | 200 → 1 | 239 801 → 901 | 0.63 → 0.09 |
+| 900 | 200 | 200 → 1 | 389 901 → 1301 | 1.06 → 0.15 |
+
+**The committed oracle measures work, not time.** A wall-clock threshold in
+a shared-runner suite goes red on host load rather than on a regression, so
+the guards assert the reactive-pass count and an id-read bound (every row
+is handed to the store with `id` behind a counting getter). Both are exact
+and reproducible; the ms column above is reported, never asserted, and it
+is jsdom — it excludes the DOM construction the trace shows as the actual
+leaf cost, so it understates the win rather than proving it.
+
+**Displacement on the PAGE axis only, and the pane-axis assertion was
+deleted rather than kept as scenery.** Both shapes are linear in the pane —
+the loop scans it P times, the batch indexes it once — so quadrupling the
+pane moves both numbers (measured ratios 2.86 vs 2.67) and the S20 cap pins
+the pane at 1000 so a "4× pane" is not one. It passed against the unfixed
+code, which is the definition of an assertion that cannot fail.
+
+**Not claimed:** that this explains the #408 sleep-duration correlation.
+That correlation remains consistency, not measurement — nobody has profiled
+across sleep durations, and this note is not the place it becomes a fact.
+The 30% of the reporter's busy window spent in extension content scripts is
+amplification of our DOM churn, measured on their browser, and is neither
+our defect nor the extensions' fault.
+
+**Apply:** when a hot path ingests a COLLECTION through a verb written for
+ONE item, the fix is the page-shaped verb, not the nearest batched
+neighbour — check the neighbour's side effects against the loop's before
+reusing it, because a cost test cannot tell the two apart.


### PR DESCRIPTION
Re #1288.

`refreshScrollback` fetched up to `PAGE_LIMIT = 200` rows on every WS join-ok and
ingested them one `appendToScrollback` per row. Each of those calls scans the pane
for a duplicate id, copies the row array, copies the channel map and writes the
Solid signal — so a full page did O(page × pane) array work and ran the pane's
reactive graph **200 times**. It now ingests the page in ONE store write.

## The issue's literal fix diverges — measured, not argued

The issue proposed reusing `mergeIntoScrollback`. I checked it against the loop
before adopting it, and it is **not the same verb**: it applies no S20 ring cap
(deliberately — a scroll-up prepend must not be truncated mid-scroll) and so never
invalidates the `loadMoreExhausted` latch an eviction implies.

I implemented that swap and ran the new specs against it. It **passes both cost
oracles** and breaks four invariants:

| assertion | result under the literal swap |
|---|---|
| ring cap holds at 1000 | ✗ pane grows to 1200 and stays |
| no eviction below the read cursor | ✗ nothing is evicted at all |
| eviction clears the loadMore latch | ✗ latch survives |
| an id repeated within one page lands once | ✗ lands twice |

It would have removed the ring cap from the reconnect catch-up path — one of the
two paths S20 names — and **every pre-existing cap test would have stayed green**,
because they all drive `appendToScrollback` directly. A cost-only test suite ships
this bug.

So `appendPageToScrollback` is the page-shaped verb carrying the cap and the latch,
and `appendToScrollback` becomes its P=1 case: one implementation, both arities.
One row scans and a page indexes — building an id `Set` per live WS message would
add allocations to the hot path this change exists to unburden.

## Measurement — same harness both sides

`scrollbackIngestCost.test.ts`, jsdom, reactive passes / id reads / ms (min of 7):

| pane | page | reactive passes | id reads | ms |
|---|---|---|---|---|
| 200 | 50  | 50 → **1** | 22 450 → **300** | 0.17 → 0.06 |
| 200 | 200 | 200 → **1** | 119 801 → **601** | 0.47 → 0.10 |
| 500 | 50  | 50 → **1** | 52 450 → **600** | 0.17 → 0.08 |
| 500 | 200 | 200 → **1** | 239 801 → **901** | 0.63 → 0.09 |
| 900 | 50  | 50 → **1** | 92 450 → **1 000** | 0.27 → 0.09 |
| 900 | 200 | 200 → **1** | 389 901 → **1 301** | 1.06 → 0.15 |

**Displacement**, page axis at pane 900: ×4 the page (50→200) multiplies the old id
reads by 4.22 (super-linear — each ingested row joins the pane the next row must
scan) and the new ones by 1.30. That is the complexity class changing, not a
constant factor.

Every row is handed to the store with `id` behind a counting getter, so "id reads"
is exact and reproducible rather than sampled.

## What the committed guard asserts, and what it does not

The guards assert the **reactive-pass count** and an **id-read bound**. Neither is
wall clock: a time threshold in a shared-runner suite goes red on host load rather
than on a regression. The ms column above is reported, never asserted — and it is
jsdom, so it excludes the DOM construction the reporter's trace shows as the actual
leaf cost. It understates the win rather than proving it.

A **pane-axis displacement assertion was written and deleted.** Both shapes are
linear in the pane (the loop scans it P times, the batch indexes it once), so
quadrupling the pane moves both numbers — measured ratios 2.86 vs 2.67 — and the
S20 cap pins the pane at 1000, so a "4× pane" is not one. It passed against the
unfixed code, which is the definition of an assertion that is scenery rather than
coverage.

## No e2e, and the number that settles it

No e2e spec, and no `MutationObserver` batch-count oracle either. The right guard
already exists and is cheaper: the unit assertion that a catch-up page costs
**1 reactive pass instead of 200**. That assertion is not decorative — restoring
the per-row loop was run as a mutant and it fired, together with both id-read
bounds. A regression to the loop is caught.

What an e2e would have to threshold is wall clock, and the wall clock does not
survive its own noise. Measured on the **fixed** path, pane 900 / page 200, 40
trials, jsdom, idle host:

| min | p50 | p95 | max | mean | sd |
|---|---|---|---|---|---|
| 0.111 | 0.171 | 0.276 | **0.917** | 0.187 | 0.123 |

The entire improvement being claimed is **0.91 ms** (1.06 → 0.15 on minima). The
fixed path's own trial-to-trial range is **0.81 ms**, and one fixed trial reached
**0.917 ms — within 14% of the unfixed best case of 1.06 ms**. A threshold placed
between the two flips on jitter alone.

And that is the *friendly* measurement: jsdom, no browser, no network, no ircd —
and **no rendering at all**. The DOM construction/teardown and cycle collection
that the reporter's trace names as the leaf cost appear in none of the numbers
above, so an e2e threshold would be set against a quantity nothing measured here
bounds. The pass count is the honest proxy for that half, and it is already
pinned at 1.

## Claims I am refusing to make

- **This does not "fix the user's freeze".** It removes a measured O(page × pane)
  cost on the verb that owns 96% of the cicchetto samples in the trace. Whether the
  remaining time disappears is not something this PR measured.
- **The #408 sleep-duration correlation stays consistency, not measurement.** The
  issue says so itself — nobody has profiled across sleep durations — and a
  plausible mechanism is not a reproduction.
- **The 30% in extension content scripts is not a defect of theirs.** It is
  amplification of our own DOM churn, measured on one reporter's browser.
- **Not a v1.1.0 regression.** `scrollback.ts` is byte-identical between the tags;
  nothing was bisected.

## Gates

- `bun run check` (biome + tsc + e2e tsc) — RC 0
- `bun run test` — 283 files, **5392 tests**, RC 0, run on the rebased tip so the
  gate covers the union with the `#201`/`#359` cic commits that landed underneath
- `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present
- Server-side tree untouched: the diff is `cicchetto/` plus the decision log
