### PR TITLE
Union: #1288 ingest batching, #1283 enrolment password, #1284 sweep

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -934,7 +934,8 @@ export type SettingsSection =
   | "watchlists"
   | "aliases"
   | "perform"
-  | "vhost";
+  | "vhost"
+  | "security";
 
 // Open the settings drawer (viewport-aware) and navigate into `section`'s
 // sub-page, returning the sub-page section locator so callers scope assertions

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -23,7 +23,9 @@
 // read its errors with the dead-token handler ARMED. Sending the password
 // without disarming it would have turned one typo into a logout of every tab
 // sharing the bearer — a regression the fix itself would have introduced.
-// "Still on the security pane, not bounced to /login" is how that is visible.
+// "the refusal is on a pane that is still there" is how that is visible, and
+// it is deliberately ONE assertion rather than two: a separate
+// `pathname !== "/login"` check never fires, because the pane vanishes first.
 //
 // Then the RIGHT password, which has to reach step two: QR and manual key on
 // screen. Enrolment STARTS here and is never confirmed — the returned secret
@@ -59,8 +61,20 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
     await form.getByLabel("Account password").fill("definitely-not-the-password");
     await form.getByRole("button", { name: "enable TOTP" }).click();
 
+    // Two claims in one wait, and the message says so because they fail the
+    // same way. There IS a refusal on the pane — and the pane is still THERE,
+    // which is the survival claim: the door is authenticated, so a wrong
+    // password answers 401, and reading that 401 with the dead-token handler
+    // armed clears the bearer and bounces RequireAuth to /login. Measured:
+    // flipping `readError(res, false)` back to the default kills exactly this
+    // assertion, with the pane gone and nothing to find.
     const alert = pane.getByRole("alert");
-    await expect(alert).toBeVisible();
+    await expect(
+      alert,
+      "no refusal on the TOTP pane — if the pane itself is gone, the 401 was " +
+        "read as a dead bearer and the app logged out (readError must stay " +
+        "disarmed on a re-auth door)",
+    ).toBeVisible();
     // The regression pin. Before the fix EVERY press landed here, whatever
     // was typed, because the request carried no password at all.
     await expect(alert).not.toHaveText(MALFORMED);
@@ -68,11 +82,6 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
 
     // No enrolment was started: no QR, no manual key.
     await expect(pane.getByTestId("totp-enrollment-form")).toHaveCount(0);
