### PR TITLE
hardening(#1353): a full session to mint a share link; bounds for the mention watchlist

### DIFF
--- a/lib/grappa/mentions.ex
+++ b/lib/grappa/mentions.ex
@@ -145,10 +145,41 @@ defmodule Grappa.Mentions do
           boolean()
   def mentioned?(body, own_nick, patterns)
       when (is_binary(body) or is_nil(body)) and is_binary(own_nick) and is_list(patterns) do
-    case build_matchers([own_nick | patterns]) do
-      [] -> false
-      compiled -> body_matches?(body, compiled)
-    end
+    matches?(body, matchers(own_nick, patterns))
+  end
+
+  @typedoc """
+  Compiled word-boundary matchers for one `(own_nick, patterns)` pair —
+  the compile-once half of `mentioned?/3`, split out so a caller with
+  many bodies and one watchlist pays the compilation once.
+  """
+  @type matchers :: [Regex.t()]
+
+  @doc """
+  Compile the matcher set for `own_nick` + `patterns`.
+
+  Pair with `matches?/2` when scanning MORE THAN ONE body against the
+  same watchlist — a per-row `mentioned?/3` re-compiles every term for
+  every row, which is what `aggregate_mentions/6` hoists out of its own
+  loop and what the row-counting callers in `Grappa.WindowCounts` do
+  through this pair. For a single body, `mentioned?/3` is the same work
+  in one call.
+  """
+  @spec matchers(own_nick :: String.t(), patterns :: [String.t()]) :: matchers()
+  def matchers(own_nick, patterns) when is_binary(own_nick) and is_list(patterns) do
+    build_matchers([own_nick | patterns])
+  end
+
+  @doc """
+  Does `body` match any of the pre-compiled `matchers`?
+
+  The predicate half of `mentioned?/3` — same rule, same result; an
+  empty matcher set never matches, and a `nil` body never matches.
+  """
+  @spec matches?(body :: String.t() | nil, matchers()) :: boolean()
+  def matches?(body, matchers)
+      when (is_binary(body) or is_nil(body)) and is_list(matchers) do
+    body_matches?(body, matchers)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -244,6 +244,19 @@ defmodule Grappa.UserSettings do
   @alias_expansion_max_bytes 512
   @aliases_max_count 200
 
+  # Structural bounds for the mention watchlist — the same treatment
+  # @aliases_max_count gives the alias map one door over: a
+  # subject-writable list carries a ceiling at the write boundary, so
+  # every reader downstream can take the list as given. Sized against
+  # real use: a watchlist is a handful of words, added one at a time
+  # from the settings drawer.
+  #
+  # Bytes, not graphemes: the bodies these terms are matched against are
+  # bytes on the wire, and `String.length/1` would admit up to four times
+  # the material for the same number.
+  @max_highlight_patterns 64
+  @max_highlight_pattern_bytes 128
+
   # Structural bounds for the #449 presence-filter map — a user-writable blob
   # needs a boundary (same rationale as @aliases_max_count / @upload_ttl_seconds_max).
   @presence_filter_max_count 2_000
@@ -384,6 +397,22 @@ defmodule Grappa.UserSettings do
   end
 
   @doc """
+  How many `highlight_patterns` entries a subject may hold.
+
+  Public so callers and tests read the number the boundary enforces
+  instead of re-declaring it.
+  """
+  @spec max_highlight_patterns() :: unquote(@max_highlight_patterns)
+  def max_highlight_patterns, do: @max_highlight_patterns
+
+  @doc """
+  The byte ceiling on one `highlight_patterns` entry. Bytes, not
+  graphemes — see the attribute's comment.
+  """
+  @spec max_highlight_pattern_bytes() :: unquote(@max_highlight_pattern_bytes)
+  def max_highlight_pattern_bytes, do: @max_highlight_pattern_bytes
+
+  @doc """
   Sets the `highlight_patterns` list for `subject`, preserving any
   other keys already present in `data`.
 
@@ -393,8 +422,12 @@ defmodule Grappa.UserSettings do
   are untouched.
 
   **Validation**: every element of `patterns` must be a non-empty
-  binary. Returns `{:error, %Ecto.Changeset{}}` if validation fails,
-  BEFORE any DB work.
+  binary of at most `max_highlight_pattern_bytes/0` bytes, and the list
+  holds at most `max_highlight_patterns/0` of them. Returns
+  `{:error, %Ecto.Changeset{}}` if validation fails, BEFORE any DB work.
+  The two ceilings are here, at the write boundary, so every reader of
+  the list — including the ones on the inbound-message path — can stay
+  simple and take the list as given.
 
   **Out of scope**: deduplication, case-folding, and regex
   validation of pattern syntax are the responsibility of the matcher
@@ -1333,21 +1366,37 @@ defmodule Grappa.UserSettings do
 
   @spec validate_patterns([term()], Subject.t()) :: :ok | {:error, Ecto.Changeset.t()}
   defp validate_patterns(patterns, subject) do
-    if Enum.all?(patterns, &(is_binary(&1) and byte_size(&1) > 0)) do
-      :ok
-    else
-      attrs = Subject.put_subject_id(%{data: %{}}, subject)
+    cond do
+      length(patterns) > @max_highlight_patterns ->
+        pattern_error(subject, "highlight_patterns must hold at most #{@max_highlight_patterns} entries")
 
-      cs =
-        %Settings{}
-        |> Settings.changeset(attrs)
-        |> Ecto.Changeset.add_error(
-          :data,
-          "highlight_patterns elements must be non-empty strings"
+      not Enum.all?(patterns, &(is_binary(&1) and byte_size(&1) > 0)) ->
+        pattern_error(subject, "highlight_patterns elements must be non-empty strings")
+
+      not Enum.all?(patterns, &(byte_size(&1) <= @max_highlight_pattern_bytes)) ->
+        pattern_error(
+          subject,
+          "each highlight_patterns entry must be at most #{@max_highlight_pattern_bytes} bytes"
         )
 
-      {:error, cs}
+      true ->
+        :ok
     end
+  end
+
+  # Clause order is load-bearing: the byte-size arm runs `byte_size/1`
+  # over every element, so it may only be reached once the shape arm has
+  # established they are all binaries.
+  @spec pattern_error(Subject.t(), String.t()) :: {:error, Ecto.Changeset.t()}
+  defp pattern_error(subject, message) do
+    attrs = Subject.put_subject_id(%{data: %{}}, subject)
+
+    cs =
+      %Settings{}
+      |> Settings.changeset(attrs)
+      |> Ecto.Changeset.add_error(:data, message)
+
+    {:error, cs}
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/grappa/window_counts.ex
+++ b/lib/grappa/window_counts.ex
@@ -219,10 +219,14 @@ defmodule Grappa.WindowCounts do
     Map.new(counts, fn {slug, per_channel} ->
       own_nick = own_nick_for_slug(own_nicks, slug)
       slug_tails = Map.get(tails, slug, %{})
+      # The watchlist is one per subject and the nick one per network, so
+      # the matcher set is constant across this network's windows: build
+      # it here rather than inside the per-window fold below.
+      matchers = slug_matchers(own_nick, patterns)
 
       windows =
         Map.new(per_channel, fn {channel, %{messages: messages, events: events}} ->
-          mentions = count_tail_mentions(Map.get(slug_tails, channel, []), own_nick, patterns)
+          mentions = count_tail_mentions(Map.get(slug_tails, channel, []), own_nick, matchers)
 
           {channel,
            %{
@@ -258,18 +262,26 @@ defmodule Grappa.WindowCounts do
   # own-sent rows (fold `sender` via the ASCII nick SSOT, #121/#525), then the
   # `Mentions.mentioned?/3` SSOT predicate. `nil` own_nick → nothing to
   # match, so no mentions.
-  @spec count_tail_mentions([%{sender: String.t(), body: String.t() | nil}], String.t() | nil, [
-          String.t()
-        ]) :: non_neg_integer()
+  @spec count_tail_mentions(
+          [%{sender: String.t(), body: String.t() | nil}],
+          String.t() | nil,
+          Mentions.matchers()
+        ) :: non_neg_integer()
   defp count_tail_mentions(_, nil, _), do: 0
 
-  defp count_tail_mentions(tail, own_nick, patterns) do
+  defp count_tail_mentions(tail, own_nick, matchers) do
     own = Identifier.canonical_target(own_nick)
 
     Enum.count(tail, fn %{sender: sender, body: body} ->
-      Identifier.canonical_target(sender) != own and Mentions.mentioned?(body, own_nick, patterns)
+      Identifier.canonical_target(sender) != own and Mentions.matches?(body, matchers)
     end)
   end
+
+  # No configured nick on this network → `count_tail_mentions/3` answers 0
+  # without consulting the matchers, so there is nothing to compile.
+  @spec slug_matchers(String.t() | nil, [String.t()]) :: Mentions.matchers()
+  defp slug_matchers(nil, _), do: []
+  defp slug_matchers(own_nick, patterns), do: Mentions.matchers(own_nick, patterns)
 
   # Counts unread content rows that mention the subject, excluding own-sent
   # rows (fold via the ASCII nick SSOT, #121/#525). Bounded by the scan cap.
@@ -286,11 +298,12 @@ defmodule Grappa.WindowCounts do
 
   defp count_mentions(subject, network_id, channel, after_id, own_nick, patterns) do
     own = Identifier.canonical_target(own_nick)
+    matchers = Mentions.matchers(own_nick, patterns)
 
     subject
     |> Scrollback.unread_content_tail(network_id, channel, after_id, own_nick, @mention_scan_cap)
     |> Enum.count(fn %{sender: sender, body: body} ->
-      Identifier.canonical_target(sender) != own and Mentions.mentioned?(body, own_nick, patterns)
+      Identifier.canonical_target(sender) != own and Mentions.matches?(body, matchers)
     end)
   end
 

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -105,14 +105,20 @@ defmodule GrappaWeb.Admin.VisitorsController do
   404, the same 404 the `DELETE` verb returns.
   """
   @spec share_token(Plug.Conn.t(), map()) ::
-          Plug.Conn.t() | {:error, :not_found | :forbidden}
+          Plug.Conn.t() | {:error, :not_found | :forbidden | :client_token_scope}
   def share_token(conn, %{"id" => id}) when is_binary(id) do
     with {:ok, visitor} <- fetch_visitor(id),
-         :ok <- refuse_incognito(visitor) do
-      # #1306 — the payload is the TAGGED subject now. This door stays
-      # visitor-only (there is no admin verb for minting a user's link),
-      # so the tag is a constant here rather than a branch.
-      {token, expires_at} = ShareToken.mint({:visitor, visitor.id})
+         :ok <- refuse_incognito(visitor),
+         # #1306 — the payload is the TAGGED subject now. This door stays
+         # visitor-only (there is no admin verb for minting a user's link),
+         # so the tag is a constant here rather than a branch.
+         #
+         # #1353 — the operator's own session kind decides whether the
+         # link exists, exactly as at the self-mint door. `:admin_authn`
+         # already carries `RequireFullSession`, so this states the rule
+         # a second time rather than adding a new one.
+         {:ok, {token, expires_at}} <-
+           ShareToken.mint({:visitor, visitor.id}, conn.assigns.current_session_kind) do
       {actor_id, actor_name} = AuthPlug.actor_from_conn(conn)
 
       # Distinct from the self-mint's `[:grappa, :share_token, :minted]`

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -60,7 +60,10 @@ defmodule GrappaWeb.ShareTokenController do
     * `:share_token_expired` → 410 Gone
     * `:share_token_consumed` → 410 Gone
 
-  Reused: `:forbidden` (an incognito visitor trying to mint — #363),
+  Reused: `:client_token_scope` → 403 (#1353 — the mint takes a full
+  session; the route's `:full_session` pipeline and
+  `GrappaWeb.ShareToken.mint/2` answer with the same atom, so one body
+  covers both), `:forbidden` (an incognito visitor trying to mint — #363),
   `:bad_request` (missing token param), `:unauthorized` (invalid
   signature), `:not_found` (the subject row gone between mint and
   consume).
@@ -84,7 +87,8 @@ defmodule GrappaWeb.ShareTokenController do
   #1306 — a user mints exactly as a visitor does; the only 403 left is
   the incognito visitor (#363).
   """
-  @spec mint(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :forbidden | :unauthorized}
+  @spec mint(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :forbidden | :unauthorized | :client_token_scope}
   def mint(conn, _) do
     case conn.assigns[:current_subject] do
       {:visitor, %Visitor{incognito: true}} ->
@@ -117,22 +121,33 @@ defmodule GrappaWeb.ShareTokenController do
   # token payload is `Subject.to_session/1`'s bare-id tuple — the same
   # discriminator `Accounts.create_session/4` takes, so the consume can
   # hand the verified payload straight through without re-deriving it.
-  @spec mint_for(Plug.Conn.t(), Subject.t()) :: Plug.Conn.t()
+  #
+  # #1353 — the kind of the session AT THE DOOR is handed to the signing
+  # boundary, which decides whether there is a token to return. The
+  # route is mounted on `:full_session`, so the refusal below is not the
+  # reachable path today; it is what keeps the rule true if the route
+  # ever moves. `current_session_kind` is assigned by
+  # `GrappaWeb.Plugs.Authn` for every authenticated bearer, user or
+  # visitor, so it is read directly rather than defaulted.
+  @spec mint_for(Plug.Conn.t(), Subject.t()) ::
+          Plug.Conn.t() | {:error, :client_token_scope}
   defp mint_for(conn, subject) do
     {kind, id} = Subject.to_session(subject)
-    {token, expires_at} = ShareToken.mint({kind, id})
 
-    :telemetry.execute(
-      [:grappa, :share_token, :minted],
-      %{count: 1},
-      %{subject_kind: kind, subject_id: id}
-    )
+    with {:ok, {token, expires_at}} <-
+           ShareToken.mint({kind, id}, conn.assigns.current_session_kind) do
+      :telemetry.execute(
+        [:grappa, :share_token, :minted],
+        %{count: 1},
+        %{subject_kind: kind, subject_id: id}
+      )
 
-    record_admin_event(subject)
+      record_admin_event(subject)
 
-    conn
-    |> put_status(:ok)
-    |> json(%{token: token, expires_at: DateTime.to_iso8601(expires_at)})
+      conn
+      |> put_status(:ok)
+      |> json(%{token: token, expires_at: DateTime.to_iso8601(expires_at)})
+    end
   end
 
   # #1306 — a USER self-mint reaches the admin register; a visitor

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -326,6 +326,19 @@ defmodule GrappaWeb.Router do
     get "/me/client-tokens", ClientTokenController, :index
     post "/me/client-tokens", ClientTokenController, :create
     delete "/me/client-tokens/:handle", ClientTokenController, :delete
+
+    # Session-sharing mint. Returns a short-TTL Phoenix-signed token +
+    # ISO8601 expires_at; the cic SPA wraps it in a shareable URL and the
+    # consume endpoint lives under /auth above (unauthenticated by
+    # design, since the signed token IS the credential there).
+    #
+    # #1353 — it belongs in THIS block, next to the token surface it
+    # resembles: what the link yields on the receiving device is a
+    # session for the same identity, so minting one is credential
+    # management by definition and takes a full session. The signing
+    # boundary (`GrappaWeb.ShareToken.mint/2`) states the same rule
+    # independently of where the route is declared.
+    post "/me/share-token", ShareTokenController, :mint
   end
 
   scope "/", GrappaWeb do
@@ -403,12 +416,6 @@ defmodule GrappaWeb.Router do
     # (no proxy change), like the sibling settings endpoints.
     get "/me/settings/display-prefs", UserSettingsController, :show_display_prefs
     put "/me/settings/display-prefs", UserSettingsController, :update_display_prefs
-
-    # Visitor session-sharing mint — visitor-only (users get 403).
-    # Returns a short-TTL Phoenix-signed token + ISO8601 expires_at.
-    # The cic SPA wraps the token in a shareable URL; the consume
-    # endpoint lives under /auth above (unauthenticated by design).
-    post "/me/share-token", ShareTokenController, :mint
 
     # #75 — themes gallery + owned library + share-by-id + server-persisted
     # active theme. Every theme is public by id (share-link target); authz

--- a/lib/grappa_web/share_token.ex
+++ b/lib/grappa_web/share_token.ex
@@ -87,18 +87,42 @@ defmodule GrappaWeb.ShareToken do
   def max_age_seconds, do: @max_age_seconds
 
   @doc """
-  Sign a token for `subject`. Returns `{token, expires_at}`, where
+  Sign a token for `subject`, on behalf of a session of kind
+  `minting_kind`. Returns `{:ok, {token, expires_at}}`, where
   `expires_at` is the absolute UTC instant at which `verify/1` starts
   refusing it — cic renders the countdown from it.
 
-  Cannot fail: `Phoenix.Token.sign/3` is pure over the endpoint's
-  secret. Both doors therefore have nothing to roll back at this step.
+  `minting_kind` is the `t:Grappa.Accounts.Session.kind/0` of the
+  session presenting itself at the door, and it decides whether there
+  is a token at all: only a full (`:web`) session mints one, and a
+  scoped per-client session is answered `{:error, :client_token_scope}`
+  — the same atom `GrappaWeb.Plugs.RequireFullSession` raises, so both
+  layers render one 403 through `GrappaWeb.FallbackController`.
+
+  ## Why the rule lives HERE and not only on the route (#1353)
+
+  What the link yields on the receiving device is a full session for
+  the identity, so the scope of the redeemed session is decided at the
+  MINT, not at the redeem. A route-shaped rule states that once, for
+  the doors that exist today; this states it for the signing act
+  itself, so a door added later inherits the rule by being unable to
+  call `mint/2` without naming the kind it is minting under.
+
+  The argument is required rather than defaulted for the same reason:
+  a default is a caller that never had to think about it.
+
+  A `:web` mint is unchanged from #1306 — same salt, same payload, same
+  TTL — so links already in flight are unaffected by this gate.
   """
-  @spec mint(subject()) :: {String.t(), DateTime.t()}
-  def mint({kind, id} = subject) when kind in [:user, :visitor] and is_binary(id) do
+  @spec mint(subject(), Grappa.Accounts.Session.kind()) ::
+          {:ok, {String.t(), DateTime.t()}} | {:error, :client_token_scope}
+  def mint({kind, id} = subject, :web) when kind in [:user, :visitor] and is_binary(id) do
     token = Phoenix.Token.sign(GrappaWeb.Endpoint, @salt, subject)
-    {token, DateTime.add(DateTime.utc_now(), @max_age_seconds, :second)}
+    {:ok, {token, DateTime.add(DateTime.utc_now(), @max_age_seconds, :second)}}
   end
+
+  def mint({kind, id}, :client) when kind in [:user, :visitor] and is_binary(id),
+    do: {:error, :client_token_scope}
 
   @doc """
   Verify a token and recover the tagged subject it was signed for.

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -171,6 +171,58 @@ defmodule Grappa.UserSettingsTest do
       assert settings.data["highlight_patterns"] == []
     end
 
+    test "accepts a list exactly at the entry cap (#1353)" do
+      # The boundary belongs to the accepted side: a cap that refuses at
+      # its own number is a different cap from the one documented, and
+      # only an at-cap arm can tell the two apart.
+      user = user_fixture()
+      patterns = for i <- 1..UserSettings.max_highlight_patterns(), do: "pattern#{i}"
+
+      assert {:ok, settings} = UserSettings.set_highlight_patterns({:user, user.id}, patterns)
+      assert length(settings.data["highlight_patterns"]) == UserSettings.max_highlight_patterns()
+    end
+
+    test "refuses a list past the entry cap (#1353)" do
+      # The ceiling is stated here, at the write boundary, which is what
+      # lets every reader on the other side of it take the list as given.
+      user = user_fixture()
+      patterns = for i <- 0..UserSettings.max_highlight_patterns(), do: "pattern#{i}"
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.set_highlight_patterns({:user, user.id}, patterns)
+    end
+
+    test "accepts a pattern exactly at the byte cap (#1353)" do
+      user = user_fixture()
+      pattern = String.duplicate("a", UserSettings.max_highlight_pattern_bytes())
+
+      assert {:ok, settings} = UserSettings.set_highlight_patterns({:user, user.id}, [pattern])
+      assert settings.data["highlight_patterns"] == [pattern]
+    end
+
+    test "refuses a pattern past the byte cap (#1353)" do
+      user = user_fixture()
+      pattern = String.duplicate("a", UserSettings.max_highlight_pattern_bytes() + 1)
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.set_highlight_patterns({:user, user.id}, [pattern])
+    end
+
+    test "the byte cap counts BYTES, not graphemes (#1353)" do
+      # A watchlist term is matched against message bodies, which are
+      # bytes on the wire; a multi-byte term must therefore be measured
+      # the same way the body it scans is. `String.length/1` here would
+      # admit four times the material `byte_size/1` admits.
+      user = user_fixture()
+      over = String.duplicate("é", UserSettings.max_highlight_pattern_bytes())
+
+      assert byte_size(over) > UserSettings.max_highlight_pattern_bytes()
+      assert String.length(over) == UserSettings.max_highlight_pattern_bytes()
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.set_highlight_patterns({:user, user.id}, [over])
+    end
+
     test "rejects a list containing an empty string" do
       user = user_fixture()
       assert {:error, %Ecto.Changeset{}} = UserSettings.set_highlight_patterns({:user, user.id}, [""])

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -39,9 +39,8 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Accounts
+  alias Grappa.{Accounts, ShareTokens}
   alias Grappa.Repo.BusyRetry
-  alias Grappa.ShareTokens
   alias GrappaWeb.ShareToken
 
   # #982 — read from the production module rather than re-declared here.

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -9,6 +9,8 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       with the same link)
     * incognito visitor subject → 403 forbidden (#363 — a non-portable
       ephemeral session must not be shareable to another device)
+    * per-client token bearer → 403 client_token_scope (#1353 — the
+      mint is credential management, so it takes a full session)
     * missing Bearer → 401 unauthorized
 
   Consume side (`/auth/share/consume`):
@@ -37,6 +39,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
   import Grappa.AuthFixtures
 
+  alias Grappa.Accounts
   alias Grappa.Repo.BusyRetry
   alias Grappa.ShareTokens
   alias GrappaWeb.ShareToken
@@ -152,6 +155,25 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       conn = post(conn, "/me/share-token")
       assert json_response(conn, 401) == %{"error" => "unauthorized"}
     end
+
+    test "only a full session mints a share link (#1353)", %{conn: conn} do
+      # A share link hands the receiving device a session for the same
+      # identity, so minting one is credential management: the door
+      # belongs on the `:full_session` scope, alongside the token
+      # surface it resembles. `GrappaWeb.RouterScopeTest` states the
+      # same thing as a table-wide invariant; this arm pins the answer
+      # at the door — the status AND the body — so a pipeline
+      # reshuffle cannot quietly downgrade it to some other 4xx.
+      {user, _} = user_and_session()
+      {:ok, client_token} = Accounts.create_client_token(user, "headless", nil, nil, [])
+
+      conn =
+        conn
+        |> put_bearer(client_token.id)
+        |> post("/me/share-token")
+
+      assert json_response(conn, 403) == %{"error" => "client_token_scope"}
+    end
   end
 
   describe "POST /auth/share/consume — visitor token" do
@@ -160,7 +182,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       # but consume tests partition by the token string itself; distinct
       # signed payloads → distinct ETS keys).
       visitor = visitor_fixture()
-      {token, _} = ShareToken.mint({:visitor, visitor.id})
+      {:ok, {token, _}} = ShareToken.mint({:visitor, visitor.id}, :web)
       {:ok, visitor: visitor, token: token}
     end
 
@@ -221,7 +243,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
   describe "POST /auth/share/consume — user token (#1306)" do
     setup do
       {user, _} = user_and_session()
-      {token, _} = ShareToken.mint({:user, user.id})
+      {:ok, {token, _}} = ShareToken.mint({:user, user.id}, :web)
       {:ok, user: user, token: token}
     end
 
@@ -258,7 +280,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       # Same 404 the visitor arm gives: a link outliving its identity is
       # one condition, not two.
       {other_user, _} = user_and_session()
-      {orphan_token, _} = ShareToken.mint({:user, other_user.id})
+      {:ok, {orphan_token, _}} = ShareToken.mint({:user, other_user.id}, :web)
       :ok = Grappa.Accounts.delete_user(other_user)
 
       orphan_conn = post(conn, "/auth/share/consume", %{"token" => orphan_token})
@@ -329,7 +351,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
   describe "POST /auth/share/consume — one-shot claim (#593)" do
     setup do
       visitor = visitor_fixture()
-      {token, _} = ShareToken.mint({:visitor, visitor.id})
+      {:ok, {token, _}} = ShareToken.mint({:visitor, visitor.id}, :web)
       {:ok, visitor: visitor, token: token}
     end
 
@@ -450,7 +472,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
     test "consume happy path emits :consumed with the subject metadata", %{conn: conn} do
       visitor = visitor_fixture()
-      {token, _} = ShareToken.mint({:visitor, visitor.id})
+      {:ok, {token, _}} = ShareToken.mint({:visitor, visitor.id}, :web)
 
       conn |> post("/auth/share/consume", %{"token" => token}) |> json_response(200)
 
@@ -486,7 +508,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       # it fires the reject telemetry once (not zero, not doubled) and never
       # the :consumed event when the mint rolls its claim back.
       visitor = visitor_fixture()
-      {token, _} = ShareToken.mint({:visitor, visitor.id})
+      {:ok, {token, _}} = ShareToken.mint({:visitor, visitor.id}, :web)
 
       BusyRetry.inject_transient_faults(10_000)
       conn |> post("/auth/share/consume", %{"token" => token}) |> json_response(503)

--- a/test/grappa_web/router_scope_test.exs
+++ b/test/grappa_web/router_scope_test.exs
@@ -9,10 +9,35 @@ defmodule GrappaWeb.RouterScopeTest do
   about it looks wrong at the call site.
 
   So this enumerates the compiled route table and actually DRIVES every
-  credential-management route with a client-token bearer, asserting the
-  scope refusal each time. Exercising beats introspecting the pipelines:
-  it survives a plug being moved between pipelines, and it fails on the
-  thing that matters — the response — rather than on a spelling.
+  route with a client-token bearer, asserting the scope refusal each
+  time. Exercising beats introspecting the pipelines: it survives a plug
+  being moved between pipelines, and it fails on the thing that matters
+  — the response — rather than on a spelling.
+
+  ## The invariant is stated as an ALLOWLIST (#1353)
+
+  It used to run the other way round: a hand-maintained list of
+  credential-looking path PREFIXES was driven, and everything else was
+  left alone. That direction fails OPEN — a route the prefixes do not
+  describe is not asserted about at all, and the invariant passes
+  vacuously over it while looking exhaustive.
+
+  This runs from the complement instead. `@client_usable_*` names what a
+  per-client token is FOR — reading, sending, and configuring the
+  connection it reads and sends on — plus `@unauthenticated_*` for the
+  routes that carry no bearer gate at all. **Every other route in the
+  table must answer `403 client_token_scope`.** A new route is therefore
+  refused by default and joining either list is a deliberate act, which
+  is the review moment that should exist.
+
+  Prefix vs exact is chosen per family, not for brevity:
+
+    * resource families whose whole point is "use the account"
+      (`/networks/...`, `/themes/...`, the push subscriptions) are
+      prefix-listed, so a sibling verb added later inherits;
+    * `/me` is exact-listed to the last route, because that namespace
+      is MIXED — the account's settings live next to the account's
+      credentials, so nothing there may be inherited by prefix.
 
   The bearer belongs to an ADMIN account on purpose. A non-admin would
   be refused by `GrappaWeb.Admin.AuthPlug` first, and every `/admin` arm
@@ -25,14 +50,72 @@ defmodule GrappaWeb.RouterScopeTest do
 
   alias Grappa.Accounts
 
-  # Paths that can change what the account IS, as opposed to using it.
-  # Prefix-matched, so `/me/totp/enrollment/confirm` is covered by
-  # `/me/totp` and a new sibling needs no edit here.
-  @credential_prefixes ["/admin", "/me/totp", "/me/passkeys", "/me/client-tokens"]
+  # Resource families a per-client token may reach in full. Prefix-
+  # matched: a verb added to one of these families is, by the family's
+  # definition, another way to use the account rather than to change it.
+  #
+  # `/networks` carries the per-network connection settings —
+  # `/identity`, `/perform`, `/password` (the upstream services secret,
+  # not the account password). They are deliberately IN this list: they
+  # configure the upstream connection a headless client exists to hold
+  # open, and #1196 shipped them reachable. Named here rather than left
+  # implicit so that moving them behind the full-session gate is a
+  # decision someone takes, not a default someone inherits.
+  @client_usable_prefixes [
+    "/networks",
+    "/themes",
+    "/push/subscriptions",
+    "/session/networks",
+    "/api/uploads",
+    "/api/server-settings"
+  ]
 
-  # Exact `{method, path}` pairs that are credential management without
-  # looking like it from the prefix alone.
-  @credential_routes [{"DELETE", "/me"}]
+  # The `/me` namespace, one route at a time — it holds the account's
+  # settings AND the account's credentials, so no prefix may stand in
+  # for it. Everything under `/me` that is not here must answer the
+  # scope refusal.
+  @client_usable_routes [
+    {"DELETE", "/auth/logout"},
+    {"GET", "/me"},
+    {"GET", "/me/theme"},
+    {"PUT", "/me/theme"},
+    # The owned-library listing. It reads as part of the `/themes`
+    # family but is spelled under `/me`, so the prefix does not reach
+    # it — which is the whole reason `/me` is enumerated.
+    {"GET", "/me/themes"},
+    {"GET", "/me/settings/notification-prefs"},
+    {"PUT", "/me/settings/notification-prefs"},
+    {"GET", "/me/settings/upload-ttl-seconds"},
+    {"PUT", "/me/settings/upload-ttl-seconds"},
+    {"GET", "/me/settings/auto-away-debounce-seconds"},
+    {"PUT", "/me/settings/auto-away-debounce-seconds"},
+    {"GET", "/me/settings/vhost"},
+    {"PUT", "/me/settings/vhost"},
+    {"GET", "/me/settings/aliases"},
+    {"PUT", "/me/settings/aliases"},
+    {"GET", "/me/settings/display-prefs"},
+    {"PUT", "/me/settings/display-prefs"}
+  ]
+
+  # Routes with no bearer gate at all — the login doors, the public
+  # discovery endpoints, the upload GET and the SPA shell. They cannot
+  # answer `client_token_scope` because nothing there reads a session,
+  # so they are excluded by name rather than by hopeful pattern.
+  @unauthenticated_routes [
+    {"GET", "/healthz"},
+    {"POST", "/auth/login"},
+    {"POST", "/auth/totp/verify"},
+    {"POST", "/auth/passkeys/options"},
+    {"POST", "/auth/passkeys/verify"},
+    {"POST", "/auth/passkeys/second-factor"},
+    {"POST", "/auth/passkeys/recover"},
+    {"POST", "/auth/share/consume"},
+    {"GET", "/push/vapid-public-key"},
+    {"GET", "/api/config"},
+    {"GET", "/uploads/:slug"},
+    {"GET", "/service-worker.js"},
+    {"GET", "/*path"}
+  ]
 
   # The loopback `/admin` scope (`POST /admin/reload`,
   # `/admin/cic-bundle-changed`) carries no bearer at all: it is gated on
@@ -46,15 +129,18 @@ defmodule GrappaWeb.RouterScopeTest do
 
   defp method(%{verb: verb}), do: verb |> Atom.to_string() |> String.upcase()
 
-  defp credential_management?(%{path: path} = route) do
-    Enum.any?(@credential_prefixes, &String.starts_with?(path, &1)) or
-      {method(route), path} in @credential_routes
+  defp client_usable?(%{path: path} = route) do
+    Enum.any?(@client_usable_prefixes, &String.starts_with?(path, &1)) or
+      {method(route), path} in @client_usable_routes
   end
 
-  defp credential_routes do
-    Enum.filter(
+  defp unauthenticated?(route), do: {method(route), route.path} in @unauthenticated_routes
+
+  # The complement: everything the two lists above do not name.
+  defp gated_routes do
+    Enum.reject(
       GrappaWeb.Router.__routes__(),
-      &(credential_management?(&1) and &1.plug != @loopback_plug)
+      &(client_usable?(&1) or unauthenticated?(&1) or &1.plug == @loopback_plug)
     )
   end
 
@@ -83,11 +169,11 @@ defmodule GrappaWeb.RouterScopeTest do
     end
   end
 
-  test "no credential-management route answers a per-client token" do
+  test "every route outside the client-usable set answers the scope refusal" do
     admin = user_fixture(is_admin: true)
     {:ok, token} = Accounts.create_client_token(admin, "headless", nil, nil, [])
 
-    for route <- credential_routes() do
+    for route <- gated_routes() do
       conn =
         Phoenix.ConnTest.build_conn()
         |> put_bearer(token.id)
@@ -95,10 +181,13 @@ defmodule GrappaWeb.RouterScopeTest do
 
       assert json_response(conn, 403) == %{"error" => "client_token_scope"},
              """
-             #{method(route)} #{route.path} is reachable by a per-client token.
+             #{method(route)} #{route.path} answers a per-client token.
 
-             Mount it on the `:full_session` scope (or `:admin_authn`) in
-             GrappaWeb.Router — see GH #1196.
+             Either mount it on the `:full_session` scope (or
+             `:admin_authn`) in GrappaWeb.Router, or — if a headless
+             client is meant to reach it — add it to
+             `@client_usable_routes` / `@client_usable_prefixes` here
+             and say why. Silence is not one of the options.
              """
     end
   end
@@ -106,18 +195,23 @@ defmodule GrappaWeb.RouterScopeTest do
   test "the invariant has something to check" do
     # A filter that matches nothing passes vacuously forever. This is the
     # arm that notices when a router refactor renames the paths out from
-    # under the prefixes above.
-    matched = credential_routes()
+    # under the lists above.
+    assert length(gated_routes()) > 40
+  end
 
-    assert length(matched) > 20
+  test "every allowlisted route still exists in the table" do
+    # The other direction of the same drift. A stale entry here silently
+    # exempts nothing today and quietly re-exempts whatever claims the
+    # path tomorrow, so an entry that matches no route is an error.
+    routes = GrappaWeb.Router.__routes__()
 
-    for prefix <- @credential_prefixes do
-      assert Enum.any?(matched, &String.starts_with?(&1.path, prefix)),
-             "no route matches the credential prefix #{prefix} any more"
+    for prefix <- @client_usable_prefixes do
+      assert Enum.any?(routes, &String.starts_with?(&1.path, prefix)),
+             "no route starts with the client-usable prefix #{prefix} any more"
     end
 
-    for {verb, path} <- @credential_routes do
-      assert Enum.any?(matched, &(&1.path == path and method(&1) == verb)),
+    for {verb, path} <- @client_usable_routes ++ @unauthenticated_routes do
+      assert Enum.any?(routes, &(&1.path == path and method(&1) == verb)),
              "no route matches #{verb} #{path} any more"
     end
   end

--- a/test/grappa_web/share_token_test.exs
+++ b/test/grappa_web/share_token_test.exs
@@ -22,17 +22,48 @@ defmodule GrappaWeb.ShareTokenTest do
   # v1-rejected test vacuous the moment the salt regressed.
   @v1_salt "visitor-share-v1"
 
-  describe "mint/1 + verify/1 round-trip" do
+  describe "mint/2 — the minting session's kind" do
+    test "a full session gets a signed token" do
+      id = Ecto.UUID.generate()
+
+      assert {:ok, {token, %DateTime{}}} = ShareToken.mint({:visitor, id}, :web)
+      assert {:ok, {:visitor, ^id}} = ShareToken.verify(token)
+    end
+
+    test "a scoped session gets no token, for either subject kind" do
+      # #1353 — the scope of the session the link yields is decided at
+      # the mint. Asserted at THIS boundary rather than only through the
+      # route, because the guarantee has to hold for a door that does
+      # not exist yet: `mint/2` cannot be called without naming the kind,
+      # and only one of the two kinds returns a token.
+      assert {:error, :client_token_scope} =
+               ShareToken.mint({:user, Ecto.UUID.generate()}, :client)
+
+      assert {:error, :client_token_scope} =
+               ShareToken.mint({:visitor, Ecto.UUID.generate()}, :client)
+    end
+
+    test "the refusal is the atom the scope gate already speaks" do
+      # One atom, one 403 body, whichever layer answers first — the
+      # pipeline's `RequireFullSession` or this one. A second spelling
+      # here would be a second wire shape for the same refusal.
+      {:error, reason} = ShareToken.mint({:user, Ecto.UUID.generate()}, :client)
+
+      assert reason == :client_token_scope
+    end
+  end
+
+  describe "mint/2 + verify/1 round-trip" do
     test "a visitor token verifies back to the tagged visitor subject" do
       id = Ecto.UUID.generate()
-      {token, _} = ShareToken.mint({:visitor, id})
+      {:ok, {token, _}} = ShareToken.mint({:visitor, id}, :web)
 
       assert {:ok, {:visitor, ^id}} = ShareToken.verify(token)
     end
 
     test "a user token verifies back to the tagged user subject" do
       id = Ecto.UUID.generate()
-      {token, _} = ShareToken.mint({:user, id})
+      {:ok, {token, _}} = ShareToken.mint({:user, id}, :web)
 
       assert {:ok, {:user, ^id}} = ShareToken.verify(token)
     end
@@ -42,15 +73,15 @@ defmodule GrappaWeb.ShareTokenTest do
       # which table the consume reads. Two tokens over the SAME uuid
       # recover two DIFFERENT subjects.
       id = Ecto.UUID.generate()
-      {visitor_token, _} = ShareToken.mint({:visitor, id})
-      {user_token, _} = ShareToken.mint({:user, id})
+      {:ok, {visitor_token, _}} = ShareToken.mint({:visitor, id}, :web)
+      {:ok, {user_token, _}} = ShareToken.mint({:user, id}, :web)
 
       assert {:ok, {:visitor, ^id}} = ShareToken.verify(visitor_token)
       assert {:ok, {:user, ^id}} = ShareToken.verify(user_token)
     end
 
     test "expires_at is max_age_seconds in the future" do
-      {_, expires_at} = ShareToken.mint({:user, Ecto.UUID.generate()})
+      {:ok, {_, expires_at}} = ShareToken.mint({:user, Ecto.UUID.generate()}, :web)
 
       delta = DateTime.diff(expires_at, DateTime.utc_now())
       assert delta >= ShareToken.max_age_seconds() - 2


### PR DESCRIPTION
Two of the three items tracked in #1353.

Per that issue's working rules, the details stay out of band: what follows
states the guard that now exists and the behaviour that is now correct, and
nothing about the shape of what it guards against.

## 1. Minting a share link takes a full session

A share link yields, on the receiving device, a session for the same
identity. That makes minting one credential management rather than a use of
the account, so the route joins the surfaces #1196 grouped under the
`:full_session` scope — next to the client-token routes it most resembles,
since both hand out a credential.

The rule is stated twice, and the two statements are independent:

* the route is declared in the gated block, which is where a reader looks
  for it;
* `GrappaWeb.ShareToken.mint/2` takes the kind of the session doing the
  minting and answers `{:error, :client_token_scope}` for a scoped one, so
  the guarantee holds at the signing act rather than at one particular
  door. A mint door added later cannot call it without naming the kind it
  mints under, and only one of the two kinds yields a token. The argument
  is required rather than defaulted for the same reason — a default is a
  caller that never had to think about it.

Both layers answer with the atom the scope gate already speaks, so there is
one 403 body whichever refuses first.

**A `:web` mint is untouched**: same salt, same payload, same TTL. Links
already in flight are unaffected, and cic needs no change.

## 2. The mention watchlist has bounds, and is compiled once per scan

Two ceilings at the write boundary give the list a finite shape: at most 64
entries, each at most 128 bytes. Both are generous against real use — a
watchlist is a handful of words, added one at a time from the settings
drawer — and both are public accessors, so callers and tests read the
enforced number instead of a second copy of it. Bytes, not graphemes: the
bodies these terms scan are bytes on the wire, and the grapheme spelling
would admit up to four times the material for the same number.

The readers then stop paying per row. `Mentions.mentioned?/3` compiles its
regexes on every call — correct for the single-body push predicate it was
written for, and wrong under `Enum.count` over a scan tail;
`aggregate_mentions/6` already hoists the identical call out of its own
loop, with a comment saying why. The compile (`matchers/2`) is now split
from the predicate (`matches?/2`), and both `WindowCounts` counters build
the set once: per call in the per-window path, per network in the bulk
path, where the nick and the watchlist are both constant across that
network's windows. `mentioned?/3` keeps its signature and is now those two
calls, so single-body callers are unchanged and one rule still decides what
a mention is.

## The scope invariant now fails closed

`GrappaWeb.RouterScopeTest` used to drive a hand-maintained list of
credential-looking path prefixes and assert the scope refusal on each. That
direction fails open: a route the prefixes do not describe is not asserted
about at all, and the invariant passes vacuously over it while looking
exhaustive.

It now runs from the complement. An allowlist names what a per-client token
is FOR — reading, sending, and configuring the connection it reads and
sends on — plus the routes that carry no bearer gate at all; **every other
route in the table must answer `403 client_token_scope`**. A new route is
refused by default, and joining either list is a deliberate act.

Prefix vs exact is chosen per family, not for brevity: resource families
whose whole point is "use the account" are prefix-listed so a sibling verb
inherits, while `/me` is exact-listed to the last route, because that
namespace holds the account's settings next to the account's credentials.

Two things worth a reviewer's eye:

* `/networks/:id/{identity,perform,password}` are deliberately in the
  client-usable set — they configure the upstream connection a headless
  client exists to hold open, and #1196 shipped them reachable. They are
  named explicitly in the test rather than left implicit, so moving them
  behind the gate becomes a decision someone takes rather than a default
  someone inherits.
* the inversion immediately paid for itself: it caught `GET /me/themes`,
  which the `/themes` prefix does not reach.

## Tests

Each guard has a test that fails without it, and each was measured by
mutation — one mutant, one assertion:

| mutation | killed by |
| --- | --- |
| the signing gate admits a scoped session | the two `mint/2` arms (and *not* the door test) |
| the route is declared in the ungated block | nothing — see below |
| the entry ceiling is removed | `refuses a list past the entry cap` only |
| the byte ceiling is removed | the two byte-cap arms only |
| `byte_size` becomes `String.length` | `the byte cap counts BYTES, not graphemes` only |

**Stated rather than glossed:** the second mutation survives silently. The
two layers are redundant by construction — no single mutation opens the
door, which is the property defence in depth is for — but the *declaration*
has no witness. `__routes__` exposes `path/verb/plug/plug_opts/helper/
metadata` and not `pipe_through` (measured, not assumed), and the only
behavioural discriminator left is whether the refusal consumes a request
budget token, which would cost a global `persistent_term` seam and
`async: false` on the whole file. Judged not worth that price; say so if
you disagree.

`scripts/check.sh` green.
