### PR TITLE
Restore unknown-is-never-fatal at three boundaries (#1338)

### DIFF
--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1981,18 +1981,33 @@ describe("userTopic", () => {
       expect(flagOrder).toBeLessThan(clearOrder);
     });
 
-    it("drops the event when code is not rate_limit_flood (narrower rejects)", async () => {
-      const fs = await import("../lib/floodSever");
+    // #1338 X-S14 — the sever ACTION (drop to login) does not depend on the
+    // code; the code only selects the copy. An additively-added sever reason
+    // must therefore still bounce the user to the login screen, generic
+    // banner and all, instead of leaving them on a dead shell holding a
+    // revoked bearer waiting for the WS reconnect-failure path (#630's
+    // stated must-not-happen).
+    it("clears auth on an unrecognised code (unknown-is-never-fatal)", async () => {
       const authMod = await import("../lib/auth");
-      channelMock.fireEvent({ kind: "web_session_severed", code: "something_else" });
-      expect(fs.setSeveredForFlood).not.toHaveBeenCalled();
-      expect(authMod.clearLocalAuth).not.toHaveBeenCalled();
+      channelMock.fireEvent({ kind: "web_session_severed", code: "operator_kill" });
+      expect(authMod.clearLocalAuth).toHaveBeenCalled();
     });
 
+    it("does NOT latch the flood copy for an unrecognised code", async () => {
+      const fs = await import("../lib/floodSever");
+      channelMock.fireEvent({ kind: "web_session_severed", code: "operator_kill" });
+      expect(fs.setSeveredForFlood).not.toHaveBeenCalled();
+    });
+
+    // The tolerance is over the VALUE of a required field, not over its
+    // absence: a payload with no `code` is malformed, not additive, and the
+    // narrower still rejects it.
     it("drops the event when code is missing (narrower rejects)", async () => {
       const fs = await import("../lib/floodSever");
+      const authMod = await import("../lib/auth");
       channelMock.fireEvent({ kind: "web_session_severed" });
       expect(fs.setSeveredForFlood).not.toHaveBeenCalled();
+      expect(authMod.clearLocalAuth).not.toHaveBeenCalled();
     });
 
     it("does NOT latch the flag for unrelated events", async () => {
@@ -2212,10 +2227,12 @@ describe("narrowUserEvent — links_bundle (#238)", () => {
   });
 });
 
-// #630 — web_session_severed: the inbound-flood sever event. `code` is a
-// closed single-value set ("rate_limit_flood"), narrowed strictly at ingress
-// (mirrors the away_confirmed / connection_progress closed-set guards).
-describe("narrowUserEvent — web_session_severed (#630)", () => {
+// #630 — web_session_severed: the inbound-flood sever event. #1338 X-S14
+// widened `code` from the closed literal to any string: the server may add a
+// sever reason additively (#447), and the event's action is code-independent,
+// so narrowing on the value would drop a terminal event. Same posture as the
+// `recover_result.reason` arm two cases up.
+describe("narrowUserEvent — web_session_severed (#630, #1338)", () => {
   it("narrows a valid rate_limit_flood event", async () => {
     const { narrowUserEvent } = await import("../lib/userTopic");
     expect(narrowUserEvent({ kind: "web_session_severed", code: "rate_limit_flood" })).toEqual({
@@ -2224,13 +2241,21 @@ describe("narrowUserEvent — web_session_severed (#630)", () => {
     });
   });
 
-  it("rejects an unknown code", async () => {
+  it("passes an unrecognised code through verbatim", async () => {
     const { narrowUserEvent } = await import("../lib/userTopic");
-    expect(narrowUserEvent({ kind: "web_session_severed", code: "nope" })).toBeNull();
+    expect(narrowUserEvent({ kind: "web_session_severed", code: "operator_kill" })).toEqual({
+      kind: "web_session_severed",
+      code: "operator_kill",
+    });
   });
 
   it("rejects a missing code", async () => {
     const { narrowUserEvent } = await import("../lib/userTopic");
     expect(narrowUserEvent({ kind: "web_session_severed" })).toBeNull();
+  });
+
+  it("rejects a non-string code", async () => {
+    const { narrowUserEvent } = await import("../lib/userTopic");
+    expect(narrowUserEvent({ kind: "web_session_severed", code: 42 })).toBeNull();
   });
 });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -48,7 +48,6 @@ import type {
   NetworksWireVisitorNetworkWithNickJson,
   NotifyWireEntry,
   QueryWindowsWireWindowsEntry,
-  RateLimitWireWebSessionSeveredEvent,
   ScrollbackMessageKind,
   ScrollbackWireArchiveWireEntry,
   ScrollbackWireT,
@@ -1327,12 +1326,17 @@ export type WireUserEvent =
   // inbound, the server broadcasts this on the user topic, THEN revokes the
   // bearer + closes the socket. cic latches `severedForFlood` (floodSever.ts)
   // so the re-login screen shows a dedicated "disconnected for sending too
-  // fast" banner. The arm reuses the generated `RateLimitWireWebSessionSevered
-  // Event` shape DIRECTLY — equality holds by construction, so no `_Assert_`
-  // pin is needed (same SSOT posture as the #410 leaf-enum aliases). `code`
-  // is a closed single-value set ("rate_limit_flood") narrowed strictly at
-  // ingress in userTopic.ts.
-  | RateLimitWireWebSessionSeveredEvent;
+  // fast" banner.
+  //
+  // #1338 X-S14 — `code` is WIDER here than in the generated mirror
+  // (`RateLimitWireWebSessionSeveredEvent` pins today's sole
+  // "rate_limit_flood"). Deliberate, and the same call as
+  // `recover_result.reason` above: the server may add a sever reason
+  // additively (#447), the drop-to-login action does not depend on the code,
+  // and a narrower ingress type would turn an additive token into a dropped
+  // terminal event. The generated literal stays the SERVER's honest
+  // statement of what it emits today; tolerance is the client's job.
+  | { kind: "web_session_severed"; code: string };
 
 // M-11 — Admin events stream. Discriminated union mirrors
 // `Grappa.AdminEvents.Wire`'s closed `event_kind` enum. Server emits

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -1010,11 +1010,16 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         reason: r.reason as string | null,
       };
     case "web_session_severed":
-      // #630 — inbound-flood web-session sever. `code` is a closed
-      // single-value set; anything but "rate_limit_flood" drops the payload
-      // (mirrors the away_confirmed / connection_progress closed-set guards).
-      if (r.code !== "rate_limit_flood") return null;
-      return { kind: "web_session_severed", code: "rate_limit_flood" };
+      // #630 — inbound-flood web-session sever. #1338 X-S14 widened `code`
+      // from the closed literal to any string, the `recover_result.reason`
+      // posture two arms up: the server may add a sever reason additively
+      // (#447), the event's ACTION does not depend on the code, and dropping
+      // a terminal event over an unrecognised value would strand the client
+      // on a dead shell holding a revoked bearer. The value is carried
+      // verbatim — it selects copy, nothing else. A missing or non-string
+      // `code` is malformed rather than additive, and still drops.
+      if (typeof r.code !== "string") return null;
+      return { kind: "web_session_severed", code: r.code };
     default:
       return null;
   }
@@ -1648,7 +1653,11 @@ moduleRoot(() => {
           //       setToken(null) does NOT reset the flood flag (the clear is
           //       guarded on a non-null bearer), so the banner survives to be
           //       rendered on the login screen.
-          setSeveredForFlood(true);
+          // #1338 X-S14 — step (2) is UNCONDITIONAL, step (1) is the copy.
+          // Only "rate_limit_flood" earns the dedicated flood banner; any
+          // other sever reason still drops to login, on the generic
+          // logged-out screen `Grappa.RateLimit.Wire` names as the fallback.
+          if (payload.code === "rate_limit_flood") setSeveredForFlood(true);
           clearLocalAuth();
           return;
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42706,3 +42706,72 @@ viewport. That those five specs scope their chip click to
 `.home-pane-network-row-parked`, and so cannot be made ambiguous by the
 seam's identically-named control, is read from their source rather than
 observed.
+<!-- entry #1338 -->
+
+---
+
+## 2026-08-15 — #1338: unknown-is-never-fatal at three boundaries, and the one place it must not reach
+
+Three findings from the 2026-08-15 codebase review (M-S2, W-S1, X-S14) are
+one class: a supervised process or a boundary that treats an unrecognised
+but legal input as FATAL, against the additive-only contract. Each is fixed
+by inheriting a shape the codebase already carries — `IRC.Client`'s logging
+`handle_info` catch-all, `MessagesController.parse_after/1`'s
+"present-and-unparseable = 400", and the `recover_result.reason` widening in
+`api.ts`. Only two things here are decisions rather than transcription.
+
+**`SessionRevocationListener`'s missing catch-all was DOCUMENTED as
+deliberate, and is reversed anyway.** The moduledoc argued that
+`Revocations.announce/1` is the sole publisher, so an unknown message means a
+second publisher appeared and a crash surfaces it. Two answers. First, the
+catch-all surfaces it too — a `Logger.warning` on the allowlisted
+`unexpected:` key, greppable, the same line `IRC.Client` has emitted for a
+year; "crash so someone notices" buys nothing a log does not, and costs the
+mailbox behind the unknown message, so a genuine `{:sessions_revoked, _}`
+queued behind it dies unserved. Second, a second publisher is a REPEATING
+condition: crashing per message walks the supervisor's restart intensity, and
+the process that turns bearer death into WS teardown is then gone for good.
+The old rationale optimised for noticing a bug and, in doing so, chose the
+failure mode (silent un-revoked sessions) it was trying to prevent. The
+moduledoc now states why the catch-all does not weaken the teardown, not
+merely that it exists — the guarantee is per-message and stateless, so
+dropping the message we cannot read and serving the next is strictly more
+teardown, never less.
+
+**In `Session.Server` the EXIT class is carved OUT of the catch-all, and that
+carve-out is load-bearing.** `init/1` traps exits, so an abnormal exit from a
+linked process arrives as a mailbox message; a blanket catch-all would answer
+a dead dependency with a log line — verbatim the "safety net that silently
+absorbs the next class of bug" CLAUDE.md names. An explicit
+`{:EXIT, _, reason} -> {:stop, reason, state}` sits AHEAD of the catch-all
+(the clean `:normal` / `:shutdown` clause is further up and keeps its own
+non-restart semantics), preserving what the pre-#1338 `FunctionClauseError`
+did by accident: `terminate/2` records the Backoff failure and the
+`:transient` supervisor rebuilds. This has a visible consequence in the test
+suite. REV-D's H12 regression used to synthesize a non-Client crash by
+sending an unhandled message — a mechanism that only worked BECAUSE there was
+no catch-all — and now drives `Process.exit/2` through the EXIT clause
+instead. That test is therefore the alarm on the carve-out: widen the
+catch-all over the EXIT class and H12 goes red.
+
+**X-S14 is widened on the CLIENT only.** `Grappa.RateLimit.Wire`'s typespec
+keeps `code: :rate_limit_flood` — an honest statement of the single reason
+the server emits today, and the `@doc`'s claim that a second one is a
+reviewed addition stays true. What was wrong was the client narrowing on that
+VALUE: the sever's action (latch, clear local auth, drop to login) does not
+depend on the code, the code only selects copy, so rejecting an unrecognised
+one left the client on a dead shell holding a revoked bearer — the #630
+comment's stated must-not-happen. `userTopic.ts` now accepts any string and
+carries it verbatim; only `"rate_limit_flood"` latches the dedicated banner,
+anything else lands on the generic logged-out screen `RateLimit.Wire` already
+names as the fallback. `api.ts` hand-widens the arm to `code: string` instead
+of reusing the generated literal mirror, the same deliberate divergence
+`recover_result.reason` documents two arms up. The tolerance is over the
+VALUE of a required field, not over its absence: a payload with no `code`, or
+a non-string one, is malformed rather than additive and still drops.
+
+**Not claimed.** No e2e was run: `issue630-flood-protection.spec.ts` exercises
+the known code only, and that path is unchanged by construction, but nothing
+was observed in a browser. Nothing here was observed in production either —
+all three are contract fixes for inputs no publisher sends TODAY, which is
+exactly why none of them had a compile error to catch them.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3733,6 +3733,29 @@ defmodule Grappa.Session.Server do
 
   def handle_info({:irc, %Message{} = msg}, state), do: delegate(msg, state)
 
+  # #1338 M-S2 — the EXIT class stays FATAL, ahead of the catch-all below.
+  # `init/1` traps exits, so a linked process dying abnormally arrives as a
+  # mailbox message; the clean `:normal` / `:shutdown` reasons have their own
+  # clause above. Answering a dead dependency with a log line is exactly the
+  # "safety net that silently absorbs the next class of bug" CLAUDE.md names,
+  # so an abnormal reason is propagated: `terminate/2` records the Backoff
+  # failure and the `:transient` supervisor rebuilds the session with fresh
+  # state, which is what happened pre-#1338 via the FunctionClauseError.
+  def handle_info({:EXIT, _, reason}, state), do: {:stop, reason, state}
+
+  # #1338 M-S2 — unknown-is-never-fatal, verbatim from `IRC.Client`. This
+  # process subscribes to `Topic.ws_presence/1` and `Topic.user_settings/1`,
+  # and the #447 additive-only contract lets a publisher add an event type at
+  # any time with no version bump and no compile error. Without this clause
+  # the first such addition takes down EVERY session of that subject with a
+  # FunctionClauseError — dropping a live IRC connection over a change made
+  # in an unrelated context. Loud, logged, and narrower than it looks: the
+  # EXIT class is handled above.
+  def handle_info(msg, state) do
+    Logger.warning("unexpected mailbox message", unexpected: inspect(msg))
+    {:noreply, state}
+  end
+
   # Terminal failure handling — k-line or permanent SASL (Decision C,
   # locked). Fires the `credential_failer` callback (if present) in a
   # detached, SUPERVISED Task so the DB transition + PubSub broadcast happen

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -481,6 +481,13 @@ defmodule GrappaWeb.MessagesController do
     end
   end
 
+  # #1338 W-S1 — same catch-all, same reason as `parse_after/1` above: the
+  # three cursors reach here straight off `Plug.Conn.Query`, which decodes
+  # `?before[]=1` to a LIST and `?before[k]=1` to a MAP. Without it those are
+  # a FunctionClauseError — a 500 with a stacktrace, past the
+  # FallbackController, for a plainly malformed request.
+  defp parse_int(_), do: {:error, :bad_request}
+
   defp parse_limit(nil), do: {:ok, @default_limit}
 
   # HTTP-boundary ceiling per CLAUDE.md "Validate at the boundary". The
@@ -493,4 +500,8 @@ defmodule GrappaWeb.MessagesController do
       _ -> {:error, :bad_request}
     end
   end
+
+  # #1338 W-S1 — `?limit[]=1` is the list-shaped twin of the cursor case
+  # above. `nil` (absent) has its own clause and keeps the default.
+  defp parse_limit(_), do: {:error, :bad_request}
 end

--- a/lib/grappa_web/session_revocation_listener.ex
+++ b/lib/grappa_web/session_revocation_listener.ex
@@ -47,11 +47,11 @@ defmodule GrappaWeb.SessionRevocationListener do
 
   use GenServer
 
-  require Logger
-
   alias Grappa.Accounts.Revocations
   alias Grappa.Subject
   alias GrappaWeb.UserSocket
+
+  require Logger
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts), do: GenServer.start_link(__MODULE__, :ok, opts)

--- a/lib/grappa_web/session_revocation_listener.ex
+++ b/lib/grappa_web/session_revocation_listener.ex
@@ -19,13 +19,35 @@ defmodule GrappaWeb.SessionRevocationListener do
   teardown broadcast goes through `GrappaWeb.Endpoint`, and a node
   without one has no sockets to close either.
 
-  No catch-all `handle_info/2`. `Revocations.announce/1` is the sole
-  publisher on the topic, so an unrecognised message means a second
-  publisher appeared — a crash surfaces it rather than dropping the
-  teardown silently.
+  ## Why the catch-all does not weaken the teardown (#1338 M-S2)
+
+  This module used to have no catch-all `handle_info/2`, on the argument
+  that `Revocations.announce/1` is the sole publisher on the topic, so an
+  unrecognised message means a second publisher appeared and a crash
+  surfaces it. The catch-all keeps that surfacing — it logs at warning
+  with the allowlisted `unexpected:` key, the same shape `Grappa.IRC.Client`
+  uses — while removing the two ways the crash made teardown WORSE, not
+  better:
+
+    * The teardown this process performs is per-MESSAGE and stateless. A
+      crash cannot roll back or retry the unrecognised message; it only
+      discards the mailbox behind it, so a genuine `{:sessions_revoked, _}`
+      queued after an unknown one dies with it. The catch-all drops the
+      message it cannot read and serves the next — strictly more teardown,
+      never less.
+    * A second publisher is a repeating condition, not a one-shot. Crashing
+      per message walks the supervisor's restart intensity, and the process
+      that turns bearer death into WS teardown is then gone for good — the
+      failure mode is silent revocations, precisely what the crash was
+      meant to prevent.
+
+  Nothing here recovers from an unknown message: it is logged loudly and
+  dropped. What survives is the ability to tear down the NEXT one.
   """
 
   use GenServer
+
+  require Logger
 
   alias Grappa.Accounts.Revocations
   alias Grappa.Subject
@@ -43,6 +65,11 @@ defmodule GrappaWeb.SessionRevocationListener do
   @impl GenServer
   def handle_info({:sessions_revoked, subject}, state) do
     :ok = subject |> Subject.label() |> UserSocket.disconnect_user_name()
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warning("unexpected mailbox message", unexpected: inspect(msg))
     {:noreply, state}
   end
 end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -989,12 +989,19 @@ defmodule Grappa.Session.ServerTest do
     # the linked-Client EXIT clause + `do_start_client/2` only; any other
     # crash class bypassed the bump and the `:transient` respawn fired with
     # no delay. The fix funnels the call into `terminate/2`'s abnormal-
-    # reason clause so every crash path bumps once. Synthesize via an
-    # unhandled message: handle_info has no catchall, so the server raises
-    # FunctionClauseError → GenServer treats the callback raise as an
-    # abnormal exit → terminate/2 fires with non-`:normal`/`:shutdown`
-    # reason → Backoff.record_failure runs.
-    test "non-Client-EXIT crash (callback raise) DOES record a Backoff failure (H12)" do
+    # reason clause so every crash path bumps once.
+    #
+    # Synthesized via an abnormal EXIT from an UNLINKED sender. It used to be
+    # an unhandled message, on the premise that `handle_info` had no
+    # catch-all; #1338 M-S2 added one (a supervised process must not die of
+    # an additively-published event), so that mechanism now returns
+    # `{:noreply, state}` and proves nothing. The EXIT class is deliberately
+    # excluded from the catch-all and is still fatal, which keeps a
+    # non-Client crash class available here: trap_exit turns
+    # `Process.exit/2` into a mailbox message → the EXIT clause stops with
+    # the abnormal reason → terminate/2 fires with non-`:normal`/`:shutdown`
+    # → Backoff.record_failure runs.
+    test "non-Client-EXIT crash DOES record a Backoff failure (H12)" do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
@@ -1006,9 +1013,9 @@ defmodule Grappa.Session.ServerTest do
       Process.flag(:trap_exit, true)
 
       # Suppress the expected GenServer crash report from polluting test
-      # output. The server WILL raise — that's the point of the test.
+      # output. The server WILL die — that's the point of the test.
       ExUnit.CaptureLog.capture_log(fn ->
-        send(pid, {:rev_d_h12_synthetic_unhandled, :rev_d_h12})
+        Process.exit(pid, :rev_d_h12_synthetic_crash)
         assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1_500
       end)
 
@@ -12486,6 +12493,68 @@ defmodule Grappa.Session.ServerTest do
                        }
                      },
                      1_000
+    end
+  end
+
+  describe "unmodelled mailbox message (#1338 M-S2)" do
+    test "an unrecognised message is logged and the session keeps serving" do
+      # The server subscribes to `Topic.ws_presence/1` and
+      # `Topic.user_settings/1` — the settings bridge is a surface the
+      # #447 additive-only contract lets grow WITHOUT a version bump. Before
+      # #1338 a second tuple published by `Grappa.UserSettings` reached 40
+      # clauses and no catch-all: FunctionClauseError, supervisor restart,
+      # and the user's IRC connection dropped by an unrelated context.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      ref = Process.monitor(pid)
+
+      log =
+        capture_log(fn ->
+          send(pid, {:user_settings_changed, :a_key_this_version_never_heard_of, true})
+
+          # A synchronous call behind the send: the mailbox is FIFO, so a
+          # reply proves the unknown message was processed, not merely
+          # queued. `connection_info/2` is the probe rather than
+          # `casemapping/2`, which answers `:ascii` for a DEAD session too
+          # and would pass against the very crash under test.
+          assert {:ok, %{server: "127.0.0.1", port: ^port}} =
+                   Session.connection_info({:user, user.id}, network.id)
+        end)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 100
+      assert Process.alive?(pid)
+      assert log =~ "unexpected mailbox message"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an abnormal EXIT from a linked process still stops the session" do
+      # The guard on the catch-all above. `init/1` sets `trap_exit`, so an
+      # abnormal exit from a linked process arrives as a MESSAGE — and a
+      # blanket catch-all would answer a dead dependency with a log line.
+      # Only `:normal` / `:shutdown` are survivable (their own clause);
+      # everything else must still take the session down so the supervisor
+      # rebuilds it. Green before #1338 (FunctionClauseError) and after
+      # (an explicit `{:stop, reason, state}`): the mutant it kills is a
+      # catch-all placed ahead of the EXIT class.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      ref = Process.monitor(pid)
+      Process.flag(:trap_exit, true)
+
+      capture_log(fn ->
+        send(pid, {:EXIT, self(), :synthetic_linked_sibling_crash})
+
+        assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1_500
+      end)
+
+      refute Process.alive?(pid)
     end
   end
 end

--- a/test/grappa_web/controllers/messages_controller_test.exs
+++ b/test/grappa_web/controllers/messages_controller_test.exs
@@ -320,6 +320,24 @@ defmodule GrappaWeb.MessagesControllerTest do
     assert json_response(conn, 400)["error"] == "bad_request"
   end
 
+  # #1338 W-S1 — `Plug.Conn.Query` decodes `?before[]=1` to a LIST and
+  # `?limit[a]=1` to a MAP. Both are shapes a client can send with no
+  # cooperation from us, and this controller's rule is "present and
+  # unparseable = 400" — not a 500 with a stacktrace past the
+  # FallbackController. `parse_after/1` already carries this catch-all;
+  # these four params were the ones left behind.
+  for param <- ~w(before after around limit) do
+    test "GET a list-valued ?#{param} returns 400, not a 500", %{conn: conn} do
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages?#{unquote(param)}[]=1")
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
+    test "GET a map-valued ?#{param} returns 400, not a 500", %{conn: conn} do
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages?#{unquote(param)}[k]=1")
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+  end
+
   test "GET ?limit=200 is accepted (boundary)", %{conn: conn, user: user, network: network} do
     seed(user, network)
     conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages?limit=200")

--- a/test/grappa_web/session_revocation_listener_test.exs
+++ b/test/grappa_web/session_revocation_listener_test.exs
@@ -15,9 +15,11 @@ defmodule GrappaWeb.SessionRevocationListenerTest do
   """
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Grappa.Accounts.{Revocations, User}
   alias Grappa.Visitors.Visitor
-  alias GrappaWeb.{Endpoint, UserSocket}
+  alias GrappaWeb.{Endpoint, SessionRevocationListener, UserSocket}
 
   test "a user announcement pushes disconnect on that user's socket id-topic" do
     name = "revoked-#{System.unique_integer([:positive])}"
@@ -47,5 +49,33 @@ defmodule GrappaWeb.SessionRevocationListenerTest do
     :ok = Revocations.announce({:user, "revoked-#{System.unique_integer([:positive])}"})
 
     refute_receive %Phoenix.Socket.Broadcast{topic: ^socket_id}, 100
+  end
+
+  # #1338 M-S2 — an unrecognised message must not cost the process. The
+  # teardown guarantee is what this listener exists for, so the test
+  # asserts BOTH halves in one go: the unknown message is survived AND a
+  # real revocation immediately after it still reaches the id-topic. A
+  # test that only proved survival would be satisfied by a listener that
+  # survived by no longer listening.
+  test "an unmodelled message is logged, and a real revocation still tears down" do
+    pid = Process.whereis(SessionRevocationListener)
+    assert is_pid(pid), "the ambient listener must be in the application tree"
+    ref = Process.monitor(pid)
+
+    name = "revoked-#{System.unique_integer([:positive])}"
+    socket_id = UserSocket.id_for_subject({:user, %User{name: name}})
+    :ok = Endpoint.subscribe(socket_id)
+
+    log =
+      capture_log(fn ->
+        send(pid, {:sessions_revoked_v2, {:user, name}, :a_field_this_version_never_heard_of})
+
+        :ok = Revocations.announce({:user, name})
+
+        assert_receive %Phoenix.Socket.Broadcast{topic: ^socket_id, event: "disconnect"}
+      end)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 100
+    assert log =~ "unexpected mailbox message"
   end
 end


### PR DESCRIPTION
Bucket from the 2026-08-15 codebase review (issue #1338): three findings, one
class — a supervised process or a boundary that treats an unrecognised but
legal input as FATAL, against the additive-only wire contract. Each fix
inherits a shape the codebase already carries rather than inventing one.

## M-S2 — `Session.Server` and `SessionRevocationListener` had no catch-all

40 `handle_info` clauses, zero catch-all, on a process subscribed to the
ws-presence and user-settings topics. The first extra tuple `Grappa.UserSettings`
broadcasts would take down every session of that subject with a
`FunctionClauseError` and drop a live IRC connection — caused by an unrelated
context, with no compile error. `IRC.Client` has carried the loud, logging
catch-all for the lower-stakes process all along; this copies it.

**The EXIT class is deliberately carved out and stays fatal.** `init/1` traps
exits, so a linked process dying abnormally arrives as a message, and answering
a dead dependency with a log line is exactly the safety net that absorbs the
next class of bug. An explicit `{:EXIT, _, reason} -> {:stop, reason, state}`
sits ahead of the catch-all and preserves what the `FunctionClauseError` did by
accident: `terminate/2` records the Backoff failure and the `:transient`
supervisor rebuilds. REV-D's H12 regression synthesized its non-Client crash
*through* the absence of a catch-all, so it now drives `Process.exit/2` through
that clause — which makes it the alarm on the carve-out.

**`SessionRevocationListener` reverses its own moduledoc**, which argued that a
crash surfaces a second publisher. It buys nothing the warning log does not,
and costs the mailbox behind the unknown message plus — since a second
publisher repeats — the process itself once restart intensity runs out. The
moduledoc now states why the catch-all does not weaken the teardown guarantee:
that guarantee is per-message and stateless, so dropping what it cannot read
and serving the next is strictly more teardown, never less.

## W-S1 — `MessagesController` 500s on list- or map-shaped pagination params

`parse_int/1` and `parse_limit/1` were binary-only, but `Plug.Conn.Query`
decodes `?before[]=1` to a list and `?before[k]=1` to a map with no cooperation
from the client. Four params answered a malformed request with a stacktrace
past the `FallbackController`, on a route documented as "present and
unparseable = 400". `parse_after/1`, one function away, already carries the
catch-all and the count endpoint already has the test.

## X-S14 — the client hard-dropped an unrecognised sever code

The sever's action (latch, clear local auth, drop to login) does not depend on
the code; the code only selects copy. Rejecting an unrecognised one left cic on
a dead shell holding a revoked bearer, waiting for the WS reconnect-failure
path — #630's own stated must-not-happen. `code` is now any string, carried
verbatim; clearing auth is unconditional, only `rate_limit_flood` latches the
dedicated banner, anything else lands on the generic logged-out screen
`Grappa.RateLimit.Wire` already names as the fallback. Widened on the CLIENT
only: the server typespec keeps the closed literal, an honest statement of what
it emits today, and `api.ts` hand-widens the arm the way `recover_result.reason`
already does two arms up.

## Tests

Failing test first for each. M-S2's sends an unmodelled message and asserts the
process survives AND keeps serving (`connection_info/2` behind the send, not
`casemapping/2`, which answers `:ascii` for a dead session and would pass
against the very crash under test); the listener's asserts a REAL revocation
still tears down after the unknown message, because survival alone is satisfied
by a listener that survived by no longer listening. A second server test pins
the EXIT carve-out.

## Verification

- cic gates green: 283 files / 5476 tests, biome + tsc, `RC=0`.
- Three client-side mutants, each killed by exactly the assertions meant for it
  and nothing else: restore the closed-set narrowing (2 failures), latch the
  banner unconditionally (1), drop the string guard (3).
- `scripts/design-notes-gate.sh` green.
- **Not run locally:** the Elixir gates — the COMPILE lane was contended, so
  the server half is gated by this PR's CI rather than by a local run.
- **Not run:** e2e. `issue630-flood-protection.spec.ts` exercises the known code
  only and that path is unchanged by construction, but nothing was observed in
  a browser.