### PR TITLE
Admin Sessions: asc/desc sorting on the three time columns (#1308)

### DIFF
--- a/cicchetto/e2e/tests/issue1308-admin-sessions-sort.spec.ts
+++ b/cicchetto/e2e/tests/issue1308-admin-sessions-sort.spec.ts
@@ -1,0 +1,105 @@
+// #1308 — the admin Sessions list had no sort at all: the order was the
+// merge's assembly order (visitors, then credentials, then orphan pids)
+// and the operator could not change it. vjt asked for asc/desc on last
+// active / last joined / last seen, default last joined desc.
+//
+// jsdom already covers the comparator and the rendered row order
+// (`adminSubjectRows.test.ts`, `AdminSessionsTab.test.tsx`). What only a
+// real stack can show is that the two halves are wired to REAL data: the
+// row set is assembled from three live endpoints, and `last joined` for a
+// user row comes from a credential field that was on the wire all along
+// and reached no row until this change. A comparator fed a null it should
+// have been fed a timestamp still sorts — it just sorts everything to the
+// bottom, and the unit tests hand it the value directly.
+//
+// The oracle is a DISPLACEMENT, not an absolute position: the stack is
+// shared and other specs mint visitors of their own, so "my row is first"
+// is a claim about their timing rather than about the sort. What cannot
+// be explained away is one pair of rows swapping places when the
+// direction flips, and the pair is chosen so the sort has to disagree
+// with the assembly order to be right — the visitor is minted NOW, so it
+// is the newest subject on the table, while the merge assembles visitors
+// BEFORE users.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
+
+import type { Page } from "@playwright/test";
+import { adminSessionRowKey, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+/** The rendered row order, as the composite keys the table is keyed on. */
+async function renderedRowKeys(page: Page): Promise<string[]> {
+  const ids = await page
+    .locator("[data-testid^='admin-session-row-']")
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid") ?? ""));
+  return ids.map((id) => id.replace("admin-session-row-", ""));
+}
+
+test("admin Sessions view: last joined desc by default, and the toggle really reorders", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const visitorNick = `sortvictim-${Date.now()}`;
+  const visitor = await mintVisitor(visitorNick);
+
+  try {
+    await page.addInitScript(
+      ([token, subjectJson]) => {
+        localStorage.setItem("grappa-token", token);
+        localStorage.setItem("grappa-subject", subjectJson);
+        localStorage.setItem("cic.installChoice", "browser");
+      },
+      [admin.token, admin.subjectJson] as const,
+    );
+    await page.goto("/");
+    await openAdminSessionsTab(page);
+
+    // Both halves of the claim need both kinds on screen: `last joined`
+    // existed on the visitor row before #1308 and on the user row only
+    // after it, so a single-kind table would pass on the old code.
+    const visitorKey = await adminSessionRowKey(page, "visitor", visitor.id);
+    await expect(page.getByTestId(`admin-session-row-${visitorKey}`)).toBeVisible();
+    const userRow = page.locator("[data-testid^='admin-session-row-user:']").first();
+    await expect(userRow).toBeVisible({ timeout: 15_000 });
+    const userKey = ((await userRow.getAttribute("data-testid")) ?? "").replace(
+      "admin-session-row-",
+      "",
+    );
+
+    const descending = await renderedRowKeys(page);
+    expect(
+      descending,
+      "both rows must be on the table for the order between them to mean anything",
+    ).toEqual(expect.arrayContaining([visitorKey, userKey]));
+
+    // The default, and the part that has to disagree with the merge: the
+    // visitor was created seconds ago and every seeded credential predates
+    // the stack, so newest-first puts the visitor ABOVE the user — the
+    // reverse of the assembly order, which lists visitors first only by
+    // accident of the same direction.
+    expect(
+      descending.indexOf(visitorKey),
+      "default is last joined DESC: the just-minted visitor outranks a seeded credential",
+    ).toBeLessThan(descending.indexOf(userKey));
+
+    // The control says which key is on and which way it points, before it
+    // is used: a toggle that reorders but never marks itself leaves the
+    // operator guessing what they are looking at.
+    const joinedButton = page.getByTestId("admin-sessions-sort-last_joined");
+    await expect(joinedButton).toHaveAttribute("aria-pressed", "true");
+    await expect(joinedButton).toContainText("▼");
+
+    await joinedButton.click();
+    await expect(joinedButton).toContainText("▲");
+
+    const ascending = await renderedRowKeys(page);
+    expect(
+      ascending.indexOf(visitorKey),
+      "ascending must put the newest subject BELOW the oldest — the pair swaps",
+    ).toBeGreaterThan(ascending.indexOf(userKey));
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -15,9 +15,15 @@ import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  DEFAULT_SESSION_SORT,
   endedSessions,
   liveSessions,
   rowActions,
+  SESSION_SORT_KEYS,
+  SESSION_SORT_LABEL,
+  type SessionSort,
+  type SessionSortKey,
+  sortSubjectRows,
 } from "./lib/adminSubjectRows";
 import {
   type AdminCredential,
@@ -145,6 +151,7 @@ const AdminSessionsTab: Component = () => {
   // tab's drill-in to `AdminUserPage`, and deliberately not a route: the
   // admin console has none.
   const [endedOpen, setEndedOpen] = createSignal(false);
+  const [sort, setSort] = createSignal<SessionSort>(DEFAULT_SESSION_SORT);
   // #1157 — the open row's verb dropdown, anchored to the button that
   // opened it. Anchored to the BUTTON RECT rather than the pointer so a
   // keyboard activation (clientX/Y both 0) does not open it in the
@@ -172,8 +179,20 @@ const AdminSessionsTab: Component = () => {
       : [],
   );
 
-  const live = createMemo<AdminSubjectRow[]>(() => liveSessions(rows()));
+  const live = createMemo<AdminSubjectRow[]>(() => sortSubjectRows(liveSessions(rows()), sort()));
   const ended = createMemo(() => endedSessions(rows()));
+
+  // #1308 — picking the key already on is what reverses it, the way a
+  // sortable column header behaves; picking a different one starts at
+  // descending, because all three are timestamps and "newest first" is
+  // what an operator wants from every one of them.
+  const cycleSort = (key: SessionSortKey): void => {
+    setSort((current) =>
+      current.key === key
+        ? { key, direction: current.direction === "desc" ? "asc" : "desc" }
+        : { key, direction: "desc" },
+    );
+  };
 
   /** The verb this row is currently asking the operator to confirm. */
   const armedKind = (row: AdminSubjectRow): ActionKind | null =>
@@ -381,6 +400,49 @@ const AdminSessionsTab: Component = () => {
                   <AdminEmpty message="no live sessions" testId="admin-sessions-empty" />
                 }
               >
+                {/* #1308 — the sort control. It lives above the table
+                  rather than on the `<th>`s because only ONE of the three
+                  keys vjt named has a column: `last active` and
+                  `last joined` are facts of the drill-down, and giving
+                  them columns is the very question (does an extra column
+                  fit at every width?) the IP half of #1308 is still
+                  waiting on a ruling for.
+
+                  Inside the `live().length > 0` branch on purpose: an
+                  empty list has nothing to order, and a live control over
+                  no rows reads as broken. */}
+                <div class="admin-sessions-sort" role="toolbar" aria-label="sort sessions">
+                  <span class="admin-sessions-sort-label" aria-hidden="true">
+                    sort
+                  </span>
+                  <For each={SESSION_SORT_KEYS}>
+                    {(key) => (
+                      <button
+                        type="button"
+                        class="adm-btn admin-sessions-sort-btn"
+                        aria-pressed={sort().key === key}
+                        onClick={() => cycleSort(key)}
+                        data-testid={`admin-sessions-sort-${key}`}
+                      >
+                        {SESSION_SORT_LABEL[key]}
+                        {/* The arrow is on the ACTIVE key only: an arrow
+                          on every button would say three orders are in
+                          force at once. `aria-pressed` says WHICH key is
+                          on but not which way it points, so the direction
+                          is spelled out for a screen reader rather than
+                          left to a glyph it would read as punctuation. */}
+                        <Show when={sort().key === key}>
+                          <span class="admin-sessions-sort-arrow" aria-hidden="true">
+                            {sort().direction === "asc" ? "▲" : "▼"}
+                          </span>
+                          <span class="sr-only">
+                            {sort().direction === "asc" ? ", ascending" : ", descending"}
+                          </span>
+                        </Show>
+                      </button>
+                    )}
+                  </For>
+                </div>
                 <AdminTable class="admin-sessions-table" data-testid="admin-sessions-table">
                   <thead>
                     <tr>

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -593,3 +593,88 @@ describe("AdminSessionsTab — load and failure", () => {
     expect(screen.queryByTestId("admin-sessions-table")).toBeNull();
   });
 });
+
+// #1308 — asc/desc on last active / last joined / last seen, default last
+// joined desc (vjt, 2026-08-14). Before this the order was the assembly
+// order and nothing else: visitors, then users, then the two
+// rows-without-a-credential classes.
+//
+// Every assertion below reads the RENDERED row order, not the sort
+// function's return: what the operator asked for is the table changing,
+// and a correct comparator wired to nothing would satisfy the unit test.
+describe("AdminSessionsTab — sorting (#1308)", () => {
+  const renderedRowKeys = (): string[] =>
+    [...document.querySelectorAll("[data-testid^='admin-session-row-']")].map((el) =>
+      (el.getAttribute("data-testid") ?? "").replace("admin-session-row-", ""),
+    );
+
+  // The visitor is the OLDER subject but the FIRST one assembled, so the
+  // dictated default has to reverse the merge's own order to be right.
+  const oldVisitor = () =>
+    parkedVisitor({ inserted_at: "2026-01-01T00:00:00Z", last_seen_at: "2026-08-20T00:00:00Z" });
+  const newCredential = () =>
+    userCredential({ inserted_at: "2026-08-01T00:00:00Z", last_seen_at: "2026-08-10T00:00:00Z" });
+
+  it("orders by last joined descending without being asked", async () => {
+    await mountWith({ visitors: [oldVisitor()], credentials: [newCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    expect(renderedRowKeys()).toEqual([USER_KEY, VISITOR_KEY]);
+  });
+
+  it("flips to ascending when the active key is picked again", async () => {
+    await mountWith({ visitors: [oldVisitor()], credentials: [newCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+    expect(renderedRowKeys(), "pre-state: the default is descending").toEqual([
+      USER_KEY,
+      VISITOR_KEY,
+    ]);
+
+    fireEvent.click(screen.getByTestId("admin-sessions-sort-last_joined"));
+
+    expect(renderedRowKeys()).toEqual([VISITOR_KEY, USER_KEY]);
+  });
+
+  it("reorders on a different key", async () => {
+    await mountWith({ visitors: [oldVisitor()], credentials: [newCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    // The visitor joined first but was SEEN last, so switching the key
+    // has to move it — and picking a new key starts descending.
+    fireEvent.click(screen.getByTestId("admin-sessions-sort-last_seen"));
+
+    expect(renderedRowKeys()).toEqual([VISITOR_KEY, USER_KEY]);
+  });
+
+  // The honesty rule, rendered. A row with no browser session on record
+  // must not lead an ascending sort as if it had been seen at the epoch.
+  it("keeps a row with an unknown timestamp at the bottom when ascending", async () => {
+    await mountWith({
+      visitors: [parkedVisitor({ last_seen_at: null })],
+      credentials: [userCredential()],
+    });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    fireEvent.click(screen.getByTestId("admin-sessions-sort-last_seen"));
+    fireEvent.click(screen.getByTestId("admin-sessions-sort-last_seen"));
+
+    expect(screen.getByTestId("admin-sessions-sort-last_seen").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(renderedRowKeys()).toEqual([USER_KEY, VISITOR_KEY]);
+  });
+
+  it("marks the active key and its direction", async () => {
+    await mountWith({ credentials: [userCredential()] });
+    await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+
+    const joined = screen.getByTestId("admin-sessions-sort-last_joined");
+    const seen = screen.getByTestId("admin-sessions-sort-last_seen");
+    expect(joined.getAttribute("aria-pressed")).toBe("true");
+    expect(seen.getAttribute("aria-pressed")).toBe("false");
+    expect(joined.textContent).toContain("▼");
+
+    fireEvent.click(joined);
+    expect(joined.textContent).toContain("▲");
+  });
+});

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -3,10 +3,12 @@ import {
   type AdminSubjectRow,
   buildSubjectRows,
   channelCount,
+  DEFAULT_SESSION_SORT,
   endedSessions,
   liveSessions,
   rowActions,
   rowKey,
+  sortSubjectRows,
 } from "../lib/adminSubjectRows";
 import type {
   AdminCredential,
@@ -461,5 +463,208 @@ describe("rowActions — reconnect is visitor-only, and chosen on LIVE truth", (
 describe("rowKey", () => {
   it("builds the composite the server parses", () => {
     expect(rowKey("visitor", VISITOR_ID, 42)).toBe(`visitor:${VISITOR_ID}:42`);
+  });
+});
+
+// #1308 — `last joined` is the DEFAULT sort, so it has to exist on both
+// kinds before the sort does. It did not: the visitor row carried
+// `visitor.inserted_at` and the user row carried nothing at all, which
+// would have made the default order half-null on day one.
+describe("last_joined_at — the default sort key, populated for BOTH kinds", () => {
+  it("takes a visitor row's from the visitor identity", () => {
+    const rows = build({ visitors: [visitor({ inserted_at: "2026-07-01T00:00:00Z" })] });
+
+    expect(rows[0]?.last_joined_at).toBe("2026-07-01T00:00:00Z");
+  });
+
+  // THE gap. The credential's `inserted_at` was on the wire all along and
+  // simply never reached the row.
+  it("takes a user row's from the credential", () => {
+    const rows = build({ credentials: [credential({ inserted_at: "2026-07-02T00:00:00Z" })] });
+
+    expect(rows[0]?.last_joined_at).toBe("2026-07-02T00:00:00Z");
+  });
+
+  it("is null on an orphan pid — there is no DB row to have been created", () => {
+    const rows = build({
+      sessions: [session({ subject_id: "deadbeef-0000-0000-0000-000000000000" })],
+    });
+
+    expect(rows[0]?.origin).toBe("orphan_pid");
+    expect(rows[0]?.last_joined_at).toBeNull();
+  });
+
+  it("is null on a log-only row — the subject it would date is gone", () => {
+    const rows = build({ logSessions: [logEntry()] });
+
+    expect(rows[0]?.origin).toBe("session_log");
+    expect(rows[0]?.last_joined_at).toBeNull();
+  });
+});
+
+// #1308 — asc/desc on the three time columns, default `last joined` desc.
+//
+// The load-bearing rule is the null placement. A missing `last_event.at`
+// is the bounded ring having forgotten, NOT a session that never ran, so
+// treating it as epoch 0 would float exactly the rows we know least about
+// to the top of an ascending sort and state a fact we do not have.
+describe("sortSubjectRows", () => {
+  const base = (): AdminSubjectRow => build({ credentials: [credential()] })[0] as AdminSubjectRow;
+
+  const at = (key: string, over: Partial<AdminSubjectRow>): AdminSubjectRow => ({
+    ...base(),
+    key,
+    ...over,
+  });
+
+  const keysOf = (rows: AdminSubjectRow[]): string[] => rows.map((r) => r.key);
+
+  it("defaults to last joined, descending", () => {
+    expect(DEFAULT_SESSION_SORT).toEqual({ key: "last_joined", direction: "desc" });
+  });
+
+  it("orders by last joined, newest first", () => {
+    const rows = [
+      at("old", { last_joined_at: "2026-08-01T00:00:00Z" }),
+      at("new", { last_joined_at: "2026-08-09T00:00:00Z" }),
+      at("mid", { last_joined_at: "2026-08-05T00:00:00Z" }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction: "desc" }))).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+  });
+
+  it("reverses on ascending", () => {
+    const rows = [
+      at("old", { last_joined_at: "2026-08-01T00:00:00Z" }),
+      at("new", { last_joined_at: "2026-08-09T00:00:00Z" }),
+      at("mid", { last_joined_at: "2026-08-05T00:00:00Z" }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction: "asc" }))).toEqual([
+      "old",
+      "mid",
+      "new",
+    ]);
+  });
+
+  it("puts a null last when descending", () => {
+    const rows = [
+      at("unknown", { last_joined_at: null }),
+      at("known", { last_joined_at: "2026-08-01T00:00:00Z" }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction: "desc" }))).toEqual([
+      "known",
+      "unknown",
+    ]);
+  });
+
+  // The one a "just negate the comparator" implementation fails: flipping
+  // the direction must NOT float the unknowns to the top.
+  it("puts a null last when ASCENDING too", () => {
+    const rows = [
+      at("unknown", { last_joined_at: null }),
+      at("known", { last_joined_at: "2026-08-01T00:00:00Z" }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction: "asc" }))).toEqual([
+      "known",
+      "unknown",
+    ]);
+  });
+
+  it("sorts last active off the session log's newest event", () => {
+    const rows = [
+      at("quiet", { last_event: logEntry({ at: "2026-08-01T00:00:00Z" }) }),
+      at("busy", { last_event: logEntry({ at: "2026-08-12T00:00:00Z" }) }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_active", direction: "desc" }))).toEqual([
+      "busy",
+      "quiet",
+    ]);
+  });
+
+  // Same rule, on the key where the null is most common: the ring forgets.
+  it("puts a row the log remembers nothing about last, in both directions", () => {
+    const rows = [
+      at("forgotten", { last_event: null }),
+      at("logged", { last_event: logEntry({ at: "2026-08-01T00:00:00Z" }) }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_active", direction: "desc" }))).toEqual([
+      "logged",
+      "forgotten",
+    ]);
+    expect(keysOf(sortSubjectRows(rows, { key: "last_active", direction: "asc" }))).toEqual([
+      "logged",
+      "forgotten",
+    ]);
+  });
+
+  it("sorts last seen off the browser-touch column", () => {
+    const rows = [
+      at("stale", { last_seen_at: "2026-08-01T00:00:00Z" }),
+      at("fresh", { last_seen_at: "2026-08-12T00:00:00Z" }),
+      at("never", { last_seen_at: null }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_seen", direction: "asc" }))).toEqual([
+      "stale",
+      "fresh",
+      "never",
+    ]);
+  });
+
+  // #1308 — the row-origin grouping survives as a TIEBREAK. Both fixtures
+  // are created at the same instant, so the only thing left to order them
+  // is the assembly order, and it must still be visitors-before-users in
+  // BOTH directions — a comparator that reverses the whole array rather
+  // than negating the key comparison flips this.
+  it("keeps the assembly order between rows the key cannot separate", () => {
+    const rows = build({
+      visitors: [visitor({ inserted_at: "2026-08-01T00:00:00Z" })],
+      credentials: [credential({ inserted_at: "2026-08-01T00:00:00Z" })],
+    });
+    expect(keysOf(rows), "pre-state: assembly puts the visitor first").toEqual([
+      `visitor:${VISITOR_ID}:42`,
+      `user:${USER_ID}:42`,
+    ]);
+
+    for (const direction of ["asc", "desc"] as const) {
+      expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction }))).toEqual([
+        `visitor:${VISITOR_ID}:42`,
+        `user:${USER_ID}:42`,
+      ]);
+    }
+  });
+
+  // A timestamp we cannot read is a timestamp we do not have. Silently
+  // ordering it as epoch 0 would be the same lie the null rule refuses.
+  it("treats an unreadable timestamp as unknown rather than as the epoch", () => {
+    const rows = [
+      at("garbage", { last_joined_at: "not-a-date" }),
+      at("known", { last_joined_at: "2026-08-01T00:00:00Z" }),
+    ];
+
+    expect(keysOf(sortSubjectRows(rows, { key: "last_joined", direction: "asc" }))).toEqual([
+      "known",
+      "garbage",
+    ]);
+  });
+
+  it("does not mutate the row set it was handed", () => {
+    const rows = [
+      at("old", { last_joined_at: "2026-08-01T00:00:00Z" }),
+      at("new", { last_joined_at: "2026-08-09T00:00:00Z" }),
+    ];
+
+    sortSubjectRows(rows, { key: "last_joined", direction: "desc" });
+
+    expect(keysOf(rows)).toEqual(["old", "new"]);
   });
 });

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -99,6 +99,12 @@ export type AdminSubjectRow = {
   /** The upstream peer, known ONLY for rows with a registry entry. */
   upstream: AdminSession["live_state"] | null;
   last_seen_at: string | null;
+  /** #1308 — when this subject's DB row was created: the visitor
+   * identity's `inserted_at`, or the credential's. `null` on the two
+   * classes that have no DB row (orphan pid, log-only). Copied onto the
+   * row for BOTH kinds because it is the DEFAULT sort key, and a default
+   * that is null on half the table is not an order. */
+  last_joined_at: string | null;
   /** Present iff `subject_kind === "visitor"`. */
   visitor: VisitorIdentity | null;
   origin: RowOrigin;
@@ -148,6 +154,77 @@ export function liveSessions(rows: AdminSubjectRow[]): AdminSubjectRow[] {
 
 export function rowKey(kind: "user" | "visitor", subjectId: string, networkId: number): string {
   return `${kind}:${subjectId}:${networkId}`;
+}
+
+/**
+ * #1308 — the three time columns the operator can order the list by
+ * (vjt, 2026-08-14). Each binds to a timestamp the row already carries;
+ * none of them is a new fact.
+ */
+export const SESSION_SORT_KEYS = ["last_active", "last_joined", "last_seen"] as const;
+export type SessionSortKey = (typeof SESSION_SORT_KEYS)[number];
+export type SessionSortDirection = "asc" | "desc";
+export type SessionSort = { key: SessionSortKey; direction: SessionSortDirection };
+
+/** Dictated default (vjt, 2026-08-14): newest arrivals at the top. */
+export const DEFAULT_SESSION_SORT: SessionSort = { key: "last_joined", direction: "desc" };
+
+/** The header labels, here rather than in the tab so the sort control and
+ * the thing it sorts cannot drift apart. */
+export const SESSION_SORT_LABEL: Record<SessionSortKey, string> = {
+  last_active: "last active",
+  last_joined: "last joined",
+  last_seen: "last seen",
+};
+
+const SESSION_SORT_FIELD: Record<SessionSortKey, (row: AdminSubjectRow) => string | null> = {
+  // The session-log ring, which forgets by construction.
+  last_active: (row) => row.last_event?.at ?? null,
+  last_joined: (row) => row.last_joined_at,
+  last_seen: (row) => row.last_seen_at,
+};
+
+/**
+ * The row's value for a key as a comparable instant, or `null` for "we do
+ * not have this". An unparseable string collapses into the same `null`:
+ * a timestamp we cannot read is a timestamp we do not have, and
+ * `Date.parse` returning `NaN` would otherwise poison every comparison it
+ * touched into `false` and leave the order to the engine.
+ */
+function sortInstant(row: AdminSubjectRow, key: SessionSortKey): number | null {
+  const iso = SESSION_SORT_FIELD[key](row);
+  if (iso === null) return null;
+  const at = Date.parse(iso);
+  return Number.isNaN(at) ? null : at;
+}
+
+/**
+ * Order the rows by one time column. Returns a new array; the caller's
+ * row set is the memo's output and stays as assembled.
+ *
+ * Two rules carry the design:
+ *
+ *   * **Unknowns sort last in BOTH directions.** A missing
+ *     `last_event.at` is the bounded ring having forgotten, not a session
+ *     that never ran, and a missing `last_joined_at` is a row with no DB
+ *     row behind it at all. Coercing either to epoch 0 would float
+ *     exactly the rows we know least about to the top of an ascending
+ *     sort and assert a date we do not have.
+ *   * **The row-origin grouping degrades to a tiebreak.** It was the
+ *     primary order (visitors, users, orphans, log-only) and stays
+ *     meaningful, so this is a STABLE sort over the assembled array and
+ *     nothing else: rows the key cannot separate keep the order the merge
+ *     gave them, in either direction.
+ */
+export function sortSubjectRows(rows: AdminSubjectRow[], sort: SessionSort): AdminSubjectRow[] {
+  const sign = sort.direction === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const left = sortInstant(a, sort.key);
+    const right = sortInstant(b, sort.key);
+    if (left === null) return right === null ? 0 : 1;
+    if (right === null) return -1;
+    return (left - right) * sign;
+  });
 }
 
 /** Channel count for the dictated column. `null` (introspection timed
@@ -258,6 +335,7 @@ export function buildSubjectRows(input: {
         live: net.live_state,
         upstream: sessionByKey.get(key)?.live_state ?? null,
         last_seen_at: v.last_seen_at,
+        last_joined_at: v.inserted_at,
         visitor: identity,
         origin: "credential",
         last_event: logByKey.get(key) ?? null,
@@ -279,6 +357,7 @@ export function buildSubjectRows(input: {
       live: c.live_state,
       upstream: sessionByKey.get(key)?.live_state ?? null,
       last_seen_at: c.last_seen_at,
+      last_joined_at: c.inserted_at,
       visitor: null,
       origin: "credential",
       last_event: logByKey.get(key) ?? null,
@@ -306,6 +385,10 @@ export function buildSubjectRows(input: {
       live: s.live_state,
       upstream: s.live_state,
       last_seen_at: s.last_seen_at,
+      // No DB row, so nothing was ever created to be dated. NOT the pid's
+      // start time: that is a different fact and this column does not
+      // claim it.
+      last_joined_at: null,
       visitor: null,
       origin: "orphan_pid",
       last_event: logByKey.get(key) ?? null,
@@ -337,6 +420,10 @@ export function buildSubjectRows(input: {
       // NOT `e.at`: this column is when a BROWSER last touched the
       // bouncer, and there is no browser session left to have touched it.
       last_seen_at: null,
+      // The subject row this would date is gone; the log carries no
+      // creation time of its own, and `e.at` is the LAST event, not the
+      // first.
+      last_joined_at: null,
       visitor: null,
       origin: "session_log",
       last_event: e,

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5481,6 +5481,42 @@ html.resize-dragging * {
   color: var(--adm-text-dim);
 }
 
+/* #1308 — the Sessions sort control, a strip above the table inside the
+   card body rather than more chrome in `.adm-card-head`: that header is a
+   no-wrap flex row shared by every admin card, and three more buttons
+   beside `Ended sessions` and `↻ refresh` would have overflowed it on the
+   narrow layout the mobile cards exist for. Here it wraps freely and
+   touches no shared rule. */
+.admin-sessions-sort {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--adm-space-2);
+  padding: var(--adm-space-2) var(--adm-space-4);
+  border-bottom: 1px solid var(--adm-line);
+}
+
+.admin-sessions-sort-label {
+  font-family: var(--adm-font);
+  font-size: 0.75rem;
+  color: var(--adm-text-dim);
+}
+
+.admin-sessions-sort-btn {
+  gap: var(--adm-space-1);
+}
+
+/* The active key. Colour is a shortcut, never the only signal: the arrow
+   glyph and `aria-pressed` both say the same thing. */
+.admin-sessions-sort-btn[aria-pressed="true"] {
+  color: var(--adm-accent);
+  border-color: var(--adm-accent);
+}
+
+.admin-sessions-sort-arrow {
+  font-size: 0.7rem;
+}
+
 /* Drill-down danger zone: the note names what Delete destroys, so it must
    read as one unit with the button rather than as loose text beside it. */
 /* A destructive verb, its explanation, and a rule separating it from

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41758,3 +41758,57 @@ not only against its own kill switch — the `Accounts` moduledoc had
 asserted in prose that the sweeps deliberately did not special-case it,
 which is how a documented non-decision outlived the feature that
 contradicted it.
+<!-- entry #1308 -->
+
+---
+
+## 2026-08-14 — #1308: an unknown timestamp sorts last, in both directions
+
+The admin Sessions list had no sort at all — the order was the merge's
+assembly order (visitors, then credentials, then orphan pids, then
+log-only rows) and the operator could not change it. vjt asked for
+asc/desc on **last active**, **last joined**, **last seen**, defaulting
+to last joined desc. Two decisions in that are worth keeping.
+
+**Nulls sort last in BOTH directions, and that is a correctness rule
+rather than a taste.** Every one of the three keys can be absent, and
+absence never means "long ago". `last_event.at` is missing because the
+session-log ring is bounded and best-effort — a session missing from it
+is not evidence it never ran. `last_joined_at` is missing on the two
+classes that have no DB row at all. Coercing either to epoch 0, which is
+what a naive `?? 0` comparator does, would float exactly the rows we know
+least about to the top of an ascending sort and state a date we do not
+have. An unparseable string collapses into the same unknown for the same
+reason.
+
+**`last joined` had to be built before it could be sorted on.** It
+existed on a visitor row (`visitor.inserted_at`) and on no user row: the
+credential's `inserted_at` was on `/admin/credentials` all along and
+simply never reached `AdminSubjectRow`. Making it the DEFAULT key without
+that would have shipped an order that was null on half the table on day
+one. No wire change was needed — the field was already published by
+`Networks.Credentials.AdminWire`; only the row-builder had to copy it.
+
+**The row-origin grouping degrades to a tiebreak rather than being
+deleted.** It is meaningful (the divergence classes sit at the bottom
+where they stand out), so the sort is a STABLE sort over the assembled
+array and nothing more: rows the key cannot separate keep the order the
+merge gave them, in either direction. No secondary comparator, no
+parallel ordering structure.
+
+**The control is a strip above the table, not sortable `<th>`s.** Only
+one of the three keys has a column — `last active` and `last joined` are
+drill-down facts — and giving them columns is the very question (does an
+extra column fit at every width?) that the source-IP half of #1308 is
+still waiting on a ruling for. It also stays out of `.adm-card-head`,
+which is a no-wrap flex row shared by every admin card and would have
+overflowed on the narrow layout the mobile cards exist for.
+
+**Scope:** the sorting half only. The source-IP half of #1308 is
+untouched and still blocked on two rulings from vjt (per-session
+`accounts_sessions.ip` versus the identity-wide `visitors.ip`, and
+whether an IP column fits at every width).
+
+**Apply:** when a sort key can be absent, ask what the absence MEANS
+before picking its sort position. If absence is ignorance rather than a
+value, it belongs at the bottom whichever way the arrow points.


### PR DESCRIPTION
The **sorting half of #1308 only**. The source-IP half is untouched: it is
still blocked on the two rulings the issue asks vjt for (per-session
`accounts_sessions.ip` versus the identity-wide `visitors.ip`, and whether an
IP column fits at every width).

## What changed

The admin Sessions list had no sort at all — the order was the merge's
assembly order (visitors, then credentials, then orphan pids, then log-only
rows) and the operator could not change it. Now: asc/desc on **last active**,
**last joined**, **last seen**, defaulting to **last joined desc**.

Three commits:

1. **`last_joined_at` onto both subject kinds.** It existed on a visitor row
   (`visitor.inserted_at`) and on no user row. The credential's `inserted_at`
   has been published by `Networks.Credentials.AdminWire` all along and simply
   never reached `AdminSubjectRow`, so making it the DEFAULT key without this
   would have shipped a first order that was null on half the table. **No wire
   change was needed** — only the row builder had to copy it.
2. **The sort itself**, plus the control and its CSS.
3. **A browser spec** for the visible outcome.

## The two rules that carry it

**Unknowns sort last in BOTH directions.** Every key can be absent and absence
never means "long ago": a missing `last_event.at` is the bounded session-log
ring having forgotten, not a session that never ran, and `last_joined_at` is
absent on the two classes with no DB row at all. The `?? 0` a comparator
reaches for by reflex would float exactly the rows we know least about to the
top of an ascending sort and assert a date we do not have. An unparseable
string collapses into the same unknown.

**The row-origin grouping degrades to a tiebreak** rather than being deleted:
a stable sort over the assembled array and nothing more, so rows the key
cannot separate keep the order the merge gave them, in either direction. No
secondary comparator, no parallel ordering structure.

**The control is a strip above the table, not sortable `<th>`s.** Only one of
the three keys has a column — `last active` and `last joined` are drill-down
facts — and giving them columns is the very question the source-IP half is
waiting on a ruling for. It also stays out of `.adm-card-head`, a no-wrap flex
row shared by every admin card that would have overflowed on the narrow
layout the mobile cards exist for.

## Gates

| gate | result |
|---|---|
| `scripts/bun.sh run check` (biome + tsc src + tsc e2e) | exit 0 |
| `scripts/bun.sh run test` | 283 files, 5418 tests, exit 0 |
| `scripts/design-notes-gate.sh` | exit 0 |
| `scripts/integration.sh` (FULL suite) | **740 passed, 1 failed in 28.0m** |

The one red is **#1080**, open and pre-existing: `issue168-scroll-authority`
settling at `1417` where `<= 50` is expected — byte-for-byte the number that
issue records, and it reproduces only under full-suite load. It is 18
positions downstream of this branch's new spec, with 17 green specs and the
same file's sibling test in between.

No server code is touched, so `scripts/check.sh` was not run.

## Mutation evidence

The new e2e spec was proven to discriminate, one mutant killing exactly one
assertion:

| mutant | what it breaks | result |
|---|---|---|
| `last_joined_at: null` on the user row | the gap this issue names | killed — the ascending assertion |
| `sign = 1` (direction ignored) | the dictated default | killed — the default-desc assertion |

## Note on the key's meaning

`last joined` binds to `inserted_at` — when the subject's DB row was created —
for both kinds, which is what the issue specifies and what the drill-down's
existing `joined` fact already meant. For a credential that is the date of the
bind, not of the last connection. Flagging it in case "last" was meant
literally; that would be a different key and a separate decision.