### PR TITLE
irc(#1345): one measured join-failure numeric set, delegated only when it correlates

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42725,7 +42725,7 @@ sweeps `:pending`), and cic drew a greyed tab that never resolved.
 `Grappa.IRC.JoinFailure` is now the single enumeration and every consumer
 derives from it. The set is read out of the two bound ircds rather than an
 RFC (azzurra/bahamut `5c41c8b`, solanum `2ce64de`), one citation per code in
-the moduledoc: **403 405 437 471 473 474 475 476 477 479 480 485**.
+the moduledoc: **403 405 471 473 474 475 476 477 479 480 485**.
 
 **481 is excluded, and that corrects the two texts that put it in.** It IS a
 `can_join` exit on bahamut (`+O` oper-only, `channel.c:1967`), but its format
@@ -42739,14 +42739,26 @@ instead of merely forgetting it. Deliberately not built here. 443
 (channel at `params[2]`) and 470 (a redirect, not a refusal) are excluded for
 shape, also on record in the moduledoc.
 
+**437 is excluded too, and it is the exclusion worth remembering.** It IS a
+JOIN exit on solanum (ERR_UNAVAILRESOURCE), but on bahamut 437 is a different
+numeric altogether — ERR_BANNICKCHANGE (`numeric.h:333`) — and `m_nick.c:525`
+passes it `chptr->chname`, so its `params[1]` is **a channel** while the
+failure is a nick change. That is a false positive the correlation cannot
+distinguish: a `/nick` while banned on a channel whose JOIN is still in
+flight would flip a live window to `:failed`. A juped channel on Libera
+therefore keeps sitting at `:pending` — the deliberate side of the trade,
+because prod is bahamut. **Cross-flavour collisions are only inert when the
+other meaning cannot present the same shape**, which is true of 476 and 485
+(solanum defines both in `numeric.h` and gives neither a `NUMERIC_STR_`, so
+core never emits them) and false of 437.
+
 **Delegation is now correlation-gated, and that is the load-bearing half.**
 `join_failure_leg?/3` delegates a member of the set only when its `params[1]`
 folds to a channel whose JOIN is in flight — the same match `EventRouter`
 performs — and it runs ahead of the deny list, on the precedence a label
-already loses to. Flat membership could not have carried this set: 437 is
-deny-listed for its NICK form, and 476/485 mean different things on the two
-ircds (ONLYSSLCLIENTS vs BADCHANMASK; CHANBANREASON vs BANNEDNICK). Under the
-gate a cross-flavour collision is inert by construction.
+already loses to. Flat membership could not have carried a set that holds
+codes meaning other things elsewhere. The correlation is `params[1]` and
+nothing looser, and 437 is the reason to keep it that way.
 
 **What the gate also repairs is a silent drop that was already there.** The
 handler's own comment promised that an uncorrelated 403/473/… "falls through

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42706,3 +42706,75 @@ viewport. That those five specs scope their chip click to
 `.home-pane-network-row-parked`, and so cannot be made ambiguous by the
 seam's identically-named control, is read from their source rather than
 observed.
+<!-- entry #1345 -->
+
+---
+
+## 2026-08-15 — #1345: one measured numeric set, and delegation that has to correlate
+
+Three lists claimed to enumerate the same thing — the numerics that abort a
+JOIN. The channel-param canonicaliser in `EventRouter` named eight, the
+handler guard one screen below it named six, and `NumericRouter`'s
+`@delegated_numerics` mirrored the same six. **477 ERR_NEEDREGGEDNICK was in
+the list that folds the channel and absent from the two that act on it**, so a
+`+R` channel — ordinary on the networks we serve — produced no
+`{:join_failed, …}` at all: the in-flight entry sat until the lazy 30 s
+sweep, `window_state[chan]` stayed `:pending` **permanently** (nothing else
+sweeps `:pending`), and cic drew a greyed tab that never resolved.
+
+`Grappa.IRC.JoinFailure` is now the single enumeration and every consumer
+derives from it. The set is read out of the two bound ircds rather than an
+RFC (azzurra/bahamut `5c41c8b`, solanum `2ce64de`), one citation per code in
+the moduledoc: **403 405 437 471 473 474 475 476 477 479 480 485**.
+
+**481 is excluded, and that corrects the two texts that put it in.** It IS a
+`can_join` exit on bahamut (`+O` oper-only, `channel.c:1967`), but its format
+string carries no channel: `":%s 481 %s :Permission Denied, …"`
+(`s_err.c:550`) has two `%s`, and the `name` m_join hands it is dropped on the
+floor. There is nothing on the wire to correlate, so a `+O` refusal cannot
+reach its window and that window still stalls at `:pending`. **The only cure
+for the uncorrelatable class is a timeout on the in-flight JOIN, not another
+numeric** — the 30 s sweep already exists and could transition the window
+instead of merely forgetting it. Deliberately not built here. 443
+(channel at `params[2]`) and 470 (a redirect, not a refusal) are excluded for
+shape, also on record in the moduledoc.
+
+**Delegation is now correlation-gated, and that is the load-bearing half.**
+`join_failure_leg?/3` delegates a member of the set only when its `params[1]`
+folds to a channel whose JOIN is in flight — the same match `EventRouter`
+performs — and it runs ahead of the deny list, on the precedence a label
+already loses to. Flat membership could not have carried this set: 437 is
+deny-listed for its NICK form, and 476/485 mean different things on the two
+ircds (ONLYSSLCLIENTS vs BADCHANMASK; CHANBANREASON vs BANNEDNICK). Under the
+gate a cross-flavour collision is inert by construction.
+
+**What the gate also repairs is a silent drop that was already there.** The
+handler's own comment promised that an uncorrelated 403/473/… "falls through
+— the caller's NumericRouter `$server` route persists it as a server
+message". Measured, that was false for as long as the codes were
+unconditionally delegated: `Server.delegate/2` hands the numeric to
+`EventRouter` alone, whose numeric catch-all returns `[]`, and nothing
+persisted it anywhere. An unsolicited 403 for `/topic #nowhere` was answered
+with silence. Uncorrelated numerics take the param scan again.
+
+**Nothing maps a numeric to a phrase, on purpose.** `reason` is the ircd's own
+trailing text and the code travels beside it as `meta.numeric`; cic stores
+both verbatim. A sentence written by us would have to be flavour-blind, and
+would tell an Azzurra user their channel mask was malformed when the server
+said "Only SSL clients can join" — the shape of the known
+`sec-nickserv-identify-oftc` defect.
+
+**I-S2, same commit's neighbourhood:** `whois_leg?/3` read `whois_pending`
+with the arity-1 ASCII fold while `EventRouter` writes those keys with
+`canonical_target/2` at the network casemapping. On rfc1459 a target holding
+`[ ] \ ~` was written `foo{1}` and looked up as `foo[1]`, so the leg missed
+and fell to the param scan #221 exists to avoid. `router_state()` now carries
+the casemapping — which is also what lets the join gate fold the echoed
+channel network-aware — and both reads fold with it.
+
+**Not established:** no gate ran locally. Docker Desktop was down on the
+worker host for the whole of this work, so `check.sh`, `mix.sh` and
+`integration.sh` were all unavailable; every test here is written but
+unobserved, and CI on the PR is the only arbiter. The measured ircd citations
+come from the public `azzurra/bahamut` and `solanum-ircd/solanum` trees at the
+refs above, not from a running server.

--- a/lib/grappa/irc.ex
+++ b/lib/grappa/irc.ex
@@ -7,8 +7,9 @@ defmodule Grappa.IRC do
   (`Grappa.IRC.Client`), the pure auth state machine
   (`Grappa.IRC.AuthFSM`), identifier validators
   (`Grappa.IRC.Identifier`), the shared IRC-registration identity tuple