-
-    // The 401 must not be read as "this bearer is dead". Still authenticated,
-    // still on the pane.
-    expect(new URL(page.url()).pathname).not.toBe("/login");
-    await expect(pane).toBeVisible();
 
     // The gate clears the field after every attempt, right or wrong, so the
     // next press cannot silently re-send what was just refused.

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -49,7 +49,10 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
   test("a wrong password is refused as a credential, not as a malformed body", async ({ page }) => {
     const user = specUser();
     await loginAs(page, user);
-    const pane = await openSettingsSection(page, "security");
+    const subpage = await openSettingsSection(page, "security");
+    // Scoped to the TOTP section: the passkey section below is a sibling
+    // inside the same subpage and renders its own alert.
+    const pane = subpage.getByTestId("totp-settings");
 
     const form = pane.getByTestId("totp-enable-form");
     await expect(form).toBeVisible();
@@ -79,7 +82,8 @@ test.describe("#1283 — TOTP enrolment asks for the account password", () => {
   test("the right password reaches the QR and the manual key", async ({ page }) => {
     const user = specUser();
     await loginAs(page, user);
-    const pane = await openSettingsSection(page, "security");
+    const subpage = await openSettingsSection(page, "security");
+    const pane = subpage.getByTestId("totp-settings");
 
     const form = pane.getByTestId("totp-enable-form");
     await form.getByLabel("Account password").fill(user.password);

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -1,0 +1,100 @@
+// #1283 — "Enable TOTP" could not work for anybody.
+//
+// `POST /me/totp/enrollment` has required the account password since
+// c1657c3b; cic went on posting a literal `"{}"`, so the controller head
+// never matched, the catch-all answered `bad_request`, and the pane rendered
+// "The request was malformed." on every press. No test caught it because
+// every test that drove the button mocked `lib/api`: the component believed
+// it had asked for an enrolment, and the wire disagreed. This spec is the
+// one that cannot be fooled that way — it drives the real pane against the
+// real endpoint and reads the answer off the screen.
+//
+// ## What it asserts, and why in this order
+//
+// The WRONG password first. A defect that answers `bad_request` to
+// everything looks identical to a working gate if you only check that
+// pressing the button produces an error, so the load-bearing assertion is
+// the NEGATIVE one: the refusal must be the credential refusal, and must NOT
+// be the malformed-body one the defect produced. That single assertion is
+// the regression pin.
+//
+// Still on the wrong-password leg: the session must SURVIVE it. The door is
+// authenticated, so a wrong password answers 401, and this caller used to
+// read its errors with the dead-token handler ARMED. Sending the password
+// without disarming it would have turned one typo into a logout of every tab
+// sharing the bearer — a regression the fix itself would have introduced.
+// "Still on the security pane, not bounced to /login" is how that is visible.
+//
+// Then the RIGHT password, which has to reach step two: QR and manual key on
+// screen. Enrolment STARTS here and is never confirmed — the returned secret
+// stays unarmed, so this spec mutates no account state. Confirming it is
+// what would revoke every other bearer and hand out the recovery codes, and
+// that is deliberately out of scope.
+//
+// The account password is never asserted ON, only typed: it is the per-test
+// subject's throwaway fixture credential, and an assertion that compares it
+// would print it into the report on failure.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: TOTP enrolment
+// is an ACCOUNT verb, not an IRC one. A visitor has no account password and
+// no security pane (the drawer row is gated on `subject.kind === "user"`),
+// so the registered class is the only one this surface has.
+
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import { expect, specUser, test } from "../fixtures/test";
+
+const MALFORMED = /malformed/i;
+
+test.describe("#1283 — TOTP enrolment asks for the account password", () => {
+  test("a wrong password is refused as a credential, not as a malformed body", async ({ page }) => {
+    const user = specUser();
+    await loginAs(page, user);
+    const pane = await openSettingsSection(page, "security");
+
+    const form = pane.getByTestId("totp-enable-form");
+    await expect(form).toBeVisible();
+    await form.getByLabel("Account password").fill("definitely-not-the-password");
+    await form.getByRole("button", { name: "enable TOTP" }).click();
+
+    const alert = pane.getByRole("alert");
+    await expect(alert).toBeVisible();
+    // The regression pin. Before the fix EVERY press landed here, whatever
+    // was typed, because the request carried no password at all.
+    await expect(alert).not.toHaveText(MALFORMED);
+    await expect(alert).toHaveText(/invalid name or password/i);
+
+    // No enrolment was started: no QR, no manual key.
+    await expect(pane.getByTestId("totp-enrollment-form")).toHaveCount(0);
+
+    // The 401 must not be read as "this bearer is dead". Still authenticated,
+    // still on the pane.
+    expect(new URL(page.url()).pathname).not.toBe("/login");
+    await expect(pane).toBeVisible();
+
+    // The gate clears the field after every attempt, right or wrong, so the
+    // next press cannot silently re-send what was just refused.
+    await expect(form.getByLabel("Account password")).toHaveValue("");
+  });
+
+  test("the right password reaches the QR and the manual key", async ({ page }) => {
+    const user = specUser();
+    await loginAs(page, user);
+    const pane = await openSettingsSection(page, "security");
+
+    const form = pane.getByTestId("totp-enable-form");
+    await form.getByLabel("Account password").fill(user.password);
+    await form.getByRole("button", { name: "enable TOTP" }).click();
+
+    const enrollment = pane.getByTestId("totp-enrollment-form");
+    await expect(enrollment).toBeVisible();
+    // Both halves of "scan it or type it" — the QR is an injected svg, the
+    // manual key is the fallback for an unscannable one. Matched as
+    // non-empty rather than compared: the value is enrolment secret material
+    // and a comparison would print it into the report.
+    await expect(enrollment.locator(".qr-frame svg")).toBeVisible();
+    await expect(enrollment.getByLabel("Manual key")).toHaveValue(/.+/);
+
+    // No refusal rode along with the success.
+    await expect(pane.getByRole("alert")).toHaveCount(0);
+  });
+});

--- a/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
+++ b/cicchetto/e2e/tests/issue1283-totp-enrolment-password.spec.ts
@@ -30,8 +30,9 @@
 // Then the RIGHT password, which has to reach step two: QR and manual key on
 // screen. Enrolment STARTS here and is never confirmed — the returned secret
 // stays unarmed, so this spec mutates no account state. Confirming it is
-// what would revoke every other bearer and hand out the recovery codes, and
-// that is deliberately out of scope.
+// what would revoke the account's other browser sessions (per-client tokens
+// survive it, #1284) and hand out the recovery codes, and that is
+// deliberately out of scope.
 //
 // The account password is never asserted ON, only typed: it is the per-test
 // subject's throwaway fixture credential, and an assertion that compares it

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
 import InlineConfirmButton from "./InlineConfirmButton";
+import { withAccountPassword } from "./lib/accountPassword";
 import {
   deletePasskey,
   finishPasskeyModeChange,
@@ -48,36 +49,13 @@ const PasskeySettings: Component = () => {
   };
   onMount(() => void reload().catch((value) => setError(errorMessage(value))));
 
-  // #729 — FIVE privileged actions consume the account password, and only one
-  // of them (add) used to sit inside the form that visually owned the field.
-  // The other four read the signal from elsewhere in the pane with no prompt
-  // of their own, so a user who never filled that form sent `""` and got a
-  // bare 401 back; and a password typed to ADD a passkey stayed live in the
-  // signal, silently re-usable to change how the account authenticates.
-  //
-  // One gate for all five: refuse locally when the field is empty (naming the
-  // blocker instead of spending a doomed request AND a slot in the server's
-  // login-throttle window), and clear the field in the `finally` — on success
-  // AND on failure, so neither a good password nor a wrong one lingers for
-  // the next click to reuse. Re-typing IS the per-action re-confirmation the
-  // pane owes for a change of this weight.
-  const withPassword = async (run: (accountPassword: string) => Promise<void>): Promise<void> => {
-    setError(null);
-    const accountPassword = password();
-    if (accountPassword === "") {
-      setError("Enter your account password to confirm this change.");
-      return;
-    }
-    setBusy(true);
-    try {
-      await run(accountPassword);
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-      setPassword("");
-    }
-  };
+  // #729 — FIVE privileged actions here consume the account password, and
+  // only one of them (add) used to sit inside the form that visually owned
+  // the field. The rationale, and the gate itself, moved to
+  // `lib/accountPassword` when #1283 gave the TOTP section its own consumers.
+  const gate = { password, setPassword, setBusy, setError };
+  const withPassword = (run: (accountPassword: string) => Promise<void>): Promise<void> =>
+    withAccountPassword(gate, run);
 
   const register = async (event: Event): Promise<void> => {
     event.preventDefault();

--- a/cicchetto/src/TotpSettings.tsx
+++ b/cicchetto/src/TotpSettings.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import { withAccountPassword } from "./lib/accountPassword";
 import {
   confirmTotpEnrollment,
   disableTotp,
@@ -41,16 +42,18 @@ const TotpSettings: Component<Props> = (props) => {
       .catch(reportError);
   });
 
-  const beginEnrollment = async (): Promise<void> => {
-    setBusy(true);
-    setError(null);
-    try {
-      setEnrollment(await startTotpEnrollment(currentToken()));
-    } catch (value) {
-      reportError(value);
-    } finally {
-      setBusy(false);
-    }
+  // #1283 — the two account-password consumers in this section go through
+  // the pane-wide gate (`lib/accountPassword`), the same one the passkey
+  // section below uses. Enrolment re-authenticates because confirming it
+  // revokes every other bearer and hands out the recovery codes; disabling
+  // always did.
+  const gate = { password, setPassword, setBusy, setError };
+
+  const beginEnrollment = async (event: Event): Promise<void> => {
+    event.preventDefault();
+    await withAccountPassword(gate, async (accountPassword) => {
+      setEnrollment(await startTotpEnrollment(currentToken(), accountPassword));
+    });
   };
 
   const confirmEnrollment = async (event: Event): Promise<void> => {
@@ -74,18 +77,11 @@ const TotpSettings: Component<Props> = (props) => {
 
   const disable = async (event: Event): Promise<void> => {
     event.preventDefault();
-    setBusy(true);
-    setError(null);
-    try {
-      await disableTotp(currentToken(), password());
+    await withAccountPassword(gate, async (accountPassword) => {
+      await disableTotp(currentToken(), accountPassword);
       setEnabled(false);
-      setPassword("");
       setRecoveryCodes([]);
-    } catch (value) {
-      reportError(value);
-    } finally {
-      setBusy(false);
-    }
+    });
   };
 
   const copyRecoveryCodes = async (): Promise<void> => {
@@ -116,9 +112,24 @@ const TotpSettings: Component<Props> = (props) => {
 
         <Show when={enabled() === false && enrollment() === null && recoveryCodes().length === 0}>
           <p>Protect account login with codes from an authenticator app.</p>
-          <button type="button" disabled={busy()} onClick={() => void beginEnrollment()}>
-            enable TOTP
-          </button>
+          {/* #1283 — no `required` on the field: the gate in
+              `withAccountPassword` is the ONE mechanism that refuses an empty
+              password across this pane, and a native constraint here would
+              make its arm unreachable in a browser while leaving it live in
+              the passkey section. */}
+          <form onSubmit={beginEnrollment} data-testid="totp-enable-form">
+            <label for="totp-enable-password">Account password</label>
+            <input
+              id="totp-enable-password"
+              type="password"
+              autocomplete="current-password"
+              value={password()}
+              onInput={(event) => setPassword(event.currentTarget.value)}
+            />
+            <button type="submit" disabled={busy()}>
+              enable TOTP
+            </button>
+          </form>
         </Show>
 
         <Show when={enrollment()} keyed>
@@ -176,7 +187,6 @@ const TotpSettings: Component<Props> = (props) => {
               autocomplete="current-password"
               value={password()}
               onInput={(event) => setPassword(event.currentTarget.value)}
-              required
             />
             <button type="submit" disabled={busy()}>
               disable TOTP

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -45,7 +45,20 @@ const ENROLLMENT = {
 
 const renderSettings = () => render(() => <TotpSettings onBack={() => undefined} />);
 
+const ACCOUNT_PASSWORD = "test-account-password";
+
+// #1283 — starting an enrolment re-authenticates, so every enrolment
+// journey now begins by typing the account password. Scoped to the enable
+// form: the passkey pane below renders a field with the same label.
+const typeAccountPassword = async (formTestId: string, value: string): Promise<void> => {
+  const form = await screen.findByTestId(formTestId);
+  await fireEvent.input(within(form).getByLabelText("Account password"), {
+    target: { value },
+  });
+};
+
 const beginEnrollment = async (): Promise<void> => {
+  await typeAccountPassword("totp-enable-form", ACCOUNT_PASSWORD);
   await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
   await screen.findByTestId("totp-enrollment-form");
 };
@@ -176,5 +189,72 @@ describe("TotpSettings — enrolment", () => {
     );
     // Still enabled: the pane must not claim a disable that never happened.
     expect(screen.getByTestId("totp-disable-form")).toBeInTheDocument();
+  });
+});
+
+describe("#1283 — starting an enrolment re-authenticates", () => {
+  // `POST /me/totp/enrollment` has demanded the account password since
+  // c1657c3b; the pane went on posting an empty body, so the button could
+  // not work for anyone — every press answered `bad_request`, rendered as
+  // "The request was malformed.". The gate is deliberate (confirming an
+  // enrolment revokes every other bearer and hands out the recovery codes),
+  // so the pane has to ask, exactly as the passkey pane does for its five
+  // privileged verbs and as the disable form already did.
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getTotpStatus.mockResolvedValue({ enabled: false });
+    api.getPasskeyStatus.mockResolvedValue({ mode: "disabled", passkeys: [] });
+    api.startTotpEnrollment.mockResolvedValue(ENROLLMENT);
+  });
+
+  it("passes the typed account password to the enrolment request", async () => {
+    renderSettings();
+    await beginEnrollment();
+
+    expect(api.startTotpEnrollment).toHaveBeenCalledWith("test-token", ACCOUNT_PASSWORD);
+  });
+
+  it("names the empty field as the blocker instead of spending a doomed request", async () => {
+    renderSettings();
+    await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Enter your account password to confirm this change.",
+      ),
+    );
+    expect(api.startTotpEnrollment).not.toHaveBeenCalled();
+  });
+
+  it("clears the field after a refusal so the next press cannot reuse it", async () => {
+    api.startTotpEnrollment.mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    renderSettings();
+    await typeAccountPassword("totp-enable-form", "wrong");
+    await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Invalid name or password.",
+      ),
+    );
+    // The refusal is NOT the malformed-body one the defect produced.
+    expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).not.toHaveTextContent(
+      "The request was malformed.",
+    );
+    // No enrolment was started, and the wrong password does not linger in
+    // the field for the next click to re-send.
+    expect(screen.queryByTestId("totp-enrollment-form")).toBeNull();
+    const form = screen.getByTestId("totp-enable-form");
+    expect((within(form).getByLabelText("Account password") as HTMLInputElement).value).toBe("");
+  });
+
+  it("keeps the field a password field, so it is never rendered in the clear", async () => {
+    renderSettings();
+    const form = await screen.findByTestId("totp-enable-form");
+    const field = within(form).getByLabelText("Account password") as HTMLInputElement;
+
+    expect(field.type).toBe("password");
+    expect(field.autocomplete).toBe("current-password");
   });
 });

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -197,7 +197,8 @@ describe("#1283 — starting an enrolment re-authenticates", () => {
   // c1657c3b; the pane went on posting an empty body, so the button could
   // not work for anyone — every press answered `bad_request`, rendered as
   // "The request was malformed.". The gate is deliberate (confirming an
-  // enrolment revokes every other bearer and hands out the recovery codes),
+  // enrolment revokes the account's other browser sessions — per-client
+  // tokens are spared, #1284 — and hands out the recovery codes),
   // so the pane has to ask, exactly as the passkey pane does for its five
   // privileged verbs and as the disable form already did.
 

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1137,3 +1137,44 @@ describe("api.me single-flight (#394)", () => {
     expect((await retry).badge_count).toBe(2);
   });
 });
+
+describe("#1283 — the enrolment door is password-gated, so cic must knock with one", () => {
+  // `POST /me/totp/enrollment` has required the account password since
+  // c1657c3b; `startTotpEnrollment` kept posting a literal `"{}"`, so the
+  // controller head never matched, the catch-all answered `bad_request` and
+  // the pane rendered "The request was malformed." for every user alive.
+  //
+  // The second test is the half the fix would break if it stopped at the
+  // body. A password-gated door can answer 401 `invalid_credentials`, and
+  // this caller read its errors with the dead-token handler ARMED — the
+  // default. Sending the password without disarming it turns one typo into
+  // a logout of every tab sharing the bearer. `disableTotp` and every
+  // `passkeyRequest` already read theirs disarmed for exactly this reason:
+  // on a re-auth door a 401 means "wrong password", never "dead bearer".
+
+  it("sends the account password in the enrolment request body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ enrollment_token: "t", secret: "s", provisioning_uri: "otpauth://x" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.startTotpEnrollment("bearer", "hunter2");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/totp/enrollment");
+    expect(JSON.parse(init.body as string)).toEqual({ password: "hunter2" });
+  });
+
+  it("a wrong password does not fire the dead-token handler", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "invalid_credentials" });
+    await expect(api.startTotpEnrollment("bearer", "wrong")).rejects.toBeInstanceOf(api.ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
@@ -1,0 +1,347 @@
+import { createEffect, createRoot, on } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+
+// #1288 — the COST of ingesting a catch-up page, and the invariants that cost
+// is not allowed to buy.
+//
+// `refreshScrollback` used to ingest its REST page one `appendToScrollback`
+// per row. Each of those is a duplicate SCAN over everything the pane already
+// holds, a copy of the whole row array, a copy of the channel map, and its own
+// Solid signal write — so a 200-row page ran the pane's reactive graph 200
+// times and did O(page x pane) work. A reporter's Firefox Profiler trace put
+// 1917 of 2002 cicchetto samples under that verb, ~1 s of saturated main
+// thread per burst.
+//
+// Two oracles here, both DELIBERATELY host-independent — a wall-clock
+// threshold in a shared-runner suite goes red on load rather than on a
+// regression, so the committed guard measures WORK, not time:
+//
+//   * reactive passes — an effect on the store signal counts one tick per
+//     store write. The honest user-visible unit: each pass is a render the
+//     browser pays for. 200 -> 1.
+//   * id reads — every row is handed to the store with `id` behind a getter
+//     that counts. The dedupe scan reads every loaded row's id once per
+//     ARRIVING row in the per-row shape (O(P*N)) and once in total in the
+//     batched one (O(P+N)). The number is exact, reproducible and moves with
+//     the mutation: restore the loop and it goes back up by two orders of
+//     magnitude on a full page.
+//
+// Both are asserted with DISPLACEMENT — the same measurement at several page
+// and pane sizes — because a single before/after pair cannot tell a constant
+// factor from a changed complexity class.
+//
+// The third block asserts what the fix must NOT cost. The issue proposed
+// reusing `mergeIntoScrollback` (already batched, in this same module); it is
+// NOT the same verb. It deliberately applies no S20 ring cap (a scroll-up
+// prepend must not be truncated mid-scroll) and so never invalidates the
+// loadMore exhausted latch either. Swapping it in would have removed the ring
+// cap from the reconnect path — the very path S20's own comment names — with
+// every existing cap test still green, because they all drive
+// `appendToScrollback` directly.
+
+vi.mock("../lib/api", () => ({
+  listMessages: vi.fn(),
+  listMessagesAfter: vi.fn(),
+  countMessagesAfter: vi.fn(),
+  sendMessage: vi.fn(),
+  isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
+  isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+}));
+
+const mockGetResumeCursor = vi.fn<(slug: string, chan: string) => number | null>(() => null);
+vi.mock("../lib/reconnectBackfill", () => ({
+  getResumeCursor: (slug: string, chan: string) => mockGetResumeCursor(slug, chan),
+  recordSeen: vi.fn(),
+}));
+
+const mockGetReadCursor = vi.fn<(slug: string, chan: string) => number | null>(() => null);
+vi.mock("../lib/readCursor", () => ({
+  getReadCursor: (slug: string, chan: string) => mockGetReadCursor(slug, chan),
+  setReadCursor: vi.fn(),
+}));
+
+const SLUG = "freenode";
+const CHAN = "#grappa";
+const KEY = channelKey(SLUG, CHAN);
+
+// Row whose `id` is a counting getter. Every read the store performs — the
+// dedupe scan, the tail comparison, the ring-cap protection scan, a sort — is
+// one tick. `counter` is a shared box so a whole page reports into one number.
+const countingRow = (id: number, counter: { reads: number }): ScrollbackMessage => {
+  const row = {
+    network: SLUG,
+    channel: CHAN,
+    server_time: id * 1000,
+    kind: "privmsg" as const,
+    sender: "alice",
+    body: `line ${id}`,
+    meta: {},
+  };
+  Object.defineProperty(row, "id", {
+    get() {
+      counter.reads++;
+      return id;
+    },
+    enumerable: true,
+  });
+  return row as ScrollbackMessage;
+};
+
+const plainRow = (id: number): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: CHAN,
+  server_time: id * 1000,
+  kind: "privmsg",
+  sender: "alice",
+  body: `line ${id}`,
+  meta: {},
+});
+
+// Fill a pane with `n` rows through the LIVE path. The seeded rows count
+// their id reads too — they are what the dedupe scan walks, so leaving them
+// plain would under-report the quadratic term by half.
+const seedPane = (
+  scrollback: typeof import("../lib/scrollback"),
+  n: number,
+  counter: { reads: number },
+): void => {
+  for (let i = 1; i <= n; i++) scrollback.appendToScrollback(KEY, countingRow(i, counter));
+};
+
+// Drive ONE catch-up page of `pageSize` rows through refreshScrollback and
+// report both oracles. The counter is zeroed after seeding, so only the
+// catch-up page is measured.
+const ingestPage = async (
+  scrollback: typeof import("../lib/scrollback"),
+  api: typeof import("../lib/api"),
+  paneSize: number,
+  pageSize: number,
+  counter: { reads: number },
+): Promise<{ reads: number; passes: number }> => {
+  const page = Array.from({ length: pageSize }, (_, i) => countingRow(paneSize + 1 + i, counter));
+  mockGetResumeCursor.mockReturnValue(paneSize);
+  vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+
+  let passes = 0;
+  const dispose = createRoot((d) => {
+    // `defer: true` so subscribing does not count as a pass.
+    createEffect(on(scrollback.scrollbackByChannel, () => void passes++, { defer: true }));
+    return d;
+  });
+  counter.reads = 0;
+
+  await scrollback.refreshScrollback(SLUG, CHAN);
+  await new Promise((r) => queueMicrotask(() => r(undefined)));
+  dispose();
+  return { reads: counter.reads, passes };
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  localStorage.setItem("grappa-token", "tok");
+  mockGetReadCursor.mockReturnValue(null);
+  mockGetResumeCursor.mockReturnValue(null);
+});
+
+describe("#1288 — a catch-up page costs ONE reactive pass", () => {
+  it("runs the pane's reactive graph once per PAGE, at every page size", async () => {
+    // Displacement on the page axis: the per-row shape scales this number
+    // linearly with the page (1 / 50 / 200); one write per page pins it at 1.
+    for (const pageSize of [1, 50, 200]) {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      const scrollback = await import("../lib/scrollback");
+      const counter = { reads: 0 };
+      seedPane(scrollback, 100, counter);
+      const { passes } = await ingestPage(scrollback, api, 100, pageSize, counter);
+      expect({ pageSize, passes }).toEqual({ pageSize, passes: 1 });
+    }
+  });
+
+  it("writes nothing at all when every row of the page is already loaded", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    seedPane(scrollback, 50, { reads: 0 });
+    // The page repeats rows 41..50, all of which the pane already holds: a
+    // wholly-duplicate page must not re-render the pane.
+    const page = Array.from({ length: 10 }, (_, i) => plainRow(41 + i));
+    mockGetResumeCursor.mockReturnValue(40);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+
+    let passes = 0;
+    const dispose = createRoot((d) => {
+      createEffect(on(scrollback.scrollbackByChannel, () => void passes++, { defer: true }));
+      return d;
+    });
+    await scrollback.refreshScrollback(SLUG, CHAN);
+    await new Promise((r) => queueMicrotask(() => r(undefined)));
+    dispose();
+
+    expect(passes).toBe(0);
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).length).toBe(50);
+  });
+});
+
+// The PAGE axis is the discriminating one, and it is the only one asserted
+// here. A displacement on the PANE axis was written first and DELETED: both
+// shapes are linear in the pane (the loop scans it P times, the batch indexes
+// it once), so quadrupling the pane moves both numbers and the ratios sit
+// 2.86 vs 2.67 — measured, not reasoned. Worse, the S20 ring cap pins the pane
+// at 1000, so a "4x pane" is not one. It passed against the unfixed code, which
+// is the definition of an assertion that is scenery rather than coverage.
+describe("#1288 — ingest work is O(page + pane), not O(page x pane)", () => {
+  it("reads each loaded row's id a bounded number of times per page", async () => {
+    const paneSize = 500;
+    const pageSize = 200;
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const counter = { reads: 0 };
+    seedPane(scrollback, paneSize, counter);
+    const { reads } = await ingestPage(scrollback, api, paneSize, pageSize, counter);
+    // Linear: one index build over the pane plus a constant number of reads
+    // per arriving row. The per-row loop reads ~paneSize ids for EVERY row of
+    // the page (~240_000 here, measured); the bound below is ~85x under that,
+    // so it cannot be met by a constant-factor tweak of the quadratic shape.
+    expect(reads).toBeLessThan(4 * (paneSize + pageSize));
+  });
+
+  it("scales linearly in the page (displacement on the page axis)", async () => {
+    const measure = async (pageSize: number): Promise<number> => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      const scrollback = await import("../lib/scrollback");
+      const counter = { reads: 0 };
+      seedPane(scrollback, 500, counter);
+      const { reads } = await ingestPage(scrollback, api, 500, pageSize, counter);
+      return reads;
+    };
+    // Quadrupling the page against a fixed pane multiplies the per-row scan by
+    // 4 in the quadratic shape (measured: 5.09x, super-linear because each
+    // ingested row joins the pane the next row must scan). Batched, the pane
+    // index is built once and only the per-row constant grows, so the ratio
+    // stays near 1.
+    const small = await measure(50);
+    const large = await measure(200);
+    expect(large / small).toBeLessThan(2);
+  });
+});
+
+describe("#1288 — the batched ingest keeps every per-row invariant", () => {
+  it("applies the S20 ring cap to a catch-up page (mergeIntoScrollback would not)", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    mockGetReadCursor.mockReturnValue(null); // no divider → free eviction
+    seedPane(scrollback, cap, { reads: 0 });
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).length).toBe(cap);
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    // A full page also triggers the #693 gap probe; answer "nothing more" so
+    // the ingest is the only thing under test.
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.length).toBe(cap);
+    expect(rows[0]?.id).toBe(201);
+    expect(rows[rows.length - 1]?.id).toBe(cap + 200);
+  });
+
+  it("never evicts a row at/after the read cursor when ingesting a page", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    const cursor = 5;
+    mockGetReadCursor.mockReturnValue(cursor);
+    seedPane(scrollback, cap, { reads: 0 });
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const ids = (scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id);
+    // The divider anchor and every unread row survive, above the cap.
+    for (let i = cursor; i <= cap + 200; i++) expect(ids).toContain(i);
+    // Only the read rows below the cursor were evictable.
+    expect(ids).not.toContain(cursor - 1);
+  });
+
+  it("resets the loadMore exhausted latch when a page evicts older history", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    mockGetReadCursor.mockReturnValue(null);
+    seedPane(scrollback, cap, { reads: 0 });
+
+    // Latch loadMore as exhausted, then prove a page-driven eviction clears it.
+    vi.mocked(api.listMessages).mockResolvedValueOnce([]);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(1);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(1);
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+    expect(scrollback.scrollbackByChannel()[KEY]?.some((m) => m.id === 1)).toBe(false);
+
+    vi.mocked(api.listMessages).mockResolvedValueOnce([]);
+    await scrollback.loadMore(SLUG, CHAN);
+    expect(api.listMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-sorts a page that interleaves with rows already at the tail (#423)", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    // A live WS row landed at the tail during the await; the REST gap page
+    // sorts BEFORE it. Store order IS display order, so the result must be
+    // canonical, not arrival-ordered.
+    scrollback.appendToScrollback(KEY, plainRow(9));
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([plainRow(6), plainRow(7), plainRow(8)]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    expect((scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id)).toEqual([6, 7, 8, 9]);
+  });
+
+  it("keeps first-write-wins on a row the pane already holds", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    scrollback.appendToScrollback(KEY, { ...plainRow(6), body: "live" });
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([
+      { ...plainRow(6), body: "fetched-dupe" },
+      { ...plainRow(7), body: "fresh" },
+    ]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.map((m) => m.body)).toEqual(["live", "fresh"]);
+  });
+
+  it("drops an id repeated WITHIN one page, as the per-row loop did", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([
+      { ...plainRow(6), body: "first" },
+      { ...plainRow(6), body: "second" },
+      { ...plainRow(7), body: "next" },
+    ]);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.map((m) => m.body)).toEqual(["first", "next"]);
+  });
+});

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ruleBody, themeCss } from "./helpers/themeCss";
 
