### PR TITLE
#1308: carry the per-session source address onto the admin session card

### DIFF
--- a/cicchetto/e2e/tests/issue1308-admin-session-ip.spec.ts
+++ b/cicchetto/e2e/tests/issue1308-admin-session-ip.spec.ts
@@ -1,0 +1,111 @@
+// #1308 — the admin Sessions view lost the source address when #1157
+// merged Visitors into it. What survived was one detail-panel fact,
+// visitor-only, reading `visitors.ip`: identity-wide, written once when
+// the visitor was provisioned, and with no user-side twin at all. A user
+// row showed no address anywhere.
+//
+// vjt ruled it (2026-08-14): the fact is `accounts_sessions.ip`, the
+// per-session one, it stays in the card, and the table grows no column.
+// So the card is not a convenience here — it is the ONLY place this
+// reaches an operator, at every width.
+//
+// jsdom already pins the fact list and the wire (`AdminSessionsTab.test.tsx`,
+// `adminSubjectRows.test.ts`, the two controller wire tests). What only a
+// real stack shows is that the value is REAL: it travels
+// login → `accounts_sessions.ip` → one batched query → two row-backed
+// endpoints → the merged row → the card. A jsdom fixture hands the
+// renderer a string and proves none of that.
+//
+// The USER row is the discriminating half. Its card had no `ip` fact to
+// begin with, so the label's mere presence there fails on the old code.
+// The visitor half is a non-regression witness and nothing more: that
+// card always rendered an address, and only the wire tests can tell
+// WHICH address it is now.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT.
+
+import type { Locator, Page } from "@playwright/test";
+import {
+  adminSessionRowKey,
+  openAdminSessionDetail,
+  openAdminSessionsTab,
+} from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// An address, of either family, rather than the em-dash the renderer
+// prints for "we do not have one". Deliberately NOT a literal: the
+// address the container observes depends on how the stack is networked,
+// and pinning `127.0.0.1` would be an assertion about docker, not about
+// the field.
+const AN_ADDRESS = /^(\d{1,3}(\.\d{1,3}){3}|[0-9a-f:]+)$/i;
+
+/** One fact's value, addressed by its label. The panel renders `upstream`
+ * — an address too — so asserting over the whole card's text could not
+ * tell the two apart, and telling them apart is the point: `upstream` is
+ * the IRC server the bouncer dialled OUT to, not where the client is. */
+async function factValue(panel: Locator, label: string): Promise<string | null> {
+  return panel.evaluate((el, wanted) => {
+    for (const pair of Array.from(el.querySelectorAll(".adm-fact"))) {
+      if (pair.querySelector("dt")?.textContent?.trim() === wanted) {
+        return pair.querySelector("dd")?.textContent?.trim() ?? null;
+      }
+    }
+    return null;
+  }, label);
+}
+
+async function loginAsAdmin(page: Page): Promise<void> {
+  const admin = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [admin.token, admin.subjectJson] as const,
+  );
+  await page.goto("/");
+  await openAdminSessionsTab(page);
+}
+
+test("admin Sessions card: the per-session source address, on BOTH subject kinds", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const vjtId = (JSON.parse(getSeededVjt().subjectJson) as { id: string }).id;
+  // The mint is the visitor's login, so it is also what writes the
+  // session row this card must be reading.
+  const visitor = await mintVisitor(`ipvictim-${Date.now()}`);
+
+  try {
+    await loginAsAdmin(page);
+
+    // THE half that fails on the old code: a user row had no `ip` fact,
+    // so this is a claim about the label existing before it is one about
+    // the value.
+    const userKey = await adminSessionRowKey(page, "user", vjtId);
+    const userPanel = await openAdminSessionDetail(page, userKey);
+    const userIp = await factValue(userPanel, "ip");
+    expect(userIp, "a user row must carry a source address fact at all").not.toBeNull();
+    expect(userIp, "and it must be the address the seeded login came from, not an em-dash").toMatch(
+      AN_ADDRESS,
+    );
+
+    // It is NOT the upstream peer. Both are on this card and both are
+    // addresses; the pair is what makes the labelling load-bearing.
+    const upstream = await factValue(userPanel, "upstream");
+    expect(upstream, "the upstream fact still renders — it just is not the client").not.toBeNull();
+    expect(upstream).not.toBe(userIp);
+
+    const visitorKey = await adminSessionRowKey(page, "visitor", visitor.id);
+    const visitorPanel = await openAdminSessionDetail(page, visitorKey);
+    expect(
+      await factValue(visitorPanel, "ip"),
+      "the visitor card kept its address through the swap",
+    ).toMatch(AN_ADDRESS);
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -725,6 +725,16 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
     // would erase it.
     { label: "connection", value: row.connection_state ?? "no DB row" },
     { label: "live", value: renderLive(row) },
+    // #1308 — the source address, and the reason it sits directly above
+    // `upstream`: the two are the opposite ends of one session and the
+    // pair is only readable together. This one is where the BROWSER came
+    // from; `upstream` is the IRC server the bouncer dialled out to.
+    //
+    // Unconditional, unlike the `visitors.ip` fact it replaces: that one
+    // lived inside the visitor-only block, so a user row showed no
+    // address anywhere, and per-session is exactly the grain a user row
+    // can answer (vjt, 2026-08-14).
+    { label: "ip", value: row.session_ip ?? "—" },
     // NO `network` fact. #1223 item 1 reported the panel repeating it,
     // and unlike the Users/Credentials repeats this one is not the
     // `.adm-col-detail` specificity defect: Sessions drops no column at
@@ -763,7 +773,6 @@ function detailFacts(row: AdminSubjectRow): { label: string; value: string }[] {
 
   if (row.visitor !== null) {
     facts.push(
-      { label: "ip", value: row.visitor.ip ?? "—" },
       { label: "expires", value: renderExpires(row) },
       { label: "joined", value: row.visitor.inserted_at },
     );

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -66,6 +66,9 @@ const parkedVisitor = (over: Partial<AdminVisitor> = {}): AdminVisitor =>
     expires_at: "2099-01-01T00:00:00Z",
     identified: false,
     ip: "1.2.3.4",
+    // #1308 — distinct from `ip` on purpose: the console renders the
+    // per-session address now, and equal fixtures could not tell which.
+    session_ip: "5.6.7.8",
     inserted_at: "2026-05-16T00:00:00Z",
     last_seen_at: null,
     networks: [
@@ -99,6 +102,7 @@ const userCredential = (over: Partial<AdminCredential> = {}): AdminCredential =>
     inserted_at: "2026-05-16T00:00:00Z",
     updated_at: "2026-05-16T00:00:00Z",
     last_seen_at: "2026-08-10T00:00:00Z",
+    session_ip: "9.9.9.9",
     live_state: LIVE,
     ...over,
   }) as AdminCredential;
@@ -403,6 +407,19 @@ describe("AdminSessionsTab — Delete is identity-wide and lives behind the dril
   });
 });
 
