### PR TITLE
e2e(#1089): order the live-append witness on a signal, not on luck

### DIFF
--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -191,6 +191,30 @@ async function installFlickerProbe(page: Page, windowMs: number): Promise<void> 
   }, windowMs);
 }
 
+// BARRIER — the sampler has recorded its BASELINE frame.
+//
+// `installFlickerProbe` schedules the first `requestAnimationFrame` and returns
+// immediately, so "the probe is installed" is NOT "the probe has sampled". Any
+// perturbation dispatched right after the install races that first callback,
+// and on CI the two quantities overlap almost exactly: delivery of a peer
+// PRIVMSG measured ~20ms twice in one trace, against a first-sample delay in
+// [0, ~23ms] (one frame period of phase jitter plus evaluate overhead). That
+// coin flip — not any assertion about the divider — is what greened the same
+// sha on a PR and reddened it on main; the 2500ms window was fully sampled on
+// both sides (150 and 152 frames), so it was never the tight edge.
+//
+// Awaiting a recorded frame before the perturbation is even DISPATCHED is a
+// strict happens-before, not a bigger guess: the row cannot render before the
+// PRIVMSG is sent, so the baseline frame necessarily carries the pre-append
+// height and `grew` cannot be starved of its lower sample.
+async function waitForProbeBaseline(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => ((window as unknown as { __i1089frames?: unknown[] }).__i1089frames?.length ?? 0) > 0,
+    undefined,
+    { timeout: 10_000 },
+  );
+}
+
 // On failure this dump is the whole story: one entry per CHANGE of the
 // (visibility, divider offset) pair, so a one-frame excursion shows as a
 // visible=…, marker=<off-screen px> entry between two on-divider entries.
@@ -267,13 +291,18 @@ test.describe("issue #1089 — switching into an unread window must not flicker"
     // the latch is armed. It appends BELOW the fold, so nothing above the
     // divider changes: the divider's on-screen offset must not move at all.
     //
-    // Connect + join BEFORE the probe: registration and JOIN take seconds, and
-    // a probe installed first would have expired by the time the line lands —
-    // the sampler would record a flat, untouched timeline and green vacuously.
+    // Connect + join BEFORE the probe so the sampled window holds the append
+    // and nothing else. This ordering used to be justified with "registration
+    // and JOIN take seconds" — that is false on CI: the red run's trace bounds
+    // connect+join at 7ms. The false premise is exactly what made the probe
+    // install look safely far from the `privmsg` and left the two adjacent with
+    // no barrier; `waitForProbeBaseline` is the ordering guarantee, the
+    // statement order is not.
     const peer = await IrcPeer.connect({ nick: `i1089-${Date.now().toString(36).slice(-6)}` });
     try {
       await peer.join(CHANNEL);
       await installFlickerProbe(page, SAMPLE_WINDOW_MS);
+      await waitForProbeBaseline(page);
       const body = `i1089 live append ${Date.now()}`;
       peer.privmsg(CHANNEL, body);
       await expect(scrollbackLines(page).filter({ hasText: body })).toHaveCount(1, {


### PR DESCRIPTION
## What was red

`issue1089-switch-into-unread-flicker.spec.ts` → *live append while parked on the divider*, failing on `main` at `35333266` while the same tree passed on a PR. The failing line is not the #1089 oracle — the core assertion passed on both sides — it is the instrumentation precondition:

```
Error: the live append did not land while the sampler was running
```

## The race, and why the message named the wrong one

Diagnosis by w2 (report on #1089; not re-derived here). Summarised:

- `installFlickerProbe` schedules its first `requestAnimationFrame` and returns, and `peer.privmsg()` goes out on the next line. Nothing orders "frame #1 recorded" before "row rendered".
- The competing quantities measured on CI: **delivery ≈ 20 ms** (twice in one trace) against a **first-sample delay in [0, ~23 ms]**. Overlapping distributions — a coin flip on frame phase.
- Both runs sampled the **full** window (150 and 152 frames over 2500 ms). The window was never the tight edge; raising `SAMPLE_WINDOW_MS` would have changed nothing.
- So the real failure is "the append landed **before** the first sample", the opposite of what the message says.

## The cure

`waitForProbeBaseline(page)` — `page.waitForFunction(() => __i1089frames.length > 0)` — between the probe install and the send. This is not a bigger guess: the row cannot render before the PRIVMSG is dispatched, so a frame recorded before the dispatch **necessarily** carries the pre-append height. `grew` can no longer be starved of its lower sample.

No assertion relaxed, no timeout raised, no `waitForTimeout` added. After this, the only way `grew` can be false is the late edge — the case the existing message already describes accurately, which is why the sampler is left as it is.

The comment justifying the statement order with *"registration and JOIN take seconds"* is corrected: the red run's trace bounds connect+join at **7 ms**. That false premise is what made the probe install look safely distant from the send and left the two adjacent with no barrier.

## Evidence

**Attribution by injection, not by repetition.** A flake is not proven absent by green runs; it is made impossible by construction, and the construction is the happens-before above. To attribute it, the losing side of the coin flip was made deterministic: a 300 ms delay injected on the sampler's first callback (~15x the measured delivery), with the barrier as the only variable.

On the **real spec file**, same injected delay, one mutation apart:

| | first sample | sampled heights | verdict |
|---|---|---|---|
| barrier present | t = 321 ms | 1647 -> 1668 (one row) | **1 passed** |
| barrier removed | — | flat | **1 failed**, `the live append did not land while the sampler was running` |

The mutant killed **exactly one** assertion — the witness, by name. A scratch two-arm harness reproduced the same pair before the mutation (`grew=false` / `grew=true`, 133 and 132 frames); it was never committed.

Unmutated runs, `--project chromium`: **12/12** green at `--repeat-each 6`, plus **6/6** green after restoring the file. Full local `scripts/bun.sh run check` RC=0 (1023 files, biome + `tsc` over `src` and `e2e`).

## What this does NOT claim

- **The flake is not proven absent.** Green repeats on this host say nothing about CI's frame timing; they are a no-hang/no-slowdown sanity, not evidence of a rate. The claim is that the ordering is now established by a signal rather than by phase luck.
- The failure rate on CI is **not** established — the diagnosis rests on two samples, which prove non-determinism and nothing more.
- The 7 ms connect+join is a bound from one run, not a general claim.
- Nothing here changes production code, and nothing here speaks to #1089's own oracle, which passed on both sides of the red.
- The late edge (append arriving after the sampler expires) is **untouched** — the report's items 2 and 3 (stoppable sampler, per-frame row count) were deliberately not taken: no measurement shows that edge firing, and after this change its failure message is already truthful.