@@ -77,6 +77,12 @@ describe("#734 TOTP enrolment QR sits in a sized, light-framed box", () => {
     });
 
     render(() => <TotpSettings onBack={() => {}} />);
+    // #1283 — enrolment re-authenticates, so the QR only appears once the
+    // account password has been typed into the enable form.
+    const enable = await screen.findByTestId("totp-enable-form");
+    await fireEvent.input(within(enable).getByLabelText("Account password"), {
+      target: { value: "test-account-password" },
+    });
     await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
 
     const form = await screen.findByTestId("totp-enrollment-form");

--- a/cicchetto/src/lib/accountPassword.ts
+++ b/cicchetto/src/lib/accountPassword.ts
@@ -1,0 +1,54 @@
+import { errorMessage } from "./friendlyApiError";
+
+// The security pane's re-auth gate, shared by every control that spends the
+// account password.
+//
+// #729 wrote it for the passkey pane's five privileged verbs, after four of
+// them read the add-passkey form's field behind the user's back: a user who
+// never filled that form sent `""` and earned a bare 401, and a password
+// typed to ADD a passkey stayed live in the signal, silently re-usable to
+// change how the account authenticates.
+//
+// #1283 gave the TOTP section its second and third consumers (enrolment now
+// re-authenticates too), which is why the gate moved out of the component:
+// two copies of "refuse an empty field, clear it afterwards" would drift,
+// and the refusal a user reads must not depend on which section they are in.
+export const ACCOUNT_PASSWORD_REQUIRED = "Enter your account password to confirm this change.";
+
+// The four signal accessors the gate drives. Each section keeps its own
+// field — one shared field across the pane would let a password typed for
+// one section be spent by another.
+export type AccountPasswordGate = {
+  password: () => string;
+  setPassword: (value: string) => void;
+  setBusy: (value: boolean) => void;
+  setError: (value: string | null) => void;
+};
+
+// Runs `action` with the typed password, or refuses locally when the field
+// is empty — naming the blocker instead of spending a doomed request.
+//
+// The field is cleared in the `finally`: on success AND on failure, so
+// neither a good password nor a wrong one lingers for the next click to
+// reuse. Re-typing IS the per-action re-confirmation a pane that changes how
+// the account authenticates owes its user.
+export async function withAccountPassword(
+  gate: AccountPasswordGate,
+  action: (accountPassword: string) => Promise<void>,
+): Promise<void> {
+  gate.setError(null);
+  const accountPassword = gate.password();
+  if (accountPassword === "") {
+    gate.setError(ACCOUNT_PASSWORD_REQUIRED);
+    return;
+  }
+  gate.setBusy(true);
+  try {
+    await action(accountPassword);
+  } catch (value) {
+    gate.setError(errorMessage(value));
+  } finally {
+    gate.setBusy(false);
+    gate.setPassword("");
+  }
+}

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1552,13 +1552,25 @@ export async function getTotpStatus(token: string): Promise<{ enabled: boolean }
   return (await res.json()) as { enabled: boolean };
 }
 
