### PR TITLE
cic(#1298): paint the watchlight-highlight bar instead of laying it out

### DIFF
--- a/cicchetto/e2e/tests/issue370-custom-highlight-visual.spec.ts
+++ b/cicchetto/e2e/tests/issue370-custom-highlight-visual.spec.ts
@@ -67,6 +67,37 @@ test("#370 — a custom /hilight word paints the same visual highlight own-nick 
     await expect(liveLine).toHaveClass(/scrollback-highlight/);
     await expect(liveLine).toHaveClass(/scrollback-mention/);
 
+    // #1298 — the highlight must not INDENT the row. The accent bar used to be
+    // `border-left: 2px` + `padding-left: 0.25rem`, inline space no other row
+    // reserved, so a highlighted line's text column sat 5.5px right of every
+    // neighbour (measured, irssi-dark at the 14px font pref). The bar is
+    // painted in the pane's gutter now, which is only half the contract: the
+    // text column must be flush with a plain row's AND the bar must still be
+    // painted. A plain peer line, sent here, is the external reference box —
+    // measuring the highlighted row against itself could not fail.
+    peer.privmsg(SEED_CHANNEL, "i370 plain neighbour line");
+    const plainLine = scrollbackLine(page, "privmsg", "i370 plain neighbour line");
+    await expect(plainLine).toBeVisible({ timeout: 15_000 });
+    await expect(plainLine).not.toHaveClass(/scrollback-highlight/);
+
+    const highlightedTime = await liveLine.locator(".scrollback-time").boundingBox();
+    const plainTime = await plainLine.locator(".scrollback-time").boundingBox();
+    if (highlightedTime === null || plainTime === null) {
+      throw new Error("a scrollback row has no timestamp box — the markup or the classes drifted");
+    }
+    expect(
+      Math.abs(highlightedTime.x - plainTime.x),
+      "a highlighted row's text column must start where a plain row's does",
+    ).toBeLessThan(0.5);
+
+    const bar = await liveLine.evaluate((el) => {
+      const cs = getComputedStyle(el, "::before");
+      return { content: cs.content, width: cs.width, background: cs.backgroundColor };
+    });
+    expect(bar.content).not.toBe("none");
+    expect(bar.width).toBe("2px");
+    expect(bar.background).not.toBe("rgba(0, 0, 0, 0)");
+
     // Phase 2 — fresh reload: the keyword list starts empty and is re-pulled
     // on the user-topic (re)join. A NEW matching line must still highlight
     // without opening settings.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2848,8 +2848,29 @@ html.resize-dragging * {
    no bold, so the two states are clearly different. */
 .scrollback-line.scrollback-highlight {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
-  border-left: 2px solid var(--accent);
-  padding-left: 0.25rem;
+  /* #1298 — anchor for the accent bar below, which is PAINTED rather than
+     laid out. The bar used to be `border-left: 2px` + `padding-left: 0.25rem`,
+     space no other row reserved: a highlighted row's content started 5.5px
+     right of every neighbour (measured, irssi-dark at the 14px font pref —
+     7px at the 20px one, both halves being rem). Reserving the same inset on
+     every row instead would mean repeating it on `.scrollback-topic-join`,
+     the day separator and the unread marker, which share that column: four
+     selectors to keep one edge straight, against one here. */
+  position: relative;
+}
+
+.scrollback-line.scrollback-highlight::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  /* Into the pane's own 1rem gutter (`.scrollback` padding), keeping the 2px
+     bar and the 0.25rem gap to the text that the padding used to provide.
+     Inside the scrollport, so nothing clips it and no axis gains a scrollbar;
+     a descendant box, so it travels with the swipe-to-reply `transform`. */
+  left: calc(-2px - 0.25rem);
+  width: 2px;
+  background: var(--accent);
 }
 
 /* C7.2: Muted events — presence/op kinds rendered with reduced contrast.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41518,3 +41518,51 @@ video, audio, a font, an image format — the fixture must use a format the
 RUNNER's engine implements, not the one the author's tools produced. Ask the
 runner with a capability probe before believing any explanation of the red;
 and before re-encoding a shared fixture, grep who else reads it.
+<!-- entry #1298 -->
+
+---
+
+## 2026-08-13 — #1298: the highlight bar is painted, not laid out
+
+`.scrollback-line.scrollback-highlight` drew its accent bar with
+`border-left: 2px` + `padding-left: 0.25rem`, on a base row whose inline
+padding is `0`. No other row reserved that space, so a highlighted row's
+text column started **5.5px** right of every neighbour — measured in
+chromium against the real stylesheet and production markup, irssi-dark at
+the default font pref. Not the 6px the issue estimated off the source:
+`html { font-size: var(--font-size) }` pins the root at 14px, so `0.25rem`
+is 3.5px and the whole displacement rides the font-size pref — 7px at the
+20px step, also measured. A custom theme changes nothing about it: only the
+bar's colour comes from `--accent`.
+
+The bar is a `::before` now, absolutely positioned into the pane's own 1rem
+gutter (`.scrollback` padding) at `left: calc(-2px - 0.25rem)` — same 2px
+bar, same gap to the text, without the layout cost. After the change every
+row's content edge measures 14.00px, highlighted or not (20.00px at the 20px
+pref); the bar's ink sits at x=9..10, inside the scrollport, and
+`scrollWidth == clientWidth` says no axis gained a scrollbar. It travels
+with the swipe-to-reply `translateX(40px)` — ink at 49..50 — because a
+pseudo-element is a descendant box, not a sibling that would have to be
+moved in step.
+
+The issue's other sizing option, reserving the same inset on EVERY row, was
+rejected on blast radius, and the measurement is what settled it:
+`.scrollback-topic-join`, the day separator and the unread marker are not
+`.scrollback-line`s, yet they share that column at exactly the same 14.00px.
+Reserving space would have had to be repeated across four selectors to keep
+one edge straight, and every row type added later would inherit that
+obligation silently. Painting costs one selector and moves nothing. The
+issue's third option — drop the bar, let the background tint carry the
+state — changes the visible design and was left alone.
+
+**Checked and unchanged:** the muted/presence rows (`font-size` + `opacity`
+only) and `.scrollback-topic-join` measure the same before and after.
+
+**Not verified:** no iOS or WebKit run — every number here is chromium at
+`deviceScaleFactor: 1`. The e2e guard added to the #370 spec (the text
+column flush with a plain row's, and the bar still painted) has NOT been
+executed: this host runs no browser outside a container, and the
+integration stack was held by another worker. Observed, not fixed:
+`MentionsWindow` puts `scrollback-highlight` on rows that are not
+`.scrollback-line`, and no rule matches that class alone — the class is
+inert there, before this change and after it.


### PR DESCRIPTION
## What

`.scrollback-line.scrollback-highlight` reserved its accent bar with
`border-left: 2px` + `padding-left: 0.25rem`, on a base row whose inline padding
is `0`. No neighbouring row reserves that space, so a highlighted row's text
column started to the right of every other row — the misalignment landing
exactly on the lines the eye is drawn to (#1298).

## Measured, before touching the CSS

Nobody had looked at a browser: the issue was read off the stylesheet. These
numbers come from chromium (headless, `deviceScaleFactor: 1`) rendering the
REAL `themes/default.css` over production markup — the markup was dumped from a
`ScrollbackPane` render, not hand-written, so the row classes are the ones the
component actually emits (day separator, plain privmsg, presence+muted JOIN,
topic-join, mention+highlight, highlight-only, notice).

Left edge of each row's content (`.scrollback-time`):

| row | before | after |
|---|---|---|
| day separator / plain / presence+muted / topic-join / notice | 14.00px | 14.00px |
| **mention + highlight** | **19.50px** | **14.00px** |
| **highlight only** | **19.50px** | **14.00px** |

Same run with a **custom theme** (`mirc-light` base + the inline custom
properties `lib/customTheme.ts` writes on `<html>`, `--accent` included, at the
20px font pref): neighbours 20.00px, highlighted rows **27.00px → 20.00px**.

So the displacement is **5.5px**, not the 6px the issue estimated: the app pins
`html { font-size: var(--font-size) }` at 14px, so `0.25rem` is 3.5px. Both
halves being rem, the defect rides the font-size pref — **7px** at the 20px step.

## The fix, and why this one

Option (1) and (2) from the issue have the same visible outcome, so this is an
implementation call: **(2)**, the bar is painted, not laid out — a `::before`
absolutely positioned into the pane's own 1rem gutter at
`left: calc(-2px - 0.25rem)`, keeping the same 2px bar and the same gap the
padding used to give.

The measurement is what chose it. `.scrollback-topic-join`, the day separator
and the unread marker are **not** `.scrollback-line`s, yet they sit at exactly
the same 14.00px. Reserving the inset on every row would therefore have to be
repeated across four selectors to keep one column straight, and every row type
added later would inherit that obligation silently. Painting costs one selector
and moves nothing else.

Option (3) — drop the bar, let the tint carry the state — is a visible design
change and is left to @vjt.

## The three checks the issue asks for

1. **`.scrollback-topic-join`** — measured 14.00px before and after. Unchanged,
   and it needs no rule of its own precisely because nothing else moved.
2. **muted / presence rows** — measured 14.00px before and after; that rule only
   touches `font-size` and `opacity`.
3. **swipe-to-reply `transform`** — driven as `lib/messageGestures.ts` does it
   (`.scrollback-line-swiping` + inline `translateX(40px)`): row left 14 → 54,
   and a pixel probe of the bar's ink moves 9..10 → 49..50. It travels, because
   a pseudo-element is a descendant box. Also checked: the bar sits inside the
   scrollport and `scrollWidth == clientWidth`, so no axis gained a scrollbar.

None of the three broke.

## Guard

Added to `issue370-custom-highlight-visual.spec.ts`, which already mounts a
highlighted row against the live stack: a plain peer line is sent as the
**external reference box** (measuring the highlighted row against itself could
not fail), the two timestamp boxes must share an x within 0.5px, and the bar's
existence is asserted alongside — otherwise deleting the bar would pass the
alignment test.

## What I will not claim

- **The e2e assertions have not been executed.** This host runs no browser
  outside a container, and the integration stack was held by another worker.
  Their only execution will be CI.
- **No iOS / WebKit run.** Every number above is chromium.
- The measurement harness is a static page, not the running app: it pins the
  box model of the real stylesheet over real markup, not the app's own layout
  chain above `.scrollback-pane`.
- Observed, not fixed: `MentionsWindow` puts `scrollback-highlight` on rows that
  are not `.scrollback-line`, and no rule matches that class alone — the class
  is inert there, before this change and after it.

## Gates

- `scripts/bun.sh run check` — RC=0 (biome + tsc over `src` and `e2e`)
- `scripts/bun.sh run test` — RC=0, 282 files / 5382 tests, run from this
  worktree
- `scripts/design-notes-gate.sh` — RC=0, "1 new entry heading(s), separator and
  marker present"