### PR TITLE
e2e(#1336): make the scroll gesture prove it landed before the send

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -62,6 +62,7 @@
 
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
+import { type ScrollGestureResult, scrollByGesture } from "./scrollGesture";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
 const MOBILE_BREAKPOINT_PX = 768;
@@ -1332,4 +1333,36 @@ export async function inlineNickColorVar(locator: Locator): Promise<string> {
     throw new Error(`expected an inline nick-colour var on the span, got style=${String(style)}`);
   }
   return match[0];
+}
+
+// #1336 — page the scrollback UP with a wheel gesture that has demonstrably
+// LANDED before the caller moves on.
+//
+// `page.mouse.wheel()` resolves before the scroll is applied (measured: the
+// pane still read its pre-gesture `scrollTop` immediately after the call, and
+// moved ~250 ms later), so a spec that wheels and reads in one breath asserts
+// about a pane nobody has moved yet — and the scroll then lands inside the
+// NEXT step. The gesture core (`scrollGesture.ts`, unit-tested without a
+// testnet) owns the hover → wheel → moved-and-held wait and REJECTS both a
+// gesture that never landed and one still in flight.
+//
+// `pixels` is the distance to travel UP, positive; the DOM's negative-is-up
+// sign convention is applied here so callers read as the operator's intent.
+// Sampling every 50 ms: two agreeing samples then mean the pane has held
+// still for 50 ms, which chromium's wheel animation (hundreds of ms of
+// continuous travel, measured) does not do mid-flight.
+export async function pageScrollbackUp(
+  page: Page,
+  pixels: number,
+  timeoutMs: number,
+): Promise<ScrollGestureResult> {
+  const pane = page.locator('[data-testid="scrollback"]');
+  return await scrollByGesture(
+    {
+      hover: () => pane.hover(),
+      wheel: async (deltaY: number) => await page.mouse.wheel(0, deltaY),
+      scrollTop: () => pane.evaluate((el) => el.scrollTop),
+    },
+    { deltaY: -pixels, timeoutMs, pollMs: 50 },
+  );
 }

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -61,12 +61,14 @@ describe("#1336 — scrollByGesture", () => {
     expect(moved).toEqual({ from: 1078, to: 800 });
   });
 