-export async function startTotpEnrollment(token: string): Promise<TotpEnrollment> {
+// #1283 — the account password is REQUIRED: the door re-authenticates,
+// because confirming the enrolment it opens revokes every other bearer
+// session and hands out the recovery codes.
+//
+// `readError(res, false)` for the same reason `disableTotp` and every
+// `passkeyRequest` use it: on a re-auth door a 401 says "wrong password",
+// not "your bearer is dead". Armed (the default), one typo here would fire
+// the dead-token handler and log out every tab sharing the bearer — the
+// #739 class, arriving through an AUTHENTICATED endpoint.
+export async function startTotpEnrollment(
+  token: string,
+  password: string,
+): Promise<TotpEnrollment> {
   const res = await fetch("/me/totp/enrollment", {
     method: "POST",
     headers: buildHeaders(token),
-    body: "{}",
+    body: JSON.stringify({ password }),
   });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   return (await res.json()) as TotpEnrollment;
 }
 

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1553,8 +1553,9 @@ export async function getTotpStatus(token: string): Promise<{ enabled: boolean }
 }
 
 // #1283 — the account password is REQUIRED: the door re-authenticates,
-// because confirming the enrolment it opens revokes every other bearer
-// session and hands out the recovery codes.
+// because confirming the enrolment it opens revokes the account's other
+// browser sessions and hands out the recovery codes. Per-client tokens
+// survive that sweep (#1284); every other bearer does not.
 //
 // `readError(res, false)` for the same reason `disableTotp` and every
 // `passkeyRequest` use it: on a re-auth door a 401 says "wrong password",

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -129,6 +129,43 @@ const byServerTimeThenId = (a: ScrollbackMessage, b: ScrollbackMessage): number 
   return a.id - b.id;
 };
 
