### PR TITLE
cic(#1331): offer the reconnect where the operator meets the parked state

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -27,6 +27,7 @@ import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { frameBudgetForTarget } from "./lib/frameBudget";
 import { frameBudgetBaseForNetwork } from "./lib/isupport";
+import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkBySlug } from "./lib/networks";
 import { routeClipboardPaste, routePastedInput } from "./lib/pasteRoute";
 import {
@@ -432,16 +433,41 @@ const ComposeBox: Component<Props> = (props) => {
     });
   };
 
-  const greyed = (): boolean => {
-    // Bucket F H4: only UserNetwork carries connection_state. Narrow on
-    // network.kind before reading the field; visitor networks are
-    // never greyed at the network level (visitors have no credential
-    // row to park / fail).
+  // Bucket F H4: only UserNetwork carries connection_state. Narrow on
+  // network.kind before reading the field; visitor networks are
+  // never greyed at the network level (visitors have no credential
+  // row to park / fail).
+  //
+  // #1331 — split out of `greyed()` because the two causes are no longer
+  // equivalent: a parked/failed NETWORK can be reconnected from here, a
+  // failed/kicked WINDOW under a live network cannot (there is nothing to
+  // unpark; the way back in is /join). The boolean below still collapses
+  // them for the visual, which is unchanged.
+  const networkGreyedState = (): string | null => {
     const net = networkBySlug(props.networkSlug);
-    if (net?.kind === "user" && NETWORK_GREYED_STATES.has(net.connection_state)) return true;
+    if (net?.kind !== "user") return null;
+    return NETWORK_GREYED_STATES.has(net.connection_state) ? net.connection_state : null;
+  };
+
+  const greyed = (): boolean => {
+    if (networkGreyedState() !== null) return true;
     const s = windowStateByChannel()[key()];
     return s !== undefined && NOT_JOINED_STATES.has(s);
   };
+
+  // #1331 — the way OUT, where the operator meets the state. `selection.ts`
+  // only redirects to Home on the park TRANSITION, so a cold load or a walk
+  // back into the window lands on a greyed compose whose only exit was
+  // knowing to go to the home pane. Same PATCH the HomePane chip and the
+  // `/connect` slash arm issue — no new verb, no new store: the slug is
+  // already a prop and the state already comes from the networks store.
+  // The verb + its pending latch + the friendly error mapping come from the
+  // shared unit; the SINK is this component's own #356 feedback seam
+  // (sticky, role=alert), so the reconnect failure lands on the one error
+  // line the compose box already has instead of a second one beside it.
+  const reconnector = createNetworkReconnect((message) =>
+    setFeedback(message === null ? null : { text: message, severity: "error" }),
+  );
 
   // #1108 — what this draft will do to the wire, from the budget the SERVER
   // published for this network (`frame_budget_base`; cic never computes the
@@ -907,7 +933,25 @@ const ComposeBox: Component<Props> = (props) => {
         )}
       </Show>
       <Show when={greyed()}>
