### PR TITLE
#1340: finish the nick-identity migration set (C-S1 stale ownNick, K-S2 muted_targets)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,13 +151,18 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   a fold-collision with an existing `new` window), the DM scrollback
   (`Scrollback.rename_dm_peer/4` — `dm_with` + outbound/orphan `channel`),
   the DM read cursor (`ReadCursor.rename_dm_peer/4` — else the migrated
-  history reads fully unread), and cic's own caches
+  history reads fully unread), the per-conversation MUTE
+  (`UserSettings.rename_muted_target/4` — nick-keyed since #1038 keyed it
+  `(network, peer)`; #1340), and cic's own caches
   (`scrollback.renameScrollbackKey` + `readCursor.renameReadCursorChannel`
   + `selection.followQueryNick`, driven by the per-channel `nick_change`,
   mirroring `members.ts`). Server-driven: `EventRouter` emits
   `{:peer_nick_renamed, old, new}`, `Session.Server.apply_effects/2`
   renames the row (`QueryWindows.rename/4`, no broadcast), migrates the
-  DM history + read cursor on `:renamed` only, and THEN broadcasts
+  DM history + read cursor on `:renamed` only, migrates the mute
+  UNCONDITIONALLY (a mute outlives the window it silenced, so gating it on
+  the window row would strand it — same posture as the `:unknown` presence
+  reset in that arm), and THEN broadcasts
   `query_windows_list` (`QueryWindows.broadcast_windows_list/2`) — the
   broadcast is a truthful "rename fully applied" barrier, so a consumer
   reacting to the event is guaranteed the history has already moved
@@ -170,8 +175,10 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   window (`/msg <ownnick>`, GH #948) — and it has its own set** on
   `{:own_nick_renamed, old, new}`: `Scrollback.rename_self_window/4`
   (rows) → `ReadCursor.rename_dm_peer/4` → `QueryWindows.rename/4` →
-  broadcast, GATED on a non-zero row count (the inverse of the peer
-  arm, which gates on the window). A window at our old nick is EITHER
+  `UserSettings.rename_muted_target/4` → broadcast, GATED on a non-zero
+  row count (the inverse of the peer arm, which gates on the window) —
+  and the mute is INSIDE that gate here, unlike the peer arm, because the
+  row count is the only evidence the window is ours (#1340). A window at our old nick is EITHER
   our self window OR a leftover query with a peer who bore that nick
   before us, and the fold-unique index makes those ONE row — only the
   scrollback's `sender` separates them (folded to MATCH; the fold is

--- a/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
@@ -15,9 +15,18 @@
 // resolved own_nick via the live `Session.current_nick/2`, so a joined
 // channel's sidebar `@n` mention badge is re-seeded LIVE on its join reply
 // — it was already correct after a rename, GREEN before the fix. The
-// client-side foreground title increment (`incrementBadge`) uses cic's own
-// `ownNickForNetwork`, updated by `own_nick_changed` — also already
-// correct. Asserting either would be green-on-both: useless.
+// client-side foreground title increment (`incrementBadge`) is the same
+// story from the other end: the server pushes the mention against the live
+// nick regardless, so the title moves whatever cic decides. Asserting either
+// would be green-on-both: useless.
+//
+// (#1340 corrects what this paragraph used to claim about the client half.
+// It said the foreground increment was "also already correct" because
+// `own_nick_changed` updates `ownNickForNetwork`. It does — but until #1340
+// the per-channel handler read a nick captured at topic-join and never saw
+// the update, so a mention of the new nick did NOT beep. Measured in
+// `subscribe.test.ts`. Unusable as a #498 observable for the masking reason
+// above, which is why the #1340 witness below asserts the teardown instead.)
 //
 // The ONLY surface that was WRONG is the GLOBAL badge (`BadgeCount.count`),
 // seeded from the server at cold-load (`/me` `badge_count`) and mirrored to
@@ -34,9 +43,9 @@
 //
 // ## Self-contained session (b-runtime, GH #498)
 //
-// The witness renames a session's LIVE nick — a destructive mutation of
-// server-side identity — so it must never touch the shared vjt session (the
-// #477-avoided destructive-on-shared-identity class). An earlier take
+// Both witnesses in this file rename a session's LIVE nick — a destructive
+// mutation of server-side identity — so neither may touch the shared vjt
+// session (the #477-avoided destructive-on-shared-identity class). An earlier take
 // boot-seeded a dedicated live session; that put an i498 session in the
 // steady state that m9b (the leak canary) and u-z-cap (user-cap) assert
 // AFTER it, reddening BOTH the full suite and scoped `--grep m9b` iso
@@ -53,10 +62,11 @@
 // 433 autokill. The parked credential left on teardown has no live pid, so
 // it is invisible to every Registry-based session/capacity count guard.
 
-import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
   accreteNetwork,
   assertMessagePersisted,
+  partChannel,
   patchNetworkConnectionState,
   restoreReadCursorToTail,
 } from "../fixtures/grappaApi";
@@ -71,6 +81,18 @@ import { expect, test } from "../fixtures/test";
 
 const CHANNEL = I498_CHANNEL;
 const SERVER_WINDOW = "Server";
+// Mirrors `channelKey(slug, name)` — `${slug} ${canonicalChannel(name)}`.
+// CHANNEL is already lower-cased, so no folding needed here.
+const TOPIC_KEY = `${I498_NETWORK_SLUG} ${CHANNEL}`;
+
+// The live per-channel subscription set, read through the #200 seam (a
+// getter over subscribe.ts's `joined` Map; production never reads it).
+const joinedTopicKeys = (page: Parameters<typeof loginAs>[0]): Promise<string[]> =>
+  page.evaluate(
+    () =>
+      (window as unknown as { __cic_joinedTopicKeys?: () => string[] }).__cic_joinedTopicKeys?.() ??
+      [],
+  );
 
 // The leading `(n)` badge prefix the title mirror writes (0 if absent),
 // read in the browser context. Same reader as `pwa-badge-title-mirror`.
@@ -106,6 +128,81 @@ test.afterAll(async () => {
   await patchNetworkConnectionState(user.token, I498_NETWORK_SLUG, {
     connection_state: "parked",
   });
+});
+
+// #1340 C-S1 — the per-channel WS handler must answer own-identity
+// questions with the LIVE nick, not the one captured when the topic was
+// joined. It shares this file because it needs the same thing #498 needs and
+// nothing else has: a session whose live nick can be destructively renamed.
+//
+// Observable: the #200 subscription teardown, read through
+// `__cic_joinedTopicKeys`. It is the one consequence of the stale capture
+// that the SERVER cannot mask. The sidebar row leaves either way (the server
+// drops the channel from `channels_changed`, and a stranded "joined" key
+// draws no pseudo-row); the beep and the title bump are shadowed by the
+// server's own push, which already resolves the live nick since #498. What
+// only cic can decide is whether the PART was OURS — and on a stale nick it
+// decides no, so `setParted` never fires and the Channel plus its handler
+// stay on the socket for the rest of the session: #200's leak, reopened by
+// any `/nick`.
+//
+// RED before the fix:  the own-PART reads as a peer's, the topic key stays
+//                      in the joined set forever.
+// GREEN after the fix: the handler resolves the renamed nick, own-PART is
+//                      detected, the subscription is torn down.
+test("#1340 — after a /nick, own-PART still tears the per-channel subscription down", async ({
+  page,
+}) => {
+  const user = getSeededI498User();
+  const runId = crypto.randomUUID().slice(0, 8);
+  const newNick = `i1340-${runId}`;
+
+  await accreteNetwork(user.token, I498_NETWORK_SLUG);
+  await patchNetworkConnectionState(user.token, I498_NETWORK_SLUG, {
+    connection_state: "connected",
+  });
+
+  await loginAs(page, user);
+  await selectChannel(page, I498_NETWORK_SLUG, SERVER_WINDOW);
+  await runCommand(page, `/join ${CHANNEL}`);
+  await selectChannel(page, I498_NETWORK_SLUG, CHANNEL, { ownNick: I498_NICK });
+  await expectOwnMember(page, I498_NICK);
+
+  // Pre-state: the subscription exists, so its later absence is a teardown
+  // and not a join that never happened.
+  await expect.poll(() => joinedTopicKeys(page), { timeout: 10_000 }).toContain(TOPIC_KEY);
+
+  try {
+    // The rename the handler must notice. Gated on the member list so the
+    // upstream NICK echo is provably processed before we PART.
+    await runCommand(page, `/nick ${newNick}`);
+    await expectOwnMember(page, newNick);
+
+    await partChannel(user.token, I498_NETWORK_SLUG, CHANNEL);
+
+    // Server-side truth — green either way, here only as a barrier proving
+    // the PART round-tripped before the assertion below is read.
+    await expect(sidebarWindow(page, I498_NETWORK_SLUG, CHANNEL)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    await expect
+      .poll(() => joinedTopicKeys(page), {
+        message: "own-PART after a rename must tear the per-channel subscription down",
+        timeout: 10_000,
+      })
+      .not.toContain(TOPIC_KEY);
+  } finally {
+    // Restore the credential nick so #498's opening baseline holds on this
+    // run and on every `--repeat-each` iteration. Best-effort: after a
+    // failure the compose box may be on a window that no longer exists.
+    try {
+      await selectChannel(page, I498_NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
+      await runCommand(page, `/nick ${I498_NICK}`);
+    } catch {
+      // The next reconnect uses the credential nick, which is still I498_NICK.
+    }
+  }
 });
 
 test("#498 — a mention of the LIVE (renamed) nick lifts the server badge on cold-load", async ({

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -4154,3 +4154,81 @@ describe("subscribe — #1108 the cold snapshot seeds the frame budget", () => {
     expect(isupport.frameBudgetBaseForNetwork(1)).toBe(481);
   });
 });
+
+// #1340 C-S1 — the per-channel handler must read the LIVE own nick.
+//
+// `own_nick_changed` patches the networks list (`mutateNetworkNick`), which
+// re-runs the join effects, but every install loop is guarded by
+// `joined.has(key)` — so an already-joined channel topic keeps whatever
+// handler it was built with. Before the fix that handler carried the nick as
+// a VALUE captured at topic-join, and after any `/nick` (or a NickServ ghost
+// recovery) every own-identity test inside it answered against the retired
+// nick. These three drive a real rename through the store and then exercise
+// the handler, rather than asserting that an accessor exists.
+describe("subscribe — own nick after a rename (#1340 C-S1)", () => {
+  const seedAndJoin = async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    return store;
+  };
+
+  it("own PART on a channel joined BEFORE the rename still projects to absence and tears the subscription down", async () => {
+    // The #200 half: a stale own nick makes `ownPart` false, so the
+    // windowState entry lingers AND the Channel + its handler stay on the
+    // socket forever — the leak #200 closed, reopened by any rename.
+    const store = await seedAndJoin();
+    const windowState = await import("../lib/windowState");
+
+    store.mutateNetworkNick(1, "zelda");
+    fireMessageEvent("#grappa", { id: 30, kind: "part", sender: "zelda" });
+
+    expect(windowState.setParted).toHaveBeenCalledWith(channelKey("freenode", "#grappa"));
+    expect(mockChannel.leave).toHaveBeenCalled();
+  });
+
+  it("a mention of the NEW nick beeps on an unfocused channel joined before the rename", async () => {
+    // The user-visible half: `shouldNotify` is the mirror of the server push
+    // predicate, and the server pushes against the live nick. With a stale
+    // nick the phone buzzes and the tab stays silent.
+    const store = await seedAndJoin();
+    const beep = await import("../lib/beep");
+
+    store.mutateNetworkNick(1, "zelda");
+    fireMessageEvent("#grappa", { id: 31, sender: "bob", body: "zelda: ping" });
+
+    expect(beep.playBeep).toHaveBeenCalled();
+  });
+
+  it("our OWN second rename is not mirrored as a peer rename", async () => {
+    // To a stale closure our own next `/nick` looks like somebody else's, so
+    // the #373 peer-migration arm fires on our own identity — cic originating
+    // a rename it is supposed to mirror. Observed through the rail WHOIS
+    // cache, one of the three caches that arm moves.
+    const store = await seedAndJoin();
+    const rail = await import("../lib/railWhois");
+
+    store.mutateNetworkNick(1, "zelda");
+    rail.ingestRailWhois("freenode", "zelda", {
+      target: "zelda",
+      host: "own.example",
+    } as never);
+
+    fireMessageEvent("#grappa", {
+      id: 32,
+      kind: "nick_change",
+      sender: "zelda",
+      meta: { new_nick: "zelda2" },
+    });
+
+    expect(rail.railWhoisFor("freenode", "zelda")?.host).toBe("own.example");
+    expect(rail.railWhoisFor("freenode", "zelda2")).toBeUndefined();
+  });
+});

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -14,6 +14,7 @@ import { setServerMention } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import {
   channelsBySlug,
+  networkBySlug,
   networkIdBySlug,
   networks,
   refetchChannels,
@@ -386,14 +387,33 @@ moduleRoot(() => {
   // broadcast → `channelsBySlug` drops the channel → close-watcher fires
   // its MRU/server/home picker for the focused-channel case. #200 also
   // tears down the per-channel WS subscription on own-PART (see below).
+  //
+  // #1340 C-S1: the own nick is resolved PER EVENT, never captured when the
+  // topic is joined. `own_nick_changed` → `mutateNetworkNick` re-runs the
+  // join effects, but each one is guarded by `joined.has(key)`, so an
+  // already-joined channel keeps the handler it was built with — a captured
+  // value would answer every own-identity test below against the retired
+  // nick for the rest of the session. Re-joining the topics on a rename was
+  // rejected: it is heavier than the problem and races the JOIN echo the way
+  // #200's revert did. Resolving from the SLUG (not from a captured
+  // `Network`) is what makes it live — `mutateNetworkNick` maps the list into
+  // fresh row objects, so a closure over the row is exactly as stale as a
+  // closure over the string.
+  const ownNickForSlug = (slug: string): string | null =>
+    untrack(() => {
+      const net = networkBySlug(slug);
+      return net === undefined ? null : ownNickForNetwork(net, user());
+    });
+
   const installChannelHandler = (
     phx: Channel,
     slug: string,
     name: string,
     key: ChannelKey,
-    ownNick: string | null,
+    ownNickAt: () => string | null,
   ) => {
     phx.on("event", (raw: unknown) => {
+      const ownNick = ownNickAt();
       // #159 E2E gap seam — a test may silence live delivery for THIS
       // per-channel topic (keyed on `key`) while the socket and every
       // OTHER channel stay live, to reproduce the socket-stays-open
@@ -885,16 +905,10 @@ moduleRoot(() => {
     if (!t) return;
     const name = socketUserName();
     const nets = networks();
-    const u = user();
     if (!name || !cbs) return;
     for (const [slug, list] of Object.entries(cbs)) {
-      // Resolve own IRC nick for this slug so BUG4/BUG5 handlers can
-      // detect self-JOIN/PART events. Single-source via
-      // `ownNickForNetwork(net, me)` — see api.ts moduledoc for why
-      // displayNick(u) is the WRONG fallback (cic H3 root cause).
       const net = nets?.find((n) => n.slug === slug) ?? null;
       if (net === null) continue;
-      const ownNick = ownNickForNetwork(net, u);
       for (const ch of list) {
         const key = channelKey(slug, ch.name);
         if (joined.has(key)) continue;
@@ -911,7 +925,7 @@ moduleRoot(() => {
           // subscription, never a merely-issued join.
           stampChannelReady(key);
         });
-        installChannelHandler(phx, slug, ch.name, key, ownNick);
+        installChannelHandler(phx, slug, ch.name, key, () => ownNickForSlug(slug));
         joined.set(key, phx);
       }
     }
@@ -940,7 +954,6 @@ moduleRoot(() => {
     if (!t) return;
     const name = socketUserName();
     const nets = networks();
-    const u = user();
     if (!name || !nets) return;
     for (const [key, state] of Object.entries(states)) {
       // Pre-subscribe on any NOT-JOINED state that has no other live
@@ -964,7 +977,6 @@ moduleRoot(() => {
       if (joined.has(typedKey)) continue;
       const net = nets.find((n) => n.slug === slug) ?? null;
       if (net === null) continue;
-      const ownNick = ownNickForNetwork(net, u);
       const phx = joinChannel(name, slug, channelName, (reply) => {
         applyJoinReplyAndSeed(slug, channelName, reply);
         void refreshScrollback(slug, channelName);
@@ -976,7 +988,7 @@ moduleRoot(() => {
         // every channel-topic join ACK stamps `__cic_channelReady`.
         stampChannelReady(typedKey);
       });
-      installChannelHandler(phx, slug, channelName, typedKey, ownNick);
+      installChannelHandler(phx, slug, channelName, typedKey, () => ownNickForSlug(slug));
       joined.set(typedKey, phx);
     }
   });
@@ -1005,17 +1017,16 @@ moduleRoot(() => {
   // `ENSURE_JOIN_ACK_TIMEOUT_MS` so a wedged WS (e.g. #193 WS-blocked-but-
   // REST-up) can't hang the send forever — past the cap the send proceeds and
   // the reconnect self-heal (refreshScrollback on the eventual rejoin) recovers
-  // the row. Own-nick uses `ownNickForNetwork` (visitor → me.nick; user →
+  // the row. Own-nick comes from `ownNickForSlug` (visitor → me.nick; user →
   // per-credential net.nick), never the displayNick fallback (cic H3).
   const ENSURE_JOIN_ACK_TIMEOUT_MS = 4000;
   const ensureQueryTopicJoined = (slug: string, target: string): Promise<void> => {
     const userName = socketUserName();
     const nets = networks();
-    const u = user();
     if (!userName || !nets) return Promise.resolve();
     const net = nets.find((n) => n.slug === slug);
     if (!net) return Promise.resolve();
-    const ownNick = ownNickForNetwork(net, u);
+    const ownNick = ownNickForSlug(slug);
     if (nickEquals(target, ownNick)) return Promise.resolve();
     const key = channelKey(slug, target);
     const pending = queryJoinAcks.get(key);
@@ -1028,7 +1039,7 @@ moduleRoot(() => {
         stampQueryWindowReady(slug, target);
         resolve();
       });
-      installChannelHandler(phx, slug, target, key, ownNick);
+      installChannelHandler(phx, slug, target, key, () => ownNickForSlug(slug));
       joined.set(key, phx);
     });
     const bounded = Promise.race([
@@ -1161,7 +1172,7 @@ moduleRoot(() => {
         applyJoinReplyAndSeed(net.slug, SERVER_WINDOW_NAME, reply);
         void refreshScrollback(net.slug, SERVER_WINDOW_NAME);
       });
-      installChannelHandler(phx, net.slug, SERVER_WINDOW_NAME, key, null);
+      installChannelHandler(phx, net.slug, SERVER_WINDOW_NAME, key, () => null);
       joined.set(key, phx);
     }
   });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42706,3 +42706,107 @@ viewport. That those five specs scope their chip click to
 `.home-pane-network-row-parked`, and so cannot be made ambiguous by the
 seam's identically-named control, is read from their source rather than
 observed.
+<!-- entry #1340 -->
+
+---
+
+## 2026-08-15 — #1340: a nick you captured is a nick you stop tracking
+
+Two findings from the 2026-08-15 codebase review, one class: something holds a
+nick from before the rename, so a `/nick` forks the identity in silence. #373
+closed that class for three stores and left it open for a closure and a map.
+
+### C-S1 — the per-channel WS handler held a snapshot
+
+`installChannelHandler` took `ownNick` as a VALUE, resolved when the topic was
+joined. `own_nick_changed` → `mutateNetworkNick` re-runs all four join effects,
+but each is guarded by `if (joined.has(key)) continue;`, so an already-joined
+channel keeps the handler it was built with — forever. Only the DM listener
+recovered, and only because the new own nick mints a new `channelKey`.
+
+The fix is an ACCESSOR read per event. Not the one the review proposed:
+`() => ownNickForNetwork(net, u)` closes over the same row object
+`mutateNetworkNick` REPLACES (`prev.map(n => n.id === id ? {...n, nick} : n)`),
+so it is exactly as stale as the string was. The accessor resolves from the
+SLUG through the live `networkBySlug` memo, `untrack`ed like the sibling
+`untrack(user)` in `routeMessage`. Rejoining the topics on a rename was
+rejected: heavier than the problem, and it races the JOIN echo the way #200's
+revert did.
+
+Dropping the two now-dead `const u = user()` reads also removed reactive
+tracking the loops no longer need. That tracking never bought anything: it
+re-ran the effect when `/me` resolved, and the `joined` guard then skipped
+every channel — the same short-circuit this entry is about. The accessor makes
+a late `/me` self-healing instead.
+
+**The measurable claim, and it corrects a comment on record.**
+`issue498-badge-follows-live-nick.spec.ts` states in its header that the
+client-side foreground increment "uses cic's own `ownNickForNetwork`, updated
+by `own_nick_changed` — also already correct". It is not: with the snapshot in
+place a mention of the NEW nick did not beep, measured in `subscribe.test.ts`.
+It stays unusable as a #498 observable, but for the OTHER reason — the server
+pushes the mention against the live nick regardless, so the title moves either
+way. The header now says so.
+
+**Which is why the e2e witness asserts the TEARDOWN.** Three of the four
+consequences are masked end-to-end: the beep and the title bump are shadowed
+by the server's own push, and the stranded window state draws no sidebar row
+(`pseudoChannelsForNetwork` skips `"joined"`, and the server has already
+dropped the channel from `channels_changed`). What only cic can decide is
+whether a PART was OURS. On a stale nick it decides no, `setParted` never
+fires, and the Channel plus its handler stay on the socket: #200's leak,
+reopened by any `/nick`. Read through `__cic_joinedTopicKeys`, measured RED
+with the fix reverted (`["azzurra i498-user", "azzurra $server", "azzurra
+#i498", "azzurra i1340-4a65ec10"]` — the topic key still there after the
+sidebar row had gone) and GREEN with it in place.
+
+The witness lives in the #498 spec file because it needs the one thing that
+file already provides and nothing else does: a session whose live nick can be
+destructively renamed without poisoning the shared vjt identity.
+
+### K-S2 — `muted_targets` was never added to the migration set
+
+#1038 re-keyed the mute on `(network, target)` where, for a DM, the target IS
+the peer nick. That made it a nick-keyed store, and nothing carried it: mute
+`guest`, they `/nick Guest2`, and the window, the DM history and the cursor
+all move while the mute key does not. The peer starts notifying again with no
+UI event explaining why, and the orphan renders in the drawer's mute picker
+for a conversation that no longer exists.
+
+`UserSettings.rename_muted_target/4` is a surgical read-modify-write over the
+stored map, deliberately not a `put_notification_prefs/2`: that writer
+full-replaces the prefs through the whole validation pipeline and its reader
+counterpart prunes elapsed snoozes. A rename migrates what the operator
+already chose — it must not rewrite the other seven fields, must not turn
+itself into a snooze sweep, and must not be refusable by the
+at-least-one-trigger guard.
+
+On a fold-collision the DESTINATION entry survives (`Map.put_new`). Both keys
+mean "silence this conversation", so the union is the only sane merge, and the
+`until` worth keeping is the one set against the identity that lives on.
+
+**Placement diverges from the review's text, with the reason on the line
+above it.** The review said to add it to the `:renamed` arm. It is
+UNCONDITIONAL instead: a mute outlives the window it silenced — closing a tab
+does not unmute it — so gating on the window row would strand exactly the mute
+nobody can then see to fix. The precedent is three lines below in the same
+function: the `:unknown` presence reset is unconditional for the same reason,
+"presence and windows are independent stores". The SELF arm is the opposite
+and stays INSIDE `migrate_self_window`'s gate, because there the row count is
+the only evidence that the window at our old nick is ours rather than a
+peer's who bore it before us.
+
+**Residual, named rather than papered over:** `notification_prefs` has no
+broadcast — cic hydrates it on every user-topic join. The server push
+predicate honours the migrated key immediately; cic's foreground beep and the
+settings drawer keep the pre-rename map until the next (re)join or reload. A
+new user-topic event would fix that and was not written: it is a wire-token
+change for a window that closes on the next reconnect.
+
+### Not established
+
+The e2e RED run surfaced a SECOND leak in the same output and it is not fixed
+here: after a rename the DM-listener holds BOTH own-nick topics
+(`"azzurra i498-user"` and `"azzurra i1340-…"`). That loop keys on the own
+nick, so the rename mints a new key and joins it, and nothing leaves the old
+one. Same family as #200, out of this bucket's scope, no issue filed yet.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -6118,7 +6118,7 @@ defmodule Grappa.Session.Server do
     # this arm — independent stores of the moved identity, each migrated on
     # its own terms. It sits ahead of the barrier broadcast because a rename
     # must never be observable half-applied.
-    {:ok, _mute} =
+    {:ok, _} =
       UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
 
     case QueryWindows.rename(
@@ -6236,7 +6236,7 @@ defmodule Grappa.Session.Server do
       # the only evidence that the window at our old nick is OURS; ungated,
       # our rename would quietly re-file a mute the operator set against a
       # peer who bore that nick before us.
-      {:ok, _mute} =
+      {:ok, _} =
         UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
 
       # Broadcast LAST, and only when a window actually moved: the event is

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -6109,6 +6109,18 @@ defmodule Grappa.Session.Server do
   # immaterial: those are `channel=#chan, dm_with=nil` and never match the
   # DM fold, so migrating after them is a no-op interaction.
   defp apply_effects([{:peer_nick_renamed, old_nick, new_nick} | rest], state) do
+    # #1340 K-S2 — the per-conversation mute joined this set when #1038 keyed
+    # it on `(network, peer nick)`. UNCONDITIONAL, and deliberately not inside
+    # the `:renamed` arm the review proposed: the mute outlives the window
+    # that was muted (closing a tab does not unmute it), so gating on the
+    # window row would strand exactly the mute nobody can see to fix. Same
+    # reasoning, and the same placement, as the presence reset at the foot of
+    # this arm — independent stores of the moved identity, each migrated on
+    # its own terms. It sits ahead of the barrier broadcast because a rename
+    # must never be observable half-applied.
+    {:ok, _mute} =
+      UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
+
     case QueryWindows.rename(
            state.subject,
            state.network_id,
@@ -6218,6 +6230,14 @@ defmodule Grappa.Session.Server do
       :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
 
       {:ok, window} = QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick)
+
+      # #1340 K-S2 — the self window's mute follows too, and INSIDE the gate,
+      # unlike the peer arm where it is unconditional. Here the row count is
+      # the only evidence that the window at our old nick is OURS; ungated,
+      # our rename would quietly re-file a mute the operator set against a
+      # peer who bore that nick before us.
+      {:ok, _mute} =
+        UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
 
       # Broadcast LAST, and only when a window actually moved: the event is
       # the truthful "rename fully applied" barrier (#373 rename-order fix).

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -618,7 +618,7 @@ defmodule Grappa.UserSettings do
 
   @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) ::
           {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp rekey_muted_target(nil, _old_key, _new_key), do: {:ok, :noop}
+  defp rekey_muted_target(nil, _, _), do: {:ok, :noop}
 
   defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
     prefs = Map.get(settings.data, @notification_prefs_key, %{})
@@ -636,7 +636,7 @@ defmodule Grappa.UserSettings do
         next_data = Map.put(settings.data, @notification_prefs_key, next_prefs)
 
         case persist(Settings.changeset(settings, %{data: next_data})) do
-          {:ok, _settings} -> {:ok, :renamed}
+          {:ok, _} -> {:ok, :renamed}
           {:error, _} = error -> error
         end
     end

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -559,6 +559,89 @@ defmodule Grappa.UserSettings do
     end
   end
 
+  @doc """
+  Moves ONE `muted_targets` entry from `old_target` to `new_target` on
+  `network_slug` — the mute's membership of the #373 nick-migration set.
+
+  Since #1038 the mute key is `(network, target)` and, for a DM, the target IS
+  the peer's nick, which makes `muted_targets` a nick-keyed store like the
+  three the peer-NICK arm already migrates. Left out of that set, a mute is
+  the one thing a rename does NOT carry: the window, the DM history and the
+  read cursor all follow, the mute key does not, and the peer the operator
+  silenced starts notifying again with nothing on screen to explain why.
+  Called from `Session.Server`'s `:peer_nick_renamed` arm and from the
+  `:own_nick_renamed` self-window migration.
+
+  ## Why it is not a `put_notification_prefs/2`
+
+  That writer full-replaces the prefs map through the whole validation
+  pipeline, and its reader counterpart PRUNES elapsed snoozes. Re-keying one
+  entry must not silently rewrite the other seven fields, must not turn a
+  rename into a snooze sweep, and must not be refusable by the
+  at-least-one-trigger guard — a rename is a MIGRATION of what the operator
+  already chose, never a new choice. So this is a surgical read-modify-write
+  over the stored map.
+
+  ## Collision
+
+  On a fold-collision — the operator had ALSO muted the destination nick —
+  the DESTINATION entry stays and the source entry is dropped. Both keys mean
+  "silence this conversation", so the union is the only sane merge, and the
+  `until` to keep is the one the operator set against the identity that
+  survives. This is the mute's shape of the same fold-collision merge
+  `QueryWindows.rename/4` performs on the window row.
+
+  Returns `{:ok, :noop}` when the two keys fold equal (a case-only NICK), when
+  the subject has no settings row, or when nothing was muted under
+  `old_target`.
+
+  > #### The client copy lags {: .warning}
+  >
+  > `notification_prefs` has NO broadcast — cic hydrates it on every
+  > user-topic join (`userTopic.ts`). The SERVER push predicate honours the
+  > migrated key immediately; cic's foreground beep and the settings drawer
+  > keep the pre-rename map until the next (re)join or reload.
+  """
+  @spec rename_muted_target(Subject.t(), String.t(), String.t(), String.t()) ::
+          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def rename_muted_target({_, _} = subject, network_slug, old_target, new_target)
+      when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
+    old_key = Identifier.channel_key(network_slug, old_target)
+    new_key = Identifier.channel_key(network_slug, new_target)
+
+    if old_key == new_key do
+      {:ok, :noop}
+    else
+      rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+    end
+  end
+
+  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) ::
+          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp rekey_muted_target(nil, _old_key, _new_key), do: {:ok, :noop}
+
+  defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
+    prefs = Map.get(settings.data, @notification_prefs_key, %{})
+    muted = if is_map(prefs), do: Map.get(prefs, "muted_targets", %{}), else: %{}
+
+    case is_map(muted) and Map.has_key?(muted, old_key) do
+      false ->
+        {:ok, :noop}
+
+      true ->
+        {entry, without_old} = Map.pop(muted, old_key)
+        # put_new, not put: the destination's own entry wins the collision.
+        next_muted = Map.put_new(without_old, new_key, entry)
+        next_prefs = Map.put(prefs, "muted_targets", next_muted)
+        next_data = Map.put(settings.data, @notification_prefs_key, next_prefs)
+
+        case persist(Settings.changeset(settings, %{data: next_data})) do
+          {:ok, _settings} -> {:ok, :renamed}
+          {:error, _} = error -> error
+        end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # upload_ttl_seconds accessors (UX-4 bucket M, 2026-05-19)
   # ---------------------------------------------------------------------------

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3162,6 +3162,56 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
+
+    test "#1340 K-S2 — the per-conversation MUTE follows the peer NICK too" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      slug = network.slug
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      # The operator silenced this peer. Since #1038 that mute is keyed on
+      # `(network, peer nick)` — a nick-keyed store, so the rename below must
+      # carry it, exactly as it carries the window, the history and the cursor.
+      assert {:ok, _} =
+               put_all_muted({:user, user.id}, %{"#{slug} guest87449" => %{"until" => nil}})
+
+      IRCServer.feed(server, ":Guest87449!~g@host JOIN #sniffo\r\n")
+      IRCServer.feed(server, ":Guest87449!~g@host PRIVMSG #{own} :ciao\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :query_windows_list,
+                         windows: %{^net_id => [%{target_nick: "Guest87449"}]}
+                       }
+                     },
+                     1_000
+
+      IRCServer.feed(server, ":Guest87449!~g@host NICK :NickTemporaneo\r\n")
+
+      # Same truthful barrier the sibling test uses: the broadcast is emitted
+      # after the migration, so reading the prefs below cannot race it.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list, windows: %{^net_id => [_ | _]}}
+                     },
+                     1_000
+
+      # Silenced before, silenced after. Left out of the set, the key would
+      # still read `guest87449` and the peer would start notifying again with
+      # nothing on screen to explain why.
+      assert Grappa.UserSettings.get_notification_prefs({:user, user.id}).muted_targets == %{
+               "#{slug} nicktemporaneo" => %{"until" => nil}
+             }
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
   end
 
   describe "#948 — the SELF window follows OUR OWN NICK change" do
@@ -3280,6 +3330,111 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
+
+    test "#1340 K-S2 — the self window's MUTE follows our own NICK" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      slug = network.slug
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, _} = put_all_muted(subject, %{"#{slug} #{own}" => %{"until" => nil}})
+
+      IRCServer.feed(server, ":#{own}!~g@host PRIVMSG #{own} :nota per me\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :query_windows_list,
+                         windows: %{^net_id => [%{target_nick: ^own}]}
+                       }
+                     },
+                     1_000
+
+      IRCServer.feed(server, ":#{own}!~g@host NICK :grappa-new\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list, windows: %{^net_id => [_ | _]}}
+                     },
+                     1_000
+
+      assert Grappa.UserSettings.get_notification_prefs(subject).muted_targets == %{
+               "#{slug} grappa-new" => %{"until" => nil}
+             }
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The same gate, applied to the mute. With no self rows the window at our
+    # old nick belongs to a PEER who bore it before us — and so does the mute
+    # standing on that key. Migrating it would silence our new identity on
+    # their behalf and un-silence them.
+    test "#1340 K-S2 — a self /nick with no self conversation leaves a same-named peer's MUTE alone" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      slug = network.slug
+
+      {:ok, _} =
+        Scrollback.persist_event(%{
+          user_id: user.id,
+          network_id: net_id,
+          channel: own,
+          server_time: System.system_time(:millisecond),
+          kind: :privmsg,
+          sender: "previous-me",
+          body: "ciao",
+          dm_with: own
+        })
+
+      {:ok, _} = QueryWindows.open(subject, net_id, own, user.name)
+      assert {:ok, _} = put_all_muted(subject, %{"#{slug} #{own}" => %{"until" => nil}})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      IRCServer.feed(server, ":#{own}!~g@host NICK :grappa-new\r\n")
+
+      refute_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list}
+                     },
+                     300
+
+      assert Grappa.UserSettings.get_notification_prefs(subject).muted_targets == %{
+               "#{slug} #{own}" => %{"until" => nil}
+             }
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
+  # #1340 K-S2 — the full prefs shape `put_notification_prefs/2` demands, with
+  # only the mute map varying. Inline in each caller it is eight lines of
+  # noise around the one field under test.
+  defp put_all_muted(subject, muted) do
+    Grappa.UserSettings.put_notification_prefs(subject, %{
+      channel_messages_all: false,
+      channel_messages_only: [],
+      channel_mentions: true,
+      private_messages_all: true,
+      private_messages_only: [],
+      presence_online: false,
+      presence_offline: false,
+      muted_targets: muted
+    })
   end
 
   describe "push notifications (B4) — trigger dispatch on inbound PRIVMSG" do

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -933,6 +933,135 @@ defmodule Grappa.UserSettingsTest do
     end
   end
 
+  describe "rename_muted_target/4 (#1340 K-S2 — the mute joins the #373 set)" do
+    test "moves the mute from the old nick to the new one, on that network only" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               put_muted(user, %{
+                 "azzurra guest" => %{"until" => nil},
+                 "libera guest" => %{"until" => nil},
+                 "azzurra #linux" => %{"until" => nil}
+               })
+
+      assert {:ok, :renamed} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "Guest2")
+
+      # The renamed peer is still silenced, under the identity they now
+      # carry; the same nick on another network and the channel mute beside
+      # it are untouched — the rename is one conversation moving, not a sweep.
+      assert read_muted(user) == %{
+               "azzurra guest2" => %{"until" => nil},
+               "libera guest" => %{"until" => nil},
+               "azzurra #linux" => %{"until" => nil}
+             }
+    end
+
+    test "carries the snooze expiry across, rather than promoting it to permanent" do
+      user = user_fixture()
+      until = System.system_time(:second) + 3_600
+
+      assert {:ok, _} = put_muted(user, %{"azzurra guest" => %{"until" => until}})
+
+      assert {:ok, :renamed} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "Guest2")
+
+      assert read_muted(user) == %{"azzurra guest2" => %{"until" => until}}
+    end
+
+    test "folds BOTH sides, so the stored key and the wire casing need not agree" do
+      user = user_fixture()
+
+      # Stored folded (every writer folds), renamed from the RAW casing the
+      # NICK line carries — the #121/#372 key/display split.
+      assert {:ok, _} = put_muted(user, %{"azzurra guest87449" => %{"until" => nil}})
+
+      assert {:ok, :renamed} =
+               UserSettings.rename_muted_target(
+                 {:user, user.id},
+                 "azzurra",
+                 "Guest87449",
+                 "NickTemporaneo"
+               )
+
+      assert read_muted(user) == %{"azzurra nicktemporaneo" => %{"until" => nil}}
+    end
+
+    test "a case-only NICK is a no-op, not a self-destructive re-key" do
+      user = user_fixture()
+
+      assert {:ok, _} = put_muted(user, %{"azzurra guest" => %{"until" => nil}})
+
+      assert {:ok, :noop} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "GUEST")
+
+      assert read_muted(user) == %{"azzurra guest" => %{"until" => nil}}
+    end
+
+    test "on a fold-collision the DESTINATION's own entry survives" do
+      user = user_fixture()
+      until = System.system_time(:second) + 3_600
+
+      # Both identities muted: `guest` permanently, `guest2` snoozed. The
+      # operator's choice about the identity that SURVIVES is the one that
+      # means something after the rename.
+      assert {:ok, _} =
+               put_muted(user, %{
+                 "azzurra guest" => %{"until" => nil},
+                 "azzurra guest2" => %{"until" => until}
+               })
+
+      assert {:ok, :renamed} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "guest2")
+
+      assert read_muted(user) == %{"azzurra guest2" => %{"until" => until}}
+    end
+
+    test "an unmuted peer renaming changes nothing" do
+      user = user_fixture()
+
+      assert {:ok, _} = put_muted(user, %{"azzurra #linux" => %{"until" => nil}})
+
+      assert {:ok, :noop} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "Guest2")
+
+      assert read_muted(user) == %{"azzurra #linux" => %{"until" => nil}}
+    end
+
+    test "a subject with no settings row at all is a no-op, not a crash" do
+      user = user_fixture()
+
+      assert {:ok, :noop} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "Guest2")
+    end
+
+    test "leaves every OTHER notification pref exactly as it was" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_notification_prefs(
+                 {:user, user.id},
+                 %{
+                   base_prefs(%{"azzurra guest" => %{"until" => nil}})
+                   | channel_messages_only: ["#linux"],
+                     private_messages_all: false,
+                     private_messages_only: ["bob"]
+                 }
+               )
+
+      before = UserSettings.get_notification_prefs({:user, user.id})
+
+      assert {:ok, :renamed} =
+               UserSettings.rename_muted_target({:user, user.id}, "azzurra", "guest", "Guest2")
+
+      after_rename = UserSettings.get_notification_prefs({:user, user.id})
+
+      # A rename migrates what the operator already chose; it is not a new
+      # choice, so nothing but the mute key may move.
+      assert Map.delete(before, :muted_targets) == Map.delete(after_rename, :muted_targets)
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # upload_ttl_seconds accessors (UX-4 bucket M, 2026-05-19)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bucket from the 2026-08-15 codebase review. One class: something holds a nick
captured before the rename, so a `/nick` forks the identity in silence — the
class #373 closed for three stores and left open for a closure and a map.

## C-S1 (HIGH) — the per-channel WS handler held a snapshot

`installChannelHandler` took `ownNick` as a VALUE resolved at topic-join, and
every install loop is guarded by `joined.has(key)`, so an already-joined
channel never rebuilds its handler. `own_nick_changed` re-runs the join
effects and the guard short-circuits all of them. After any `/nick` the
handler answered every own-identity question against the retired nick: the
beep followed the old nick, own-PART stopped being detected (reopening #200's
subscription leak), own presence echoes stopped being recognised, and our own
next rename looked like a peer's.

The parameter is now an accessor read per event.

**The review's proposed fix would not have worked, and this is measured.** It
suggested `() => ownNickForNetwork(net, u)`. `mutateNetworkNick` maps the list
into fresh row objects (`prev.map(n => n.id === id ? {...n, nick} : n)`), so a
closure over the row is exactly as stale as the string was. The accessor
resolves from the SLUG through the live `networkBySlug` memo instead.

Rejoining the topics on a rename was rejected: heavier than the problem, and
it races the JOIN echo the way #200's revert did.

## K-S2 (MEDIUM) — `muted_targets` was never in the migration set

#1038 re-keyed the mute on `(network, target)` where, for a DM, the target IS
the peer nick. `UserSettings.rename_muted_target/4` adds it to the set, on
both rename arms.

**Placement diverges from the review's text, deliberately.** In the peer arm
the migration is UNCONDITIONAL rather than gated on `:renamed`: a mute
outlives the window it silenced — closing a tab does not unmute it — so
gating on the window row would strand exactly the mute nobody can then see to
fix. The precedent is three lines below, where the presence reset is
unconditional for the same reason. The self arm is the opposite and stays
INSIDE `migrate_self_window`'s gate, because there the row count is the only
evidence the window at our old nick is ours and not a peer's who bore it
before us.

## Evidence

Every gate below was run and read locally before Docker Desktop died on the
worker host. **The full `scripts/integration.sh` was NOT run** — it died at
container bring-up with zero specs executed. CI is the arbiter for it.

| Gate | Result |
|---|---|
| `bun run test` (cic) | 283 files, 5477 tests, RC=0 |
| `bun run check` (biome + tsc + e2e tsconfig) | RC=0 |
| `scripts/check.sh` (clean tree, at `b4b278ed`) | 8 doctests, 60 properties, 6201 tests, 0 failures; dialyzer 0 errors; credo clean |
| e2e `--grep "#1340"` | RED with the fix reverted, GREEN with it |
| Elixir targeted, K-S2 | RED with both hooks removed (2 failures), GREEN restored (536 tests, 0 failures) |
| `scripts/integration.sh` (full) | **NOT RUN** — Docker Desktop down |

Both halves are proven by displacement, not by a green alone.

### Why the e2e witness asserts the teardown

Three of C-S1's four consequences are masked end-to-end: the beep and the
title bump are shadowed by the server's own push, which already resolves the
live nick since #498, and the stranded window state draws no sidebar row
(`pseudoChannelsForNetwork` skips `"joined"`, and the server has already
dropped the channel from `channels_changed`). What only cic can decide is
whether a PART was OURS. Read through `__cic_joinedTopicKeys`; RED output was
`["azzurra i498-user", "azzurra $server", "azzurra #i498", "azzurra
i1340-4a65ec10"]` — the topic key still present after the sidebar row had
already gone.

It lives in the #498 spec file because it needs the one thing that file
already provides: a session whose live nick can be destructively renamed
without poisoning the shared vjt identity.

### A comment on record is corrected

That file's header claimed the client-side foreground increment was "also
already correct" after a rename because `own_nick_changed` updates
`ownNickForNetwork`. It does — but the per-channel handler never saw the
update, so a mention of the new nick did not beep. Measured in
`subscribe.test.ts`; the header now says so.

## Scope notes

- The scoped e2e green is attributable to the cic commit; it was measured
  before the K-S2 server change existed. That spec does not touch the mute.
- Residual, named in DESIGN_NOTES rather than papered over: notification prefs
  have no broadcast, so cic keeps the pre-rename mute map until its next
  user-topic join. The server push predicate — the one that reaches the phone
  — honours the migrated key immediately.
- The second leak the RED run exposed (after a rename the DM-listener holds
  BOTH own-nick topics) is #1341 and is deliberately NOT in this branch.