-  validators (`Grappa.IRC.Identity`, #211 phase 2), and CTCP framing
-  classification (`Grappa.IRC.CTCP`). Phase 6's IRCv3 listener facade
+  validators (`Grappa.IRC.Identity`, #211 phase 2), the measured
+  JOIN-failure numeric set (`Grappa.IRC.JoinFailure`, #1345), and CTCP
+  framing classification (`Grappa.IRC.CTCP`). Phase 6's IRCv3 listener facade
   reuses the parser + message struct directly and reuses the AuthFSM
   SHAPE (pure FSM with `(state, [iodata])` step contract) for a peer
   server-side registration FSM. The module set is intentionally
@@ -22,5 +23,5 @@ defmodule Grappa.IRC do
   use Boundary,
     top_level?: true,
     deps: [Grappa.OutboundV6Pool],
-    exports: [AuthFSM, Client, CTCP, Identifier, Identity, LineSplit, Message]
+    exports: [AuthFSM, Client, CTCP, Identifier, Identity, JoinFailure, LineSplit, Message]
 end

--- a/lib/grappa/irc/join_failure.ex
+++ b/lib/grappa/irc/join_failure.ex
@@ -1,0 +1,80 @@
+defmodule Grappa.IRC.JoinFailure do
+  @moduledoc """
+  The numerics that abort a JOIN we sent — one enumeration, measured.
+
+  #1345. Three independent copies of this set used to exist: the
+  channel-param canonicalisation guard in `Session.EventRouter`, the
+  `@join_failure_numerics` handler guard one screen below it, and the
+  `@delegated_numerics` block in `Session.NumericRouter`. The first named
+  eight codes, the other two named six — so a JOIN rejected with 477
+  (`+R`, common on the networks we serve) produced no `{:join_failed, …}`
+  effect, `window_state[chan]` stayed `:pending` forever, and cic drew a
+  greyed tab that never resolved. Every consumer now derives its list from
+  `numerics/0`; there is nothing left to truncate independently.
+
+  ## Membership rule
+
+  A numeric belongs here iff it (a) aborts a JOIN on a bound ircd and
+  (b) carries the rejected channel at `params[1]` — the shape
+  `:server <code> <own_nick_echo> <channel> :<reason>` the correlation
+  against `in_flight_joins` needs. Both halves are read out of the ircd
+  sources, never out of an RFC: **azzurra/bahamut @ `5c41c8b`**
+  (`src/channel.c`, `src/s_err.c`, `include/numeric.h`) and
+  **solanum @ `2ce64de`** (`modules/core/m_join.c`, `ircd/channel.c`,
+  `include/messages.h`).
+
+  | num | bahamut | solanum |
+  |-----|---------|---------|
+  | 403 | `channel.c:2221` NOSUCHCHANNEL | `m_join.c:213` NOSUCHCHANNEL |
+  | 405 | `channel.c:2354` TOOMANYCHANNELS | `m_join.c:317` TOOMANYCHANNELS |
+  | 437 | — (nick-only) | `m_join.c:242/303/328` UNAVAILRESOURCE |
+  | 471 | `can_join channel.c:1971` (+l) | `can_join channel.c:776` (+l) |
+  | 473 | `can_join channel.c:1941` (+i) | `can_join channel.c:761` (+i) |
+  | 474 | `can_join channel.c:1939` (+b) | `can_join channel.c:737` (+b) |
+  | 475 | `can_join channel.c:1969` (+k) | `can_join channel.c:743` (+k) |
+  | 476 | `can_join channel.c:1973` ONLYSSLCLIENTS | BADCHANMASK — not a JOIN exit |
+  | 477 | `can_join channel.c:1937/1943/1945` (+R) | `can_join channel.c:778` (+r) |
+  | 479 | defined, unemitted | `m_join.c:198/221` BADCHANNAME |
+  | 480 | `s_err.c` NULL slot | `can_join channel.c:785` THROTTLE (+j) |
+  | 485 | `channel.c:2313` CHANBANREASON (quarantine) | BANNEDNICK — unrelated |
+
+  **The same number means different things on the two ircds** (476, 485),
+  which is exactly why nothing here maps a numeric to a phrase: the
+  `reason` that reaches cic is the ircd's OWN trailing text, and the code
+  travels beside it as `meta.numeric`. A flavour-blind sentence written by
+  us would tell an Azzurra user their channel mask was malformed when the
+  server said "Only SSL clients can join". Cross-flavour collisions are
+  inert for a second reason too: delegation is correlation-gated, so a
+  numeric only ever reaches the join-failure path when its `params[1]`
+  matches a channel whose JOIN we have in flight.
+
+  ## Measured exclusions
+
+  * **481 ERR_NOPRIVILEGES** — a genuine `can_join` exit on bahamut
+    (`channel.c:1967`, `+O` oper-only channels), but its format string
+    carries NO channel: `":%s 481 %s :Permission Denied, …"`
+    (`s_err.c:550`) has two `%s`, and the `name` argument m_join passes is
+    dropped on the floor. There is nothing on the wire to correlate, so a
+    `+O` rejection cannot reach the window it belongs to and that window
+    stays `:pending`. 481 is also emitted 29 times from `s_serv.c` alone
+    for ordinary oper-command refusals. Covering it needs an in-flight
+    JOIN timeout, not a numeric.
+  * **443 ERR_USERONCHANNEL** (solanum `m_join.c:144`) — channel sits at
+    `params[2]`, not `params[1]` (`"%s %s :is already on channel"`).
+  * **470 ERR_LINKCHANNEL** (solanum `m_join.c:346`) — a REDIRECT, not a
+    refusal: the client is then joined to the linked channel. Two channel
+    params, and the honest handling is a rename, not a failure.
+  """
+
+  @numerics [403, 405, 437, 471, 473, 474, 475, 476, 477, 479, 480, 485]
+
+  @doc """
+  The join-failure numeric set, ascending.
+
+  Callers bind it into a module attribute at compile time
+  (`@join_failure_numerics JoinFailure.numerics()`) so it can be used in a
+  guard; that makes every consumer recompile when this list changes.
+  """
+  @spec numerics() :: [pos_integer(), ...]
+  def numerics, do: @numerics
+end

--- a/lib/grappa/irc/join_failure.ex
+++ b/lib/grappa/irc/join_failure.ex
@@ -51,8 +51,8 @@ defmodule Grappa.IRC.JoinFailure do
 
   ## Measured exclusions
 
-  * **437** — the one collision that is NOT inert, and the reason the guard
-    below matches `params[1]` and nothing looser. On solanum it is
+  * **437** — the one collision that is NOT inert, and the proof that the
+    `params[1]` guard is a correlation, not a safety filter. On solanum it is
     ERR_UNAVAILRESOURCE, a real JOIN exit (`m_join.c:242/303/328`). On
     bahamut 437 is a DIFFERENT numeric, ERR_BANNICKCHANGE
     (`include/numeric.h:333`), and its `params[1]` is **a channel**:

--- a/lib/grappa/irc/join_failure.ex
+++ b/lib/grappa/irc/join_failure.ex
@@ -27,29 +27,44 @@ defmodule Grappa.IRC.JoinFailure do
   |-----|---------|---------|
   | 403 | `channel.c:2221` NOSUCHCHANNEL | `m_join.c:213` NOSUCHCHANNEL |
   | 405 | `channel.c:2354` TOOMANYCHANNELS | `m_join.c:317` TOOMANYCHANNELS |
-  | 437 | — (nick-only) | `m_join.c:242/303/328` UNAVAILRESOURCE |
   | 471 | `can_join channel.c:1971` (+l) | `can_join channel.c:776` (+l) |
   | 473 | `can_join channel.c:1941` (+i) | `can_join channel.c:761` (+i) |
   | 474 | `can_join channel.c:1939` (+b) | `can_join channel.c:737` (+b) |
   | 475 | `can_join channel.c:1969` (+k) | `can_join channel.c:743` (+k) |
-  | 476 | `can_join channel.c:1973` ONLYSSLCLIENTS | BADCHANMASK — not a JOIN exit |
+  | 476 | `can_join channel.c:1973` ONLYSSLCLIENTS | BADCHANMASK, no format string |
   | 477 | `can_join channel.c:1937/1943/1945` (+R) | `can_join channel.c:778` (+r) |
-  | 479 | defined, unemitted | `m_join.c:198/221` BADCHANNAME |
-  | 480 | `s_err.c` NULL slot | `can_join channel.c:785` THROTTLE (+j) |
-  | 485 | `channel.c:2313` CHANBANREASON (quarantine) | BANNEDNICK — unrelated |
+  | 479 | `check_channelname channel.c:2002`, called from `m_join:2204` | `m_join.c:198/221` |
+  | 480 | not in `numeric.h` | `can_join channel.c:785` THROTTLE (+j) |
+  | 485 | `channel.c:2313` CHANBANREASON (quarantine) | BANNEDNICK, no format string |
 
-  **The same number means different things on the two ircds** (476, 485),
-  which is exactly why nothing here maps a numeric to a phrase: the
-  `reason` that reaches cic is the ircd's OWN trailing text, and the code
-  travels beside it as `meta.numeric`. A flavour-blind sentence written by
-  us would tell an Azzurra user their channel mask was malformed when the
-  server said "Only SSL clients can join". Cross-flavour collisions are
-  inert for a second reason too: delegation is correlation-gated, so a
-  numeric only ever reaches the join-failure path when its `params[1]`
-  matches a channel whose JOIN we have in flight.
+  **The same number means different things on the two ircds**, which is
+  exactly why nothing here maps a numeric to a phrase: the `reason` that
+  reaches cic is the ircd's OWN trailing text, and the code travels beside
+  it as `meta.numeric`. A flavour-blind sentence written by us would tell
+  an Azzurra user their channel mask was malformed when the server said
+  "Only SSL clients can join". The two collisions above are additionally
+  inert on the wire: solanum defines 476 and 485 in `include/numeric.h`
+  but gives neither a `NUMERIC_STR_` format string, so core never emits
+  them. And even an emitted collision would have to arrive for a channel
+  whose JOIN we hold in flight before it reached this path at all —
+  delegation is correlation-gated.
 
   ## Measured exclusions
 
+  * **437** — the one collision that is NOT inert, and the reason the guard
+    below matches `params[1]` and nothing looser. On solanum it is
+    ERR_UNAVAILRESOURCE, a real JOIN exit (`m_join.c:242/303/328`). On
+    bahamut 437 is a DIFFERENT numeric, ERR_BANNICKCHANGE
+    (`include/numeric.h:333`), and its `params[1]` is **a channel**:
+    `m_nick.c:525` passes `lp->value.chptr->chname` for
+    `":%s 437 %s %s :Cannot change nickname while banned or moderated on
+    channel"`. So on prod a `/nick` while banned on a channel whose JOIN we
+    still hold in flight would correlate and flip a live window to
+    `:failed` with a nick-change reason — the ghost-correlation hazard the
+    self-JOIN strip in `server.ex:5600` already guards against for the
+    real failure numerics. A juped channel on Libera therefore keeps
+    sitting at `:pending`; that is the deliberate side of the trade, and
+    covering it needs the flavour, not a wider set.
   * **481 ERR_NOPRIVILEGES** — a genuine `can_join` exit on bahamut
     (`channel.c:1967`, `+O` oper-only channels), but its format string
     carries NO channel: `":%s 481 %s :Permission Denied, …"`
@@ -66,7 +81,17 @@ defmodule Grappa.IRC.JoinFailure do
     params, and the honest handling is a rename, not a failure.
   """
 
-  @numerics [403, 405, 437, 471, 473, 474, 475, 476, 477, 479, 480, 485]
+  @numerics [403, 405, 471, 473, 474, 475, 476, 477, 479, 480, 485]
+
+  @typedoc """
+  One measured join-failure numeric.
+
+  The union mirrors `@numerics` exactly, and has to: `:underspecs` rejects a
+  contract wider than the success typing, and a contract narrower than it is
+  invalid, so a code added to one and not the other is a Dialyzer error in
+  either direction. The two cannot drift apart in silence.
+  """
+  @type t :: 403 | 405 | 471 | 473 | 474 | 475 | 476 | 477 | 479 | 480 | 485
 
   @doc """
   The join-failure numeric set, ascending.
@@ -75,6 +100,6 @@ defmodule Grappa.IRC.JoinFailure do
   (`@join_failure_numerics JoinFailure.numerics()`) so it can be used in a
   guard; that makes every consumer recompile when this list changes.
   """
-  @spec numerics() :: [pos_integer(), ...]
+  @spec numerics() :: [t(), ...]
   def numerics, do: @numerics
 end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -88,7 +88,7 @@ defmodule Grappa.Session.EventRouter do
   in `Session.Server.handle_info` — out of this router's scope.
   """
 
-  alias Grappa.IRC.{CTCP, Identifier, Message}
+  alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Message}
   alias Grappa.{Scrollback, Session}
   alias Grappa.Session.{IdentityState, ISupport, ListModes, NumericRouter, Presence}
 
@@ -323,11 +323,19 @@ defmodule Grappa.Session.EventRouter do
   # Numerics where channel is at param 1 (after the own-nick echo).
   # 332 RPL_TOPIC / 333 RPL_TOPICWHOTIME / 331 RPL_NOTOPIC / 329
   # RPL_CREATIONTIME / 324 RPL_CHANNELMODEIS / 366 RPL_ENDOFNAMES /
-  # 352 RPL_WHOREPLY / join-failure 403/405/471/473/474/475/476/477 /
-  # #376 BANLIST 367 RPL_BANLIST + 368 RPL_ENDOFBANLIST (fold the
-  # channel key so the bundle keys/broadcasts on one window — #364).
+  # 352 RPL_WHOREPLY / #376 BANLIST 367 RPL_BANLIST + 368
+  # RPL_ENDOFBANLIST (fold the channel key so the bundle
+  # keys/broadcasts on one window — #364), plus the join-failure set.
+  #
+  # #1345 — that last group used to be an eight-code literal here while
+  # the handler guard below held six, and the two drifted apart in the
+  # only direction that matters: a 477 folded here reached no handler.
+  # Both now read `JoinFailure.numerics()`.
+  @channel_param1_numerics [332, 333, 331, 329, 324, 366, 352, 367, 368] ++
+                             JoinFailure.numerics()
+
   defp do_canonicalize_params({:numeric, n}, [own_nick, ch | rest], cm)
-       when n in [332, 333, 331, 329, 324, 366, 352, 367, 368, 403, 405, 471, 473, 474, 475, 476, 477] and
+       when n in @channel_param1_numerics and
               is_binary(ch) do
     [own_nick, normalize_channel(ch, cm) | rest]
   end
@@ -1724,19 +1732,27 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
-  # CP15 B2 — JOIN failure numerics. Six codes carry the same shape:
+  # CP15 B2 — JOIN failure numerics. Every code in the set carries the
+  # same shape:
   #   :server <code> <own_nick_echo> <channel> :<reason>
   # When the channel matches an in-flight JOIN (case-insensitive RFC 2812
   # §2.2 lookup against state.in_flight_joins), emit {:join_failed, ch,
   # reason, numeric} and strip the entry from state. NumericRouter marks
-  # these codes :delegated so the existing scan-based persist path doesn't
-  # double-process — the apply_effects arm in Session.Server is the
-  # canonical persist + broadcast surface.
+  # the numeric :delegated on exactly the same correlation so the
+  # scan-based persist path doesn't double-process — the apply_effects arm
+  # in Session.Server is the canonical persist + broadcast surface.
   #
-  # No-match (server emits an unsolicited 471/473/etc., or the in-flight
-  # entry was already swept by TTL): fall through with no effect — the
-  # caller's NumericRouter $server route persists it as a server message.
-  @join_failure_numerics [471, 473, 474, 475, 403, 405]
+  # No-match (server emits an unsolicited 403/474/etc., or the in-flight
+  # entry was already swept by TTL): fall through with no effect. #1345 —
+  # this comment used to promise the caller's NumericRouter "$server route
+  # persists it as a server message", which was false for as long as the
+  # codes were UNCONDITIONALLY delegated: `Server.delegate/2` routes to
+  # EventRouter alone, and the numeric catch-all here returns no effect,
+  # so an uncorrelated one was dropped in silence. Correlation-gated
+  # delegation makes the promise true again — and it is what lets the set
+  # hold codes that mean something else outside a JOIN (437's nick form,
+  # 476/485 on solanum), since those never match an in-flight channel.
+  @join_failure_numerics JoinFailure.numerics()
 
   defp do_route(
          %Message{command: {:numeric, code}, params: [_, channel, reason | _]},
@@ -3893,7 +3909,7 @@ defmodule Grappa.Session.EventRouter do
 
   DERIVED from the `extra_lines` fold that absorbed it rather than tracked in
   a parallel flag — the fold IS the absorption, so the two cannot drift.
-  `Session.Server` feeds this into `NumericRouter.new_router_state/4` so the
+  `Session.Server` feeds this into `NumericRouter.new_router_state/6` so the
   operator's NEXT 401 for the same nick routes to its query window instead of
   being eaten by the bundle too.
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1748,8 +1748,8 @@ defmodule Grappa.Session.EventRouter do
   # EventRouter alone, and the numeric catch-all here returns no effect,
   # so an uncorrelated one was dropped in silence. Correlation-gated
   # delegation makes the promise true again — and it is what lets the set
-  # hold codes that mean something else outside a JOIN (437's nick form,
-  # 476/485 on solanum), since those never match an in-flight channel.
+  # hold a code that means something else on the other bound ircd (476,
+  # 485), since those never match an in-flight channel.
   @join_failure_numerics JoinFailure.numerics()
 
   defp do_route(

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -331,12 +331,10 @@ defmodule Grappa.Session.EventRouter do
   # the handler guard below held six, and the two drifted apart in the
   # only direction that matters: a 477 folded here reached no handler.
   # Both now read `JoinFailure.numerics()`.
-  @channel_param1_numerics [332, 333, 331, 329, 324, 366, 352, 367, 368] ++
-                             JoinFailure.numerics()
+  @channel_param1_numerics [332, 333, 331, 329, 324, 366, 352, 367, 368] ++ JoinFailure.numerics()
 
   defp do_canonicalize_params({:numeric, n}, [own_nick, ch | rest], cm)
-       when n in @channel_param1_numerics and
-              is_binary(ch) do
+       when n in @channel_param1_numerics and is_binary(ch) do
     [own_nick, normalize_channel(ch, cm) | rest]
   end
 

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -1121,9 +1121,17 @@ defmodule Grappa.Session.NumericRouter do
   # of a WHOIS in flight AND the code is one this WHOIS may still absorb.
   # Any other param shape (empty, own-nick-only, channel-shaped) yields
   # false → normal param scan.
+  #
+  # #1345 I-S2 — the fold is network-aware (`canonical_target/2`) because
+  # the keys were WRITTEN that way: EventRouter builds `whois_pending`
+  # with `normalize_nick(target, casemapping(state))`. Reading them back
+  # with the arity-1 ASCII fold made the two disagree on an rfc1459
+  # network — a target holding `[ ] \ ~` keys as `foo{1}` and was looked
+  # up as `foo[1]`, so the leg missed and fell to the param scan #221
+  # exists to avoid. CLAUDE.md #537: a folded WRITE forces a folded READ.
   @spec whois_leg?(1..999, [term()], router_state()) :: boolean()
   defp whois_leg?(code, [_, target | _], state) when is_binary(target) do
-    key = Identifier.canonical_target(target)
+    key = Identifier.canonical_target(target, state.casemapping)
 
     MapSet.member?(state.whois_targets, key) and
       absorbable_whois_leg?(code, MapSet.member?(state.whois_nosuchnick_absorbed, key))

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -61,6 +61,15 @@ defmodule Grappa.Session.NumericRouter do
         hostnames whose syntax overlaps with nicks) → `{:query, nick}`.
      c. else → `{:server, nil}`.
 
+  Two of the delegations are **correlation-gated** rather than flat set
+  membership, and both run at priority 1: `whois_leg?/3` (#221, a numeric
+  whose `params[1]` is a WHOIS in flight) and `join_failure_leg?/3` (#1345,
+  a `Grappa.IRC.JoinFailure` code whose `params[1]` is a JOIN in flight).
+  A gated delegation is the right shape whenever the SAME numeric is
+  owned by a handler in one context and is ordinary routable content in
+  another — it delegates the correlated occurrence and leaves every other
+  one visible, which flat membership cannot express.
+
   ## Design notes
 
   * The deny list is closed-set on purpose — adding a numeric to it is a
@@ -118,7 +127,7 @@ defmodule Grappa.Session.NumericRouter do
   `Grappa.Session.EventRouter` for delegated numeric handling.
   """
 
-  alias Grappa.IRC.{Identifier, Message}
+  alias Grappa.IRC.{Identifier, JoinFailure, Message}
 
   @typedoc """
   The resolved routing destination for a numeric.
@@ -167,12 +176,27 @@ defmodule Grappa.Session.NumericRouter do
     * `whois_nosuchnick_absorbed` — the subset of `whois_targets` whose
       pending WHOIS has ALREADY absorbed a 401 ERR_NOSUCHNICK (#785). See
       the error-class carve-out on `absorbable_whois_leg?/2`.
+    * `in_flight_channels` — the folded-key set of JOINs currently in
+      flight (`MapSet.new(Map.keys(state.in_flight_joins))`). #1345: a
+      join-failure numeric is delegated ONLY when its `params[1]` folds
+      into this set, which is the same correlation EventRouter's
+      `{:join_failed, …}` clause performs. Uncorrelated ones stay on the
+      normal route and remain visible, and a code that means something
+      else outside a JOIN (437's nick form, 476/485 on solanum) is inert.
+    * `casemapping` — the network's identifier casemapping from 005
+      (`ISupport.casemapping/1`), `:ascii` when no 005 has landed. #537:
+      the accumulator keys above are written with the NETWORK fold, so
+      every read here must fold the same way. On an rfc1459 network a
+      key holding `[ ] \\ ~` is written `foo{1}`, and an ASCII-only read
+      looking for `foo[1]` misses it.
   """
   @type router_state :: %{
           required(:own_nick) => String.t() | nil,
           required(:labels_pending) => %{String.t() => window_ref()},
           required(:whois_targets) => MapSet.t(String.t()),
-          required(:whois_nosuchnick_absorbed) => MapSet.t(String.t())
+          required(:whois_nosuchnick_absorbed) => MapSet.t(String.t()),
+          required(:in_flight_channels) => MapSet.t(String.t()),
+          required(:casemapping) => Identifier.casemapping()
         }
 
   # ---------------------------------------------------------------------------
@@ -653,20 +677,21 @@ defmodule Grappa.Session.NumericRouter do
                         371,
                         374,
                         351,
-                        # CP15 B2 — JOIN failure numerics. EventRouter
-                        # correlates against state.in_flight_joins and
-                        # emits {:join_failed, ch, reason, code}. The
-                        # apply_effects arm in Session.Server persists a
-                        # :notice row + broadcasts on the per-channel
-                        # topic — without delegation, the param-derived
-                        # scan-route also persists the same numeric on
-                        # `$server`, doubling the row.
-                        471,
-                        473,
-                        474,
-                        475,
-                        403,
-                        405,
+                        # CP15 B2 — the JOIN failure numerics USED to sit
+                        # here as an unconditional six. #1345 moved them
+                        # to `join_failure_leg?/3`, a correlation gate on
+                        # the same in-flight-JOIN match EventRouter's
+                        # `{:join_failed, …}` clause performs — see
+                        # `Grappa.IRC.JoinFailure` for the measured set.
+                        # The double-persist this block existed to prevent
+                        # is still prevented (matched → delegated only,
+                        # uncorrelated → scan only, never both), and the
+                        # gate is what lets the set carry codes that mean
+                        # something else outside a JOIN: unconditional
+                        # delegation would have swallowed those in silence,
+                        # because `Server.delegate/2` hands the numeric to
+                        # EventRouter alone and its numeric catch-all
+                        # returns no effect.
                         # Cluster `channel-created-notice` 2026-05-13 —
                         # channel-state numerics that EventRouter caches
                         # into state.{topics, channel_modes, channels_created}
@@ -848,14 +873,25 @@ defmodule Grappa.Session.NumericRouter do
           String.t() | nil,
           %{String.t() => window_ref()},
           MapSet.t(String.t()),
-          MapSet.t(String.t())
+          MapSet.t(String.t()),
+          MapSet.t(String.t()),
+          Identifier.casemapping()
         ) :: router_state()
-  def new_router_state(own_nick, labels_pending, whois_targets, whois_nosuchnick_absorbed) do
+  def new_router_state(
+        own_nick,
+        labels_pending,
+        whois_targets,
+        whois_nosuchnick_absorbed,
+        in_flight_channels,
+        casemapping
+      ) do
     %{
       own_nick: own_nick,
       labels_pending: labels_pending,
       whois_targets: whois_targets,
-      whois_nosuchnick_absorbed: whois_nosuchnick_absorbed
+      whois_nosuchnick_absorbed: whois_nosuchnick_absorbed,
+      in_flight_channels: in_flight_channels,
+      casemapping: casemapping
     }
   end
 
@@ -956,7 +992,8 @@ defmodule Grappa.Session.NumericRouter do
         # lingering away label is harmless (bounded by prepare_label's
         # lazy TTL sweep on the next away command; 305/306 both delegate,
         # so it can never misroute another numeric).
-        if MapSet.member?(@delegated_numerics, code) do
+        if MapSet.member?(@delegated_numerics, code) or
+             join_failure_leg?(code, msg.params, state) do
           :delegated
         else
           window_ref_to_decision(window_ref)
@@ -995,10 +1032,46 @@ defmodule Grappa.Session.NumericRouter do
     end
   end
 
+  # #1345 — the join-failure gate runs AHEAD of the class dispatch, on the
+  # same "delegation wins" precedence the label arm above uses. It has to:
+  # 437 ERR_UNAVAILRESOURCE is deny-listed for its NICK form, and the
+  # channel form would never reach `:scan` to be tested there.
   @spec param_derived_route(1..999, Message.t(), router_state()) :: routing_decision()
   defp param_derived_route(code, msg, state) do
-    route_for_class(numeric_class(code), msg, state)
+    if join_failure_leg?(code, msg.params, state) do
+      :delegated
+    else
+      route_for_class(numeric_class(code), msg, state)
+    end
   end
+
+  # True iff `code` can abort a JOIN (`Grappa.IRC.JoinFailure`, measured
+  # against both bound ircds) AND `params[1]` folds to a channel whose JOIN
+  # is in flight right now. That second half is the whole design: it is the
+  # SAME correlation EventRouter runs before emitting `{:join_failed, …}`,
+  # so the two decisions cannot disagree — matched, only EventRouter
+  # persists; unmatched, only the scan route does; never both, never
+  # neither. It also keeps a cross-flavour numeric collision inert (485 is
+  # a quarantined-channel refusal on bahamut and ERR_BANNEDNICK on solanum)
+  # and leaves 437's nick form on its deny-listed route, since a nick never
+  # folds into the channel set.
+  @join_failure_numerics MapSet.new(JoinFailure.numerics())
+
+  # The param shape is the handler's shape, `[_, channel, reason | _]`, not
+  # merely "something at params[1]": a delegation the EventRouter clause
+  # then declines to match is exactly the silent drop this gate exists to
+  # end. The two predicates have to be the same predicate.
+  @spec join_failure_leg?(1..999, [term()], router_state()) :: boolean()
+  defp join_failure_leg?(code, [_, channel, reason | _], state)
+       when is_binary(channel) and is_binary(reason) do
+    MapSet.member?(@join_failure_numerics, code) and
+      MapSet.member?(
+        state.in_flight_channels,
+        Identifier.canonical_target(channel, state.casemapping)
+      )
+  end
+
+  defp join_failure_leg?(_, _, _), do: false
 
   # HIGH-31 (no-silent-drops B6.9a 2026-05-14): pre-fix this was a
   # 3-arm `cond` chain inside `param_derived_route/3`, mixing the

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -1054,12 +1054,15 @@ defmodule Grappa.Session.NumericRouter do
   # neither. It also keeps a cross-flavour numeric collision inert (485 is
   # a quarantined-channel refusal on bahamut and ERR_BANNEDNICK on solanum).
   #
-  # `params[1]` is the WHOLE correlation on purpose — do not loosen it to
-  # "a channel anywhere in the params". 437 is the counter-example that
-  # earned its exclusion: on bahamut it is ERR_BANNICKCHANGE and carries a
-  # channel there for a NICK failure (`m_nick.c:525`), so a looser guard
-  # would flip a live window to `:failed` off a nick error. See
-  # `Grappa.IRC.JoinFailure`'s exclusion list before adding a code.
+  # `params[1]` is the WHOLE correlation, and it is NOT a filter that makes
+  # any code safe to add. 437 is the proof: on bahamut it is
+  # ERR_BANNICKCHANGE and puts a CHANNEL at `params[1]`
+  # (`m_nick.c:525` passes `chptr->chname`) for a NICK failure, so it would
+  # correlate against a live in-flight JOIN and flip that window to
+  # `:failed` — under this exact guard, not a looser one. What protects us
+  # is that 437 is not in the set. Read `Grappa.IRC.JoinFailure`'s
+  # exclusion list before adding a code, and check the ircd's format
+  # string: membership is a claim about MEANING, not about shape.
   @join_failure_numerics MapSet.new(JoinFailure.numerics())
 
   # The param shape is the handler's shape, `[_, channel, reason | _]`, not

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -1062,13 +1062,9 @@ defmodule Grappa.Session.NumericRouter do
   # then declines to match is exactly the silent drop this gate exists to
   # end. The two predicates have to be the same predicate.
   @spec join_failure_leg?(1..999, [term()], router_state()) :: boolean()
-  defp join_failure_leg?(code, [_, channel, reason | _], state)
-       when is_binary(channel) and is_binary(reason) do
+  defp join_failure_leg?(code, [_, channel, reason | _], state) when is_binary(channel) and is_binary(reason) do
     MapSet.member?(@join_failure_numerics, code) and
-      MapSet.member?(
-        state.in_flight_channels,
-        Identifier.canonical_target(channel, state.casemapping)
-      )
+      MapSet.member?(state.in_flight_channels, Identifier.canonical_target(channel, state.casemapping))
   end
 
   defp join_failure_leg?(_, _, _), do: false

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -182,7 +182,7 @@ defmodule Grappa.Session.NumericRouter do
       into this set, which is the same correlation EventRouter's
       `{:join_failed, …}` clause performs. Uncorrelated ones stay on the
       normal route and remain visible, and a code that means something
-      else outside a JOIN (437's nick form, 476/485 on solanum) is inert.
+      else outside a JOIN (476/485 across the two ircds) is inert.
     * `casemapping` — the network's identifier casemapping from 005
       (`ISupport.casemapping/1`), `:ascii` when no 005 has landed. #537:
       the accumulator keys above are written with the NETWORK fold, so
@@ -1033,9 +1033,9 @@ defmodule Grappa.Session.NumericRouter do
   end
 
   # #1345 — the join-failure gate runs AHEAD of the class dispatch, on the
-  # same "delegation wins" precedence the label arm above uses. It has to:
-  # 437 ERR_UNAVAILRESOURCE is deny-listed for its NICK form, and the
-  # channel form would never reach `:scan` to be tested there.
+  # same "delegation wins" precedence the label arm above uses, so that a
+  # member of the set is never intercepted by the deny list on its way to
+  # the correlation test.
   @spec param_derived_route(1..999, Message.t(), router_state()) :: routing_decision()
   defp param_derived_route(code, msg, state) do
     if join_failure_leg?(code, msg.params, state) do
@@ -1052,9 +1052,14 @@ defmodule Grappa.Session.NumericRouter do
   # so the two decisions cannot disagree — matched, only EventRouter
   # persists; unmatched, only the scan route does; never both, never
   # neither. It also keeps a cross-flavour numeric collision inert (485 is
-  # a quarantined-channel refusal on bahamut and ERR_BANNEDNICK on solanum)
-  # and leaves 437's nick form on its deny-listed route, since a nick never
-  # folds into the channel set.
+  # a quarantined-channel refusal on bahamut and ERR_BANNEDNICK on solanum).
+  #
+  # `params[1]` is the WHOLE correlation on purpose — do not loosen it to
+  # "a channel anywhere in the params". 437 is the counter-example that
+  # earned its exclusion: on bahamut it is ERR_BANNICKCHANGE and carries a
+  # channel there for a NICK failure (`m_nick.c:525`), so a looser guard
+  # would flip a live window to `:failed` off a nick error. See
+  # `Grappa.IRC.JoinFailure`'s exclusion list before adding a code.
   @join_failure_numerics MapSet.new(JoinFailure.numerics())
 
   # The param shape is the handler's shape, `[_, channel, reason | _]`, not

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4913,11 +4913,12 @@ defmodule Grappa.Session.Server do
   # ---------------------------------------------------------------------------
 
   # Builds the `NumericRouter.router_state()` view from full Session.Server
-  # state. CP13: the router only needs `own_nick` (to skip the params[0]
-  # echo and exclude self-mentions from query candidates) and
-  # `labels_pending` (for labeled-response correlation). It no longer reads
-  # `last_command_window` or `open_query_nicks` — the new "scan-then-server"
-  # fallback is purely syntactic on params.
+  # state. CP13: the router needs `own_nick` (to skip the params[0] echo and
+  # exclude self-mentions from query candidates) and `labels_pending` (for
+  # labeled-response correlation). It no longer reads `last_command_window`
+  # or `open_query_nicks` — the "scan-then-server" fallback is purely
+  # syntactic on params. The two correlation sets that follow (#221 WHOIS,
+  # #1345 in-flight JOIN) are what keep a stateful numeric off the scan.
   defp build_router_state(state) do
     NumericRouter.new_router_state(
       state.nick,
@@ -4929,7 +4930,16 @@ defmodule Grappa.Session.Server do
       MapSet.new(Map.keys(Map.get(state, :whois_pending, %{}))),
       # #785 — of those, the ones whose bundle already absorbed a 401. The
       # accumulator shape is EventRouter's, so the derivation lives there.
-      EventRouter.whois_nosuchnick_absorbed(state)
+      EventRouter.whois_nosuchnick_absorbed(state),
+      # #1345 — the in-flight JOIN keys (already folded by
+      # `record_in_flight_join/2`). Lets the router delegate a join-failure
+      # numeric ONLY when it correlates, so an uncorrelated one stays
+      # visible instead of vanishing into EventRouter's numeric catch-all.
+      # Map.get keeps a pre-CP15 hot-reloaded state map safe.
+      MapSet.new(Map.keys(Map.get(state, :in_flight_joins, %{}))),
+      # #537 — the fold both accumulator reads above must use: the keys
+      # were written network-aware, so the lookup has to be too.
+      session_casemapping(state)
     )
   end
 

--- a/test/grappa/irc/join_failure_test.exs
+++ b/test/grappa/irc/join_failure_test.exs
@@ -23,8 +23,6 @@ defmodule Grappa.IRC.JoinFailureTest do
     403,
     # 405 ERR_TOOMANYCHANNELS — bahamut channel.c:2354, solanum m_join.c:317
     405,
-    # 437 ERR_UNAVAILRESOURCE — solanum m_join.c:242/303/328 (channel form)
-    437,
     # 471 ERR_CHANNELISFULL (+l) — both, can_join
     471,
     # 473 ERR_INVITEONLYCHAN (+i) — both, can_join
@@ -63,6 +61,16 @@ defmodule Grappa.IRC.JoinFailureTest do
       refute 481 in JoinFailure.numerics()
       refute 443 in JoinFailure.numerics()
       refute 470 in JoinFailure.numerics()
+    end
+
+    test "excludes 437 — on bahamut it is ERR_BANNICKCHANGE and carries a channel" do
+      # The one exclusion that is NOT about shape. 437 IS a JOIN exit on
+      # solanum (UNAVAILRESOURCE), but on bahamut — all of prod — it is a
+      # different numeric whose params[1] is the channel a NICK was refused
+      # on (`m_nick.c:525`). It would correlate against a live in-flight
+      # JOIN and flip that window to :failed off a nick error, so it stays
+      # out and a juped channel on Libera keeps sitting at :pending.
+      refute 437 in JoinFailure.numerics()
     end
 
     test "is ascending and duplicate-free" do

--- a/test/grappa/irc/join_failure_test.exs
+++ b/test/grappa/irc/join_failure_test.exs
@@ -1,0 +1,75 @@
+defmodule Grappa.IRC.JoinFailureTest do
+  @moduledoc """
+  #1345 — the truncation gate for the join-failure numeric set.
+
+  The expected list below is written out by hand, from the ircd sources
+  cited in `Grappa.IRC.JoinFailure`'s moduledoc, and is deliberately NOT
+  derived from `numerics/0`: a test that asks the production list to
+  confirm itself passes vacuously through exactly the truncation that made
+  a `+R` channel hang at `:pending` forever.
+
+  Everything else that consumes the set (both `EventRouter` guards, the
+  `NumericRouter` correlation gate) derives from `numerics/0`, so this is
+  the one place where a dropped code becomes a red test.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRC.JoinFailure
+
+  # azzurra/bahamut @ 5c41c8b + solanum @ 2ce64de. One line per code, so a
+  # deletion is a visible deletion in review, not a shortened literal.
+  @measured [
+    # 403 ERR_NOSUCHCHANNEL — bahamut channel.c:2221, solanum m_join.c:213
+    403,
+    # 405 ERR_TOOMANYCHANNELS — bahamut channel.c:2354, solanum m_join.c:317
+    405,
+    # 437 ERR_UNAVAILRESOURCE — solanum m_join.c:242/303/328 (channel form)
+    437,
+    # 471 ERR_CHANNELISFULL (+l) — both, can_join
+    471,
+    # 473 ERR_INVITEONLYCHAN (+i) — both, can_join
+    473,
+    # 474 ERR_BANNEDFROMCHAN (+b) — both, can_join
+    474,
+    # 475 ERR_BADCHANNELKEY (+k) — both, can_join
+    475,
+    # 476 ERR_ONLYSSLCLIENTS — bahamut channel.c:1973
+    476,
+    # 477 ERR_NEEDREGGEDNICK (+R/+r) — both, can_join
+    477,
+    # 479 ERR_BADCHANNAME — solanum m_join.c:198/221
+    479,
+    # 480 ERR_THROTTLE (+j) — solanum channel.c:785
+    480,
+    # 485 ERR_CHANBANREASON (quarantined channel) — bahamut channel.c:2313
+    485
+  ]
+
+  describe "numerics/0" do
+    test "is exactly the measured set — a dropped code is the #1345 bug" do
+      assert JoinFailure.numerics() == @measured
+    end
+
+    test "carries the two codes whose absence was #1345 (476, 477)" do
+      assert 477 in JoinFailure.numerics()
+      assert 476 in JoinFailure.numerics()
+    end
+
+    test "excludes the numerics that carry no correlatable channel" do
+      # 481 ERR_NOPRIVILEGES has no channel param (bahamut s_err.c:550),
+      # 443 ERR_USERONCHANNEL carries it at params[2], 470 ERR_LINKCHANNEL
+      # is a redirect. Including any of them would either misread the
+      # reason slot or swallow an unrelated error. See the moduledoc.
+      refute 481 in JoinFailure.numerics()
+      refute 443 in JoinFailure.numerics()
+      refute 470 in JoinFailure.numerics()
+    end
+
+    test "is ascending and duplicate-free" do
+      numerics = JoinFailure.numerics()
+
+      assert numerics == Enum.sort(numerics)
+      assert numerics == Enum.uniq(numerics)
+    end
+  end
+end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1921,8 +1921,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 477}, ["vjt", "#Foo[1]", "identify first"], {:server, "irc.test.org"})
 
-      assert {:cont, next_state, [{:join_failed, "#foo{1}", _, 477}]} =
-               EventRouter.route(m, state)
+      assert {:cont, next_state, [{:join_failed, "#foo{1}", _, 477}]} = EventRouter.route(m, state)
 
       refute Map.has_key?(next_state.in_flight_joins, "#foo{1}")
     end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -11,7 +11,7 @@ defmodule Grappa.Session.EventRouterTest do
   """
   use ExUnit.Case, async: true
 
-  alias Grappa.IRC.{Message, Parser}
+  alias Grappa.IRC.{JoinFailure, Message, Parser}
   alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, Wire}
 
   @user_id "00000000-0000-0000-0000-000000000001"
@@ -1815,14 +1815,14 @@ defmodule Grappa.Session.EventRouterTest do
     # §2.2 lookup) and strips the matched entry from the returned next_state
     # so a re-issued JOIN can be tracked again without stale interference.
 
-    for {numeric, reason} <- [
-          {471, "Cannot join channel (+l)"},
-          {473, "Cannot join channel (+i)"},
-          {474, "Cannot join channel (+b)"},
-          {475, "Cannot join channel (+k)"},
-          {403, "No such channel"},
-          {405, "You have joined too many channels"}
-        ] do
+    # #1345 — driven by `JoinFailure.numerics()`, not by a literal that has
+    # to be remembered: the six hardcoded here used to be a THIRD copy of a
+    # set the router and the canonicaliser each held separately, and 476/477
+    # were missing from two of the three. The set itself is pinned against a
+    # hand-written measured literal in `Grappa.IRC.JoinFailureTest`.
+    for numeric <- JoinFailure.numerics() do
+      reason = "Cannot join channel"
+
       test "#{numeric} on in-flight #channel emits {:join_failed, _, _, #{numeric}} + strips entry" do
         state = in_flight_state("#sniffo")
 
@@ -1867,9 +1867,12 @@ defmodule Grappa.Session.EventRouterTest do
       end
 
       test "#{numeric} with no in-flight entry emits NO :join_failed effect" do
-        # Falls through to NumericRouter's existing $server route via the
-        # scan-router path (re-asserted in Session.Server integration).
-        # EventRouter itself returns no :join_failed and leaves state alone.
+        # EventRouter returns no :join_failed and leaves state alone. #1345 —
+        # what happens NEXT is the correlation gate's business: with nothing
+        # in flight `NumericRouter` never delegates the numeric in the first
+        # place, so it takes its ordinary route and stays visible. Before the
+        # gate, delegation was unconditional and this arm was where the
+        # numeric quietly died.
         state = base_state(%{in_flight_joins: %{}})
 
         m =
@@ -1882,6 +1885,46 @@ defmodule Grappa.Session.EventRouterTest do
         assert {:cont, ^state, effects} = EventRouter.route(m, state)
         refute Enum.any?(effects, &match?({:join_failed, _, _, _}, &1))
       end
+    end
+
+    test "477 on a +R channel fails the window and carries the SERVER's own reason" do
+      # The #1345 defect in one case: bahamut's `can_join` 477 for a `+R`
+      # channel (`src/channel.c:1943`) produced no effect at all, so the
+      # window sat at `:pending` forever. The reason travels verbatim —
+      # nothing here maps a numeric to a phrase, because 476/485 mean
+      # different things on the two bound ircds.
+      reason = "You need to identify to a registered nick to join that channel."
+      state = in_flight_state("#sniffo")
+      m = msg({:numeric, 477}, ["vjt", "#sniffo", reason], {:server, "irc.test.org"})
+
+      assert {:cont, _, [{:join_failed, "#sniffo", ^reason, 477}]} = EventRouter.route(m, state)
+    end
+
+    test "476 means ONLYSSLCLIENTS on bahamut and still fails the window" do
+      reason = "Only SSL clients can join"
+      state = in_flight_state("#sniffo")
+      m = msg({:numeric, 476}, ["vjt", "#sniffo", reason], {:server, "irc.test.org"})
+
+      assert {:cont, _, [{:join_failed, "#sniffo", ^reason, 476}]} = EventRouter.route(m, state)
+    end
+
+    test "the in-flight lookup folds the channel network-aware on rfc1459" do
+      # `#Foo[1]` echoed back for an in-flight `#foo{1}` is the SAME channel
+      # on solanum, so the correlation must hit. The canonicalisation guard
+      # this depends on reads the join-failure set too — deriving both from
+      # `JoinFailure.numerics()` is what keeps them in step.
+      state =
+        base_state(%{
+          isupport: %{ISupport.default() | casemapping: :rfc1459},
+          in_flight_joins: %{"#foo{1}" => {"#foo{1}", 12_345, nil}}
+        })
+
+      m = msg({:numeric, 477}, ["vjt", "#Foo[1]", "identify first"], {:server, "irc.test.org"})
+
+      assert {:cont, next_state, [{:join_failed, "#foo{1}", _, 477}]} =
+               EventRouter.route(m, state)
+
+      refute Map.has_key?(next_state.in_flight_joins, "#foo{1}")
     end
   end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -946,14 +946,6 @@ defmodule Grappa.Session.NumericRouterTest do
     # measured code delegate when it correlates, and does none of them
     # delegate when it does not? Truncating the set turns the pin red;
     # breaking the gate turns these red.
-    # 437 is the one member that is ALSO deny-listed (for its nick form), so
-    # its uncorrelated route is `$server`, not the channel window. Every
-    # other member falls to the param scan.
-    uncorrelated = fn
-      437, _channel -> {:server, nil}
-      _code, channel -> {:channel, channel}
-    end
-
     for code <- JoinFailure.numerics() do
       test "#{code} on an in-flight JOIN is delegated to EventRouter" do
         m = msg(unquote(code), ["vjt", "#sniffo", "Cannot join channel"])
@@ -968,14 +960,14 @@ defmodule Grappa.Session.NumericRouterTest do
         # in silence rather than landing in a window.
         m = msg(unquote(code), ["vjt", "#sniffo", "Cannot join channel"])
 
-        assert unquote(Macro.escape(uncorrelated.(code, "#sniffo"))) == NumericRouter.route(m, state())
+        assert {:channel, "#sniffo"} = NumericRouter.route(m, state())
       end
 
       test "#{code} for a DIFFERENT channel than the in-flight one is not delegated" do
         m = msg(unquote(code), ["vjt", "#altrove", "Cannot join channel"])
         st = state(in_flight_channels: MapSet.new(["#sniffo"]))
 
-        assert unquote(Macro.escape(uncorrelated.(code, "#altrove"))) == NumericRouter.route(m, st)
+        assert {:channel, "#altrove"} = NumericRouter.route(m, st)
       end
     end
 
@@ -1010,12 +1002,14 @@ defmodule Grappa.Session.NumericRouterTest do
       assert {:channel, "#foo[1]"} = NumericRouter.route(m, st)
     end
 
-    test "437's NICK form keeps its deny-listed $server route while a JOIN is in flight" do
-      # ERR_UNAVAILRESOURCE is dual-use: `Nick/channel is temporarily
-      # unavailable`. The channel form belongs to the JOIN, the nick form
-      # answers a /nick — and the gate separates them by shape, because a
-      # nick never folds into the in-flight CHANNEL set.
-      m = msg(437, ["vjt", "presanick", "Nick/channel is temporarily unavailable"])
+    test "437 is NOT delegated even when its channel matches an in-flight JOIN" do
+      # The exclusion that shape alone would not have caught. On bahamut —
+      # all of prod — 437 is ERR_BANNICKCHANGE and `params[1]` is the
+      # channel a NICK was refused on (`m_nick.c:525`), a perfect false
+      # positive for the correlation. Keeping it out of the set is what
+      # stops a nick error from flipping a live window to :failed; the
+      # numeric stays on its deny-listed $server route.
+      m = msg(437, ["vjt", "#sniffo", "Cannot change nickname while banned or moderated on channel"])
       st = state(in_flight_channels: MapSet.new(["#sniffo"]))
 
       assert {:server, nil} = NumericRouter.route(m, st)

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -12,7 +12,7 @@ defmodule Grappa.Session.NumericRouterTest do
 
   use ExUnitProperties
 
-  alias Grappa.IRC.Message
+  alias Grappa.IRC.{JoinFailure, Message}
   alias Grappa.Session.NumericRouter
 
   # ---------------------------------------------------------------------------
@@ -32,7 +32,9 @@ defmodule Grappa.Session.NumericRouterTest do
       own_nick: Keyword.get(opts, :own_nick, "vjt"),
       labels_pending: Keyword.get(opts, :labels_pending, %{}),
       whois_targets: Keyword.get(opts, :whois_targets, MapSet.new()),
-      whois_nosuchnick_absorbed: Keyword.get(opts, :whois_nosuchnick_absorbed, MapSet.new())
+      whois_nosuchnick_absorbed: Keyword.get(opts, :whois_nosuchnick_absorbed, MapSet.new()),
+      in_flight_channels: Keyword.get(opts, :in_flight_channels, MapSet.new()),
+      casemapping: Keyword.get(opts, :casemapping, :ascii)
     }
   end
 
@@ -153,13 +155,11 @@ defmodule Grappa.Session.NumericRouterTest do
     259,
     423,
     447,
-    # CP15 B2 — JOIN failure numerics (EventRouter handles them now)
-    471,
-    473,
-    474,
-    475,
-    403,
-    405,
+    # CP15 B2 — the JOIN failure numerics are NOT here any more (#1345).
+    # They are delegated by `join_failure_leg?/3`, gated on an in-flight
+    # JOIN, and get their own describe block below: flat membership would
+    # have swallowed every uncorrelated occurrence, which is why this
+    # mirror must NOT grow them back.
     # Channel-state numerics (EventRouter caches into state.topics /
     # state.channel_modes / state.channels_created — must be delegated
     # so Server.handle_info doesn't double-persist them as `:notice`
@@ -913,6 +913,116 @@ defmodule Grappa.Session.NumericRouterTest do
     test "a 401 with NO whois in flight routes to the query window (pre-#221 behaviour)" do
       m = msg(401, ["vjt", "ghost", "No such nick/channel"])
       assert {:query, "ghost"} = NumericRouter.route(m, state())
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #1345 — the join-failure correlation gate
+  # ---------------------------------------------------------------------------
+
+  describe "join-failure gate (#1345)" do
+    # The set is pinned by its own literal in `Grappa.IRC.JoinFailureTest`;
+    # iterating it here asks the behavioural question instead: does EVERY
+    # measured code delegate when it correlates, and does none of them
+    # delegate when it does not? Truncating the set turns the pin red;
+    # breaking the gate turns these red.
+    # 437 is the one member that is ALSO deny-listed (for its nick form), so
+    # its uncorrelated route is `$server`, not the channel window. Every
+    # other member falls to the param scan.
+    uncorrelated = fn
+      437, _channel -> {:server, nil}
+      _code, channel -> {:channel, channel}
+    end
+
+    for code <- JoinFailure.numerics() do
+      test "#{code} on an in-flight JOIN is delegated to EventRouter" do
+        m = msg(unquote(code), ["vjt", "#sniffo", "Cannot join channel"])
+        st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+        assert :delegated = NumericRouter.route(m, st)
+      end
+
+      test "#{code} with NO in-flight JOIN stays visible on its normal route" do
+        # The pre-#1345 unconditional delegation sent this to EventRouter's
+        # numeric catch-all, which emits no effect — so the row was dropped
+        # in silence rather than landing in a window.
+        m = msg(unquote(code), ["vjt", "#sniffo", "Cannot join channel"])
+
+        assert unquote(Macro.escape(uncorrelated.(code, "#sniffo"))) ==
+                 NumericRouter.route(m, state())
+      end
+
+      test "#{code} for a DIFFERENT channel than the in-flight one is not delegated" do
+        m = msg(unquote(code), ["vjt", "#altrove", "Cannot join channel"])
+        st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+        assert unquote(Macro.escape(uncorrelated.(code, "#altrove"))) ==
+                 NumericRouter.route(m, st)
+      end
+    end
+
+    test "477 is the code #1345 was filed for — a +R channel must reach the handler" do
+      m = msg(477, ["vjt", "#sniffo", "You need to identify to a registered nick"])
+      st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "the gate folds the echoed channel case-insensitively (ASCII)" do
+      m = msg(477, ["vjt", "#SNIFFO", "You need to identify"])
+      st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "the gate folds with the NETWORK casemapping on rfc1459" do
+      # `#foo[1]` and `#foo{1}` are ONE channel on solanum/Libera, so the
+      # in-flight key written as `#foo{1}` must match the `#foo[1]` the
+      # server echoes back. Same write/read fold rule as the WHOIS leg.
+      m = msg(477, ["vjt", "#foo[1]", "You need to identify"])
+      st = state(in_flight_channels: MapSet.new(["#foo{1}"]), casemapping: :rfc1459)
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "on :ascii the same pair stays DISTINCT (no over-fold)" do
+      m = msg(477, ["vjt", "#foo[1]", "You need to identify"])
+      st = state(in_flight_channels: MapSet.new(["#foo{1}"]), casemapping: :ascii)
+
+      assert {:channel, "#foo[1]"} = NumericRouter.route(m, st)
+    end
+
+    test "437's NICK form keeps its deny-listed $server route while a JOIN is in flight" do
+      # ERR_UNAVAILRESOURCE is dual-use: `Nick/channel is temporarily
+      # unavailable`. The channel form belongs to the JOIN, the nick form
+      # answers a /nick — and the gate separates them by shape, because a
+      # nick never folds into the in-flight CHANNEL set.
+      m = msg(437, ["vjt", "presanick", "Nick/channel is temporarily unavailable"])
+      st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+      assert {:server, nil} = NumericRouter.route(m, st)
+    end
+
+    test "a non-join numeric with a channel param is untouched by the gate" do
+      # 482 ERR_CHANOPRIVSNEEDED answers a MODE/KICK, and can perfectly well
+      # arrive for a channel whose JOIN is in flight. It is not in the set,
+      # so it routes to the channel window as always.
+      m = msg(482, ["vjt", "#sniffo", "You're not channel operator"])
+      st = state(in_flight_channels: MapSet.new(["#sniffo"]))
+
+      assert {:channel, "#sniffo"} = NumericRouter.route(m, st)
+    end
+
+    test "delegation still wins over a matching label" do
+      m = msg_tagged(477, ["vjt", "#sniffo", "You need to identify"], "lbl")
+
+      st =
+        state(
+          in_flight_channels: MapSet.new(["#sniffo"]),
+          labels_pending: %{"lbl" => %{kind: :server, target: nil}}
+        )
+
+      assert :delegated = NumericRouter.route(m, st)
     end
   end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -968,16 +968,14 @@ defmodule Grappa.Session.NumericRouterTest do
         # in silence rather than landing in a window.
         m = msg(unquote(code), ["vjt", "#sniffo", "Cannot join channel"])
 
-        assert unquote(Macro.escape(uncorrelated.(code, "#sniffo"))) ==
-                 NumericRouter.route(m, state())
+        assert unquote(Macro.escape(uncorrelated.(code, "#sniffo"))) == NumericRouter.route(m, state())
       end
 
       test "#{code} for a DIFFERENT channel than the in-flight one is not delegated" do
         m = msg(unquote(code), ["vjt", "#altrove", "Cannot join channel"])
         st = state(in_flight_channels: MapSet.new(["#sniffo"]))
 
-        assert unquote(Macro.escape(uncorrelated.(code, "#altrove"))) ==
-                 NumericRouter.route(m, st)
+        assert unquote(Macro.escape(uncorrelated.(code, "#altrove"))) == NumericRouter.route(m, st)
       end
     end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -822,6 +822,26 @@ defmodule Grappa.Session.NumericRouterTest do
       assert :delegated = NumericRouter.route(m, st)
     end
 
+    test "the whois-leg guard folds with the NETWORK casemapping (#1345 I-S2)" do
+      # `whois_pending` keys are WRITTEN with `canonical_target/2` at the
+      # network's casemapping (event_router.ex `normalize_nick/2`), so the
+      # read has to fold the same way. Reading with the arity-1 ASCII fold
+      # made an rfc1459 target holding `[ ] \ ~` key as `foo{1}` and look
+      # up as `foo[1]`: the leg missed and fell to the very param scan
+      # #221 exists to avoid.
+      m = msg(617, ["vjt", "alice[1]", "some new WHOIS line"])
+      st = state(whois_targets: MapSet.new(["alice{1}"]), casemapping: :rfc1459)
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "the whois-leg fold does NOT over-fold on an :ascii network (#525 posture)" do
+      m = msg(617, ["vjt", "alice[1]", "some new WHOIS line"])
+      st = state(whois_targets: MapSet.new(["alice{1}"]), casemapping: :ascii)
+
+      assert {:query, "alice[1]"} = NumericRouter.route(m, st)
+    end
+
     test "an unknown numeric with NO matching in-flight whois still param-scans (query for the nick)" do
       # No whois in flight → the nick-shaped param routes to a query window
       # exactly as before (pre-#221 behaviour preserved for the non-whois case).

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5704,11 +5704,12 @@ defmodule Grappa.Session.ServerTest do
       assert row.body == "Cannot join channel (+i)"
       assert row.meta == %{numeric: 473}
 
-      # Regression: NumericRouter @delegated_numerics must include 473 so
-      # the param-derived $server scan-route does NOT also persist a row
-      # for the same numeric. Without delegation the channel would get
-      # one notice (apply_effects) AND $server would get one notice (scan
-      # route) — the failure would surface twice.
+      # Regression: NumericRouter must delegate 473 while the JOIN is in
+      # flight (#1345's `join_failure_leg?/3`) so the param-derived
+      # scan-route does NOT also persist a row for the same numeric.
+      # Without delegation the channel would get one notice
+      # (apply_effects) AND the scan route another — the failure would
+      # surface twice.
       assert [] = Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 10, nil, false)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
@@ -5757,8 +5758,9 @@ defmodule Grappa.Session.ServerTest do
     test "473 with no in-flight entry does NOT emit join_failed broadcast (regression)" do
       # No-match: the failure numeric arrives without an in-flight tracker
       # (server-emitted, or post-TTL-sweep). EventRouter must NOT emit
-      # :join_failed; the existing NumericRouter $server route persists
-      # it as a server-window notice. The user-topic stays silent (F1).
+      # :join_failed, and the router must not delegate it either — it
+      # takes the param scan to the channel window (#1345; the sibling
+      # test below asserts that landing). The user-topic stays silent (F1).
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
 
@@ -5782,6 +5784,96 @@ defmodule Grappa.Session.ServerTest do
       state = SessionStateHelpers.fetch(pid)
       assert WindowState.state_of(SessionStateHelpers.window_state(state), "#sniffo") == nil
       assert WindowState.failure_meta(SessionStateHelpers.window_state(state), "#sniffo") == nil
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "477 ERR_NEEDREGGEDNICK flips the window to :failed and ships the numeric to cic (#1345)" do
+      # The defect #1345 was filed for, end to end. 477 is a `+R`
+      # registered-only refusal (bahamut `src/channel.c:1943`, solanum
+      # `ircd/channel.c:778`) — common on the networks we serve, and until
+      # now missing from BOTH the handler guard and the delegated set, so
+      # the JOIN produced no effect at all: the window sat at `:pending`
+      # forever and cic drew a greyed tab that never resolved.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      :ok = Session.send_join({:user, user.id}, network.id, "#registrati", nil)
+
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      reason = "You need to identify to a registered nick to join that channel."
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 477 grappa-test #registrati :#{reason}\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :join_failed,
+                         channel: "#registrati",
+                         state: :failed,
+                         reason: ^reason,
+                         numeric: 477
+                       }
+                     },
+                     1_000
+
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      state = SessionStateHelpers.fetch(pid)
+      assert WindowState.state_of(SessionStateHelpers.window_state(state), "#registrati") == :failed
+
+      assert WindowState.failure_meta(SessionStateHelpers.window_state(state), "#registrati") ==
+               %{reason: reason, numeric: 477}
+
+      refute Map.has_key?(SessionStateHelpers.in_flight_joins(state), "#registrati")
+
+      # The reason cic renders is the ircd's OWN trailing text plus the raw
+      # code — nothing on this path maps a numeric to a phrase, because the
+      # two bound ircds disagree about what 476 and 485 mean.
+      [row] = Scrollback.fetch({:user, user.id}, network.id, "#registrati", nil, 10, nil, false)
+      assert row.kind == :notice
+      assert row.body == reason
+      assert row.meta == %{numeric: 477}
+
+      # Correlation-gated delegation still suppresses the scan route, so the
+      # failure surfaces once, not twice.
+      assert [] = Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 10, nil, false)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an UNCORRELATED join-failure numeric stays visible instead of vanishing (#1345)" do
+      # The other half of the gate. While these codes were delegated
+      # unconditionally, an uncorrelated one reached `Server.delegate/2` →
+      # EventRouter's numeric catch-all → no effect → nothing persisted
+      # anywhere: a `/topic #nowhere` 403 answered with silence. Delegating
+      # only the correlated occurrence puts it back on the scan route.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+
+      # No send_join → in_flight_joins is empty.
+      IRCServer.feed(server, ":irc.test.org 403 grappa-test #nowhere :No such channel\r\n")
+
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      [row] = Scrollback.fetch({:user, user.id}, network.id, "#nowhere", nil, 10, nil, false)
+      assert row.kind == :notice
+      assert row.body == "No such channel"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Issue #1345 (bucket from the 2026-08-15 code review): I-S1 (HIGH) and I-S2 (MEDIUM).

## The defect

`477 ERR_NEEDREGGEDNICK` was named by the channel-param canonicaliser
(`event_router.ex:326/330`) and missing from both lists that act on the
numeric (`@join_failure_numerics`, `NumericRouter.@delegated_numerics`). A
JOIN rejected by a `+R` channel therefore produced no `{:join_failed, …}`
effect: the in-flight entry waited for the lazy 30 s sweep, the window stayed
`:pending` permanently (`WindowState.set_failed/4` is reachable from that
effect alone), and cic drew a greyed tab that never resolved.

## Shape of the fix

Not a longer literal. `Grappa.IRC.JoinFailure` is the single enumeration and
all three consumers derive from it, so there is nothing left to truncate
independently. Delegation is **correlation-gated** (`join_failure_leg?/3`):
a member of the set is delegated only when its `params[1]` folds to a channel
whose JOIN is in flight — the same match `EventRouter` performs — so the two
decisions cannot disagree.

## The set comes from the ircd sources, not from the issue text

Read out of azzurra/bahamut `5c41c8b` and solanum `2ce64de`, one citation per
code in the moduledoc: **403 405 471 473 474 475 476 477 479 480 485**.

Corrections to the issue body, all measured:

* **481 is excluded**, although it IS a `can_join` exit (`+O`,
  `channel.c:1967`). Its format string carries **no channel** —
  `":%s 481 %s :Permission Denied, …"` (`s_err.c:550`) has two `%s` and drops
  the `name` m_join passes. Nothing on the wire to correlate, so a `+O`
  refusal cannot reach its window and that window still stalls at
  `:pending`. 481 is also emitted 29× from `s_serv.c` alone for ordinary
  oper-command refusals. **The cure for the uncorrelatable class is a timeout
  on the in-flight JOIN, not another numeric** — deliberately not built here.
* **437 is excluded, and it is the interesting one.** It IS a JOIN exit on
  solanum (ERR_UNAVAILRESOURCE), but on bahamut — all of prod — 437 is a
  different numeric, ERR_BANNICKCHANGE (`numeric.h:333`), and `m_nick.c:525`
  passes it `chptr->chname`: `params[1]` is a **channel** while the failure
  is a nick change. It would correlate against a live in-flight JOIN and flip
  that window to `:failed` off a `/nick` — the ghost-correlation hazard the
  self-JOIN strip (`server.ex:5600`, lifecycle review HIGH S1) already guards
  for the real failure numerics. A juped channel on Libera keeps sitting at
  `:pending` instead; prod wins the trade.
* **479, 480, 485 are added**: JOIN error exits carrying the channel at
  `params[1]` on one of the two ircds. 479 is emitted by bahamut too, from
  `check_channelname` (`channel.c:2002`, called on the JOIN path at `:2204`);
  480 is absent from bahamut's `numeric.h` entirely. 443 (channel at
  `params[2]`) and 470 (a redirect, not a refusal) stay out for shape.

**A cross-flavour collision is inert only when the other meaning cannot
present the same shape.** That holds for 476 (ONLYSSLCLIENTS vs BADCHANMASK)
and 485 (CHANBANREASON vs BANNEDNICK) — solanum defines both in `numeric.h`
and gives neither a `NUMERIC_STR_` format string, so core never emits them —
and fails for 437, which is why the guard comment tells the next reader not
to loosen `params[1]`.

Nothing in the change maps a numeric to a phrase: `reason` is the ircd's own
trailing text and the code rides beside it as `meta.numeric`, so no
flavour-blind sentence is invented.

## A silent drop the old comment denied

The handler's comment promised that an uncorrelated 403/473/… "falls through —
the caller's NumericRouter `$server` route persists it as a server message".
Measured, that was false while the codes were unconditionally delegated:
`Server.delegate/2` hands the numeric to `EventRouter` alone, whose numeric
catch-all (`event_router.ex:2483`) returns `[]`, and nothing persisted it
anywhere — an unsolicited 403 answered a `/topic` with silence. The gate puts
those back on the param scan; a test pins the landing.

## I-S2

`whois_leg?/3` read `whois_pending` with the arity-1 ASCII fold while
`EventRouter` writes those keys with `canonical_target/2` at the network
casemapping. On rfc1459 a target holding `[ ] \ ~` is written `foo{1}` and was
looked up as `foo[1]`. The casemapping now travels in `router_state()` (the
join gate needs the same fold) and both reads use it. On `:ascii` — all of
prod — nothing moves.

## Gates

| gate | result |
|------|--------|
| `scripts/check.sh` | **NOT RUN** — Docker Desktop down on the worker host for the whole change |
| `scripts/test.sh` | **NOT RUN** — same |
| `scripts/integration.sh` | **NOT RUN** — same |
| `scripts/design-notes-gate.sh` | **PASS** (pure bash, run on the branch tip) |

Every test here is written and **unobserved**: no red was seen before the fix
and no green after it. CI is the only arbiter — the first run was red on
Credo (a named unused variable in a test helper, now deleted along with the
helper) and on Dialyzer (`numerics/0`'s contract was wider than its success
typing; the return type is the measured union via a new `@type t`, so the
union and the list now pin each other in both directions). `mix format` was
unavailable too, so the formatter's joins are applied by hand.

## Not established / adjacent findings

* The `+O` (481) window still stalls at `:pending`, and so does a juped
  channel on solanum (437) — both need the in-flight JOIN timeout.
* Not touched, pre-existing: `server.ex:3293` consumes **any** 433/437 as
  `{:nick_error, code}` while a recover-identity is armed, without checking
  the param shape.
* Not touched, pre-existing: the self-JOIN strip at `server.ex:5605` deletes
  the in-flight entry with `Identifier.canonical_target/1` (ASCII) while
  `record_in_flight_join/2` wrote the key network-folded — the same I-S2
  mismatch, one layer over, so on rfc1459 a national-char channel leaves the
  ghost behind.