### PR TITLE
scripts(#1311): the bun self-heal must ask whether the deps are installed

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41878,3 +41878,37 @@ throttled upstream reply, widening it by "a bit" re-loses the same race
 one tick later. Measure the arrival with the assert UNCENSORED first: if
 the values come out on a lattice, place the budget in ticks above the
 measured maximum rather than in milliseconds above the mode.
+<!-- entry #1311 -->
+
+---
+
+## 2026-08-14 — #1311: existence is not installedness
+
+`scripts/bun.sh` self-heals a fresh worktree by installing
+`cicchetto/node_modules` and `cicchetto/e2e/node_modules` on demand, and
+it decided whether to do so with `[ ! -d ]`. That predicate answers "does
+the directory exist"; the question the self-heal actually has is "are the
+dependencies there". The two diverge routinely, not exotically.
+
+`cicchetto/e2e/compose.yaml` mounts a named volume at `/work/node_modules`,
+and `/work` is the host's `cicchetto/e2e` bind. For the volume to mount,
+that path must exist inside `/work` — so docker materialises it on the
+host, EMPTY. Every worktree that runs the testnet before its first
+`bun run check` therefore owns a directory that satisfies the guard with
+no toolchain in it, and the check dies with `TS2688 Cannot find type
+definition file for '@playwright/test'`: a bootstrap gap reported as a
+type error in the branch under test, arriving exactly when a worker is
+gating a diff. Order decides, so it presents as intermittent rather than
+as a permanent break — which is what kept it alive.
+
+**The volume is not the defect and was not touched.** Its comment explains
+why the runner needs it: without it the `.:/work` bind hides the image's
+own install. Two individually reasonable halves met. The half answerable
+in one line is the guard, now `needs_install`, which treats absent and
+empty alike because to a caller that needs `tsc` they are one state.
+
+**Apply:** when a guard exists to spare a bootstrap step, write the
+predicate over the RESOURCE the step produces, not over a container that
+something else may have created for its own reasons. A directory, a lock
+file, a pid file can all be materialised by a neighbour; only the contents
+witness the work.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -161,6 +161,15 @@ self-heals both trees, pre-installing on demand for every non-install
 verb. Either signature means you invoked something other than the
 wrapper, or the install failed earlier in the same run — scroll up.
 
+**A worktree that ran the testnet has an `e2e/node_modules` that exists
+and is EMPTY**, because `cicchetto/e2e/compose.yaml` mounts a named volume
+at `/work/node_modules` inside the `.:/work` bind and docker materialises
+that mount point on the host. Until #1311 the self-heal tested existence
+only, so those worktrees skipped the install and hit the `@playwright/test`
+signature above; the guard now tests for CONTENT, and absence and
+emptiness are one state. If you see the self-heal install on a tree that
+looks populated, check whether it holds anything.
+
 **`scripts/bun.sh run check` counts a biome FORMAT violation as an
 ERROR, and hides which file it came from.** `check` starts with `biome
 check`: a line biome would reflow (a long `foo({ a, b, c })`

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -66,15 +66,29 @@ run_bun() {
 # absent toolchain reported as a missing command or a type error. The
 # install-family verbs manage node_modules themselves — skip those.
 # Why: docs/TESTING.md § "Architecture: why the scripts exist" (#484).
+#
+# The question is "are the dependencies there", NOT "does the directory
+# exist" — those differ, and the difference is routine (#1311). The e2e
+# stack mounts a named volume at /work/node_modules INSIDE the `.:/work`
+# bind of cicchetto/e2e, so docker materialises an EMPTY
+# cicchetto/e2e/node_modules on the host: any worktree that ran the testnet
+# before its first `run check` satisfied an existence test with nothing
+# installed, and the check died with `TS2688 Cannot find type definition
+# file for '@playwright/test'` — an absent toolchain wearing the mask of a
+# type error in the branch under test.
+needs_install() {
+    [ -z "$(ls -A "$1" 2>/dev/null)" ]
+}
+
 case "${1:-}" in
     install | add | remove | update | outdated | pm | ci | link | unlink) ;;
     *)
-        if [ ! -d "$CICCHETTO_DIR/node_modules" ]; then
-            printf 'scripts/bun.sh: cicchetto/node_modules missing — running bun install...\n' >&2
+        if needs_install "$CICCHETTO_DIR/node_modules"; then
+            printf 'scripts/bun.sh: cicchetto/node_modules has no dependencies installed — running bun install...\n' >&2
             run_bun "$BUN_IMAGE" bun install >&2
         fi
-        if [ ! -d "$CICCHETTO_DIR/e2e/node_modules" ]; then
-            printf 'scripts/bun.sh: cicchetto/e2e/node_modules missing — running bun install --cwd e2e...\n' >&2
+        if needs_install "$CICCHETTO_DIR/e2e/node_modules"; then
+            printf 'scripts/bun.sh: cicchetto/e2e/node_modules has no dependencies installed — running bun install --cwd e2e...\n' >&2
             run_bun "$BUN_IMAGE" bun install --cwd e2e >&2
         fi
         ;;

--- a/test/scripts/bun_self_heal_test.bats
+++ b/test/scripts/bun_self_heal_test.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/bun.sh — the node_modules self-heal (#1311).
+#
+# WHY THIS EXISTS
+#
+# The e2e stack mounts a named volume at /work/node_modules INSIDE the
+# `.:/work` bind of cicchetto/e2e (cicchetto/e2e/compose.yaml), and docker
+# materialises that mount point on the host. Every worktree that has run the
+# testnet therefore owns an EMPTY cicchetto/e2e/node_modules — and a guard
+# spelled `[ ! -d ]` reads an empty directory as "installed". The first
+# `bun run check` then dies with `TS2688 Cannot find type definition file for
+# '@playwright/test'`, which reads like a type error in the branch under test
+# rather than an absent toolchain.
+#
+# "Does the directory exist" is not "are the dependencies there". These cases
+# pin the second question, on BOTH guards, in both directions.
+#
+# Scope: asserts WHICH bun invocations reach the container for a given
+# on-disk state. `docker` is stubbed on PATH, so no container starts and no
+# real install runs — this pins the GUARD, not the install.
+
+load ../bats_helpers
+
+setup() {
+    REAL_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+
+    # A throwaway tree shaped like a checkout, so _lib.sh can resolve
+    # SRC_ROOT (dirname of the script, since $PWD is not a worktree root) and
+    # REPO_ROOT (git --git-common-dir, hence the init). PHYSICAL path: on
+    # macOS $TMPDIR is a symlink, and _lib.sh compares SRC_ROOT to a
+    # git-resolved REPO_ROOT.
+    FIXTURE="$(cd "$BATS_TEST_TMPDIR" && pwd -P)/fixture"
+    mkdir -p "$FIXTURE/scripts" "$FIXTURE/infra/packaging" "$FIXTURE/cicchetto/e2e"
+    git -C "$FIXTURE" init -q
+
+    cp "$REAL_ROOT/scripts/_lib.sh" "$FIXTURE/scripts/_lib.sh"
+    cp "$REAL_ROOT/scripts/bun.sh" "$FIXTURE/scripts/bun.sh"
+    cp "$REAL_ROOT/infra/packaging/version.sh" "$FIXTURE/infra/packaging/version.sh"
+    chmod +x "$FIXTURE/scripts/bun.sh" "$FIXTURE/infra/packaging/version.sh"
+    # bun.sh derives GRAPPA_VERSION through version.sh, which reads this.
+    printf '9.9.9\n' > "$FIXTURE/VERSION"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %s' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+
+    # MANDATORY, not tidiness: _lib.sh reads $PWD first and only falls back to
+    # the script's own directory when $PWD is not a checkout root. bats runs
+    # from the real worktree, which IS one — so without this the fixture is
+    # ignored and every case silently measures the developer's own
+    # cicchetto/.
+    cd "$FIXTURE"
+}
+
+# A node_modules directory with dependencies actually installed in it.
+populate() {
+    mkdir -p "$1/typescript"
+    touch "$1/typescript/package.json"
+}
+
+# The mount point docker leaves behind: the directory exists, and holds
+# nothing.
+materialise_empty() {
+    mkdir -p "$1"
+}
+
+@test "the fixture, not the real checkout, is the subject under test" {
+    populate "$FIXTURE/cicchetto/node_modules"
+    populate "$FIXTURE/cicchetto/e2e/node_modules"
+
+    run "$FIXTURE/scripts/bun.sh" run check
+    [ "$status" -eq 0 ]
+
+    grep -q -- "-v $FIXTURE/cicchetto:/app " "$ARGV_LOG"
+    refute grep -q -- "-v $REAL_ROOT/cicchetto:/app " "$ARGV_LOG"
+}
+
+@test "empty cicchetto/e2e/node_modules still installs the e2e toolchain" {
+    populate "$FIXTURE/cicchetto/node_modules"
+    materialise_empty "$FIXTURE/cicchetto/e2e/node_modules"
+
+    run "$FIXTURE/scripts/bun.sh" run check
+    [ "$status" -eq 0 ]
+
+    grep -q ' bun install --cwd e2e$' "$ARGV_LOG"
+    refute grep -q ' bun install$' "$ARGV_LOG"
+}
+
+@test "empty cicchetto/node_modules still installs the cic toolchain" {
+    materialise_empty "$FIXTURE/cicchetto/node_modules"
+    populate "$FIXTURE/cicchetto/e2e/node_modules"
+
+    run "$FIXTURE/scripts/bun.sh" run check
+    [ "$status" -eq 0 ]
+
+    grep -q ' bun install$' "$ARGV_LOG"
+    refute grep -q ' bun install --cwd e2e$' "$ARGV_LOG"
+}
+
+@test "absent node_modules install both toolchains" {
+    run "$FIXTURE/scripts/bun.sh" run check
+    [ "$status" -eq 0 ]
+
+    grep -q ' bun install$' "$ARGV_LOG"
+    grep -q ' bun install --cwd e2e$' "$ARGV_LOG"
+}
+
+@test "populated node_modules install nothing and run the asked-for verb" {
+    populate "$FIXTURE/cicchetto/node_modules"
+    populate "$FIXTURE/cicchetto/e2e/node_modules"
+
+    run "$FIXTURE/scripts/bun.sh" run check
+    [ "$status" -eq 0 ]
+
+    # The real invocation is the witness that the run happened at all — the
+    # two refutes below hold vacuously against an empty log.
+    grep -q ' bun run check$' "$ARGV_LOG"
+    refute grep -q ' bun install$' "$ARGV_LOG"
+    refute grep -q ' bun install --cwd e2e$' "$ARGV_LOG"
+}
+
+@test "install-family verbs skip the self-heal even with empty node_modules" {
+    materialise_empty "$FIXTURE/cicchetto/node_modules"
+    materialise_empty "$FIXTURE/cicchetto/e2e/node_modules"
+
+    run "$FIXTURE/scripts/bun.sh" install
+    [ "$status" -eq 0 ]
+
+    # Exactly one docker invocation: the operator's own `bun install`.
+    [ "$(wc -l < "$ARGV_LOG")" -eq 1 ]
+}


### PR DESCRIPTION
## What

`scripts/bun.sh` guarded its `node_modules` self-heal with `[ ! -d ]` on
both trees. That predicate answers *does the directory exist*; the
question the self-heal has is *are the dependencies there*. The two
diverge routinely.

`cicchetto/e2e/compose.yaml` mounts a named volume at `/work/node_modules`
inside the `.:/work` bind of `cicchetto/e2e`, so docker materialises that
mount point on the host — EMPTY. Any worktree that ran the testnet before
its first `bun run check` satisfied the guard with no toolchain installed,
and the check died with `TS2688 Cannot find type definition file for
'@playwright/test'`: an absent toolchain wearing the mask of a type error
in the branch under test, arriving exactly when a worker is gating a diff.

The volume is not the defect and is untouched — its comment explains why
the runner needs it. `needs_install` covers absence and emptiness in one
test, because to a caller that needs `tsc` they are one state. The log
lines no longer say "missing" about a directory that exists.

## Reproduction, both sides, one host

Same worktree, same materialised-empty `cicchetto/e2e/node_modules`
(0 entries, left behind by a real `scripts/integration.sh` run):

| `scripts/bun.sh` | self-heal output | `run check` |
| --- | --- | --- |
| `origin/main` | no lines at all | `TS2688 @playwright/test`, rc 1 |
| this branch | the e2e install fires, and only it | 59 packages, rc 0 |

The cic guard stays correctly silent on both sides: that tree was
populated, and only the e2e one was empty. Restoring the branch's script
left `git status` clean, so the two runs differ in the guard and nothing
else.

## Test plan

- [x] `scripts/bats.sh test/scripts/bun_self_heal_test.bats` — 6 cases,
      `docker` stubbed on PATH. Red first: the two empty-directory cases
      failed and the other four passed; green after the fix, 6/6.
- [x] `scripts/bats.sh` (full set) — `1..477`, 0 failures.
- [x] `scripts/shellcheck.sh` — 74 scripts, rc 0.
- [x] `scripts/bun.sh run check` — rc 0 (the post-fix row above).
- [x] `scripts/design-notes-gate.sh` — 1 new entry, separator and marker
      present.

The suite pins WHICH bun invocations reach the container for a given
on-disk state, in both directions, so neither an always-install
regression nor a return of the existence test can land quietly. Its first
case pins that the fixture, not the developer's own checkout, is the
subject: `_lib.sh` prefers `$PWD`, bats runs from the real worktree, and
the first draft of the suite silently measured the wrong tree and passed.