### PR TITLE
#378: web push for /notify presence transitions

### DIFF
--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1740,6 +1740,38 @@ const SettingsDrawer: Component<Props> = (props) => {
                 />
               </label>
 
+              {/* #378 — the /notify watch list curates WHO; these two gate
+                  whether a transition also becomes an OS notification. The
+                  labels say "push" on purpose: unlike every other checkbox
+                  here, these gate ONLY push — the in-app toast fires either
+                  way — so "watched nick comes online" would read as "notify
+                  me at all". */}
+              <h3>watched nicks</h3>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={prefs().presence_online}
+                  disabled={savingPrefs()}
+                  onChange={(e) =>
+                    togglePref("presence_online", (e.currentTarget as HTMLInputElement).checked)
+                  }
+                  data-testid="pref-presence-online"
+                />
+                push when a watched nick comes online
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={prefs().presence_offline}
+                  disabled={savingPrefs()}
+                  onChange={(e) =>
+                    togglePref("presence_offline", (e.currentTarget as HTMLInputElement).checked)
+                  }
+                  data-testid="pref-presence-offline"
+                />
+                push when a watched nick goes offline
+              </label>
+
               <h3>muted conversations</h3>
               <p class="prefs-hint">
                 A muted conversation never notifies — not even when someone says your nick. A mute

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -436,7 +436,7 @@ describe("SettingsDrawer display options section (#443)", () => {
 });
 
 describe("SettingsDrawer notifications section", () => {
-  it("renders the master toggle + 4 prefs checkboxes + 2 whitelist inputs", () => {
+  it("renders the master toggle + 5 prefs checkboxes + 2 whitelist inputs", () => {
     wrap(true);
     openSub("push-settings-entry");
     expect(screen.getByTestId("push-master-toggle")).toBeInTheDocument();
@@ -445,6 +445,37 @@ describe("SettingsDrawer notifications section", () => {
     expect(screen.getByTestId("pref-private-all")).toBeInTheDocument();
     expect(screen.getByTestId("pref-channels-only")).toBeInTheDocument();
     expect(screen.getByTestId("pref-nicks-only")).toBeInTheDocument();
+    // #378 — the two /notify presence gates.
+    expect(screen.getByTestId("pref-presence-online")).toBeInTheDocument();
+    expect(screen.getByTestId("pref-presence-offline")).toBeInTheDocument();
+  });
+
+  it("toggling a presence pref PUTs the whole map with that field flipped (#378)", async () => {
+    const userSettings = await import("../lib/userSettings");
+    wrap(true);
+    openSub("push-settings-entry");
+    await waitFor(() => {
+      expect(userSettings.getNotificationPrefs).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId("pref-presence-online"));
+
+    await waitFor(() => {
+      expect(userSettings.putNotificationPrefs).toHaveBeenCalled();
+    });
+
+    const body = (userSettings.putNotificationPrefs as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+
+    // The save path is a FULL PUT, and the server's `cast_bools` requires
+    // every boolean present — so the flipped field is not enough, the other
+    // six have to ride along or the save 422s.
+    expect(body[1]).toEqual({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      presence_online: true,
+    });
   });
 
   it("loads prefs on mount via getNotificationPrefs", async () => {

--- a/cicchetto/src/__tests__/pushPayload.test.ts
+++ b/cicchetto/src/__tests__/pushPayload.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import presencePayloads from "../lib/presencePushPayloads.json";
 import { narrowPushPayload, parsePushTargetUrl } from "../lib/pushPayload";
 
 // Push notifications cluster B2 (2026-05-14) — pushPayload helpers.
@@ -143,5 +144,49 @@ describe("parsePushTargetUrl", () => {
 
   it("returns null on malformed URL", () => {
     expect(parsePushTargetUrl("not a url at all")).toBeNull();
+  });
+});
+
+// #378 — /notify presence push, cross-language drift gate.
+//
+// The payload contract between `Grappa.Push.Payload` and this module is
+// hand-synced: there is no codegen gate over it the way `scripts/check.sh`
+// has one for `wireTypes.ts`. A payload literal COPIED into this file would
+// not be a tripwire — change `build_presence/3` and the copy does not move.
+//
+// So both ports read ONE fixture: the ExUnit
+// `Grappa.Push.PresencePayloadParityTest` asserts the server EMITS these
+// exact bytes, and the cases below assert the SW ACCEPTS them and resolves
+// the deep link. Change either side and the fixture has to move, which
+// drags the other side's assertion with it. Same technique as
+// `shouldNotifyTruthTable.json`.
+describe("presence push payloads — shared-fixture parity with build_presence/3", () => {
+  type PresenceCase = {
+    name: string;
+    nick: string;
+    presence: "online" | "offline";
+    network_slug: string;
+    payload: { title: string; body: string; tag: string; url: string };
+    target: { networkSlug: string; channelName: string; kind: "channel" | "query" };
+  };
+
+  const cases = presencePayloads as PresenceCase[];
+
+  it("the shared fixture is non-empty (guards an accidental empty array)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(cases)("$name — the SW narrower accepts it verbatim", (c) => {
+    expect(narrowPushPayload(c.payload)).toEqual(c.payload);
+  });
+
+  it.each(cases)("$name — no badge is stamped on a presence transition", (c) => {
+    // A presence transition creates no unread message, so the server omits
+    // `badge` and the SW must leave the home-screen icon untouched.
+    expect(narrowPushPayload(c.payload)).not.toHaveProperty("badge");
+  });
+
+  it.each(cases)("$name — notificationclick lands on the watched nick's query", (c) => {
+    expect(parsePushTargetUrl(c.payload.url)).toEqual(c.target);
   });
 });

--- a/cicchetto/src/__tests__/pushTriggers.test.ts
+++ b/cicchetto/src/__tests__/pushTriggers.test.ts
@@ -16,7 +16,15 @@ type TruthCase = {
   message: ShouldNotifyMessage;
   network_slug: string;
   own_nick: string;
-  prefs: NotificationPrefs;
+  // #378 added two presence booleans to `NotificationPrefs`. They are NOT in
+  // the shared fixture and must not be: this table drives the MESSAGE
+  // predicate, which never reads them, and the ExUnit twin likewise builds
+  // its prefs map from the fixture's keys alone. Filling 30+ rows with two
+  // irrelevant booleans would say they matter here. They are supplied at the
+  // call site instead — and ONLY they, never the other defaults: a case that
+  // omits `private_messages_all` means it, and spreading defaults over it
+  // would silently rewrite the case.
+  prefs: Omit<NotificationPrefs, "presence_online" | "presence_offline">;
   patterns: string[];
   expected: boolean;
 };
@@ -34,7 +42,9 @@ describe("shouldNotify — shared truth-table parity with should_notify?/5", () 
       // fixture carries cases that differ ONLY in the slug, and a hardcoded
       // one here would make them indistinguishable on this port while the
       // ExUnit side still told them apart.
-      expect(shouldNotify(c.message, c.network_slug, c.own_nick, c.prefs, c.patterns)).toBe(
+      const prefs = { presence_online: false, presence_offline: false, ...c.prefs };
+
+      expect(shouldNotify(c.message, c.network_slug, c.own_nick, prefs, c.patterns)).toBe(
         c.expected,
       );
     });

--- a/cicchetto/src/__tests__/userSettings.test.ts
+++ b/cicchetto/src/__tests__/userSettings.test.ts
@@ -25,6 +25,8 @@ const sample = {
   channel_mentions: true,
   private_messages_all: true,
   private_messages_only: [],
+  presence_online: false,
+  presence_offline: false,
 };
 
 beforeEach(() => {
@@ -45,6 +47,12 @@ describe("DEFAULT_NOTIFICATION_PREFS", () => {
       channel_mentions: true,
       private_messages_all: true,
       private_messages_only: [],
+      // #378 — presence push is opt-IN in both directions. Mirrors the
+      // server's `default_notification_prefs/0`: a subject who never opened
+      // Settings gets no lockscreen banner when a watched nick flips, only
+      // the in-app toast (which these prefs do not gate).
+      presence_online: false,
+      presence_offline: false,
       // #866 — nothing muted by default. This map must stay byte-identical to
       // the server's `UserSettings.default_notification_prefs/0`: it is what
       // an un-hydrated client decides beeps with, so a divergence here means

--- a/cicchetto/src/lib/presencePushPayloads.json
+++ b/cicchetto/src/lib/presencePushPayloads.json
@@ -1,0 +1,67 @@
+[
+  {
+    "name": "a watched nick comes online",
+    "nick": "alice",
+    "presence": "online",
+    "network_slug": "azzurra",
+    "payload": {
+      "title": "alice is online",
+      "body": "on azzurra",
+      "tag": "azzurra:presence:alice",
+      "url": "/?network=azzurra&channel=alice"
+    },
+    "target": { "networkSlug": "azzurra", "channelName": "alice", "kind": "query" }
+  },
+  {
+    "name": "a watched nick goes offline",
+    "nick": "alice",
+    "presence": "offline",
+    "network_slug": "azzurra",
+    "payload": {
+      "title": "alice went offline",
+      "body": "on azzurra",
+      "tag": "azzurra:presence:alice",
+      "url": "/?network=azzurra&channel=alice"
+    },
+    "target": { "networkSlug": "azzurra", "channelName": "alice", "kind": "query" }
+  },
+  {
+    "name": "the tag folds the nick while title and url keep it raw",
+    "nick": "Alice",
+    "presence": "online",
+    "network_slug": "libera",
+    "payload": {
+      "title": "Alice is online",
+      "body": "on libera",
+      "tag": "libera:presence:alice",
+      "url": "/?network=libera&channel=Alice"
+    },
+    "target": { "networkSlug": "libera", "channelName": "Alice", "kind": "query" }
+  },
+  {
+    "name": "brackets survive the fold and percent-encode in the url",
+    "nick": "Al[i]ce",
+    "presence": "online",
+    "network_slug": "libera",
+    "payload": {
+      "title": "Al[i]ce is online",
+      "body": "on libera",
+      "tag": "libera:presence:al[i]ce",
+      "url": "/?network=libera&channel=Al%5Bi%5Dce"
+    },
+    "target": { "networkSlug": "libera", "channelName": "Al[i]ce", "kind": "query" }
+  },
+  {
+    "name": "a non-ASCII nick round-trips through the url",
+    "nick": "Renée",
+    "presence": "offline",
+    "network_slug": "azzurra",
+    "payload": {
+      "title": "Renée went offline",
+      "body": "on azzurra",
+      "tag": "azzurra:presence:renée",
+      "url": "/?network=azzurra&channel=Ren%C3%A9e"
+    },
+    "target": { "networkSlug": "azzurra", "channelName": "Renée", "kind": "query" }
+  }
+]

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -39,6 +39,13 @@ export type NotificationPrefs = {
   channel_mentions: boolean;
   private_messages_all: boolean;
   private_messages_only: string[];
+  // #378 — the two `/notify` presence gates. They gate PUSH only: the in-app
+  // presence toast fires regardless, on `initial: false` alone. Required (not
+  // optional like `muted_targets`) because the server's `cast_bools` requires
+  // every boolean present in a PUT — the full-PUT save path below has to
+  // carry them or the save 422s.
+  presence_online: boolean;
+  presence_offline: boolean;
   // Optional because cic ships independently of the server (#618): a bundle
   // newer than the BEAM it talks to must tolerate the field being absent
   // rather than crash the predicate on every arriving message. Present in
@@ -56,6 +63,8 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   channel_mentions: true,
   private_messages_all: true,
   private_messages_only: [],
+  presence_online: false,
+  presence_offline: false,
   muted_targets: {},
 };
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42091,3 +42091,116 @@ still say what it is". If two id spaces would share one signed
 namespace, tag the payload AND move the salt in the same change — the
 tag makes the new tokens readable, and only the salt bump makes the old
 ones unreadable.
+<!-- entry #378 -->
+
+---
+
+## 2026-08-14 — #378: `/notify` presence transitions push, and only transitions
+
+`/notify` (#247) already classified every MONITOR/WATCH report as a
+baseline or a genuine flip, and cic already toasted the flips. The toast
+only exists while a client is attached, so the OS-level push had to
+originate where the classification happens — `Session.Server`'s
+`presence_changed` effect arm, next to the broadcast that was already
+there. One effect, two consumers: the wire event feeds the attached
+clients, `Push.Triggers.dispatch_presence/4` feeds the closed ones.
+
+**The `:initial` gate sits in the function head, before the Task spawn.**
+Not an optimisation detail — it is the difference between a connect
+spawning zero Tasks and spawning one per watched nick. Every baseline
+shape folds into that one gate: the MONITOR/WATCH arm burst at
+end-of-MOTD, a bulk `/notify add` (`track/2` seeds `:unknown`), the 421
+fallback re-arm, and every reconnect re-seed. The cost is the delivery
+guarantee, and it is worth stating plainly rather than overselling: the
+presence map dies with the process, so anything that happens while grappa
+is reconnecting re-seeds as a baseline and is never pushed. The promise is
+"only while the session stayed continuously connected". Fixing that needs
+a restart-surviving map (the `Session.Backoff` ETS-above-the-supervisor
+pattern); out of scope here.
+
+**Both prefs default OFF.** The first design defaulted `presence_online`
+on, as an "intended opt-out rollout". It cannot be one: at `read_bool/3` a
+map written by someone who deliberately configured push is
+byte-indistinguishable from a never-configured one, so a default-on key
+overrides an explicitly-expressed preference on the deploy that ships it.
+Default-off makes the two new checkboxes the opt-in and deletes the
+problem for zero code.
+
+**The two prefs are NOT in `@prefs_trigger_keys`, and the two attributes
+now diverge for the first time.** `ensure_at_least_one_trigger/2` exists
+to reject a prefs map that silently mutes all MESSAGE push. Counting
+presence there would let a user uncheck every message trigger and pass
+validation on the strength of `presence_online` alone — exactly the state
+the guard prevents. Accepted consequence: a presence-only-push
+configuration is unrepresentable, ≥1 message trigger must stay on. Both
+attributes carry a why-comment now, because the next reader sees two
+identical-looking lists and one of them is load-bearing.
+
+**A boolean added to `@prefs_bool_keys` is REQUIRED in a PUT**, so a cic
+bundle older than this change 422s until it reloads. Accepted: server and
+bundle ship together, the window is already-open tabs. The tempting fix —
+make the two new booleans absence-tolerant like `muted_targets` (#866) —
+was rejected: `muted_targets` is exempt because a client that has never
+heard of it is saying nothing about mutes it cannot reconstruct, whereas a
+boolean map with two classes of boolean is the half-migrated shape
+CLAUDE.md forbids. Reverse skew (new cic, old BEAM) is silently lossy —
+the old server drops the unknown keys without error. Stated, not fixed.
+
+**The tag carries a `presence:` infix.** `Payload.build/3` writes
+`"<slug>:<channel_or_dm_peer>"`, so a bare-nick presence tag would EQUAL
+the DM tag for that nick, and the OS would coalesce alice's DM banner with
+alice's presence banner — each silently overwriting the other. `:` is
+excluded from both `nickname` and `chanstring` in RFC 2812, which is what
+makes the infix a proof rather than a convention; the guard is a
+StreamData property over both grammars, not one example. The nick folds in
+the tag and only there, so flaps of the same nick coalesce into one
+banner while the title and the deep link keep the display case.
+
+**Badge omitted, deliberately.** `BadgeSource.count/1` counts unread
+MESSAGES; a presence flip creates none. Stamping the current count would
+attach a stale, causally-unrelated number and cost a DB read per
+transition — and absent `badge` is already defined as "leave the icon
+alone". It also keeps `build_presence/3` a pure function of three
+arguments.
+
+**A rename is not a transition — the false half of it, anyway.** A watched
+peer renaming vacates its nick, and the ircd reports that as a genuine
+offline flip: "alice went offline" about someone who is still here. #247
+could live with that for a status dot; a lockscreen banner is an identity
+assertion. The `{:peer_nick_renamed, _, _}` arm now demotes the entry to
+`:unknown` (`Presence.reset/2`), so the vacancy report classifies
+`:initial` and stays silent.
+
+The design also claimed this buys the other half — that a DIFFERENT human
+taking the freed nick would stay silent too. **Measured: it does not, and
+one demotion cannot buy it.** The vacancy report CONSUMES the `:unknown`
+and re-baselines the entry to `:offline`, so the next online report for
+that nick is a genuine transition and pushes. Chasing it means a second
+"vacated" state living beside the presence map — parallel state needing
+housekeeping, for a case #247 already ruled on: the watch list watches
+NICKS, not people. Left as behaviour, with a test that pins it so it is a
+decision on the record rather than a field surprise. Bounded further by
+IRC itself: a NICK reaches us only from channel-sharing peers.
+`notify_entries` stays outside the #373 rename-migration set, per #247 —
+the watch entry does not follow the rename.
+
+**No debounce, and the real bound named.** N transitions in one numeric
+produce N pushes; the per-nick tag coalesces repeat flaps of the SAME nick
+and does not bound a burst. What bounds it is the 64-entry watch cap per
+(subject, network), both prefs defaulting off, and the fact that our own
+reconnect produces baselines rather than a burst. A per-nick timer is
+parallel state needing housekeeping — heavier than the residual problem.
+
+**Drift gate: one shared fixture, not a copied literal.** The payload
+contract to `pushPayload.ts` is hand-synced with no codegen gate. A
+payload literal copied into a vitest file is not a tripwire — change the
+builder and the copy does not move. So `presencePushPayloads.json` is read
+by both ports, the technique `shouldNotifyTruthTable.json` established:
+ExUnit asserts the server EMITS those bytes, vitest asserts the SW ACCEPTS
+them and that `parsePushTargetUrl` lands on the watched nick's query
+window.
+
+**Apply:** when a second event class reuses a delivery pipeline, the
+question is not "can it reuse the payload builder" but "which 20% does not
+fit". Here it was three things — no row, no badge, and a dedup key that
+would have collided with the first class's.

--- a/lib/grappa/push/payload.ex
+++ b/lib/grappa/push/payload.ex
@@ -22,6 +22,15 @@ defmodule Grappa.Push.Payload do
       body = message body verbatim. Reader sees both who spoke and
       where in one glance.
 
+  ## Presence transitions (#378)
+
+  `build_presence/3` is the sibling constructor for a `/notify` presence
+  flip. It returns the same `t()` and needs no service-worker change, but
+  it is a SEPARATE function rather than a clause of `build/3`: that one is
+  hard-wired to a `%Scrollback.Message{}`, and a presence transition has no
+  row, no sender and no body. It is also PURE in all three arguments — no
+  `subject`, no badge count, no DB (see the badge note below).
+
   ## Tag — OS-level dedup key
 
   Format: `"<network_slug>:<channel_or_dm_peer>"`. Browsers + mobile
@@ -112,6 +121,53 @@ defmodule Grappa.Push.Payload do
       url: build_url(network_slug, deep_link_target)
     }
   end
+
+  @doc """
+  Builds a notification payload for a `/notify` presence transition (#378).
+
+  Pure function of its three arguments — deliberately no `subject` and no
+  badge stamp: `Push.BadgeSource.count/1` counts unread MESSAGES, and a
+  presence flip creates none, so stamping the current count would attach a
+  stale, causally-unrelated number and cost a DB read per transition. An
+  absent `badge` leaves the home-screen icon untouched, which is exactly
+  right here.
+
+  ## Copy
+
+  `"<nick> is online"` / `"<nick> went offline"`, body `"on <slug>"`. The
+  verbs are the ones cic's in-app toast already renders for the SAME event
+  (`Toasts.tsx`) — one event, one spelling. The network rides in the body
+  because a watch list spanning two networks otherwise produces two
+  identical-looking banners.
+
+  ## Tag
+
+  `"<network_slug>:presence:<folded_nick>"`. The `presence:` infix is
+  load-bearing, not decoration: `build/3` writes
+  `"<slug>:<channel_or_dm_peer>"`, so a BARE-nick presence tag would equal
+  the DM tag for that same nick and the OS would coalesce alice's DM banner
+  with alice's presence banner, each overwriting the other. `:` is excluded
+  from both `nickname` and `chanstring` in RFC 2812, so no legal message
+  tag can ever collide with this one.
+
+  The nick FOLDS in the tag (and only there): flaps of `Alice` and `alice`
+  coalesce under one banner, and an online banner replaces the stale
+  offline one for the same nick — free OS-level flap coalescing. The title
+  and the deep link keep the nick RAW, per the key/display split.
+  """
+  @spec build_presence(nick :: String.t(), :online | :offline, network_slug :: String.t()) :: t()
+  def build_presence(nick, presence, network_slug)
+      when is_binary(nick) and presence in [:online, :offline] and is_binary(network_slug) do
+    %{
+      title: "#{nick} #{presence_verb(presence)}",
+      body: "on #{network_slug}",
+      tag: "#{network_slug}:presence:#{Grappa.IRC.Identifier.canonical_target(nick)}",
+      url: build_url(network_slug, nick)
+    }
+  end
+
+  defp presence_verb(:online), do: "is online"
+  defp presence_verb(:offline), do: "went offline"
 
   @doc """
   Stamps the PWA icon-badge count onto a built payload (door #1,

--- a/lib/grappa/push/payload.ex
+++ b/lib/grappa/push/payload.ex
@@ -64,6 +64,7 @@ defmodule Grappa.Push.Payload do
   trivial to test.
   """
 
+  alias Grappa.IRC.Identifier
   alias Grappa.Scrollback.Message
 
   @typedoc """
@@ -101,8 +102,8 @@ defmodule Grappa.Push.Payload do
       when is_binary(network_slug) and is_binary(own_nick) do
     dm? =
       is_binary(message.channel) and
-        Grappa.IRC.Identifier.canonical_target(message.channel) ==
-          Grappa.IRC.Identifier.canonical_target(own_nick)
+        Identifier.canonical_target(message.channel) ==
+          Identifier.canonical_target(own_nick)
 
     sender = message.sender || ""
     body = message.body || ""
@@ -161,7 +162,7 @@ defmodule Grappa.Push.Payload do
     %{
       title: "#{nick} #{presence_verb(presence)}",
       body: "on #{network_slug}",
-      tag: "#{network_slug}:presence:#{Grappa.IRC.Identifier.canonical_target(nick)}",
+      tag: "#{network_slug}:presence:#{Identifier.canonical_target(nick)}",
       url: build_url(network_slug, nick)
     }
   end

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -257,7 +257,7 @@ defmodule Grappa.Push.Triggers do
     :ok
   end
 
-  def dispatch_presence(_nick, _presence, :initial, _ctx), do: :ok
+  def dispatch_presence(_, _, :initial, _), do: :ok
 
   # ---------------------------------------------------------------------------
   # Public — pure predicate (testable in isolation)

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -6,11 +6,16 @@ defmodule Grappa.Push.Triggers do
 
   ## Where this fits
 
-  `Grappa.Session.Server`'s `apply_effects/2` `:persist` arm calls
-  `evaluate_and_dispatch/2` immediately after a successful
-  `Scrollback.persist_event/1` for a `:privmsg` or `:action` row. The
-  call is fire-and-forget — Triggers spawns an unlinked `Task` so the
-  hot path stays sub-millisecond and Sender failures don't bleed into
+  `Grappa.Session.Persistor` calls `evaluate_and_dispatch/2` immediately
+  after a successful `Scrollback.persist_event/1` for a `:privmsg` or
+  `:action` row — it owns the post-persist obligations (#369 A3), which is
+  why the call moved off `Session.Server`'s `apply_effects/2` `:persist`
+  arm. `dispatch_presence/4` is the one Push entry point `Session.Server`
+  still calls directly: a presence transition persists no row, so there is
+  nothing for `Persistor` to be the guardian of.
+
+  Both calls are fire-and-forget — Triggers spawns an unlinked `Task` so
+  the hot path stays sub-millisecond and Sender failures don't bleed into
   the mailbox.
 
   ## Decision logic — `should_notify?/5`
@@ -66,6 +71,20 @@ defmodule Grappa.Push.Triggers do
   All other kinds (`:join`, `:part`, `:quit`, `:nick_change`,
   `:mode`, `:topic`, `:kick`, `:server_event`) are presence /
   control plane and do not push.
+
+  ## The second trigger class — `/notify` presence (#378)
+
+  Scrollback KINDS still never push, as above. What does push is a
+  `/notify` presence TRANSITION, via `dispatch_presence/4` — a different
+  event on a different path (`Session.Server`'s `presence_changed` effect
+  arm, no `%Message{}` involved), gated by its own two prefs
+  `presence_online` / `presence_offline`, both default OFF. Baselines
+  (`:initial`) never push, whatever the prefs: adding a watch list or
+  reconnecting must not fire a notification storm.
+
+  The two classes are deliberately orthogonal — the watch list curates
+  WHO, the prefs gate push-vs-toast-only globally, and neither pref is a
+  member of `UserSettings`' at-least-one-trigger set (see there for why).
 
   #395 — the kind gate reads `Message.notify_kinds/0` (a subset of
   `Message.content_kinds/0`, derived from ONE projection declaration) via
@@ -130,6 +149,17 @@ defmodule Grappa.Push.Triggers do
   """
   @type prefs :: UserSettings.notification_prefs()
 
+  @typedoc """
+  Classification of one `/notify` presence report — the closed pair
+  `t:Grappa.Session.Presence.change_kind/0` carries.
+
+  DUPLICATED rather than referenced on purpose: `Presence` is not a
+  `Grappa.Session` export, and `Grappa.Push` cannot dep `Grappa.Session`
+  anyway because `Grappa.Session` already deps `Grappa.Push` — that is a
+  Boundary cycle. Two atoms are cheaper than either alternative.
+  """
+  @type presence_kind :: :initial | :transition
+
   # ---------------------------------------------------------------------------
   # Public — call from Session.Server
   # ---------------------------------------------------------------------------
@@ -189,6 +219,46 @@ defmodule Grappa.Push.Triggers do
 
   def evaluate_and_dispatch(%Message{}, _), do: :ok
 
+  @doc """
+  Dispatches the Web Push for one `/notify` presence report (#378).
+
+  Same fire-and-forget shape as `evaluate_and_dispatch/2`: unlinked `Task`,
+  always `:ok`, no `try/rescue` (the no-silent-drops contract above).
+
+  A baseline (`:initial`) short-circuits in the FUNCTION HEAD, before the
+  Task spawn — that is the whole point of splitting the clause rather than
+  branching inside: a MONITOR/WATCH baseline burst on connect, a bulk
+  `/notify add`, and every reconnect re-arm are the high-volume shapes, and
+  they must spawn ZERO Tasks, not N no-op ones.
+
+  There is deliberately NO catch-all clause. `change_kind()` is a closed
+  pair, so a third kind must crash `Session.Server` rather than be dropped
+  in silence.
+  """
+  @spec dispatch_presence(String.t(), :online | :offline, presence_kind(), ctx()) :: :ok
+  def dispatch_presence(nick, presence, :transition, ctx)
+      when is_binary(nick) and presence in [:online, :offline] and is_map(ctx) do
+    %{subject: subject, subject_label: subject_label, network_slug: network_slug} = ctx
+
+    {:ok, _} =
+      Task.start(fn ->
+        prefs = UserSettings.get_notification_prefs(subject)
+
+        # #182 — the same foreground-suppression gate as the message path,
+        # and for the same reason it is a SEPARATE step: the pure predicate
+        # stays free of IO. If ANY device has the PWA on-screen, the in-app
+        # presence toast IS the notification and the push is skipped.
+        if should_notify_presence?(presence, prefs) and
+             not WSPresence.any_visible?(subject_label) do
+          Push.Sender.send_to_subject(subject, Payload.build_presence(nick, presence, network_slug))
+        end
+      end)
+
+    :ok
+  end
+
+  def dispatch_presence(_nick, _presence, :initial, _ctx), do: :ok
+
   # ---------------------------------------------------------------------------
   # Public — pure predicate (testable in isolation)
   # ---------------------------------------------------------------------------
@@ -246,6 +316,23 @@ defmodule Grappa.Push.Triggers do
       true -> channel_match?(message, prefs, own_nick, patterns)
     end
   end
+
+  @doc """
+  Returns `true` when a presence transition in `presence` should push,
+  given `prefs`. Pure — the twin of `should_notify?/5` for the second
+  trigger class.
+
+  `Map.fetch!/2`, not `Map.get/3` with a default: `merge_with_defaults/1`
+  guarantees both keys are present in every prefs map a reader can get,
+  so a fallback would be a second place stating the default — and it
+  would state it silently if that guarantee ever broke.
+  """
+  @spec should_notify_presence?(:online | :offline, prefs()) :: boolean()
+  def should_notify_presence?(:online, prefs) when is_map(prefs),
+    do: Map.fetch!(prefs, :presence_online)
+
+  def should_notify_presence?(:offline, prefs) when is_map(prefs),
+    do: Map.fetch!(prefs, :presence_offline)
 
   # ---------------------------------------------------------------------------
   # Private

--- a/lib/grappa/session/presence.ex
+++ b/lib/grappa/session/presence.ex
@@ -151,11 +151,18 @@ defmodule Grappa.Session.Presence do
   The rename path (#378). A watched peer renaming emits `601`/`605` (or
   `731`) for the nick it vacated, which IS a genuine offline transition by
   every local test — but it is not the assertion a push would make ("alice
-  went offline"), and worse, whoever takes the freed nick next produces an
-  online report about a DIFFERENT human. #247 could live with that for a
+  went offline" about someone still here). #247 could live with that for a
   status dot; a lockscreen banner is an identity claim, so the entry is
-  demoted to "no baseline yet" and the imminent report re-establishes it
+  demoted to "no baseline yet" and the vacancy report re-establishes it
   silently. The watch ENTRY deliberately does not follow the rename.
+
+  Bounded, and the bound is on the record: this buys the FALSE departure
+  only. The vacancy report consumes the `:unknown`, re-baselining the entry
+  to `:offline`, so a DIFFERENT human later taking the freed nick is a
+  genuine transition and does push. Suppressing that needs a second
+  "vacated" state beside this map — parallel state needing housekeeping,
+  for a case #247 already ruled on: the watch list watches NICKS, not
+  people. Pinned by `Grappa.Session.PresencePushTest`.
   """
   @spec reset(state_map(), String.t()) :: state_map()
   def reset(map, nick) when is_map(map) and is_binary(nick) do

--- a/lib/grappa/session/presence.ex
+++ b/lib/grappa/session/presence.ex
@@ -144,6 +144,30 @@ defmodule Grappa.Session.Presence do
   end
 
   @doc """
+  Puts a tracked `nick` back to `:unknown`, so its NEXT report classifies
+  `:initial` instead of `:transition`. Untracked nicks are left alone —
+  never invent an entry the DB list doesn't carry.
+
+  The rename path (#378). A watched peer renaming emits `601`/`605` (or
+  `731`) for the nick it vacated, which IS a genuine offline transition by
+  every local test — but it is not the assertion a push would make ("alice
+  went offline"), and worse, whoever takes the freed nick next produces an
+  online report about a DIFFERENT human. #247 could live with that for a
+  status dot; a lockscreen banner is an identity claim, so the entry is
+  demoted to "no baseline yet" and the imminent report re-establishes it
+  silently. The watch ENTRY deliberately does not follow the rename.
+  """
+  @spec reset(state_map(), String.t()) :: state_map()
+  def reset(map, nick) when is_map(map) and is_binary(nick) do
+    key = Identifier.canonical_target(nick)
+
+    case Map.fetch(map, key) do
+      {:ok, _} -> Map.put(map, key, :unknown)
+      :error -> map
+    end
+  end
+
+  @doc """
   Drops `nicks` (folded) from the map — the live `/notify del` /
   `clear` path.
   """

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -93,6 +93,7 @@ defmodule Grappa.Session.Server do
 
   alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, LineSplit, Message}
   alias Grappa.Net.SourceAliasManager
+  alias Grappa.Push.Triggers, as: PushTriggers
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire
 
@@ -5319,6 +5320,21 @@ defmodule Grappa.Session.Server do
         )
       )
 
+    # #378 — one effect, two consumers: the wire broadcast above feeds the
+    # attached clients' in-app toast, this feeds the OS-level push for the
+    # clients that are NOT attached. Both gates (baseline-vs-transition and
+    # the two prefs) live in Triggers, per the canonical-gate rule the
+    # message path documents — the effect arm must not fork the decision.
+    # `source` is a transport detail and does not travel: a notification
+    # cannot care whether MONITOR or WATCH carried the report.
+    :ok =
+      PushTriggers.dispatch_presence(nick, presence, kind, %{
+        subject: state.subject,
+        subject_label: state.subject_label,
+        network_slug: state.network_slug,
+        own_nick: state.nick
+      })
+
     apply_effects(rest, state)
   end
 
@@ -6120,7 +6136,14 @@ defmodule Grappa.Session.Server do
         :ok
     end
 
-    apply_effects(rest, state)
+    # #378 — a rename is not a presence transition. The vacated nick draws a
+    # 601/605/731 from the ircd, which classifies as a genuine offline flip
+    # and would push "<old> went offline" about someone who is still here;
+    # whoever grabs the freed nick next then pushes "<old> is online" about a
+    # different human. Demote the entry to `:unknown` and both reports become
+    # baselines, which never push. Unconditional on whether a query window
+    # moved: presence and windows are independent stores.
+    apply_effects(rest, reset_presence_for(state, old_nick))
   end
 
   # #514: WE renamed. Deliberately NOT the peer arm above with the arguments
@@ -7127,6 +7150,14 @@ defmodule Grappa.Session.Server do
       |> Presence.untrack(removed)
 
     Map.put(state, :presence, next_map)
+  end
+
+  # #378 — see the `{:peer_nick_renamed, _, _}` arm. `Map.get` with a default
+  # because `:presence` only exists on state once the watch armed; a rename
+  # observed before end-of-MOTD has nothing to demote.
+  @spec reset_presence_for(t(), String.t()) :: t()
+  defp reset_presence_for(state, nick) do
+    Map.put(state, :presence, Presence.reset(Map.get(state, :presence, %{}), nick))
   end
 
   @spec send_sync_lines(t(), ISupport.presence_mechanism(), [String.t()], [String.t()]) :: :ok

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -93,8 +93,8 @@ defmodule Grappa.Session.Server do
 
   alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, LineSplit, Message}
   alias Grappa.Net.SourceAliasManager
-  alias Grappa.Push.Triggers, as: PushTriggers
   alias Grappa.PubSub.Topic
+  alias Grappa.Push.Triggers, as: PushTriggers
   alias Grappa.Scrollback.Wire
 
   alias Grappa.Session.{

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -145,7 +145,11 @@ defmodule Grappa.UserSettings do
   @typedoc """
   Per-subject notification preferences — push-notifications cluster B3.
 
-  Three booleans + two string-list whitelists + one mute map (#866).
+  Five booleans + two string-list whitelists + one mute map (#866).
+  Three of the booleans gate MESSAGE push; `presence_online` /
+  `presence_offline` gate `/notify` presence push (#378) and are a
+  SEPARATE trigger class — see `@prefs_trigger_keys` for why they are
+  excluded from the at-least-one-trigger guard.
   Whitelist semantics: IF `channel_messages_all` is true the
   `channel_messages_only` list is ignored at trigger-eval time (UI greys
   it out, server still stores the value so toggling `_all` off restores
@@ -168,6 +172,8 @@ defmodule Grappa.UserSettings do
           channel_mentions: boolean(),
           private_messages_all: boolean(),
           private_messages_only: [String.t()],
+          presence_online: boolean(),
+          presence_offline: boolean(),
           muted_targets: muted_targets()
         }
 
@@ -436,6 +442,14 @@ defmodule Grappa.UserSettings do
   for IRC users" — opt out of all-channel-noise, opt in to mentions
   and DMs.
 
+  Both `/notify` presence prefs default OFF (#378), in both directions.
+  A stored map written by someone who deliberately configured push is
+  byte-indistinguishable from a never-configured one at `read_bool/3`, so
+  a default-ON key would override an explicitly-expressed preference on
+  the deploy that introduced it. Default-off makes the two new checkboxes
+  the opt-in and costs nothing: #247's Watched panel already tells users
+  the feature exists.
+
   The spec's return type is the wider `notification_prefs()` (not the
   Dialyzer-inferred singleton shape) so callers can pattern-match
   the result interchangeably with `get_notification_prefs/1` results.
@@ -449,6 +463,8 @@ defmodule Grappa.UserSettings do
       channel_mentions: true,
       private_messages_all: true,
       private_messages_only: [],
+      presence_online: false,
+      presence_offline: false,
       muted_targets: %{}
     }
   end
@@ -502,10 +518,11 @@ defmodule Grappa.UserSettings do
 
   ## Validation
 
-    * At least one of the five trigger flags must be true. A prefs
-      shape with every trigger off would silently mute the subject;
-      surface that as `:no_triggers_enabled` rather than persist a
-      "notifications never fire" config.
+    * At least one MESSAGE trigger flag (`@prefs_trigger_keys`) must be
+      true. A prefs shape with every one of them off would silently mute
+      the subject; surface that as `:no_triggers_enabled` rather than
+      persist a "notifications never fire" config. The `/notify` presence
+      flags do NOT count here — see `@prefs_trigger_keys`.
     * `channel_messages_only` and `private_messages_only` must be
       lists of non-empty strings. Channel names AND nicks are
       lowercased + trimmed before persistence (IRC nicks/channels
@@ -1254,7 +1271,25 @@ defmodule Grappa.UserSettings do
   # notification_prefs helpers
   # ---------------------------------------------------------------------------
 
-  @prefs_bool_keys ~w(channel_messages_all channel_mentions private_messages_all)a
+  # 🔴 These two lists are NO LONGER the same list, since #378 — do not
+  # "tidy up" the duplication.
+  #
+  # `@prefs_bool_keys` is every boolean in the map: it drives the read
+  # (`merge_with_defaults/1`), the validate/write (`cast_bools/2`) and hence
+  # `stringify_prefs`. `@prefs_trigger_keys` is the subset that
+  # `ensure_at_least_one_trigger/2` counts, and its whole job is to reject a
+  # prefs map that would silently mute all MESSAGE push.
+  #
+  # The `/notify` presence booleans are an orthogonal trigger class, so they
+  # belong to the first list and NOT the second: were they counted, a user
+  # unchecking every message trigger would pass validation on the strength of
+  # `presence_online` alone — silently muting messages, which is precisely
+  # what the guard exists to prevent. Accepted consequence: a
+  # presence-only-push configuration is unrepresentable (≥1 message trigger
+  # must stay on). The invariant that must hold is
+  # `@prefs_trigger_keys ⊆ @prefs_bool_keys` — a trigger key outside the bool
+  # list would blow up `Map.fetch!/2` in the validator.
+  @prefs_bool_keys ~w(channel_messages_all channel_mentions private_messages_all presence_online presence_offline)a
   @prefs_list_keys ~w(channel_messages_only private_messages_only)a
   @prefs_trigger_keys ~w(channel_messages_all channel_mentions private_messages_all)a
 

--- a/lib/grappa_web/controllers/user_settings_controller.ex
+++ b/lib/grappa_web/controllers/user_settings_controller.ex
@@ -12,8 +12,10 @@ defmodule GrappaWeb.UserSettingsController do
 
     * `PUT /me/settings/notification-prefs` — body matches the
       `notification_prefs()` shape directly (5 booleans + 2 string
-      lists). 200 with the persisted shape on success. Validation
-      lives in `put_notification_prefs/2`: at least one trigger
+      lists + the `muted_targets` map). EVERY boolean must be present:
+      a bundle older than a boolean-adding release 422s until it
+      reloads. 200 with the persisted shape on success. Validation
+      lives in `put_notification_prefs/2`: at least one MESSAGE trigger
       enabled, list elements non-empty strings, whitelists normalized
       (lowercase + trim). 422 with `field_errors.notification_prefs`
       on validation failure (uniform changeset envelope per

--- a/test/grappa/push/payload_test.exs
+++ b/test/grappa/push/payload_test.exs
@@ -5,6 +5,7 @@ defmodule Grappa.Push.PayloadTest do
   Pure function under test — no DB, `async: true` safe.
   """
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Grappa.Push.Payload
   alias Grappa.Scrollback.Message
@@ -20,6 +21,21 @@ defmodule Grappa.Push.PayloadTest do
       dm_with: opts[:dm_with]
     }
   end
+
+  # RFC 2812 `nickname` body characters, minus `:` — the grammar excludes it
+  # and the tag separator relies on that exclusion (see the disjointness
+  # property below).
+  defp nick_gen do
+    StreamData.string(
+      [?a..?z, ?A..?Z, ?0..?9, ?[, ?], ?\\, ?^, ?_, ?{, ?|, ?}, ?-],
+      min_length: 1,
+      max_length: 12
+    )
+  end
+
+  defp channel_gen, do: StreamData.map(nick_gen(), &("#" <> &1))
+
+  defp slug_gen, do: StreamData.string([?a..?z, ?0..?9, ?-], min_length: 1, max_length: 10)
 
   describe "build/3 — channel message" do
     test "title is '<sender> in <channel>'" do
@@ -106,6 +122,78 @@ defmodule Grappa.Push.PayloadTest do
     test "a zero badge is still stamped explicitly (cleared state)" do
       base = Payload.build(msg(channel: "#sniffo"), "libera", "vjt")
       assert Payload.put_badge(base, 0).badge == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # build_presence/3 — /notify presence transitions (#378)
+  # ---------------------------------------------------------------------------
+
+  describe "build_presence/3" do
+    test "an online transition reads '<nick> is online / on <network>'" do
+      payload = Payload.build_presence("alice", :online, "azzurra")
+
+      # LITERALS, not a re-derivation through the production builder:
+      # asserting `payload.title == "#{nick} #{verb}"` would be a tautology
+      # that survives any copy change. Same discipline as build/3 above.
+      assert payload.title == "alice is online"
+      assert payload.body == "on azzurra"
+    end
+
+    test "an offline transition spells the verb the in-app toast already spells" do
+      # cic's `Toasts.tsx` renders "is online" / "went offline" for the SAME
+      # event. One event, one spelling — the push follows the shipped copy
+      # rather than inventing a second one ("is offline").
+      payload = Payload.build_presence("alice", :offline, "azzurra")
+
+      assert payload.title == "alice went offline"
+      assert payload.body == "on azzurra"
+    end
+
+    test "the tag folds the nick, the title and url keep it raw" do
+      payload = Payload.build_presence("Alice", :online, "libera")
+
+      assert payload.tag == "libera:presence:alice"
+      assert payload.title == "Alice is online"
+      assert payload.url == "/?network=libera&channel=Alice"
+    end
+
+    test "brackets are NOT folded (CASEMAPPING=ascii) and percent-encode in the url" do
+      payload = Payload.build_presence("Al[i]ce", :online, "libera")
+
+      assert payload.tag == "libera:presence:al[i]ce"
+      assert payload.url == "/?network=libera&channel=Al%5Bi%5Dce"
+    end
+
+    test "badge is OMITTED — a presence transition creates no unread message" do
+      payload = Payload.build_presence("alice", :online, "azzurra")
+
+      refute Map.has_key?(payload, :badge)
+      assert Enum.sort(Map.keys(payload)) == [:body, :tag, :title, :url]
+    end
+  end
+
+  describe "build_presence/3 — tag disjointness from message tags" do
+    # The collision this guards is a function of the nick and channel
+    # GRAMMARS, not of one example: a bare-nick presence tag would equal the
+    # DM tag for the same nick, so alice's DM banner and alice's presence
+    # banner would coalesce under one OS tag and overwrite each other. `:` is
+    # excluded from both `nickname` and `chanstring` in RFC 2812, which is
+    # WHY the `presence:` infix is safe — so generate over the grammars.
+    property "a presence tag never equals a message tag on the same network" do
+      check all(
+              nick <- nick_gen(),
+              slug <- slug_gen(),
+              channel <- channel_gen()
+            ) do
+        presence_tag = Payload.build_presence(nick, :online, slug).tag
+
+        dm = msg(channel: "vjt", sender: nick, dm_with: nick, body: "ping")
+        chan = msg(channel: channel, sender: nick, body: "ping")
+
+        refute presence_tag == Payload.build(dm, slug, "vjt").tag
+        refute presence_tag == Payload.build(chan, slug, "vjt").tag
+      end
     end
   end
 end

--- a/test/grappa/push/presence_payload_parity_test.exs
+++ b/test/grappa/push/presence_payload_parity_test.exs
@@ -1,0 +1,57 @@
+defmodule Grappa.Push.PresencePayloadParityTest do
+  @moduledoc """
+  Cross-language drift gate for the `/notify` presence push payload (#378).
+
+  The payload contract between `Grappa.Push.Payload` (server) and
+  `cicchetto/src/lib/pushPayload.ts` (the service worker's narrower +
+  deep-link parser) is hand-synced — there is no codegen gate over it, the
+  way `scripts/check.sh` has one for `wireTypes.ts`. A hand-COPIED literal
+  in a vitest file would not be a tripwire at all: change
+  `build_presence/3` and the TS literal simply doesn't move.
+
+  So both ports run against ONE shared fixture
+  (`cicchetto/src/lib/presencePushPayloads.json`) — the technique
+  `Grappa.Push.ShouldNotifyParityTest` already established for the notify
+  predicate. THIS suite asserts the server EMITS each fixture payload
+  byte-for-byte; the vitest `pushPayload.test.ts` asserts the SW ACCEPTS
+  the same bytes and resolves the deep link. Change one side and the
+  fixture has to move, which drags the other side's assertion with it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Push.Payload
+
+  @fixture_path Path.expand(
+                  "../../../cicchetto/src/lib/presencePushPayloads.json",
+                  __DIR__
+                )
+  @external_resource @fixture_path
+  @fixture @fixture_path |> File.read!() |> Jason.decode!()
+
+  # Literal atoms created at this module's compile time, not
+  # `String.to_existing_atom/1` — the sibling parity suite's rationale:
+  # that call races module load order when the file runs in isolation.
+  @presences %{"online" => :online, "offline" => :offline}
+
+  test "the shared fixture is non-empty (guards an accidental empty array)" do
+    assert length(@fixture) >= 4
+  end
+
+  for testcase <- @fixture do
+    test "build_presence/3 — #{testcase["name"]}" do
+      c = unquote(Macro.escape(testcase))
+
+      built =
+        Payload.build_presence(
+          c["nick"],
+          Map.fetch!(@presences, c["presence"]),
+          c["network_slug"]
+        )
+
+      # Atom-keyed server shape vs the JSON's string keys: compare through
+      # the string projection so a NEW server key (or a dropped one) fails
+      # here rather than silently shipping a field the SW never sees.
+      assert Map.new(built, fn {k, v} -> {Atom.to_string(k), v} end) == c["payload"]
+    end
+  end
+end

--- a/test/grappa/push/triggers_test.exs
+++ b/test/grappa/push/triggers_test.exs
@@ -553,7 +553,9 @@ defmodule Grappa.Push.TriggersTest do
           channel_messages_only: [],
           channel_mentions: false,
           private_messages_all: true,
-          private_messages_only: []
+          private_messages_only: [],
+          presence_online: false,
+          presence_offline: false
         })
 
       # Mention body but mentions OFF → no notify
@@ -713,6 +715,190 @@ defmodule Grappa.Push.TriggersTest do
       refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
 
       Process.exit(device, :kill)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # dispatch_presence/4 — /notify presence transitions (#378)
+  #
+  # A SECOND trigger class, orthogonal to the message one: the watch list
+  # curates WHO, these two prefs gate push-vs-toast-only globally. The
+  # baseline gate (`:initial`) sits in the function HEAD, before the Task
+  # spawn — a MONITOR baseline burst on connect must spawn zero Tasks.
+  # ---------------------------------------------------------------------------
+
+  describe "should_notify_presence?/2 — pure predicate" do
+    test "online reads presence_online, offline reads presence_offline" do
+      for {online_pref, offline_pref} <- [{false, false}, {false, true}, {true, false}, {true, true}] do
+        p = prefs(presence_online: online_pref, presence_offline: offline_pref)
+
+        assert Triggers.should_notify_presence?(:online, p) == online_pref,
+               "online with #{inspect({online_pref, offline_pref})}"
+
+        assert Triggers.should_notify_presence?(:offline, p) == offline_pref,
+               "offline with #{inspect({online_pref, offline_pref})}"
+      end
+    end
+
+    test "both default OFF — presence push is opt-in" do
+      refute Triggers.should_notify_presence?(:online, default_prefs())
+      refute Triggers.should_notify_presence?(:offline, default_prefs())
+    end
+  end
+
+  defp presence_ctx(subject, label) do
+    %{subject: subject, subject_label: label, network_slug: "azzurra", own_nick: "vjt"}
+  end
+
+  defp with_presence_prefs(subject, overrides) do
+    {:ok, _} = UserSettings.put_notification_prefs(subject, prefs(overrides))
+    :ok
+  end
+
+  describe "dispatch_presence/4 — gates" do
+    setup do
+      :ok = WSPresence.reset_for_test()
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, endpoint: "http://localhost:#{bypass.port}/wp"}
+    end
+
+    test "an :initial baseline NEVER pushes, even with the pref on", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true, presence_offline: true)
+
+      assert :ok =
+               Triggers.dispatch_presence("alice", :online, :initial, presence_ctx(subject, user.name))
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+    end
+
+    test "a :transition with the pref OFF pushes nothing", %{bypass: bypass, endpoint: endpoint} do
+      attach_telemetry([[:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: false)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :online,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+    end
+
+    test "a :transition with the pref ON and no visible device pushes", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :send, :start], [:grappa, :push, :send, :stop]])
+      Bypass.expect(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :online,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      assert_receive {:telemetry, [:grappa, :push, :send, :start], %{count: 1}, %{subject: ^subject}},
+                     2_000
+
+      assert_receive {:telemetry, [:grappa, :push, :send, :stop], _, %{subject: ^subject}}, 2_000
+    end
+
+    test "the two directions are independent axes — online on, offline off", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true, presence_offline: false)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :offline,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+    end
+
+    test "a VISIBLE device suppresses the presence push too (#182 gate)", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+      assert WSPresence.any_visible?(user.name)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :online,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
+
+    test "VISITOR parity — a visitor subject pushes on the same gate", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :send, :start], [:grappa, :push, :send, :stop]])
+      Bypass.expect(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
+
+      visitor = visitor_fixture()
+      subject = {:visitor, visitor.id}
+      label = "visitor:" <> visitor.id
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true)
+
+      assert :ok =
+               Triggers.dispatch_presence("alice", :online, :transition, presence_ctx(subject, label))
+
+      assert_receive {:telemetry, [:grappa, :push, :send, :start], %{count: 1}, %{subject: ^subject}},
+                     2_000
+
+      assert_receive {:telemetry, [:grappa, :push, :send, :stop], _, %{subject: ^subject}}, 2_000
     end
   end
 end

--- a/test/grappa/session/presence_push_test.exs
+++ b/test/grappa/session/presence_push_test.exs
@@ -158,7 +158,7 @@ defmodule Grappa.Session.PresencePushTest do
     end)
 
     {server, port} = start_server()
-    {user, network, _subject} = watching_session(port, endpoint, ["#pp"])
+    {user, network, _} = watching_session(port, endpoint, ["#pp"])
 
     pid = start_session_for(user, network)
     :ok = arm_monitor(server)

--- a/test/grappa/session/presence_push_test.exs
+++ b/test/grappa/session/presence_push_test.exs
@@ -1,0 +1,235 @@
+defmodule Grappa.Session.PresencePushTest do
+  @moduledoc """
+  End-to-end gate for the `/notify` presence web push (#378).
+
+  Drives the WHOLE path — real `Session.Server`, real `EventRouter`
+  numerics off the `Grappa.IRCServer` fake ircd, real `Push.Triggers`
+  dispatch, real `Push.Sender` fan-out against a Bypass vendor — because
+  the two halves this issue can get wrong are only visible together:
+
+    * a MONITOR **baseline** (730) must push NOTHING, however aggressive
+      the prefs. That gate sits in `dispatch_presence/4`'s function head,
+      so a connect-time burst spawns zero Tasks;
+    * a live **transition** (731) must push, with the payload
+      `Payload.build_presence/3` builds.
+
+  Also pins the rename fix AND its measured limit. A watched peer renaming
+  emits `731` (or `601`/`605`) for the freed nick, which without the
+  presence reset in the `{:peer_nick_renamed, _, _}` arm would be a genuine
+  `:transition` — "alice went offline" on the lockscreen about someone who
+  merely renamed. That half is fixed. The other half the design claimed —
+  silence when a DIFFERENT human takes the freed nick — is NOT bought by
+  the reset, and the last test here pins that boundary rather than leaving
+  it to be discovered in the field.
+
+  `async: false` — `SessionRegistry` / `SessionSupervisor` / `WSPresence`
+  are singletons, same rationale as `Grappa.Session.ServerTest`.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Push, UserSettings, WSPresence}
+
+  # Real P-256 client public key + auth secret (mirrors sender_test /
+  # triggers_test); the encryption preamble crashes on random bytes.
+  @client_p256dh "BCfaYE5dGabdzef68MI0SN24b4Gsf1t_N3ftUlWaFGzkuudjHLor0CRjosM3c7SLZ7PfFufpsFUh8vsO1t8wCHs"
+  @client_auth "3aw2ceVFv0OIBXxAvkAlSA"
+
+  setup do
+    :ok = WSPresence.reset_for_test()
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, endpoint: "http://localhost:#{bypass.port}/wp"}
+  end
+
+  defp start_server do
+    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {server, IRCServer.port(server)}
+  end
+
+  defp attach_telemetry(events) do
+    test_pid = self()
+    handler_id = "presence-push-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn event, measurements, metadata, _ -> send(test_pid, {:telemetry, event, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  # A subject watching "Foo" on a MONITOR network, subscribed to push, with
+  # BOTH presence prefs on — so anything that stays silent below is silent
+  # because of a gate, never because of a pref.
+  defp watching_session(port, endpoint, autojoin) do
+    user = user_fixture(name: "presence-push-#{System.unique_integer([:positive])}")
+
+    {network, _} =
+      network_with_server(port: port, slug: "pp-#{System.unique_integer([:positive])}")
+
+    _ = credential_fixture(user, network, %{nick: "grappa-test", autojoin_channels: autojoin})
+    subject = {:user, user.id}
+
+    {:ok, _} = Grappa.Notify.add(subject, network.id, ["Foo"], user.name)
+
+    {:ok, _} =
+      Push.create(subject, %{
+        endpoint: endpoint,
+        p256dh_key: @client_p256dh,
+        auth_key: @client_auth,
+        user_agent: "Mozilla/5.0 presence-push-test"
+      })
+
+    {:ok, _} =
+      UserSettings.put_notification_prefs(
+        subject,
+        Map.merge(UserSettings.default_notification_prefs(), %{
+          presence_online: true,
+          presence_offline: true
+        })
+      )
+
+    {user, network, subject}
+  end
+
+  defp arm_monitor(server) do
+    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+    IRCServer.feed(server, ":irc.test.org 005 grappa-test MONITOR=100 :are supported\r\n")
+    IRCServer.feed(server, ":irc.test.org 376 grappa-test :End of /MOTD command.\r\n")
+    {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "MONITOR + Foo\r\n"), 1_000)
+    :ok
+  end
+
+  test "730 baseline pushes NOTHING; 731 transition pushes the presence payload", %{
+    bypass: bypass,
+    endpoint: endpoint
+  } do
+    attach_telemetry([[:grappa, :push, :send, :start], [:grappa, :push, :send, :stop]])
+
+    # The vendor request body is AES-GCM ciphertext — the assertion that the
+    # right payload went out is the telemetry pair plus the parity-gated
+    # builder, not a body match. What Bypass proves here is that exactly ONE
+    # delivery reached a vendor across baseline + transition.
+    test_pid = self()
+
+    Bypass.expect(bypass, "POST", "/wp", fn conn ->
+      send(test_pid, :vendor_hit)
+      Plug.Conn.resp(conn, 201, "")
+    end)
+
+    {server, port} = start_server()
+    {user, network, subject} = watching_session(port, endpoint, [])
+
+    pid = start_session_for(user, network)
+    :ok = arm_monitor(server)
+
+    # 730 RPL_MONONLINE — the baseline snapshot for an already-online Foo.
+    IRCServer.feed(server, ":irc.test.org 730 grappa-test :Foo!user@host\r\n")
+
+    refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 500
+    refute_received :vendor_hit
+
+    # 731 RPL_MONOFFLINE — a genuine transition.
+    IRCServer.feed(server, ":irc.test.org 731 grappa-test :Foo\r\n")
+
+    assert_receive {:telemetry, [:grappa, :push, :send, :start], %{count: 1}, %{subject: ^subject}},
+                   2_000
+
+    assert_receive {:telemetry, [:grappa, :push, :send, :stop], _, %{subject: ^subject}}, 2_000
+    assert_received :vendor_hit
+
+    assert {:ok, %{"foo" => :offline}} = Grappa.Session.presence_snapshot(subject, network.id)
+
+    :ok = GenServer.stop(pid, :normal, 1_000)
+  end
+
+  test "a watched peer RENAMING does not push — the freed nick's 731 is a baseline again", %{
+    bypass: bypass,
+    endpoint: endpoint
+  } do
+    attach_telemetry([[:grappa, :push, :send, :start]])
+
+    Bypass.stub(bypass, "POST", "/wp", fn conn ->
+      Plug.Conn.resp(conn, 500, "should-not-happen")
+    end)
+
+    {server, port} = start_server()
+    {user, network, _subject} = watching_session(port, endpoint, ["#pp"])
+
+    pid = start_session_for(user, network)
+    :ok = arm_monitor(server)
+
+    # IRC delivers a peer's NICK only to channel-sharing peers, so the rename
+    # is only OBSERVABLE (and this fix only reachable) when Foo shares a
+    # channel with us. Seed that membership — outside it, the design's stated
+    # boundary applies and a rename is indistinguishable from a real part.
+    IRCServer.feed(server, ":grappa-test!u@h JOIN :#pp\r\n")
+    IRCServer.feed(server, ":irc.test.org 353 grappa-test = #pp :grappa-test Foo\r\n")
+    IRCServer.feed(server, ":irc.test.org 366 grappa-test #pp :End of /NAMES list.\r\n")
+
+    # Baseline: Foo is online.
+    IRCServer.feed(server, ":irc.test.org 730 grappa-test :Foo!user@host\r\n")
+    refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+    # Foo renames to Bar. The presence entry for "foo" goes back to :unknown,
+    # so the 731 the ircd sends for the vacated nick classifies :initial.
+    IRCServer.feed(server, ":Foo!user@host NICK :Bar\r\n")
+    IRCServer.feed(server, ":irc.test.org 731 grappa-test :Foo\r\n")
+
+    refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 500
+
+    :ok = GenServer.stop(pid, :normal, 1_000)
+  end
+
+  test "someone ELSE taking the freed nick DOES push — the accepted #247 boundary", %{
+    bypass: bypass,
+    endpoint: endpoint
+  } do
+    # #378's design listed this as a second thing the rename fix buys ("the
+    # freed nick taken by someone else ⇒ no push"). MEASURED: it does not,
+    # and it cannot with a single demotion. `reset/2` puts the entry back to
+    # `:unknown`, and the vacancy report (731) CONSUMES that — it re-baselines
+    # to `:offline`. The next online report for the nick is therefore a
+    # genuine transition and pushes.
+    #
+    # Kept as behaviour rather than chased, because the alternative is a
+    # second "vacated" state living beside the presence map — parallel state
+    # needing housekeeping, for a case #247 already ruled on: the watch list
+    # watches NICKS, not people. What the fix does buy is the FALSE half — no
+    # "went offline" for a peer who is still here under a new nick — and that
+    # is the assertion in the test above. This one pins the boundary so it is
+    # a decision on the record, not a surprise in the field.
+    attach_telemetry([[:grappa, :push, :send, :start], [:grappa, :push, :send, :stop]])
+    Bypass.expect(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
+
+    {server, port} = start_server()
+    {user, network, subject} = watching_session(port, endpoint, ["#pp"])
+
+    pid = start_session_for(user, network)
+    :ok = arm_monitor(server)
+
+    IRCServer.feed(server, ":grappa-test!u@h JOIN :#pp\r\n")
+    IRCServer.feed(server, ":irc.test.org 353 grappa-test = #pp :grappa-test Foo\r\n")
+    IRCServer.feed(server, ":irc.test.org 366 grappa-test #pp :End of /NAMES list.\r\n")
+
+    IRCServer.feed(server, ":irc.test.org 730 grappa-test :Foo!user@host\r\n")
+    IRCServer.feed(server, ":Foo!user@host NICK :Bar\r\n")
+    IRCServer.feed(server, ":irc.test.org 731 grappa-test :Foo\r\n")
+    refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 500
+
+    IRCServer.feed(server, ":irc.test.org 730 grappa-test :Foo!other@host\r\n")
+
+    assert_receive {:telemetry, [:grappa, :push, :send, :start], %{count: 1}, %{subject: ^subject}},
+                   2_000
+
+    # Await fan-out completion so the vendor POST has landed before `on_exit`
+    # verifies the Bypass expectation.
+    assert_receive {:telemetry, [:grappa, :push, :send, :stop], _, %{subject: ^subject}}, 2_000
+
+    :ok = GenServer.stop(pid, :normal, 1_000)
+  end
+end

--- a/test/grappa/session/presence_test.exs
+++ b/test/grappa/session/presence_test.exs
@@ -122,10 +122,10 @@ defmodule Grappa.Session.PresenceTest do
 
   describe "reset/2 — a rename is not a transition (#378)" do
     test "a tracked nick goes back to :unknown, so the next report is :initial" do
-      map = Presence.seed(["Alice"])
-      {:changed, :initial, map} = Presence.apply_report(map, "Alice", :online)
+      seeded = Presence.seed(["Alice"])
+      {:changed, :initial, online} = Presence.apply_report(seeded, "Alice", :online)
 
-      reset = Presence.reset(map, "Alice")
+      reset = Presence.reset(online, "Alice")
       assert reset == %{"alice" => :unknown}
 
       # And that is the whole point: the 601/605 that follows the NICK now

--- a/test/grappa/session/presence_test.exs
+++ b/test/grappa/session/presence_test.exs
@@ -119,4 +119,28 @@ defmodule Grappa.Session.PresenceTest do
       assert Presence.untrack(map, ["FOO[1]"]) == %{"bar" => :unknown}
     end
   end
+
+  describe "reset/2 — a rename is not a transition (#378)" do
+    test "a tracked nick goes back to :unknown, so the next report is :initial" do
+      map = Presence.seed(["Alice"])
+      {:changed, :initial, map} = Presence.apply_report(map, "Alice", :online)
+
+      reset = Presence.reset(map, "Alice")
+      assert reset == %{"alice" => :unknown}
+
+      # And that is the whole point: the 601/605 that follows the NICK now
+      # classifies :initial, which never pushes.
+      assert {:changed, :initial, _} = Presence.apply_report(reset, "Alice", :offline)
+    end
+
+    test "the match folds — the display case of the renamed nick is irrelevant" do
+      map = Presence.seed(["Alice"])
+      assert Presence.reset(map, "ALICE") == %{"alice" => :unknown}
+    end
+
+    test "an untracked nick leaves the map untouched — never invents an entry" do
+      map = Presence.seed(["Alice"])
+      assert Presence.reset(map, "bob") == map
+    end
+  end
 end

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -297,7 +297,9 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
           channel_messages_only: [],
           channel_mentions: true,
           private_messages_all: true,
-          private_messages_only: []
+          private_messages_only: [],
+          presence_online: false,
+          presence_offline: false
         })
 
       {:ok, _} = UserSettings.put_display_prefs(subject, valid_wire(%{"time_format" => "hm"}))

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -291,6 +291,8 @@ defmodule Grappa.UserSettingsTest do
                channel_mentions: true,
                private_messages_all: true,
                private_messages_only: [],
+               presence_online: false,
+               presence_offline: false,
                # #866 — nothing muted by default. This map is also mirrored
                # byte-for-byte by cic's DEFAULT_NOTIFICATION_PREFS, so an
                # un-hydrated client behaves like a subject who configured
@@ -351,6 +353,35 @@ defmodule Grappa.UserSettingsTest do
       assert result.private_messages_only == []
     end
 
+    test "a legacy row written before #378 inherits both presence prefs OFF" do
+      # The rollout contract: `notification_prefs` is string-keyed JSON in the
+      # existing `:map` column, so there is no migration — every row written
+      # before the two keys existed flows through `merge_with_defaults/1` and
+      # inherits `false`/`false`. Presence push is therefore opt-IN: nobody
+      # who never opened Settings starts receiving lockscreen banners.
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      Repo.update!(
+        Settings.changeset(settings, %{
+          data: %{
+            "notification_prefs" => %{
+              "channel_messages_all" => false,
+              "channel_messages_only" => [],
+              "channel_mentions" => true,
+              "private_messages_all" => true,
+              "private_messages_only" => []
+            }
+          }
+        })
+      )
+
+      result = UserSettings.get_notification_prefs({:user, user.id})
+
+      assert result.presence_online == false
+      assert result.presence_offline == false
+    end
+
     test "drops empty strings from stored whitelist on read (defensive)" do
       user = user_fixture()
       {:ok, settings} = UserSettings.get_or_init({:user, user.id})
@@ -381,6 +412,8 @@ defmodule Grappa.UserSettingsTest do
         channel_mentions: true,
         private_messages_all: false,
         private_messages_only: ["alice"],
+        presence_online: false,
+        presence_offline: false,
         muted_targets: %{"azzurra #noisy" => %{"until" => nil}}
       }
 
@@ -396,7 +429,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: ["  #SBiffo  ", "#Italia"],
         channel_mentions: true,
         private_messages_all: false,
-        private_messages_only: ["  Alice ", "BOB"]
+        private_messages_only: ["  Alice ", "BOB"],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -418,7 +453,9 @@ defmodule Grappa.UserSettingsTest do
         channel_mentions: true,
         private_messages_all: false,
         # Nicks fold via canonical_nick (ASCII): case only; `[ ~` are kept.
-        private_messages_only: ["Foo[Bar]", "quux~"]
+        private_messages_only: ["Foo[Bar]", "quux~"],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -436,7 +473,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: ["#a", "#b", "#A", "#c", "#B"],
         channel_mentions: true,
         private_messages_all: true,
-        private_messages_only: []
+        private_messages_only: [],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -453,7 +492,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: ["#sbiffo"],
         channel_mentions: true,
         private_messages_all: true,
-        private_messages_only: ["alice"]
+        private_messages_only: ["alice"],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -471,7 +512,51 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: [],
         channel_mentions: false,
         private_messages_all: false,
+        private_messages_only: [],
+        presence_online: false,
+        presence_offline: false
+      }
+
+      assert {:error, %Ecto.Changeset{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
+    end
+
+    test "rejects a PUT that omits the presence keys (deploy-skew 422, stated)" do
+      # `cast_bools/2` requires EVERY `@prefs_bool_keys` member present, which
+      # is the contract the three original booleans already had. A cic bundle
+      # older than #378 therefore 422s until it reloads — accepted: server and
+      # bundle ship together, so the window is already-open tabs. Making the
+      # two new booleans optional would create two classes of boolean in one
+      # map, which is worse than the window.
+      user = user_fixture()
+
+      prefs = %{
+        channel_messages_all: false,
+        channel_messages_only: [],
+        channel_mentions: true,
+        private_messages_all: true,
         private_messages_only: []
+      }
+
+      assert {:error, %Ecto.Changeset{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
+    end
+
+    test "presence prefs are NOT triggers — all message triggers off still rejects" do
+      # The `@prefs_trigger_keys` exclusion, pinned behaviourally. That
+      # validator exists to reject a map that silently mutes all MESSAGE push.
+      # If the presence keys joined the list, this map would pass validation
+      # because `presence_online` is true — muting messages, which is exactly
+      # what the guard prevents. Consequence, accepted for v1: a
+      # presence-only-push configuration is unrepresentable.
+      user = user_fixture()
+
+      prefs = %{
+        channel_messages_all: false,
+        channel_messages_only: [],
+        channel_mentions: false,
+        private_messages_all: false,
+        private_messages_only: [],
+        presence_online: true,
+        presence_offline: true
       }
 
       assert {:error, %Ecto.Changeset{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -485,7 +570,9 @@ defmodule Grappa.UserSettingsTest do
         "channel_messages_only" => ["#italia"],
         "channel_mentions" => true,
         "private_messages_all" => true,
-        "private_messages_only" => []
+        "private_messages_only" => [],
+        "presence_online" => false,
+        "presence_offline" => false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -503,7 +590,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: [],
         channel_mentions: "yes",
         private_messages_all: true,
-        private_messages_only: []
+        private_messages_only: [],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:error, %Ecto.Changeset{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -517,7 +606,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: "#italia",
         channel_mentions: true,
         private_messages_all: true,
-        private_messages_only: []
+        private_messages_only: [],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:error, %Ecto.Changeset{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -532,7 +623,9 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: [],
         channel_mentions: true,
         private_messages_all: true,
-        private_messages_only: []
+        private_messages_only: [],
+        presence_online: false,
+        presence_offline: false
       }
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -551,6 +644,8 @@ defmodule Grappa.UserSettingsTest do
       channel_mentions: true,
       private_messages_all: true,
       private_messages_only: [],
+      presence_online: false,
+      presence_offline: false,
       muted_targets: muted
     }
   end
@@ -950,7 +1045,9 @@ defmodule Grappa.UserSettingsTest do
           channel_messages_only: [],
           channel_mentions: true,
           private_messages_all: true,
-          private_messages_only: []
+          private_messages_only: [],
+          presence_online: false,
+          presence_offline: false
         })
 
       assert {:ok, _} = UserSettings.put_upload_ttl_seconds({:user, user.id}, 3600)

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -32,6 +32,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       "channel_mentions" => true,
       "private_messages_all" => true,
       "private_messages_only" => [],
+      "presence_online" => false,
+      "presence_offline" => false,
       # #866 — nothing muted by default; the wire carries the key so a client
       # can tell "no mutes" from "a server that predates the field".
       "muted_targets" => %{}
@@ -81,7 +83,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
           channel_messages_only: ["#sbiffo"],
           channel_mentions: true,
           private_messages_all: false,
-          private_messages_only: ["alice"]
+          private_messages_only: ["alice"],
+          presence_online: false,
+          presence_offline: false
         })
 
       conn = get(conn, "/me/settings/notification-prefs")
@@ -94,6 +98,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "channel_mentions" => true,
                "private_messages_all" => false,
                "private_messages_only" => ["alice"],
+               "presence_online" => false,
+               "presence_offline" => false,
                "muted_targets" => %{}
              }
     end
@@ -377,7 +383,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
           channel_messages_only: ["#sbiffo"],
           channel_mentions: true,
           private_messages_all: true,
-          private_messages_only: []
+          private_messages_only: [],
+          presence_online: false,
+          presence_offline: false
         })
 
       conn = put(conn, "/me/settings/upload-ttl-seconds", %{"upload_ttl_seconds" => 3600})


### PR DESCRIPTION
Extends the B2/B4 Web Push pipeline so a `/notify` presence transition
fires an OS-level notification when the PWA is closed.

**Source of truth for this PR is the revised design**, i.e.
[@gmsrc's comment on #378](https://github.com/vjt/grappa-irc/issues/378#issuecomment-5083678372),
which opens *"Supersedes the original issue body"* — the original was
authored against a stale checkout and every Elixir line citation had
drifted. It marks four decisions **[CHANGED]** against the body; all four
are implemented here. Where body and comment disagree, the comment wins,
and each such point is called out below.

## What lands

- `Payload.build_presence/3` — a sibling of `build/3`, not a clause of
  it: that one is hard-wired to a `%Scrollback.Message{}` and a presence
  flip has no row, no sender, no body.
- `Triggers.dispatch_presence/4` + the pure `should_notify_presence?/2`.
- Two `notification_prefs` booleans, `presence_online` /
  `presence_offline`, both default OFF, with two checkboxes in the cic
  notifications fieldset.
- One call in `Session.Server`'s `presence_changed` effect arm, next to
  the broadcast already there.
- `Presence.reset/2`, wired into the peer-rename arm.

## The four things that are easy to get wrong

**`:initial` never pushes, and the gate is in the function head.** Before
the `Task.start`, not inside it — the difference between a connect
spawning zero Tasks and spawning one per watched nick. The one gate
covers every baseline shape: the arm burst at end-of-MOTD, a bulk
`/notify add`, the 421 fallback re-arm, every reconnect re-seed.

**The prefs are NOT in `@prefs_trigger_keys`.** The two attributes now
diverge for the first time, so both carry a why-comment.
`ensure_at_least_one_trigger/2` exists to reject a map that silently
mutes all MESSAGE push; counting presence there would let someone
uncheck every message trigger and pass validation on `presence_online`
alone. Accepted consequence: presence-only push is unrepresentable.

**The tag carries a `presence:` infix.** `build/3` writes
`"<slug>:<channel_or_dm_peer>"`, so a bare-nick presence tag would EQUAL
the DM tag for that nick — alice's DM banner and alice's presence banner
would coalesce under one OS tag, each overwriting the other. `:` is
excluded from both `nickname` and `chanstring` in RFC 2812, so the
disjointness is a property of the grammars, and the guard is a
StreamData property over them rather than one example.

**`badge` is omitted.** `BadgeSource.count/1` counts unread MESSAGES and
a presence flip creates none; stamping it would attach a stale,
causally-unrelated number and cost a DB read per transition. Absent
already means "leave the icon alone".

## Divergences from the issue body, and one from the design comment

- **Both prefs default OFF.** The issue BODY prescribes
  `presence_online: true` ("a watched nick appearing is exactly the event
  the watch list exists for"). The revised comment reverses it under
  **[CHANGED] Both default off**, and that is the form implemented:
  *"a stored prefs map written by a user who deliberately configured push
  is byte-indistinguishable from a never-configured one at `read_bool/3`
  — so a default-on flip overrides an explicitly-expressed preference,
  and the first thing an annoyed user does (open Settings in an
  already-open tab and PUT) hits the deploy-skew 422."* Default-off makes
  the two new checkboxes the opt-in and costs nothing: #247's Watched
  panel already advertises the feature.
- The other three **[CHANGED]** points from the same comment, also
  implemented: no `push_ctx/1` extraction (the message-path call site is
  `Persistor`, a different module deriving its ctx from `session_ctx()` —
  two call sites, two modules, four keys, built inline); `Push` owns its
  own `presence_kind()` rather than referencing
  `Session.Presence.change_kind()` (unexported, and `Grappa.Session`
  already deps `Grappa.Push`, so the reference would be a Boundary
  cycle); and `Map.fetch!/2` on the prefs rather than `Map.get(..., false)`
  (`merge_with_defaults/1` guarantees the key, so a fallback would state
  the default a second time — silently, if that guarantee broke).
- **Copy follows the in-app toast** — `"is online"` / `"went offline"`,
  not `"is offline"`. The design flagged the mismatch and left the choice
  open; the server follows the shipped user-visible spelling rather than
  changing it.
- **§7 (a `class: :message | :presence` tag on the Sender telemetry) is
  NOT here.** It touches `sender.ex`, which #1314 is rewriting. Deferred
  deliberately; the gate tests observe the existing `[:grappa, :push,
  :send, :start|:stop]` pair plus Bypass, exactly as `triggers_test`
  already does.
- **The rename fix buys less than the design claimed, and this PR says
  so.** The design listed two outcomes — no false "went offline" for a
  peer who renamed, AND silence when a different human takes the freed
  nick. Measured: only the first. The vacancy report consumes the
  `:unknown` the reset installs and re-baselines the entry to `:offline`,
  so the next online report is a genuine transition and pushes. Chasing
  it needs a second "vacated" state beside the presence map — parallel
  state needing housekeeping, for a case #247 already ruled on (the watch
  list watches NICKS, not people). Left as behaviour, with a test that
  pins it so it is a decision on the record rather than a field surprise.

## Deploy skew, stated

A boolean added to `@prefs_bool_keys` is REQUIRED in a PUT, so a cic
bundle older than this change 422s until it reloads. Server and bundle
ship together, so the window is already-open tabs. Making the two new
booleans absence-tolerant (like `muted_targets`, #866) was rejected:
that key is exempt because a client that never heard of it cannot
reconstruct the mutes its silence would clear, whereas two classes of
boolean in one map is the half-migrated shape CLAUDE.md forbids. Reverse
skew (new cic, old BEAM) is silently lossy — the old server drops the
unknown keys without error.

## Why the drift gate is a fixture, not a literal

The payload contract to `pushPayload.ts` is hand-synced; there is no
codegen gate over it the way `scripts/check.sh` has one for
`wireTypes.ts`. **A payload literal pasted into a vitest file is not a
tripwire**: change `build_presence/3` and the literal does not move, so
the test stays green while the two sides diverge. So both ports read ONE
fixture, `cicchetto/src/lib/presencePushPayloads.json` — ExUnit asserts
the server EMITS those bytes, vitest asserts the SW accepts them and
that `parsePushTargetUrl` lands on the watched nick's query window. Same
technique as `shouldNotifyTruthTable.json`. That is the lesson, not a
detail: the tripwire has to be the thing BOTH sides read.

## Deploy class: HOT

Verified on the final diff: no migration (the prefs are JSON keys in the
existing `user_settings.data` `:map` column), no `Session.Server`
state-shape change (`state.presence` already exists; `reset/2` rewrites a
value in it), prefs read per-dispatch inside the Task rather than cached
in process state, no `VERSION`/`mix.exs` touch. Everything else is new
functions and clauses in existing modules plus one call in an
`apply_effects` arm. cic bundle ships alongside.

## Gates

- `scripts/check.sh` — **RC=0**: credo `found no issues`, Sobelow
  `Total errors: 0, Skipped: 0`, ExUnit `8 doctests, 60 properties, 6142
  tests, 0 failures`.
- `scripts/bun.sh run test` — **5445/5445**, RC=0.
  `scripts/bun.sh run check` (biome + tsc + e2e tsc) — RC=0.
- `scripts/bats.sh` — **477 ok, 0 not ok**, RC=0.
- Playwright e2e not run: no cic behaviour change beyond two checkboxes,
  and the SW path is byte-identical to message pushes.

### Mutation evidence

The COMPILE lane arrived after the code was written, so the TDD red was
never observable. Three surgical mutants stand in for it, each restored
after measuring:

| mutant | killed |
|---|---|
| drop the `presence:` tag infix | 8 assertions, incl. the disjointness property (shrank to nick `"a"`) |
| `:initial` falls through to the transition path | 4, incl. all three e2e |
| `Presence.reset/2` becomes a no-op | 3, incl. both rename e2e |

