### PR TITLE
Union for 1.2.0: #1329 + #1324 + #1332, gated once

### DIFF
--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -191,6 +191,30 @@ async function installFlickerProbe(page: Page, windowMs: number): Promise<void> 
   }, windowMs);
 }
 
+// BARRIER — the sampler has recorded its BASELINE frame.
+//
+// `installFlickerProbe` schedules the first `requestAnimationFrame` and returns
+// immediately, so "the probe is installed" is NOT "the probe has sampled". Any
+// perturbation dispatched right after the install races that first callback,
+// and on CI the two quantities overlap almost exactly: delivery of a peer
+// PRIVMSG measured ~20ms twice in one trace, against a first-sample delay in
+// [0, ~23ms] (one frame period of phase jitter plus evaluate overhead). That
+// coin flip — not any assertion about the divider — is what greened the same
+// sha on a PR and reddened it on main; the 2500ms window was fully sampled on
+// both sides (150 and 152 frames), so it was never the tight edge.
+//
+// Awaiting a recorded frame before the perturbation is even DISPATCHED is a
+// strict happens-before, not a bigger guess: the row cannot render before the
+// PRIVMSG is sent, so the baseline frame necessarily carries the pre-append
+// height and `grew` cannot be starved of its lower sample.
+async function waitForProbeBaseline(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => ((window as unknown as { __i1089frames?: unknown[] }).__i1089frames?.length ?? 0) > 0,
+    undefined,
+    { timeout: 10_000 },
+  );
+}
+
 // On failure this dump is the whole story: one entry per CHANGE of the
 // (visibility, divider offset) pair, so a one-frame excursion shows as a
 // visible=…, marker=<off-screen px> entry between two on-divider entries.
@@ -267,13 +291,18 @@ test.describe("issue #1089 — switching into an unread window must not flicker"
     // the latch is armed. It appends BELOW the fold, so nothing above the
     // divider changes: the divider's on-screen offset must not move at all.
     //
-    // Connect + join BEFORE the probe: registration and JOIN take seconds, and
-    // a probe installed first would have expired by the time the line lands —
-    // the sampler would record a flat, untouched timeline and green vacuously.
+    // Connect + join BEFORE the probe so the sampled window holds the append
+    // and nothing else. This ordering used to be justified with "registration
+    // and JOIN take seconds" — that is false on CI: the red run's trace bounds
+    // connect+join at 7ms. The false premise is exactly what made the probe
+    // install look safely far from the `privmsg` and left the two adjacent with
+    // no barrier; `waitForProbeBaseline` is the ordering guarantee, the
+    // statement order is not.
     const peer = await IrcPeer.connect({ nick: `i1089-${Date.now().toString(36).slice(-6)}` });
     try {
       await peer.join(CHANNEL);
       await installFlickerProbe(page, SAMPLE_WINDOW_MS);
+      await waitForProbeBaseline(page);
       const body = `i1089 live append ${Date.now()}`;
       peer.privmsg(CHANNEL, body);
       await expect(scrollbackLines(page).filter({ hasText: body })).toHaveCount(1, {

--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -44,6 +44,29 @@
 // pane left at the tail would advance the cursor to the newest row, unread
 // would fall to zero, and the ceiling would never be approached.
 //
+// ── Why the peer joins during SETUP, and not as part of the gesture ──────
+//
+// A peer's JOIN is a scrollback row like any other. Server side, an
+// other-user JOIN emits `:persist :join` (`lib/grappa/session/event_router.ex`,
+// pinned by `test/grappa/session/event_router_test.exs:1727` — "JOIN-other
+// adds nick to state.members[channel] + emits :persist :join"). Client side
+// nothing filters it back out: `subscribe.ts`'s `routeMessage` appends every
+// message with no kind gate, and `capScrollbackRing`'s `unreadHeld` counts
+// rows by id with no kind gate either.
+//
+// So a JOIN issued AFTER the cursor is planted lands above it, and the
+// "one row" crossing is really TWO: the JOIN takes the protected region past
+// the ceiling and the bound bites once (banner at `unreadHeld`), then the
+// PRIVMSG bites it again — and `scrollback.ts`'s accumulation on the second
+// bite (`current.missed + unreadDropped`, deliberate: after the first bite the
+// store only ever holds one page, so a recount would report the bound forever
+// while the operator is thousands behind) reports `UNREAD_BOUND + 1`.
+//
+// That number is an artefact of the setup, not the behaviour under test. The
+// peer therefore joins BEFORE anything is measured, so its row is part of the
+// read history the cursor is planted into, and the gesture is the single
+// PRIVMSG this spec says it is.
+//
 // ── NOT covered here, deliberately ───────────────────────────────────────
 //
 // The far-behind banner's own behaviour (jump, dismiss, badge) belongs to
@@ -79,6 +102,7 @@ const UNREAD_BOUND = 200;
 // above the bound so the planted cursor has somewhere to sit.
 const SEED_COUNT = 420;
 const SEED_SENDER = "seed-bot";
+const PEER_NICK = "bound1229";
 
 // One short of the ceiling: the protected region is the cursor row plus the
 // rows after it, so `UNREAD_BOUND - 1` unread rows leave exactly `UNREAD_BOUND`
@@ -118,66 +142,83 @@ test.describe("#1229 — the unread retention bound", () => {
       { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: SEED_COUNT, seedSender: SEED_SENDER }] },
     );
 
-    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
-    expect(rows.length).toBeGreaterThan(UNREAD_BEFORE + 20);
-
-    const cursorRow = rows[rows.length - 1 - UNREAD_BEFORE];
-    const oldestUnread = rows[rows.length - UNREAD_BEFORE];
-    const readContextRow = rows[rows.length - 1 - UNREAD_BEFORE - 10];
-    if (!cursorRow || !oldestUnread || !readContextRow) {
-      throw new Error("#1229 spec: seeded rows missing an index");
-    }
-    // Precondition, guarded rather than assumed: exactly one short of the
-    // ceiling. One row above and the pane would already be far behind on load.
-    expect(rows.filter((r) => r.id > cursorRow.id).length).toBe(UNREAD_BEFORE);
-
-    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
-
-    await loginAs(page, vjt);
-    await selectChannel(page, NETWORK_SLUG, CHANNEL);
-
-    const bar = page.locator('[data-testid="far-behind-bar"]');
-    const marker = page.locator('[data-testid="unread-marker"]');
-    await expect(marker).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
-    await expect(bar).toHaveCount(0);
-
-    // Scroll up into the read context. Not to the very top: that is the
-    // `loadMore` trigger, and a prepend would move `scrollTop` for reasons
-    // that have nothing to do with the bound.
-    await page.evaluate(() => {
-      const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-      if (el === null) throw new Error("#1229 spec: scrollback container missing");
-      el.scrollTop = Math.floor(el.scrollHeight * 0.25);
-    });
-    const before = await scrollGeometry(page);
-    expect(before.scrollTop).toBeGreaterThan(0);
-    expect(before.scrollHeight - before.scrollTop - before.clientHeight).toBeGreaterThan(
-      SCROLL_TOLERANCE_PX,
-    );
-
-    // The settle writer runs on a debounce; give it its window and then prove
-    // it did NOT move the cursor. Forward-only refusal is what holds the
-    // precondition, so it is asserted, not assumed.
-    await expect
-      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), {
-        timeout: OUTCOME_TIMEOUT_MS,
-      })
-      .toBe(cursorRow.id);
-
-    const oldestUnreadLine = page.locator(
-      `.scrollback-line:has-text(${JSON.stringify(oldestUnread.body)})`,
-    );
-    const readContextLine = page.locator(
-      `.scrollback-line:has-text(${JSON.stringify(readContextRow.body)})`,
-    );
-    await expect(oldestUnreadLine).toHaveCount(1);
-    await expect(readContextLine).toHaveCount(1);
-
-    // ── The gesture: one live row, which makes the protected region one past
-    // the ceiling.
-    const peer = await IrcPeer.connect({ nick: "bound1229" });
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
     try {
       await peer.join(CHANNEL);
+      // `join()` resolves on the ircd's echo to the PEER, which says nothing
+      // about grappa having persisted the row it produces on OUR session. The
+      // cursor is planted by id, so wait for that row to exist before reading
+      // the ids — otherwise it lands above the cursor and is unread after all,
+      // which is the whole failure this ordering exists to prevent.
+      await expect
+        .poll(
+          async () => {
+            const seen = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+            return seen.some((r) => r.kind === "join" && r.sender === PEER_NICK);
+          },
+          { timeout: OUTCOME_TIMEOUT_MS },
+        )
+        .toBe(true);
+
+      const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+      expect(rows.length).toBeGreaterThan(UNREAD_BEFORE + 20);
+
+      const cursorRow = rows[rows.length - 1 - UNREAD_BEFORE];
+      const oldestUnread = rows[rows.length - UNREAD_BEFORE];
+      const readContextRow = rows[rows.length - 1 - UNREAD_BEFORE - 10];
+      if (!cursorRow || !oldestUnread || !readContextRow) {
+        throw new Error("#1229 spec: seeded rows missing an index");
+      }
+      // Precondition, guarded rather than assumed: exactly one short of the
+      // ceiling. One row above and the pane would already be far behind on
+      // load. This is also what proves the peer's JOIN landed BELOW the
+      // cursor — if it had not, this count would be one too high.
+      expect(rows.filter((r) => r.id > cursorRow.id).length).toBe(UNREAD_BEFORE);
+
+      await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+      await loginAs(page, vjt);
+      await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+      const bar = page.locator('[data-testid="far-behind-bar"]');
+      const marker = page.locator('[data-testid="unread-marker"]');
+      await expect(marker).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
+      await expect(bar).toHaveCount(0);
+
+      // Scroll up into the read context. Not to the very top: that is the
+      // `loadMore` trigger, and a prepend would move `scrollTop` for reasons
+      // that have nothing to do with the bound.
+      await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+        if (el === null) throw new Error("#1229 spec: scrollback container missing");
+        el.scrollTop = Math.floor(el.scrollHeight * 0.25);
+      });
+      const before = await scrollGeometry(page);
+      expect(before.scrollTop).toBeGreaterThan(0);
+      expect(before.scrollHeight - before.scrollTop - before.clientHeight).toBeGreaterThan(
+        SCROLL_TOLERANCE_PX,
+      );
+
+      // The settle writer runs on a debounce; give it its window and then
+      // prove it did NOT move the cursor. Forward-only refusal is what holds
+      // the precondition, so it is asserted, not assumed.
+      await expect
+        .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), {
+          timeout: OUTCOME_TIMEOUT_MS,
+        })
+        .toBe(cursorRow.id);
+
+      const oldestUnreadLine = page.locator(
+        `.scrollback-line:has-text(${JSON.stringify(oldestUnread.body)})`,
+      );
+      const readContextLine = page.locator(
+        `.scrollback-line:has-text(${JSON.stringify(readContextRow.body)})`,
+      );
+      await expect(oldestUnreadLine).toHaveCount(1);
+      await expect(readContextLine).toHaveCount(1);
+
+      // ── The gesture: one live row, which makes the protected region one
+      // past the ceiling.
       peer.privmsg(CHANNEL, "the row that crosses the ceiling");
 
       // (2) the state transition, seen from outside