+// Read ONE fact out of a detail panel by its label. `toHaveTextContent`
+// over the whole panel cannot tell "the address is the ip fact" from "the
+// address appears somewhere on the card", and #1308 turns on exactly that
+// distinction: `upstream` renders an address too.
+function factValue(panel: HTMLElement, label: string): string | null {
+  for (const pair of Array.from(panel.querySelectorAll(".adm-fact"))) {
+    if (pair.querySelector("dt")?.textContent?.trim() === label) {
+      return pair.querySelector("dd")?.textContent?.trim() ?? null;
+    }
+  }
+  return null;
+}
+
 describe("AdminSessionsTab — the drill-down keeps both sources of truth", () => {
   it("shows DB intent and live pid separately when they disagree", async () => {
     // The U-0 divergence: the credential still says connected, the BEAM
@@ -431,7 +448,62 @@ describe("AdminSessionsTab — the drill-down keeps both sources of truth", () =
     fireEvent.click(await screen.findByTestId(`admin-session-details-${VISITOR_KEY}`));
 
     const panel = await screen.findByTestId(`admin-session-detail-${VISITOR_KEY}`);
-    expect(panel).toHaveTextContent("1.2.3.4");
+    expect(panel).toHaveTextContent("expires");
+    expect(panel).toHaveTextContent("2026-05-16T00:00:00Z");
+  });
+
+  // #1308 — the address the operator asked for is the SESSION's, and it
+  // must reach both kinds. The user half is the new rendering: that card
+  // carried no address at all before, because the only one the console
+  // had was the visitor identity's.
+  it("shows the per-session source address on a USER row", async () => {
+    await mountWith({ credentials: [userCredential()] });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${USER_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+    expect(factValue(panel, "ip")).toBe("9.9.9.9");
+  });
+
+  it("shows the per-session source address on a VISITOR row", async () => {
+    await mountWith({ visitors: [parkedVisitor()] });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${VISITOR_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${VISITOR_KEY}`);
+    expect(factValue(panel, "ip")).toBe("5.6.7.8");
+  });
+
+  // vjt (2026-08-14): "we can drop visitors.ip". The identity-wide
+  // address is off the VIEW — still on the wire, still on the row, no
+  // longer shown, because two addresses labelled almost the same is how
+  // an operator reads the wrong one.
+  it("no longer shows the identity-wide visitors.ip", async () => {
+    await mountWith({ visitors: [parkedVisitor()] });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${VISITOR_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${VISITOR_KEY}`);
+    expect(panel).not.toHaveTextContent("1.2.3.4");
+  });
+
+  // The trap the issue names: `live_state.peer_address` is the upstream
+  // IRC endpoint the bouncer's socket landed on. It renders — under
+  // `upstream`, which is what it is — and must never be what the `ip`
+  // fact reports.
+  it("does not pass the upstream peer off as the client's address", async () => {
+    await mountWith({
+      credentials: [userCredential({ session_ip: null })],
+      sessions: [userSession()],
+    });
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${USER_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${USER_KEY}`);
+    expect(factValue(panel, "upstream")).toContain("allnight6.azzurra.chat");
+    // Unknown, and said so — not quietly backfilled from the socket's
+    // other end, which is the one address this panel must never borrow.
+    expect(factValue(panel, "ip")).toBe("—");
   });
 });
 

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -83,6 +83,7 @@ const OTHER_NETWORK: AdminNetwork = { ...NETWORK, id: 9, slug: "libera" };
 
 const CRED: AdminCredential = {
   last_seen_at: null,
+  session_ip: null,
   user_id: USER.id,
   network_id: NETWORK.id,
   network_slug: NETWORK.slug,

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -47,6 +47,10 @@ vi.mock("../lib/api", async () => {
     adminDeleteNetwork: vi.fn(),
     adminListServers: vi.fn(),
     adminListFeaturedChannels: vi.fn(),
+    adminListVisitors: vi.fn(),
+    adminListCredentials: vi.fn(),
+    adminListSessions: vi.fn(),
+    adminListSessionLogSessions: vi.fn(),
   };
 });
 
@@ -55,12 +59,18 @@ vi.mock("../lib/socket", () => ({
 }));
 
 import AdminNetworksTab from "../AdminNetworksTab";
+import AdminSessionsTab from "../AdminSessionsTab";
 import AdminUsersTab from "../AdminUsersTab";
+import type { AdminCredential } from "../lib/api";
 import {
+  adminListCredentials,
   adminListFeaturedChannels,
   adminListNetworks,
   adminListServers,
+  adminListSessionLogSessions,
+  adminListSessions,
   adminListUsers,
+  adminListVisitors,
 } from "../lib/api";
 
 const ALICE: AdminUser = {
@@ -208,5 +218,55 @@ describe("#1074 — Networks drops its secondary columns on a phone", () => {
     const panelRow = panel.closest("tr");
     expect(panelRow).not.toBeNull();
     expect(row.nextElementSibling).toBe(panelRow);
+  });
+});
+
+// #1308 — the per-session source address, on the form factor the card
+// exists for. vjt ruled the fact stays in the card and the table grows no
+// column ("reworking the layout comes later"), so a phone reaching it is
+// the whole delivery: below 900px the card is not a convenience, it is
+// the only place the operator can read this.
+describe("#1308 — the source address is reachable on a phone", () => {
+  const SESSION_USER_ID = "00000000-0000-0000-0000-0000000000aa";
+  const SESSION_USER_KEY = `user:${SESSION_USER_ID}:1`;
+
+  const CREDENTIAL = {
+    user_id: SESSION_USER_ID,
+    network_id: 1,
+    network_slug: "bahamut-test",
+    nick: "alice",
+    ident: null,
+    realname: null,
+    sasl_user: null,
+    auth_method: "sasl",
+    auth_command_template: null,
+    autojoin_channels: [],
+    last_joined_channels: [],
+    connection_state: "parked",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-05-16T00:00:00Z",
+    updated_at: "2026-05-16T00:00:00Z",
+    last_seen_at: "2026-08-10T00:00:00Z",
+    session_ip: "198.51.100.7",
+    live_state: null,
+  } as unknown as AdminCredential;
+
+  it("puts it in the USER row's own detail, which is where a phone can read it", async () => {
+    vi.mocked(adminListVisitors).mockResolvedValue([]);
+    vi.mocked(adminListCredentials).mockResolvedValue([CREDENTIAL]);
+    vi.mocked(adminListSessions).mockResolvedValue([]);
+    vi.mocked(adminListSessionLogSessions).mockResolvedValue([]);
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    render(() => <AdminSessionsTab />);
+
+    fireEvent.click(await screen.findByTestId(`admin-session-details-${SESSION_USER_KEY}`));
+
+    const panel = await screen.findByTestId(`admin-session-detail-${SESSION_USER_KEY}`);
+    const labels = Array.from(panel.querySelectorAll(".adm-fact dt")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(labels).toContain("ip");
+    expect(panel).toHaveTextContent("198.51.100.7");
   });
 });

--- a/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
+++ b/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
@@ -66,6 +66,7 @@ const NETWORK = {
 // collapse has anything to collapse.
 const userCredential = (): AdminCredential =>
   ({
+    session_ip: null,
     user_id: USER_ID,
     network_id: 1,
     network_slug: "azzurra",

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -46,6 +46,10 @@ const visitor = (over: Partial<AdminVisitor> = {}): AdminVisitor =>
     expires_at: "2026-08-20T00:00:00Z",
     identified: false,
     ip: "10.0.0.5",
+    // #1308 — deliberately NOT `ip`: the identity-wide address and the
+    // newest session's are different facts, and a fixture that made them
+    // equal could not tell which one the row carried.
+    session_ip: "203.0.113.9",
     inserted_at: "2026-08-01T00:00:00Z",
     last_seen_at: "2026-08-10T00:00:00Z",
     networks: [
@@ -79,6 +83,7 @@ const credential = (over: Partial<AdminCredential> = {}): AdminCredential =>
     inserted_at: "2026-08-01T00:00:00Z",
     updated_at: "2026-08-01T00:00:00Z",
     last_seen_at: "2026-08-09T00:00:00Z",
+    session_ip: "198.51.100.7",
     live_state: null,
     ...over,
   }) as AdminCredential;
@@ -263,6 +268,53 @@ describe("buildSubjectRows — the /admin/sessions left join", () => {
 
     expect(rows).toHaveLength(2);
     expect(new Set(rows.map((r) => r.key)).size).toBe(2);
+  });
+});
+
+// #1308 — the source address. The user half is the new fact: before this
+// the row type had no field for it at all, so a user row could show no
+// address anywhere, and the only one the console had was the visitor
+// identity's.
+describe("buildSubjectRows — the per-session source address", () => {
+  it("carries the newest session's address onto a USER row", () => {
+    const rows = build({ credentials: [credential()] });
+
+    expect(rows[0]?.session_ip).toBe("198.51.100.7");
+  });
+
+  it("carries it onto a VISITOR row without collapsing it into the identity ip", () => {
+    const rows = build({ visitors: [visitor()] });
+
+    // Both, and different: `ip` says where the identity was born,
+    // `session_ip` where this session comes from. One value standing in
+    // for the other is the mistake the pair exists to prevent.
+    expect(rows[0]?.session_ip).toBe("203.0.113.9");
+    expect(rows[0]?.visitor?.ip).toBe("10.0.0.5");
+  });
+
+  it("reports null on an orphan pid rather than the upstream peer address", () => {
+    const orphan = session({ subject_id: "deadbeef-0000-0000-0000-000000000000" });
+
+    const rows = build({ sessions: [orphan] });
+
+    // `203.0.113.5` IS on this row — as `upstream.peer_address`, the IRC
+    // server the bouncer dialled. Reporting it as the client's address
+    // would be a lie, so the honest answer is that we do not have one.
+    expect(rows[0]?.upstream?.peer_address).toBe("203.0.113.5");
+    expect(rows[0]?.session_ip).toBeNull();
+  });
+
+  it("reports null on a log-only row, whose subject is gone", () => {
+    const rows = build({ logSessions: [logEntry()] });
+
+    expect(rows[0]?.origin).toBe("session_log");
+    expect(rows[0]?.session_ip).toBeNull();
+  });
+
+  it("passes a missing address through as null instead of inventing one", () => {
+    const rows = build({ credentials: [credential({ session_ip: null })] });
+
+    expect(rows[0]?.session_ip).toBeNull();
   });
 });
 

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -65,6 +65,11 @@ export type VisitorIdentity = {
   visitor_id: string;
   expires_at: string | null;
   inserted_at: string;
+  /** Where the IDENTITY was first seen — `visitors.ip`, written once at
+   * provisioning and identity-wide like everything else here. #1308 took
+   * it off the console in favour of the per-session `session_ip`, which
+   * is the address the operator was actually asking for; it stays on the
+   * row because it is still on the wire and answers its own question. */
   ip: string | null;
   identified: boolean;
 };
@@ -99,6 +104,15 @@ export type AdminSubjectRow = {
   /** The upstream peer, known ONLY for rows with a registry entry. */
   upstream: AdminSession["live_state"] | null;
   last_seen_at: string | null;
+  /** #1308 — the source address of the subject's newest browser session
+   * (`accounts_sessions.ip`), for BOTH kinds. `null` on the classes that
+   * have no subject row to have logged in (orphan pid, log-only) and on
+   * a subject that never did.
+   *
+   * NOT `upstream.peer_address`: that is the IRC server the bouncer's own
+   * socket landed on, and calling it the client's address would be a lie.
+   * Not `visitor.ip` either — see `VisitorIdentity`. */
+  session_ip: string | null;
   /** #1308 — when this subject's DB row was created: the visitor
    * identity's `inserted_at`, or the credential's. `null` on the two
    * classes that have no DB row (orphan pid, log-only). Copied onto the
@@ -335,6 +349,7 @@ export function buildSubjectRows(input: {
         live: net.live_state,
         upstream: sessionByKey.get(key)?.live_state ?? null,
         last_seen_at: v.last_seen_at,
+        session_ip: v.session_ip,
         last_joined_at: v.inserted_at,
         visitor: identity,
         origin: "credential",
@@ -357,6 +372,7 @@ export function buildSubjectRows(input: {
       live: c.live_state,
       upstream: sessionByKey.get(key)?.live_state ?? null,
       last_seen_at: c.last_seen_at,
+      session_ip: c.session_ip,
       last_joined_at: c.inserted_at,
       visitor: null,
       origin: "credential",
@@ -385,6 +401,10 @@ export function buildSubjectRows(input: {
       live: s.live_state,
       upstream: s.live_state,
       last_seen_at: s.last_seen_at,
+      // No subject row, so no login of its own to have an address. The
+      // pid's upstream peer is a DIFFERENT address and stays in
+      // `upstream`, where it is labelled as what it is.
+      session_ip: null,
       // No DB row, so nothing was ever created to be dated. NOT the pid's
       // start time: that is a different fact and this column does not
       // claim it.
@@ -420,6 +440,9 @@ export function buildSubjectRows(input: {
       // NOT `e.at`: this column is when a BROWSER last touched the
       // bouncer, and there is no browser session left to have touched it.
       last_seen_at: null,
+      // Same reason: the subject whose session this was is gone, and the
+      // log keeps no address of its own.
+      session_ip: null,
       // The subject row this would date is gone; the log carries no
       // creation time of its own, and `e.at` is the LAST event, not the
       // first.

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -624,6 +624,7 @@ export const S_NetworksCredentialsAdminWireT = {
     inserted_at: "s",
     updated_at: "s",
     last_seen_at: { u: ["s", "z"] },
+    session_ip: { u: ["s", "z"] },
     live_state: { u: [S_NetworksCredentialsAdminWireLiveStateJson, "z"] },
   },
 } as const;
@@ -1425,6 +1426,7 @@ export const S_VisitorsAdminWireT = {
     expires_at: { u: ["s", "z"] },
     identified: "b",
     ip: { u: ["s", "z"] },
+    session_ip: { u: ["s", "z"] },
     inserted_at: "s",
     last_seen_at: { u: ["s", "z"] },
     networks: { a: S_VisitorsAdminWireNetworkJson },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -585,6 +585,7 @@ export type NetworksCredentialsAdminWireT = {
   inserted_at: string;
   updated_at: string;
   last_seen_at: string | null;
+  session_ip: string | null;
   live_state: NetworksCredentialsAdminWireLiveStateJson | null;
 };
 
@@ -1438,6 +1439,7 @@ export type VisitorsAdminWireT = {
   expires_at: string | null;
   identified: boolean;
   ip: string | null;
+  session_ip: string | null;
   inserted_at: string;
   last_seen_at: string | null;
   networks: VisitorsAdminWireNetworkJson[];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41912,3 +41912,68 @@ predicate over the RESOURCE the step produces, not over a container that
 something else may have created for its own reasons. A directory, a lock
 file, a pid file can all be materialised by a neighbour; only the contents
 witness the work.
+<!-- entry #1308-ip -->
+
+---
+
+## 2026-08-14 — #1308: the source address is per-SESSION, and it is a login address
+
+#1157 merged the Visitors tab into the unified admin Sessions view and
+dropped the source-IP column on the way. What survived was one
+detail-panel fact, visitor-only, reading `visitors.ip`. vjt ruled the
+replacement (2026-08-14): *"yes account_sessions.ip and we can drop
+visitors.ip, keep it in the current card, reworking the layout comes
+later."* Four things in carrying that out are worth keeping.
+
+**The two addresses answer different questions, and only one of them is
+the operator's.** `visitors.ip` is written once, on the identity row, at
+provisioning: it says where a visitor was FIRST seen, identity-wide, and
+it does not follow the session. `accounts_sessions.ip` is per cookie
+session. Once a visitor reconnects from another network the two disagree,
+and the one an operator opens this pane for is the second. The
+identity-wide one is out of the VIEW and still on the wire — the client
+contract is additive-only, `GET /admin/visitors` has always published
+`ip`, and removing a field to tidy up a console is how a wire breaks a
+reader nobody enumerated.
+
+**`session_ip` is where that session LOGGED IN from, not where its newest
+request came from.** `Session.touch_changeset/2` moves `last_seen_at`
+alone, so a `:web` row keeps the address `create_session/4` recorded for
+its whole life; the `:client` rows of #1196 are the exception, because
+`record_client_token_use/4` refreshes address and timestamp together. The
+field is named and documented for what it is rather than for the pairing
+it travels in: `last_seen_ip` would have read as "the address of the last
+touch" and been wrong for every browser session in the system. Making the
+touch write the address too was rejected as out of scope — it is a
+behaviour change to the auth hot path, and the ruling asked for a column
+that exists, not for a new one to be maintained.
+
+**The address must come from the SAME ROW as the timestamp, so the query
+picks a row rather than aggregating columns.** `max_last_seen_by_subject_ids/2`
+grouped by subject and selected `max(last_seen_at)`; adding `s.ip` beside
+it would have worked on SQLite — bare columns beside `min()`/`max()` come
+from the matching row — and worked by dialect quirk, invisible to a reader
+and to a future PostgreSQL swap. It is now
+`newest_touch_by_subject_ids/2`: one `row_number() OVER (PARTITION BY
+subject ORDER BY last_seen_at DESC)` subquery filtered to rank 1, still
+one batched query per `subject_kind`, still no per-row cost. A
+multi-device subject therefore collapses to its most recent device, and
+the address is THAT device's — never coalesced across rows to avoid a
+null, which would report an address the subject has stopped using.
+
+**Rendering it on the user row is new code, not a value swap.** The
+existing fact lived inside `if (row.visitor !== null)`, so a user row
+carried no address anywhere and `AdminSubjectRow` had no field for one.
+The fact is now unconditional and sits directly above `upstream`, which
+is deliberate: `live_state.peer_address` is the upstream IRC endpoint the
+bouncer's own socket landed on, it renders on the same card, and
+labelling it "ip" would be a lie to the operator. The two are adjacent so
+the labels have to do their work.
+
+**Scope:** no migration, no column dropped from `visitors`, and no table
+column at any width — the fact keeps its place in the card and the layout
+rework is a separate call (vjt, same ruling).
+
+**Apply:** when one wire field is replaced by a better one, ask whether
+the old field is a WORSE ANSWER or a DIFFERENT QUESTION. A different
+question stays on the wire and leaves the view.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -181,47 +181,98 @@ defmodule Grappa.Accounts do
     |> Map.new(fn user -> {user.id, user} end)
   end
 
+  @typedoc """
+  What the subject's NEWEST cookie session says about them: when it
+  last touched the bouncer, and the source address recorded on it.
+
+  `ip` is `nil` for a row minted by a caller that had no connection to
+  read one from (every mix task), and for a row created before the
+  column existed.
+  """
+  @type touch :: %{last_seen_at: DateTime.t() | nil, ip: String.t() | nil}
+
+  # The answer for a subject with no cookie session at all — the U-0
+  # honesty case, spelled once so no caller invents a different shape
+  # for it. `last_seen_at: nil` is what the wire has always carried
+  # there; `ip: nil` joins it for the same reason.
+  @no_touch %{last_seen_at: nil, ip: nil}
+
   @doc """
-  Batched MAX(`last_seen_at`) across cookie sessions, keyed by
-  subject id. Used by `GrappaWeb.Admin.SessionsController` to
-  surface "when did this subject's browser last touch the bouncer"
-  alongside live BEAM state (mailbox, memory).
+  Batched newest-cookie-session lookup, keyed by subject id. Used by
+  the three admin listings to surface "when did this subject's browser
+  last touch the bouncer, and where from" alongside live BEAM state.
 
-  `subject_kind` discriminates the column: `:user` selects
-  `user_id`, `:visitor` selects `visitor_id`. Result map keys are
-  ONLY ids that had at least one cookie session — missing ids
-  signal the U-0 honesty case (`nil` on the wire: bouncer pid
-  exists but no browser ever logged in).
+  `subject_kind` discriminates the column: `:user` selects `user_id`,
+  `:visitor` selects `visitor_id`. Result map keys are ONLY ids that
+  had at least one cookie session — missing ids signal the U-0 honesty
+  case (bouncer pid exists but no browser ever logged in); read them
+  through `touch_of/2` rather than `Map.get/2` so that case keeps one
+  shape.
 
-  MAX across N cookie rows per subject collapses multi-device
-  users to "most recent touch." Both `Accounts.authenticate/1`
-  (REST plug) and `UserSocket.connect/3` (WS upgrade) bump
-  `last_seen_at`, cadence-capped at 60 s — so the timestamp is
-  per-minute precision in practice, ISO8601 microseconds on the
-  wire only because the underlying column is `:utc_datetime_usec`.
+  One row per subject: the session with the greatest `last_seen_at`,
+  picked by `row_number()` rather than by `MAX()` with bare columns,
+  because the address must come from THE SAME ROW as the timestamp and
+  SQLite's bare-column-beside-max rule is a dialect quirk no reader
+  should have to know. Multi-device subjects therefore collapse to
+  "most recent device", and the address is that device's — never a
+  coalesce across rows, which would report an address the subject is
+  no longer at.
+
+  #1308 — `ip` is where that session LOGGED IN FROM, not where its
+  newest request came from: `Session.touch_changeset/2` moves
+  `last_seen_at` alone, so a `:web` row keeps the address
+  `create_session/4` recorded for its whole life (a `:client` row is
+  the exception — `record_client_token_use/4` refreshes both). It is
+  per-SESSION all the same, which is what the operator asked for and
+  what `visitors.ip` — identity-wide, frozen at first sight — is not.
+
+  Both `Accounts.authenticate/1` (REST plug) and `UserSocket.connect/3`
+  (WS upgrade) bump `last_seen_at`, cadence-capped at 60 s — so the
+  timestamp is per-minute precision in practice, ISO8601 microseconds
+  on the wire only because the underlying column is
+  `:utc_datetime_usec`.
 
   Empty input → `%{}` (skip the round-trip).
   """
-  @spec max_last_seen_by_subject_ids(:user | :visitor, [Ecto.UUID.t()]) ::
-          %{Ecto.UUID.t() => DateTime.t()}
-  def max_last_seen_by_subject_ids(_, []), do: %{}
+  @spec newest_touch_by_subject_ids(:user | :visitor, [Ecto.UUID.t()]) ::
+          %{Ecto.UUID.t() => touch()}
+  def newest_touch_by_subject_ids(_, []), do: %{}
 
-  def max_last_seen_by_subject_ids(:user, ids) when is_list(ids) do
-    Session
-    |> where([s], s.user_id in ^ids)
-    |> group_by([s], s.user_id)
-    |> select([s], {s.user_id, max(s.last_seen_at)})
-    |> Repo.all()
-    |> Map.new()
-  end
+  def newest_touch_by_subject_ids(:user, ids) when is_list(ids),
+    do: newest_touch(:user_id, ids)
 
-  def max_last_seen_by_subject_ids(:visitor, ids) when is_list(ids) do
-    Session
-    |> where([s], s.visitor_id in ^ids)
-    |> group_by([s], s.visitor_id)
-    |> select([s], {s.visitor_id, max(s.last_seen_at)})
-    |> Repo.all()
-    |> Map.new()
+  def newest_touch_by_subject_ids(:visitor, ids) when is_list(ids),
+    do: newest_touch(:visitor_id, ids)
+
+  @doc """
+  Reads one subject out of a `newest_touch_by_subject_ids/2` map,
+  answering the "no cookie session on record" shape for an absent id
+  instead of a bare `nil` every call site would have to unwrap.
+  """
+  @spec touch_of(%{optional(Ecto.UUID.t()) => touch()}, Ecto.UUID.t()) :: touch()
+  def touch_of(touches, subject_id) when is_map(touches) and is_binary(subject_id),
+    do: Map.get(touches, subject_id, @no_touch)
+
+  @spec newest_touch(:user_id | :visitor_id, [Ecto.UUID.t()]) :: %{Ecto.UUID.t() => touch()}
+  defp newest_touch(column, ids) do
+    ranked =
+      from(s in Session,
+        where: field(s, ^column) in ^ids,
+        select: %{
+          subject_id: field(s, ^column),
+          last_seen_at: s.last_seen_at,
+          ip: s.ip,
+          rank: over(row_number(), partition_by: field(s, ^column), order_by: [desc: s.last_seen_at])
+        }
+      )
+
+    newest =
+      from(r in subquery(ranked),
+        where: r.rank == 1,
+        select: {r.subject_id, %{last_seen_at: r.last_seen_at, ip: r.ip}}
+      )
+
+    newest |> Repo.all() |> Map.new()
   end
 
   @doc """

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -91,6 +91,7 @@ defmodule Grappa.Networks.Credentials.AdminWire do
           inserted_at: DateTime.t(),
           updated_at: DateTime.t(),
           last_seen_at: DateTime.t() | nil,
+          session_ip: String.t() | nil,
           live_state: live_state_json() | nil
         }
 
@@ -132,12 +133,12 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   JSON shape. `live` is `nil` when no `Session.Server` is registered
   for `{:user, user_id} × network_id` — the U-0 honesty signal.
 
-  `last_seen_at` is the OWNING USER's newest browser-session touch
-  (`Grappa.Accounts.max_last_seen_by_subject_ids/2`). It is a property
-  of the subject, not of this network, so a user bound to three networks
-  reports the same value on all three rows — the same subject-wide grain
-  `GET /admin/sessions` already publishes. `nil` = no
-  `accounts_sessions` row on record.
+  `last_seen_at` and `session_ip` are the OWNING USER's newest browser
+  session (`Grappa.Accounts.newest_touch_by_subject_ids/2`). They are
+  properties of the subject, not of this network, so a user bound to
+  three networks reports the same values on all three rows — the same
+  subject-wide grain `GET /admin/sessions` already publishes. `nil` =
+  no `accounts_sessions` row on record.
 
   #1157 — see the twin note on `Grappa.Visitors.AdminWire`: the admin's
   unified session list is ROW-backed, so a parked credential (no pid, no
@@ -145,14 +146,32 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   operator a truthful last-seen instead of a `—` that reads "never
   used".
 
+  #1308 — `session_ip` is the address that session logged in from, and
+  it is the FIRST source address a user row has ever carried: before
+  this the console could show one only for a visitor, out of the
+  identity-wide `visitors.ip`, and there is no such column on the user
+  side to fall back to. Never to be confused with
+  `live_state.peer_address`, which is the upstream IRC endpoint the
+  bouncer's own socket landed on.
+
   Crashes loudly when `:network` association isn't preloaded — the
   wire carries `network_slug`, not `network_id` alone.
   """
-  @spec credential_to_admin_json(Credential.t(), SessionEntry.t() | nil, DateTime.t() | nil) ::
-          t()
-  def credential_to_admin_json(%Credential{network: %Network{slug: slug}} = c, live, last_seen_at) do
+  @spec credential_to_admin_json(
+          Credential.t(),
+          SessionEntry.t() | nil,
+          DateTime.t() | nil,
+          String.t() | nil
+        ) :: t()
+  def credential_to_admin_json(
+        %Credential{network: %Network{slug: slug}} = c,
+        live,
+        last_seen_at,
+        session_ip
+      ) do
     %{
       last_seen_at: last_seen_at,
+      session_ip: session_ip,
       user_id: c.user_id,
       network_id: c.network_id,
       network_slug: slug,

--- a/lib/grappa/visitors/admin_wire.ex
+++ b/lib/grappa/visitors/admin_wire.ex
@@ -66,6 +66,7 @@ defmodule Grappa.Visitors.AdminWire do
           expires_at: DateTime.t() | nil,
           identified: boolean(),
           ip: String.t() | nil,
+          session_ip: String.t() | nil,
           inserted_at: DateTime.t(),
           last_seen_at: DateTime.t() | nil,
           networks: [network_json()]
@@ -78,29 +79,41 @@ defmodule Grappa.Visitors.AdminWire do
   when no `Session.Server` is registered for `{:visitor, v.id} ×
   credential.network_id` — the U-0 honesty signal.
 
-  `last_seen_at` is the visitor's newest browser-session touch
-  (`Grappa.Accounts.max_last_seen_by_subject_ids/2`), identity-wide like
-  `expires_at` — it is a property of the subject, not of one network.
-  `nil` means no `accounts_sessions` row has ever been seen for it.
+  `last_seen_at` and `session_ip` both come from the visitor's newest
+  browser session (`Grappa.Accounts.newest_touch_by_subject_ids/2`),
+  identity-wide like `expires_at` — properties of the subject, not of
+  one network. `nil` on either means no `accounts_sessions` row has
+  ever been seen for it.
 
-  #1157 — the field is here because the admin's unified session list is
-  ROW-backed: it must show a last-seen for a parked or expired visitor,
-  which by construction has no registry entry and so never appears in
-  `GET /admin/sessions`, where this value used to live alone. A column
-  reading `—` for every inactive row would say "never used", which is
-  not what the server observed — it is what the server never asked.
+  #1157 — the fields are here because the admin's unified session list
+  is ROW-backed: it must show a last-seen for a parked or expired
+  visitor, which by construction has no registry entry and so never
+  appears in `GET /admin/sessions`, where this value used to live alone.
+  A column reading `—` for every inactive row would say "never used",
+  which is not what the server observed — it is what the server never
+  asked.
+
+  #1308 — `session_ip` is the address the newest session logged in
+  from. `ip` beside it is a DIFFERENT fact and stays: `visitors.ip` is
+  written once on the identity row, so it answers "where was this
+  visitor first seen", not "where is this session coming from". The
+  admin console renders the per-session one (vjt, 2026-08-14); the
+  identity-wide one keeps its place on the wire because the contract is
+  additive-only and other readers exist.
   """
   @spec visitor_to_admin_json(
           Visitor.t(),
           [{Credential.t(), SessionEntry.t() | nil}],
-          DateTime.t() | nil
+          DateTime.t() | nil,
+          String.t() | nil
         ) :: t()
-  def visitor_to_admin_json(%Visitor{} = v, per_network, last_seen_at)
+  def visitor_to_admin_json(%Visitor{} = v, per_network, last_seen_at, session_ip)
       when is_list(per_network) do
     %{
       id: v.id,
       expires_at: v.expires_at,
       last_seen_at: last_seen_at,
+      session_ip: session_ip,
       # #211 phase 7 — "identified/registered" is DERIVED from the
       # credentials (any network holds a committed NickServ secret), not a
       # `visitors.expires_at`-nil flag. The per_network list is already

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -66,21 +66,24 @@ defmodule GrappaWeb.Admin.CredentialsController do
     # yields N rows sharing one subject-wide last-seen, so resolve per
     # USER, not per row.
     user_ids = creds |> Enum.map(& &1.user_id) |> Enum.uniq()
-    last_seen = Accounts.max_last_seen_by_subject_ids(:user, user_ids)
+    touches = Accounts.newest_touch_by_subject_ids(:user, user_ids)
 
     rows =
       for cred <- creds do
         live = LiveIntrospection.lookup_session({:user, cred.user_id}, cred.network_id)
-        AdminWire.credential_to_admin_json(cred, live, Map.get(last_seen, cred.user_id))
+        touch = Accounts.touch_of(touches, cred.user_id)
+        AdminWire.credential_to_admin_json(cred, live, touch.last_seen_at, touch.ip)
       end
 
     json(conn, %{credentials: rows})
   end
 
   # Single-row twin of the batch above, for the create / update replies.
-  @spec user_last_seen(Ecto.UUID.t()) :: DateTime.t() | nil
-  defp user_last_seen(user_id) do
-    Map.get(Accounts.max_last_seen_by_subject_ids(:user, [user_id]), user_id)
+  @spec user_touch(Ecto.UUID.t()) :: Accounts.touch()
+  defp user_touch(user_id) do
+    :user
+    |> Accounts.newest_touch_by_subject_ids([user_id])
+    |> Accounts.touch_of(user_id)
   end
 
   @doc """
@@ -103,11 +106,12 @@ defmodule GrappaWeb.Admin.CredentialsController do
            Credentials.update_credential_with_session_lifecycle(user, network, attrs) do
       :ok = emit_credential_updated(user, network, action, conn)
       live = LiveIntrospection.lookup_session({:user, updated.user_id}, updated.network_id)
+      touch = user_touch(updated.user_id)
 
       json(
         conn,
         updated
-        |> AdminWire.credential_to_admin_json(live, user_last_seen(updated.user_id))
+        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip)
         |> AdminWire.with_session_action(action)
       )
     end
@@ -138,12 +142,13 @@ defmodule GrappaWeb.Admin.CredentialsController do
       :ok = emit_credential_bound(user, network, cred, conn)
       {cred, outcome} = connect_bound_credential(cred)
       live = LiveIntrospection.lookup_session({:user, cred.user_id}, cred.network_id)
+      touch = user_touch(cred.user_id)
 
       conn
       |> put_status(:created)
       |> json(
         cred
-        |> AdminWire.credential_to_admin_json(live, user_last_seen(cred.user_id))
+        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip)
         |> AdminWire.with_bind_outcome(outcome)
       )
     end

--- a/lib/grappa_web/controllers/admin/sessions_controller.ex
+++ b/lib/grappa_web/controllers/admin/sessions_controller.ex
@@ -93,13 +93,15 @@ defmodule GrappaWeb.Admin.SessionsController do
     entries = LiveIntrospection.list_sessions()
     {user_ids, visitor_ids} = partition_subject_ids(entries)
     labels = SubjectLabels.resolve(Enum.map(entries, & &1.subject))
-    # MAX(accounts_sessions.last_seen_at) per subject. Two batched
-    # queries (one per subject_kind, same shape as the labels lookup)
-    # so the controller's DB cost stays O(1) regardless of session
-    # count. Missing keys → `nil` on the wire, same U-0 honesty rule
-    # the label resolution uses.
-    user_last_seen = Accounts.max_last_seen_by_subject_ids(:user, user_ids)
-    visitor_last_seen = Accounts.max_last_seen_by_subject_ids(:visitor, visitor_ids)
+    # The newest cookie session per subject. Two batched queries (one
+    # per subject_kind, same shape as the labels lookup) so the
+    # controller's DB cost stays O(1) regardless of session count.
+    # Missing keys → `nil` on the wire, same U-0 honesty rule the label
+    # resolution uses. This wire takes the timestamp only: #1308 put the
+    # source address on the two ROW-backed listings, which are the ones
+    # the admin console builds its rows from.
+    user_touches = Accounts.newest_touch_by_subject_ids(:user, user_ids)
+    visitor_touches = Accounts.newest_touch_by_subject_ids(:visitor, visitor_ids)
     # #550 — resolve every connected session's upstream peer reverse-DNS in
     # ONE batched, lock-free PtrCache read. Out of band (a cold/expired
     # entry fires an async resolve so the NEXT scan is warm) — NEVER a
@@ -117,7 +119,7 @@ defmodule GrappaWeb.Admin.SessionsController do
         AdminWire.session_to_admin_json(
           entry,
           Map.get(labels, entry.subject),
-          resolve_last_seen(entry, user_last_seen, visitor_last_seen),
+          resolve_last_seen(entry, user_touches, visitor_touches),
           resolve_peer_name(entry, peer_names)
         )
       end)
@@ -141,11 +143,11 @@ defmodule GrappaWeb.Admin.SessionsController do
     end)
   end
 
-  defp resolve_last_seen(%{subject: {:user, id}}, user_last_seen, _),
-    do: Map.get(user_last_seen, id)
+  defp resolve_last_seen(%{subject: {:user, id}}, user_touches, _),
+    do: Accounts.touch_of(user_touches, id).last_seen_at
 
-  defp resolve_last_seen(%{subject: {:visitor, id}}, _, visitor_last_seen),
-    do: Map.get(visitor_last_seen, id)
+  defp resolve_last_seen(%{subject: {:visitor, id}}, _, visitor_touches),
+    do: Accounts.touch_of(visitor_touches, id).last_seen_at
 
   # #550 — the reverse-DNS name for this entry's upstream peer, or nil when
   # the session is not connected (no address to resolve) or the batched

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -72,11 +72,13 @@ defmodule GrappaWeb.Admin.VisitorsController do
     # `SessionsController.index/2` already uses. Resolved HERE rather
     # than inside the wire so the render stays a pure projection.
     visitor_ids = Enum.map(entries, fn {v, _} -> v.id end)
-    last_seen = Accounts.max_last_seen_by_subject_ids(:visitor, visitor_ids)
+    touches = Accounts.newest_touch_by_subject_ids(:visitor, visitor_ids)
 
     rows =
-      for {v, per_network} <- entries,
-          do: AdminWire.visitor_to_admin_json(v, per_network, Map.get(last_seen, v.id))
+      for {v, per_network} <- entries do
+        touch = Accounts.touch_of(touches, v.id)
+        AdminWire.visitor_to_admin_json(v, per_network, touch.last_seen_at, touch.ip)
+      end
 
     json(conn, %{visitors: rows})
   end

--- a/test/grappa/accounts_test.exs
+++ b/test/grappa/accounts_test.exs
@@ -1,6 +1,8 @@
 defmodule Grappa.AccountsTest do
   use Grappa.DataCase, async: true
 
+  import Grappa.AuthFixtures, only: [visitor_fixture: 1]
+
   alias Grappa.Accounts
   alias Grappa.Accounts.User
   alias Grappa.Repo.BusyRetry
@@ -561,6 +563,86 @@ defmodule Grappa.AccountsTest do
 
       assert ["srch-alice", "srch-bob", "srch-charlie"] ==
                Enum.map(Accounts.search_users("srch-", 10), & &1.name)
+    end
+  end
+
+  # #1308 — the admin console's source-address column. The contract that
+  # matters is the PAIRING: the address must come from the very row the
+  # timestamp came from, because a multi-device subject has several and
+  # the operator is being told where that subject is now.
+  describe "newest_touch_by_subject_ids/2" do
+    defp move_last_seen(%{id: id}, seconds_ago) do
+      when_seen = DateTime.add(DateTime.utc_now(), -seconds_ago, :second)
+      query = from(s in Grappa.Accounts.Session, where: s.id == ^id)
+      {1, _} = Repo.update_all(query, set: [last_seen_at: when_seen])
+      when_seen
+    end
+
+    test "returns the newest session's timestamp AND that session's address" do
+      {:ok, user} = Accounts.create_user(%{name: "touch-two-devices", password: @password})
+      {:ok, old} = Accounts.create_session({:user, user.id}, "198.51.100.7", "old-ua", [])
+      {:ok, new} = Accounts.create_session({:user, user.id}, "203.0.113.9", "new-ua", [])
+      _ = move_last_seen(old, 3600)
+      newest_at = move_last_seen(new, 60)
+
+      touches = Accounts.newest_touch_by_subject_ids(:user, [user.id])
+
+      # Both halves, or the test passes on a query that reads the address
+      # off an arbitrary row and the timestamp off the right one.
+      assert %{last_seen_at: at, ip: "203.0.113.9"} = Accounts.touch_of(touches, user.id)
+      assert DateTime.compare(at, newest_at) == :eq
+    end
+
+    test "reports the newest session's nil address rather than an older row's" do
+      {:ok, user} = Accounts.create_user(%{name: "touch-addressless", password: @password})
+      {:ok, old} = Accounts.create_session({:user, user.id}, "198.51.100.7", "ua", [])
+      {:ok, new} = Accounts.create_session({:user, user.id}, nil, nil, [])
+      _ = move_last_seen(old, 3600)
+      _ = move_last_seen(new, 60)
+
+      touches = Accounts.newest_touch_by_subject_ids(:user, [user.id])
+
+      # Coalescing to the older row would answer "the subject is at
+      # 198.51.100.7", which is a claim about an address they have not
+      # used since. Unknown is the honest answer.
+      assert %{ip: nil} = Accounts.touch_of(touches, user.id)
+    end
+
+    test "a visitor's sessions are keyed off visitor_id, not user_id" do
+      visitor = visitor_fixture(nick: "touch-visitor")
+      {:ok, _} = Accounts.create_session({:visitor, visitor.id}, "192.0.2.44", "ua", [])
+
+      assert %{ip: "192.0.2.44"} =
+               Accounts.touch_of(
+                 Accounts.newest_touch_by_subject_ids(:visitor, [visitor.id]),
+                 visitor.id
+               )
+    end
+
+    test "a subject with no session at all is absent from the map, and reads as unknown" do
+      {:ok, user} = Accounts.create_user(%{name: "touch-never", password: @password})
+
+      touches = Accounts.newest_touch_by_subject_ids(:user, [user.id])
+
+      refute Map.has_key?(touches, user.id)
+      assert Accounts.touch_of(touches, user.id) == %{last_seen_at: nil, ip: nil}
+    end
+
+    test "one query serves N subjects, each with its own newest address" do
+      {:ok, a} = Accounts.create_user(%{name: "touch-batch-a", password: @password})
+      {:ok, b} = Accounts.create_user(%{name: "touch-batch-b", password: @password})
+      {:ok, _} = Accounts.create_session({:user, a.id}, "198.51.100.1", "ua", [])
+      {:ok, _} = Accounts.create_session({:user, b.id}, "198.51.100.2", "ua", [])
+
+      touches = Accounts.newest_touch_by_subject_ids(:user, [a.id, b.id])
+
+      assert Accounts.touch_of(touches, a.id).ip == "198.51.100.1"
+      assert Accounts.touch_of(touches, b.id).ip == "198.51.100.2"
+    end
+
+    test "empty input skips the round-trip" do
+      assert Accounts.newest_touch_by_subject_ids(:user, []) == %{}
+      assert Accounts.newest_touch_by_subject_ids(:visitor, []) == %{}
     end
   end
 end

--- a/test/grappa/networks/credentials/admin_wire_test.exs
+++ b/test/grappa/networks/credentials/admin_wire_test.exs
@@ -37,7 +37,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
     }
   end
 
-  describe "credential_to_admin_json/3" do
+  describe "credential_to_admin_json/4" do
     test "projects operator-relevant fields + nil live_state when no session" do
       now = DateTime.utc_now()
       c = %{credential_fixture() | inserted_at: now, updated_at: now}
@@ -57,7 +57,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
                inserted_at: ^now,
                updated_at: ^now,
                live_state: nil
-             } = AdminWire.credential_to_admin_json(c, nil, nil)
+             } = AdminWire.credential_to_admin_json(c, nil, nil, nil)
     end
 
     test "projects live_state when a SessionEntry is supplied" do
@@ -92,7 +92,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
                  joined_channels: ["#bofh"],
                  introspection_degraded: []
                }
-             } = AdminWire.credential_to_admin_json(c, entry, nil)
+             } = AdminWire.credential_to_admin_json(c, entry, nil, nil)
 
       assert is_binary(pid_str)
       assert String.starts_with?(pid_str, "#PID<")
@@ -113,18 +113,35 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
       seen = DateTime.truncate(DateTime.utc_now(), :second)
 
       assert %{last_seen_at: ^seen, live_state: nil} =
-               AdminWire.credential_to_admin_json(credential_fixture(), nil, seen)
+               AdminWire.credential_to_admin_json(credential_fixture(), nil, seen, nil)
     end
 
     test "renders last_seen_at: nil when the user has never been seen" do
-      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil)
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
 
       assert Map.has_key?(json, :last_seen_at)
       assert json.last_seen_at == nil
     end
 
+    # #1308 — the first source address a user row has ever carried. Pinned
+    # on a row whose `live_state` is nil so the value cannot be mistaken
+    # for anything the registry supplied: `live_state.peer_address` is the
+    # UPSTREAM endpoint, and rendering that as the client's address would
+    # be a lie to the operator.
+    test "carries session_ip on a row with no live session" do
+      assert %{session_ip: "203.0.113.9", live_state: nil} =
+               AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, "203.0.113.9")
+    end
+
+    test "renders session_ip: nil when the user has never logged in" do
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
+
+      assert Map.has_key?(json, :session_ip)
+      assert json.session_ip == nil
+    end
+
     test "NEVER includes password_encrypted or password (credential material exclusion)" do
-      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil)
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
 
       refute Map.has_key?(json, :password)
       refute Map.has_key?(json, :password_encrypted)

--- a/test/grappa/visitors/admin_wire_test.exs
+++ b/test/grappa/visitors/admin_wire_test.exs
@@ -9,7 +9,7 @@ defmodule Grappa.Visitors.AdminWireTest do
   ## #211 phase 7 — multi-network shape
 
   A visitor is multi-network; per-network identity (nick) + connection
-  state live on the credential. So `visitor_to_admin_json/3` takes a
+  state live on the credential. So `visitor_to_admin_json/4` takes a
   `[{%Credential{}, live_state | nil}]` list and renders a `:networks`
   list — one entry per credential.
 
@@ -30,7 +30,7 @@ defmodule Grappa.Visitors.AdminWireTest do
   alias Grappa.Visitors
   alias Grappa.Visitors.{AdminWire, Visitor}
 
-  describe "visitor_to_admin_json/3" do
+  describe "visitor_to_admin_json/4" do
     test "includes operator-visible fields + per-network live_state and never password_encrypted" do
       network = network_fixture(slug: "azzurra-#{System.unique_integer([:positive])}")
 
@@ -55,7 +55,7 @@ defmodule Grappa.Visitors.AdminWireTest do
         introspection_degraded: []
       }
 
-      json = AdminWire.visitor_to_admin_json(v, [{cred, live}], nil)
+      json = AdminWire.visitor_to_admin_json(v, [{cred, live}], nil, nil)
 
       assert json.id == v.id
       assert json.ip == "10.0.0.5"
@@ -86,7 +86,7 @@ defmodule Grappa.Visitors.AdminWireTest do
       {:ok, v} = Visitors.find_or_provision_anon("solo", network.slug, "10.0.0.5")
       [cred] = Credentials.list_visitor_credentials(v.id)
 
-      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil)
+      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil, nil)
 
       assert [net] = json.networks
       assert net.live_state == nil
@@ -97,7 +97,7 @@ defmodule Grappa.Visitors.AdminWireTest do
       # A bare visitor row whose slug does not resolve → no credential.
       v = visitor_fixture(nick: "bare", network_slug: "no-such-network")
 
-      json = AdminWire.visitor_to_admin_json(v, [], nil)
+      json = AdminWire.visitor_to_admin_json(v, [], nil, nil)
 
       assert json.networks == []
     end
@@ -111,7 +111,7 @@ defmodule Grappa.Visitors.AdminWireTest do
       # holds a committed secret), so the credential list must be passed in.
       [cred] = Credentials.list_visitor_credentials(v.id)
 
-      json = AdminWire.visitor_to_admin_json(identified, [{cred, nil}], nil)
+      json = AdminWire.visitor_to_admin_json(identified, [{cred, nil}], nil, nil)
 
       assert json.identified == true
       refute Map.has_key?(json, :password_encrypted)
@@ -126,7 +126,7 @@ defmodule Grappa.Visitors.AdminWireTest do
       [cred] = Credentials.list_visitor_credentials(v.id)
       seen = DateTime.truncate(DateTime.utc_now(), :second)
 
-      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], seen)
+      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], seen, nil)
 
       assert json.last_seen_at == seen
       assert [%{live_state: nil}] = json.networks
@@ -137,10 +137,37 @@ defmodule Grappa.Visitors.AdminWireTest do
       {:ok, v} = Visitors.find_or_provision_anon("never", network.slug, "10.0.0.5")
       [cred] = Credentials.list_visitor_credentials(v.id)
 
-      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil)
+      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil, nil)
 
       assert Map.has_key?(json, :last_seen_at)
       assert json.last_seen_at == nil
+    end
+
+    # #1308 — the two addresses answer different questions and the wire
+    # must keep them apart. `ip` is the identity row's, written once when
+    # the visitor was first provisioned; `session_ip` is the newest cookie
+    # session's. Feed them DIFFERENT values, or a single-value fixture
+    # would pass with the two fields wired to the same source.
+    test "session_ip is the per-session address, distinct from the identity-wide ip" do
+      network = network_fixture(slug: "azzurra-#{System.unique_integer([:positive])}")
+      {:ok, v} = Visitors.find_or_provision_anon("roamer", network.slug, "10.0.0.5")
+      [cred] = Credentials.list_visitor_credentials(v.id)
+
+      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil, "203.0.113.9")
+
+      assert json.session_ip == "203.0.113.9"
+      assert json.ip == "10.0.0.5"
+    end
+
+    test "renders session_ip: nil when the newest session recorded no address" do
+      network = network_fixture(slug: "azzurra-#{System.unique_integer([:positive])}")
+      {:ok, v} = Visitors.find_or_provision_anon("addressless", network.slug, "10.0.0.5")
+      [cred] = Credentials.list_visitor_credentials(v.id)
+
+      json = AdminWire.visitor_to_admin_json(v, [{cred, nil}], nil, nil)
+
+      assert Map.has_key?(json, :session_ip)
+      assert json.session_ip == nil
     end
   end
 end

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -130,6 +130,42 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
       assert row["last_seen_at"] == nil
     end
 
+    # #1308 — a user row could not show a source address at all before
+    # this: the only one the console had was `visitors.ip`, and there is
+    # no user-side twin of that column. The address rides the SAME
+    # batched lookup as `last_seen_at`, so assert both, from the same
+    # session, or a query that pairs them wrongly still passes.
+    test "200 + session_ip from the user's newest browser session", %{conn: conn} do
+      {user, network, _} = bound_credential()
+      {:ok, _} = Accounts.create_session({:user, user.id}, "203.0.113.9", "ua", [])
+
+      session = admin_session()
+      conn = conn |> put_bearer(session.id) |> get("/admin/credentials")
+
+      row =
+        Enum.find(json_response(conn, 200)["credentials"], fn r ->
+          r["user_id"] == user.id and r["network_id"] == network.id
+        end)
+
+      assert row["session_ip"] == "203.0.113.9"
+      assert row["last_seen_at"] != nil
+    end
+
+    test "200 + session_ip: null for a user that never had a browser session", %{conn: conn} do
+      {user, network, _} = bound_credential()
+
+      session = admin_session()
+      conn = conn |> put_bearer(session.id) |> get("/admin/credentials")
+
+      row =
+        Enum.find(json_response(conn, 200)["credentials"], fn r ->
+          r["user_id"] == user.id and r["network_id"] == network.id
+        end)
+
+      assert Map.has_key?(row, "session_ip")
+      assert row["session_ip"] == nil
+    end
+
     test "200 + NEVER includes password_encrypted or password (defense-in-depth)", %{conn: conn} do
       _ = bound_credential()
 

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -260,6 +260,52 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
       assert Map.has_key?(row, "last_seen_at")
       assert row["last_seen_at"] == nil
     end
+
+    # #1308 — the visitor row already carried an address, and it answers a
+    # different question: `ip` is the identity row's, written once when
+    # the visitor was provisioned. `session_ip` is the newest browser
+    # session's. Provision from one address and log in from another, or
+    # the two fields are indistinguishable and the console cannot be shown
+    # to render the per-session one.
+    test "200 + session_ip from the newest session, beside the identity-wide ip", %{conn: conn} do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      {:ok, _} = Grappa.Networks.find_or_create_network(%{slug: slug})
+
+      visitor =
+        visitor_fixture(
+          network_slug: slug,
+          nick: "roamer-#{System.unique_integer([:positive])}",
+          ip: "10.0.0.5"
+        )
+
+      {:ok, _} = Accounts.create_session({:visitor, visitor.id}, "203.0.113.9", "ua", [])
+      session = admin_session()
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/visitors")
+      row = Enum.find(json_response(conn, 200)["visitors"], &(&1["id"] == visitor.id))
+
+      assert row["session_ip"] == "203.0.113.9"
+      assert row["ip"] == "10.0.0.5"
+    end
+
+    test "200 + session_ip: null for a visitor that never had a browser session", %{conn: conn} do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      {:ok, _} = Grappa.Networks.find_or_create_network(%{slug: slug})
+
+      visitor =
+        visitor_fixture(
+          network_slug: slug,
+          nick: "unseen-ip-#{System.unique_integer([:positive])}"
+        )
+
+      session = admin_session()
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/visitors")
+      row = Enum.find(json_response(conn, 200)["visitors"], &(&1["id"] == visitor.id))
+
+      assert Map.has_key?(row, "session_ip")
+      assert row["session_ip"] == nil
+    end
   end
 
   describe "POST /admin/visitors/:id/share-token — auth gate (#982)" do


### PR DESCRIPTION
The Sessions view lost the source address when #1157 merged Visitors into
it. What survived was one detail-panel fact, visitor-only, reading
`visitors.ip`: identity-wide, written once at provisioning, with no
user-side twin at all — so a user row showed no address anywhere.

vjt ruled it on 2026-08-14: the fact is `accounts_sessions.ip`, the
per-session one, it stays in the card, and the table grows no column
(`visitors.ip` may be dropped later; reworking the layout comes later).
The sorting half of #1308 shipped separately as #1309 and is untouched
here.

## What changed

- `Accounts.max_last_seen_by_subject_ids/2` becomes
  `newest_touch_by_subject_ids/2`, returning `%{id => %{last_seen_at:, ip:}}`.
  It picks a ROW with `row_number() OVER (PARTITION BY subject ORDER BY
  last_seen_at DESC)` filtered to rank 1, rather than `MAX()` beside bare
  columns — that shape happens to work on SQLite but is a dialect quirk,
  not a contract. Still one batched query per subject kind.
- `session_ip` is additive and snake_case on `GET /admin/visitors` and
  `GET /admin/credentials`. `/admin/sessions` keeps taking only the
  timestamp. `visitors.ip` STAYS on the wire — it answers a different
  question and the contract is additive-only. No migration, no column
  removed.
- cic renders `ip` unconditionally on every session card, directly above
  `upstream`, `null` on orphan-pid and log-only rows. `row.visitor.ip` is
  no longer read by the renderer.

## The trap, recorded so the next reader does not fall in it

`live_state.peer_address` / `peer_port` / `peer_name` is the IRC upstream
DESTINATION — the server the bouncer dialled OUT to — not where the
client came from. The card carries both, adjacent and labelled, because
the pair is only readable together.

`session_ip` is a LOGIN address, not the last-touch one:
`Session.touch_changeset/2` moves only `last_seen_at`. (The `:client`
rows of #1196 are the exception — `record_client_token_use/4` refreshes
both.) It is documented that way everywhere and claimed no stronger.

## Verification

- `scripts/check.sh` RC=0 — 8 doctests, 59 properties, 6114 tests, 0
  failures; Dialyzer passed; Credo 5783 mods/funs, no issues; wireTypes
  AND wireSchema in sync.
- `scripts/bun.sh run check` RC=0 · `scripts/bun.sh run test` RC=0
  (283 files / 5428 tests).
- Red before green, measured: 6 cic mutants + 3 server mutants, all
  killed, baseline and restore both green.
- e2e paired red→green with the identical command, only the source
  differing. The mutant moves the `ip` fact back inside the visitor-only
  block; the run dies at `issue1308-admin-session-ip.spec.ts:91`,
  `a user row must carry a source address fact at all`, `Received: null`
  — the pre-registered verdict. Restored: `1 passed (11.7s)`, RC=0.

### Gap in the local ship gate — reasoning, not measurement

The full `scripts/integration.sh` ran on this branch based on
`15c55546`: **741 passed, 1 failed, 28.3m**. The single failure is
`p0b-peer-away.spec.ts:30`, at the 5000 ms `peer-away-banner` wait on
line 62 — the exact line `2d8ca6d1` (#1307) raises to 10 s on main,
because bahamut's fake-lag ceiling makes that banner arrive on a
one-second lattice. It is a known flake already cured upstream, not a
regression from this branch, and it is reported rather than hidden.

The branch has since been rebased onto `860d7daa`, so the suite result
above does NOT cover two deltas: #1307's own p0b spec change, and
#1311's `scripts/bun.sh` + `test/scripts/bun_self_heal_test.bats` +
docs. Neither is touched by this branch and both are gated on main —
but that is REASONING about the delta, not a measurement of this tip.
CI on this PR gates the real tip.

Rebase was checked two-sided: the branch's contribution numstat is
identical before and after (add=794 del=96, per-file unchanged), the
DESIGN_NOTES boundary shape reads text / marker / blank / `---` / blank
/ heading on the real file, the `<!-- entry #1308-ip -->` marker is
unique file-wide (distinct from #1309's `<!-- entry #1308 -->`), and
`scripts/design-notes-gate.sh` is RC=0.