### PR TITLE
docs(#1037): document the two compose-only env knobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,29 @@ LOG_LEVEL=info
 # net.ipv6.ip_nonlocal_bind=1). Docker cannot provide either — leave unset.
 # GRAPPA_SUBSTRATE=docker
 
+# ─── cicchetto bundle build (compose-only, `--profile prod`) ──────────────────
+# #1037: both are read by compose.yaml ALONE — neither reaches config/runtime.exs
+# or bin/start.sh, so neither is an app var. Every deploy wrapper already sets
+# them; documented for the operator who drives `docker compose --profile prod
+# run --rm cicchetto-build` by hand.
+#
+# GRAPPA_VERSION is the `cicchetto-build` `environment:` entry vite bakes into
+# `<meta name="cicchetto-version">` (#538/#652). Compose forwards it as EMPTY
+# when unset and vite then REFUSES to build, rather than ship an unversioned
+# bundle — the container mounts only ./cicchetto, so it cannot read the
+# repo-root VERSION itself. The wrappers derive it per launch via
+# infra/packaging/version.sh. Set it to stamp a bundle with something other
+# than the checkout's VERSION.
+# GRAPPA_VERSION=
+#
+# CIC_BUILD_OUT is the host side of that service's `volumes:` mount — where the
+# built SPA lands. Defaults to the directory the BEAM serves (CIC_DIST_ROOT
+# above). vite EMPTIES its out dir before writing, so building straight into
+# the served directory serves an empty SPA for the whole build (#1020): the
+# wrappers point this at a staging sibling and rename it into place. Override
+# with the same staging-then-rename discipline.
+# CIC_BUILD_OUT=./runtime/cicchetto-dist
+
 # ─── T31 admission captcha (optional — leave unset for Disabled provider) ─────
 # config/runtime.exs reads these env vars to populate :grappa, :admission
 # config (provider, secret, public site key). Provider absent / unknown =

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42348,3 +42348,38 @@ nick.
 MISSING or merely UNPROJECTED. Unprojected is an additive wire field and
 a batched join at the edge; missing is a migration, and the two should
 never be argued as one change.
+<!-- entry #1037 -->
+
+---
+
+## 2026-08-14 — #1037: document the two compose-only knobs, not the class
+
+#1036 made `compose.yaml` a derived source for the env-registry drift pin.
+That makes an orchestration var ALLOWED in `.env.example`; it does not make
+it REQUIRED there, and only `app_vars/0` — what `config/runtime.exs` and
+`bin/start.sh` read — is required. `GRAPPA_VERSION` and `CIC_BUILD_OUT` lived
+in that gap: compose reads both, nothing demanded they be written down, and
+an operator driving the `cicchetto-build` service by hand had to read
+`compose.yaml` to learn they exist.
+
+Ruling (vjt): document them in `.env.example` and leave the pin untouched.
+Requiring every compose-interpolated var instead would need an exemption set
+for internal wiring — the hand-kept parallel list #1036 had just deleted, and
+the exact shape whose drift the pin exists to catch. Declaring compose-only
+knobs deliberately undocumented was refused on the facts: both are
+operator-facing. An entry that does not say WHICH block reads the var is not
+documentation, so each names its side of the service — `GRAPPA_VERSION` the
+`environment:` vite bakes into `<meta cicchetto-version>`, `CIC_BUILD_OUT` the
+`volumes:` source the SPA is written to.
+
+Two of the issue's "not verified" items were measured while the file was
+open. The pair IS the whole set: every `${VAR}` interpolation in
+`compose.yaml` (35 of them) minus the names `.env.example` already declares
+leaves exactly these two. And the `${VAR:-}` ghost written inside a comment
+— a text scan counts it as a read, so it can only ever widen the allow-set —
+is gone from `compose.yaml` altogether: #1159 (`85a1f188`) deleted the line
+the issue cited, and no other prose interpolation survives.
+
+**Accepted cost, stated so the next one is not read as a regression:** this
+fixes the instance, not the class. A third compose-only knob added tomorrow
+is undocumented again, and no gate says so.


### PR DESCRIPTION
Implements the ruling on #1037 (option 1): `GRAPPA_VERSION` and `CIC_BUILD_OUT`
get an entry in `.env.example`, and the drift pin stays exactly as it is.

## What changed

- **`.env.example`** — a new `cicchetto bundle build (compose-only, --profile
  prod)` section. Each entry names the block that reads it, since an entry that
  does not say which of the two it steers is not documentation:
  - `GRAPPA_VERSION` → the `cicchetto-build` `environment:` value vite bakes
    into `<meta name="cicchetto-version">` (#538/#652). Compose forwards it
    EMPTY when unset and vite then refuses to build, rather than ship an
    unversioned bundle; the container mounts only `./cicchetto`, so it cannot
    read the repo-root `VERSION` itself.
  - `CIC_BUILD_OUT` → the host side of that service's `volumes:` mount.
    Defaults to the directory the BEAM serves, and vite empties its out dir
    before writing, so a build straight into the served directory serves an
    empty SPA for its whole duration (#1020) — hence the staging-then-rename
    discipline the wrappers use.
- **`docs/DESIGN_NOTES.md`** — the ruling, the two options refused and why, and
  the accepted cost (this fixes the instance, not the class).

`Grappa.Config.EnvRegistryDriftTest` is untouched: orchestration vars remain
*allowed* in `.env.example`, not *required*, and no exemption list is
introduced.

## Measured

- **The pair is the whole set.** Every `${VAR}` interpolation in
  `compose.yaml` (35 occurrences, 32 distinct names) minus the names
  `.env.example` already declares — matched with the same
  `^#?\s*([A-Z][A-Z0-9_]*)=` shape the drift pin uses — leaves exactly
  `GRAPPA_VERSION` and `CIC_BUILD_OUT`. This retires the issue's "not verified
  that these two are the only ones".
- **The comment-borne `${VAR:-}` ghost is gone.** The prose interpolation the
  issue cited at `compose.yaml:131` no longer exists: #1159 (`85a1f188`)
  deleted that line, and no other prose interpolation survives in the file.
- `scripts/design-notes-gate.sh` → RC=0, "1 new entry heading(s), separator and
  marker present".
- `scripts/bats.sh` → **477 ok / 0 not ok**, RC=0 (the `BW02` lines in the tail
  are pre-existing bats-core warnings in files this branch does not touch).

## Not claimed

- **`Grappa.Config.EnvRegistryDriftTest` was NOT run** on this branch — no
  Elixir gate was run at all. By inspection the pin should stay green (its
  orphan check subtracts vars consumed by `compose.yaml`, and the
  `cicchetto-build` service sits outside the subtracted `grappa`
  `environment:` block), but that is reasoning, not a measurement.
- **A stale sentence is left behind, deliberately.** The pin's moduledoc reads
  "a compose-only knob may still go undocumented (`GRAPPA_VERSION`,
  `CIC_BUILD_OUT` are, today)". The limit it states — allowed, not required —
  stays true; the parenthetical example does not, once this lands. Correcting
  it would mean touching the test, which the ruling excludes, so it is flagged
  here rather than changed.