### PR TITLE
admin(#1315): the account behind a credential row, beside the nick

### DIFF
--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -501,6 +501,24 @@ const AdminSessionsTab: Component = () => {
                                     rows are on their own page now, so the
                                     badge would have nothing to mark. */}
                                     <span class="admin-session-nick">{renderLabel(row)}</span>
+                                    {/* #1315 — the account behind a user
+                                    row, beside the nick and never in
+                                    place of it: services renaming a
+                                    session to `GuestNNNNN` leaves a nick
+                                    that identifies nobody, and the only
+                                    other thing the row carried was a UUID
+                                    that is not printed anywhere. Absent
+                                    on every class with no account
+                                    (visitor, orphan pid, log-only), where
+                                    an empty element would read as an
+                                    account we failed to fetch. */}
+                                    <Show when={row.user_name}>
+                                      {(name) => (
+                                        <span class="admin-session-account" title="account">
+                                          {name()}
+                                        </span>
+                                      )}
+                                    </Show>
                                   </span>
                                   <span class="admin-session-network">
                                     {row.network_slug ?? `network ${row.network_id}`}

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -86,6 +86,9 @@ const parkedVisitor = (over: Partial<AdminVisitor> = {}): AdminVisitor =>
 const userCredential = (over: Partial<AdminCredential> = {}): AdminCredential =>
   ({
     user_id: USER_ID,
+    // #1315 — the account, kept distinct from the nick it configured so a
+    // render that printed one where the other belongs is visible.
+    user_name: "vjt-the-account",
     network_id: 1,
     network_slug: "azzurra",
     nick: "vjt",
@@ -201,6 +204,27 @@ describe("AdminSessionsTab — the dictated columns", () => {
     const row = await screen.findByTestId(`admin-session-row-${USER_KEY}`);
     expect(row.textContent).toContain("user");
     expect(row.textContent).toContain("vjt");
+  });
+
+  // #1315 — BESIDE the nick, not instead of it. A session services renamed
+  // to `GuestNNNNN` was identified by nothing the operator could act on:
+  // the nick is the rename, and the `user_id` is not printed anywhere on
+  // the card. Asserting both elements separately is what makes a render
+  // that swapped one for the other fail here.
+  it("shows the account name beside the configured nick on a user row", async () => {
+    await mountWith({ credentials: [userCredential()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${USER_KEY}`);
+    expect(row.querySelector(".admin-session-nick")?.textContent).toBe("vjt");
+    expect(row.querySelector(".admin-session-account")?.textContent).toBe("vjt-the-account");
+  });
+
+  it("shows no account element on a visitor row, which has no account", async () => {
+    await mountWith({ visitors: [parkedVisitor()] });
+
+    const row = await screen.findByTestId(`admin-session-row-${VISITOR_KEY}`);
+    expect(row.querySelector(".admin-session-nick")?.textContent).toBe("guest1");
+    expect(row.querySelector(".admin-session-account")).toBeNull();
   });
 
   it("shows the network under the nick", async () => {

--- a/cicchetto/src/__tests__/AdminUserPage.test.tsx
+++ b/cicchetto/src/__tests__/AdminUserPage.test.tsx
@@ -85,6 +85,8 @@ const CRED: AdminCredential = {
   last_seen_at: null,
   session_ip: null,
   user_id: USER.id,
+  // #1315 — the account this credential belongs to, as the server sends it.
+  user_name: USER.name,
   network_id: NETWORK.id,
   network_slug: NETWORK.slug,
   nick: "alice",

--- a/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
+++ b/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
@@ -68,6 +68,7 @@ const userCredential = (): AdminCredential =>
   ({
     session_ip: null,
     user_id: USER_ID,
+    user_name: "vjt-the-account",
     network_id: 1,
     network_slug: "azzurra",
     nick: "vjt",

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -322,6 +322,44 @@ describe("buildSubjectRows — the per-session source address", () => {
   });
 });
 
+// #1315, the ruling itself (vjt on `#grappa`: "show the credential nick
+// where one is available", amended to "the same for the user cred"). It
+// is ONE rule for both subject kinds, not a visitor rule with a user
+// exception, so it gets ONE block — and it closes with a pin rather than
+// a change, because both kinds already read this way.
+//
+// This is the scenario the issue is named for: services rename the
+// session to `GuestNNNNN`, and the row must keep saying what the operator
+// CONFIGURED while the live nick stays beside it, unreconciled (#618).
+// Computing either from the other is what would erase the divergence.
+describe("buildSubjectRows — the label is the CREDENTIAL nick, on both kinds", () => {
+  it("keeps a USER row on the configured nick when the live session diverges", () => {
+    const rows = build({ credentials: [credential({ live_state: live({ nick: "Guest12345" }) })] });
+
+    expect(rows[0]?.label).toBe("vjt");
+    expect(rows[0]?.live?.nick).toBe("Guest12345");
+  });
+
+  it("keeps a VISITOR row on the configured nick when the live session diverges", () => {
+    const renamed = visitor({
+      networks: [
+        {
+          network_slug: "azzurra",
+          network_id: 42,
+          nick: "guest1",
+          connection_state: "connected",
+          live_state: live({ nick: "Guest12345" }),
+        },
+      ],
+    });
+
+    const rows = build({ visitors: [renamed] });
+
+    expect(rows[0]?.label).toBe("guest1");
+    expect(rows[0]?.live?.nick).toBe("Guest12345");
+  });
+});
+
 // #1315 — the account behind a user row. The console identified a user
 // row by its configured nick alone, so a session services had renamed to
 // `GuestNNNNN` read as nobody: the only other thing on the row is a UUID,
@@ -341,19 +379,6 @@ describe("buildSubjectRows — the account name behind a user row", () => {
 
     expect(rows[0]?.user_name).toBeNull();
     expect(rows[0]?.label).toBe("vjt");
-  });
-
-  // The ruling's other half for a user row: "show the credential nick
-  // where one is available" — already true, and now pinned rather than
-  // rebuilt. This is the scenario the issue is named for: services rename
-  // the session to `GuestNNNNN`, and the row must keep saying what the
-  // operator CONFIGURED while the live nick stays visible beside it,
-  // neither computed from the other (#618).
-  it("keeps the label on the configured nick when the live session diverges", () => {
-    const rows = build({ credentials: [credential({ live_state: live({ nick: "Guest12345" }) })] });
-
-    expect(rows[0]?.label).toBe("vjt");
-    expect(rows[0]?.live?.nick).toBe("Guest12345");
   });
 
   it("reports null on a visitor row, which has no account at all", () => {

--- a/cicchetto/src/__tests__/adminSubjectRows.test.ts
+++ b/cicchetto/src/__tests__/adminSubjectRows.test.ts
@@ -67,6 +67,10 @@ const visitor = (over: Partial<AdminVisitor> = {}): AdminVisitor =>
 const credential = (over: Partial<AdminCredential> = {}): AdminCredential =>
   ({
     user_id: USER_ID,
+    // #1315 — deliberately NOT the nick: the account and the nick it
+    // configured are two facts, and a fixture where they agree cannot tell
+    // which one the row is carrying.
+    user_name: "vjt-the-account",
     network_id: 42,
     network_slug: "azzurra",
     nick: "vjt",
@@ -315,6 +319,60 @@ describe("buildSubjectRows — the per-session source address", () => {
     const rows = build({ credentials: [credential({ session_ip: null })] });
 
     expect(rows[0]?.session_ip).toBeNull();
+  });
+});
+
+// #1315 — the account behind a user row. The console identified a user
+// row by its configured nick alone, so a session services had renamed to
+// `GuestNNNNN` read as nobody: the only other thing on the row is a UUID,
+// and that is not rendered anywhere. The name is an ADDITIONAL fact and
+// the nick stays exactly where it was (vjt's ruling: show the credential
+// nick where one is available, per the #618 never-reconcile posture).
+describe("buildSubjectRows — the account name behind a user row", () => {
+  it("carries the account name onto a user row without displacing the nick", () => {
+    const rows = build({ credentials: [credential()] });
+
+    expect(rows[0]?.user_name).toBe("vjt-the-account");
+    expect(rows[0]?.label).toBe("vjt");
+  });
+
+  it("passes a missing account name through as null instead of inventing one", () => {
+    const rows = build({ credentials: [credential({ user_name: null })] });
+
+    expect(rows[0]?.user_name).toBeNull();
+    expect(rows[0]?.label).toBe("vjt");
+  });
+
+  // The ruling's other half for a user row: "show the credential nick
+  // where one is available" — already true, and now pinned rather than
+  // rebuilt. This is the scenario the issue is named for: services rename
+  // the session to `GuestNNNNN`, and the row must keep saying what the
+  // operator CONFIGURED while the live nick stays visible beside it,
+  // neither computed from the other (#618).
+  it("keeps the label on the configured nick when the live session diverges", () => {
+    const rows = build({ credentials: [credential({ live_state: live({ nick: "Guest12345" }) })] });
+
+    expect(rows[0]?.label).toBe("vjt");
+    expect(rows[0]?.live?.nick).toBe("Guest12345");
+  });
+
+  it("reports null on a visitor row, which has no account at all", () => {
+    const rows = build({ visitors: [visitor()] });
+
+    expect(rows[0]?.subject_kind).toBe("visitor");
+    expect(rows[0]?.user_name).toBeNull();
+  });
+
+  it("reports null on the two classes with no credential row behind them", () => {
+    const orphan = build({
+      sessions: [session({ subject_id: "deadbeef-0000-0000-0000-000000000000" })],
+    });
+    const logOnly = build({ logSessions: [logEntry()] });
+
+    expect(orphan[0]?.origin).toBe("orphan_pid");
+    expect(orphan[0]?.user_name).toBeNull();
+    expect(logOnly[0]?.origin).toBe("session_log");
+    expect(logOnly[0]?.user_name).toBeNull();
   });
 });
 

--- a/cicchetto/src/lib/adminSubjectRows.ts
+++ b/cicchetto/src/lib/adminSubjectRows.ts
@@ -91,6 +91,16 @@ export type AdminSubjectRow = {
   /** Display name: the configured nick, or the user's account name.
    * `null` only on an orphan-pid row whose DB row is gone. */
   label: string | null;
+  /** #1315 — the ACCOUNT behind a user row (`users.name`), beside the
+   * nick rather than instead of it: a session services renamed to
+   * `GuestNNNNN` keeps a nick that identifies nobody, and the only other
+   * thing the row had was a UUID the card never printed.
+   *
+   * `null` on every class that has no user credential behind it — a
+   * visitor (which has no account at all), an orphan pid, a log-only row
+   * — and on a user row whose name the server could not resolve. Never
+   * derived from `label`: the two are separate facts, per #618. */
+  user_name: string | null;
   network_id: number;
   /** `null` when the FK resolves to no known network (deleted-network
    * race). Never blanked silently — the caller renders the raw id. */
@@ -343,6 +353,7 @@ export function buildSubjectRows(input: {
         subject_kind: "visitor",
         subject_id: v.id,
         label: net.nick,
+        user_name: null,
         network_id: net.network_id,
         network_slug: net.network_slug,
         connection_state: net.connection_state,
@@ -366,6 +377,7 @@ export function buildSubjectRows(input: {
       subject_kind: "user",
       subject_id: c.user_id,
       label: c.nick,
+      user_name: c.user_name,
       network_id: c.network_id,
       network_slug: c.network_slug,
       connection_state: c.connection_state,
@@ -395,6 +407,11 @@ export function buildSubjectRows(input: {
       subject_kind: s.subject_kind,
       subject_id: s.subject_id,
       label: s.subject_label,
+      // #1315 — no credential row, so no account fact to carry. On a USER
+      // orphan `subject_label` IS the account name, and it is already the
+      // label: repeating it here would print the same string twice under
+      // two different meanings.
+      user_name: null,
       network_id: s.network_id,
       network_slug: slugOf(networks, s.network_id),
       connection_state: null,
@@ -430,6 +447,9 @@ export function buildSubjectRows(input: {
       subject_kind: parsed.kind,
       subject_id: parsed.subjectId,
       label: e.nick,
+      // The log has no account column, and the subject row that held one
+      // is gone. Absent, not blank.
+      user_name: null,
       network_id: parsed.networkId,
       // The log stores the slug it saw at emit time; fall back to the
       // live network list, then to null (the caller renders the raw id).

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -614,6 +614,7 @@ export const S_NetworksCredentialsAdminWireSpawnError = {
 export const S_NetworksCredentialsAdminWireT = {
   o: {
     user_id: "s",
+    user_name: { u: ["s", "z"] },
     network_id: "i",
     network_slug: "s",
     nick: "s",

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -578,6 +578,7 @@ export type NetworksCredentialsAdminWireLiveStateJson = {
 
 export type NetworksCredentialsAdminWireT = {
   user_id: string;
+  user_name: string | null;
   network_id: number;
   network_slug: string;
   nick: string;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5470,6 +5470,20 @@ html.resize-dragging * {
   overflow-wrap: anywhere;
 }
 
+/* #1315 — the account name sits ON the identity line, dimmed and a size
+   down for the same reason the network line is: it qualifies the nick
+   rather than competing with it, and the nick is what the admin verbs act
+   on. Same treatment as `.admin-session-network` deliberately — one
+   visual weight for "context about this row's identity", so a third fact
+   would not need a third style. */
+.admin-session-account {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--adm-text-dim);
+  overflow-wrap: anywhere;
+}
+
 /* Second line — dimmed and a size down because it qualifies the nick above
    rather than competing with it. `font-weight: 400` undoes
    `.adm-row-expand`'s 600: the disclosure is bold because it is the row's

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42325,6 +42325,16 @@ already fetched in their `with` chain. A field added at one door only
 would have made the console's answer depend on which verb last touched
 the row.
 
+**The other half of the ruling closes with a PIN, not a change.** "Show
+the credential nick where one is available" was already true on both
+subject kinds — `adminSubjectRows.ts` reads `net.nick` for a visitor and
+`c.nick` for a user, and `Visitors.AdminWire` has carried the credential
+nick beside `live_state.nick` since #618. Pinning it is not ceremony:
+each of the two assertions dies to its own mutant (a label following
+`live_state.nick`) and to nothing else in a 109-test suite, so before
+this the console could have started rendering the live nick on either
+kind without one test noticing.
+
 **What did NOT change, deliberately.** No `configured_nick` column and no
 migration. No change to `Credentials.update_visitor_credential_nick/3` or
 its `auth_method: :none` gate — the #561 invariant (an identified

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42281,3 +42281,60 @@ ours were false for a year. And when a swap changes a library's return
 vocabulary, enumerate the shapes from its source before writing the
 adapter: the branch that matters is rarely the one that changes
 behaviour loudly, it is the one that quietly stops sweeping.
+<!-- entry #1315 -->
+
+---
+
+## 2026-08-14 — #1315: the account is a second identity fact, not a better nick
+
+**A session forced onto `GuestNNNNN` by services was unidentifiable in the
+admin console, and only half of that was a rendering job.** The console
+prints one identity string per row (`adminSubjectRows.ts`), and for a user
+row that string is the credential nick. When Azzurra's services rename an
+unidentified session, the nick becomes `GuestNNNNN` and the row's other
+column is a bare `user_id` UUID that the card never printed — so the
+operator had nothing to act on. vjt's ruling (on `#grappa`): *show the
+credential nick where one is available*, neither option 1 (a
+`configured_nick` column) nor option 2 (stop echoing for anon), and the
+amendment extends the same rule to the user credential rather than making
+it a visitor rule with a user exception.
+
+**So the fix is additive: `users.name` joins the wire beside `nick`, and
+nothing about the nick changes.** `Credentials.AdminWire.t` gains
+`user_name`, `AdminSubjectRow` gains `user_name`, and the identity line
+renders both. The two are separate facts and neither is computed from the
+other — the same posture #618 set for `nick` against `live_state.nick`,
+for the same reason: the divergence IS the information. A row reading
+`Guest12345 · vjt` says what the operator configured, who the account is,
+and that services moved it, all at once; collapsing any pair of those
+would erase exactly the state the console exists to show.
+
+**The name is resolved by the CALLER, not read off an association.**
+`credential_to_admin_json/5` takes it as an argument, like `last_seen_at`
+and `session_ip` before it (#1157, #1308), and the controller fills it
+from `GrappaWeb.Admin.SubjectLabels.resolve/1` — the batched
+subject→display-name join every other admin listing already uses. A
+`Repo.preload(:user)` would have read the same column with a shorter
+diff, and put a per-row `users` lookup on the one endpoint that
+enumerates the entire table. `nil` means the caller resolved no name;
+the console still has `user_id`, and we do not fabricate a placeholder.
+
+**Three doors render this shape, so all three pass the name.** `GET`
+resolves it batched; `PATCH` and `POST` take it from the `%User{}` they
+already fetched in their `with` chain. A field added at one door only
+would have made the console's answer depend on which verb last touched
+the row.
+
+**What did NOT change, deliberately.** No `configured_nick` column and no
+migration. No change to `Credentials.update_visitor_credential_nick/3` or
+its `auth_method: :none` gate — the #561 invariant (an identified
+credential's nick is its login key) stands untouched, and the anon
+visitor's overwritten nick stays unrecoverable, which is the accepted
+cost of declining option 1. The recoverable set and the echo-writable set
+are disjoint by construction, so no `/recover` path reads a clobbered
+nick.
+
+**Apply:** when a row is unidentifiable, ask whether the identity is
+MISSING or merely UNPROJECTED. Unprojected is an additive wire field and
+a batched join at the edge; missing is a migration, and the two should
+never be argued as one change.

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -75,6 +75,7 @@ defmodule Grappa.Networks.Credentials.AdminWire do
 
   @type t :: %{
           user_id: Ecto.UUID.t(),
+          user_name: String.t() | nil,
           network_id: integer(),
           network_slug: String.t(),
           nick: String.t(),
@@ -146,6 +147,17 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   operator a truthful last-seen instead of a `—` that reads "never
   used".
 
+  #1315 — `user_name` is the ACCOUNT behind the row (`users.name`), and
+  like the two above it is resolved by the caller rather than read off the
+  credential: `GrappaWeb.Admin.SubjectLabels` already batches that lookup
+  for every admin listing, and an association read here would put an N+1
+  on the one page that enumerates the whole table. `nil` means the caller
+  resolved no name — missing is missing, and the console still has
+  `user_id`. It is an ADDITIONAL identity fact, never a substitute for
+  `nick`: the ruling (vjt, on #1315) is that the row shows the credential
+  nick where one is available, and the account name beside it, with
+  neither computed from the other.
+
   #1308 — `session_ip` is the address that session logged in from, and
   it is the FIRST source address a user row has ever carried: before
   this the console could show one only for a visitor, out of the
@@ -161,18 +173,21 @@ defmodule Grappa.Networks.Credentials.AdminWire do
           Credential.t(),
           SessionEntry.t() | nil,
           DateTime.t() | nil,
+          String.t() | nil,
           String.t() | nil
         ) :: t()
   def credential_to_admin_json(
         %Credential{network: %Network{slug: slug}} = c,
         live,
         last_seen_at,
-        session_ip
+        session_ip,
+        user_name
       ) do
     %{
       last_seen_at: last_seen_at,
       session_ip: session_ip,
       user_id: c.user_id,
+      user_name: user_name,
       network_id: c.network_id,
       network_slug: slug,
       nick: c.nick,

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -51,7 +51,7 @@ defmodule GrappaWeb.Admin.CredentialsController do
   alias Grappa.AdminEvents.Wire, as: AdminEventsWire
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.Networks.Credentials.AdminWire
-  alias GrappaWeb.Admin.AuthPlug
+  alias GrappaWeb.Admin.{AuthPlug, SubjectLabels}
   alias GrappaWeb.Validation
 
   @doc """
@@ -68,11 +68,24 @@ defmodule GrappaWeb.Admin.CredentialsController do
     user_ids = creds |> Enum.map(& &1.user_id) |> Enum.uniq()
     touches = Accounts.newest_touch_by_subject_ids(:user, user_ids)
 
+    # #1315 — the account name, through the resolver every other admin
+    # listing already joins on. Batched for the same reason as the touches
+    # above: this endpoint enumerates the whole table, which is exactly
+    # where a per-row `users` lookup would hide an N+1.
+    names = SubjectLabels.resolve(Enum.map(user_ids, &{:user, &1}))
+
     rows =
       for cred <- creds do
         live = LiveIntrospection.lookup_session({:user, cred.user_id}, cred.network_id)
         touch = Accounts.touch_of(touches, cred.user_id)
-        AdminWire.credential_to_admin_json(cred, live, touch.last_seen_at, touch.ip)
+
+        AdminWire.credential_to_admin_json(
+          cred,
+          live,
+          touch.last_seen_at,
+          touch.ip,
+          Map.get(names, {:user, cred.user_id})
+        )
       end
 
     json(conn, %{credentials: rows})
@@ -111,7 +124,7 @@ defmodule GrappaWeb.Admin.CredentialsController do
       json(
         conn,
         updated
-        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip)
+        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip, user.name)
         |> AdminWire.with_session_action(action)
       )
     end
@@ -148,7 +161,7 @@ defmodule GrappaWeb.Admin.CredentialsController do
       |> put_status(:created)
       |> json(
         cred
-        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip)
+        |> AdminWire.credential_to_admin_json(live, touch.last_seen_at, touch.ip, user.name)
         |> AdminWire.with_bind_outcome(outcome)
       )
     end

--- a/test/grappa/networks/credentials/admin_wire_test.exs
+++ b/test/grappa/networks/credentials/admin_wire_test.exs
@@ -37,7 +37,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
     }
   end
 
-  describe "credential_to_admin_json/4" do
+  describe "credential_to_admin_json/5" do
     test "projects operator-relevant fields + nil live_state when no session" do
       now = DateTime.utc_now()
       c = %{credential_fixture() | inserted_at: now, updated_at: now}
@@ -57,7 +57,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
                inserted_at: ^now,
                updated_at: ^now,
                live_state: nil
-             } = AdminWire.credential_to_admin_json(c, nil, nil, nil)
+             } = AdminWire.credential_to_admin_json(c, nil, nil, nil, nil)
     end
 
     test "projects live_state when a SessionEntry is supplied" do
@@ -92,7 +92,7 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
                  joined_channels: ["#bofh"],
                  introspection_degraded: []
                }
-             } = AdminWire.credential_to_admin_json(c, entry, nil, nil)
+             } = AdminWire.credential_to_admin_json(c, entry, nil, nil, nil)
 
       assert is_binary(pid_str)
       assert String.starts_with?(pid_str, "#PID<")
@@ -113,11 +113,11 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
       seen = DateTime.truncate(DateTime.utc_now(), :second)
 
       assert %{last_seen_at: ^seen, live_state: nil} =
-               AdminWire.credential_to_admin_json(credential_fixture(), nil, seen, nil)
+               AdminWire.credential_to_admin_json(credential_fixture(), nil, seen, nil, nil)
     end
 
     test "renders last_seen_at: nil when the user has never been seen" do
-      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil, nil)
 
       assert Map.has_key?(json, :last_seen_at)
       assert json.last_seen_at == nil
@@ -130,18 +130,43 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
     # be a lie to the operator.
     test "carries session_ip on a row with no live session" do
       assert %{session_ip: "203.0.113.9", live_state: nil} =
-               AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, "203.0.113.9")
+               AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, "203.0.113.9", nil)
     end
 
     test "renders session_ip: nil when the user has never logged in" do
-      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil, nil)
 
       assert Map.has_key?(json, :session_ip)
       assert json.session_ip == nil
     end
 
+    # #1315 — the account BEHIND the row, which the wire did not carry at
+    # all. The operator read a nick and a `user_id`, and services renaming
+    # a session to `GuestNNNNN` left a row nothing on the card identified.
+    # Deliberately unequal to the credential nick: a projection that put
+    # `c.nick` in this key would satisfy a fixture where the two agree.
+    test "carries the account name beside the credential nick" do
+      json =
+        AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil, "vjt-the-account")
+
+      assert json.user_name == "vjt-the-account"
+      # Additive, per the #618 posture: an extra identity fact, never a
+      # substitute for the configured nick.
+      assert json.nick == "vjt"
+    end
+
+    # Missing is missing, as on every other admin projection: the caller
+    # resolves the name and hands over `nil` when there is none, and the
+    # console falls back to the `user_id` it still has. We never fabricate.
+    test "renders user_name: nil when the caller resolved no account name" do
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil, nil)
+
+      assert Map.has_key?(json, :user_name)
+      assert json.user_name == nil
+    end
+
     test "NEVER includes password_encrypted or password (credential material exclusion)" do
-      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil)
+      json = AdminWire.credential_to_admin_json(credential_fixture(), nil, nil, nil, nil)
 
       refute Map.has_key?(json, :password)
       refute Map.has_key?(json, :password_encrypted)

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -166,6 +166,29 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
       assert row["session_ip"] == nil
     end
 
+    # #1315 — who the row IS, not just which nick it configured. The
+    # console rendered `nick` alone, so a session services had renamed to
+    # `GuestNNNNN` was identified by nothing at all: `user_id` is a bare
+    # UUID and is not even on the card. The account name is an additional
+    # identity fact, resolved from `users.name` — assert it against BOTH
+    # the account and the nick, which the fixture keeps distinct, or a
+    # projection that echoed the nick into the key would pass.
+    test "200 + user_name is the owning account, beside the nick", %{conn: conn} do
+      {user, network, _} = bound_credential()
+
+      session = admin_session()
+      conn = conn |> put_bearer(session.id) |> get("/admin/credentials")
+
+      row =
+        Enum.find(json_response(conn, 200)["credentials"], fn r ->
+          r["user_id"] == user.id and r["network_id"] == network.id
+        end)
+
+      assert row["user_name"] == user.name
+      assert row["nick"] == "vjt"
+      refute row["user_name"] == row["nick"]
+    end
+
     test "200 + NEVER includes password_encrypted or password (defense-in-depth)", %{conn: conn} do
       _ = bound_credential()
 
@@ -213,6 +236,26 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
       reload = Credentials.get_credential!(user, network)
       assert reload.nick == "renamed"
+    end
+
+    # #1315 — the PATCH reply is one GET row, so it owes the same identity
+    # fact. Three doors render this shape and a field added at only one of
+    # them makes the console's answer depend on which verb last touched
+    # the row.
+    test "200 + the reply carries user_name like an index row", %{conn: conn} do
+      {user, network, _} = bound_credential()
+
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/admin/credentials/#{user.id}/#{network.id}", Jason.encode!(%{nick: "renamed"}))
+
+      body = json_response(conn, 200)
+      assert body["user_name"] == user.name
+      assert body["nick"] == "renamed"
     end
 
     test "200 + edits autojoin_channels + realname together", %{conn: conn} do
@@ -443,6 +486,35 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
       # Verify cred persisted.
       assert {:ok, _} = Credentials.get_credential(target_user, network)
+    end
+
+    # #1315 — third door, same shape. The bind reply is what the console
+    # renders for the row it just created, before any refetch.
+    test "201 + the bind reply carries user_name", %{conn: conn} do
+      target_user = user_fixture(name: "bind-name-#{System.unique_integer([:positive])}")
+
+      {:ok, network} =
+        Networks.find_or_create_network(%{slug: "bind-name-#{System.unique_integer([:positive])}"})
+
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/admin/credentials",
+          Jason.encode!(%{
+            user_id: target_user.id,
+            network_id: network.id,
+            nick: "vjt",
+            auth_method: "none"
+          })
+        )
+
+      body = json_response(conn, 201)
+      assert body["user_name"] == target_user.name
+      assert body["nick"] == "vjt"
     end
 
     test "201 + binds with auth_method :auto + password", %{conn: conn} do


### PR DESCRIPTION
## What

The user half of #1315, under vjt's ruling (*"show the credential nick where one is available"*, amended to *"the same for the user cred"*): **neither** migration option, no change to the anon echo.

1. **`users.name` joins the admin credential wire** as `user_name`, beside `nick` — additive, snake_case, never a substitute.
2. **cic renders it** on the identity line of a user row, dimmed like the network line under it.
3. **Both subject kinds get the pin** the ruling asks for: the row's label is the CONFIGURED nick, with the live nick beside it, unreconciled (#618).

## Why

A session Azzurra's services rename to `GuestNNNNN` was unidentifiable in the console. The row prints one identity string — the credential nick — and the only other thing it carried was a `user_id` UUID that the card never rendered. When the nick stopped naming anybody, nothing on the row did.

Nothing was lost on the user side: the fact exists in the DB and simply was not projected.

## Design calls

- **Argument, not `Repo.preload(:user)`.** The name comes through `GrappaWeb.Admin.SubjectLabels.resolve/1`, the batched subject→name join every other admin listing already uses. `GET /admin/credentials` enumerates the whole table, which is exactly where an association read would hide an N+1. Same shape as `last_seen_at` (#1157) and `session_ip` (#1308) on this wire.
- **`nil` is rendered, not fabricated.** Missing is missing; the console still has `user_id`.
- **All three doors pass it** (GET batched, PATCH/POST from the `%User{}` already in their `with`), so the console's answer does not depend on which verb last touched the row.
- **`wireTypes.ts` + `wireSchema.ts` regenerated**, never hand-edited — a hand-edited type would leave the payload travelling unvalidated with the static gate still green. The regeneration made two unrelated fixtures fail to compile, which is the twin doing its job.

## Explicitly out of scope

No `configured_nick` column, no migration, no change to `Credentials.update_visitor_credential_nick/3` or its `auth_method: :none` gate (#561 stands). The anon visitor's overwritten nick stays unrecoverable — the accepted cost of declining option 1. Per the issue's first comment, the echo-writable set and the recoverable set are disjoint by construction, so this was never a broken `/recover`.

## How the assertions were sized

Every one by mutation; no mutant killed zero, and each pin dies to its own:

| mutant | assertions killed |
|---|---|
| wire echoes `c.nick` into `user_name` | 5 (wire ×2, GET, PATCH, POST) |
| `index` drops the resolved name | 1 — the GET test only |
| both write doors pass `nil` | 2 — the PATCH and POST tests only |
| user row's label follows `live_state.nick` | 1 — the USER pin only |
| visitor row's label follows `live_state.nick` | 1 — the VISITOR pin only |
| `user_name: c.nick` on the cic row | 3 (row ×2, tab) |
| visitor row invents an account name | 2 (row, tab) |
| the render's `Show` gates on `label` | 2 — both tab assertions |

## Gates

- `scripts/check.sh` — **RC=0** (6119 tests, credo, dialyzer, sobelow, doctor, bats, `gen_wire_types --check`), measured on the pre-rebase base `774c387f`.
- Post-rebase onto `5316048d`: the two touched server suites (55 tests) and `gen_wire_types --check` re-run green; the branch's `--numstat` contribution is byte-identical on both sides of the rebase.
- cic: `bun run test` **5438 passed**, `bun run check` RC=0, `design-notes-gate.sh` RC=0.
- **No e2e.** The sibling #1308 shipped a browser witness for its console field; this one has none. Say so if you want it and I will take the e2e lane.