### PR TITLE
deploy(#1287): classify a VERSION bump COLD on the release substrates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,7 +716,10 @@ is due. Don't just look at todo.md.
    the RUNNING node resolves to its BOOT directory `lib/grappa-<old>/ebin`.
    Nothing in the old directory changed, so `/admin/reload` answers
    `{"failed":[],"reloaded":[]}` and the node keeps serving the old number
-   with the new code on disk. Plan a restart for any release bump.
+   with the new code on disk. Plan a restart for any release bump —
+   `Preflight` enforces it since #1287 (reason `version`), on the two
+   substrates that boot a `mix release`; docker stays HOT because its
+   bind-mounted `mix phx.server` layout puts no vsn in the lib-dir path.
    Do NOT re-hardcode `@version` in `mix.exs`: it reads `VERSION` at build
    time, and re-inlining a literal silently reinstates the COLD (guarded by
    `version_single_source_test.exs`). Invoke deploy scripts by ABSOLUTE

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41425,7 +41425,14 @@ daemon's code path in its own words. Docker boots differently: the
 container execs `mix phx.server` over a bind-mounted tree, and
 `:code.lib_dir(:grappa)` measures as `/app/_build/dev/lib/grappa`, with no
 vsn anywhere in it, so the recompiled beams land exactly where the node is
-already looking. COLDing docker for a file its boot layout is immune to
+already looking. That container has no release stage to reach at all:
+`Dockerfile:53` is `CMD ["bin/start.sh"]`, `bin/start.sh:76` is
+`exec mix phx.server`, the word `release` does not appear in the Dockerfile,
+and `bin/start.sh:5-7` says in as many words that the file exists *instead
+of* `rel/env.sh.eex` because the release stage was dropped — "`mix phx.server`
+is the canonical boot path in dev, prod, and CI". So the boot path is one
+path, not one per env, and the `lib/<app>-<vsn>/` layout is unreachable on
+docker regardless of `MIX_ENV`. COLDing docker for a file its boot layout is immune to
 would be the needless-restart class the substrate argument was introduced
 to prevent (2026-06-10, #923), and on an always-on bouncer every restart
 drops every IRC session. The asymmetry is pinned by its own test rather
@@ -41443,8 +41450,13 @@ name of the directory the code lives in.
 
 **Not measured, and not claimed:** anything about `MIX_ENV=prod` inside the
 container. The `_build/<env>/lib/grappa` reading above was taken at
-`MIX_ENV=dev`; the env name is the only segment that differs in Mix's build
-layout, but no prod container was stood up to confirm it. Nor was any
+`MIX_ENV=dev`, and no prod container was stood up to confirm it — standing
+one up would have written into the `_build/prod` every worktree on this host
+shares, and a poisoned cache is a debt someone else pays in a red they cannot
+attribute. The source evidence in the paragraph above closes the gap
+differently and should be read for exactly what it is: it proves the boot
+path is SINGLE and not parameterised by env, which is not the same thing as
+having watched it run under `MIX_ENV=prod`. Nor was any
 production host probed — the reproduction is the operator's, in the issue.
 Two further defects the issue raises are deliberately left alone: the
 reload endpoint could compare the running vsn against the one on disk and

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41380,3 +41380,78 @@ retry is already counted somewhere that survives the restart — a failure
 counter kept for backoff is usually also the attempt ordinal, and deriving the
 second use from it costs one argument instead of one more thing to keep in
 sync.
+<!-- entry #1287 -->
+
+---
+
+## 2026-08-13 — #1287: the version bump is also the directory name
+
+A `VERSION`-only bump classified `:hot`, the deploy took the hot path,
+`POST /admin/reload` answered `{"failed":[],"reloaded":[],"migrated":[]}`,
+and the node went on running the old code. Reproduced in production on a
+self-hosted `:linux` install going v1.0.0 → v1.1.0: roughly six and a half
+hours serving the v1.0.0 BEAM under a v1.1.0 git history and config, with
+nothing in the deploy output to say so.
+
+The reason the reload cannot report the miss is worth stating precisely,
+because it is what decides where the fix belongs. `mix.exs` reads `VERSION`
+to stamp the OTP application vsn, so `mix release` lays the fresh artifacts
+under `lib/grappa-<new>/ebin`. The running node resolves
+`:code.lib_dir(:grappa)` from the code server's path list as it stood at
+load time, which is the BOOT directory `lib/grappa-<old>/ebin`.
+`HotReload.reload_modified/0` walks that directory, diffs it against
+itself, and correctly finds nothing. `reloaded: []` is not an error it
+withheld; it is the honest answer to the question it was asked. The
+migration scan lands in the same stale tree through
+`Application.app_dir/1,2`, so a new migration is not found-and-failed, it
+is absent. A downstream guard could notice the symptom, but the only place
+that can prevent it is the classifier, which is why `HotReload` is
+untouched here.
+
+The classifier could not see it. Before #652 the number lived in `mix.exs`
+and `mix_deps?/1` cold-tripped every bump — by accident, as a side effect
+of where the string was stored. #652 moved the number to a repo-root
+`VERSION` file and removed the accident without replacing the rule, and
+`grep -ci "vsn\|version"` over `preflight.ex` returned 0. The verdict on a
+release cut therefore depended on whatever else the commit range happened
+to touch. Measured on the real incident range before the fix
+(`4879785c^..4879785c`, the v1.1.0 cut, `VERSION` alone), substrate linux:
+`no unsafe markers → HOT`, exit 0. After: `version: VERSION`, exit 3.
+
+**Scoped to the release substrates, not universal.** The defect is that the
+vsn enters the lib directory's PATH, and that layout is what `mix release`
+produces — `infra/freebsd/deploy.sh:116` names `lib/grappa-X.Y/ebin` as the
+daemon's code path in its own words. Docker boots differently: the
+container execs `mix phx.server` over a bind-mounted tree, and
+`:code.lib_dir(:grappa)` measures as `/app/_build/dev/lib/grappa`, with no
+vsn anywhere in it, so the recompiled beams land exactly where the node is
+already looking. COLDing docker for a file its boot layout is immune to
+would be the needless-restart class the substrate argument was introduced
+to prevent (2026-06-10, #923), and on an always-on bouncer every restart
+drops every IRC session. The asymmetry is pinned by its own test rather
+than left to the comment: if the container ever moves to a release layout,
+that test is where it surfaces, instead of a self-hoster six hours later.
+`filter_on/4` takes a list of substrates at every call site now — this is
+the first class that spans two, and one helper with two shapes is two
+patterns for the next reader to choose between.
+
+This reverses the posture two tests pinned as a #652 acceptance criterion.
+That posture was not careless: the concern was that a bump must not
+cold-restart production over a string, and as a statement about strings it
+was right. What it could not see is that this particular string is also the
+name of the directory the code lives in.
+
+**Not measured, and not claimed:** anything about `MIX_ENV=prod` inside the
+container. The `_build/<env>/lib/grappa` reading above was taken at
+`MIX_ENV=dev`; the env name is the only segment that differs in Mix's build
+layout, but no prod container was stood up to confirm it. Nor was any
+production host probed — the reproduction is the operator's, in the issue.
+Two further defects the issue raises are deliberately left alone: the
+reload endpoint could compare the running vsn against the one on disk and
+refuse instead of answering empty lists, and the completed-deploy marker is
+written before the deploy is observed to have landed, which is what makes
+an ineffective hot deploy permanent and silent on retry.
+
+**Apply:** when a value moves out of a file to become its own SSOT, check
+what was classifying it *by side effect* at the old location. The move is
+visible in review; the rule that quietly stopped applying is not.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1334,10 +1334,13 @@ OTP application vsn, so the bump moves the release's lib directory to
 `:code.lib_dir(:grappa)` — the directory `Grappa.HotReload.reload_modified/0`
 walks — to its BOOT directory `lib/grappa-<old>/ebin`. Nothing in there
 changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}` and the node
-serves the OLD number with the new code already on disk. `Preflight.mix_deps?`
-no longer forces COLD on such a bump, so preflight will offer you a hot deploy
-anyway — that misclassification is a behaviour defect tracked on its own, not
-a licence to ship the bump hot. Corollary: an **unplanned** prod move (a
+serves the OLD number with the new code already on disk. **Preflight enforces
+this since #1287** — a diff touching `VERSION` is COLD with reason
+`version: VERSION` on `:jail` and `:linux`, so you no longer have to remember
+it. It stays HOT on `:docker`, which boots `mix phx.server` over a bind-mount
+and has no vsn in its lib-directory path; that asymmetry is pinned by a test,
+so if the container ever moves to a release layout, that test is where it
+surfaces. Corollary: an **unplanned** prod move (a
 migration, a jail cutover) is still something you version BEFORE, not after —
 bump `VERSION` in the range so the artifact self-reports honestly rather than
 patching a string afterward. Do NOT re-hardcode `@version` in `mix.exs`: it

--- a/lib/grappa/deploy/preflight.ex
+++ b/lib/grappa/deploy/preflight.ex
@@ -39,7 +39,11 @@ defmodule Grappa.Deploy.Preflight do
   `:linux` and irrelevant elsewhere, and the whole nginx class —
   `infra/linux/nginx.conf` plus the shared `infra/snippets/*` proxy
   surface — is HOT on `:jail`, which since the jail-nginx removal
-  runs no proxy of its own at all (#923 scoping, widened). The 2026-06-10 metadata-strip
+  runs no proxy of its own at all (#923 scoping, widened). The repo-root
+  `VERSION` file spans TWO substrates rather than one: it is COLD on
+  `:jail` and `:linux`, which boot a `mix release` whose lib directory
+  carries the vsn in its path, and HOT on `:docker`, which does not —
+  see `version?/1`. The 2026-06-10 metadata-strip
   deploy cold-restarted prod (ALL IRC sessions dropped) for a
   Dockerfile diff the jail never reads — on an always-on bouncer
   every needless restart is incident-grade, so the substrate is an
@@ -73,6 +77,7 @@ defmodule Grappa.Deploy.Preflight do
           | {:migration, [String.t()]}
           | {:nginx, [String.t()]}
           | {:config, [String.t()]}
+          | {:version, [String.t()]}
           | {:state_shape, [String.t()]}
 
   @type verdict :: {:hot, []} | {:cold, [reason()]}
@@ -88,6 +93,10 @@ defmodule Grappa.Deploy.Preflight do
   @type migration_class :: :hot | :cold
 
   @substrates [:docker, :jail, :linux]
+  # The substrates that boot from a `mix release` artifact, whose lib
+  # directory carries the OTP application vsn in its PATH. Docker is
+  # absent by construction, not by omission — see `version?/1`.
+  @release_substrates [:jail, :linux]
   # CLI-boundary mirror of @substrates — derived, not hand-kept, so a
   # third substrate can't be accepted by classify_paths/2 yet rejected
   # at the cli/1 guard (or vice versa).
@@ -127,12 +136,13 @@ defmodule Grappa.Deploy.Preflight do
       []
       |> add_reason(:mix_deps, Enum.filter(paths, &mix_deps?/1))
       |> add_reason(:application, Enum.filter(paths, &application?/1))
-      |> add_reason(:image_substrate, filter_on(:docker, substrate, paths, &docker_image?/1))
-      |> add_reason(:rc_d, filter_on(:jail, substrate, paths, &rc_d?/1))
-      |> add_reason(:systemd_unit, filter_on(:linux, substrate, paths, &systemd_unit?/1))
+      |> add_reason(:image_substrate, filter_on([:docker], substrate, paths, &docker_image?/1))
+      |> add_reason(:rc_d, filter_on([:jail], substrate, paths, &rc_d?/1))
+      |> add_reason(:systemd_unit, filter_on([:linux], substrate, paths, &systemd_unit?/1))
       |> add_reason(:migration, contract_migrations(paths, migration_source_fn))
-      |> add_reason(:nginx, filter_on(:linux, substrate, paths, &nginx?/1))
+      |> add_reason(:nginx, filter_on([:linux], substrate, paths, &nginx?/1))
       |> add_reason(:config, Enum.filter(paths, &config?/1))
+      |> add_reason(:version, filter_on(@release_substrates, substrate, paths, &version?/1))
       |> Enum.reverse()
 
     case reasons do
@@ -397,11 +407,14 @@ defmodule Grappa.Deploy.Preflight do
   defp add_reason(reasons, _, []), do: reasons
   defp add_reason(reasons, kind, files), do: [{kind, files} | reasons]
 
-  # Substrate-scoped filter: the predicate only applies when the diff
-  # is being classified FOR the substrate that reads those files.
-  # First head matches when scope == substrate.
-  defp filter_on(scope, scope, paths, pred), do: Enum.filter(paths, pred)
-  defp filter_on(_, _, _, _), do: []
+  # Substrate-scoped filter: the predicate only applies when the diff is
+  # being classified FOR a substrate that reads those files. The scope is
+  # always a LIST, including at the single-substrate call sites — one
+  # shape for one helper, so the next class that spans two substrates
+  # has nothing to choose between.
+  defp filter_on(scopes, substrate, paths, pred) do
+    if substrate in scopes, do: Enum.filter(paths, pred), else: []
+  end
 
   # Class 1: dep / build config.
   defp mix_deps?(path), do: path in ["mix.lock", "mix.exs"]
@@ -651,6 +664,41 @@ defmodule Grappa.Deploy.Preflight do
   defp config?(path) do
     String.starts_with?(path, "config/") and String.ends_with?(path, ".exs")
   end
+
+  # Class 8 (#1287): the repo-root VERSION file — the SSOT for the OTP
+  # application vsn, which `mix.exs` reads at build time. COLD on the
+  # substrates that boot a `mix release`, and ONLY those.
+  #
+  # The bump does not merely change a string: it moves every artifact to
+  # `lib/grappa-<new>/ebin`, while the running node keeps resolving
+  # `:code.lib_dir(:grappa)` — the directory `HotReload.reload_modified/0`
+  # walks, and the root `Ecto.Migrator` reaches through
+  # `Application.app_dir/1,2` — to the BOOT directory `lib/grappa-<old>/ebin`.
+  # The new artifacts land in a SIBLING the node never looks at, so the
+  # reload diffs the stale tree against itself and answers
+  # `{"failed":[],"reloaded":[],"migrated":[]}`. That is indistinguishable
+  # from "nothing to do": the miss cannot be reported, only prevented here.
+  # Repro'd in production 2026-08-13 on a self-hosted `:linux` install
+  # deploying v1.0.0 → v1.1.0 — ~6.5 hours serving the old BEAM under the
+  # new git history. Before #652 the number lived in `mix.exs` and
+  # `mix_deps?/1` caught the bump by accident; moving it to VERSION removed
+  # the accident without replacing the rule.
+  #
+  # Docker is excluded by MEASUREMENT, not by omission: the container execs
+  # `mix phx.server` over a bind-mounted tree (`bin/start.sh:76`), where
+  # `:code.lib_dir(:grappa)` is `/app/_build/<env>/lib/grappa` — no vsn in
+  # the path, so the fresh beams land where the node is already looking.
+  # The two release substrates say the opposite in their own words:
+  # `infra/freebsd/deploy.sh:116` names `lib/grappa-X.Y/ebin` as the
+  # daemon's code path. COLDing docker for a file its boot layout is immune
+  # to would be the needless-restart class the substrate argument exists to
+  # prevent (moduledoc: 2026-06-10, #923) — on an always-on bouncer every
+  # restart drops every IRC session.
+  #
+  # Exact repo-root match: a sibling `VERSION` elsewhere in the tree (e.g.
+  # `cicchetto/VERSION`) is a different file with no bearing on the OTP vsn.
+  defp version?("VERSION"), do: true
+  defp version?(_), do: false
 
   # Walk the AST collecting nodes that match any of:
   #   * `@type t :: %{...}`     — bare-map state typespec

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -275,30 +275,51 @@ defmodule Grappa.Deploy.PreflightTest do
     end
   end
 
+  describe "classify_paths/2 — Class 8: VERSION (COLD on the release substrates)" do
+    # #1287, repro'd in production 2026-08-13 on a v1.0.0 → v1.1.0 deploy:
+    # the bump moves the release's lib directory to `lib/grappa-<new>/ebin`
+    # while the running node keeps resolving `:code.lib_dir(:grappa)` to its
+    # BOOT directory, so the hot reload diffs a stale tree against itself and
+    # answers `{"reloaded":[]}` — a success shape it has no way to distinguish
+    # from "nothing to do". REVERSES the #652 pin that used to live in the HOT
+    # describe below.
+    test "VERSION → cold (:version) on jail (mix release, versioned lib dir)" do
+      assert {:cold, reasons} = Preflight.classify_paths(["VERSION"], :jail)
+      assert {:version, ["VERSION"]} in reasons
+    end
+
+    test "VERSION → cold (:version) on linux (mix release, versioned lib dir)" do
+      assert {:cold, reasons} = Preflight.classify_paths(["VERSION"], :linux)
+      assert {:version, ["VERSION"]} in reasons
+    end
+
+    test "VERSION → hot on docker (mix phx.server, unversioned _build lib dir)" do
+      # The container execs `mix phx.server` over a bind-mounted tree
+      # (bin/start.sh), so `:code.lib_dir(:grappa)` is `_build/<env>/lib/grappa`
+      # — no vsn in the path, and the reload sees the fresh beams. COLDing
+      # docker for a file its boot layout is immune to is the needless-restart
+      # class the substrate argument exists to prevent (moduledoc, 2026-06-10).
+      assert {:hot, []} = Preflight.classify_paths(["VERSION"], :docker)
+    end
+
+    test "the real bump-commit shape (VERSION + version.ex) → cold on linux" do
+      assert {:cold, reasons} =
+               Preflight.classify_paths(["VERSION", "lib/grappa/version.ex"], :linux)
+
+      assert {:version, ["VERSION"]} in reasons
+    end
+
+    test "a VERSION-named file elsewhere in the tree → hot (exact repo-root match)" do
+      for substrate <- @substrates do
+        assert {:hot, []} = Preflight.classify_paths(["cicchetto/VERSION"], substrate)
+      end
+    end
+  end
+
   describe "classify_paths/2 — HOT path" do
     test "empty diff → hot on both substrates" do
       for substrate <- @substrates do
         assert {:hot, []} = Preflight.classify_paths([], substrate)
-      end
-    end
-
-    test "VERSION (a bump-only diff) → hot on every substrate (#652)" do
-      # The #652 acceptance criterion: the version SSOT moved out of mix.exs
-      # into the repo-root VERSION file precisely so a bump is HOT — it is NOT
-      # a Class 1 mix_deps path, so it falls through to HOT and every IRC
-      # session survives the deploy.
-      for substrate <- @substrates do
-        assert {:hot, []} = Preflight.classify_paths(["VERSION"], substrate)
-      end
-    end
-
-    test "VERSION rides with a hot module change → still hot (#652)" do
-      # The real bump commit shape: VERSION plus the recompiled Grappa.Version
-      # beam's source (version.ex is a regular module, not long-lived) — the
-      # whole diff must stay HOT.
-      for substrate <- @substrates do
-        assert {:hot, []} =
-                 Preflight.classify_paths(["VERSION", "lib/grappa/version.ex"], substrate)
       end
     end
 


### PR DESCRIPTION
Fixes the classification half of #1287. A `VERSION`-only bump was
classified `:hot`, the deploy took the hot path, `POST /admin/reload`
answered `{"failed":[],"reloaded":[],"migrated":[]}`, and the node kept
running the old code — reproduced in production on a self-hosted
`:linux` install going v1.0.0 → v1.1.0, roughly six and a half hours
serving the old BEAM under the new git history.

## Why the fix is in the classifier and not in `HotReload`

`mix.exs` reads `VERSION` to stamp the OTP application vsn, so
`mix release` writes the fresh artifacts to `lib/grappa-<new>/ebin`
while the running node keeps resolving `:code.lib_dir(:grappa)` to its
BOOT directory `lib/grappa-<old>/ebin`. `reload_modified/0` walks that
stale tree and diffs it against itself. `reloaded: []` is not a
swallowed error — it is the honest answer to the question asked, and it
is indistinguishable from "nothing to do". The migration scan reaches
the same stale path through `Application.app_dir/1,2`, so a new
migration is not found-and-failed, it is absent. The miss cannot be
reported downstream; it can only be prevented before the hot path is
chosen. `HotReload` is untouched here on purpose.

## Why the classifier could not see it

Before #652 the number lived in `mix.exs`, and `mix_deps?/1` cold-tripped
every bump — by accident, as a side effect of where the string was
stored. #652 moved it to a repo-root `VERSION` file, removing the
accident without replacing the rule: `grep -ci "vsn\|version"` over
`preflight.ex` returned 0, so the verdict on a release cut fell to
whatever else the range happened to touch.

## Measured, not deduced

On the real incident range (`4879785c^..4879785c`, the v1.1.0 cut,
`VERSION` alone), through `Preflight.cli`:

| | before | after |
|---|---|---|
| linux | `no unsafe markers → HOT`, exit 0 | `version: VERSION`, exit 3 |
| jail  | — | `version: VERSION`, exit 3 |
| docker | — | `no unsafe markers → HOT`, exit 0 |

## Scoped to the release substrates

The defect is that the vsn enters the lib directory's PATH, which is
what `mix release` produces — `infra/freebsd/deploy.sh:116` names
`lib/grappa-X.Y/ebin` as the daemon's code path in its own words. Docker
execs `mix phx.server` over a bind-mount, and `:code.lib_dir(:grappa)`
measures as `/app/_build/dev/lib/grappa` — no vsn, so the recompiled
beams land where the node is already looking. That container has no
release stage to reach in any env: `Dockerfile:53` is
`CMD ["bin/start.sh"]`, `bin/start.sh:76` is `exec mix phx.server`, the
word `release` does not appear in the Dockerfile, and `bin/start.sh:5-7`
says the file exists *instead of* `rel/env.sh.eex` because the release
stage was dropped — "`mix phx.server` is the canonical boot path in dev,
prod, and CI". COLDing docker for a file
its boot layout is immune to is the needless-restart class the substrate
argument exists to prevent (2026-06-10, #923), and every restart drops
every IRC session. The docker case is pinned by its own test, so a
future layout change surfaces there rather than at a self-hoster.

`filter_on/4` now takes a list of substrates at every call site: this is
the first class spanning two, and one helper with two shapes is two
patterns to choose between.

## This reverses a pinned #652 posture

Two tests asserted `VERSION → :hot` on every substrate, citing #652 as an
acceptance criterion. They are rewritten, not supplemented. The posture
was not careless — the concern was that a bump must not cold-restart
production over a string, and as a statement about strings it was right.
What it could not see is that this string is also the name of the
directory the code lives in.

## Not in scope, and worth its own issue

Item 5 of #1287 is a second, independent defect and is deliberately
untouched here: the completed-deploy marker (`runtime/last-deployed-sha`)
is written before the deploy is observed to have landed, so an
ineffective hot deploy still records success and a re-run short-circuits
with "nothing to do". That is what turned this incident from a miss into
a one-way door — it survives this fix for any future hot-path miss, and
needs enqueueing separately. Item 2 (the reload endpoint comparing the
running vsn against the one on disk instead of answering empty lists) is
likewise left alone.

## What I refuse to claim

- No production host was probed. The reproduction is the operator's, in
  the issue; the mechanism was re-derived here from source and measured
  against the classifier, not against a live deploy.
- The `_build` path reading was taken at `MIX_ENV=dev`, and no
  `MIX_ENV=prod` container was stood up to confirm it: standing one up
  would have written into the `_build/prod` that every worktree on this
  host shares, and a poisoned cache is a debt someone else pays in a red
  they cannot attribute. The source evidence above closes that gap from
  the repo, and should be read for exactly what it is — it proves the
  boot path is SINGLE and not parameterised by env, which is not the
  same as having watched it run under `MIX_ENV=prod`.
- Nothing is claimed about whether a *cold* deploy of a bump was ever
  affected, or about substrates other than the three the classifier
  accepts.

## Gates

`scripts/check.sh` rc=0 on the code tip — 6096 tests / 0 failures, Dialyzer 0 errors,
Credo clean over 5779 mods/funs, Sobelow, doctor, 471 bats ok. Working
tree clean before and after. Both new pins were proven with measured
mutants: universal scope kills the docker test and only that one; a
suffix match on `version?/1` kills the `cicchetto/VERSION` test and only
that one.