-        <p class="compose-box-not-joined muted">(not joined)</p>
+        <p class="compose-box-not-joined muted">
+          (not joined)
+          {/* #1331 — the action rides the line that already states the
+              state, and only on the NETWORK cause. Same accessible name as
+              the HomePane chip (`Reconnect <slug>`): it is the same verb on
+              the same subject, and the two never render together (HomePane
+              renders no compose box). */}
+          <Show when={networkGreyedState()}>
+            <button
+              type="button"
+              class="compose-box-reconnect"
+              disabled={reconnector.pending()}
+              aria-label={`Reconnect ${props.networkSlug}`}
+              onClick={() => void reconnector.reconnect(props.networkSlug)}
+            >
+              {reconnector.pending() ? "Reconnecting…" : "Reconnect"}
+            </button>
+          </Show>
+        </p>
       </Show>
       {/* #356 — feedback seam. Severity drives BOTH the class (red error vs
           green notice) and the ARIA live role: role=alert (assertive) for

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -5,7 +5,6 @@ import {
   addNetwork,
   type ConnectionState,
   getFeaturedChannels,
-  patchNetwork,
   postJoin,
 } from "./lib/api";
 import { token } from "./lib/auth";
@@ -20,6 +19,7 @@ import {
   type SessionLifetimeCopy,
 } from "./lib/homeSessionCopy";
 import { identifiedForNetwork } from "./lib/identity";
+import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkIdBySlug, refetchNetworks, refetchUser, user } from "./lib/networks";
 import { flavorForSlug, registerableFlavor } from "./lib/registrationTemplates";
 import { openRegistrationWizard } from "./lib/registrationWizard";
@@ -421,33 +421,15 @@ const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
 };
 
 const DisconnectedRow: Component<{ row: HomeRow }> = (props) => {
+  // #1331 — the PATCH, the pending latch and the friendly error mapping moved
+  // to `lib/networkReconnect` when the greyed compose seam grew the same
+  // action; this row keeps its own error SINK (the `role="alert"` span below)
+  // and nothing else. Server emits connection_state_changed (REV-J M15 folded
+  // the prior home_network_state_changed arm into it), userTopic.ts patches
+  // homeData() in place, and this sub-component unmounts — no local success
+  // state to clean up.
   const [error, setError] = createSignal<string | null>(null);
-  const [pending, setPending] = createSignal(false);
-
-  const onReconnect = async () => {
-    const t = token();
-    if (!t) return;
-    setError(null);
-    setPending(true);
-    try {
-      await patchNetwork(t, props.row.slug, { connection_state: "connected" });
-      // Server emits connection_state_changed (REV-J M15 folded the
-      // prior home_network_state_changed arm into it); userTopic.ts
-      // patches homeData() in place. The row will re-render as
-      // connected and this sub-component will unmount — no local state
-      // cleanup needed.
-    } catch (err) {
-      // feedback_silent_retry_anti_pattern: errors MUST surface above
-      // the threshold. friendlyApiError maps known cap/admission codes
-      // to operator-facing copy; unknown errors collapse to the
-      // ApiError.message verbatim (status + code token).
-      const friendly =
-        err instanceof ApiError ? friendlyApiError(err) : "reconnect failed (unknown error)";
-      setError(friendly);
-    } finally {
-      setPending(false);
-    }
-  };
+  const reconnector = createNetworkReconnect(setError);
 
   return (
     <li
@@ -474,11 +456,11 @@ const DisconnectedRow: Component<{ row: HomeRow }> = (props) => {
           <button
             type="button"
             class="adm-btn home-pane-network-action home-pane-network-reconnect"
-            disabled={pending()}
+            disabled={reconnector.pending()}
             aria-label={`Reconnect ${props.row.slug}`}
-            onClick={() => void onReconnect()}
+            onClick={() => void reconnector.reconnect(props.row.slug)}
           >
-            {pending() ? "Reconnecting…" : "Reconnect"}
+            {reconnector.pending() ? "Reconnecting…" : "Reconnect"}
           </button>
         </div>
       </div>

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -77,6 +77,18 @@ vi.mock("../lib/uploadHost", async () => {
 let mockWindowState: Record<string, string> = {};
 let mockNetworkConnectionState: Record<string, string | undefined> = {};
 
+// #1331 — the seam's reconnect issues the SAME `PATCH /networks/:slug` the
+// HomePane chip and the `/connect` slash arm already issue. Only that one
+// export is replaced: everything else in `lib/api` stays real, because the
+// module is a transitive dependency of half the compose path and a blanket
+// factory would silently stub verbs these tests rely on.
+const mockPatchNetwork = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return { ...actual, patchNetwork: (...args: unknown[]) => mockPatchNetwork(...args) };
+});
+
 vi.mock("../lib/windowState", () => ({
   windowStateByChannel: () => mockWindowState,
 }));
@@ -102,6 +114,10 @@ vi.mock("../lib/networks", () => ({
 }));
 
 import ComposeBox from "../ComposeBox";
+// #1331 — the reconnect reads the REAL token store (the seam calls
+// `token()` exactly as every other authed verb does); the mock stops at the
+// network boundary.
+import { setToken } from "../lib/auth";
 // #1226 — the REAL away store, not a mock: it is the production feed for the
 // seam (userTopic's `away_confirmed` arm calls exactly this setter).
 import { setAwayState } from "../lib/awayStatus";
@@ -132,6 +148,7 @@ beforeEach(() => {
   setMockQueueFull(false);
   mockFramePreview = null;
   mockFrameBudgetBase = 393;
+  setToken(null);
 });
 
 describe("ComposeBox", () => {
@@ -1113,6 +1130,67 @@ describe("ComposeBox", () => {
       render(() => <ComposeBox networkSlug="freenode" channelName="vjt" />);
       const form = document.querySelector(".compose-box");
       expect(form?.classList.contains("compose-box-greyed")).toBe(true);
+    });
+  });
+
+  // #1331 — the way OUT of the state the seam above renders. The greyed
+  // compose is where the operator MEETS a parked network (selection.ts only
+  // redirects to Home on the transition, so a cold load or a walk back into
+  // the window lands here with no exit), and the reconnect chip lived only
+  // on HomePane. The action is gated on the NETWORK cause, not on `greyed()`:
+  // a kicked or failed WINDOW under a live network has nothing to reconnect.
+  describe("#1331 — inline reconnect in the greyed seam", () => {
+    it("offers Reconnect when the network is parked", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      mockWindowState = { "freenode #a": "joined" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByRole("button", { name: /reconnect freenode/i })).toBeInTheDocument();
+    });
+
+    it("offers Reconnect when the network is failed", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByRole("button", { name: /reconnect freenode/i })).toBeInTheDocument();
+    });
+
+    it("does NOT offer Reconnect for a KICKED window on a live network", () => {
+      mockNetworkConnectionState = { freenode: "connected" };
+      mockWindowState = { "freenode #a": "kicked" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const form = document.querySelector(".compose-box");
+      expect(form?.classList.contains("compose-box-greyed")).toBe(true);
+      expect(screen.queryByRole("button", { name: /reconnect/i })).toBeNull();
+    });
+
+    it("does NOT offer Reconnect when nothing is greyed", () => {
+      mockNetworkConnectionState = { freenode: "connected" };
+      mockWindowState = { "freenode #a": "joined" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.queryByRole("button", { name: /reconnect/i })).toBeNull();
+    });
+
+    it("clicking it issues the unpark PATCH for THIS network", async () => {
+      setToken("tok-1331");
+      mockNetworkConnectionState = { freenode: "parked" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      fireEvent.click(screen.getByRole("button", { name: /reconnect freenode/i }));
+      await waitFor(() =>
+        expect(mockPatchNetwork).toHaveBeenCalledWith("tok-1331", "freenode", {
+          connection_state: "connected",
+        }),
+      );
+    });
+
+    it("surfaces a rejected reconnect in the existing error seam", async () => {
+      setToken("tok-1331");
+      mockPatchNetwork.mockRejectedValueOnce(new Error("boom"));
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      fireEvent.click(screen.getByRole("button", { name: /reconnect freenode/i }));
+      await waitFor(() => expect(document.querySelector(".compose-box-error")).not.toBeNull());
     });
   });
 

--- a/cicchetto/src/lib/networkReconnect.ts
+++ b/cicchetto/src/lib/networkReconnect.ts
@@ -1,0 +1,62 @@
+import { type Accessor, createSignal } from "solid-js";
+import { ApiError, patchNetwork } from "./api";
+import { token } from "./auth";
+import { friendlyApiError } from "./friendlyApiError";
+
+// #1331 — the unpark verb, shared by every surface that offers it.
+//
+// The PATCH itself is one line, but the UX around it is not: an awaited
+// request with a pending latch (the button disables and relabels) and a
+// friendly-mapped failure the operator must read
+// (feedback_silent_retry_anti_pattern). That trio lived inside HomePane's
+// `DisconnectedRow`; #1331 puts a second reconnect in the greyed compose
+// seam, where the operator actually meets a parked network, and a second
+// hand-rolled copy would be the drift this repo keeps paying for.
+//
+// Deliberately NOT `lib/reconnect.ts`: despite the name, that is the #282
+// vhost bounce — it selects `connected` networks and does park-THEN-connect.
+// Pointing it at a parked network would be the wrong verb on the wrong set.
+//
+// NO confirmation modal, and that is a decision on record, not an omission:
+// #283 (2026-07-20) settled that Reconnect is the awaited-PATCH UX while
+// DISCONNECT is the one behind the #195 confirm modal — see the comment on
+// `HomePane`'s `onDisconnect`. Reconnect is also trivially reversible, which
+// is the property the modal exists to protect. Every caller must keep that
+// shape or the surfaces diverge again.
+//
+// The error SINK is the caller's, because each surface already owns an error
+// line and inventing a second one next to it is how a component ends up with
+// two contradictory alerts: HomePane has its `role="alert"` span, ComposeBox
+// has the #356 feedback seam. `null` means "clear it" and is emitted once at
+// the start of every attempt, so a previous failure never outlives the retry
+// that supersedes it.
+
+export type NetworkReconnect = {
+  pending: Accessor<boolean>;
+  reconnect: (networkSlug: string) => Promise<void>;
+};
+
+export function createNetworkReconnect(
+  onError: (message: string | null) => void,
+): NetworkReconnect {
+  const [pending, setPending] = createSignal(false);
+
+  const reconnect = async (networkSlug: string): Promise<void> => {
+    const t = token();
+    if (t === null) return;
+    onError(null);
+    setPending(true);
+    try {
+      await patchNetwork(t, networkSlug, { connection_state: "connected" });
+      // No success state to set: the server emits connection_state_changed,
+      // userTopic patches the networks store in place, and every surface
+      // reading that store re-renders itself out of the parked shape.
+    } catch (err) {
+      onError(err instanceof ApiError ? friendlyApiError(err) : "reconnect failed (unknown error)");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return { pending, reconnect };
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2023,6 +2023,38 @@ html.resize-dragging * {
   font-style: italic;
 }
 
+/* #1331 — the reconnect action on the seam that already states the network
+   is parked. Same fill/hover/disabled idiom as the HomePane chip
+   (.home-pane-network-reconnect) because it is the same verb on the same
+   subject; only the geometry is smaller, since it rides an inline muted
+   line rather than a card heading. `--tap-min` is 44px ABSOLUTE: rem here
+   would track the user's text-size setting and shrink the tap target below
+   the HIG floor at S/M. */
+.compose-box-reconnect {
+  margin-left: 0.5rem;
+  min-height: var(--tap-min);
+  padding: 0.15rem 0.6rem;
+  background: var(--accent);
+  color: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  font-weight: bold;
+  font-style: normal;
+  cursor: pointer;
+}
+
+.compose-box-reconnect:hover:not(:disabled) {
+  background: var(--bg);
+  color: var(--accent);
+}
+
+.compose-box-reconnect:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
 /* TopicBar */
 
 .topic-bar {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42566,3 +42566,79 @@ GET per resume seam for opted-in users (single-flighted by
 state that drifts, guarding a request smaller than the headers carrying it.
 The size is an estimate — the ~88-byte base64url key plus its JSON envelope —
 not a measurement; nobody has counted the bytes on the wire.
+<!-- entry #1331 -->
+
+---
+
+## 2026-08-14 — #1331: put the exit where the operator meets the dead end
+
+The greyed compose seam already stated that a network was parked. The only
+way *out* of it was the chip on `HomePane`, which the operator had to know to
+go and find. `lib/selection.ts:712-742` softens that and deliberately stops
+short: it redirects to Home on the park **transition** only, so that a parked
+window stays reachable for its history (`:700-702`). Three entries therefore
+still land on a greyed compose with no exit — a cold load with the network
+already parked, a walk back into the window, and another device parking it
+while this tab was closed. The first two are pinned as intentional by
+`src/__tests__/selection.test.ts:828` and `:853`; the fix is an exit at the
+dead end, not another redirect, so both stay green.
+
+**Three placements were on the table, and the tiebreak was cost, not taste.**
+An action on the sidebar row was ruled out. That left the action inline in
+the seam, or a single implementation on `HomePane` with the seam pointing at
+it. The rule was set *before* measuring: inline **if** it costs no serious
+prop-drilling — at most two hops and no new plumbing — otherwise point at
+HomePane and keep one home for the verb.
+
+**Measured: zero hops.** `ComposeBox`'s props are `{ networkSlug, channelName }`
+and nothing else (`ComposeBox.tsx:102-105`), and both call sites already pass
+the slug (`Shell.tsx:708`, `:989`); the state comes from `networkBySlug`, a
+module-scope store accessor rather than a prop; the verb needs `patchNetwork`
+and `token`, two plain imports. No new context, no new store, no `Shell.tsx`
+edit. Zero is below the threshold, so the seam gets the button.
+
+**The action is gated on the NETWORK cause, not on the collapsed `greyed()`
+boolean.** A failed or kicked *window* under a live network has nothing to
+unpark — the way back in is `/join` — so `networkGreyedState()` was split out
+of `greyed()` and the button hangs off that. The greyed visual and the
+`(not joined)` copy are unchanged.
+
+**A second surface for a verb is an extraction, not a copy.** The PATCH is
+one line, but the UX around it is not: awaited request, pending latch,
+friendly-mapped failure. That trio was a closure inside `HomePane`'s
+`DisconnectedRow`, and two hand-rolled implementations of the same recovery
+drift. `lib/networkReconnect.ts` now owns it and `DisconnectedRow` was moved
+onto it **in the same commit** — an extraction that leaves the original
+behind is just a copy with a preamble. The error *sink* stays with the caller,
+because each surface already owns an error line and a second one beside it
+would contradict the first: HomePane keeps its `role="alert"` span, the seam
+uses the #356 feedback line.
+
+**`lib/reconnect.ts` was left out on purpose, and the boundary is worth
+recording because the name argues against it.** Despite being called that, it
+is the #282 vhost bounce: it selects **connected** networks and does
+park-then-connect. On a parked network that is the wrong verb on the wrong
+set.
+
+**No confirmation modal — and this is a decision on record, not an
+omission.** The #195 confirm modal belongs to **Disconnect**; Reconnect is
+the awaited-PATCH UX by the ruling on #283 (2026-07-20), recorded in the
+comment on `HomePane`'s `onDisconnect` (`:299-307`: *"match the ×, not
+Reconnect's awaited-PATCH UX"*). Reconnect is also trivially reversible,
+which is the property that modal exists to protect. The comment alone is only
+an older opinion; what settles it is the consequence — five e2e specs press
+Reconnect with no confirm step and would hang on the click
+(`cp15-b6-parked-disconnect-reconnect.spec.ts:208`,
+`issue100-reconnecting-badge.spec.ts:123`,
+`issue248-lusers-no-auto-surface.spec.ts:106`,
+`issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts:113`,
+`issue511-failed-autojoin-dismiss-durable.spec.ts:133`). Changing the verb's
+UX is therefore a separate change that would touch the chip too and rewrite
+those five specs.
+
+**Not claimed:** the affordance is pinned at unit level only — no e2e was
+written or run, and nothing was checked in a real browser or on a mobile
+viewport. That those five specs scope their chip click to
+`.home-pane-network-row-parked`, and so cannot be made ambiguous by the
+seam's identically-named control, is read from their source rather than
+observed.


### PR DESCRIPTION
## The gap

The greyed compose seam already stated that a network was parked. The only way *out* of it was the chip on `HomePane`, which the operator had to know to go and find.

`lib/selection.ts:702-740` softens that but does not close it: it redirects to Home on the park **transition** only, and deliberately so (`:700-703`, *"so the operator can still navigate BACK to a parked window (to view history) without bouncing back to home"*). So three entries still land on a greyed compose with no exit — a cold load with the network already parked (`prev === undefined`, `:726`), a walk back into the window, and another device parking it while this tab was closed. The first two are **pinned as intentional** by `src/__tests__/selection.test.ts:828` and `:853`, and this change leaves both green.

## The number that decided the placement

The ruling was: inline **if** it costs no serious prop-drilling — threshold **≤2 hops and no new plumbing**, otherwise point the seam at HomePane instead.

**Measured: ZERO hops.**

- `ComposeBox` props are `{ networkSlug, channelName }` and nothing else (`ComposeBox.tsx:105-108`); both call sites (`Shell.tsx:708`, `:989`) already pass the slug.
- The state comes from `networkBySlug`, a **module-scope store accessor**, not a prop (`ComposeBox.tsx:440`).
- The verb needs `patchNetwork` + `token`, both plain module imports.

No new context, no new store, no new global, no `Shell.tsx` edit. Zero is below the threshold, so: inline.

## What changed

**The action is gated on the NETWORK cause, not on `greyed()`.** A failed or kicked *window* under a live network has nothing to unpark — its way back in is `/join`. That required splitting `networkGreyedState()` out of the collapsed boolean. The greyed *visual* is unchanged, and the `(not joined)` copy is untouched.

**`lib/networkReconnect.ts` is an extraction, not a second copy.** The PATCH is one line, but the UX around it is not — awaited request, pending latch, friendly-mapped failure — and that trio now has one home instead of two that drift apart. `HomePane`'s `DisconnectedRow` was moved onto it in the same commit.

Each caller keeps its own error **sink**, because both surfaces already own an error line and a second one beside it would contradict the first: HomePane keeps its `role="alert"` span, the seam uses the existing #356 feedback line (sticky, `role=alert`).

Deliberately **not** reused: `lib/reconnect.ts`, which despite its name is the #282 vhost bounce — it selects `connected` networks and does park-**then**-connect. Wrong verb on the wrong set.

**No confirmation modal**, matching the HomePane chip exactly. #283 (2026-07-20) settled that Reconnect is the awaited-PATCH UX while DISCONNECT is the one behind the #195 confirm modal — recorded in the comment on `HomePane`'s `onDisconnect` (`:299-307`: *"match the ×, not Reconnect's awaited-PATCH UX"*). Reconnect is also trivially reversible, which is the property that modal exists to protect. Adding one here would have been a new UX for the verb rather than a reuse of the chip's, and it would have broken the five specs below, none of which has a confirm step after the click.

## New witnesses, and proof they are not decoration

Six tests in `src/__tests__/ComposeBox.test.tsx`, under `#1331 — inline reconnect in the greyed seam`: offered on a parked network, offered on a failed one, **not** offered for a kicked window on a live network, **not** offered when nothing is greyed, the click issues the unpark PATCH for *this* slug, and a rejected reconnect surfaces in the existing error seam.

TDD: the four positives were read RED first, by name — `Unable to find an accessible element with the role "button" and name /reconnect freenode/i`.

The two **negative** tests would be decoration if nothing could kill them, so both were checked by mutation:

| mutant | result |
|---|---|
| gate the button on `greyed()` instead of `networkGreyedState()` | **1 failed / 114 passed** — only the kicked-window test, by name |
| hoist the button out of the greyed seam (render unconditionally) | **2 failed** — both negatives |

The first mutant kills exactly one assertion, and it is the one that encodes the network-vs-window distinction.

## Gates

`scripts/bun.sh run check` RC=0 (biome + `tsc` over `src` and `e2e`). `scripts/bun.sh run test`: **283 files / 5466 tests**, all green — the HomePane suite included, which is the one that would have caught the extraction changing its row's behaviour.

The five e2e specs that press the HomePane chip as their park→reconnect *fixture* (`cp15-b6-parked-disconnect-reconnect.spec.ts:181`, `issue100-reconnecting-badge.spec.ts:92`, `issue248-lusers-no-auto-surface.spec.ts:100`, `issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts:113`, `issue511-failed-autojoin-dismiss-durable.spec.ts:133`) all resolve it **scoped** to a `.home-pane-network-row-parked` locator, so the seam's identically-named control cannot make them ambiguous. The two never render together in any case — HomePane renders no compose box.

## What this does NOT claim

- **No e2e was written and none was run.** The new affordance is pinned at unit level only. The scoping argument above is read from the five specs' source, not observed in a browser.
- **Nothing was verified in a real browser at all** — no visual check, no mobile viewport, no tap-target measurement. The chip sizes its tap target with `--tap-min` (44px absolute, not rem) but that is a reading of the token, not a measured box.
- The `(not joined)` copy stays wrong for a parked network — the operator never failed to join anything. Flagged during the recon as a separate, smaller change; deliberately not bundled here.
- Bare `/connect` still errors (`slashCommands.ts:561-565`) while bare `/disconnect` defaults to the active network. That asymmetry is untouched.
- No measurement of how often the dead-end entries actually occur; the issue's report is the only evidence that they do.