--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -1,0 +1,202 @@
+// #1229 — the unread exemption has a ceiling now, and crossing it is visible.
+//
+// S20's ring cap never evicts a row at/after the read cursor. That exemption
+// had no ceiling, so a channel the operator does not read holds ALL of its
+// unread rows and the cap does nothing. Since the pane renders every retained
+// row (measured on origin/main: 1084 retained rows produce 1084
+// `.scrollback-line` nodes, ratio 1.0000, no windowing anywhere in the render
+// path), retention and rendered DOM are the same curve — ~19-26 KB of renderer
+// memory per row, ~26 MB for the reporter's window, against a ceiling iOS
+// applies per web process.
+//
+// The bound is one page of unread (`UNREAD_RETENTION_CAP = PAGE_LIMIT`), and
+// past it the window joins the far-behind state the client already has for
+// exactly this shape: divider suppressed, "N unread — jump back" banner,
+// `jumpToUnread` rebuilding the region from the server.
+//
+// ── What this spec pins, and why each assertion is here ──────────────────
+//
+// The gesture is ONE live PRIVMSG, not a flood. The cursor is planted so the
+// window sits at one page of unread MINUS one, so a single arriving row is the
+// whole crossing — a burst would prove the same thing while also inviting the
+// ircd's flood kill into the spec.
+//
+//   1. Before the gesture: no bar, and the in-pane divider is there. Without
+//      this the outcome could be a bar that was already up for another reason
+//      (a cold far-behind resume, #693) and the spec would test nothing.
+//   2. After it: the bar is up with the honest total, and the divider is gone.
+//      That is the state transition, seen from outside.
+//   3. The OLDEST unread row is gone from the DOM, and the rows the operator
+//      is looking at are NOT. This is the one assertion that distinguishes the
+//      implementation that shipped from the simpler one that did not: dropping
+//      "everything but the newest page" would have satisfied (2) while
+//      deleting the screen out from under a reader scrolled up in history.
+//      The absence assertion is only meaningful because the list is not
+//      virtualised — every retained row is in the DOM whatever the scroll
+//      position, which is the same measurement that motivated the fix.
+//   4. `scrollTop` is preserved across the bite, within the tolerance the
+//      sibling scroll specs use. Rows leaving from BELOW the fold must not
+//      move the viewport.
+//
+// Scrolling up is also what keeps the precondition alive: `setCursorIfAdvances`
+// is forward-only, so with the pane scrolled into the read context the settle
+// writer can only propose an id BELOW the planted cursor, and is refused. A
+// pane left at the tail would advance the cursor to the newest row, unread
+// would fall to zero, and the ceiling would never be approached.
+//
+// ── NOT covered here, deliberately ───────────────────────────────────────
+//
+// The far-behind banner's own behaviour (jump, dismiss, badge) belongs to
+// #693/#888/#1019 and is pinned there; this spec asserts only that the bound
+// DELIVERS the window into that state. The memory figures above are not
+// asserted by any e2e — they were measured with a browser and a heap probe,
+// and a spec that re-measured them would be pinning the host, not the product.
+//
+// This spec does NOT claim anything about the half-height frame #1229 was
+// filed for: that reproduces with the admin pane focused and zero scrollback
+// rows mounted, so no scrollback bound can explain it.
+
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  getReadCursor,
+  resetSubject,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// `UNREAD_RETENTION_CAP` in `lib/scrollback.ts` — one page, the same number
+// `isFarBehind` already draws the line at. Mirrored rather than imported: the
+// e2e bundle is the built app, and a spec that imported the source constant
+// would keep passing if the shipped bundle disagreed with it.
+const UNREAD_BOUND = 200;
+
+// Enough history that the pane has a read context to be scrolled up INTO,
+// above the bound so the planted cursor has somewhere to sit.
+const SEED_COUNT = 420;
+const SEED_SENDER = "seed-bot";
+
+// One short of the ceiling: the protected region is the cursor row plus the
+// rows after it, so `UNREAD_BOUND - 1` unread rows leave exactly `UNREAD_BOUND`
+// protected — the last state before the bound bites.
+const UNREAD_BEFORE = UNREAD_BOUND - 1;
+
+const OUTCOME_TIMEOUT_MS = 10_000;
+// The tolerance `issue196-preview-scroll-preserve` uses for "the viewport did
+// not move": sub-pixel geometry, not a budget for a jump.
+const SCROLL_TOLERANCE_PX = 3;
+
+const scrollGeometry = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (el === null) throw new Error("#1229 spec: scrollback container missing");
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
+  });
+
+test.describe("#1229 — the unread retention bound", () => {
+  test.use({ viewport: { width: 800, height: 400 } });
+
+  test("crossing one page of unread prunes from the divider and raises the far-behind bar", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = specUser();
+    const admin = getSeededAdmin();
+
+    await resetSubject(
+      admin.token,
+      vjt.name,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThan(UNREAD_BEFORE + 20);
+
+    const cursorRow = rows[rows.length - 1 - UNREAD_BEFORE];
+    const oldestUnread = rows[rows.length - UNREAD_BEFORE];
+    const readContextRow = rows[rows.length - 1 - UNREAD_BEFORE - 10];
+    if (!cursorRow || !oldestUnread || !readContextRow) {
+      throw new Error("#1229 spec: seeded rows missing an index");
+    }
+    // Precondition, guarded rather than assumed: exactly one short of the
+    // ceiling. One row above and the pane would already be far behind on load.
+    expect(rows.filter((r) => r.id > cursorRow.id).length).toBe(UNREAD_BEFORE);
+
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    const bar = page.locator('[data-testid="far-behind-bar"]');
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
+    await expect(bar).toHaveCount(0);
+
+    // Scroll up into the read context. Not to the very top: that is the
+    // `loadMore` trigger, and a prepend would move `scrollTop` for reasons
+    // that have nothing to do with the bound.
+    await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+      if (el === null) throw new Error("#1229 spec: scrollback container missing");
+      el.scrollTop = Math.floor(el.scrollHeight * 0.25);
+    });
+    const before = await scrollGeometry(page);
+    expect(before.scrollTop).toBeGreaterThan(0);
+    expect(before.scrollHeight - before.scrollTop - before.clientHeight).toBeGreaterThan(
+      SCROLL_TOLERANCE_PX,
+    );
+
+    // The settle writer runs on a debounce; give it its window and then prove
+    // it did NOT move the cursor. Forward-only refusal is what holds the
+    // precondition, so it is asserted, not assumed.
+    await expect
+      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), {
+        timeout: OUTCOME_TIMEOUT_MS,
+      })
+      .toBe(cursorRow.id);
+
+    const oldestUnreadLine = page.locator(
+      `.scrollback-line:has-text(${JSON.stringify(oldestUnread.body)})`,
+    );
+    const readContextLine = page.locator(
+      `.scrollback-line:has-text(${JSON.stringify(readContextRow.body)})`,
+    );
+    await expect(oldestUnreadLine).toHaveCount(1);
+    await expect(readContextLine).toHaveCount(1);
+
+    // ── The gesture: one live row, which makes the protected region one past
+    // the ceiling.
+    const peer = await IrcPeer.connect({ nick: "bound1229" });
+    try {
+      await peer.join(CHANNEL);
+      peer.privmsg(CHANNEL, "the row that crosses the ceiling");
+
+      // (2) the state transition, seen from outside
+      await expect(bar).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+      await expect(bar).toContainText(String(UNREAD_BOUND));
+      await expect(marker).toHaveCount(0);
+
+      // (3) pruned from the divider, not from the screen
+      await expect(oldestUnreadLine).toHaveCount(0);
+      await expect(readContextLine).toHaveCount(1);
+      await expect(
+        page.locator('.scrollback-line:has-text("the row that crosses the ceiling")'),
+      ).toHaveCount(1);
+
+      // (4) the viewport did not move
+      const after = await scrollGeometry(page);
+      expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(SCROLL_TOLERANCE_PX);
+    } finally {
+      await peer.part(CHANNEL, "done");
+    }
+  });
+});

--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -17,9 +17,10 @@
 // ── What this spec pins, and why each assertion is here ──────────────────
 //
 // The gesture is ONE live PRIVMSG, not a flood. The cursor is planted so the
-// window sits at one page of unread MINUS one, so a single arriving row is the
-// whole crossing — a burst would prove the same thing while also inviting the
-// ircd's flood kill into the spec.
+// window sits at exactly one page of unread — the widest window every path
+// still calls near — so a single arriving row is the whole crossing; a burst
+// would prove the same thing while also inviting the ircd's flood kill into
+// the spec.
 //
 //   1. Before the gesture: no bar, and the in-pane divider is there. Without
 //      this the outcome could be a bar that was already up for another reason
@@ -104,10 +105,12 @@ const SEED_COUNT = 420;
 const SEED_SENDER = "seed-bot";
 const PEER_NICK = "bound1229";
 
-// One short of the ceiling: the protected region is the cursor row plus the
-// rows after it, so `UNREAD_BOUND - 1` unread rows leave exactly `UNREAD_BOUND`
-// protected — the last state before the bound bites.
-const UNREAD_BEFORE = UNREAD_BOUND - 1;
+// AT the ceiling, which is the last state before the bound bites: the bound is
+// on the UNREAD region alone (the boundary row the divider anchors on is never
+// this bound's to drop), and it is crossed at `> UNREAD_BOUND` — the same
+// comparison `isFarBehind` makes, so a window holding exactly one page is still
+// classified near by every path. One arriving row is the whole crossing.
+const UNREAD_BEFORE = UNREAD_BOUND;
 
 const OUTCOME_TIMEOUT_MS = 10_000;
 // The tolerance `issue196-preview-scroll-preserve` uses for "the viewport did
