### PR TITLE
push(#1321): log the rejection reason, not just the HTTP status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Grappa.Application
 ├── Grappa.AdminEvents                 (M-11 admin-event ring buffer + telemetry sink)
 ├── Grappa.SessionLog                  (#215 IRC session-lifecycle log sink)
 ├── Grappa.DbLatency                   (#357 SQLite write/query-latency telemetry sink)
+├── Grappa.Push.VendorLog              (#1321 push rejection-reason telemetry sink)
 ├── Grappa.ShareTokens                 (ETS one-shot share-link tokens, both subject kinds)
 ├── Grappa.RateLimit.DailyQuota        (#75 per-(bucket, subject, day) creation quota)
 ├── Grappa.RateLimit.FailureWindow     (S6 per-(bucket, key) login-throttle window)

--- a/config/config.exs
+++ b/config/config.exs
@@ -534,6 +534,12 @@ config :logger, :console,
     :endpoint,
     :status,
     :count,
+    # #1321 — `Grappa.Push.VendorLog`'s rejection line. `:vendor` is the
+    # HOST of the push service that rejected a delivery: the line records
+    # the host only, never the path, because a path segment can itself be
+    # a credential. The reason string itself rides the pre-existing
+    # `:reason` key, length-capped at the sink.
+    :vendor,
     # M-11 admin-events: `:topic` is the PubSub topic that failed (string,
     # e.g. `"grappa:admin:events"`); `:kind` is the typed event-kind atom
     # (`:visitor_deleted`, `:circuit_reset`, etc.) that was about to be

--- a/config/test.exs
+++ b/config/test.exs
@@ -157,6 +157,11 @@ config :grappa, :attach_session_log_telemetry, false
 # would make snapshot assertions flaky. Aggregation tests attach the
 # handler explicitly + drain via `reset/0` (test/grappa/db_latency_test.exs).
 config :grappa, :attach_db_latency_telemetry, false
+# #1321 — VendorLog singleton attach OFF in test env. The handler only
+# logs, so a global attach would write a push rejection into whatever
+# test happens to be capturing the Logger stream. Its own tests attach
+# the handler explicitly (test/grappa/push/vendor_log_test.exs).
+config :grappa, :attach_push_vendor_log_telemetry, false
 config :phoenix, :plug_init_mode, :runtime
 config :phoenix, :json_library, Jason
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42452,3 +42452,51 @@ primary method it is. The issue named that cost and vjt asked for the move
 anyway. The doors sit LAST in the panel, adjacent to Connect, because they
 are actions rather than identity fields like realname/ident — a placement
 choice, cheap to flip, not a constraint.
+<!-- entry #1321 -->
+
+---
+
+## 2026-08-14 — #1321: the rejection reason, by the only route that carries it
+
+A rejected web push logged a bare status code, which is indistinguishable
+from a bad JWT, a stale application server key, a clock skew or an expired
+subscription. The services write the reason into the response body, and
+reading it turns an afternoon of guessing into a one-field diagnosis.
+
+**Why a telemetry sink and not plumbing.** `ExNudge.send_notification/3`
+binds the response on the failure branch and returns
+`{:error, {:http_error, status}}`, so the response never leaves the library
+by the call path — and its own `@spec` for `send_notifications/3` promises a
+response it does not hand back, the same unreliability `Grappa.Push.Sender`
+already documents about the library's declared types. There was therefore no
+"plumb it through the sender" branch to choose. The body leaves by exactly
+one route: the library's `[:ex_nudge, :send_notification]` event carries it
+as `metadata.error_reason` for every non-2xx the library did not classify
+itself. `Grappa.Push.VendorLog` attaches there, in the shape the tree already
+uses for `Grappa.SessionLog` and `Grappa.DbLatency`.
+
+**The issue's ask needs amending on one point: `retry-after` is
+unreachable.** Response HEADERS never leave the library by any route,
+telemetry included, and there is no bump to wait for (1.0.2, 2025-07-28, is
+the latest release). The ruling asked for the status AND the body; the body
+can be had, the headers cannot.
+
+**An integer `http_status_code` is the exact discriminator.** The library
+classifies 410 / 413 and transport failures itself and passes an atom in
+place of the response, so those events carry a nil status and no body. The
+sink keys on the integer, which is also its silence boundary: those paths
+already log at the sender with everything there is to say, and a second line
+would be noise. Per log honesty the silence is "no body was carried", not
+"work was skipped".
+
+**Two constraints on what reaches stdout**, which persists across restarts
+and ships out with any log forwarder. The line records the endpoint's HOST
+only and never its path, because a path segment can itself be a credential;
+an operator correlates with the sender's own line for the same delivery. And
+the reason is length-capped and folded onto one line — it is vendor text of
+unbounded size and arbitrary bytes, so it is made valid UTF-8 before folding,
+and the cap is what stops an error page from becoming a log flood.
+
+**Scope held.** Per the maintainer's ruling on #1323 the reason string is for
+human diagnosis only: no code matches on it, and the 404 / 410 sweep is
+untouched — a 400 sweeps nothing, whatever reason it carries.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -269,6 +269,18 @@ defmodule Grappa.Application do
         # attach); unlike AdminEvents/SessionLog it needs NO sandbox
         # allow — the fold touches no Repo.
         {Grappa.DbLatency, attach_telemetry: attach_db_latency_telemetry?()},
+        # VendorLog (#1321): singleton GenServer that attaches to the
+        # `[:ex_nudge, :send_notification]` event in init/1 and logs the
+        # rejection reason a push service returned in the response body —
+        # the ONLY route by which that body leaves the library, so the
+        # sender cannot report it itself. Same slot as the sinks above and
+        # BEFORE Endpoint, so a delivery triggered by the first WS event
+        # already has a handler; it holds no state at all beyond the
+        # attachment, so nothing orders it against Repo/Registry. Restart:
+        # :permanent (infrastructure). `attach_telemetry: false` in test
+        # env so the handler doesn't write into every suite's captured
+        # Logger stream (per-test opt-in via manual attach).
+        {Grappa.Push.VendorLog, attach_telemetry: attach_push_vendor_log_telemetry?()},
         # ShareTokens: ETS-backed one-shot set for share-link token
         # redemption (#1306 — both subject kinds; the ledger keys on the
         # token string, which carries no kind). Must come before Endpoint
@@ -575,6 +587,14 @@ defmodule Grappa.Application do
   @spec attach_db_latency_telemetry?() :: boolean()
   defp attach_db_latency_telemetry?,
     do: Application.get_env(:grappa, :attach_db_latency_telemetry, true)
+
+  # #1321 — same test-env opt-out shape. The reason is neither sandbox
+  # ownership nor determinism: the handler only logs, and a globally
+  # attached one would emit into the Logger stream any test captures.
+  # Defaults true — prod/dev attach at boot.
+  @spec attach_push_vendor_log_telemetry?() :: boolean()
+  defp attach_push_vendor_log_telemetry?,
+    do: Application.get_env(:grappa, :attach_push_vendor_log_telemetry, true)
 
   @impl Application
   def config_change(changed, _, removed) do

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -79,7 +79,7 @@ defmodule Grappa.Push do
       Grappa.Visitors.Visitor,
       Grappa.WSPresence
     ],
-    exports: [BadgeSource, Payload, Sender, Subscription, Triggers]
+    exports: [BadgeSource, Payload, Sender, Subscription, Triggers, VendorLog]
 
   import Ecto.Query
 

--- a/lib/grappa/push/vendor_log.ex
+++ b/lib/grappa/push/vendor_log.ex
@@ -1,0 +1,158 @@
+defmodule Grappa.Push.VendorLog do
+  @moduledoc """
+  Records what a push service SAID when it rejected a delivery (#1321).
+
+  `Grappa.Push.Sender` logs the HTTP status of a rejected push and
+  nothing else, because the status is all it is given. A bare `400` or
+  `403` is indistinguishable from a bad JWT, a stale application server
+  key, a clock skew or an expired subscription — the services write the
+  actual reason into the response BODY, and the diagnosis is one field
+  long once you can read it.
+
+  ## Why a telemetry sink instead of plumbing it through the sender
+
+  There is no plumbing route. `ExNudge.send_notification/3` binds the
+  `%HTTPoison.Response{}` on the failure branch and returns
+  `{:error, {:http_error, status}}` — the response never leaves the
+  library (its own `@spec` for `send_notifications/3` promises a
+  response it does not hand back; `Grappa.Push.Sender` already documents
+  that the declared types are narrower than the returns).
+
+  The body IS reachable, by exactly one route: the library's
+  `[:ex_nudge, :send_notification]` telemetry event carries the response
+  body as `metadata.error_reason` whenever the response was a non-2xx it
+  did not classify itself. So this module attaches there.
+
+  Consequences of that route, both deliberate:
+
+    * **`retry-after` is unreachable.** Response HEADERS never leave
+      `ExNudge` by any route, telemetry included. The issue asks for it;
+      it cannot be had without a change upstream, and the last release is
+      1.0.2 (2025-07-28).
+    * **Terminal and transport failures stay silent here.** The library
+      classifies 410 / 413 and transport errors itself and passes an atom
+      in place of a response, so the event carries a nil
+      `http_status_code` and no body. Those paths already log at the
+      sender with everything there is to say; a second line would add
+      noise, not information. An integer `http_status_code` is therefore
+      the exact discriminator for "a vendor body exists", and this
+      handler keys on it.
+
+  ## What the line may contain
+
+  Per the maintainer's ruling on #1323 the reason string is for human
+  diagnosis ONLY: no code matches on it, subscriptions keep being swept
+  on 404 / 410 alone, and a 400 sweeps nothing whatever reason it
+  carries.
+
+  Two rules constrain what reaches stdout, which persists across
+  restarts and ships out with any log forwarder:
+
+    * **The host, never the path.** The line records the endpoint's host
+      alone, because a path segment can itself be a credential. Operators
+      correlate with the sender's own `push.send http error` line, which
+      is emitted for the same delivery.
+    * **The body is capped** (`@max_reason_bytes`) and folded onto one
+      line. It is vendor text of unbounded size and arbitrary bytes;
+      the cap is what keeps an error PAGE from becoming a log flood, and
+      the fold is what keeps the line greppable.
+
+  ## Restart strategy / test isolation
+
+  `:permanent` singleton (registered as `__MODULE__`) holding no state:
+  it owns nothing but its own telemetry attachment, which `init/1`
+  re-establishes on every restart. The handler logs synchronously in the
+  emitting process — unlike the sinks it is modelled on
+  (`Grappa.SessionLog`, `Grappa.DbLatency`) it does no Repo or ETS work,
+  so there is nothing to move off the caller, and a delivery Task is not
+  a hot path. Boots with `attach_telemetry: false` in test env
+  (`config/test.exs`), so tests attach the handler explicitly instead of
+  folding every suite's push telemetry into the shared Logger stream.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @handler_id "grappa-push-vendor-log"
+  @event [:ex_nudge, :send_notification]
+
+  # Genuine config default (correct production behavior): these are small
+  # error documents — a couple of hundred bytes is the whole reason, and
+  # anything past it is a vendor error page, not a diagnosis.
+  @max_reason_bytes 256
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl GenServer
+  def init(opts) do
+    if Keyword.get(opts, :attach_telemetry, true) do
+      # Detach-then-attach so a brutal_kill restart (terminate/2 never
+      # runs) doesn't leave a stale handler bound to a dead pid. Detach
+      # of an unknown id is `:ok`, so this is safe on first boot too.
+      _ = :telemetry.detach(@handler_id)
+
+      :ok = :telemetry.attach(@handler_id, @event, &__MODULE__.handle_telemetry/4, nil)
+    end
+
+    # No state: the attachment is the whole job.
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def terminate(_, _) do
+    :ok = :telemetry.detach(@handler_id)
+  end
+
+  @doc false
+  # Runs in the EMITTER's process (per :telemetry semantics) — the
+  # `Grappa.Push.Sender` fan-out Task, never a hot path.
+  @spec handle_telemetry([atom()], map(), map(), term()) :: :ok
+  def handle_telemetry(_, _, %{status: :error, http_status_code: status} = metadata, _)
+      when is_integer(status) do
+    Logger.warning("push.vendor rejected",
+      status: status,
+      vendor: host(metadata),
+      reason: reason(metadata)
+    )
+  end
+
+  def handle_telemetry(_, _, _, _), do: :ok
+
+  # The endpoint's host and nothing else — a path segment can itself be
+  # a credential. `ExNudge` hands over an endpoint it has already
+  # partially masked; this does not rely on that.
+  @spec host(map()) :: String.t()
+  defp host(%{endpoint: endpoint}) when is_binary(endpoint) do
+    case URI.parse(endpoint) do
+      %URI{host: host} when is_binary(host) -> host
+      _ -> "unknown"
+    end
+  end
+
+  defp host(_), do: "unknown"
+
+  # A body is what an integer `http_status_code` implies, but the library's
+  # declared types are already known to be narrower than what it returns
+  # (see `Grappa.Push.Sender.normalize/1`), so a non-binary reason is
+  # reported rather than crashed on.
+  @spec reason(map()) :: String.t()
+  defp reason(%{error_reason: body}) when is_binary(body), do: body |> cap() |> one_line()
+  defp reason(%{error_reason: other}), do: inspect(other)
+
+  @spec cap(binary()) :: binary()
+  defp cap(body) when byte_size(body) <= @max_reason_bytes, do: body
+  defp cap(body), do: binary_slice(body, 0, @max_reason_bytes) <> " …(truncated)"
+
+  # Vendor bytes, not a string: `cap/1` can cut mid-codepoint and the body
+  # may not be UTF-8 at all, so make it valid BEFORE folding the
+  # whitespace — one Logger line stays greppable.
+  @spec one_line(binary()) :: String.t()
+  defp one_line(text) do
+    text
+    |> String.replace_invalid()
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
+end

--- a/lib/grappa/push/vendor_log.ex
+++ b/lib/grappa/push/vendor_log.ex
@@ -113,8 +113,8 @@ defmodule Grappa.Push.VendorLog do
       when is_integer(status) do
     Logger.warning("push.vendor rejected",
       status: status,
-      vendor: host(metadata),
-      reason: reason(metadata)
+      vendor: host(Map.get(metadata, :endpoint)),
+      reason: reason(Map.get(metadata, :error_reason))
     )
   end
 
@@ -123,8 +123,8 @@ defmodule Grappa.Push.VendorLog do
   # The endpoint's host and nothing else — a path segment can itself be
   # a credential. `ExNudge` hands over an endpoint it has already
   # partially masked; this does not rely on that.
-  @spec host(map()) :: String.t()
-  defp host(%{endpoint: endpoint}) when is_binary(endpoint) do
+  @spec host(term()) :: String.t()
+  defp host(endpoint) when is_binary(endpoint) do
     case URI.parse(endpoint) do
       %URI{host: host} when is_binary(host) -> host
       _ -> "unknown"
@@ -137,9 +137,9 @@ defmodule Grappa.Push.VendorLog do
   # declared types are already known to be narrower than what it returns
   # (see `Grappa.Push.Sender.normalize/1`), so a non-binary reason is
   # reported rather than crashed on.
-  @spec reason(map()) :: String.t()
-  defp reason(%{error_reason: body}) when is_binary(body), do: body |> cap() |> one_line()
-  defp reason(%{error_reason: other}), do: inspect(other)
+  @spec reason(term()) :: String.t()
+  defp reason(body) when is_binary(body), do: body |> cap() |> one_line()
+  defp reason(other), do: inspect(other)
 
   @spec cap(binary()) :: binary()
   defp cap(body) when byte_size(body) <= @max_reason_bytes, do: body

--- a/test/grappa/push/vendor_log_test.exs
+++ b/test/grappa/push/vendor_log_test.exs
@@ -1,0 +1,126 @@
+defmodule Grappa.Push.VendorLogTest do
+  @moduledoc """
+  #1321 — the push service's OWN words on a rejected delivery.
+
+  `async: false`: the handler is a globally-attached `:telemetry`
+  handler under a fixed id, and the assertions read the shared Logger
+  stream via `capture_log/1`. The singleton boots with
+  `attach_telemetry: false` under test (`config/test.exs`, mirror of
+  `Grappa.DbLatency`), so each test attaches the production handler
+  function explicitly.
+
+  The events emitted here are the ones `ExNudge.Telemetry` actually
+  produces: a non-2xx response yields an integer `http_status_code`
+  with the response BODY as `error_reason`, while the terminal 410 /
+  413 and the transport failures yield a nil `http_status_code` and an
+  atom-or-inspected reason. That split is what the handler keys on, so
+  the fixtures pin it.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Push.VendorLog
+
+  @handler_id "grappa-push-vendor-log-test"
+  @event [:ex_nudge, :send_notification]
+
+  # An endpoint in the shape the telemetry event carries it. The path
+  # segment is treated as a credential — the handler records the host
+  # and nothing else.
+  @endpoint "https://push.example.invalid/vXrN4tPq2Ke"
+
+  setup do
+    :ok = :telemetry.attach(@handler_id, @event, &VendorLog.handle_telemetry/4, nil)
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+    :ok
+  end
+
+  defp emit(metadata) do
+    :telemetry.execute(@event, %{duration: 12, payload_size: 200}, Map.new(metadata))
+  end
+
+  defp rejection(overrides) do
+    Map.merge(
+      %{
+        endpoint: @endpoint,
+        status: :error,
+        http_status_code: 400,
+        error_reason: ~s({"reason":"VapidPkHashMismatch"})
+      },
+      Map.new(overrides)
+    )
+  end
+
+  describe "vendor rejections" do
+    test "logs the vendor's reason, not just the status" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      assert log =~ "VapidPkHashMismatch"
+    end
+
+    test "logs the HTTP status alongside the reason" do
+      log = capture_log(fn -> emit(rejection(http_status_code: 403)) end)
+
+      assert log =~ "403"
+    end
+
+    test "names the host so the line stands on its own" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      assert log =~ "push.example.invalid"
+    end
+
+    test "never prints the endpoint path — a path segment can itself be a credential" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      refute log =~ "vXrN4tPq2Ke"
+    end
+
+    test "caps the body — a vendor may answer with a whole error page" do
+      body = String.duplicate("a", 4000) <> "TAIL_OF_THE_BODY"
+
+      log = capture_log(fn -> emit(rejection(error_reason: body)) end)
+
+      refute log =~ "TAIL_OF_THE_BODY"
+    end
+
+    test "says so when it truncated" do
+      log = capture_log(fn -> emit(rejection(error_reason: String.duplicate("a", 4000))) end)
+
+      assert log =~ "truncated"
+    end
+
+    test "keeps the reason on ONE line — the log is grepped, not parsed" do
+      log = capture_log(fn -> emit(rejection(error_reason: "line one\nline two")) end)
+
+      assert log =~ "line one line two"
+    end
+
+    test "survives a body that is not valid UTF-8" do
+      log = capture_log(fn -> emit(rejection(error_reason: <<0xFF, 0xFE, "Bad">>)) end)
+
+      assert log =~ "Bad"
+    end
+  end
+
+  describe "events the sender already reports" do
+    test "stays silent on a delivered notification" do
+      log =
+        capture_log(fn ->
+          emit(%{endpoint: @endpoint, status: :success, http_status_code: 201, error_reason: nil})
+        end)
+
+      refute log =~ "push.vendor"
+    end
+
+    test "stays silent when there is no vendor body to add (410, transport failure)" do
+      log =
+        capture_log(fn ->
+          emit(rejection(http_status_code: nil, error_reason: :subscription_expired))
+        end)
+
+      refute log =~ "push.vendor"
+    end
+  end
+end


### PR DESCRIPTION
## What

A rejected web push logged a bare status code. A `400` or a `403` on its own
is indistinguishable from a bad JWT, a stale application server key, a clock
skew or an expired subscription — the services write the reason into the
response body, and reading it turns an afternoon of guessing into a
one-field diagnosis.

`Grappa.Push.VendorLog` is a supervised telemetry sink that logs that reason
next to the status, in the shape the tree already uses for
`Grappa.SessionLog` and `Grappa.DbLatency`.

## Why a sink and not plumbing in the sender

The issue suggested checking whether the library already surfaces the body,
in which case this would be a change in `sender.ex` alone. It does not.
`ExNudge.send_notification/3` binds the response on the failure branch and
returns `{:error, {:http_error, status}}` — the response never leaves the
library by the call path, and its own `@spec` for `send_notifications/3`
promises a response it does not hand back (the same unreliability
`Grappa.Push.Sender` already documents about the library's declared types).

The body leaves by exactly one route: the library's own
`[:ex_nudge, :send_notification]` event carries it as `error_reason` for
every non-2xx it did not classify itself. That is where this attaches.

## 🔴 The ask needs amending on one point: `retry-after` is unreachable

The issue asks for the status, the body **and** `retry-after`. The first two
are delivered; the third cannot be, and not for want of trying: response
HEADERS never leave `ExNudge` by any route it exposes, telemetry included.
There is no bump to wait for either — 1.0.2 (2025-07-28) is the latest
release. Getting `retry-after` needs a change upstream or a different
client, which is not this issue.

## What it deliberately does not log

Terminal and transport failures. The library classifies 410 / 413 and
transport errors itself and passes an atom in place of a response, so those
events carry a nil `http_status_code` and no body at all. An integer
`http_status_code` is therefore the exact discriminator for "a vendor body
exists", and the handler keys on it; those paths already log at the sender
with everything there is to say, so a second line would be noise. The
silence is "no body was carried", not "work was skipped".

## What reaches stdout

stdout persists across restarts and ships out with any log forwarder, so two
rules constrain the line:

- **The host, never the path.** The line records the endpoint's host alone,
  because a path segment can itself be a credential. An operator correlates
  with the sender's own `push.send http error` line for the same delivery.
- **The reason is length-capped and folded onto one line.** It is vendor
  text of unbounded size and arbitrary bytes, so it is made valid UTF-8
  before folding; the cap is what stops an error page from becoming a log
  flood.

Per the maintainer's ruling on #1323 the reason is for human diagnosis only:
no code matches on it, and the 404 / 410 sweep semantics are untouched.

## Test plan

- [x] `test/grappa/push/vendor_log_test.exs` — 10 tests, written before the
      module existed and observed red (4 genuine failures; the other 6
      assertions passed on the telemetry crash report the missing handler
      produced, so they were not trusted and were re-verified by mutation).
- [x] **Mutation**: 7 mutants applied one at a time to the production module
      — drop the status, drop the host, freeze the reason, make the cap a
      no-op, drop the `is_integer/1` guard, match any status, drop
      `String.replace_invalid/1`. All 7 killed, each with clean attribution
      (the reason mutant kills the four reason assertions, the cap mutant
      kills its two; the rest are 1:1).
- [x] `scripts/check.sh` green (format, Credo, Dialyzer, Sobelow, 6190
      tests).