-  it("does not return on the FIRST movement — it waits for the value to hold", async () => {
-    // 900 is a mid-flight sample; returning it would report a position the
-    // pane is about to leave, which is the whole defect being fixed.
-    const { pane } = fakePane([1078, 900, 800, 800]);
+  it("does not return on a mid-flight sample — it waits for two that AGREE", async () => {
+    // 900 and 800 are both mid-flight: the pane is still travelling and each
+    // would report a position it is about to leave, which is the whole defect
+    // being fixed. Only 700 repeats, so only 700 is a resting place. A
+    // "return once it changed twice" implementation answers 800 here.
+    const { pane } = fakePane([1078, 900, 800, 700, 700]);
     const moved = await scrollByGesture(pane, { deltaY: -4000, timeoutMs: 1_000, pollMs: 1 });
-    expect(moved.to).not.toBe(900);
+    expect(moved.to).toBe(700);
   });
 
   it("REJECTS when the wheel never moved the pane", async () => {

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -1,0 +1,95 @@
+// #1336 — the gesture is the instrument two scroll specs are judged by, so it
+// has to be evidence rather than a hope. Runs under the cic vitest project
+// (same reason, same shape as `whoisWait.test.ts`): the wait is deliberately
+// free of Playwright, so it is provable without a testnet.
+//
+// The cases that matter are the ones the OLD idiom
+// (`expect.poll(async () => { wheel(); return distance })`) got wrong:
+// the wheel had not been applied yet when the predicate was read, and the
+// predicate was ALREADY true of the pre-gesture state — measured on
+// issue168-scroll-authority, where `scrollTop` was byte-identical (1078)
+// before and after the "page up", and the scroll landed ~250 ms later,
+// inside the next step.
+
+import { describe, expect, it } from "vitest";
+import { type ScrollPane, scrollByGesture } from "./scrollGesture";
+
+type Recorded = { calls: string[]; pane: ScrollPane };
+
+// A pane whose scrollTop walks the given script, one entry per read.
+function fakePane(script: readonly number[]): Recorded {
+  const calls: string[] = [];
+  let reads = 0;
+  return {
+    calls,
+    pane: {
+      hover: async () => {
+        calls.push("hover");
+      },
+      wheel: async (deltaY: number) => {
+        calls.push(`wheel:${deltaY}`);
+      },
+      scrollTop: async () => {
+        const value = script[Math.min(reads, script.length - 1)] ?? 0;
+        reads += 1;
+        calls.push(`read:${value}`);
+        return value;
+      },
+    },
+  };
+}
+
+async function failureOf(gesture: Promise<unknown>): Promise<string> {
+  try {
+    await gesture;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected the gesture to reject, but it resolved");
+}
+
+describe("#1336 — scrollByGesture", () => {
+  it("hovers BEFORE it wheels", async () => {
+    const { calls, pane } = fakePane([1078, 500, 500]);
+    await scrollByGesture(pane, { deltaY: -4000, timeoutMs: 1_000, pollMs: 1 });
+    expect(calls.indexOf("hover")).toBeLessThan(calls.indexOf("wheel:-4000"));
+  });
+
+  it("returns the from/to pair once the scroll has moved and settled", async () => {
+    const { pane } = fakePane([1078, 900, 800, 800]);
+    const moved = await scrollByGesture(pane, { deltaY: -4000, timeoutMs: 1_000, pollMs: 1 });
+    expect(moved).toEqual({ from: 1078, to: 800 });
+  });
+
+  it("does not return on the FIRST movement — it waits for the value to hold", async () => {
+    // 900 is a mid-flight sample; returning it would report a position the
+    // pane is about to leave, which is the whole defect being fixed.
+    const { pane } = fakePane([1078, 900, 800, 800]);
+    const moved = await scrollByGesture(pane, { deltaY: -4000, timeoutMs: 1_000, pollMs: 1 });
+    expect(moved.to).not.toBe(900);
+  });
+
+  it("REJECTS when the wheel never moved the pane", async () => {
+    // Measured: a wheel dispatched with the mouse elsewhere is inert and the
+    // old idiom passed anyway, for a whole run.
+    const { pane } = fakePane([1078]);
+    expect(
+      await failureOf(scrollByGesture(pane, { deltaY: -4000, timeoutMs: 20, pollMs: 1 })),
+    ).toContain("never moved");
+  });
+
+  it("REJECTS when the pane is still moving at the deadline", async () => {
+    let value = 1078;
+    const pane: ScrollPane = {
+      hover: async () => {},
+      wheel: async () => {},
+      scrollTop: async () => {
+        value -= 10;
+        return value;
+      },
+    };
+    expect(
+      await failureOf(scrollByGesture(pane, { deltaY: -4000, timeoutMs: 20, pollMs: 1 })),
+    ).toContain("never settled");
+  });
+});

--- a/cicchetto/e2e/fixtures/scrollGesture.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.ts
@@ -1,0 +1,109 @@
+// #1336 — a scroll gesture that has actually LANDED before the test moves on.
+//
+// The idiom this replaces read like a gesture and was not one:
+//
+//     await expect.poll(async () => { await page.mouse.wheel(0, -4000);
+//                                     return distanceToBottom(page) })
+//       .toBeGreaterThan(50);
+//
+// Two independent defects, both measured on `issue168-scroll-authority`
+// (2026-08-15, dev host):
+//
+//   * `page.mouse.wheel()` RESOLVES BEFORE THE SCROLL IS APPLIED. The probe
+//     read `scrollTop=1078` immediately after the wheel — byte-identical to
+//     the pre-gesture read — and the pane was still at 1078 when the poll
+//     returned. On a sibling spec the injected wheel landed ~250 ms later,
+//     i.e. inside whatever the test did next.
+//   * THE PREDICATE WAS ALREADY TRUE. The pane sat 339 px from the bottom on
+//     the cold-mount marker, so `> 50` held before the wheel; the poll exited
+//     on its first evaluation and the assertion said "the operator paged up"
+//     about a pane nobody had touched. A gate satisfied by the pre-existing
+//     state is not a gate — the same shape as #1117's negative assertions
+//     passing on an empty recorder.
+//
+// The consequence is not cosmetic. The scroll lands late, and if it lands
+// after a send, `ScrollbackPane`'s `onScroll` reads the scrollTop DECREASE as
+// the operator leaving the tail, disarms the follow intent, and the deferred
+// tail-follow yields — the pane freezes wherever the late scroll left it, for
+// good. That is the whole of #1080 / #1079: a frozen pane's distance-to-bottom
+// is invariant under later content growth, which is why both reported the SAME
+// number every time they tripped (1417 = a pane at scrollTop 0; 337 = a pane
+// still on the marker).
+//
+// So the contract here is: hover, wheel, then wait for the pane to MOVE and
+// then HOLD, and REJECT if it never did either. Rejecting on "never moved" is
+// the positive control the old idiom lacked: while building this, an injected
+// wheel was silently inert for an entire run because the mouse was not over
+// the pane, and every assertion downstream still passed.
+//
+// Free of Playwright by construction (the caller adapts a Page to `ScrollPane`)
+// for the reason `whoisWait.ts` gives: the instrument a claim is judged by has
+// to be provable itself, and that means unit-testable without a testnet.
+
+export type ScrollPane = {
+  hover(): Promise<void>;
+  wheel(deltaY: number): Promise<void>;
+  scrollTop(): Promise<number>;
+};
+
+export type ScrollGestureOptions = {
+  // Wheel delta, in the sign the DOM uses: NEGATIVE scrolls up.
+  readonly deltaY: number;
+  // Budget for the whole gesture — dispatch, travel and settle.
+  readonly timeoutMs: number;
+  // Gap between scrollTop samples.
+  readonly pollMs: number;
+};
+
+export type ScrollGestureResult = {
+  readonly from: number;
+  readonly to: number;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Perform the gesture and resolve only once the pane has moved AND come to
+// rest. Rejects rather than resolving on either failure, because "it did not
+// move" and "it is still moving" are both the wrong thing to tell a caller who
+// is about to assert on the position.
+//
+// SETTLED means two consecutive samples agree at a value different from where
+// the pane started. A single post-movement sample is not enough: chromium
+// delivers a wheel as an animation, so the first changed value is mid-flight
+// and reporting it would name a position the pane is about to leave.
+//
+// A gesture the pane cannot honour (already clamped at the requested end) is a
+// REJECT, not a silent success: the caller asked for a displacement, and
+// "already there" does not establish the operator-intent the wheel stands for.
+export async function scrollByGesture(
+  pane: ScrollPane,
+  opts: ScrollGestureOptions,
+): Promise<ScrollGestureResult> {
+  const { deltaY, timeoutMs, pollMs } = opts;
+  const from = await pane.scrollTop();
+
+  await pane.hover();
+  await pane.wheel(deltaY);
+
+  const deadline = Date.now() + timeoutMs;
+  let moved = false;
+  let previous = from;
+
+  while (Date.now() < deadline) {
+    const current = await pane.scrollTop();
+    if (current !== from) {
+      if (moved && current === previous) return { from, to: current };
+      moved = true;
+    }
+    previous = current;
+    await sleep(pollMs);
+  }
+
+  throw new Error(
+    moved
+      ? `scrollByGesture: wheel(${deltaY}) never settled within ${timeoutMs}ms ` +
+          `(from ${from}, last ${previous}) — the pane was still moving when the budget ran out`
+      : `scrollByGesture: wheel(${deltaY}) never moved the pane within ${timeoutMs}ms ` +
+          `(scrollTop stayed ${from}) — the gesture was not delivered, or the pane is already clamped`,
+  );
+}

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -41,6 +41,7 @@ import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
+  pageScrollbackUp,
   scrollbackLines,
   selectChannel,
   waitForScrollbackRefreshed,
@@ -192,12 +193,15 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // marker-activation latch (arms the operator-input gate), so the subsequent
     // send goes through the normal follow path. A programmatic scrollTop set
     // would not arm the gate; the wheel event marks a genuine operator scroll.
-    await page.locator('[data-testid="scrollback"]').hover();
+    //
+    // #1336 — the gesture must have LANDED before the send. This used to wheel
+    // inside the poll below, which returned on its first evaluation because the
+    // pane was already 339px above the tail on the marker: the `> 50` was true
+    // of a pane nobody had moved, and the wheel's scroll arrived later, inside
+    // the send window, where it disarms the follow intent and freezes the pane.
+    await pageScrollbackUp(page, 4000, 5_000);
     await expect
-      .poll(async () => {
-        await page.mouse.wheel(0, -4000);
-        return await distanceToBottom(page);
-      })
+      .poll(async () => await distanceToBottom(page))
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // SEND — must snap back to the bottom UNCONDITIONALLY (issue #168 asks:


### PR DESCRIPTION
First step of the #1336 epic: the deterministic pair (#1080 / #1079). This ships the
**instrument only** — no product code, no assertion, threshold or timeout changed.

## The defect this fixes

`issue168-scroll-authority`'s "operator PAGES UP" wheeled *inside* the `expect.poll` that
was supposed to observe it:

```ts
await page.locator('[data-testid="scrollback"]').hover();
await expect
  .poll(async () => { await page.mouse.wheel(0, -4000); return await distanceToBottom(page); })
  .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
```

Two independent defects, both measured on the dev host (2026-08-15):

* **`page.mouse.wheel()` resolves before the scroll is applied.** A geometry probe read
  `scrollTop=1078` immediately before and immediately after the call. On a sibling spec
  an injected wheel landed **~250 ms later**.
* **The predicate was already true of the pre-gesture state.** The cold-mount marker
  leaves the pane **339 px** above the tail, so `> 50` held *before* the wheel and the
  poll returned on its first evaluation — the assertion described a pane nobody had
  moved.

The consequence is the epic's "same number twice". The scroll lands late; if it lands
after the send, `ScrollbackPane`'s `onScroll` reads the `scrollTop` DECREASE as the
operator leaving the tail (`nextFollowMode(_, "scroll-up") → false`), and the deferred
tail-follow yields on `if (!followMode()) return`. The pane then freezes wherever the
late scroll left it, permanently — and a frozen pane's distance-to-bottom does not change
when content grows. That is why #1080 reported **1417** (a pane at `scrollTop 0`;
`maxScroll = 1629 − 212`, measured) and #1079 reported **337** (`1627 − 1078 − 212`, the
pane still on the marker) *every single time they tripped*.

Attribution was by displacement, in the previous round: injecting a scroll-up right after
`composeSend` reproduces the freeze in isolation and the failing value tracks the
injection one-for-one — `−4000 → 2464` (clamped at the top), `−300 → 300`,
`−100 → 107`.

## What is in the diff

* `cicchetto/e2e/fixtures/scrollGesture.ts` — hover → wheel → **wait for the pane to MOVE
  and then HOLD**, rejecting if it did neither. Playwright-free by construction so it is
  unit-testable without a testnet, the argument `whoisWait.ts` already makes here: the
  instrument a claim is judged by has to be provable itself.
* `cicchetto/e2e/fixtures/scrollGesture.test.ts` — 5 unit tests.
* `cicchetto/e2e/fixtures/cicchettoPage.ts` — `pageScrollbackUp(page, pixels, timeoutMs)`,
  the Playwright adapter (additive export).
* `cicchetto/e2e/tests/issue168-scroll-authority.spec.ts` — the one call site. **The
  assertion is unchanged**: same predicate, same threshold, same timeout. It is simply no
  longer evaluated against a pane the test has not touched yet.

## Evidence

* **TDD, red read by name**: `Failed to resolve import "./scrollGesture" from
  "e2e/fixtures/scrollGesture.test.ts"` before the module existed.
* **Mutation, one mutant at a time:**

  | mutant | tests killed |
  |---|---|
  | return on the FIRST changed sample (drop the hold requirement) | **2** — the settle witness and the still-moving reject |
  | wheel BEFORE hover | **1** — the ordering test |
  | never-moved resolves `{from, from}` instead of rejecting | **1** — the inert-gesture reject |

  The first version of the settle witness **survived its own mutant** (the fake script
  could not tell "held still" from "changed twice"); commit `d586c3ad` tightens it.

* **In-situ positive control.** Removing the `hover()` from the adapter turns the spec RED
  with `scrollByGesture: wheel(-4000) never moved the pane within 5000ms (scrollTop stayed
  1078)`. `1078` is the marker position — **exactly the state the old idiom passed on**.

* **Gates.** `scripts/bun.sh run check` RC=0 (biome + tsc over `src` and `e2e`). Pair
  (`issue168-scroll-authority` + `scroll-on-window-switch`, chromium): 6 passed.
  **Full `scripts/integration.sh`: 747 passed / 0 failed, RC=0, 28.7 min.**

## Scope, and what is deliberately absent

* **One call site.** The other spec of the pair, `scroll-on-window-switch`, has **no
  gesture at all** — every gesture-shaped token in it is inside a comment. It parks on the
  marker through a *programmatic* activation, so the shared cause has two different
  triggers and only #1080's is the gesture idiom.
* **Nothing built for #1079.** The same core could serve it as a pre-send *settle*
  barrier, but its late-scroll source is inference, not measurement — a barrier over an
  unmeasured write is the symptom-papering this epic exists to refuse.
* **The other six `mouse.wheel` specs are untouched**, including
  `login-advanced-scroll-reachability.spec.ts:85-89`, which carries the identical idiom.
  Named, not converted: the brief was to see the mechanism hold on the pair first.
* **No product change.** `ScrollbackPane.tsx` is untouched. Whether "#168 scrolls to the
  bottom *unconditionally*" should survive a scroll arriving a few hundred ms after enter
  is a product question, open with the maintainer, and nothing here assumes an answer.

## Not claimed

* **The natural failure was never reproduced.** Every red above was produced by an
  injected scroll or a deliberate mutant, so this cannot be called a fix for #1080 — only
  that the spec no longer asserts about an untouched pane and the gesture can no longer
  land inside the send window on this host.
* **The 50 ms sample gap is a choice, not a measurement** — I did not profile chromium's
  wheel animation to prove it cannot plateau for that long mid-flight.
* The full-suite green was measured at base `575e203a`; `origin/main` has since moved to
  `3a8eddec`, whose delta is **docs-only** (`docs/reviews/`, 2 files).