@@ -169,10 +172,10 @@ test.describe("#1229 — the unread retention bound", () => {
       if (!cursorRow || !oldestUnread || !readContextRow) {
         throw new Error("#1229 spec: seeded rows missing an index");
       }
-      // Precondition, guarded rather than assumed: exactly one short of the
-      // ceiling. One row above and the pane would already be far behind on
-      // load. This is also what proves the peer's JOIN landed BELOW the
-      // cursor — if it had not, this count would be one too high.
+      // Precondition, guarded rather than assumed: exactly AT the ceiling. One
+      // row above and the pane would already be far behind on load. This is
+      // also what proves the peer's JOIN landed BELOW the cursor — if it had
+      // not, this count would be one too high.
       expect(rows.filter((r) => r.id > cursorRow.id).length).toBe(UNREAD_BEFORE);
 
       await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
@@ -223,7 +226,9 @@ test.describe("#1229 — the unread retention bound", () => {
 
       // (2) the state transition, seen from outside
       await expect(bar).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
-      await expect(bar).toContainText(String(UNREAD_BOUND));
+      // The count is how far behind the operator actually is, taken BEFORE the
+      // bite and so including the row that crossed — not the page still held.
+      await expect(bar).toContainText(String(UNREAD_BOUND + 1));
       await expect(marker).toHaveCount(0);
 
       // (3) pruned from the divider, not from the screen

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -27,6 +27,7 @@ import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { frameBudgetForTarget } from "./lib/frameBudget";
 import { frameBudgetBaseForNetwork } from "./lib/isupport";
+import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkBySlug } from "./lib/networks";
 import { routeClipboardPaste, routePastedInput } from "./lib/pasteRoute";
 import {
@@ -432,16 +433,41 @@ const ComposeBox: Component<Props> = (props) => {
     });
   };
 
-  const greyed = (): boolean => {
-    // Bucket F H4: only UserNetwork carries connection_state. Narrow on
-    // network.kind before reading the field; visitor networks are
-    // never greyed at the network level (visitors have no credential
-    // row to park / fail).
+  // Bucket F H4: only UserNetwork carries connection_state. Narrow on
+  // network.kind before reading the field; visitor networks are
+  // never greyed at the network level (visitors have no credential
+  // row to park / fail).
+  //
+  // #1331 — split out of `greyed()` because the two causes are no longer
+  // equivalent: a parked/failed NETWORK can be reconnected from here, a
+  // failed/kicked WINDOW under a live network cannot (there is nothing to
+  // unpark; the way back in is /join). The boolean below still collapses
+  // them for the visual, which is unchanged.
+  const networkGreyedState = (): string | null => {
     const net = networkBySlug(props.networkSlug);
-    if (net?.kind === "user" && NETWORK_GREYED_STATES.has(net.connection_state)) return true;
+    if (net?.kind !== "user") return null;
+    return NETWORK_GREYED_STATES.has(net.connection_state) ? net.connection_state : null;
+  };
+
+  const greyed = (): boolean => {
+    if (networkGreyedState() !== null) return true;
     const s = windowStateByChannel()[key()];
     return s !== undefined && NOT_JOINED_STATES.has(s);
   };
+
+  // #1331 — the way OUT, where the operator meets the state. `selection.ts`
+  // only redirects to Home on the park TRANSITION, so a cold load or a walk
+  // back into the window lands on a greyed compose whose only exit was
+  // knowing to go to the home pane. Same PATCH the HomePane chip and the
+  // `/connect` slash arm issue — no new verb, no new store: the slug is
+  // already a prop and the state already comes from the networks store.
+  // The verb + its pending latch + the friendly error mapping come from the
+  // shared unit; the SINK is this component's own #356 feedback seam
+  // (sticky, role=alert), so the reconnect failure lands on the one error
+  // line the compose box already has instead of a second one beside it.
+  const reconnector = createNetworkReconnect((message) =>
+    setFeedback(message === null ? null : { text: message, severity: "error" }),
+  );
 
   // #1108 — what this draft will do to the wire, from the budget the SERVER
   // published for this network (`frame_budget_base`; cic never computes the
@@ -907,7 +933,25 @@ const ComposeBox: Component<Props> = (props) => {
         )}
       </Show>
       <Show when={greyed()}>
-        <p class="compose-box-not-joined muted">(not joined)</p>
+        <p class="compose-box-not-joined muted">
+          (not joined)
+          {/* #1331 — the action rides the line that already states the
+              state, and only on the NETWORK cause. Same accessible name as
+              the HomePane chip (`Reconnect <slug>`): it is the same verb on
+              the same subject, and the two never render together (HomePane
+              renders no compose box). */}
+          <Show when={networkGreyedState()}>
+            <button
+              type="button"
+              class="compose-box-reconnect"
+              disabled={reconnector.pending()}
+              aria-label={`Reconnect ${props.networkSlug}`}
+              onClick={() => void reconnector.reconnect(props.networkSlug)}
+            >
+              {reconnector.pending() ? "Reconnecting…" : "Reconnect"}
+            </button>
+          </Show>
+        </p>
       </Show>
       {/* #356 — feedback seam. Severity drives BOTH the class (red error vs
           green notice) and the ARIA live role: role=alert (assertive) for

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -5,7 +5,6 @@ import {
   addNetwork,
   type ConnectionState,
   getFeaturedChannels,
-  patchNetwork,
   postJoin,
 } from "./lib/api";
 import { token } from "./lib/auth";
@@ -20,6 +19,7 @@ import {
   type SessionLifetimeCopy,
 } from "./lib/homeSessionCopy";
 import { identifiedForNetwork } from "./lib/identity";
+import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkIdBySlug, refetchNetworks, refetchUser, user } from "./lib/networks";
 import { flavorForSlug, registerableFlavor } from "./lib/registrationTemplates";
 import { openRegistrationWizard } from "./lib/registrationWizard";
@@ -421,33 +421,15 @@ const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
 };
 
 const DisconnectedRow: Component<{ row: HomeRow }> = (props) => {
+  // #1331 — the PATCH, the pending latch and the friendly error mapping moved
+  // to `lib/networkReconnect` when the greyed compose seam grew the same
+  // action; this row keeps its own error SINK (the `role="alert"` span below)
+  // and nothing else. Server emits connection_state_changed (REV-J M15 folded
+  // the prior home_network_state_changed arm into it), userTopic.ts patches
+  // homeData() in place, and this sub-component unmounts — no local success
+  // state to clean up.
   const [error, setError] = createSignal<string | null>(null);
-  const [pending, setPending] = createSignal(false);
-
-  const onReconnect = async () => {
-    const t = token();
-    if (!t) return;
-    setError(null);
-    setPending(true);
-    try {
-      await patchNetwork(t, props.row.slug, { connection_state: "connected" });
-      // Server emits connection_state_changed (REV-J M15 folded the
-      // prior home_network_state_changed arm into it); userTopic.ts
-      // patches homeData() in place. The row will re-render as
-      // connected and this sub-component will unmount — no local state
-      // cleanup needed.
-    } catch (err) {
-      // feedback_silent_retry_anti_pattern: errors MUST surface above
-      // the threshold. friendlyApiError maps known cap/admission codes
-      // to operator-facing copy; unknown errors collapse to the
-      // ApiError.message verbatim (status + code token).
-      const friendly =
-        err instanceof ApiError ? friendlyApiError(err) : "reconnect failed (unknown error)";
-      setError(friendly);
-    } finally {
-      setPending(false);
-    }
-  };
+  const reconnector = createNetworkReconnect(setError);
 
   return (
     <li
@@ -474,11 +456,11 @@ const DisconnectedRow: Component<{ row: HomeRow }> = (props) => {
           <button
             type="button"
             class="adm-btn home-pane-network-action home-pane-network-reconnect"
-            disabled={pending()}
+            disabled={reconnector.pending()}
             aria-label={`Reconnect ${props.row.slug}`}
-            onClick={() => void onReconnect()}
+            onClick={() => void reconnector.reconnect(props.row.slug)}
           >
-            {pending() ? "Reconnecting…" : "Reconnect"}
+            {reconnector.pending() ? "Reconnecting…" : "Reconnect"}
           </button>
         </div>
       </div>

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -3022,22 +3022,15 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (isOverlayFrozen()) {
       intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
     }
-    // #1229 — the `farBehindByChannel` conjunct is NOT redundant with the DOM
-    // probe beside it. This gate runs at the commit frame; the write it admits
-    // lands two frames later (`dispatchScrollWrite`'s deferred leg). A rows
-    // change that arms far-behind sets that signal SYNCHRONOUSLY with the rows,
-    // while the divider it suppresses (`injectMarker`, the same conjunct) is
-    // still in the DOM here — so the probe says yes, and by the time
-    // "marker-or-tail" resolves there is no marker and it falls to the TAIL,
-    // yanking a reader parked in their history and re-arming follow-mode.
-    // Entering far-behind IS the scroll contract — stay where you are, the
-    // jump-back affordance carries the count — so the activation is DENIED
-    // rather than re-aimed: there is no divider left to activate on.
-    if (
-      markerActivationPending() &&
-      farBehindByChannel()[k] === undefined &&
-      listRef.querySelector('[data-testid="unread-marker"]')
-    ) {
+    // #1229 — this DOM probe is what keeps a suppressed divider from being
+    // activated: crossing the unread ceiling drops the divider (`injectMarker`),
+    // and the deferred leg of a marker-activation would then find no node and
+    // fall to the TAIL, yanking a reader parked in their history. The probe only
+    // answers correctly because the store publishes the pruned rows and the
+    // far-behind flag in ONE flush, so the divider is already gone from the DOM
+    // by the time this gate runs. Split into two writes it said yes to a divider
+    // that was about to vanish — see `appendPageToScrollback`'s batch.
+    if (markerActivationPending() && listRef.querySelector('[data-testid="unread-marker"]')) {
       intents.push({ kind: "marker-activation", key: k, lifetime: "sticky" });
     }
     if (followMode()) {

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -3022,7 +3022,22 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (isOverlayFrozen()) {
       intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
     }
-    if (markerActivationPending() && listRef.querySelector('[data-testid="unread-marker"]')) {
+    // #1229 — the `farBehindByChannel` conjunct is NOT redundant with the DOM
+    // probe beside it. This gate runs at the commit frame; the write it admits
+    // lands two frames later (`dispatchScrollWrite`'s deferred leg). A rows
+    // change that arms far-behind sets that signal SYNCHRONOUSLY with the rows,
+    // while the divider it suppresses (`injectMarker`, the same conjunct) is
+    // still in the DOM here — so the probe says yes, and by the time
+    // "marker-or-tail" resolves there is no marker and it falls to the TAIL,
+    // yanking a reader parked in their history and re-arming follow-mode.
+    // Entering far-behind IS the scroll contract — stay where you are, the
+    // jump-back affordance carries the count — so the activation is DENIED
+    // rather than re-aimed: there is no divider left to activate on.
+    if (
+      markerActivationPending() &&
+      farBehindByChannel()[k] === undefined &&
+      listRef.querySelector('[data-testid="unread-marker"]')
+    ) {
       intents.push({ kind: "marker-activation", key: k, lifetime: "sticky" });
     }
     if (followMode()) {

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -77,6 +77,18 @@ vi.mock("../lib/uploadHost", async () => {
 let mockWindowState: Record<string, string> = {};
 let mockNetworkConnectionState: Record<string, string | undefined> = {};
 
+// #1331 — the seam's reconnect issues the SAME `PATCH /networks/:slug` the
+// HomePane chip and the `/connect` slash arm already issue. Only that one
+// export is replaced: everything else in `lib/api` stays real, because the
+// module is a transitive dependency of half the compose path and a blanket
+// factory would silently stub verbs these tests rely on.
+const mockPatchNetwork = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return { ...actual, patchNetwork: (...args: unknown[]) => mockPatchNetwork(...args) };
+});
+
 vi.mock("../lib/windowState", () => ({
   windowStateByChannel: () => mockWindowState,
 }));
@@ -102,6 +114,10 @@ vi.mock("../lib/networks", () => ({
 }));
 
 import ComposeBox from "../ComposeBox";
+// #1331 — the reconnect reads the REAL token store (the seam calls
+// `token()` exactly as every other authed verb does); the mock stops at the
+// network boundary.
+import { setToken } from "../lib/auth";
 // #1226 — the REAL away store, not a mock: it is the production feed for the
 // seam (userTopic's `away_confirmed` arm calls exactly this setter).
 import { setAwayState } from "../lib/awayStatus";
@@ -132,6 +148,7 @@ beforeEach(() => {
   setMockQueueFull(false);
   mockFramePreview = null;
   mockFrameBudgetBase = 393;
+  setToken(null);
 });
 
 describe("ComposeBox", () => {
@@ -1113,6 +1130,67 @@ describe("ComposeBox", () => {
       render(() => <ComposeBox networkSlug="freenode" channelName="vjt" />);
       const form = document.querySelector(".compose-box");
       expect(form?.classList.contains("compose-box-greyed")).toBe(true);
+    });
+  });
+
+  // #1331 — the way OUT of the state the seam above renders. The greyed
+  // compose is where the operator MEETS a parked network (selection.ts only
+  // redirects to Home on the transition, so a cold load or a walk back into
+  // the window lands here with no exit), and the reconnect chip lived only
+  // on HomePane. The action is gated on the NETWORK cause, not on `greyed()`:
+  // a kicked or failed WINDOW under a live network has nothing to reconnect.
+  describe("#1331 — inline reconnect in the greyed seam", () => {
+    it("offers Reconnect when the network is parked", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      mockWindowState = { "freenode #a": "joined" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByRole("button", { name: /reconnect freenode/i })).toBeInTheDocument();
+    });
+
+    it("offers Reconnect when the network is failed", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.getByRole("button", { name: /reconnect freenode/i })).toBeInTheDocument();
+    });
+
+    it("does NOT offer Reconnect for a KICKED window on a live network", () => {
+      mockNetworkConnectionState = { freenode: "connected" };
+      mockWindowState = { "freenode #a": "kicked" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const form = document.querySelector(".compose-box");
+      expect(form?.classList.contains("compose-box-greyed")).toBe(true);
+      expect(screen.queryByRole("button", { name: /reconnect/i })).toBeNull();
+    });
+
+    it("does NOT offer Reconnect when nothing is greyed", () => {
+      mockNetworkConnectionState = { freenode: "connected" };
+      mockWindowState = { "freenode #a": "joined" };
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      expect(screen.queryByRole("button", { name: /reconnect/i })).toBeNull();
+    });
+
+    it("clicking it issues the unpark PATCH for THIS network", async () => {
+      setToken("tok-1331");
+      mockNetworkConnectionState = { freenode: "parked" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      fireEvent.click(screen.getByRole("button", { name: /reconnect freenode/i }));
+      await waitFor(() =>
+        expect(mockPatchNetwork).toHaveBeenCalledWith("tok-1331", "freenode", {
+          connection_state: "connected",
+        }),
+      );
+    });
+
+    it("surfaces a rejected reconnect in the existing error seam", async () => {
+      setToken("tok-1331");
+      mockPatchNetwork.mockRejectedValueOnce(new Error("boom"));
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockWindowState = {};
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      fireEvent.click(screen.getByRole("button", { name: /reconnect freenode/i }));
+      await waitFor(() => expect(document.querySelector(".compose-box-error")).not.toBeNull());
     });
   });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, within } from "@solidjs/testing-library";
-import { createSignal } from "solid-js";
+import { batch, createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScrollbackMessage, WhoisBundle } from "../lib/api";
 import { activeAudio, closeAudio } from "../lib/audioPlayer";
@@ -1835,6 +1835,64 @@ describe("ScrollbackPane", () => {
       await flushRaf();
 
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "start" });
+    });
+
+    // #1229 — the content-change gate and the deferred write read the divider
+    // TWO FRAMES apart. When ONE rows change both admits the marker-activation
+    // intent and arms far-behind — which is exactly what crossing the unread
+    // ceiling does — the divider is suppressed (`injectMarker`, the
+    // `farBehindByChannel` conjunct) before the deferred leg runs, so
+    // "marker-or-tail" finds no node and falls to the TAIL, yanking a reader who
+    // was parked in their history and re-arming follow-mode. Measured in CI on
+    // this spec's e2e twin: scrollTop 1324 → 1078 (the sync leg, divider still
+    // mounted) → 4954 (the deferred leg, tail), while only one row of 23px had
+    // left the list. Entering far-behind promises the reader "you stay where you
+    // are, here is jump-back"; the pane must not contradict the affordance it
+    // just rendered, so the intent is denied rather than re-aimed.
+    it("a rows change that arms far-behind fires NO activation scroll (#1229)", async () => {
+      seedReadCursor("freenode", "#grappa", 1);
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      await flushRaf();
+      // Pre-state, asserted rather than assumed: the divider IS mounted (so the
+      // gate has a node to admit the intent on) and the latch is still armed —
+      // nothing here is operator input or an own send.
+      expect(screen.queryByTestId("unread-marker")).not.toBeNull();
+
+      // The reader scrolls UP into their history: followMode goes false, so a
+      // tail-follow intent cannot be what moves the pane below.
+      Object.defineProperty(list, "scrollHeight", { value: 5000, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 400, writable: true, configurable: true });
+      list.dispatchEvent(new Event("scroll"));
+      list.scrollTop = 100;
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull());
+      await flushRaf();
+      scrollIntoViewSpy.mockClear();
+
+      // Crossing the ceiling: one row lands AND the window enters far-behind in
+      // the same commit.
+      const proto = fixture[0];
+      if (!proto) throw new Error("fixture[0] missing");
+      // ONE flush, mirroring the store: `appendPageToScrollback` publishes the
+      // pruned rows and the far-behind flag inside a single `batch`, pinned by
+      // "publishes the pruned rows and the far-behind flag in ONE flush" in
+      // scrollback.test.ts. Two separate writes here would drive the pane
+      // through a state the store cannot produce.
+      batch(() => {
+        setScrollback({
+          "freenode #grappa": [
+            ...fixture,
+            { ...proto, id: 4, server_time: 1_700_000_003_000, sender: "peer", body: "crossing" },
+          ],
+        });
+        setFarBehind({ "freenode #grappa": { missed: 201, resumeFrom: 1 } });
+      });
+      await flushRaf();
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1618,10 +1618,55 @@ describe("appendToScrollback — #1229 unread-retention bound", () => {
     // NEWEST page — the live tail is never what gets dropped.
     expect(rows.filter((m) => m.id > cursor).length).toBe(bound);
     expect(rows[rows.length - 1]?.id).toBe(total);
-    // The read context below the divider is untouched by this bound (the ring
-    // cap still owns it), so the total is that plus one page — bounded, where
-    // before the fix it was `total` and grew with every arriving row.
-    expect(rows.length).toBe(cursor - 1 + bound);
+    // The read context is untouched by this bound (the ring cap still owns
+    // it), boundary row included: `cursor` read rows plus one page of unread —
+    // bounded, where before the fix it was `total` and grew with every
+    // arriving row.
+    expect(rows.length).toBe(cursor + bound);
+    expect(rows.map((m) => m.id)).toContain(cursor);
+  });
+
+  // The FIRST bite, by exactly one row. Every other case in this file sits a
+  // page or more away from the ceiling, where a one-row phase error in the
+  // trim is invisible — so nothing pinned WHICH end the trim takes, nor WHERE
+  // the threshold sits. Those are the two facts the bound is made of.
+  it("bites one row past the ceiling, dropping the OLDEST unread and never the boundary", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const key = channelKey("freenode", "#grappa");
+    const cursor = 10;
+    mockGetReadCursor.mockReturnValue(cursor);
+    const total = cursor + bound + 1;
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    const ids = (scrollback.scrollbackByChannel()[key] ?? []).map((m) => m.id);
+    // The boundary row is READ. The divider anchors on it and this module's
+    // rule exempts `id >= cursor`, so it is not this bound's to drop: the
+    // ceiling is on the UNREAD region, and the row that leaves is the oldest
+    // unread — the one just under the divider.
+    expect(ids).toContain(cursor);
+    expect(ids).not.toContain(cursor + 1);
+    expect(ids.filter((id) => id > cursor).length).toBe(bound);
+    expect(ids[ids.length - 1]).toBe(total);
+  });
+
+  it("does not bite AT one page of unread — the line `isFarBehind` already draws", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const key = channelKey("freenode", "#grappa");
+    const cursor = 10;
+    mockGetReadCursor.mockReturnValue(cursor);
+    // Exactly one page of unread. `isFarBehind(gap) = gap > PAGE_LIMIT` calls
+    // this window near, and the bound shares that constant deliberately: a
+    // bite here would arm the far-behind banner for a window that the reload
+    // path (`loadInitialScrollback`'s gap probe) classifies as not far behind,
+    // which is the drift the shared constant exists to prevent.
+    const total = cursor + bound;
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    const rows = scrollback.scrollbackByChannel()[key] ?? [];
+    expect(rows.length).toBe(total);
+    expect(scrollback.farBehindByChannel()[key]).toBeUndefined();
   });
 
   it("hands the pruned window to the existing far-behind state, with an honest missed count", async () => {

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1530,21 +1530,25 @@ describe("appendToScrollback — S20 per-channel ring cap", () => {
     const scrollback = await import("../lib/scrollback");
     const cap = scrollback.SCROLLBACK_RING_CAP;
     const key = channelKey("freenode", "#grappa");
-    // Cursor near the very start → almost the whole buffer is "unread"
-    // (id > cursor). Appending well past the cap must NOT drop any row
-    // with id >= cursor — dropping the boundary would break the divider.
-    const cursor = 5;
-    mockGetReadCursor.mockReturnValue(cursor);
+    // Appending well past the cap must NOT drop any row with id >= cursor —
+    // dropping the boundary would break the divider. #1229 put a ceiling on
+    // that exemption, so the scenario is stated within it: the unread region
+    // here is one page minus one, where the S20 promise still holds in full.
+    // Above the ceiling the window becomes far-behind instead — pinned in
+    // "appendToScrollback — #1229 unread-retention bound" below.
     const total = cap + 200;
+    const cursor = total - (scrollback.UNREAD_RETENTION_CAP - 1);
+    mockGetReadCursor.mockReturnValue(cursor);
     for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
     const ids = (scrollback.scrollbackByChannel()[key] ?? []).map((m) => m.id);
-    // The divider anchor (the cursor row) + every unread row survive, even
-    // though that leaves the buffer temporarily above the cap.
+    // The divider anchor (the cursor row) + every unread row survive.
     expect(ids).toContain(cursor);
     for (let i = cursor; i <= total; i++) expect(ids).toContain(i);
-    // Only the read rows below the cursor (id < cursor) are evictable.
+    // Read rows below the cursor are the evictable ones, and were evicted.
     expect(ids).not.toContain(1);
-    expect(ids).not.toContain(cursor - 1);
+    expect(ids).not.toContain(total - cap);
+    // The exemption held without tipping into far-behind.
+    expect(scrollback.farBehindByChannel()[key]).toBeUndefined();
   });
 
   it("resets the loadMore exhausted latch on eviction so scroll-up can re-page older history", async () => {
@@ -1569,6 +1573,94 @@ describe("appendToScrollback — S20 per-channel ring cap", () => {
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
     await scrollback.loadMore("freenode", "#grappa");
     expect(api.listMessages).toHaveBeenCalledTimes(2);
+  });
+});
+
+// #1229 — S20's exemption had no ceiling: every row at/after the read cursor
+// was unevictable, so a busy channel the operator never reads holds ALL of
+// them and the ring cap does nothing (the module said so itself). Measured on
+// the reporter's window: 1084 unread rows, and because the pane renders every
+// retained row (`<For each={rows()}>`, no virtualisation) that is ~26 MB of
+// renderer memory in ONE window, against a per-web-process ceiling on iOS.
+//
+// The bound reuses the threshold the codebase already has rather than adding a
+// second one: `isFarBehind(gap) = gap > PAGE_LIMIT`. Past one page of unread
+// the client ALREADY considers the window far behind and already has the UX
+// for it (`anchorAtTail` keeps one page, the divider is suppressed, the
+// "N unread — jump back" banner + `jumpToUnread` rebuild the region from the
+// server). So: retain one page of unread, and enter that existing state
+// instead of inventing a new one.
+describe("appendToScrollback — #1229 unread-retention bound", () => {
+  const mkRow = (id: number): import("../lib/api").ScrollbackMessage => ({
+    id,
+    network: "freenode",
+    channel: "#grappa",
+    server_time: id,
+    kind: "privmsg",
+    sender: "peer",
+    body: `line ${id}`,
+    meta: {},
+  });
+
+  it("bounds an all-unread channel at one page instead of growing without limit", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const cursor = 5;
+    mockGetReadCursor.mockReturnValue(cursor);
+    const scrollback = await import("../lib/scrollback");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const key = channelKey("freenode", "#grappa");
+    // Well past BOTH the ring cap and the unread bound, with a cursor near
+    // the start — the shape that grew without limit before this bound.
+    const total = scrollback.SCROLLBACK_RING_CAP + 200;
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    const rows = scrollback.scrollbackByChannel()[key] ?? [];
+    // The bound is on the UNREAD region: one page of it survives, and it is the
+    // NEWEST page — the live tail is never what gets dropped.
+    expect(rows.filter((m) => m.id > cursor).length).toBe(bound);
+    expect(rows[rows.length - 1]?.id).toBe(total);
+    // The read context below the divider is untouched by this bound (the ring
+    // cap still owns it), so the total is that plus one page — bounded, where
+    // before the fix it was `total` and grew with every arriving row.
+    expect(rows.length).toBe(cursor - 1 + bound);
+  });
+
+  it("hands the pruned window to the existing far-behind state, with an honest missed count", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const cursor = 5;
+    mockGetReadCursor.mockReturnValue(cursor);
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    const total = scrollback.SCROLLBACK_RING_CAP + 200;
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    const far = scrollback.farBehindByChannel()[key];
+    // `resumeFrom` is the untouched read cursor — `jumpToUnread` rebuilds the
+    // region around it from the server, exactly as it does after
+    // `anchorAtTail`.
+    expect(far?.resumeFrom).toBe(cursor);
+    // `missed` must be the TOTAL unread (id > cursor), not the slice still
+    // held: the banner would otherwise under-report by an order of magnitude
+    // once the pruning has been running for a while.
+    expect(far?.missed).toBe(total - cursor);
+  });
+
+  it("leaves the divider contract untouched while the unread region fits in one page", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    const key = channelKey("freenode", "#grappa");
+    // 101 unread — under the bound, so S20's behaviour must be byte-identical:
+    // evict from the read prefix only, never the boundary or its unread rows.
+    const total = cap + 100;
+    const cursor = total - 100;
+    mockGetReadCursor.mockReturnValue(cursor);
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    const rows = scrollback.scrollbackByChannel()[key] ?? [];
+    const ids = rows.map((m) => m.id);
+    expect(rows.length).toBe(cap);
+    expect(ids).toContain(cursor);
+    for (let i = cursor; i <= total; i++) expect(ids).toContain(i);
+    // No pruning of unread happened → the window is NOT far behind.
+    expect(scrollback.farBehindByChannel()[key]).toBeUndefined();
   });
 });
 

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1688,6 +1688,43 @@ describe("appendToScrollback — #1229 unread-retention bound", () => {
     expect(far?.missed).toBe(total - cursor);
   });
 
+  // The prune and the far-behind arming are ONE transition, so a consumer woken
+  // by the rows change must not be able to observe the window pruned but not yet
+  // far behind. `ScrollbackPane`'s content-change gate reads exactly that pair:
+  // on the two-write version it saw a still-rendered divider with far-behind
+  // unset, admitted a divider activation, and the deferred write then landed
+  // with the divider suppressed and tail-snapped a reader parked in history.
+  it("publishes the pruned rows and the far-behind flag in ONE flush", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const key = channelKey("freenode", "#grappa");
+    const cursor = 10;
+    mockGetReadCursor.mockReturnValue(cursor);
+    // One short of the ceiling: the NEXT append is the crossing.
+    const total = cursor + bound;
+    for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
+    expect(scrollback.farBehindByChannel()[key]).toBeUndefined();
+
+    const seen: boolean[] = [];
+    const dispose = createRoot((d) => {
+      createEffect(
+        on(
+          () => scrollback.scrollbackByChannel()[key],
+          () => void seen.push(scrollback.farBehindByChannel()[key] !== undefined),
+          { defer: true },
+        ),
+      );
+      return d;
+    });
+    scrollback.appendToScrollback(key, mkRow(total + 1));
+    await new Promise((r) => queueMicrotask(() => r(undefined)));
+    dispose();
+
+    // Woken once, and the window was ALREADY far behind when it woke.
+    expect(seen).toEqual([true]);
+  });
+
   it("leaves the divider contract untouched while the unread region fits in one page", async () => {
     localStorage.setItem("grappa-token", "tok");
     const scrollback = await import("../lib/scrollback");

--- a/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
@@ -258,7 +258,10 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     const api = await import("../lib/api");
     const scrollback = await import("../lib/scrollback");
     const cap = scrollback.SCROLLBACK_RING_CAP;
-    const cursor = 5;
+    // #1229 — stated within the unread ceiling, where this promise still holds
+    // in full: one page minus one of unread. Past the ceiling the page ingest
+    // prunes to a page and arms far-behind, pinned in the sibling case below.
+    const cursor = cap + 200 - (scrollback.UNREAD_RETENTION_CAP - 1);
     mockGetReadCursor.mockReturnValue(cursor);
     seedPane(scrollback, cap, { reads: 0 });
 
@@ -272,7 +275,29 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     // The divider anchor and every unread row survive, above the cap.
     for (let i = cursor; i <= cap + 200; i++) expect(ids).toContain(i);
     // Only the read rows below the cursor were evictable.
-    expect(ids).not.toContain(cursor - 1);
+    expect(ids).not.toContain(cursor - cap);
+    expect(scrollback.farBehindByChannel()[KEY]).toBeUndefined();
+  });
+
+  it("#1229 — a page that lands past the unread ceiling prunes to one page and arms far-behind", async () => {
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const cap = scrollback.SCROLLBACK_RING_CAP;
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const cursor = 5;
+    mockGetReadCursor.mockReturnValue(cursor);
+    seedPane(scrollback, cap, { reads: 0 });
+
+    const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
+    mockGetResumeCursor.mockReturnValue(cap);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    await scrollback.refreshScrollback(SLUG, CHAN);
+
+    const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
+    expect(rows.filter((m) => m.id > cursor).length).toBe(bound);
+    expect(rows[rows.length - 1]?.id).toBe(cap + 200);
+    expect(scrollback.farBehindByChannel()[KEY]?.resumeFrom).toBe(cursor);
   });
 
   it("resets the loadMore exhausted latch when a page evicts older history", async () => {

--- a/cicchetto/src/lib/networkReconnect.ts
+++ b/cicchetto/src/lib/networkReconnect.ts
@@ -1,0 +1,62 @@
+import { type Accessor, createSignal } from "solid-js";
+import { ApiError, patchNetwork } from "./api";
+import { token } from "./auth";
+import { friendlyApiError } from "./friendlyApiError";
+
+// #1331 — the unpark verb, shared by every surface that offers it.
+//
+// The PATCH itself is one line, but the UX around it is not: an awaited
+// request with a pending latch (the button disables and relabels) and a
+// friendly-mapped failure the operator must read
+// (feedback_silent_retry_anti_pattern). That trio lived inside HomePane's
+// `DisconnectedRow`; #1331 puts a second reconnect in the greyed compose
+// seam, where the operator actually meets a parked network, and a second
+// hand-rolled copy would be the drift this repo keeps paying for.
+//
+// Deliberately NOT `lib/reconnect.ts`: despite the name, that is the #282
+// vhost bounce — it selects `connected` networks and does park-THEN-connect.
+// Pointing it at a parked network would be the wrong verb on the wrong set.
+//
+// NO confirmation modal, and that is a decision on record, not an omission:
+// #283 (2026-07-20) settled that Reconnect is the awaited-PATCH UX while
+// DISCONNECT is the one behind the #195 confirm modal — see the comment on
+// `HomePane`'s `onDisconnect`. Reconnect is also trivially reversible, which
+// is the property the modal exists to protect. Every caller must keep that
+// shape or the surfaces diverge again.
+//
+// The error SINK is the caller's, because each surface already owns an error
+// line and inventing a second one next to it is how a component ends up with
+// two contradictory alerts: HomePane has its `role="alert"` span, ComposeBox
+// has the #356 feedback seam. `null` means "clear it" and is emitted once at
+// the start of every attempt, so a previous failure never outlives the retry
+// that supersedes it.
+
+export type NetworkReconnect = {
+  pending: Accessor<boolean>;
+  reconnect: (networkSlug: string) => Promise<void>;
+};
+
+export function createNetworkReconnect(
+  onError: (message: string | null) => void,
+): NetworkReconnect {
+  const [pending, setPending] = createSignal(false);
+
+  const reconnect = async (networkSlug: string): Promise<void> => {
+    const t = token();
+    if (t === null) return;
+    onError(null);
+    setPending(true);
+    try {
+      await patchNetwork(t, networkSlug, { connection_state: "connected" });
+      // No success state to set: the server emits connection_state_changed,
+      // userTopic patches the networks store in place, and every surface
+      // reading that store re-renders itself out of the parked shape.
+    } catch (err) {
+      onError(err instanceof ApiError ? friendlyApiError(err) : "reconnect failed (unknown error)");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return { pending, reconnect };
+}

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -94,11 +94,9 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 //     up re-pages them.
 //   * A channel that is BUSY but never focused this session, carrying a stale
 //     non-null cursor (e.g. set on another device), holds every live row as
-//     unread (id > cursor) → all protected → the buffer can grow past the
-//     cap. That is the cost of the divider invariant, not an oversight: those
-//     rows can't be dropped without corrupting the (server-authoritative)
-//     unread count + divider. It bounds the moment the operator reads the
-//     channel — the cursor advances and the now-read rows become evictable.
+//     unread (id > cursor) → all protected. #1229 bounds that case too — see
+//     `UNREAD_RETENTION_CAP` below; up to one page of unread is still exempt,
+//     so this cap remains a soft ceiling by exactly that much.
 export const SCROLLBACK_RING_CAP = 1000;
 
 // #693 — ONE page. The server's `@max_http_limit`, and the ceiling on every
@@ -119,6 +117,29 @@ const PAGE_LIMIT = 200;
 // bottom (200 rows a gesture) to reach the present. At or below it, one more
 // fetch drains the rest, so contiguity is cheap and worth keeping.
 const isFarBehind = (gap: number): boolean => gap > PAGE_LIMIT;
+
+// #1229 — the ceiling S20's cursor exemption never had. Every row at/after the
+// read cursor was unevictable, so a channel the operator does not read holds
+// ALL of them and the ring cap above does nothing. Measured on the reporter's
+// window: 1084 unread rows; and because the pane renders every retained row
+// (`<For each={rows()}>`, no virtualisation) each one costs ~19-26 KB of
+// renderer memory, i.e. ~26 MB in ONE window against a ceiling iOS applies per
+// web process. Retention and rendered DOM are the same curve, so bounding the
+// store IS the DOM fix.
+//
+// The number is PAGE_LIMIT and deliberately not a new constant: `isFarBehind`
+// already draws the line at "more than one page behind", so past this bound the
+// client ALREADY classifies the window as far behind, and already has the whole
+// apparatus for it — `anchorAtTail` keeps exactly one page, the divider is
+// suppressed (`ScrollbackPane`'s `injectMarker` gate), and the
+// "N unread — jump back" banner + `jumpToUnread` rebuild the region from the
+// server, which owns it. A second threshold here would be a second answer to
+// the same question, free to drift from the first.
+//
+// So the rule is: retain one page of unread and enter that existing state,
+// rather than invent a pruned-window UX. Below the bound nothing changes — the
+// divider contract is byte-identical to S20.
+export const UNREAD_RETENTION_CAP = PAGE_LIMIT;
 
 // Canonical scrollback ordering: `server_time` ASC, `id` ASC tie-break —
 // the client mirror of the server's `[desc: server_time, desc: id]`
@@ -174,19 +195,71 @@ const isCanonicallyOrdered = (rows: ScrollbackMessage[]): boolean => {
 // cursor); a pathological all-unread channel simply holds above the cap until
 // the operator reads (advancing the cursor makes those rows evictable). With
 // no cursor (fresh channel, no divider) eviction is unconstrained.
-const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): ScrollbackMessage[] => {
-  if (rows.length <= SCROLLBACK_RING_CAP) return rows;
-  let dropCount = rows.length - SCROLLBACK_RING_CAP;
+// What the cap did, so the caller can arm the far-behind state without the
+// pure updater reaching for a signal. `unreadDropped > 0` is the ONLY way a row
+// at/after the cursor ever leaves the store on this path.
+type CappedRing = {
+  rows: ScrollbackMessage[];
+  unreadDropped: number;
+  // Unread rows (id > cursor) held BEFORE the drop — the banner's count the
+  // first time the bound bites. Afterwards the caller accumulates.
+  unreadHeld: number;
+  cursor: number | null;
+};
+
+const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRing => {
   const decoded = decodeChannelKey(key);
   const cursor = decoded ? getReadCursor(decoded.slug, decoded.name) : null;
-  if (cursor !== null) {
-    // Rows are ASC by id, so the first index with id >= cursor bounds the
-    // evictable prefix (everything before it is read-context below the divider).
-    const firstProtected = rows.findIndex((m) => m.id >= cursor);
-    const maxDroppable = firstProtected === -1 ? rows.length : firstProtected;
+  // Rows are ASC by id, so the first index with id >= cursor bounds the
+  // evictable prefix (everything before it is read-context below the divider).
+  const firstProtected = cursor === null ? -1 : rows.findIndex((m) => m.id >= cursor);
+  const protectedCount = firstProtected === -1 ? 0 : rows.length - firstProtected;
+
+  // #1229 — the protected region has a ceiling of its own, applied BEFORE the
+  // ring cap because it can bite while the total is still under it (900 unread
+  // and no read history is 900 rows the operator cannot see the top of).
+  //
+  // It drops the OLDEST unread — the rows just under the divider — and not
+  // simply "everything but the newest page", which would have been one slice
+  // instead of two. The difference is the operator scrolled UP reading history
+  // while a busy channel runs on below them: their cursor sits at the last row
+  // they can see, so the arriving rows are unread and the ceiling bites: the
+  // one-slice version deletes the screen they are reading, the pane jumps to
+  // the tail. Dropping from just below the divider instead removes rows that
+  // are off-screen BELOW, leaving `scrollTop` and everything above it intact.
+  // What remains of the read context is then trimmed by the ring cap, exactly
+  // as it was before this bound existed.
+  const overflowUnread =
+    cursor !== null && protectedCount > UNREAD_RETENTION_CAP
+      ? protectedCount - UNREAD_RETENTION_CAP
+      : 0;
+  const afterUnreadTrim =
+    overflowUnread > 0
+      ? [...rows.slice(0, firstProtected), ...rows.slice(firstProtected + overflowUnread)]
+      : rows;
+
+  const unreadHeld =
+    cursor === null
+      ? 0
+      : (() => {
+          const firstUnread = rows.findIndex((m) => m.id > cursor);
+          return firstUnread === -1 ? 0 : rows.length - firstUnread;
+        })();
+
+  const surplus = afterUnreadTrim.length - SCROLLBACK_RING_CAP;
+  let dropCount = surplus > 0 ? surplus : 0;
+  if (cursor !== null && dropCount > 0) {
+    // The evictable prefix shrank with the unread trim only in its tail, so the
+    // read-context boundary is still where it was: `firstProtected`.
+    const maxDroppable = firstProtected === -1 ? afterUnreadTrim.length : firstProtected;
     if (dropCount > maxDroppable) dropCount = maxDroppable;
   }
-  return dropCount > 0 ? rows.slice(dropCount) : rows;
+  return {
+    rows: dropCount > 0 ? afterUnreadTrim.slice(dropCount) : afterUnreadTrim,
+    unreadDropped: overflowUnread,
+    unreadHeld,
+    cursor,
+  };
 };
 
 // #788 — how THE identity rule applies to this module. The predicate itself,
@@ -441,6 +514,13 @@ const exports = identityScopedStore((onIdentityChange) => {
     // consumed after it runs (Solid calls a plain-signal updater exactly once,
     // synchronously) — keeps the setter body free of the Set side-effect.
     let evicted = false;
+    // #1229 — same shape as `evicted` above, for the other side effect the cap
+    // can imply: rows at/after the cursor were dropped, so the window is now
+    // far behind and the pane must say so instead of drawing a divider it can
+    // no longer place.
+    let unreadDropped = 0;
+    let unreadHeld = 0;
+    let prunedCursor = 0;
     setScrollbackByChannel((prev) => {
       const existing = prev[key] ?? [];
       const fresh = freshRows(existing, page);
@@ -462,13 +542,34 @@ const exports = identityScopedStore((onIdentityChange) => {
           ? [...existing, ...fresh]
           : [...existing, ...fresh].sort(byServerTimeThenId);
       const capped = capScrollbackRing(key, next);
-      evicted = capped.length < next.length;
-      return { ...prev, [key]: capped };
+      evicted = capped.rows.length < next.length;
+      unreadDropped = capped.unreadDropped;
+      unreadHeld = capped.unreadHeld;
+      prunedCursor = capped.cursor ?? 0;
+      return { ...prev, [key]: capped.rows };
     });
     // Eviction removed older history → the loadMore exhausted latch (if set)
     // is now stale: the server DOES have rows older than the new oldest. Clear
     // it so a scroll-to-top re-pages the evicted region.
     if (evicted) loadMoreExhausted.delete(key);
+    // #1229 — the pruned window joins the #693 far-behind state: divider
+    // suppressed, "N unread — jump back" banner up, `jumpToUnread` rebuilding
+    // the region from the server around this same `resumeFrom`. `missed`
+    // ACCUMULATES once the state is up: after the first bite the store only
+    // ever holds one page, so a recount would report 200 forever while the
+    // operator is thousands behind.
+    if (unreadDropped > 0) {
+      setFarBehindByChannel((prev) => {
+        const current = prev[key];
+        return {
+          ...prev,
+          [key]: {
+            missed: current === undefined ? unreadHeld : current.missed + unreadDropped,
+            resumeFrom: prunedCursor,
+          },
+        };
+      });
+    }
   };
 
   const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -213,7 +213,14 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRi
   // Rows are ASC by id, so the first index with id >= cursor bounds the
   // evictable prefix (everything before it is read-context below the divider).
   const firstProtected = cursor === null ? -1 : rows.findIndex((m) => m.id >= cursor);
-  const protectedCount = firstProtected === -1 ? 0 : rows.length - firstProtected;
+  // The UNREAD region is `id > cursor` — one row narrower than the protected
+  // region, which also holds the boundary row the divider anchors on. The
+  // ceiling below is on THIS count, so both numbers are needed and they are
+  // not interchangeable: measuring the ceiling against the protected region
+  // instead spends the boundary row as the first eviction and moves the bite
+  // one row early (see the two invariants restated below).
+  const firstUnread = cursor === null ? -1 : rows.findIndex((m) => m.id > cursor);
+  const unreadCount = firstUnread === -1 ? 0 : rows.length - firstUnread;
 
   // #1229 — the protected region has a ceiling of its own, applied BEFORE the
   // ring cap because it can bite while the total is still under it (900 unread
@@ -229,22 +236,23 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRi
   // are off-screen BELOW, leaving `scrollTop` and everything above it intact.
   // What remains of the read context is then trimmed by the ring cap, exactly
   // as it was before this bound existed.
+  //
+  // Two invariants decide the arithmetic, and both are one row wide:
+  //   * the BOUNDARY row (`id === cursor`, the newest READ row) is not this
+  //     bound's to drop — it is what the divider anchors on, and the rule this
+  //     whole function is built around exempts `id >= cursor`. So the trim
+  //     starts at `firstUnread`, never at `firstProtected`.
+  //   * the ceiling is crossed at `unreadCount > UNREAD_RETENTION_CAP`, the
+  //     SAME comparison `isFarBehind` makes, because the bound's job is to
+  //     deliver the window into that state. Biting at `=== CAP` would arm the
+  //     banner for a window the reload path's gap probe still calls near, and
+  //     the shared constant exists precisely so those two cannot disagree.
   const overflowUnread =
-    cursor !== null && protectedCount > UNREAD_RETENTION_CAP
-      ? protectedCount - UNREAD_RETENTION_CAP
-      : 0;
+    unreadCount > UNREAD_RETENTION_CAP ? unreadCount - UNREAD_RETENTION_CAP : 0;
   const afterUnreadTrim =
     overflowUnread > 0
-      ? [...rows.slice(0, firstProtected), ...rows.slice(firstProtected + overflowUnread)]
+      ? [...rows.slice(0, firstUnread), ...rows.slice(firstUnread + overflowUnread)]
       : rows;
-
-  const unreadHeld =
-    cursor === null
-      ? 0
-      : (() => {
-          const firstUnread = rows.findIndex((m) => m.id > cursor);
-          return firstUnread === -1 ? 0 : rows.length - firstUnread;
-        })();
 
   const surplus = afterUnreadTrim.length - SCROLLBACK_RING_CAP;
   let dropCount = surplus > 0 ? surplus : 0;
@@ -257,7 +265,7 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRi
   return {
     rows: dropCount > 0 ? afterUnreadTrim.slice(dropCount) : afterUnreadTrim,
     unreadDropped: overflowUnread,
-    unreadHeld,
+    unreadHeld: unreadCount,
     cursor,
   };
 };

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { batch, createSignal } from "solid-js";
 import {
   sendMessage as apiSendMessage,
   countMessagesAfter,
@@ -529,55 +529,66 @@ const exports = identityScopedStore((onIdentityChange) => {
     let unreadDropped = 0;
     let unreadHeld = 0;
     let prunedCursor = 0;
-    setScrollbackByChannel((prev) => {
-      const existing = prev[key] ?? [];
-      const fresh = freshRows(existing, page);
-      // Nothing new: return the SAME object so Solid's equality check skips
-      // the write entirely. A wholly-duplicate page (every row already live)
-      // must not re-render the pane.
-      if (fresh.length === 0) return prev;
-      const tail = existing[existing.length - 1];
-      const head = fresh[0];
-      // #423 order-safe insert, generalised from one row to a page: append
-      // without sorting when the arriving rows are themselves in canonical
-      // order AND start at/after the current tail — true of every live append
-      // and of every ASC catch-up page. Re-sort only when they interleave with
-      // rows the pane already holds.
-      const next =
-        head !== undefined &&
-        (tail === undefined || byServerTimeThenId(head, tail) >= 0) &&
-        isCanonicallyOrdered(fresh)
-          ? [...existing, ...fresh]
-          : [...existing, ...fresh].sort(byServerTimeThenId);
-      const capped = capScrollbackRing(key, next);
-      evicted = capped.rows.length < next.length;
-      unreadDropped = capped.unreadDropped;
-      unreadHeld = capped.unreadHeld;
-      prunedCursor = capped.cursor ?? 0;
-      return { ...prev, [key]: capped.rows };
-    });
-    // Eviction removed older history → the loadMore exhausted latch (if set)
-    // is now stale: the server DOES have rows older than the new oldest. Clear
-    // it so a scroll-to-top re-pages the evicted region.
-    if (evicted) loadMoreExhausted.delete(key);
-    // #1229 — the pruned window joins the #693 far-behind state: divider
-    // suppressed, "N unread — jump back" banner up, `jumpToUnread` rebuilding
-    // the region from the server around this same `resumeFrom`. `missed`
-    // ACCUMULATES once the state is up: after the first bite the store only
-    // ever holds one page, so a recount would report 200 forever while the
-    // operator is thousands behind.
-    if (unreadDropped > 0) {
-      setFarBehindByChannel((prev) => {
-        const current = prev[key];
-        return {
-          ...prev,
-          [key]: {
-            missed: current === undefined ? unreadHeld : current.missed + unreadDropped,
-            resumeFrom: prunedCursor,
-          },
-        };
+    // #1229 — the rows and the far-behind flag are ONE state transition and must
+    // reach consumers in ONE flush. Published as two writes, Solid runs every
+    // effect of the rows change FIRST, in a world where the window has already
+    // been pruned but is not yet far behind — a state that never logically
+    // exists. `ScrollbackPane`'s content-change gate is one such consumer and it
+    // read exactly that: it admitted a divider activation (divider still
+    // rendered, far-behind not yet set) whose deferred write landed two frames
+    // later with the divider suppressed, and tail-snapped a reader parked in
+    // their history.
+    batch(() => {
+      setScrollbackByChannel((prev) => {
+        const existing = prev[key] ?? [];
+        const fresh = freshRows(existing, page);
+        // Nothing new: return the SAME object so Solid's equality check skips
+        // the write entirely. A wholly-duplicate page (every row already live)
+        // must not re-render the pane.
+        if (fresh.length === 0) return prev;
+        const tail = existing[existing.length - 1];
+        const head = fresh[0];
+        // #423 order-safe insert, generalised from one row to a page: append
+        // without sorting when the arriving rows are themselves in canonical
+        // order AND start at/after the current tail — true of every live append
+        // and of every ASC catch-up page. Re-sort only when they interleave with
+        // rows the pane already holds.
+        const next =
+          head !== undefined &&
+          (tail === undefined || byServerTimeThenId(head, tail) >= 0) &&
+          isCanonicallyOrdered(fresh)
+            ? [...existing, ...fresh]
+            : [...existing, ...fresh].sort(byServerTimeThenId);
+        const capped = capScrollbackRing(key, next);
+        evicted = capped.rows.length < next.length;
+        unreadDropped = capped.unreadDropped;
+        unreadHeld = capped.unreadHeld;
+        prunedCursor = capped.cursor ?? 0;
+        return { ...prev, [key]: capped.rows };
       });
-    }
+      // Eviction removed older history → the loadMore exhausted latch (if set)
+      // is now stale: the server DOES have rows older than the new oldest. Clear
+      // it so a scroll-to-top re-pages the evicted region.
+      if (evicted) loadMoreExhausted.delete(key);
+      // #1229 — the pruned window joins the #693 far-behind state: divider
+      // suppressed, "N unread — jump back" banner up, `jumpToUnread` rebuilding
+      // the region from the server around this same `resumeFrom`. `missed`
+      // ACCUMULATES once the state is up: after the first bite the store only
+      // ever holds one page, so a recount would report 200 forever while the
+      // operator is thousands behind.
+      if (unreadDropped > 0) {
+        setFarBehindByChannel((prev) => {
+          const current = prev[key];
+          return {
+            ...prev,
+            [key]: {
+              missed: current === undefined ? unreadHeld : current.missed + unreadDropped,
+              resumeFrom: prunedCursor,
+            },
+          };
+        });
+      }
+    });
   };
 
   const appendToScrollback = (key: ChannelKey, msg: ScrollbackMessage) => {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2023,6 +2023,38 @@ html.resize-dragging * {
   font-style: italic;
 }
 
+/* #1331 — the reconnect action on the seam that already states the network
+   is parked. Same fill/hover/disabled idiom as the HomePane chip
+   (.home-pane-network-reconnect) because it is the same verb on the same
+   subject; only the geometry is smaller, since it rides an inline muted
+   line rather than a card heading. `--tap-min` is 44px ABSOLUTE: rem here
+   would track the user's text-size setting and shrink the tap target below
+   the HIG floor at S/M. */
+.compose-box-reconnect {
+  margin-left: 0.5rem;
+  min-height: var(--tap-min);
+  padding: 0.15rem 0.6rem;
+  background: var(--accent);
+  color: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  font-weight: bold;
+  font-style: normal;
+  cursor: pointer;
+}
+
+.compose-box-reconnect:hover:not(:disabled) {
+  background: var(--bg);
+  color: var(--accent);
+}
+
+.compose-box-reconnect:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
 /* TopicBar */
 
 .topic-bar {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42566,3 +42566,67 @@ GET per resume seam for opted-in users (single-flighted by
 state that drifts, guarding a request smaller than the headers carrying it.
 The size is an estimate — the ~88-byte base64url key plus its JSON envelope —
 not a measurement; nobody has counted the bytes on the wire.
+<!-- entry #1229 -->
+
+---
+
+## 2026-08-14 — #1229: the unread exemption gets a ceiling, and the DOM follows the store
+
+S20 capped the per-channel ring at 1000 rows but exempted every row at or
+after the read cursor, because the in-pane divider anchors on that boundary.
+The exemption had no ceiling of its own, and the module said so in its own
+comment: a channel the operator never reads holds ALL of its unread rows and
+the cap does nothing. That was accepted as "the cost of the divider
+invariant". What was missing was its price.
+
+Measured on `origin/main` before choosing anything:
+
+- The pane renders EVERY retained row. `<For each={rows()}>`, no windowing,
+  no slice anywhere in the render path: 1084 retained rows produce 1084
+  `.scrollback-line` nodes, ratio 1.0000 (day separators only ever ADD rows,
+  never subtract). So there is no screen-bounded ceiling on the DOM.
+- A rendered row costs 32.3 KB of renderer RSS over the first 500 and 18.8 KB
+  marginal past that — chromium, real theme CSS, 390x844, production row
+  markup, `VmRSS` of the renderer process, fresh browser per data point. The
+  same row costs 249 B as a JS object (JSC).
+- So the reporter's 1084-unread window is ~26.5 MB in ONE window, ~100x the
+  stored bytes, against a memory ceiling iOS applies per web process.
+
+Retention and rendered DOM are therefore one curve, which is why the ruling
+took pruning over `content-visibility` or virtualisation: bounding the store
+IS the DOM fix, and it is the only one of the three that converts an
+unbounded term into a bounded one.
+
+**The number is `PAGE_LIMIT`, not a new constant.** `isFarBehind(gap) = gap >
+PAGE_LIMIT` already draws the line at "more than one page behind", so past
+this bound the client ALREADY classifies the window as far behind and already
+owns the apparatus for it: `anchorAtTail` keeps exactly one page, the divider
+is suppressed, and the "N unread — jump back" banner plus `jumpToUnread`
+rebuild the region from the server that owns it. A second threshold would be
+a second answer to the same question, free to drift from the first. The work
+was to REACH that state sooner, not to invent a pruned-window UX.
+
+**It drops the oldest unread, not "everything but the newest page."** The
+one-slice version is simpler and was rejected: the operator scrolled UP
+reading history has their cursor at the last row they can see, so rows
+arriving below are unread, and when the ceiling bites the one-slice version
+deletes the screen they are reading and the pane jumps to the tail. Dropping
+from just below the divider removes rows that are off-screen BELOW, so
+`scrollTop` and everything above it survive; what is left of the read context
+is then trimmed by the ring cap exactly as before. The e2e pins that
+property, not just the banner.
+
+**`missed` accumulates.** After the first bite the store only ever holds one
+page, so recomputing the banner's count from the rows would report 200 for
+ever while the operator is thousands behind.
+
+**What this does NOT do, recorded because the issue it is filed under moved
+while it was being written.** #1229 was reported as a half-height shell after
+returning from a long background. That frame reproduces with the ADMIN pane
+focused — `AdminPane` and `ScrollbackPane` are alternative branches of one
+`<Switch>`, so there are zero `.scrollback-line` nodes mounted — and it
+therefore cannot be explained by scrollback weight, by this bound, or by the
+unread count. This entry records a real and measured memory fix; it does not
+record a fix for the reported symptom, and the two must not be fused. The
+half-height frame's live hypothesis is the height RECALCULATION when a pane
+is unmounted and remounted by that `<Switch>` on return from background.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42630,3 +42630,79 @@ unread count. This entry records a real and measured memory fix; it does not
 record a fix for the reported symptom, and the two must not be fused. The
 half-height frame's live hypothesis is the height RECALCULATION when a pane
 is unmounted and remounted by that `<Switch>` on return from background.
+<!-- entry #1331 -->
+
+---
+
+## 2026-08-14 — #1331: put the exit where the operator meets the dead end
+
+The greyed compose seam already stated that a network was parked. The only
+way *out* of it was the chip on `HomePane`, which the operator had to know to
+go and find. `lib/selection.ts:712-742` softens that and deliberately stops
+short: it redirects to Home on the park **transition** only, so that a parked
+window stays reachable for its history (`:700-702`). Three entries therefore
+still land on a greyed compose with no exit — a cold load with the network
+already parked, a walk back into the window, and another device parking it
+while this tab was closed. The first two are pinned as intentional by
+`src/__tests__/selection.test.ts:828` and `:853`; the fix is an exit at the
+dead end, not another redirect, so both stay green.
+
+**Three placements were on the table, and the tiebreak was cost, not taste.**
+An action on the sidebar row was ruled out. That left the action inline in
+the seam, or a single implementation on `HomePane` with the seam pointing at
+it. The rule was set *before* measuring: inline **if** it costs no serious
+prop-drilling — at most two hops and no new plumbing — otherwise point at
+HomePane and keep one home for the verb.
+
+**Measured: zero hops.** `ComposeBox`'s props are `{ networkSlug, channelName }`
+and nothing else (`ComposeBox.tsx:102-105`), and both call sites already pass
+the slug (`Shell.tsx:708`, `:989`); the state comes from `networkBySlug`, a
+module-scope store accessor rather than a prop; the verb needs `patchNetwork`
+and `token`, two plain imports. No new context, no new store, no `Shell.tsx`
+edit. Zero is below the threshold, so the seam gets the button.
+
+**The action is gated on the NETWORK cause, not on the collapsed `greyed()`
+boolean.** A failed or kicked *window* under a live network has nothing to
+unpark — the way back in is `/join` — so `networkGreyedState()` was split out
+of `greyed()` and the button hangs off that. The greyed visual and the
+`(not joined)` copy are unchanged.
+
+**A second surface for a verb is an extraction, not a copy.** The PATCH is
+one line, but the UX around it is not: awaited request, pending latch,
+friendly-mapped failure. That trio was a closure inside `HomePane`'s
+`DisconnectedRow`, and two hand-rolled implementations of the same recovery
+drift. `lib/networkReconnect.ts` now owns it and `DisconnectedRow` was moved
+onto it **in the same commit** — an extraction that leaves the original
+behind is just a copy with a preamble. The error *sink* stays with the caller,
+because each surface already owns an error line and a second one beside it
+would contradict the first: HomePane keeps its `role="alert"` span, the seam
+uses the #356 feedback line.
+
+**`lib/reconnect.ts` was left out on purpose, and the boundary is worth
+recording because the name argues against it.** Despite being called that, it
+is the #282 vhost bounce: it selects **connected** networks and does
+park-then-connect. On a parked network that is the wrong verb on the wrong
+set.
+
+**No confirmation modal — and this is a decision on record, not an
+omission.** The #195 confirm modal belongs to **Disconnect**; Reconnect is
+the awaited-PATCH UX by the ruling on #283 (2026-07-20), recorded in the
+comment on `HomePane`'s `onDisconnect` (`:299-307`: *"match the ×, not
+Reconnect's awaited-PATCH UX"*). Reconnect is also trivially reversible,
+which is the property that modal exists to protect. The comment alone is only
+an older opinion; what settles it is the consequence — five e2e specs press
+Reconnect with no confirm step and would hang on the click
+(`cp15-b6-parked-disconnect-reconnect.spec.ts:208`,
+`issue100-reconnecting-badge.spec.ts:123`,
+`issue248-lusers-no-auto-surface.spec.ts:106`,
+`issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts:113`,
+`issue511-failed-autojoin-dismiss-durable.spec.ts:133`). Changing the verb's
+UX is therefore a separate change that would touch the chip too and rewrite
+those five specs.
+
+**Not claimed:** the affordance is pinned at unit level only — no e2e was
+written or run, and nothing was checked in a real browser or on a mobile
+viewport. That those five specs scope their chip click to
+`.home-pane-network-row-parked`, and so cannot be made ambiguous by the
+seam's identically-named control, is read from their source rather than
+observed.


### PR DESCRIPTION
## Union branch — one gate, one merge

This branch carries three independent changes that were each green
against `6e555382`. A green check attests `branch + base`. It never
attests `branch + the other branches`. Merging three separately-green
PRs one after another therefore ships a combination that nothing has
ever gated — and because **two of the three append to
`docs/DESIGN_NOTES.md`**, they cannot fast-forward past each other:
landing them one at a time costs two rebases and two full `integration`
rounds, each one re-staling what is left. So the three are cherry-picked
onto current `main` here and gated **once, together**.

### What it carries

| Issue | Original PR | Commits | Area |
|-------|-------------|---------|------|
| #1089 | #1329 | 1 | order the live-append witness on a signal, not on luck |
| #1229 | #1324 | 7 | bound the unread exemption at `UNREAD_RETENTION_CAP` |
| #1331 | #1332 | 2 | offer the reconnect where the operator meets the parked state |

The commits are unchanged in content; only their SHAs differ, because
they were cherry-picked onto a newer base. Each PR was replayed with
**its own merge-base** (`base=$(git merge-base origin/main $HEAD); git
cherry-pick $base..$HEAD`), in the order #1329 → #1324 → #1332. Nothing
was edited, reworded, squashed or reordered: `git range-diff` against
each source reports `=` for nine of the ten commits, and the tenth
(`docs(#1331)`) differs only in **hunk context** — it now appends after
the #1229 entry instead of after #1323 — with identical added lines.

### Why the combination is safe to gate as one

Outside the decision log the three barely meet: #1089 is one e2e spec,
#1229 is `cicchetto/src/lib/scrollback.ts` + `ScrollbackPane.tsx` and
their tests, #1331 is a new `cicchetto/src/lib/networkReconnect.ts` plus
`HomePane.tsx`, `ComposeBox.tsx` and the theme. The one genuinely shared
file is `docs/DESIGN_NOTES.md`, where the two entries append at the same
point.

`docs/DESIGN_NOTES.md` carries `merge=union` in `.gitattributes`, so the
two entries merged without a conflict. That is convenient and not by
itself trustworthy — a union merge is exactly where an entry separator
gets eaten, and the eater removes three lines (blank / `---` / blank)
without ever showing up as a deletion. So the per-PR contribution was
pinned by `--numstat` before the union and the union verified to be the
exact sum:

| check | expected | measured |
|-------|----------|----------|
| `git diff --numstat origin/main HEAD -- docs/DESIGN_NOTES.md` | `140  0` | `140  0` |
| #1324's entry alone, against its own merge-base | 64 | `64  0` |
| #1332's entry alone, against its own merge-base | 76 | `76  0` |
| `grep -c '<!-- entry #1229 -->'` | 1 | 1 |
| `grep -c '<!-- entry #1331 -->'` | 1 | 1 |
| duplicated pre-existing markers | none | none |
| entry markers file-wide | 29 → 31 | 29 → 31 |

140 is the exact sum of 64 and 76, with zero deletions. Both entries are
whole and contiguous: `#1229` occupies 64 consecutive lines and `#1331`
the 76 that follow it to the end of the file. The boundary shape of each
was read on the bytes — prose, marker, blank, `---`, blank, heading —
and matches the shape of the last pre-existing entry, `#1323`.
`scripts/design-notes-gate.sh` passes.

### Gates on this branch

- `scripts/bun.sh run check` (biome + `tsc --noEmit` + `tsc --noEmit -p
  e2e/tsconfig.json`): exit 0.
- `scripts/bun.sh run test`: 283 files, 5474 tests, all passing, exit 0.
- `scripts/design-notes-gate.sh`: exit 0, `2 new entry heading(s),
  separator and marker present`.
- `origin/main` re-read after the gate run: still `6e555382`, so the
  gate is attested against the base this branch merges into.

### Note for the merger

The replay changes the commit SHAs, so GitHub will not close #1324,
#1329 and #1332 on its own; they are to be closed by hand, on content.
