### PR TITLE
cic(#1323): reconcile the VAPID key instead of recalling it

### DIFF
--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearVapidPublicKeyCache,
   deletePushSubscription,
   disablePush,
+  enablePush,
   ensurePushSubscription,
+  fetchVapidPublicKey,
   formatDeviceActivity,
-  getVapidPublicKey,
   listPushDevices,
   type PushDeviceSummary,
   postPushSubscription,
@@ -31,9 +31,12 @@ const sample = {
   publicKey: "BJk1234567890abcdefghijklmnopqrstuv-_wxyzABC",
 };
 
+// #1323 — the key the operator rotated TO. Same length class as `sample`
+// so both decode cleanly through `vapidKeyToUint8Array`.
+const ROTATED_KEY = "BRotated9876543210zyxwvutsrqponmlkjihgfe-_AB";
+
 beforeEach(() => {
   localStorage.clear();
-  clearVapidPublicKeyCache();
 });
 
 afterEach(() => {
@@ -46,6 +49,9 @@ afterEach(() => {
 // (pushManager / Notification / fetch); the real push.ts handlers run.
 const SUB_ID_KEY = "cic.pushSubscriptionId";
 const SUB_ENDPOINT_KEY = "cic.pushSubscriptionEndpoint";
+// #1323 — the key the LIVE subscription was created with (not a read-through
+// cache: nothing is ever served from it).
+const SUBSCRIBED_KEY = "cic.vapidPublicKey";
 
 function fakeSub(endpoint: string): PushSubscription {
   return {
@@ -80,14 +86,34 @@ function stubPushEnv(opts: {
   return { getSubscription, subscribe };
 }
 
+// The body of the `POST /push/subscriptions` the run made, or null when it
+// registered nothing.
+function postedSubscription(
+  fetchMock: ReturnType<typeof vi.spyOn>,
+): { endpoint?: string; supersedes?: string } | null {
+  const call = fetchMock.mock.calls.find(
+    (args: unknown[]) =>
+      args[0] === "/push/subscriptions" && (args[1] as RequestInit | undefined)?.method === "POST",
+  ) as [string, RequestInit] | undefined;
+  return call === undefined ? null : JSON.parse(call[1].body as string);
+}
+
+// The application server key bytes handed to the FIRST `pushManager.subscribe`
+// call — the assertion that says WHICH VAPID key a subscription was born with.
+function firstSubscribeKeyBytes(subscribe: ReturnType<typeof vi.fn>): number[] {
+  const [options] = subscribe.mock.calls[0] as [PushSubscriptionOptionsInit];
+  return Array.from(options.applicationServerKey as Uint8Array);
+}
+
 // Route fetch by URL: VAPID key GET, subscription POST, subscription DELETE.
-function stubPushFetch(): ReturnType<typeof vi.spyOn> {
+// `servedKey` is what the server currently signs with — the axis #1323 turns on.
+function stubPushFetch(servedKey: string): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL, init?) => {
     const url = String(input);
     const method = init?.method ?? "GET";
     if (url.includes("/push/vapid-public-key")) {
       return Promise.resolve(
-        new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
+        new Response(JSON.stringify({ public_key: servedKey }), { status: 200 }),
       );
     }
     if (url === "/push/subscriptions" && method === "POST") {
@@ -111,7 +137,7 @@ describe("disablePush — #181: DELETE the stashed row, never orphan it", () => 
     // the push service keeps 2xx-ing a dead endpoint forever.
     localStorage.setItem(SUB_ID_KEY, "srv-ghost");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ existingSubscription: null });
 
     const removed = await disablePush("tok");
@@ -126,7 +152,7 @@ describe("disablePush — #181: DELETE the stashed row, never orphan it", () => 
   });
 
   it("no server DELETE when there is no stashed id to clean up", async () => {
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ existingSubscription: null });
     await disablePush("tok");
     expect(fetchMock).not.toHaveBeenCalled();
@@ -137,7 +163,7 @@ describe("ensurePushSubscription — #181: renew a dropped-but-wanted subscripti
   it("re-subscribes and POSTs supersedes=<old endpoint> on a silent drop", async () => {
     localStorage.setItem(SUB_ID_KEY, "srv-old");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({
       permission: "granted",
       existingSubscription: null,
@@ -147,93 +173,168 @@ describe("ensurePushSubscription — #181: renew a dropped-but-wanted subscripti
     const outcome = await ensurePushSubscription("tok");
 
     expect(outcome).toBe("renewed");
-    const post = fetchMock.mock.calls.find(
-      (call: unknown[]) =>
-        call[0] === "/push/subscriptions" &&
-        (call[1] as RequestInit | undefined)?.method === "POST",
-    );
-    expect(post).toBeDefined();
-    const body = JSON.parse((post![1] as RequestInit).body as string);
-    expect(body.endpoint).toBe("https://push.example/NEW");
-    expect(body.supersedes).toBe("https://push.example/OLD");
-    // fresh server id + endpoint stashed for the next cycle
+    const body = postedSubscription(fetchMock);
+    expect(body?.endpoint).toBe("https://push.example/NEW");
+    expect(body?.supersedes).toBe("https://push.example/OLD");
+    // fresh server id + endpoint stashed for the next cycle, plus (#1323) the
+    // key this subscription was created with.
     expect(localStorage.getItem(SUB_ID_KEY)).toBe("srv-new");
     expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(sample.publicKey);
   });
 
-  it("no-ops when a live subscription is already present", async () => {
+  it("keeps a live subscription whose key still matches what the server serves", async () => {
     localStorage.setItem(SUB_ID_KEY, "srv-old");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/LIVE");
-    const fetchMock = stubPushFetch();
-    stubPushEnv({
-      permission: "granted",
-      existingSubscription: fakeSub("https://push.example/LIVE"),
-    });
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    const fetchMock = stubPushFetch(sample.publicKey);
+    const live = fakeSub("https://push.example/LIVE");
+    const { subscribe } = stubPushEnv({ permission: "granted", existingSubscription: live });
 
     expect(await ensurePushSubscription("tok")).toBe("present");
-    expect(fetchMock).not.toHaveBeenCalled();
+
+    // #1323 — the key IS revalidated (one GET), it just matched: nothing is
+    // torn down and no row is registered.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/push/vapid-public-key");
+    expect(vi.mocked(live.unsubscribe)).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
   });
 
   it("skips (never prompts) when permission is not granted", async () => {
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ permission: "default", existingSubscription: null });
     expect(await ensurePushSubscription("tok")).toBe("skipped");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does nothing when the user never opted in (no stashed endpoint = no intent)", async () => {
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ permission: "granted", existingSubscription: null });
     expect(await ensurePushSubscription("tok")).toBe("no-intent");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
-describe("getVapidPublicKey", () => {
-  it("fetches + caches on first call", async () => {
+// ── #1323 — a rotated VAPID key must heal itself, with no user gesture ──
+// Measured on staging: a subscription created with key A can never be signed
+// for once the server serves key B (`400 VapidPkHashMismatch` from Apple,
+// `403` from FCM). The client held the old key in localStorage and never
+// looked again, so nothing on either side reconciled — push died silently and
+// permanently. These tests pin the reconciliation at both doors.
+describe("#1323 — VAPID rotation heals on the ensure seam", () => {
+  it("drops the stale subscription and re-subscribes with the served key", async () => {
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    const fetchMock = stubPushFetch(ROTATED_KEY);
+    const live = fakeSub("https://push.example/OLD");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: live,
+      subscribeResult: fakeSub("https://push.example/NEW"),
+    });
+
+    expect(await ensurePushSubscription("tok")).toBe("rekeyed");
+
+    expect(vi.mocked(live.unsubscribe)).toHaveBeenCalled();
+    expect(firstSubscribeKeyBytes(subscribe)).toEqual(
+      Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
+    );
+    expect(postedSubscription(fetchMock)?.endpoint).toBe("https://push.example/NEW");
+    // The record now names the key the LIVE subscription was created with.
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
+    expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");
+  });
+
+  it("leaves the recorded key untouched when the re-subscribe fails", async () => {
+    // Recording the served key before the subscribe succeeds would re-create
+    // the #1323 silence one seam later: the next pass would see
+    // recorded == served, answer "present", and never heal.
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    stubPushFetch(ROTATED_KEY);
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: fakeSub("https://push.example/OLD"),
+    });
+    subscribe.mockRejectedValue(new Error("subscribe blew up"));
+
+    await expect(ensurePushSubscription("tok")).rejects.toThrow(/subscribe blew up/);
+
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(sample.publicKey);
+  });
+});
+
+describe("#1323 — enablePush subscribes with the served key, never a recorded one", () => {
+  it("drops a subscription bound to a superseded key before subscribing", async () => {
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    stubPushFetch(ROTATED_KEY);
+    const live = fakeSub("https://push.example/OLD");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: live,
+      subscribeResult: fakeSub("https://push.example/NEW"),
+    });
+
+    expect(await enablePush("tok")).toEqual({ status: "enabled", subscriptionId: "srv-new" });
+
+    expect(vi.mocked(live.unsubscribe)).toHaveBeenCalled();
+    expect(firstSubscribeKeyBytes(subscribe)).toEqual(
+      Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
+    );
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
+  });
+
+  it("unsubscribes the conflicting subscription when the browser raises InvalidAccessError", async () => {
+    // The browser's own guard: an existing subscription bound to another key.
+    // Re-fetching the key cannot clear it — only unsubscribing can.
+    stubPushFetch(sample.publicKey);
+    const conflicting = fakeSub("https://push.example/CONFLICT");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: conflicting,
+    });
+    subscribe
+      .mockRejectedValueOnce(new DOMException("different key", "InvalidAccessError"))
+      .mockResolvedValue(fakeSub("https://push.example/NEW"));
+
+    expect(await enablePush("tok")).toEqual({ status: "enabled", subscriptionId: "srv-new" });
+
+    expect(vi.mocked(conflicting.unsubscribe)).toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("fetchVapidPublicKey", () => {
+  it("always GETs — a recorded key is never served in its place (#1323)", async () => {
+    localStorage.setItem(SUBSCRIBED_KEY, "stale-value");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(
         new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
       );
 
-    expect(await getVapidPublicKey()).toBe(sample.publicKey);
+    expect(await fetchVapidPublicKey()).toBe(sample.publicKey);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem("cic.vapidPublicKey")).toBe(sample.publicKey);
-  });
-
-  it("returns cached value on subsequent calls without fetching", async () => {
-    localStorage.setItem("cic.vapidPublicKey", sample.publicKey);
-    const fetchMock = vi.spyOn(globalThis, "fetch");
-
-    expect(await getVapidPublicKey()).toBe(sample.publicKey);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("forceRefresh bypasses the cache", async () => {
-    localStorage.setItem("cic.vapidPublicKey", "stale-value");
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
-      );
-
-    expect(await getVapidPublicKey(true)).toBe(sample.publicKey);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem("cic.vapidPublicKey")).toBe(sample.publicKey);
+    // Reading the key does NOT record it: only a successful subscribe does.
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe("stale-value");
   });
 
   it("throws ApiError on non-OK response", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
-    await expect(getVapidPublicKey()).rejects.toThrow(/500/);
+    await expect(fetchVapidPublicKey()).rejects.toThrow(/500/);
   });
 
   it("throws ApiError on malformed body", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 200 }),
     );
-    await expect(getVapidPublicKey()).rejects.toThrow(/vapid_malformed/);
+    await expect(fetchVapidPublicKey()).rejects.toThrow(/vapid_malformed/);
   });
 });
 

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -242,7 +242,12 @@ describe("#1323 — VAPID rotation heals on the ensure seam", () => {
     expect(firstSubscribeKeyBytes(subscribe)).toEqual(
       Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
     );
-    expect(postedSubscription(fetchMock)?.endpoint).toBe("https://push.example/NEW");
+    const body = postedSubscription(fetchMock);
+    expect(body?.endpoint).toBe("https://push.example/NEW");
+    // The row the client is REPLACING is named on the way in — the same #181
+    // `supersedes` the renew branch uses, not a reap: the server is told which
+    // row died, it does not infer it from a 4xx (the thing #1325 declined).
+    expect(body?.supersedes).toBe("https://push.example/OLD");
     // The record now names the key the LIVE subscription was created with.
     expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
     expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -5,25 +5,38 @@
 // key, base64url-decodes it for `pushManager.subscribe`, and POSTs
 // the resulting subscription JSON to /push/subscriptions.
 //
-// B2 ships the lower half: VAPID-key fetching + cache, the
+// B2 ships the lower half: VAPID-key fetching, the
 // subscribe/unsubscribe primitives. The B3 settings UI imports this
 // module's `enablePush` / `disablePush` / `listPushDevices` to drive
 // the master toggle dance.
 //
-// ## VAPID public-key cache
+// ## The VAPID public key is fetched, never recalled (#1323)
 //
-// Key fetched from `GET /push/vapid-public-key` on first use, cached
-// in localStorage so subsequent subscribe calls don't round-trip.
-// Refresh path: cic catches `InvalidApplicationServerKey` from the
-// browser's `pushManager.subscribe` and re-fetches once. No HTTP
-// cache headers — operator-rotation is rare and the payload is ~88
-// bytes; localStorage is the authoritative cache.
+// `localStorage["cic.vapidPublicKey"]` used to be a read-through cache:
+// populated on first fetch, returned unconditionally afterwards. That is
+// what made an operator key rotation a silent, permanent kill — measured on
+// staging as `400 {"reason":"VapidPkHashMismatch"}` from Apple (and `403`
+// from FCM for the same failure in Google's vocabulary). The push service
+// binds a subscription to the key that CREATED it, so a client subscribing
+// with the recalled old key produces a perfectly valid subscription the
+// server can never sign for. No exception is raised anywhere: the browser
+// sees nothing inconsistent, the UI says push is on, the server logs a
+// rejection nobody reads.
+//
+// So the same storage key now means something else: **the key the LIVE
+// subscription was created with**, written ONLY after a subscribe succeeds
+// and cleared with the subscription. It is a comparison anchor, never a
+// source. Every subscribe fetches the served key and reconciles against it;
+// on a difference the browser subscription is dropped and re-created. The
+// re-meaning needs no migration — the old cache was populated at subscribe
+// time, so a client broken by a rotation already holds exactly the key it
+// subscribed with, which is what makes it heal on its first ensure seam.
 
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
 
-const VAPID_PUBLIC_KEY_STORAGE_KEY = "cic.vapidPublicKey";
+const SUBSCRIBED_VAPID_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
 /**
  * #459 — THE single, synchronous "can push actually be delivered here?" gate,
@@ -52,18 +65,12 @@ export function pushAvailable(): boolean {
 }
 
 /**
- * Fetches the server's VAPID public key, returning the cached value
- * when present. The key is non-secret per the W3C Push spec; storing
- * it in localStorage is fine.
- *
- * @param forceRefresh — bypass the cache (used after an
- *   `InvalidApplicationServerKey` exception).
+ * The VAPID public key the server signs with, straight from
+ * `GET /push/vapid-public-key`. Always a round-trip: nothing is recalled
+ * from storage (see the moduledoc — recalling it is #1323). The key is
+ * non-secret per the W3C Push spec, and the payload is ~90 bytes.
  */
-export async function getVapidPublicKey(forceRefresh = false): Promise<string> {
-  if (!forceRefresh) {
-    const cached = localStorage.getItem(VAPID_PUBLIC_KEY_STORAGE_KEY);
-    if (cached !== null && cached !== "") return cached;
-  }
+export async function fetchVapidPublicKey(): Promise<string> {
   const res = await fetch("/push/vapid-public-key", {
     headers: { "content-type": "application/json" },
   });
@@ -74,7 +81,6 @@ export async function getVapidPublicKey(forceRefresh = false): Promise<string> {
   if (typeof body.public_key !== "string" || body.public_key === "") {
     throw new ApiError(500, "vapid_malformed");
   }
-  localStorage.setItem(VAPID_PUBLIC_KEY_STORAGE_KEY, body.public_key);
   return body.public_key;
 }
 
@@ -94,11 +100,6 @@ export function vapidKeyToUint8Array(base64Url: string): Uint8Array {
     out[i] = raw.charCodeAt(i);
   }
   return out;
-}
-
-/** Clears the cached VAPID key — used by tests + after a server rotation. */
-export function clearVapidPublicKeyCache(): void {
-  localStorage.removeItem(VAPID_PUBLIC_KEY_STORAGE_KEY);
 }
 
 /**
@@ -223,9 +224,13 @@ export async function listPushDevices(token: string): Promise<PushDeviceSummary[
 const SUBSCRIPTION_ID_STORAGE_KEY = "cic.pushSubscriptionId";
 const SUBSCRIPTION_ENDPOINT_STORAGE_KEY = "cic.pushSubscriptionEndpoint";
 
-function rememberSubscription(id: SubscriptionId, endpoint: string): void {
+function rememberSubscription(id: SubscriptionId, endpoint: string, vapidKey: string): void {
   localStorage.setItem(SUBSCRIPTION_ID_STORAGE_KEY, id);
   localStorage.setItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY, endpoint);
+  // #1323 — recorded only here, i.e. only once a subscribe has succeeded.
+  // Recording the served key any earlier would make the NEXT reconciliation
+  // read "same key" off a subscription that was never re-created.
+  localStorage.setItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY, vapidKey);
 }
 
 /**
@@ -248,6 +253,7 @@ export function subscriptionIdForEndpoint(endpoint: string): SubscriptionId | nu
 function forgetSubscription(): void {
   localStorage.removeItem(SUBSCRIPTION_ID_STORAGE_KEY);
   localStorage.removeItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY);
+  localStorage.removeItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY);
 }
 
 /**
@@ -283,11 +289,10 @@ export type EnablePushResult =
  *      programmatic re-asks until the user clears site data).
  *   3. If `default`, request permission. On `denied`/`default` after
  *      the prompt, bail with `permission_denied`/`permission_dismissed`.
- *   4. Get the SW registration (waits for ready). Fetch the VAPID
- *      public key (cached). Subscribe via `pushManager.subscribe`.
- *      On `InvalidApplicationServerKey`, refresh the cached key once
- *      and retry — protects against operator-rotated VAPID keys
- *      sticking around in localStorage.
+ *   4. Get the SW registration (waits for ready). Fetch the served VAPID
+ *      public key and reconcile it against the key our live subscription
+ *      was created with (#1323); on a rotation, drop that subscription
+ *      before subscribing with the fresh key.
  *   5. POST the subscription to `/push/subscriptions`. Return the
  *      created subscription's id so the UI can refresh its devices
  *      list directly without an extra GET round-trip.
@@ -314,7 +319,7 @@ export async function enablePush(token: string): Promise<EnablePushResult> {
     return { status: "unsupported", reason: "no_push_manager" };
   }
 
-  const subscription = await subscribeWithVapidRetry(registration);
+  const { subscription, key } = await subscribeWithCurrentVapidKey(registration);
   const json = subscription.toJSON() as {
     endpoint?: string;
     keys?: { p256dh?: string; auth?: string };
@@ -330,7 +335,7 @@ export async function enablePush(token: string): Promise<EnablePushResult> {
     endpoint: json.endpoint,
     keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
   });
-  rememberSubscription(created.id, json.endpoint);
+  rememberSubscription(created.id, json.endpoint, key);
   return { status: "enabled", subscriptionId: created.id };
 }
 
@@ -392,27 +397,32 @@ export async function disablePush(token: string): Promise<boolean> {
  *
  *   * "renewed"   — the browser subscription had dropped; re-subscribed
  *     and POSTed the fresh subscription (superseding the old row).
- *   * "present"   — a live subscription already exists (or a same-endpoint
- *     replay), nothing to do.
+ *   * "rekeyed"   — #1323: the server serves a VAPID key that supersedes the
+ *     one the live subscription was created with, so that subscription can
+ *     never be signed for; it was dropped and re-created with the fresh key.
+ *   * "present"   — a live subscription exists AND was created with the key
+ *     the server still serves (or a same-endpoint replay), nothing to do.
  *   * "skipped"   — the runtime can't push (no Notification / SW /
  *     pushManager) or permission isn't `granted`. Never prompts here.
  *   * "no-intent" — the user never opted in / disabled push (no stashed
  *     endpoint), so there is nothing to renew.
  */
-export type EnsurePushOutcome = "renewed" | "present" | "skipped" | "no-intent";
+export type EnsurePushOutcome = "renewed" | "rekeyed" | "present" | "skipped" | "no-intent";
 
 /**
  * #181 — renew a dropped-but-still-wanted push subscription on the
  * SW-update / app-resume lifecycle seams (wired by `lib/pushResubscribe.ts`).
  *
  * RENEW-ONLY: it never prompts for permission and never opts a user in.
- * It acts only when ALL hold: `Notification.permission === "granted"`, the
- * user previously opted in (a stashed endpoint proves intent — cleared on
- * disable), AND the browser's live `pushManager.getSubscription()` has gone
- * `null` (the silent drop the issue describes). On that exact state it
- * re-subscribes via the SAME VAPID path as the initial enable and POSTs the
- * fresh subscription with `supersedes: <old endpoint>` so the server prunes
- * the ghost row. A `422` replay (endpoint did not rotate) counts as present.
+ * It acts only when BOTH hold: `Notification.permission === "granted"` and
+ * the user previously opted in (a stashed endpoint proves intent — cleared
+ * on disable). Given those, it re-subscribes in two states: the browser's
+ * live `pushManager.getSubscription()` has gone `null` (#181's silent drop),
+ * or the server's VAPID key has moved past the one the live subscription was
+ * created with (#1323's silent mismatch, which no browser reports). Either
+ * way it POSTs the fresh subscription with `supersedes: <old endpoint>` so
+ * the server prunes the row it replaces. A `422` replay (endpoint did not
+ * rotate) counts as present.
  */
 export async function ensurePushSubscription(token: string): Promise<EnsurePushOutcome> {
   if (typeof Notification === "undefined") return "skipped";
@@ -425,10 +435,20 @@ export async function ensurePushSubscription(token: string): Promise<EnsurePushO
   const registration = await navigator.serviceWorker.ready;
   if (registration.pushManager === undefined) return "skipped";
 
-  const existing = await registration.pushManager.getSubscription();
-  if (existing !== null) return "present";
+  // #1323 — the reconciliation seam. A subscription created with a
+  // superseded VAPID key is indistinguishable from a healthy one from here:
+  // it exists, it looks valid, and the push service rejects every send to it
+  // forever. The served key is the only thing that tells them apart, so ask
+  // for it before believing a live subscription.
+  const { key, rotated } = await reconcileVapidKey();
 
-  const subscription = await subscribeWithVapidRetry(registration);
+  const existing = await registration.pushManager.getSubscription();
+  if (existing !== null) {
+    if (!rotated) return "present";
+    await existing.unsubscribe();
+  }
+
+  const subscription = await subscribeWithKey(registration, key);
   const json = subscription.toJSON() as {
     endpoint?: string;
     keys?: { p256dh?: string; auth?: string };
@@ -447,45 +467,84 @@ export async function ensurePushSubscription(token: string): Promise<EnsurePushO
       keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
       supersedes: stashedEndpoint,
     });
-    rememberSubscription(created.id, json.endpoint);
-    return "renewed";
+    rememberSubscription(created.id, json.endpoint, key);
+    return rotated ? "rekeyed" : "renewed";
   } catch (err) {
     if (err instanceof ApiError && err.status === 422) {
       // Endpoint did not rotate — the server row already exists (replay).
       // Re-point the endpoint stash at the live sub; the id is unchanged.
+      // The key record moves too: the subscription in hand WAS created with
+      // it, and leaving the superseded one behind would re-tear-down the
+      // same subscription on every following seam.
       localStorage.setItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY, json.endpoint);
+      localStorage.setItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY, key);
       return "present";
     }
     throw err;
   }
 }
 
-async function subscribeWithVapidRetry(
+/**
+ * #1323 — the served key plus whether it supersedes the one our live
+ * subscription was created with. `rotated` is false when we have no record
+ * (nothing was ever subscribed here, or site data was cleared): an absent
+ * record proves nothing, so it must not trigger a teardown.
+ */
+async function reconcileVapidKey(): Promise<{ key: string; rotated: boolean }> {
+  const subscribedWith = localStorage.getItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY);
+  const key = await fetchVapidPublicKey();
+  return {
+    key,
+    rotated: subscribedWith !== null && subscribedWith !== "" && subscribedWith !== key,
+  };
+}
+
+/**
+ * Subscribes with exactly `key`, dropping a conflicting subscription rather
+ * than giving up. `InvalidAccessError` is the browser refusing to hand back
+ * a subscription bound to a DIFFERENT application server key — re-fetching
+ * the key cannot resolve that (it is already the current one); only
+ * unsubscribing the incumbent can.
+ */
+async function subscribeWithKey(
   registration: ServiceWorkerRegistration,
+  key: string,
 ): Promise<PushSubscription> {
-  const tryOnce = async (forceRefresh: boolean): Promise<PushSubscription> => {
-    const key = await getVapidPublicKey(forceRefresh);
-    const bytes = vapidKeyToUint8Array(key);
-    return registration.pushManager.subscribe({
-      userVisibleOnly: true,
-      // Cast: BufferSource accepts a Uint8Array, but TS DOM lib's
-      // PushSubscriptionOptionsInit narrows applicationServerKey to
-      // ArrayBufferView<ArrayBuffer> (vs the wider ArrayBufferLike
-      // returned by Uint8Array's typed-array union). The runtime
-      // contract is byte-for-byte: we send the raw key bytes.
-      applicationServerKey: bytes as BufferSource,
-    });
+  const options: PushSubscriptionOptionsInit = {
+    userVisibleOnly: true,
+    // Cast: BufferSource accepts a Uint8Array, but TS DOM lib's
+    // PushSubscriptionOptionsInit narrows applicationServerKey to
+    // ArrayBufferView<ArrayBuffer> (vs the wider ArrayBufferLike
+    // returned by Uint8Array's typed-array union). The runtime
+    // contract is byte-for-byte: we send the raw key bytes.
+    applicationServerKey: vapidKeyToUint8Array(key) as BufferSource,
   };
   try {
-    return await tryOnce(false);
+    return await registration.pushManager.subscribe(options);
   } catch (err) {
     if (err instanceof DOMException && err.name === "InvalidAccessError") {
-      // Browsers throw InvalidAccessError when the cached VAPID key no
-      // longer matches the SW's existing subscription (operator key
-      // rotation). Refresh once + retry.
-      clearVapidPublicKeyCache();
-      return tryOnce(true);
+      await dropLiveSubscription(registration);
+      return registration.pushManager.subscribe(options);
     }
     throw err;
   }
+}
+
+/** Releases the browser-side subscription, if the SW still holds one. */
+async function dropLiveSubscription(registration: ServiceWorkerRegistration): Promise<void> {
+  const live = await registration.pushManager.getSubscription();
+  if (live !== null) await live.unsubscribe();
+}
+
+/**
+ * The one subscribe door: reconcile against the served key, drop a
+ * subscription bound to a superseded one, then subscribe. Returns the key it
+ * subscribed with so the caller can record it once the server row exists.
+ */
+async function subscribeWithCurrentVapidKey(
+  registration: ServiceWorkerRegistration,
+): Promise<{ subscription: PushSubscription; key: string }> {
+  const { key, rotated } = await reconcileVapidKey();
+  if (rotated) await dropLiveSubscription(registration);
+  return { subscription: await subscribeWithKey(registration, key), key };
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42503,12 +42503,18 @@ believes a live subscription, and reports the teardown as its own outcome
 changed accordingly: re-fetching the key cannot clear a subscription bound to
 a different one, so the retry now unsubscribes the incumbent instead.
 
-**Accepted costs, stated so they are not read as oversights.** One ~150-byte
+**The row it replaces is named on the way in.** The `rekeyed` POST carries
+`supersedes: <old endpoint>`, exactly as `renewed` does — #181's field, on the
+wire since then and implemented server-side, so same problem, same solution
+and no new mechanism. This is the opposite of the reap #1325 declined: there
+the SERVER would infer a row's death from a run of 4xx it must read a vendor
+string to understand; here the CLIENT declares the one row it is itself
+replacing, at the moment it replaces it, with no status parsing anywhere. A
+`400` still sweeps nothing.
+
+**Accepted cost, stated so it is not read as an oversight.** One ~150-byte
 GET per resume seam for opted-in users (single-flighted by
 `pushResubscribe`), deliberately unthrottled: a throttle would be duplicated
 state that drifts, guarding a request smaller than the headers carrying it.
-And the superseded server row is left in place — `400` deliberately never
-sweeps (#1325, closed `not planned`), so the row costs one wasted request per
-notification forever. Having the client delete the row it is itself replacing
-is a different mechanism from a reason-string reap, and it is held pending a
-ruling rather than assumed.
+The size is an estimate — the ~88-byte base64url key plus its JSON envelope —
+not a measurement; nobody has counted the bytes on the wire.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42452,3 +42452,63 @@ primary method it is. The issue named that cost and vjt asked for the move
 anyway. The doors sit LAST in the panel, adjacent to Connect, because they
 are actions rather than identity fields like realname/ident — a placement
 choice, cheap to flip, not a constraint.
+<!-- entry #1323 -->
+
+---
+
+## 2026-08-14 — #1323: a key you recall is a key you never check
+
+Web push from staging was rejected on every attempt. Probing Apple's real
+endpoint with a freshly signed VAPID JWT returned `400
+{"reason":"VapidPkHashMismatch"}`; FCM had answered `403` to an Android
+subscription the same day, which is the same failure in Google's vocabulary.
+The server was cleared by measurement, not assumption: `GET
+/push/vapid-public-key` served byte-for-byte the key the container signs
+with, and the keypair was internally consistent.
+
+The mismatch was client-side. `cic.vapidPublicKey` in localStorage was a
+read-through cache: populated on first fetch, returned unconditionally ever
+after, refreshed only when the browser raised
+`InvalidApplicationServerKey`. That trigger cannot fire on the failure we
+had — the browser raises it when an EXISTING subscription conflicts with a
+NEW key handed to `subscribe()`, and here the client handed it the OLD key
+it had just recalled. Nothing is inconsistent from the browser's seat, so it
+produces a perfectly valid subscription that the server can never sign for.
+The UI says push is on; the server logs a rejection nobody reads; no state
+exists in which anything looks wrong. Any VAPID rotation was therefore a
+silent, permanent kill for every already-installed client.
+
+**The storage key was re-meant rather than deleted.** It now records *the key
+the LIVE subscription was created with*, written ONLY after a subscribe
+succeeds and cleared with the subscription — a comparison anchor, never a
+source. Every subscribe fetches the served key (`fetchVapidPublicKey`, no
+recall path left to misuse) and reconciles; on a difference the browser
+subscription is unsubscribed and re-created with the fresh key. Recording the
+served key any earlier — at fetch time, as the old cache did — would restore
+the silence one seam later: a failed re-subscribe would leave
+`recorded == served`, and the next pass would read that as health.
+
+The re-meaning needs no migration, which is why it was preferred to a new
+key. The old cache was only ever populated at subscribe time, so a client
+broken by the rotation already holds exactly the key it subscribed with —
+the fleet heals on its first seam.
+
+**The reconciliation lives on the ensure seam, not only at the toggle.** The
+ruling asked for no user gesture and for a rotation that heals itself; a
+check that runs only inside `enablePush` waits for a toggle that a working-
+looking client never gets. So `ensurePushSubscription` — already wired to
+boot / `controllerchange` / `visibilitychange` by #181 — reconciles before it
+believes a live subscription, and reports the teardown as its own outcome
+(`rekeyed`, distinct from #181's `renewed`). `InvalidAccessError` recovery
+changed accordingly: re-fetching the key cannot clear a subscription bound to
+a different one, so the retry now unsubscribes the incumbent instead.
+
+**Accepted costs, stated so they are not read as oversights.** One ~150-byte
+GET per resume seam for opted-in users (single-flighted by
+`pushResubscribe`), deliberately unthrottled: a throttle would be duplicated
+state that drifts, guarding a request smaller than the headers carrying it.
+And the superseded server row is left in place — `400` deliberately never
+sweeps (#1325, closed `not planned`), so the row costs one wasted request per
+notification forever. Having the client delete the row it is itself replacing
+is a different mechanism from a reason-string reap, and it is held pending a
+ruling rather than assumed.


### PR DESCRIPTION
## What was broken

`cicchetto` cached the VAPID public key in `localStorage["cic.vapidPublicKey"]` and returned it
unconditionally forever. The only refresh path was an `InvalidApplicationServerKey` exception — which
**cannot fire on this failure**: the browser raises it when an *existing* subscription conflicts with
a *new* key handed to `subscribe()`, and here the client handed it the *old* key it had just
recalled. Nothing looks inconsistent from the browser's seat, so it mints a perfectly valid
subscription the server can never sign for.

Measured on staging (#1323): `400 {"reason":"VapidPkHashMismatch"}` from `web.push.apple.com`, and
`403` from FCM for the same failure in Google's vocabulary. The server was cleared by measurement —
`GET /push/vapid-public-key` serves byte-for-byte the key the container signs with.

## What changed

- **`cic.vapidPublicKey` is re-meant, not deleted**: it now records *the key the LIVE subscription was
  created with*, written **only after a subscribe succeeds** and cleared with the subscription. A
  comparison anchor, never a source.
- **`getVapidPublicKey` → `fetchVapidPublicKey`**: always a round-trip, no recall path left to misuse.
- **Reconciliation on the ensure seam**, not only at the toggle. `enablePush` needs a user gesture a
  working-looking client never gets, so the check sits in `ensurePushSubscription` (boot /
  `controllerchange` / `visibilitychange`, wired by #181). On `recorded !== served` it unsubscribes and
  re-subscribes with the fresh key, reporting `rekeyed` — a new `EnsurePushOutcome`, distinct from
  #181's `renewed`.
- **`InvalidAccessError` recovery corrected**: re-fetching the key cannot clear a subscription bound to
  a *different* key. The retry now unsubscribes the incumbent.

**No migration needed**, and that is why the storage key was re-meant rather than replaced: the old
cache was only ever populated at subscribe time, so a client broken by the rotation already holds
exactly the key it subscribed with. The installed fleet heals on its first seam.

**Ordering matters**: recording the served key at *fetch* time (as the old cache did) would rebuild
the silence one seam later — a failed re-subscribe would leave `recorded == served` and the next pass
would read that as health. A test pins it.

## The replaced row is named, and that is not a reap

The `rekeyed` POST carries **`supersedes: <old endpoint>`, #181's field** — on the wire since then,
implemented server-side by `Grappa.Push.insert_superseding/3`, and already sent by the `renewed`
branch it shares a tail with. Same problem, same solution; no new field, no server change.

This is the **opposite** of the reap closed as `not planned` in #1325. There the *server* would infer
a row's death from a run of 4xx, which requires parsing a vendor error string to mean anything. Here
the *client* declares the single row it is itself replacing, at the moment it replaces it. **No status
is matched anywhere, and a `400` still sweeps nothing.**

## Cost accepted, stated so it is not read as an oversight

**One `GET /push/vapid-public-key` per resume seam** for opted-in users, single-flighted by
`pushResubscribe`. **Deliberately unthrottled**: a throttle would be duplicated state that drifts,
guarding a request smaller than the headers carrying it. Size is an **estimate, not a measurement** —
~150 bytes, from the ~88-byte base64url key plus the JSON envelope. Nobody has counted the bytes on
the wire.

## Verification debt — read this before closing

The defect is **measured**; the automatic cure is **deduced**.

What #1323's second comment proves is narrower than it looks: a maintainer **reinstalled the PWA by
hand** and the fresh subscription delivered. That establishes *a re-subscription with the current key
delivers* — it does **not** exercise this code path. **Nothing here has run on a real device.** What
remains unproven is that the unattended `unsubscribe()` → `subscribe(fresh key)` on the ensure seam
produces a subscription the push service accepts, on iOS in particular, where the SW lifecycle is
where #181's silent drop came from in the first place.

**A real-device verification is required before this closes.** No `Closes #1323` on purpose.

## Test coverage

vitest, TDD (red first — the rotation cases returned `'present'`, the exact silence):

- rotation on the ensure seam → `rekeyed`, live subscription unsubscribed, `subscribe()` called with
  the *served* key bytes, record updated
- **the `rekeyed` POST carries `supersedes: <old endpoint>`** — proven non-vacuous by mutation:
  deleting the field from the shared tail fails exactly two assertions, this one and #181's
- matching key → `present`, revalidated (one GET) but nothing torn down
- **re-subscribe fails → the recorded key is left alone** (the ordering trap above)
- `enablePush` drops a subscription bound to a superseded key
- `InvalidAccessError` → incumbent unsubscribed, retry succeeds
- `fetchVapidPublicKey` never reads or writes storage

`bun run test` 5457/5457 green, `bun run check` clean. **No e2e**: an honest one needs the stack
restarted with a *different* `VAPID_PUBLIC_KEY` mid-spec, and even then it cannot assert delivery
(Apple/FCM are unreachable from CI). An e2e that does not rotate the key would assert nothing.