### PR TITLE
e2e(#1307): budget the away banner in ircd ticks, not milliseconds

### DIFF
--- a/cicchetto/e2e/tests/p0b-peer-away.spec.ts
+++ b/cicchetto/e2e/tests/p0b-peer-away.spec.ts
@@ -58,8 +58,18 @@ test("P-0b — /msg to away peer surfaces peer_away banner in DM window", async 
     // Banner renders peer + the away message verbatim. Server is the
     // source of truth for the message text; the "is away" framing is
     // built by cic per feedback_no_localized_strings_server_side.
+    // Banner budget is 10 s, not 5 s, and the number is measured (#1307).
+    // The 301 crosses bahamut's fake-lag ceiling: `do_client_queue` drains
+    // the recvQ only while `cptr->since - timeofday < 10` (s_bsd.c), and
+    // `timeofday` is a `time_t` — whole seconds. So the reply resumes on an
+    // integer-second boundary and the banner arrives on a 1 s LATTICE. Over
+    // 20 uncensored local iterations at a constant −3.5 s headroom the
+    // arrivals were 2.91 (x2) / 3.92 (x4) / 4.91 (x12) / 5.93 (x2): the old 5 s
+    // budget cut 54 ms above the MODE, so it failed whenever the run landed
+    // one tick out. 10 s clears the measured maximum by four ticks, and is
+    // what `issue270-peer-away-overlap` already budgets for this same banner.
     const banner = page.locator("[data-testid='peer-away-banner']");
-    await expect(banner).toBeVisible({ timeout: 5_000 });
+    await expect(banner).toBeVisible({ timeout: 10_000 });
     await expect(banner).toContainText(peer.nick);
     await expect(banner).toContainText("is away");
     await expect(banner).toContainText(AWAY_MESSAGE);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41812,3 +41812,69 @@ whether an IP column fits at every width).
 **Apply:** when a sort key can be absent, ask what the absence MEANS
 before picking its sort position. If absence is ignorance rather than a
 value, it belongs at the bottom whichever way the arrow points.
+<!-- entry #1307 -->
+
+---
+
+## 2026-08-14 — #1307: the away banner is late on a one-second lattice
+
+`p0b-peer-away` failed intermittently on a 5 s `toBeVisible`, always at
+the same line. #1307 measured that the banner ARRIVES — the reds miss by
+tens of milliseconds — and deliberately left the remedy open, with one
+condition attached: a wider budget needs a MEASURED tail behind it,
+because a failing `toBeVisible` is censored at its own deadline and
+nothing in the data bounded how far past 5 s the arrival could go.
+
+**Uncensoring the assert turned the "unexplained residual" into a
+lattice.** Twenty local iterations with the budget temporarily raised to
+60 s (throwaway edit, reverted) and the arrival printed per iteration:
+
+```
+2.908 2.912 | 3.907 3.927 3.927 3.930 | 4.900 4.908 4.914 4.914 4.917
+4.920 4.921 4.922 4.924 4.926 4.932 4.946 | 5.918 5.931
+```
+
+Four values one second apart, each carrying the same ~0.92 s of
+pipeline. The server-side `upstream send` headroom was constant across
+every iteration (−1.55 s at the rail WHOIS, −3.52 s at the operator's
+PRIVMSG), so the command count is NOT what picks the step. #1307's
+"bimodal at fixed headroom, something else decides the side" residual is
+this lattice seen through a 5 s window — explained, not hidden.
+
+**The mechanism is bahamut's clock, and it counts in whole seconds.**
+`do_client_queue` (`src/s_bsd.c`) drains a client's recvQ only while
+`cptr->since - timeofday < 10`, and `timeofday` is a `time_t` refreshed
+from `time(NULL)` once per io loop. Above the fake-lag ceiling the ircd
+still READS grappa's socket but stops PARSING it, and the test that lets
+parsing resume cannot change value until the whole second turns. A
+throttled reply therefore returns on a second boundary and never between
+two. Source gives the structure; the twenty iterations give the
+magnitude — and here they agree.
+
+**So the budget is 10 s, and the number is the lattice's.** The old 5 s
+cut 54 ms above the MODE — 12 of 20 iterations arrived at 4.9 s — which
+is why the spec looked comfortable and failed about one run in ten: any
+iteration landing one tick out was lost, and 2 of 20 did. 10 s clears
+the measured maximum (5.931 s) by four ticks, and is what the sibling
+`issue270-peer-away-overlap` already budgets for this same banner, so
+the two specs stop disagreeing about the cost of the same round trip.
+
+**A barrier was the other candidate and was rejected on coupling.**
+Waiting for the rail's WHOIS card to fill before timing the banner would
+have absorbed the same delay without a new number, since the speculative
+WHOIS that `/msg` provokes is answered ahead of the 301. It welds P-0b
+to behaviour that is not P-0b's contract: the rail's on-screen fetch has
+already been added (#606), removed (#800) and reshaped (#782), and the
+next reshape would turn this spec into a slow red for a reason having
+nothing to do with peer-away.
+
+**Not claimed.** That the lattice stops at 5.9 s — twenty iterations on
+one idle host bound what was OBSERVED, not the distribution. That CI
+behaves as this host does. And nothing here touches the rail's
+auto-WHOIS, which stays exactly as #782 shipped it.
+
+**Apply:** when an e2e budget sits just above the modal arrival of a
+throttled upstream reply, widening it by "a bit" re-loses the same race
+one tick later. Measure the arrival with the assert UNCENSORED first: if
+the values come out on a lattice, place the budget in ticks above the
+measured maximum rather than in milliseconds above the mode.


### PR DESCRIPTION
## Summary

`p0b-peer-away` failed about one run in ten on a 5 s `toBeVisible`.
#1307 measured that the banner ARRIVES — the reds miss by tens of
milliseconds — and left the remedy open on one condition: a wider
budget needs a MEASURED tail behind it, because a failing assert is
censored at its own deadline.

This raises that one budget to **10 s** and records why in
`docs/DESIGN_NOTES.md`. No production code changes; the rail's
auto-WHOIS is untouched.

## The number is measured, and it changed the diagnosis

Twenty local iterations with the assert temporarily uncensored (60 s,
throwaway edit, reverted — tree verified clean) printing the arrival
per iteration. Every value landed on a **one-second lattice**:

| arrival | n |
|---|---|
| 2.908, 2.912 | 2 |
| 3.907, 3.927, 3.927, 3.930 | 4 |
| 4.900 … 4.946 (12 values) | 12 |
| 5.918, 5.931 | 2 |

Four steps one second apart, each carrying the same ~0.92 s of
pipeline. The server-side `upstream send` headroom was **constant**
across all twenty (−1.55 s at the rail WHOIS, −3.52 s at the operator's
PRIVMSG), so the command count is not what picks the step.

**This answers #1307's open residual instead of hiding it.** The
"bimodal at a fixed −3.5 s headroom, something other than the command
count decides the side" observation is this lattice seen through a 5 s
window. The mechanism is bahamut's own clock: `do_client_queue`
(`src/s_bsd.c`) drains a client's recvQ only while
`cptr->since - timeofday < 10`, and `timeofday` is a `time_t` refreshed
from `time(NULL)` once per io loop — above the fake-lag ceiling the
ircd keeps READING the socket but stops PARSING it, and the test that
lets parsing resume cannot change value until the whole second turns.
So a throttled reply comes back on a second boundary, never between
two.

## Why 10 s specifically

The old budget cut **54 ms above the MODE** — 12 of 20 iterations
arrived at 4.9 s — which is why the spec looked comfortable and lost
roughly one run in ten: any iteration one tick out was gone, and 2 of
20 were. Against the same twenty arrivals, 5 s fails 2 and 10 s fails
0, with the measured maximum (5.931 s) cleared by four ticks. 10 s is
also what the sibling `issue270-peer-away-overlap` already budgets for
this same banner, so the two specs stop disagreeing about the cost of
the same round trip.

The oracle is unchanged: the assert is still the banner appearing, with
its nick, "is away" and the away message.

## Rejected alternative

A barrier on the rail's WHOIS card before timing the banner. It would
absorb the same delay without a new number, since the speculative WHOIS
that `/msg` provokes is answered ahead of the 301 — but it welds P-0b
to behaviour that is not P-0b's contract. The rail's on-screen fetch
has been added (#606), removed (#800) and reshaped (#782); the next
reshape would turn this spec into a slow red for a reason having
nothing to do with peer-away.

## Not claimed

- **That the lattice stops at 5.9 s.** Twenty iterations on one idle
  host bound what was OBSERVED, not the distribution.
- **That CI behaves as this host does.** The modal step here is 4.9 s;
  #1307's local baseline sat at 3.9 s. Which step a host lands on
  moves, which is another reason the budget is placed in ticks.
- **A failure rate.** 2/20 over the old budget is this host's
  reproduction, not CI's frequency.
- Nothing about the rail's auto-WHOIS, per the ruling on #1307.

## Test plan

- [x] `scripts/bun.sh run check` (biome + tsc over src and e2e) — rc 0
- [x] `scripts/design-notes-gate.sh` — rc 0, 1 new entry, separator and
      marker present
- [x] `scripts/integration.sh --grep "P-0b|#270" --repeat-each 5` —
      10 passed, rc 0
- [ ] Full integration suite — CI