### PR TITLE
docs(#1290): stop claiming aes128gcm and RFC 8292 we do not send

### DIFF
--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -16,19 +16,31 @@ defmodule Grappa.Push.Sender do
   (the device-list UX) and for the client-side registration flow. It does
   NOT branch delivery here: a UnifiedPush registration carries a real
   P-256 keypair + auth secret too, generated client-side the same way
-  a browser's `PushManager.subscribe()` does internally, so the
-  IDENTICAL VAPID-signed `aes128gcm` encrypted POST this module
-  already sends for Web Push works unchanged for a UnifiedPush
-  endpoint — distributors are reasoned, not observed, to relay whatever
-  bytes and headers they are given; a Web-Push-vendor's OWN push service
-  (Google FCM, Mozilla autopush) is the party that verifies the VAPID JWT
-  against the subscribed key, and no end-to-end delivery against a live
-  UnifiedPush distributor has confirmed the same holds there. If a
-  distributor turns out to reject or strip an unrecognized VAPID header,
-  the failure surfaces through the ordinary paths below (dead-endpoint
-  cleanup, per-sub telemetry) — confined to `unifiedpush` rows, no webpush
-  behavior affected. `send_to_subscription/2` reads no branch on
-  `:provider` at all regardless.
+  a browser's `PushManager.subscribe()` does internally.
+  `send_to_subscription/2` reads no branch on `:provider` at all.
+
+  ## What we actually put on the wire — the pre-RFC drafts (#1290)
+
+  NOT `aes128gcm`. An earlier revision of this docstring claimed the
+  POST below was "the IDENTICAL VAPID-signed `aes128gcm` encrypted
+  POST"; that was never checked against the dependency and is false.
+  `WebPushElixir` 0.8.0 emits draft-ietf-webpush-encryption-04
+  `aesgcm` (`deps/web_push_elixir/lib/web_push_elixir.ex:50,147`) and
+  draft-ietf-webpush-vapid-01 `Authorization: WebPush <jwt>` (`:146`).
+
+  The gap is structural, not cosmetic. Under `aesgcm` the salt and the
+  server ephemeral public key — both mandatory HKDF inputs — travel as
+  the `encryption:` and `crypto-key:` headers while the body is the
+  bare ciphertext (`:150-151,161`). RFC 8291 puts the same two values
+  in the body's own binary header, so the body decrypts standalone.
+  Any transport that does not preserve headers therefore hands the
+  application an undecryptable blob — reported for UnifiedPush by the
+  Resentin author (theirs; the header-discarding half is not measured
+  here, the dependency half above is).
+
+  What keeps browser push working is the big push services still
+  accepting a draft they superseded, not the draft being acceptable.
+  #1290 tracks the fix and owns the route decision.
 
   ## Subject-scoped — V3 (2026-05-15)
 

--- a/mix.exs
+++ b/mix.exs
@@ -280,7 +280,13 @@ defmodule Grappa.MixProject do
       {:argon2_elixir, "~> 4.1"},
       {:cloak, "~> 1.1"},
       {:cloak_ecto, "~> 1.3"},
-      # Web Push delivery (RFC 8030 / VAPID RFC 8292). Picked over
+      # Web Push delivery. RFC 8030 (the delivery protocol —
+      # TTL/Urgency/Topic) is honoured; the encryption and VAPID layers
+      # are NOT the RFCs this comment used to advertise. 0.8.0 emits
+      # draft-ietf-webpush-encryption-04 `aesgcm` and
+      # draft-ietf-webpush-vapid-01 `Authorization: WebPush <jwt>`, not
+      # RFC 8291 `aes128gcm` + RFC 8292 `vapid t=…, k=…`. See #1290 and
+      # the wire section of `Grappa.Push.Sender`. Picked over
       # `web_push_encryption` (last release 2021-09-15, no native
       # 410-Gone signal) because:
       #   * Active maintenance — 0.8.0 released 2026-05-04.


### PR DESCRIPTION
Two comments in the tree assert a wire format the dependency does not
emit. Both were written from a neighbouring comment rather than from
the code path, and #1290 calls for correcting them ahead of — and
independently of — whichever route the fix itself takes.

Prose only. No behaviour change, no dependency change: the `mix.exs`
edit is the comment above `{:web_push_elixir, "~> 0.8"}` and nothing
else. Verified mechanically — the full diff contains no non-comment
line.

## What was false

`lib/grappa/push/sender.ex` — the `:provider` section called the POST
"the IDENTICAL VAPID-signed `aes128gcm` encrypted POST this module
already sends". We do not send `aes128gcm`.

`mix.exs` — the dependency comment advertised "RFC 8030 / VAPID
RFC 8292". RFC 8030 is honoured; RFC 8292 is not.

## What the pinned dependency actually emits

Read from `deps/web_push_elixir/lib/web_push_elixir.ex` at 0.8.0, the
version in `mix.lock` on `main`:

- `:50` — `content_encryption_key_info = "Content-Encoding: aesgcm"
  <> <<0>> <> "P-256" <> context` and `:147`
  `{"content-encoding", "aesgcm"}` ⇒
  draft-ietf-webpush-encryption-04, not RFC 8291.
- `:146` — `{"authorization", "WebPush #{signed_json_web_token}"}` ⇒
  draft-ietf-webpush-vapid-01, not RFC 8292 `vapid t=…, k=…`.

The replacement text also records *why* the gap is structural rather
than cosmetic, because that is the part a reader cannot recover from
the RFC numbers alone: under `aesgcm` the salt and the server
ephemeral public key — both mandatory HKDF inputs — travel as the
`encryption:` and `crypto-key:` headers (`:150-151`) while the body is
the bare ciphertext (`:161`). RFC 8291 puts the same two values in the
body's own binary header, so the body decrypts standalone.

Attribution is kept split in the comment, deliberately: the dependency
half above is measured here; that a transport may discard the headers
is the Resentin author's report, not something measured in this repo.

## Deliberately not in this PR

- The `/api/config` capability field and the wire-format pinning test.
  Both are in the issue's acceptance list, and the shape of both
  depends on which route the fix takes — they would have to be
  rewritten once that is decided.
- Any route work. The route decision is open on #1290.

Refs #1290.