+// #1288 — the rows of `page` the pane does not already hold, in arrival order.
+// First-write-wins, including WITHIN the page: an id repeated twice in one
+// page yields the first occurrence, which is what the per-row loop this
+// replaced did by deduping against a list it was growing as it went.
+//
+// One row SCANS and a page INDEXES, deliberately. The live WS append is the
+// hot path and arrives one row at a time; it pays a single O(n) comparison
+// pass and allocates nothing, where building a Set of every loaded id would
+// cost it two allocations per message on a busy channel — more GC churn, which
+// is the thing the profile complained about. A page cannot afford the scan:
+// doing it P times IS the O(P*n) this exists to remove.
+const freshRows = (
+  existing: ScrollbackMessage[],
+  page: ScrollbackMessage[],
+): ScrollbackMessage[] => {
+  const only = page.length === 1 ? page[0] : undefined;
+  if (only !== undefined) return existing.some((m) => m.id === only.id) ? [] : page;
+  const ids = new Set<number>();
+  for (const m of existing) ids.add(m.id);
+  return page.filter((m) => {
+    if (ids.has(m.id)) return false;
+    ids.add(m.id);
+    return true;
+  });
+};
+
+// Are these rows already in the order the store keeps them? Gates the
+// append-without-sorting fast path below.
+const isCanonicallyOrdered = (rows: ScrollbackMessage[]): boolean => {
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1];
+    const cur = rows[i];
+    if (prev !== undefined && cur !== undefined && byServerTimeThenId(prev, cur) > 0) return false;
+  }
+  return true;
+};
+
 // Trim `rows` (ASC by id) to the ring cap by dropping the OLDEST, but NEVER a
 // row at/after the read cursor: the in-pane `── XX unread ──` divider anchors
 // on the cursor and its unread rows (CLAUDE.md "Read state is server-owned"),
