### PR TITLE
union(#1321 + #1323): push vendor-log sink and VAPID key reconciliation, gated once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Grappa.Application
 ├── Grappa.AdminEvents                 (M-11 admin-event ring buffer + telemetry sink)
 ├── Grappa.SessionLog                  (#215 IRC session-lifecycle log sink)
 ├── Grappa.DbLatency                   (#357 SQLite write/query-latency telemetry sink)
+├── Grappa.Push.VendorLog              (#1321 push rejection-reason telemetry sink)
 ├── Grappa.ShareTokens                 (ETS one-shot share-link tokens, both subject kinds)
 ├── Grappa.RateLimit.DailyQuota        (#75 per-(bucket, subject, day) creation quota)
 ├── Grappa.RateLimit.FailureWindow     (S6 per-(bucket, key) login-throttle window)

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearVapidPublicKeyCache,
   deletePushSubscription,
   disablePush,
+  enablePush,
   ensurePushSubscription,
+  fetchVapidPublicKey,
   formatDeviceActivity,
-  getVapidPublicKey,
   listPushDevices,
   type PushDeviceSummary,
   postPushSubscription,
@@ -31,9 +31,12 @@ const sample = {
   publicKey: "BJk1234567890abcdefghijklmnopqrstuv-_wxyzABC",
 };
 
+// #1323 — the key the operator rotated TO. Same length class as `sample`
+// so both decode cleanly through `vapidKeyToUint8Array`.
+const ROTATED_KEY = "BRotated9876543210zyxwvutsrqponmlkjihgfe-_AB";
+
 beforeEach(() => {
   localStorage.clear();
-  clearVapidPublicKeyCache();
 });
 
 afterEach(() => {
@@ -46,6 +49,9 @@ afterEach(() => {
 // (pushManager / Notification / fetch); the real push.ts handlers run.
 const SUB_ID_KEY = "cic.pushSubscriptionId";
 const SUB_ENDPOINT_KEY = "cic.pushSubscriptionEndpoint";
+// #1323 — the key the LIVE subscription was created with (not a read-through
+// cache: nothing is ever served from it).
+const SUBSCRIBED_KEY = "cic.vapidPublicKey";
 
 function fakeSub(endpoint: string): PushSubscription {
   return {
@@ -80,14 +86,34 @@ function stubPushEnv(opts: {
   return { getSubscription, subscribe };
 }
 
+// The body of the `POST /push/subscriptions` the run made, or null when it
+// registered nothing.
+function postedSubscription(
+  fetchMock: ReturnType<typeof vi.spyOn>,
+): { endpoint?: string; supersedes?: string } | null {
+  const call = fetchMock.mock.calls.find(
+    (args: unknown[]) =>
+      args[0] === "/push/subscriptions" && (args[1] as RequestInit | undefined)?.method === "POST",
+  ) as [string, RequestInit] | undefined;
+  return call === undefined ? null : JSON.parse(call[1].body as string);
+}
+
+// The application server key bytes handed to the FIRST `pushManager.subscribe`
+// call — the assertion that says WHICH VAPID key a subscription was born with.
+function firstSubscribeKeyBytes(subscribe: ReturnType<typeof vi.fn>): number[] {
+  const [options] = subscribe.mock.calls[0] as [PushSubscriptionOptionsInit];
+  return Array.from(options.applicationServerKey as Uint8Array);
+}
+
 // Route fetch by URL: VAPID key GET, subscription POST, subscription DELETE.
-function stubPushFetch(): ReturnType<typeof vi.spyOn> {
+// `servedKey` is what the server currently signs with — the axis #1323 turns on.
+function stubPushFetch(servedKey: string): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL, init?) => {
     const url = String(input);
     const method = init?.method ?? "GET";
     if (url.includes("/push/vapid-public-key")) {
       return Promise.resolve(
-        new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
+        new Response(JSON.stringify({ public_key: servedKey }), { status: 200 }),
       );
     }
     if (url === "/push/subscriptions" && method === "POST") {
@@ -111,7 +137,7 @@ describe("disablePush — #181: DELETE the stashed row, never orphan it", () => 
     // the push service keeps 2xx-ing a dead endpoint forever.
     localStorage.setItem(SUB_ID_KEY, "srv-ghost");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ existingSubscription: null });
 
     const removed = await disablePush("tok");
@@ -126,7 +152,7 @@ describe("disablePush — #181: DELETE the stashed row, never orphan it", () => 
   });
 
   it("no server DELETE when there is no stashed id to clean up", async () => {
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ existingSubscription: null });
     await disablePush("tok");
     expect(fetchMock).not.toHaveBeenCalled();
@@ -137,7 +163,7 @@ describe("ensurePushSubscription — #181: renew a dropped-but-wanted subscripti
   it("re-subscribes and POSTs supersedes=<old endpoint> on a silent drop", async () => {
     localStorage.setItem(SUB_ID_KEY, "srv-old");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({
       permission: "granted",
       existingSubscription: null,
@@ -147,93 +173,168 @@ describe("ensurePushSubscription — #181: renew a dropped-but-wanted subscripti
     const outcome = await ensurePushSubscription("tok");
 
     expect(outcome).toBe("renewed");
-    const post = fetchMock.mock.calls.find(
-      (call: unknown[]) =>
-        call[0] === "/push/subscriptions" &&
-        (call[1] as RequestInit | undefined)?.method === "POST",
-    );
-    expect(post).toBeDefined();
-    const body = JSON.parse((post![1] as RequestInit).body as string);
-    expect(body.endpoint).toBe("https://push.example/NEW");
-    expect(body.supersedes).toBe("https://push.example/OLD");
-    // fresh server id + endpoint stashed for the next cycle
+    const body = postedSubscription(fetchMock);
+    expect(body?.endpoint).toBe("https://push.example/NEW");
+    expect(body?.supersedes).toBe("https://push.example/OLD");
+    // fresh server id + endpoint stashed for the next cycle, plus (#1323) the
+    // key this subscription was created with.
     expect(localStorage.getItem(SUB_ID_KEY)).toBe("srv-new");
     expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(sample.publicKey);
   });
 
-  it("no-ops when a live subscription is already present", async () => {
+  it("keeps a live subscription whose key still matches what the server serves", async () => {
     localStorage.setItem(SUB_ID_KEY, "srv-old");
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/LIVE");
-    const fetchMock = stubPushFetch();
-    stubPushEnv({
-      permission: "granted",
-      existingSubscription: fakeSub("https://push.example/LIVE"),
-    });
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    const fetchMock = stubPushFetch(sample.publicKey);
+    const live = fakeSub("https://push.example/LIVE");
+    const { subscribe } = stubPushEnv({ permission: "granted", existingSubscription: live });
 
     expect(await ensurePushSubscription("tok")).toBe("present");
-    expect(fetchMock).not.toHaveBeenCalled();
+
+    // #1323 — the key IS revalidated (one GET), it just matched: nothing is
+    // torn down and no row is registered.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/push/vapid-public-key");
+    expect(vi.mocked(live.unsubscribe)).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
   });
 
   it("skips (never prompts) when permission is not granted", async () => {
     localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ permission: "default", existingSubscription: null });
     expect(await ensurePushSubscription("tok")).toBe("skipped");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does nothing when the user never opted in (no stashed endpoint = no intent)", async () => {
-    const fetchMock = stubPushFetch();
+    const fetchMock = stubPushFetch(sample.publicKey);
     stubPushEnv({ permission: "granted", existingSubscription: null });
     expect(await ensurePushSubscription("tok")).toBe("no-intent");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
-describe("getVapidPublicKey", () => {
-  it("fetches + caches on first call", async () => {
+// ── #1323 — a rotated VAPID key must heal itself, with no user gesture ──
+// Measured on staging: a subscription created with key A can never be signed
+// for once the server serves key B (`400 VapidPkHashMismatch` from Apple,
+// `403` from FCM). The client held the old key in localStorage and never
+// looked again, so nothing on either side reconciled — push died silently and
+// permanently. These tests pin the reconciliation at both doors.
+describe("#1323 — VAPID rotation heals on the ensure seam", () => {
+  it("drops the stale subscription and re-subscribes with the served key", async () => {
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    const fetchMock = stubPushFetch(ROTATED_KEY);
+    const live = fakeSub("https://push.example/OLD");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: live,
+      subscribeResult: fakeSub("https://push.example/NEW"),
+    });
+
+    expect(await ensurePushSubscription("tok")).toBe("rekeyed");
+
+    expect(vi.mocked(live.unsubscribe)).toHaveBeenCalled();
+    expect(firstSubscribeKeyBytes(subscribe)).toEqual(
+      Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
+    );
+    expect(postedSubscription(fetchMock)?.endpoint).toBe("https://push.example/NEW");
+    // The record now names the key the LIVE subscription was created with.
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
+    expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");
+  });
+
+  it("leaves the recorded key untouched when the re-subscribe fails", async () => {
+    // Recording the served key before the subscribe succeeds would re-create
+    // the #1323 silence one seam later: the next pass would see
+    // recorded == served, answer "present", and never heal.
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    stubPushFetch(ROTATED_KEY);
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: fakeSub("https://push.example/OLD"),
+    });
+    subscribe.mockRejectedValue(new Error("subscribe blew up"));
+
+    await expect(ensurePushSubscription("tok")).rejects.toThrow(/subscribe blew up/);
+
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(sample.publicKey);
+  });
+});
+
+describe("#1323 — enablePush subscribes with the served key, never a recorded one", () => {
+  it("drops a subscription bound to a superseded key before subscribing", async () => {
+    localStorage.setItem(SUB_ID_KEY, "srv-old");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/OLD");
+    localStorage.setItem(SUBSCRIBED_KEY, sample.publicKey);
+    stubPushFetch(ROTATED_KEY);
+    const live = fakeSub("https://push.example/OLD");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: live,
+      subscribeResult: fakeSub("https://push.example/NEW"),
+    });
+
+    expect(await enablePush("tok")).toEqual({ status: "enabled", subscriptionId: "srv-new" });
+
+    expect(vi.mocked(live.unsubscribe)).toHaveBeenCalled();
+    expect(firstSubscribeKeyBytes(subscribe)).toEqual(
+      Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
+    );
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
+  });
+
+  it("unsubscribes the conflicting subscription when the browser raises InvalidAccessError", async () => {
+    // The browser's own guard: an existing subscription bound to another key.
+    // Re-fetching the key cannot clear it — only unsubscribing can.
+    stubPushFetch(sample.publicKey);
+    const conflicting = fakeSub("https://push.example/CONFLICT");
+    const { subscribe } = stubPushEnv({
+      permission: "granted",
+      existingSubscription: conflicting,
+    });
+    subscribe
+      .mockRejectedValueOnce(new DOMException("different key", "InvalidAccessError"))
+      .mockResolvedValue(fakeSub("https://push.example/NEW"));
+
+    expect(await enablePush("tok")).toEqual({ status: "enabled", subscriptionId: "srv-new" });
+
+    expect(vi.mocked(conflicting.unsubscribe)).toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("fetchVapidPublicKey", () => {
+  it("always GETs — a recorded key is never served in its place (#1323)", async () => {
+    localStorage.setItem(SUBSCRIBED_KEY, "stale-value");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(
         new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
       );
 
-    expect(await getVapidPublicKey()).toBe(sample.publicKey);
+    expect(await fetchVapidPublicKey()).toBe(sample.publicKey);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem("cic.vapidPublicKey")).toBe(sample.publicKey);
-  });
-
-  it("returns cached value on subsequent calls without fetching", async () => {
-    localStorage.setItem("cic.vapidPublicKey", sample.publicKey);
-    const fetchMock = vi.spyOn(globalThis, "fetch");
-
-    expect(await getVapidPublicKey()).toBe(sample.publicKey);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("forceRefresh bypasses the cache", async () => {
-    localStorage.setItem("cic.vapidPublicKey", "stale-value");
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ public_key: sample.publicKey }), { status: 200 }),
-      );
-
-    expect(await getVapidPublicKey(true)).toBe(sample.publicKey);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem("cic.vapidPublicKey")).toBe(sample.publicKey);
+    // Reading the key does NOT record it: only a successful subscribe does.
+    expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe("stale-value");
   });
 
   it("throws ApiError on non-OK response", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
-    await expect(getVapidPublicKey()).rejects.toThrow(/500/);
+    await expect(fetchVapidPublicKey()).rejects.toThrow(/500/);
   });
 
   it("throws ApiError on malformed body", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 200 }),
     );
-    await expect(getVapidPublicKey()).rejects.toThrow(/vapid_malformed/);
+    await expect(fetchVapidPublicKey()).rejects.toThrow(/vapid_malformed/);
   });
 });
 

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -242,7 +242,12 @@ describe("#1323 — VAPID rotation heals on the ensure seam", () => {
     expect(firstSubscribeKeyBytes(subscribe)).toEqual(
       Array.from(vapidKeyToUint8Array(ROTATED_KEY)),
     );
-    expect(postedSubscription(fetchMock)?.endpoint).toBe("https://push.example/NEW");
+    const body = postedSubscription(fetchMock);
+    expect(body?.endpoint).toBe("https://push.example/NEW");
+    // The row the client is REPLACING is named on the way in — the same #181
+    // `supersedes` the renew branch uses, not a reap: the server is told which
+    // row died, it does not infer it from a 4xx (the thing #1325 declined).
+    expect(body?.supersedes).toBe("https://push.example/OLD");
     // The record now names the key the LIVE subscription was created with.
     expect(localStorage.getItem(SUBSCRIBED_KEY)).toBe(ROTATED_KEY);
     expect(localStorage.getItem(SUB_ENDPOINT_KEY)).toBe("https://push.example/NEW");

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -5,25 +5,38 @@
 // key, base64url-decodes it for `pushManager.subscribe`, and POSTs
 // the resulting subscription JSON to /push/subscriptions.
 //
-// B2 ships the lower half: VAPID-key fetching + cache, the
+// B2 ships the lower half: VAPID-key fetching, the
 // subscribe/unsubscribe primitives. The B3 settings UI imports this
 // module's `enablePush` / `disablePush` / `listPushDevices` to drive
 // the master toggle dance.
 //
-// ## VAPID public-key cache
+// ## The VAPID public key is fetched, never recalled (#1323)
 //
-// Key fetched from `GET /push/vapid-public-key` on first use, cached
-// in localStorage so subsequent subscribe calls don't round-trip.
-// Refresh path: cic catches `InvalidApplicationServerKey` from the
-// browser's `pushManager.subscribe` and re-fetches once. No HTTP
-// cache headers — operator-rotation is rare and the payload is ~88
-// bytes; localStorage is the authoritative cache.
+// `localStorage["cic.vapidPublicKey"]` used to be a read-through cache:
+// populated on first fetch, returned unconditionally afterwards. That is
+// what made an operator key rotation a silent, permanent kill — measured on
+// staging as `400 {"reason":"VapidPkHashMismatch"}` from Apple (and `403`
+// from FCM for the same failure in Google's vocabulary). The push service
+// binds a subscription to the key that CREATED it, so a client subscribing
+// with the recalled old key produces a perfectly valid subscription the
+// server can never sign for. No exception is raised anywhere: the browser
+// sees nothing inconsistent, the UI says push is on, the server logs a
+// rejection nobody reads.
+//
+// So the same storage key now means something else: **the key the LIVE
+// subscription was created with**, written ONLY after a subscribe succeeds
+// and cleared with the subscription. It is a comparison anchor, never a
+// source. Every subscribe fetches the served key and reconciles against it;
+// on a difference the browser subscription is dropped and re-created. The
+// re-meaning needs no migration — the old cache was populated at subscribe
+// time, so a client broken by a rotation already holds exactly the key it
+// subscribed with, which is what makes it heal on its first ensure seam.
 
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
 
-const VAPID_PUBLIC_KEY_STORAGE_KEY = "cic.vapidPublicKey";
+const SUBSCRIBED_VAPID_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
 /**
  * #459 — THE single, synchronous "can push actually be delivered here?" gate,
@@ -52,18 +65,12 @@ export function pushAvailable(): boolean {
 }
 
 /**
- * Fetches the server's VAPID public key, returning the cached value
- * when present. The key is non-secret per the W3C Push spec; storing
- * it in localStorage is fine.
- *
- * @param forceRefresh — bypass the cache (used after an
- *   `InvalidApplicationServerKey` exception).
+ * The VAPID public key the server signs with, straight from
+ * `GET /push/vapid-public-key`. Always a round-trip: nothing is recalled
+ * from storage (see the moduledoc — recalling it is #1323). The key is
+ * non-secret per the W3C Push spec, and the payload is ~90 bytes.
  */
-export async function getVapidPublicKey(forceRefresh = false): Promise<string> {
-  if (!forceRefresh) {
-    const cached = localStorage.getItem(VAPID_PUBLIC_KEY_STORAGE_KEY);
-    if (cached !== null && cached !== "") return cached;
-  }
+export async function fetchVapidPublicKey(): Promise<string> {
   const res = await fetch("/push/vapid-public-key", {
     headers: { "content-type": "application/json" },
   });
@@ -74,7 +81,6 @@ export async function getVapidPublicKey(forceRefresh = false): Promise<string> {
   if (typeof body.public_key !== "string" || body.public_key === "") {
     throw new ApiError(500, "vapid_malformed");
   }
-  localStorage.setItem(VAPID_PUBLIC_KEY_STORAGE_KEY, body.public_key);
   return body.public_key;
 }
 
@@ -94,11 +100,6 @@ export function vapidKeyToUint8Array(base64Url: string): Uint8Array {
     out[i] = raw.charCodeAt(i);
   }
   return out;
-}
-
-/** Clears the cached VAPID key — used by tests + after a server rotation. */
-export function clearVapidPublicKeyCache(): void {
-  localStorage.removeItem(VAPID_PUBLIC_KEY_STORAGE_KEY);
 }
 
 /**
@@ -223,9 +224,13 @@ export async function listPushDevices(token: string): Promise<PushDeviceSummary[
 const SUBSCRIPTION_ID_STORAGE_KEY = "cic.pushSubscriptionId";
 const SUBSCRIPTION_ENDPOINT_STORAGE_KEY = "cic.pushSubscriptionEndpoint";
 
-function rememberSubscription(id: SubscriptionId, endpoint: string): void {
+function rememberSubscription(id: SubscriptionId, endpoint: string, vapidKey: string): void {
   localStorage.setItem(SUBSCRIPTION_ID_STORAGE_KEY, id);
   localStorage.setItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY, endpoint);
+  // #1323 — recorded only here, i.e. only once a subscribe has succeeded.
+  // Recording the served key any earlier would make the NEXT reconciliation
+  // read "same key" off a subscription that was never re-created.
+  localStorage.setItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY, vapidKey);
 }
 
 /**
@@ -248,6 +253,7 @@ export function subscriptionIdForEndpoint(endpoint: string): SubscriptionId | nu
 function forgetSubscription(): void {
   localStorage.removeItem(SUBSCRIPTION_ID_STORAGE_KEY);
   localStorage.removeItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY);
+  localStorage.removeItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY);
 }
 
 /**
@@ -283,11 +289,10 @@ export type EnablePushResult =
  *      programmatic re-asks until the user clears site data).
  *   3. If `default`, request permission. On `denied`/`default` after
  *      the prompt, bail with `permission_denied`/`permission_dismissed`.
- *   4. Get the SW registration (waits for ready). Fetch the VAPID
- *      public key (cached). Subscribe via `pushManager.subscribe`.
- *      On `InvalidApplicationServerKey`, refresh the cached key once
- *      and retry — protects against operator-rotated VAPID keys
- *      sticking around in localStorage.
+ *   4. Get the SW registration (waits for ready). Fetch the served VAPID
+ *      public key and reconcile it against the key our live subscription
+ *      was created with (#1323); on a rotation, drop that subscription
+ *      before subscribing with the fresh key.
  *   5. POST the subscription to `/push/subscriptions`. Return the
  *      created subscription's id so the UI can refresh its devices
  *      list directly without an extra GET round-trip.
@@ -314,7 +319,7 @@ export async function enablePush(token: string): Promise<EnablePushResult> {
     return { status: "unsupported", reason: "no_push_manager" };
   }
 
-  const subscription = await subscribeWithVapidRetry(registration);
+  const { subscription, key } = await subscribeWithCurrentVapidKey(registration);
   const json = subscription.toJSON() as {
     endpoint?: string;
     keys?: { p256dh?: string; auth?: string };
@@ -330,7 +335,7 @@ export async function enablePush(token: string): Promise<EnablePushResult> {
     endpoint: json.endpoint,
     keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
   });
-  rememberSubscription(created.id, json.endpoint);
+  rememberSubscription(created.id, json.endpoint, key);
   return { status: "enabled", subscriptionId: created.id };
 }
 
@@ -392,27 +397,32 @@ export async function disablePush(token: string): Promise<boolean> {
  *
  *   * "renewed"   — the browser subscription had dropped; re-subscribed
  *     and POSTed the fresh subscription (superseding the old row).
- *   * "present"   — a live subscription already exists (or a same-endpoint
- *     replay), nothing to do.
+ *   * "rekeyed"   — #1323: the server serves a VAPID key that supersedes the
+ *     one the live subscription was created with, so that subscription can
+ *     never be signed for; it was dropped and re-created with the fresh key.
+ *   * "present"   — a live subscription exists AND was created with the key
+ *     the server still serves (or a same-endpoint replay), nothing to do.
  *   * "skipped"   — the runtime can't push (no Notification / SW /
  *     pushManager) or permission isn't `granted`. Never prompts here.
  *   * "no-intent" — the user never opted in / disabled push (no stashed
  *     endpoint), so there is nothing to renew.
  */
-export type EnsurePushOutcome = "renewed" | "present" | "skipped" | "no-intent";
+export type EnsurePushOutcome = "renewed" | "rekeyed" | "present" | "skipped" | "no-intent";
 
 /**
  * #181 — renew a dropped-but-still-wanted push subscription on the
  * SW-update / app-resume lifecycle seams (wired by `lib/pushResubscribe.ts`).
  *
  * RENEW-ONLY: it never prompts for permission and never opts a user in.
- * It acts only when ALL hold: `Notification.permission === "granted"`, the
- * user previously opted in (a stashed endpoint proves intent — cleared on
- * disable), AND the browser's live `pushManager.getSubscription()` has gone
- * `null` (the silent drop the issue describes). On that exact state it
- * re-subscribes via the SAME VAPID path as the initial enable and POSTs the
- * fresh subscription with `supersedes: <old endpoint>` so the server prunes
- * the ghost row. A `422` replay (endpoint did not rotate) counts as present.
+ * It acts only when BOTH hold: `Notification.permission === "granted"` and
+ * the user previously opted in (a stashed endpoint proves intent — cleared
+ * on disable). Given those, it re-subscribes in two states: the browser's
+ * live `pushManager.getSubscription()` has gone `null` (#181's silent drop),
+ * or the server's VAPID key has moved past the one the live subscription was
+ * created with (#1323's silent mismatch, which no browser reports). Either
+ * way it POSTs the fresh subscription with `supersedes: <old endpoint>` so
+ * the server prunes the row it replaces. A `422` replay (endpoint did not
+ * rotate) counts as present.
  */
 export async function ensurePushSubscription(token: string): Promise<EnsurePushOutcome> {
   if (typeof Notification === "undefined") return "skipped";
@@ -425,10 +435,20 @@ export async function ensurePushSubscription(token: string): Promise<EnsurePushO
   const registration = await navigator.serviceWorker.ready;
   if (registration.pushManager === undefined) return "skipped";
 
-  const existing = await registration.pushManager.getSubscription();
-  if (existing !== null) return "present";
+  // #1323 — the reconciliation seam. A subscription created with a
+  // superseded VAPID key is indistinguishable from a healthy one from here:
+  // it exists, it looks valid, and the push service rejects every send to it
+  // forever. The served key is the only thing that tells them apart, so ask
+  // for it before believing a live subscription.
+  const { key, rotated } = await reconcileVapidKey();
 
-  const subscription = await subscribeWithVapidRetry(registration);
+  const existing = await registration.pushManager.getSubscription();
+  if (existing !== null) {
+    if (!rotated) return "present";
+    await existing.unsubscribe();
+  }
+
+  const subscription = await subscribeWithKey(registration, key);
   const json = subscription.toJSON() as {
     endpoint?: string;
     keys?: { p256dh?: string; auth?: string };
@@ -447,45 +467,84 @@ export async function ensurePushSubscription(token: string): Promise<EnsurePushO
       keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
       supersedes: stashedEndpoint,
     });
-    rememberSubscription(created.id, json.endpoint);
-    return "renewed";
+    rememberSubscription(created.id, json.endpoint, key);
+    return rotated ? "rekeyed" : "renewed";
   } catch (err) {
     if (err instanceof ApiError && err.status === 422) {
       // Endpoint did not rotate — the server row already exists (replay).
       // Re-point the endpoint stash at the live sub; the id is unchanged.
+      // The key record moves too: the subscription in hand WAS created with
+      // it, and leaving the superseded one behind would re-tear-down the
+      // same subscription on every following seam.
       localStorage.setItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY, json.endpoint);
+      localStorage.setItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY, key);
       return "present";
     }
     throw err;
   }
 }
 
-async function subscribeWithVapidRetry(
+/**
+ * #1323 — the served key plus whether it supersedes the one our live
+ * subscription was created with. `rotated` is false when we have no record
+ * (nothing was ever subscribed here, or site data was cleared): an absent
+ * record proves nothing, so it must not trigger a teardown.
+ */
+async function reconcileVapidKey(): Promise<{ key: string; rotated: boolean }> {
+  const subscribedWith = localStorage.getItem(SUBSCRIBED_VAPID_KEY_STORAGE_KEY);
+  const key = await fetchVapidPublicKey();
+  return {
+    key,
+    rotated: subscribedWith !== null && subscribedWith !== "" && subscribedWith !== key,
+  };
+}
+
+/**
+ * Subscribes with exactly `key`, dropping a conflicting subscription rather
+ * than giving up. `InvalidAccessError` is the browser refusing to hand back
+ * a subscription bound to a DIFFERENT application server key — re-fetching
+ * the key cannot resolve that (it is already the current one); only
+ * unsubscribing the incumbent can.
+ */
+async function subscribeWithKey(
   registration: ServiceWorkerRegistration,
+  key: string,
 ): Promise<PushSubscription> {
-  const tryOnce = async (forceRefresh: boolean): Promise<PushSubscription> => {
-    const key = await getVapidPublicKey(forceRefresh);
-    const bytes = vapidKeyToUint8Array(key);
-    return registration.pushManager.subscribe({
-      userVisibleOnly: true,
-      // Cast: BufferSource accepts a Uint8Array, but TS DOM lib's
-      // PushSubscriptionOptionsInit narrows applicationServerKey to
-      // ArrayBufferView<ArrayBuffer> (vs the wider ArrayBufferLike
-      // returned by Uint8Array's typed-array union). The runtime
-      // contract is byte-for-byte: we send the raw key bytes.
-      applicationServerKey: bytes as BufferSource,
-    });
+  const options: PushSubscriptionOptionsInit = {
+    userVisibleOnly: true,
+    // Cast: BufferSource accepts a Uint8Array, but TS DOM lib's
+    // PushSubscriptionOptionsInit narrows applicationServerKey to
+    // ArrayBufferView<ArrayBuffer> (vs the wider ArrayBufferLike
+    // returned by Uint8Array's typed-array union). The runtime
+    // contract is byte-for-byte: we send the raw key bytes.
+    applicationServerKey: vapidKeyToUint8Array(key) as BufferSource,
   };
   try {
-    return await tryOnce(false);
+    return await registration.pushManager.subscribe(options);
   } catch (err) {
     if (err instanceof DOMException && err.name === "InvalidAccessError") {
-      // Browsers throw InvalidAccessError when the cached VAPID key no
-      // longer matches the SW's existing subscription (operator key
-      // rotation). Refresh once + retry.
-      clearVapidPublicKeyCache();
-      return tryOnce(true);
+      await dropLiveSubscription(registration);
+      return registration.pushManager.subscribe(options);
     }
     throw err;
   }
+}
+
+/** Releases the browser-side subscription, if the SW still holds one. */
+async function dropLiveSubscription(registration: ServiceWorkerRegistration): Promise<void> {
+  const live = await registration.pushManager.getSubscription();
+  if (live !== null) await live.unsubscribe();
+}
+
+/**
+ * The one subscribe door: reconcile against the served key, drop a
+ * subscription bound to a superseded one, then subscribe. Returns the key it
+ * subscribed with so the caller can record it once the server row exists.
+ */
+async function subscribeWithCurrentVapidKey(
+  registration: ServiceWorkerRegistration,
+): Promise<{ subscription: PushSubscription; key: string }> {
+  const { key, rotated } = await reconcileVapidKey();
+  if (rotated) await dropLiveSubscription(registration);
+  return { subscription: await subscribeWithKey(registration, key), key };
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -534,6 +534,12 @@ config :logger, :console,
     :endpoint,
     :status,
     :count,
+    # #1321 — `Grappa.Push.VendorLog`'s rejection line. `:vendor` is the
+    # HOST of the push service that rejected a delivery: the line records
+    # the host only, never the path, because a path segment can itself be
+    # a credential. The reason string itself rides the pre-existing
+    # `:reason` key, length-capped at the sink.
+    :vendor,
     # M-11 admin-events: `:topic` is the PubSub topic that failed (string,
     # e.g. `"grappa:admin:events"`); `:kind` is the typed event-kind atom
     # (`:visitor_deleted`, `:circuit_reset`, etc.) that was about to be

--- a/config/test.exs
+++ b/config/test.exs
@@ -157,6 +157,11 @@ config :grappa, :attach_session_log_telemetry, false
 # would make snapshot assertions flaky. Aggregation tests attach the
 # handler explicitly + drain via `reset/0` (test/grappa/db_latency_test.exs).
 config :grappa, :attach_db_latency_telemetry, false
+# #1321 — VendorLog singleton attach OFF in test env. The handler only
+# logs, so a global attach would write a push rejection into whatever
+# test happens to be capturing the Logger stream. Its own tests attach
+# the handler explicitly (test/grappa/push/vendor_log_test.exs).
+config :grappa, :attach_push_vendor_log_telemetry, false
 config :phoenix, :plug_init_mode, :runtime
 config :phoenix, :json_library, Jason
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42452,3 +42452,51 @@ primary method it is. The issue named that cost and vjt asked for the move
 anyway. The doors sit LAST in the panel, adjacent to Connect, because they
 are actions rather than identity fields like realname/ident — a placement
 choice, cheap to flip, not a constraint.
+<!-- entry #1321 -->
+
+---
+
+## 2026-08-14 — #1321: the rejection reason, by the only route that carries it
+
+A rejected web push logged a bare status code, which is indistinguishable
+from a bad JWT, a stale application server key, a clock skew or an expired
+subscription. The services write the reason into the response body, and
+reading it turns an afternoon of guessing into a one-field diagnosis.
+
+**Why a telemetry sink and not plumbing.** `ExNudge.send_notification/3`
+binds the response on the failure branch and returns
+`{:error, {:http_error, status}}`, so the response never leaves the library
+by the call path — and its own `@spec` for `send_notifications/3` promises a
+response it does not hand back, the same unreliability `Grappa.Push.Sender`
+already documents about the library's declared types. There was therefore no
+"plumb it through the sender" branch to choose. The body leaves by exactly
+one route: the library's `[:ex_nudge, :send_notification]` event carries it
+as `metadata.error_reason` for every non-2xx the library did not classify
+itself. `Grappa.Push.VendorLog` attaches there, in the shape the tree already
+uses for `Grappa.SessionLog` and `Grappa.DbLatency`.
+
+**The issue's ask needs amending on one point: `retry-after` is
+unreachable.** Response HEADERS never leave the library by any route,
+telemetry included, and there is no bump to wait for (1.0.2, 2025-07-28, is
+the latest release). The ruling asked for the status AND the body; the body
+can be had, the headers cannot.
+
+**An integer `http_status_code` is the exact discriminator.** The library
+classifies 410 / 413 and transport failures itself and passes an atom in
+place of the response, so those events carry a nil status and no body. The
+sink keys on the integer, which is also its silence boundary: those paths
+already log at the sender with everything there is to say, and a second line
+would be noise. Per log honesty the silence is "no body was carried", not
+"work was skipped".
+
+**Two constraints on what reaches stdout**, which persists across restarts
+and ships out with any log forwarder. The line records the endpoint's HOST
+only and never its path, because a path segment can itself be a credential;
+an operator correlates with the sender's own line for the same delivery. And
+the reason is length-capped and folded onto one line — it is vendor text of
+unbounded size and arbitrary bytes, so it is made valid UTF-8 before folding,
+and the cap is what stops an error page from becoming a log flood.
+
+**Scope held.** Per the maintainer's ruling on #1323 the reason string is for
+human diagnosis only: no code matches on it, and the 404 / 410 sweep is
+untouched — a 400 sweeps nothing, whatever reason it carries.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42551,12 +42551,18 @@ believes a live subscription, and reports the teardown as its own outcome
 changed accordingly: re-fetching the key cannot clear a subscription bound to
 a different one, so the retry now unsubscribes the incumbent instead.
 
-**Accepted costs, stated so they are not read as oversights.** One ~150-byte
+**The row it replaces is named on the way in.** The `rekeyed` POST carries
+`supersedes: <old endpoint>`, exactly as `renewed` does — #181's field, on the
+wire since then and implemented server-side, so same problem, same solution
+and no new mechanism. This is the opposite of the reap #1325 declined: there
+the SERVER would infer a row's death from a run of 4xx it must read a vendor
+string to understand; here the CLIENT declares the one row it is itself
+replacing, at the moment it replaces it, with no status parsing anywhere. A
+`400` still sweeps nothing.
+
+**Accepted cost, stated so it is not read as an oversight.** One ~150-byte
 GET per resume seam for opted-in users (single-flighted by
 `pushResubscribe`), deliberately unthrottled: a throttle would be duplicated
 state that drifts, guarding a request smaller than the headers carrying it.
-And the superseded server row is left in place — `400` deliberately never
-sweeps (#1325, closed `not planned`), so the row costs one wasted request per
-notification forever. Having the client delete the row it is itself replacing
-is a different mechanism from a reason-string reap, and it is held pending a
-ruling rather than assumed.
+The size is an estimate — the ~88-byte base64url key plus its JSON envelope —
+not a measurement; nobody has counted the bytes on the wire.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42500,3 +42500,63 @@ and the cap is what stops an error page from becoming a log flood.
 **Scope held.** Per the maintainer's ruling on #1323 the reason string is for
 human diagnosis only: no code matches on it, and the 404 / 410 sweep is
 untouched — a 400 sweeps nothing, whatever reason it carries.
+<!-- entry #1323 -->
+
+---
+
+## 2026-08-14 — #1323: a key you recall is a key you never check
+
+Web push from staging was rejected on every attempt. Probing Apple's real
+endpoint with a freshly signed VAPID JWT returned `400
+{"reason":"VapidPkHashMismatch"}`; FCM had answered `403` to an Android
+subscription the same day, which is the same failure in Google's vocabulary.
+The server was cleared by measurement, not assumption: `GET
+/push/vapid-public-key` served byte-for-byte the key the container signs
+with, and the keypair was internally consistent.
+
+The mismatch was client-side. `cic.vapidPublicKey` in localStorage was a
+read-through cache: populated on first fetch, returned unconditionally ever
+after, refreshed only when the browser raised
+`InvalidApplicationServerKey`. That trigger cannot fire on the failure we
+had — the browser raises it when an EXISTING subscription conflicts with a
+NEW key handed to `subscribe()`, and here the client handed it the OLD key
+it had just recalled. Nothing is inconsistent from the browser's seat, so it
+produces a perfectly valid subscription that the server can never sign for.
+The UI says push is on; the server logs a rejection nobody reads; no state
+exists in which anything looks wrong. Any VAPID rotation was therefore a
+silent, permanent kill for every already-installed client.
+
+**The storage key was re-meant rather than deleted.** It now records *the key
+the LIVE subscription was created with*, written ONLY after a subscribe
+succeeds and cleared with the subscription — a comparison anchor, never a
+source. Every subscribe fetches the served key (`fetchVapidPublicKey`, no
+recall path left to misuse) and reconciles; on a difference the browser
+subscription is unsubscribed and re-created with the fresh key. Recording the
+served key any earlier — at fetch time, as the old cache did — would restore
+the silence one seam later: a failed re-subscribe would leave
+`recorded == served`, and the next pass would read that as health.
+
+The re-meaning needs no migration, which is why it was preferred to a new
+key. The old cache was only ever populated at subscribe time, so a client
+broken by the rotation already holds exactly the key it subscribed with —
+the fleet heals on its first seam.
+
+**The reconciliation lives on the ensure seam, not only at the toggle.** The
+ruling asked for no user gesture and for a rotation that heals itself; a
+check that runs only inside `enablePush` waits for a toggle that a working-
+looking client never gets. So `ensurePushSubscription` — already wired to
+boot / `controllerchange` / `visibilitychange` by #181 — reconciles before it
+believes a live subscription, and reports the teardown as its own outcome
+(`rekeyed`, distinct from #181's `renewed`). `InvalidAccessError` recovery
+changed accordingly: re-fetching the key cannot clear a subscription bound to
+a different one, so the retry now unsubscribes the incumbent instead.
+
+**Accepted costs, stated so they are not read as oversights.** One ~150-byte
+GET per resume seam for opted-in users (single-flighted by
+`pushResubscribe`), deliberately unthrottled: a throttle would be duplicated
+state that drifts, guarding a request smaller than the headers carrying it.
+And the superseded server row is left in place — `400` deliberately never
+sweeps (#1325, closed `not planned`), so the row costs one wasted request per
+notification forever. Having the client delete the row it is itself replacing
+is a different mechanism from a reason-string reap, and it is held pending a
+ruling rather than assumed.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -269,6 +269,18 @@ defmodule Grappa.Application do
         # attach); unlike AdminEvents/SessionLog it needs NO sandbox
         # allow — the fold touches no Repo.
         {Grappa.DbLatency, attach_telemetry: attach_db_latency_telemetry?()},
+        # VendorLog (#1321): singleton GenServer that attaches to the
+        # `[:ex_nudge, :send_notification]` event in init/1 and logs the
+        # rejection reason a push service returned in the response body —
+        # the ONLY route by which that body leaves the library, so the
+        # sender cannot report it itself. Same slot as the sinks above and
+        # BEFORE Endpoint, so a delivery triggered by the first WS event
+        # already has a handler; it holds no state at all beyond the
+        # attachment, so nothing orders it against Repo/Registry. Restart:
+        # :permanent (infrastructure). `attach_telemetry: false` in test
+        # env so the handler doesn't write into every suite's captured
+        # Logger stream (per-test opt-in via manual attach).
+        {Grappa.Push.VendorLog, attach_telemetry: attach_push_vendor_log_telemetry?()},
         # ShareTokens: ETS-backed one-shot set for share-link token
         # redemption (#1306 — both subject kinds; the ledger keys on the
         # token string, which carries no kind). Must come before Endpoint
@@ -575,6 +587,14 @@ defmodule Grappa.Application do
   @spec attach_db_latency_telemetry?() :: boolean()
   defp attach_db_latency_telemetry?,
     do: Application.get_env(:grappa, :attach_db_latency_telemetry, true)
+
+  # #1321 — same test-env opt-out shape. The reason is neither sandbox
+  # ownership nor determinism: the handler only logs, and a globally
+  # attached one would emit into the Logger stream any test captures.
+  # Defaults true — prod/dev attach at boot.
+  @spec attach_push_vendor_log_telemetry?() :: boolean()
+  defp attach_push_vendor_log_telemetry?,
+    do: Application.get_env(:grappa, :attach_push_vendor_log_telemetry, true)
 
   @impl Application
   def config_change(changed, _, removed) do

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -79,7 +79,7 @@ defmodule Grappa.Push do
       Grappa.Visitors.Visitor,
       Grappa.WSPresence
     ],
-    exports: [BadgeSource, Payload, Sender, Subscription, Triggers]
+    exports: [BadgeSource, Payload, Sender, Subscription, Triggers, VendorLog]
 
   import Ecto.Query
 

--- a/lib/grappa/push/vendor_log.ex
+++ b/lib/grappa/push/vendor_log.ex
@@ -1,0 +1,158 @@
+defmodule Grappa.Push.VendorLog do
+  @moduledoc """
+  Records what a push service SAID when it rejected a delivery (#1321).
+
+  `Grappa.Push.Sender` logs the HTTP status of a rejected push and
+  nothing else, because the status is all it is given. A bare `400` or
+  `403` is indistinguishable from a bad JWT, a stale application server
+  key, a clock skew or an expired subscription — the services write the
+  actual reason into the response BODY, and the diagnosis is one field
+  long once you can read it.
+
+  ## Why a telemetry sink instead of plumbing it through the sender
+
+  There is no plumbing route. `ExNudge.send_notification/3` binds the
+  `%HTTPoison.Response{}` on the failure branch and returns
+  `{:error, {:http_error, status}}` — the response never leaves the
+  library (its own `@spec` for `send_notifications/3` promises a
+  response it does not hand back; `Grappa.Push.Sender` already documents
+  that the declared types are narrower than the returns).
+
+  The body IS reachable, by exactly one route: the library's
+  `[:ex_nudge, :send_notification]` telemetry event carries the response
+  body as `metadata.error_reason` whenever the response was a non-2xx it
+  did not classify itself. So this module attaches there.
+
+  Consequences of that route, both deliberate:
+
+    * **`retry-after` is unreachable.** Response HEADERS never leave
+      `ExNudge` by any route, telemetry included. The issue asks for it;
+      it cannot be had without a change upstream, and the last release is
+      1.0.2 (2025-07-28).
+    * **Terminal and transport failures stay silent here.** The library
+      classifies 410 / 413 and transport errors itself and passes an atom
+      in place of a response, so the event carries a nil
+      `http_status_code` and no body. Those paths already log at the
+      sender with everything there is to say; a second line would add
+      noise, not information. An integer `http_status_code` is therefore
+      the exact discriminator for "a vendor body exists", and this
+      handler keys on it.
+
+  ## What the line may contain
+
+  Per the maintainer's ruling on #1323 the reason string is for human
+  diagnosis ONLY: no code matches on it, subscriptions keep being swept
+  on 404 / 410 alone, and a 400 sweeps nothing whatever reason it
+  carries.
+
+  Two rules constrain what reaches stdout, which persists across
+  restarts and ships out with any log forwarder:
+
+    * **The host, never the path.** The line records the endpoint's host
+      alone, because a path segment can itself be a credential. Operators
+      correlate with the sender's own `push.send http error` line, which
+      is emitted for the same delivery.
+    * **The body is capped** (`@max_reason_bytes`) and folded onto one
+      line. It is vendor text of unbounded size and arbitrary bytes;
+      the cap is what keeps an error PAGE from becoming a log flood, and
+      the fold is what keeps the line greppable.
+
+  ## Restart strategy / test isolation
+
+  `:permanent` singleton (registered as `__MODULE__`) holding no state:
+  it owns nothing but its own telemetry attachment, which `init/1`
+  re-establishes on every restart. The handler logs synchronously in the
+  emitting process — unlike the sinks it is modelled on
+  (`Grappa.SessionLog`, `Grappa.DbLatency`) it does no Repo or ETS work,
+  so there is nothing to move off the caller, and a delivery Task is not
+  a hot path. Boots with `attach_telemetry: false` in test env
+  (`config/test.exs`), so tests attach the handler explicitly instead of
+  folding every suite's push telemetry into the shared Logger stream.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @handler_id "grappa-push-vendor-log"
+  @event [:ex_nudge, :send_notification]
+
+  # Genuine config default (correct production behavior): these are small
+  # error documents — a couple of hundred bytes is the whole reason, and
+  # anything past it is a vendor error page, not a diagnosis.
+  @max_reason_bytes 256
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl GenServer
+  def init(opts) do
+    if Keyword.get(opts, :attach_telemetry, true) do
+      # Detach-then-attach so a brutal_kill restart (terminate/2 never
+      # runs) doesn't leave a stale handler bound to a dead pid. Detach
+      # of an unknown id is `:ok`, so this is safe on first boot too.
+      _ = :telemetry.detach(@handler_id)
+
+      :ok = :telemetry.attach(@handler_id, @event, &__MODULE__.handle_telemetry/4, nil)
+    end
+
+    # No state: the attachment is the whole job.
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def terminate(_, _) do
+    :ok = :telemetry.detach(@handler_id)
+  end
+
+  @doc false
+  # Runs in the EMITTER's process (per :telemetry semantics) — the
+  # `Grappa.Push.Sender` fan-out Task, never a hot path.
+  @spec handle_telemetry([atom()], map(), map(), term()) :: :ok
+  def handle_telemetry(_, _, %{status: :error, http_status_code: status} = metadata, _)
+      when is_integer(status) do
+    Logger.warning("push.vendor rejected",
+      status: status,
+      vendor: host(metadata),
+      reason: reason(metadata)
+    )
+  end
+
+  def handle_telemetry(_, _, _, _), do: :ok
+
+  # The endpoint's host and nothing else — a path segment can itself be
+  # a credential. `ExNudge` hands over an endpoint it has already
+  # partially masked; this does not rely on that.
+  @spec host(map()) :: String.t()
+  defp host(%{endpoint: endpoint}) when is_binary(endpoint) do
+    case URI.parse(endpoint) do
+      %URI{host: host} when is_binary(host) -> host
+      _ -> "unknown"
+    end
+  end
+
+  defp host(_), do: "unknown"
+
+  # A body is what an integer `http_status_code` implies, but the library's
+  # declared types are already known to be narrower than what it returns
+  # (see `Grappa.Push.Sender.normalize/1`), so a non-binary reason is
+  # reported rather than crashed on.
+  @spec reason(map()) :: String.t()
+  defp reason(%{error_reason: body}) when is_binary(body), do: body |> cap() |> one_line()
+  defp reason(%{error_reason: other}), do: inspect(other)
+
+  @spec cap(binary()) :: binary()
+  defp cap(body) when byte_size(body) <= @max_reason_bytes, do: body
+  defp cap(body), do: binary_slice(body, 0, @max_reason_bytes) <> " …(truncated)"
+
+  # Vendor bytes, not a string: `cap/1` can cut mid-codepoint and the body
+  # may not be UTF-8 at all, so make it valid BEFORE folding the
+  # whitespace — one Logger line stays greppable.
+  @spec one_line(binary()) :: String.t()
+  defp one_line(text) do
+    text
+    |> String.replace_invalid()
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
+end

--- a/lib/grappa/push/vendor_log.ex
+++ b/lib/grappa/push/vendor_log.ex
@@ -113,8 +113,8 @@ defmodule Grappa.Push.VendorLog do
       when is_integer(status) do
     Logger.warning("push.vendor rejected",
       status: status,
-      vendor: host(metadata),
-      reason: reason(metadata)
+      vendor: host(Map.get(metadata, :endpoint)),
+      reason: reason(Map.get(metadata, :error_reason))
     )
   end
 
@@ -123,8 +123,8 @@ defmodule Grappa.Push.VendorLog do
   # The endpoint's host and nothing else — a path segment can itself be
   # a credential. `ExNudge` hands over an endpoint it has already
   # partially masked; this does not rely on that.
-  @spec host(map()) :: String.t()
-  defp host(%{endpoint: endpoint}) when is_binary(endpoint) do
+  @spec host(term()) :: String.t()
+  defp host(endpoint) when is_binary(endpoint) do
     case URI.parse(endpoint) do
       %URI{host: host} when is_binary(host) -> host
       _ -> "unknown"
@@ -137,9 +137,9 @@ defmodule Grappa.Push.VendorLog do
   # declared types are already known to be narrower than what it returns
   # (see `Grappa.Push.Sender.normalize/1`), so a non-binary reason is
   # reported rather than crashed on.
-  @spec reason(map()) :: String.t()
-  defp reason(%{error_reason: body}) when is_binary(body), do: body |> cap() |> one_line()
-  defp reason(%{error_reason: other}), do: inspect(other)
+  @spec reason(term()) :: String.t()
+  defp reason(body) when is_binary(body), do: body |> cap() |> one_line()
+  defp reason(other), do: inspect(other)
 
   @spec cap(binary()) :: binary()
   defp cap(body) when byte_size(body) <= @max_reason_bytes, do: body

--- a/test/grappa/push/vendor_log_test.exs
+++ b/test/grappa/push/vendor_log_test.exs
@@ -1,0 +1,126 @@
+defmodule Grappa.Push.VendorLogTest do
+  @moduledoc """
+  #1321 — the push service's OWN words on a rejected delivery.
+
+  `async: false`: the handler is a globally-attached `:telemetry`
+  handler under a fixed id, and the assertions read the shared Logger
+  stream via `capture_log/1`. The singleton boots with
+  `attach_telemetry: false` under test (`config/test.exs`, mirror of
+  `Grappa.DbLatency`), so each test attaches the production handler
+  function explicitly.
+
+  The events emitted here are the ones `ExNudge.Telemetry` actually
+  produces: a non-2xx response yields an integer `http_status_code`
+  with the response BODY as `error_reason`, while the terminal 410 /
+  413 and the transport failures yield a nil `http_status_code` and an
+  atom-or-inspected reason. That split is what the handler keys on, so
+  the fixtures pin it.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Push.VendorLog
+
+  @handler_id "grappa-push-vendor-log-test"
+  @event [:ex_nudge, :send_notification]
+
+  # An endpoint in the shape the telemetry event carries it. The path
+  # segment is treated as a credential — the handler records the host
+  # and nothing else.
+  @endpoint "https://push.example.invalid/vXrN4tPq2Ke"
+
+  setup do
+    :ok = :telemetry.attach(@handler_id, @event, &VendorLog.handle_telemetry/4, nil)
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+    :ok
+  end
+
+  defp emit(metadata) do
+    :telemetry.execute(@event, %{duration: 12, payload_size: 200}, Map.new(metadata))
+  end
+
+  defp rejection(overrides) do
+    Map.merge(
+      %{
+        endpoint: @endpoint,
+        status: :error,
+        http_status_code: 400,
+        error_reason: ~s({"reason":"VapidPkHashMismatch"})
+      },
+      Map.new(overrides)
+    )
+  end
+
+  describe "vendor rejections" do
+    test "logs the vendor's reason, not just the status" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      assert log =~ "VapidPkHashMismatch"
+    end
+
+    test "logs the HTTP status alongside the reason" do
+      log = capture_log(fn -> emit(rejection(http_status_code: 403)) end)
+
+      assert log =~ "403"
+    end
+
+    test "names the host so the line stands on its own" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      assert log =~ "push.example.invalid"
+    end
+
+    test "never prints the endpoint path — a path segment can itself be a credential" do
+      log = capture_log(fn -> emit(rejection([])) end)
+
+      refute log =~ "vXrN4tPq2Ke"
+    end
+
+    test "caps the body — a vendor may answer with a whole error page" do
+      body = String.duplicate("a", 4000) <> "TAIL_OF_THE_BODY"
+
+      log = capture_log(fn -> emit(rejection(error_reason: body)) end)
+
+      refute log =~ "TAIL_OF_THE_BODY"
+    end
+
+    test "says so when it truncated" do
+      log = capture_log(fn -> emit(rejection(error_reason: String.duplicate("a", 4000))) end)
+
+      assert log =~ "truncated"
+    end
+
+    test "keeps the reason on ONE line — the log is grepped, not parsed" do
+      log = capture_log(fn -> emit(rejection(error_reason: "line one\nline two")) end)
+
+      assert log =~ "line one line two"
+    end
+
+    test "survives a body that is not valid UTF-8" do
+      log = capture_log(fn -> emit(rejection(error_reason: <<0xFF, 0xFE, "Bad">>)) end)
+
+      assert log =~ "Bad"
+    end
+  end
+
+  describe "events the sender already reports" do
+    test "stays silent on a delivered notification" do
+      log =
+        capture_log(fn ->
+          emit(%{endpoint: @endpoint, status: :success, http_status_code: 201, error_reason: nil})
+        end)
+
+      refute log =~ "push.vendor"
+    end
+
+    test "stays silent when there is no vendor body to add (410, transport failure)" do
+      log =
+        capture_log(fn ->
+          emit(rejection(http_status_code: nil, error_reason: :subscription_expired))
+        end)
+
+      refute log =~ "push.vendor"
+    end
+  end
+end


### PR DESCRIPTION
## What this is

The **union of #1327 (issue #1323) and #1328 (issue #1321)**, replayed onto
`origin/main` `35333266`. It **supersedes both** — those two PRs should not be
merged; this one carries every commit of each, with the shas changed by the
replay.

- **#1321 — `Grappa.Push.VendorLog`** (server): a telemetry sink that logs the
  reason a push service gave for rejecting a delivery (status plus a capped
  body), attached to `[:ex_nudge, :send_notification]` — the only route by
  which that body leaves the library, which binds the response on the error
  arm and does not return it. Three commits: the sink, the docs, and a
  Dialyzer-driven refactor. As stated on #1328, `retry-after` remains
  **unreachable** (no header escapes ExNudge by any route), and the ask on
  issue #1321 needs amending on that point.
- **#1323 — VAPID key reconciliation** (cic): the key is reconciled instead of
  recalled, plus a test pinning that the rekeyed branch names the row it
  replaces.

## Why one union instead of two merges

Merging either one turns the other **`CONFLICTING`** on `docs/DESIGN_NOTES.md`:
the `merge=union` driver that makes appended entries coexist is a **local**
git configuration, and GitHub does not apply it. **A `CONFLICTING` PR runs zero
CI**, so the survivor would have to be rebased and would then pay a full
`integration` of its own. As a union we pay **one**.

It is also the more honest gate, not merely the cheaper one: both changes touch
the push path, and **textual non-overlap is not semantic independence**. Gating
them together tests what will actually be on `main`.

## Verification of the replay

Both PRs had the same merge-base (`35333266`), so each contributed its full
range. Checked two-sided against `origin/main`:

- `docs/DESIGN_NOTES.md`: **114 additions, 0 deletions** — exactly 48 (#1321) +
  66 (#1323). Neither entry lost a line to the union driver.
- `git diff origin/main...HEAD --numstat` contains the files of both PRs and
  **nothing else** (10 files: 8 server-side from #1321, 2 cic from #1323, plus
  the shared decision log).
- Entry markers appear **once each**: `<!-- entry #1321 -->`,
  `<!-- entry #1323 -->`, and main's own `<!-- entry #1322 -->` is intact at the
  line it already occupied.
- Boundary shape read on the file for both new entries: previous entry's last
  line, then marker / blank / `---` / blank / heading, with no blank ahead of
  the marker.

## Gates

- `scripts/design-notes-gate.sh` — green, "2 new entry heading(s), separator and
  marker present".
- `bun run check` (biome + tsc + e2e tsc) — green.
- Full cic unit suite — green, 5460 tests.

**Not run on this branch:** the Elixir side. I hold no compile lane, so
`scripts/check.sh` / `mix` were not executed against the union. #1328's server
gates were green on its own branch at this same base (6190 tests, 0 Dialyzer, 0
Sobelow, bats), and the replay changed no server file's content — but that is an
argument, not a measurement, and CI is what will settle it.

## Housekeeping

#1327 and #1328 stay open and are **not** closed by this PR: the replay changed
their shas, so GitHub cannot close them automatically, and they should be closed
by content once this merges. Deliberately no auto-closing keyword for the two
issues either.