@@ -369,25 +406,61 @@ const exports = identityScopedStore((onIdentityChange) => {
   // no re-sort), so push only when the row is at/after the tail; otherwise
   // re-sort it into position. Costs one comparison against the tail on the hot
   // path and a re-sort only on the rare out-of-order row.
-  const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {
+  //
+  // #1288 — this is the PAGE-shaped verb, and `appendToScrollback` below is
+  // its P=1 case. The live WS handler ingests one row; `refreshScrollback`
+  // ingests a whole REST catch-up page, and used to do it by calling the
+  // single-row verb once per row. That cost O(page * pane) array work and —
+  // the part that reaches the DOM — one Solid signal write, hence one reactive
+  // pass, PER MESSAGE. A reporter's Firefox Profiler trace (desktop, 9 s
+  // capture) put 1917 of 2002 cicchetto samples under `refreshScrollback`, in
+  // 21 bursts of 20-180 ms, with DOM construction/teardown and cycle
+  // collection as the native leaves. One write per page collapses that to
+  // O(page + pane) and a single pass.
+  //
+  // Why NOT `mergeIntoScrollback`, which is already batched and sits right
+  // below: it is a different verb, not a faster spelling of this one. It
+  // applies no S20 ring cap — deliberately, so a scroll-up prepend is not
+  // truncated mid-scroll — and therefore never invalidates the loadMore
+  // exhausted latch an eviction implies. Reusing it here would have silently
+  // dropped the cap from the reconnect catch-up path, which is one of the two
+  // paths S20 was written for.
+  //
+  // The cap is applied ONCE over the union instead of after every row. Same
+  // result on every ordinary ingest: eviction only ever drops from the head,
+  // the protected suffix is decided by the same read cursor either way, and
+  // the arithmetic (drop min(surplus, unprotected-prefix)) does not care
+  // whether the surplus arrived in one step or P. The two differ only when a
+  // page carries rows OLDER than what the cap is evicting, where the batch
+  // keeps the newest CAP rows of the union and the loop could keep a late
+  // arrival while having already dropped a newer row.
+  const appendPageToScrollback = (key: ChannelKey, page: ScrollbackMessage[]): void => {
+    if (page.length === 0) return;
     // S20: track whether the ring cap evicted older rows so we can reset the
     // loadMore exhausted latch below. Computed inside the pure updater,
     // consumed after it runs (Solid calls a plain-signal updater exactly once,
     // synchronously) — keeps the setter body free of the Set side-effect.
     let evicted = false;
     setScrollbackByChannel((prev) => {
-      const existing = prev[key];
-      if (existing?.some((m) => m.id === msg.id)) return prev;
-      let next: ScrollbackMessage[];
-      if (!existing || existing.length === 0) {
-        next = [msg];
-      } else {
-        const tail = existing[existing.length - 1];
-        next =
-          tail && byServerTimeThenId(msg, tail) < 0
-            ? [...existing, msg].sort(byServerTimeThenId)
-            : [...existing, msg];
-      }
+      const existing = prev[key] ?? [];
+      const fresh = freshRows(existing, page);
+      // Nothing new: return the SAME object so Solid's equality check skips
+      // the write entirely. A wholly-duplicate page (every row already live)
+      // must not re-render the pane.
+      if (fresh.length === 0) return prev;
+      const tail = existing[existing.length - 1];
+      const head = fresh[0];
+      // #423 order-safe insert, generalised from one row to a page: append
+      // without sorting when the arriving rows are themselves in canonical
+      // order AND start at/after the current tail — true of every live append
+      // and of every ASC catch-up page. Re-sort only when they interleave with
+      // rows the pane already holds.
+      const next =
+        head !== undefined &&
+        (tail === undefined || byServerTimeThenId(head, tail) >= 0) &&
+        isCanonicallyOrdered(fresh)
+          ? [...existing, ...fresh]
+          : [...existing, ...fresh].sort(byServerTimeThenId);
       const capped = capScrollbackRing(key, next);
       evicted = capped.length < next.length;
       return { ...prev, [key]: capped };
@@ -396,6 +469,10 @@ const exports = identityScopedStore((onIdentityChange) => {
     // is now stale: the server DOES have rows older than the new oldest. Clear
     // it so a scroll-to-top re-pages the evicted region.
     if (evicted) loadMoreExhausted.delete(key);
+  };
+
+  const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {
+    appendPageToScrollback(key, [msg]);
   };
 
   // Merge a freshly-fetched REST page into the per-channel list. Server
@@ -1074,13 +1151,14 @@ const exports = identityScopedStore((onIdentityChange) => {
       // api.ts helper signature.
       const page = await listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT);
       if (identityMoved(t)) return;
-      for (const msg of page) {
-        appendToScrollback(key, msg);
-        // Roll the high-water mark forward as we ingest so a second
-        // disconnect mid-refresh resumes from the new highest id
-        // rather than the original cursor.
-        recordSeen(key, msg);
-      }
+      // #1288 — ONE store write for the whole page (see
+      // `appendPageToScrollback`). `recordSeen` still walks it row by row: it
+      // is a plain Map high-water mark with no reactive surface, so iterating
+      // it costs nothing the profile can see, and no await separates it from
+      // the ingest — the "second disconnect mid-refresh" its roll-forward
+      // exists for cannot land between the two.
+      appendPageToScrollback(key, page);
+      for (const msg of page) recordSeen(key, msg);
       // #161: a FULL-cap refresh page means the server tail may be further
       // ahead than what we just appended (a >200-message reconnect re-opens
       // the forward gap). Invalidate the forward-tail latch so the next

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -356,9 +356,12 @@ Three properties worth designing around:
   may also skip `/auth/login` entirely and present it directly as
   `Authorization: Bearer <token>` / the WS bearer subprotocol (§3a).
 - **It does not expire while idle.** A browser session dies after seven
-  days of silence; a client token does not. Revocation by its owner is
-  the only thing that ends it — expect a `401`, and surface it as "this
-  token was revoked", not as a transient network error.
+  days of silence; a client token does not. Only revocation ends it —
+  by its owner, or by an operator resetting the account's factors or
+  rotating its password. Its owner arming, disarming or changing a
+  second factor does NOT (#1284), so minting the token first and arming
+  the factor afterwards is a safe order. Expect a `401`, and surface it
+  as "this token was revoked", not as a transient network error.
 - **It is scoped.** A client token can read and send as the account, and
   that is all. The account's own credential surfaces — `/admin/*`,
   `/me/totp*`, `/me/passkeys*`, `DELETE /me`, and the token routes

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41566,3 +41566,82 @@ integration stack was held by another worker. Observed, not fixed:
 `MentionsWindow` puts `scrollback-highlight` on rows that are not
 `.scrollback-line`, and no rule matches that class alone — the class is
 inert there, before this change and after it.
+<!-- entry #1288 -->
+
+---
+
+## 2026-08-13 — #1288: a catch-up page is one store write, not two hundred
+
+`refreshScrollback` fetches up to `PAGE_LIMIT = 200` rows on every WS
+join-ok and used to ingest them one `appendToScrollback` per row. Each of
+those calls scans the whole pane for a duplicate id, copies the row array,
+copies the channel map, and writes the Solid signal — so a full page did
+O(page × pane) array work and ran the pane's reactive graph **200 times**.
+A reporter's Firefox Profiler trace (desktop, full JS stacks, the
+granularity #408 lacked) put 1917 of 2002 cicchetto samples under that one
+verb, in 21 bursts of 20–180 ms, with DOM construction/teardown and cycle
+collection as the native leaves. It now ingests the page in ONE store write.
+
+**The batched shape already in this module is not the same verb.** The
+issue proposed reusing `mergeIntoScrollback`, and it does dedupe by Set and
+write once — but it deliberately applies no S20 ring cap (a scroll-up
+prepend must not be truncated mid-scroll) and so never invalidates the
+`loadMoreExhausted` latch an eviction implies. Swapping it in was measured
+against the new specs: it passes both cost oracles and breaks four
+invariants — the pane grows to 1200 rows and stays there, no row is ever
+evicted, the latch survives, and an id repeated within one page lands
+twice. It would have removed the ring cap from the reconnect catch-up path,
+which is one of the two paths S20 names, and **every pre-existing cap test
+would have stayed green**, because they all drive `appendToScrollback`
+directly. So `appendPageToScrollback` is the page-shaped verb and
+`appendToScrollback` is now its P=1 case: one implementation, both arities.
+
+**One row scans, a page indexes.** The live WS append pays a single O(n)
+comparison pass and allocates nothing; building a Set of every loaded id
+would cost it two allocations per message on a busy channel, which is more
+of the GC churn the profile complains about. A page cannot afford the scan
+— doing it P times IS the cost being removed.
+
+**The cap is applied once over the union**, not after every row. Identical
+on every ordinary ingest: eviction only drops from the head and the
+protected suffix is decided by the same read cursor, so `min(surplus,
+unprotected-prefix)` does not care whether the surplus arrived in one step
+or in P. The two differ only when a page carries rows OLDER than what is
+being evicted, where the batch keeps the newest CAP rows of the union and
+the loop could keep a late arrival having already dropped a newer row.
+
+**Measured, both sides, same harness** (`scrollbackIngestCost.test.ts`,
+jsdom) — reactive passes / id reads / ms, before → after:
+
+| pane | page | passes | id reads | ms |
+|---|---|---|---|---|
+| 200 | 200 | 200 → 1 | 119 801 → 601 | 0.47 → 0.10 |
+| 500 | 200 | 200 → 1 | 239 801 → 901 | 0.63 → 0.09 |
+| 900 | 200 | 200 → 1 | 389 901 → 1301 | 1.06 → 0.15 |
+
+**The committed oracle measures work, not time.** A wall-clock threshold in
+a shared-runner suite goes red on host load rather than on a regression, so
+the guards assert the reactive-pass count and an id-read bound (every row
+is handed to the store with `id` behind a counting getter). Both are exact
+and reproducible; the ms column above is reported, never asserted, and it
+is jsdom — it excludes the DOM construction the trace shows as the actual
+leaf cost, so it understates the win rather than proving it.
+
+**Displacement on the PAGE axis only, and the pane-axis assertion was
+deleted rather than kept as scenery.** Both shapes are linear in the pane —
+the loop scans it P times, the batch indexes it once — so quadrupling the
+pane moves both numbers (measured ratios 2.86 vs 2.67) and the S20 cap pins
+the pane at 1000 so a "4× pane" is not one. It passed against the unfixed
+code, which is the definition of an assertion that cannot fail.
+
+**Not claimed:** that this explains the #408 sleep-duration correlation.
+That correlation remains consistency, not measurement — nobody has profiled
+across sleep durations, and this note is not the place it becomes a fact.
+The 30% of the reporter's busy window spent in extension content scripts is
+amplification of our DOM churn, measured on their browser, and is neither
+our defect nor the extensions' fault.
+
+**Apply:** when a hot path ingests a COLLECTION through a verb written for
+ONE item, the fix is the page-shaped verb, not the nearest batched
+neighbour — check the neighbour's side effects against the loop's before
+reusing it, because a cost test cannot tell the two apart.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41645,3 +41645,65 @@ our defect nor the extensions' fault.
 ONE item, the fix is the page-shaped verb, not the nearest batched
 neighbour — check the neighbour's side effects against the loop's before
 reusing it, because a cost test cannot tell the two apart.
+<!-- entry #1283 -->
+
+---
+
+## 2026-08-13 — #1283: the enrolment door asks for a password, so cic knocks with one
+
+`POST /me/totp/enrollment` has demanded the account password since c1657c3b.
+cic kept posting a literal `"{}"`, so the controller head never matched, the
+catch-all answered `bad_request`, and every press of **Enable TOTP** rendered
+"The request was malformed." The button could not work for anyone, on any
+substrate, for anybody's password.
+
+**The gate stays; the client learns to knock.** Re-authenticating before
+arming a second factor is the deliberate posture c1657c3b argued for:
+confirming an enrolment revokes every other bearer session and hands out the
+recovery codes, so a borrowed token alone must not be able to arm a factor
+the real owner does not hold. Weakening the server to admit the client would
+undo the fix the client failed to notice.
+
+**The census, because a gate is a sample and not a list.** Seven
+authenticated endpoints require the account password: `POST
+/me/totp/enrollment`, `DELETE /me/totp`, `POST /me/client-tokens`, `POST
+/me/passkeys/registration/options`, `POST /me/passkeys/mode/options`, `POST
+/me/passkeys/passwordless/recovery`, `DELETE /me/passkeys/:id`. c1657c3b made
+exactly ONE of them newly password-gated — the enrolment start — and moved
+`disable_totp/3` onto the new `Accounts.verify_password/2` without changing
+its contract. Of the seven, six were already answered correctly by cic; the
+`/me/client-tokens` mint has no cic caller at all (the issue's "the way the
+client-token mint flow already must" describes an API-only flow — cic has no
+mint UI, and `client_token` appears in `cicchetto/src` only as error copy).
+So the defect was one caller, and the proven negative on the other six is the
+result, not a shrug.
+
+**The half the body fix would have broken.** A password-gated door answers
+401 `invalid_credentials`, and `startTotpEnrollment` read its errors with the
+dead-token handler ARMED — the `readError` default. Sending the password
+without disarming it turns one typo into a logout of every tab sharing the
+bearer: the #739 class, arriving this time through an AUTHENTICATED endpoint.
+`disableTotp` and every `passkeyRequest` already read theirs disarmed for
+exactly this reason. On a re-auth door a 401 means "wrong password", never
+"dead bearer" — that distinction is now the third member of the #739 rule,
+and the reason it has an e2e assertion of its own rather than a comment.
+
+**One gate for the whole pane.** #729 wrote "refuse an empty field locally,
+clear it in the `finally`" for the passkey section's five verbs. The TOTP
+section now has two consumers of its own, so the gate moved to
+`lib/accountPassword.ts` rather than being copied: two copies of the rule
+would drift, and the refusal a user reads must not depend on which section of
+one pane they are standing in. Each section keeps its OWN field — one shared
+field would let a password typed for one section be spent by another, which
+is the #729 defect at pane scope.
+
+Consequently the disable field loses its `required` attribute. A native
+constraint makes the code gate's arm unreachable in a browser while leaving
+it live in the passkey section: two mechanisms for one rule, and only one of
+them testable. The gate is the mechanism.
+
+**Apply:** when a server-side requirement is added to an endpoint, the
+callers are part of the change. And when the added requirement is a
+credential, check what the endpoint's new failure code does on the way back —
+a 401 that used to be unreachable is not the same 401 the caller was written
+against.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41707,3 +41707,54 @@ callers are part of the change. And when the added requirement is a
 credential, check what the endpoint's new failure code does on the way back —
 a 401 that used to be unreachable is not the same 401 the caller was written
 against.
+<!-- entry #1284 -->
+
+---
+
+## 2026-08-13 — #1284: who is at the door decides whether a client token dies
+
+`revoke_other_sessions_for_user!/2` swept an account's live bearers by
+`user_id` alone. A per-client token (#1196) is a `Session` row like any
+other, so arming TOTP revoked the exact credential the feature exists to
+provide — and the order `CLIENT_PROTOCOL.md` §7 puts an operator on (mint
+the token, hand it to the headless client, then arm the factor) was the
+order that broke. Silently: the enrolment succeeds, the recovery codes
+print, and the bridge starts answering `401 invalid_credentials`,
+indistinguishable from a wrong password.
+
+**Ruled: exclude.** The sweep now carries `s.kind != :client`, on all
+three of its call-sites — TOTP enrolment (`accounts.ex`), TOTP disable
+(same), and the passkey mode transaction (`webauthn.ex`). The first was
+the reported one; the other two were censused and ruled together, because
+they are one class rather than three cases.
+
+**The line is WHO is at the door, not WHICH factor moved.** All three
+call-sites are reached by an account holder who has just proven they hold
+the account — a password, a TOTP code, a passkey assertion — and who is
+changing their factors precisely so the headless credential keeps working.
+Operator recovery (`reset_totp` / `reset_passkeys`) and admin password
+rotation are the opposite: nobody proved anything, and burning every
+derived credential is the defensible blast radius. Those doors were
+already a DIFFERENT function — `revoke_sessions_for_user!/1`, the
+whole-account sweep with no `other` and no `kind` filter — so the fix
+needed nothing added there, only a test pinning that the filter did not
+leak into it.
+
+**Why a filter in the function and not a flag on the call.** An opt-out
+argument would put the security posture at three call-sites where it can
+drift, and a default argument would make the safe answer the one nobody
+typed (house rule). One function, one behaviour, and the docstring states
+what it no longer revokes; a caller that wants everything gone asks for
+the whole-account sweep by name.
+
+`!= :client` rather than `== :web`, so a future third kind is swept until
+someone rules otherwise — fail-closed is the right default for a revoke,
+and `:client` is the only kind with an argument for surviving.
+
+**Apply:** when a sweep exists to protect an account, ask what the door
+PROVED before deciding how wide it reaches. And a credential whose whole
+purpose is to outlive a change must be tested against the change itself,
+not only against its own kill switch — the `Accounts` moduledoc had
+asserted in prose that the sweeps deliberately did not special-case it,
+which is how a documented non-decision outlived the feature that
+contradicted it.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -62,13 +62,20 @@ defmodule Grappa.Accounts do
       `GrappaWeb.Plugs.RequireFullSession`, so it can read and send but
       cannot administer, re-credential, or re-mint.
 
-  What is deliberately NOT special-cased: the revoke sweeps. Every
-  credential-material change that already evicts an account's other
-  sessions (`revoke_other_sessions_for_user!/2`, reached from TOTP
-  enrolment / disable; `revoke_sessions_for_user/1`, reached from the
-  operator resets) evicts its client tokens along with them. That is the
-  fail-closed direction and it costs no branch: arming or resetting a
-  second factor is exactly the moment a re-issue is wanted.
+  The third difference is which revoke sweep reaches it (GH #1284), and
+  the line is WHO is at the door:
+
+    * a sweep the account holder triggered, having just proven they hold
+      the account — arming or disarming TOTP, changing passkey mode —
+      spares them (`revoke_other_sessions_for_user!/2`). The point of the
+      credential is to outlive a change to the account's factors; revoking
+      it there made the documented order (mint, then arm) lock the client
+      out at the moment the factor was confirmed;
+    * a sweep nobody proved they hold the account to reach — operator
+      recovery, admin password rotation — takes them
+      (`revoke_sessions_for_user/1` and its `!` twin, no `kind` filter).
+
+  A token's own kill switch is `revoke_client_token/2`.
   """
   use Boundary,
     top_level?: true,
@@ -844,7 +851,19 @@ defmodule Grappa.Accounts do
   end
 
   @doc """
-  Revokes every live bearer for `user` except the current session.
+  Revokes every live WEB bearer for `user` except the current session.
+
+  It does NOT revoke the account's `:client` tokens (GH #1284). Every
+  caller here is a door the account holder has just proven they hold —
+  arming TOTP, disarming it under password, changing passkey mode — and a
+  client token is the credential #1196 exists to keep alive ACROSS such a
+  change. Sweeping by `user_id` alone made the documented order (mint the
+  token, then arm the factor) lock the client out at the moment the factor
+  was confirmed, with a `401` the operator could not tell from a wrong
+  password. The kill switch for a token is `revoke_client_token/2`, and
+  operator recovery still burns everything through the whole-account
+  `revoke_sessions_for_user!/1` — which is a different function, and
+  deliberately carries no `kind` filter.
 
   In-transaction only — every caller (TOTP enrolment/disable, the passkey
   mode transaction) already runs inside a
@@ -857,9 +876,14 @@ defmodule Grappa.Accounts do
   @spec revoke_other_sessions_for_user!(User.t(), Ecto.UUID.t()) :: :ok
   def revoke_other_sessions_for_user!(%User{id: user_id, name: name}, current_session_id)
       when is_binary(current_session_id) do
+    # `!= :client` rather than `== :web`: a future third kind is swept until
+    # someone rules otherwise, which is the fail-closed direction for a
+    # revoke. Only `:client` has an argument for surviving, and it is above.
     query =
       from(s in Session,
-        where: s.user_id == ^user_id and s.id != ^current_session_id and is_nil(s.revoked_at)
+        where:
+          s.user_id == ^user_id and s.id != ^current_session_id and is_nil(s.revoked_at) and
+            s.kind != :client
       )
 
     Repo.update_all(query, set: [revoked_at: DateTime.utc_now()])

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -150,7 +150,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       now = 1_700_000_000
       {:ok, code} = TOTP.code_at(@rfc_secret, now)
 
-      assert {:ok, _codes} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
+      assert {:ok, _} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
 
       assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
       assert {:error, :revoked} = Accounts.authenticate(other.id)
@@ -164,7 +164,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       other = session_fixture(armed)
       token = client_token(armed, "bicchierino bridge")
 
-      assert {:ok, _user} = Accounts.disable_totp(armed, current.id, password)
+      assert {:ok, _} = Accounts.disable_totp(armed, current.id, password)
 
       assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
       assert {:error, :revoked} = Accounts.authenticate(other.id)
@@ -191,7 +191,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
       armed = arm(user)
       token = client_token(armed, "bicchierino bridge")
 
-      assert {:ok, _user} = Accounts.reset_totp(armed.name)
+      assert {:ok, _} = Accounts.reset_totp(armed.name)
 
       assert {:error, :revoked} = Accounts.authenticate(token.id)
     end
@@ -200,7 +200,7 @@ defmodule Grappa.Accounts.ClientTokenTest do
   defp arm(user) do
     now = 1_700_000_000
     {:ok, code} = TOTP.code_at(@rfc_secret, now)
-    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    {:ok, _} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
     Accounts.get_user!(user.id)
   end
 

--- a/test/grappa/accounts/client_token_test.exs
+++ b/test/grappa/accounts/client_token_test.exs
@@ -8,9 +8,10 @@ defmodule Grappa.Accounts.ClientTokenTest do
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, Repo}
-  alias Grappa.Accounts.{Session, Wire}
+  alias Grappa.Accounts.{Session, TOTP, WebAuthn, Wire}
 
   @thirty_days 30 * 24 * 3600
+  @rfc_secret "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
 
   defp idle_for(%Session{} = session, seconds) do
     session
@@ -120,10 +121,11 @@ defmodule Grappa.Accounts.ClientTokenTest do
       assert Accounts.list_client_tokens(user) == []
     end
 
-    test "a credential-material sweep takes the client tokens with it" do
-      # Not a special case in the code, and this arm is what keeps it from
-      # becoming one: arming or resetting a second factor evicts an
-      # account's other sessions, and a client token is one of them.
+    test "a whole-account sweep takes the client tokens with it" do
+      # The revoke-EVERY-session door (admin password rotation, operator
+      # recovery) draws no line at `kind`: nobody proved they hold the
+      # account, so every derived credential goes. Contrast the
+      # revoke-every-OTHER-session door below, which spares them.
       user = user_fixture()
       token = client_token(user, "issued before the reset")
 
@@ -131,6 +133,75 @@ defmodule Grappa.Accounts.ClientTokenTest do
 
       assert {:error, :revoked} = Accounts.authenticate(token.id)
     end
+  end
+
+  # GH #1284. `revoke_other_sessions_for_user!/2` swept by `user_id` alone,
+  # so arming TOTP killed the very credential #1196 exists to keep alive —
+  # silently, with a 401 the operator could not tell from a wrong password.
+  # Each test pins BOTH halves: the token survives AND the browser bearer
+  # still dies, because a filter that revoked nothing would pass on the
+  # first assertion alone.
+  describe "the revoke-other-sessions sweep spares client tokens" do
+    test "arming TOTP" do
+      user = user_fixture()
+      current = session_fixture(user)
+      other = session_fixture(user)
+      token = client_token(user, "bicchierino bridge")
+      now = 1_700_000_000
+      {:ok, code} = TOTP.code_at(@rfc_secret, now)
+
+      assert {:ok, _codes} = Accounts.confirm_totp_enrollment(user, current.id, @rfc_secret, code, now)
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+      assert {:ok, %Session{}} = Accounts.authenticate(current.id)
+    end
+
+    test "disabling TOTP" do
+      {user, password} = user_fixture_with_password()
+      armed = arm(user)
+      current = session_fixture(armed)
+      other = session_fixture(armed)
+      token = client_token(armed, "bicchierino bridge")
+
+      assert {:ok, _user} = Accounts.disable_totp(armed, current.id, password)
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+    end
+
+    test "changing passkey mode" do
+      user = user_fixture()
+      current = session_fixture(user)
+      other = session_fixture(user)
+      token = client_token(user, "bicchierino bridge")
+
+      assert {:ok, :second_factor} = WebAuthn.set_mode(user, :second_factor, current.id, [])
+
+      assert {:ok, %Session{kind: :client}} = Accounts.authenticate(token.id)
+      assert {:error, :revoked} = Accounts.authenticate(other.id)
+    end
+
+    # The other side of the ruling: the recovery door is reached by an
+    # operator, not by a proven account holder, so it keeps burning every
+    # credential. It is a DIFFERENT function (`revoke_sessions_for_user!/1`,
+    # no `other`) and the `kind` filter must not reach it.
+    test "but operator recovery still burns them" do
+      user = user_fixture()
+      armed = arm(user)
+      token = client_token(armed, "bicchierino bridge")
+
+      assert {:ok, _user} = Accounts.reset_totp(armed.name)
+
+      assert {:error, :revoked} = Accounts.authenticate(token.id)
+    end
+  end
+
+  defp arm(user) do
+    now = 1_700_000_000
+    {:ok, code} = TOTP.code_at(@rfc_secret, now)
+    {:ok, _codes} = TOTP.confirm_enrollment(user, @rfc_secret, code, now)
+    Accounts.get_user!(user.id)
   end
 
   describe "authenticate_client_token/5" do


### PR DESCRIPTION
## Union of three branches, gated once

Three open PRs all pay the `integration` lane. Merged one after the
other they would cost three runs, and — worse — no green would ever
attest the three **together**: a green attests `branch + base`, never
`branch + the other branches landing beside it`. So the commits are
replayed onto one branch and gated once. They were assembled on
`30ba4049` and gated there; the branch has since been rebased onto
`090e46ea`, which is the base this PR asks to merge into.

### Sources

Head shas are the ORIGINAL ones. The replay rewrites them, so GitHub
will not close these PRs from this branch — they are closed by content.

| PR | issue | source branch | merge-base | head |
|----|-------|---------------|------------|------|
| #1296 | #1288 | `w1-1288-refresh-scrollback-batch` | `30ba4049` | `dfed3a42` |
| #1294 | #1283 | `w1-1283-totp-password` | `d76145ed` | `f7d791f0` |
| #1295 | #1284 | `w2/totp-1284` | `d76145ed` | `4df8d63f` |

Seven commits, replayed least-to-most invasive (cic perf → cic auth →
server auth), so a red gate is unwound from the top. An eighth commit
is the union's own, and is described below.

### Why these three in one branch, and what it caught

#1294 and #1295 are the two halves of the same TOTP flow: #1283 makes
the enrolment reachable (cic asks for the account password), #1284
changes what confirming it revokes (client tokens no longer die).
Neither had ever been gated with the other.

**They share no source file** — the whole textual overlap is
`docs/DESIGN_NOTES.md` — **and the crossing bit anyway.** Three
comments written by #1283 stated that confirming an enrolment revokes
every other bearer the account holds. #1284 then filtered that sweep
to `s.kind != :client`, so a per-client token survives the door those
comments describe as fatal to it. Each half was true against its own
base; assembling them is what made the prose false.

No test catches it and none ever would: the e2e spec deliberately
starts an enrolment and never confirms it, so it never crosses the
sweep #1284 changed. The eighth commit repairs the three sentences —
prose only, all three sites belonging to #1283 — and restores
agreement with `CLIENT_PROTOCOL.md` §7 as #1284 rewrote it.

The general point is worth keeping: **textual non-overlap is not
semantic independence.** Two branches that touch disjoint files can
still leave the tree stating something untrue, and only a gate that
holds them together can show it.

### Contribution integrity

Each PR's `--numstat` was pinned before the replay and re-diffed after
it, then pinned again before the rebase and re-diffed after that too.
All three are byte-identical to their pins at the current tip,
`DESIGN_NOTES.md` included (79 / 62 / 51 additions, 0 deletions; 192
total). The rebase was the exposed moment — main had gained three
entries (#1287, #1292, #1298) while this branch carries three — and the
test is two-sided on purpose: **additions unchanged AND deletions
zero**, because the union driver eats a separator while leaving every
commit intact, and the tell is additions short of three, not a
deletion. Marker census at the tip: 17 `<!-- entry #... -->`, no
duplicates; the branch adds 3 headings, 3 `---` and 3 markers, and
`scripts/design-notes-gate.sh` passes against the new base.

The eighth commit is the only departure from the pinned contributions,
and it is accounted for: +1 net line in each of three files, 0
deletions, `DESIGN_NOTES.md` untouched. The three per-PR ranges remain
identical to their pins after it.

Boundary shape was read on the file rather than assumed. All three new
entries land as `prose / marker / blank / --- / blank / heading`, which
is the file's prevailing form — not its only one: `<!-- entry #201 -->`
already carried an extra blank line before the marker, and that
pre-existing variation was left alone.

### What this PR does not claim

- **Not that the three source PRs are individually still green.** The
  gate here attests the union at its tip, which is the only thing a
  green can attest.
- **Not that the DESIGN_NOTES entries are in date order.** They are in
  append order, and all three carry the same date.
- **Not that #1284's behaviour was reviewed.** Its commits were
  replayed, not judged; only the three #1283 comments it contradicted
  were repaired.
