### PR TITLE
cic: stop the compose box concatenating quotes blindly (#1356, #1357)

### DIFF
--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
-import { addQuoteCommand, addQuoteToCompose } from "../lib/addQuote";
+import { ADDQUOTE_COMMAND, addQuoteCommand, addQuoteToCompose } from "../lib/addQuote";
 import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
@@ -176,6 +176,56 @@ describe("addQuoteToCompose", () => {
     setDraft(KEY, "bozza ");
     addQuoteToCompose(msg({}), NET, CHAN);
     expect(getDraft(KEY)).toBe("bozza !addquote <vjt> ciao mondo");
+  });
+
+  // #1356 — ONE verb, N payloads. A second long-press while a quote is already
+  // in the draft appends that message's `<nick> body` and nothing else: a
+  // second `!addquote` mid-line leaves the bot reading one command, and the
+  // rest of the line gets swallowed into the first quote's body.
+  it("appends a second quote without repeating the verb", () => {
+    mountCompose();
+    addQuoteToCompose(msg({ sender: "ska", body: "io oggi ho messo un reggiseno" }), NET, CHAN);
+    addQuoteToCompose(msg({ id: 2, sender: "alk", body: "se lo allacciano davanti" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe(
+      "!addquote <ska> io oggi ho messo un reggiseno <alk> se lo allacciano davanti",
+    );
+  });
+
+  // N, not two: an implementation that only recognises the verb at the HEAD of
+  // the draft, or that flips a one-shot flag, passes the arm above and repeats
+  // the verb here.
+  it("keeps accumulating past the second payload", () => {
+    mountCompose();
+    for (const sender of ["ska", "alk", "cle"]) {
+      addQuoteToCompose(msg({ sender, body: `detto da ${sender}` }), NET, CHAN);
+    }
+    expect(getDraft(KEY)).toBe(
+      "!addquote <ska> detto da ska <alk> detto da alk <cle> detto da cle",
+    );
+  });
+
+  // The accumulated payload keeps the head the SCROLLBACK rendered (#1264), so
+  // an action joins the line as `* nick` — the verb is what must not repeat,
+  // the attribution is what must not be dropped.
+  it("accumulates an action under its rendered head", () => {
+    mountCompose();
+    addQuoteToCompose(msg({ sender: "ska", body: "primo" }), NET, CHAN);
+    addQuoteToCompose(
+      msg({ id: 2, kind: "action", sender: "alk", body: "\x01ACTION waves\x01" }),
+      NET,
+      CHAN,
+    );
+    expect(getDraft(KEY)).toBe("!addquote <ska> primo * alk waves");
+  });
+
+  // The verb carries its own trailing space, so a hand-typed `!addquote ` must
+  // not earn a second one. Same door, same draft inspection: the separator is
+  // ONE space, and only where there is not one already.
+  it("does not double the space after a hand-typed verb", () => {
+    mountCompose();
+    setDraft(KEY, ADDQUOTE_COMMAND);
+    addQuoteToCompose(msg({}), NET, CHAN);
+    expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -379,4 +379,40 @@ describe("replyToMessage", () => {
     replyToMessage(msg({ kind: "part", body: null }), NET, CHAN);
     expect(getDraft(KEY)).toBe("");
   });
+
+  // #1357 — the line accumulates, the MARKER does not repeat (vjt, 2026-08-15).
+  // A second reply used to bury the first tail mid-line, where `<<` reads as
+  // part of the quoted text and the answer typed at the caret belongs to the
+  // last quote only. The tail's own LEADING space (#1235, so it never sits
+  // flush against the last word) is what separates the two quotes afterwards.
+  it("keeps both quotes and moves the tail to the end", () => {
+    mountCompose();
+    replyToMessage(msg({ sender: "a", body: "primo" }), NET, CHAN);
+    replyToMessage(msg({ id: 2, sender: "b", body: "secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("<a> primo <b> secondo << ");
+  });
+
+  // Stated as a COUNT rather than as a shape, because "one marker" is the
+  // ruling — an implementation that emits the right string for two replies and
+  // a second tail for three passes the arm above.
+  it("leaves exactly one tail after N replies", () => {
+    mountCompose();
+    for (const sender of ["a", "b", "c"]) {
+      replyToMessage(msg({ sender, body: `da ${sender}` }), NET, CHAN);
+    }
+    expect(getDraft(KEY)).toBe("<a> da a <b> da b <c> da c << ");
+    expect(getDraft(KEY).split(REPLY_QUOTE_TAIL.trim())).toHaveLength(2);
+  });
+
+  // Acceptance criterion 3: once the operator has typed their answer, the tail
+  // is no longer at the end and is no longer OURS to remove — cutting it there
+  // would rewrite their sentence, and the new quote must still land after what
+  // they wrote. So this line keeps two markers, deliberately: the alternative
+  // is mangling text a human typed.
+  it("does not touch a tail the operator has already typed past", () => {
+    mountCompose();
+    setDraft(KEY, "<a> primo << ciao");
+    replyToMessage(msg({ sender: "b", body: "secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("<a> primo << ciao<b> secondo << ");
+  });
 });

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -1,4 +1,6 @@
 import type { ScrollbackMessage } from "./api";
+import { channelKey } from "./channelKey";
+import { getDraft } from "./compose";
 import { appendToCompose } from "./composeAppend";
 import { attributionHead, quotableBody } from "./quotableBody";
 
@@ -34,6 +36,34 @@ export function addQuoteCommand(msg: ScrollbackMessage): string | null {
   return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg)} ${body}`;
 }
 
+// #1356 — ONE verb, N payloads. What a long-press adds to THIS draft: the whole
+// command when the line has no `!addquote` yet, and the bare `<nick> body` when
+// it already does. A second verb mid-line is not a second quote — the bot reads
+// one command per line, so everything past the first `!addquote` is swallowed
+// into the first quote's body.
+//
+// The rule lives HERE and not in `appendToCompose`, which the reply quote
+// (#1067) and the off-compose printable-key handler also go through: for those
+// two, appending to an existing draft is exactly right. Blind concatenation is
+// the shared verb; knowing what `!addquote` means is this door's business.
+//
+// `includes`, not `startsWith`: a half-typed draft (`ciao !addquote <a> x`)
+// still holds a command the bot will read as one. A draft that merely mentions
+// the verb in prose therefore suppresses it too — accepted, because on the same
+// line the bot would not tell the two apart either.
+//
+// The separator is ONE space and no token (vjt's spec is emphatic on the token:
+// there is none). It goes in only when the draft does not already end in
+// whitespace, so a hand-typed `!addquote ` — the verb ships its own trailing
+// space — does not earn a second one.
+export function addQuoteAppendText(draft: string, msg: ScrollbackMessage): string | null {
+  const body = quotableBody(msg);
+  if (body === null) return null;
+  const payload = `${attributionHead(msg)} ${body}`;
+  if (!draft.includes(ADDQUOTE_COMMAND)) return `${ADDQUOTE_COMMAND}${payload}`;
+  return draft.endsWith(" ") ? payload : ` ${payload}`;
+}
+
 // Drop the command into the window's compose box with the caret at the end and
 // REVEALED — `!addquote ` plus a body overflows the rows=1 textarea nearly
 // every time, which is why #1107 waited on #1105/#1113. `appendToCompose` owns
@@ -43,7 +73,7 @@ export function addQuoteToCompose(
   networkSlug: string,
   channelName: string,
 ): void {
-  const command = addQuoteCommand(msg);
-  if (command === null) return;
-  appendToCompose(networkSlug, channelName, command);
+  const text = addQuoteAppendText(getDraft(channelKey(networkSlug, channelName)), msg);
+  if (text === null) return;
+  appendToCompose(networkSlug, channelName, text);
 }

--- a/cicchetto/src/lib/composeAppend.ts
+++ b/cicchetto/src/lib/composeAppend.ts
@@ -16,11 +16,29 @@ import { placeCaretAtEndInView } from "./composeCaret";
 // DOM-touching by nature (the caret is not in the store), so it lives here
 // rather than in `lib/compose.ts`, which is deliberately DOM-free.
 export function appendToCompose(networkSlug: string, channelName: string, text: string): void {
+  updateCompose(networkSlug, channelName, (draft) => draft + text);
+}
+
+// #1357 — the same dance for a door that must REWRITE the draft rather than
+// only extend it: the second reply drops the first quote's now-mid-line ` << `
+// marker before adding its own. Append cannot express that, and doing it as a
+// `setDraft` next to an `appendToCompose` call would split one edit into two
+// writes that disagree when there is no composer mounted — the strip would
+// land and the quote would not.
+//
+// `next` receives the current draft and returns the whole new one. Everything
+// below the first line is why this exists as one function: focus, the iOS
+// scroll short-circuit and the caret reveal are a single dance, and a second
+// copy of it is a second place to forget one of the three.
+export function updateCompose(
+  networkSlug: string,
+  channelName: string,
+  next: (draft: string) => string,
+): void {
   const ta = document.querySelector<HTMLTextAreaElement>(".compose-box textarea");
   if (ta === null) return;
   const key = channelKey(networkSlug, channelName);
-  const next = getDraft(key) + text;
-  setDraft(key, next);
+  setDraft(key, next(getDraft(key)));
   // UX-6 D9 — `preventScroll: true` short-circuits iOS Safari's "scroll the
   // focused input into view" auto-scroll path (WebKit `_zoomToFocusRect` in
   // WKContentView). Baseline since iOS Safari 15.5; without it iOS shifts the

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,5 +1,5 @@
 import type { ScrollbackMessage } from "./api";
-import { appendToCompose } from "./composeAppend";
+import { updateCompose } from "./composeAppend";
 import { attributionHead, quotableBody } from "./quotableBody";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
@@ -52,6 +52,32 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   return `${attributionHead(msg)} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
+// The marker and its trailing space — the part of the tail a second reply takes
+// back. The LEADING space stays: #1235 put it there so the tail never sits
+// flush against the last word, and it is exactly the one space the next quote
+// needs in front of it. Derived from the tail rather than spelled again, so the
+// two cannot drift.
+const REPLY_QUOTE_MARKER = REPLY_QUOTE_TAIL.trimStart();
+
+// #1357 — what the draft must look like BEFORE this reply's quote is appended.
+// vjt's ruling (2026-08-15): the line accumulates, the marker does not repeat,
+// so a draft that ENDS with our tail sheds the marker and the new quote brings
+// the only one — `<a> primo <b> secondo << `.
+//
+// Only when the tail is at the END. Once the operator has typed their answer
+// the tail is mid-line, and cutting it there rewrites a human's sentence to fix
+// our own duplication; that line keeps two markers on purpose, because the
+// alternative is mangling text somebody wrote.
+//
+// THIS is the function to change if replace-semantics ever wins (vjt: "start
+// with 2, we change it later if needed") — last-swipe-wins means returning the
+// draft with its whole quote removed instead of just the marker. The door below
+// hands it the draft and appends to whatever comes back, so nothing else moves.
+export function draftBeforeReplyQuote(draft: string): string {
+  if (!draft.endsWith(REPLY_QUOTE_TAIL)) return draft;
+  return draft.slice(0, draft.length - REPLY_QUOTE_MARKER.length);
+}
+
 // Drop the quote into the window's compose box with the caret at the end. A
 // no-op for a row with nothing to quote — the gesture still slid and snapped
 // back, which is the honest feedback for "armed, but this row has no reply".
@@ -62,5 +88,5 @@ export function replyToMessage(
 ): void {
   const quote = replyQuote(msg);
   if (quote === null) return;
-  appendToCompose(networkSlug, channelName, quote);
+  updateCompose(networkSlug, channelName, (draft) => draftBeforeReplyQuote(draft) + quote);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43020,3 +43020,55 @@ worker host for the whole of this work, so `check.sh`, `mix.sh` and
 unobserved, and CI on the PR is the only arbiter. The measured ircd citations
 come from the public `azzurra/bahamut` and `solanum-ircd/solanum` trees at the
 refs above, not from a running server.
+<!-- entry #1356 -->
+
+---
+
+## 2026-08-15 — #1356/#1357: the compose line accumulates, and what must not repeat differs by door
+
+`appendToCompose` does `getDraft(key) + text` and never looks at the draft.
+Three doors ride it — `!addquote`, the reply quote, and the off-compose
+printable-key handler — and two of them were producing garbage from that one
+blindness: a second long-press wrote `<ska> primo!addquote <alk> secondo`
+(the bot reads one command per line, so the second quote was not malformed,
+it was eaten), and a second reply buried the first ` << ` mid-line, where
+the marker reads as quoted text and the answer at the caret belongs to the
+last quote only.
+
+**One root, opposite remedies — which is why they stayed two issues.** vjt's
+rulings agree on the LINE (it accumulates, in both doors) and diverge on what
+must not repeat: for `!addquote` the VERB, for reply the MARKER. So the fix
+belongs in each door and not in the shared verb, where a guard would break
+the printable-key handler, for which appending to a live draft is simply
+correct.
+
+**`!addquote` (#1356)** appends the bare `<nick> body` when the draft already
+holds the command. The predicate is `includes`, not `startsWith`: a half-typed
+draft still carries a command the bot will read as one. Cost accepted and
+named — a draft that merely mentions the verb in prose suppresses it too, and
+on the same line the bot could not tell those apart either. The separator is
+one space and no token, added only when the draft does not already end in
+whitespace, so the verb's own trailing space is not doubled.
+
+**Reply (#1357)** strips the marker only when the tail is at the END. The
+tail's LEADING space (#1235, so it never sits flush against the last word) is
+then exactly the separator the next quote needs, so nothing new was invented
+to keep two quotes apart. Once the operator has typed their answer the tail is
+mid-line and is no longer ours: cutting it there rewrites a human's sentence
+to fix our own duplication, so that line keeps two markers on purpose. Refusing
+the second swipe was ruled out; replace-semantics (last swipe wins) was NOT —
+vjt: "start with 2, we change it later if needed" — so the whole decision is
+`draftBeforeReplyQuote`, one function to swap.
+
+**Why `updateCompose` exists.** Reply must REMOVE characters, which append
+cannot express. Doing it as a `setDraft` beside the append would split one
+edit into two writes that disagree exactly when no composer is mounted: the
+strip lands, the quote does not. So the focus + iOS-scroll-short-circuit +
+caret-reveal dance is now parameterised by a draft transform, with
+`appendToCompose` one line on top of it. `!addquote` deliberately stays on the
+append verb — it must not touch the composer at all for an unquotable row,
+and a transform callback would focus one.
+
+**Not established:** jsdom only. Both behaviours are asserted on the compose
+STORE; that a real engine shows the caret after the surviving tail is the
+e2e's job and no e2e was run for this pair.


### PR DESCRIPTION
`appendToCompose` does `getDraft(key) + text` and never looks at the draft. Three doors ride it; two of them were producing garbage from that one blindness. Same root, **opposite** remedies — which is why they stayed two issues, and why both fixes live in their own door rather than in the shared verb (the off-compose printable-key handler appends to a live draft legitimately, and a guard there would break it).

## #1356 — `!addquote` accumulates: one verb, N payloads

A second long-press wrote `<ska> primo!addquote <alk> secondo`. The bot reads one command per line, so the second quote was not malformed — it was eaten.

Now a draft that already holds the command gets the bare `<nick> body` appended. The predicate is `includes`, not `startsWith`, so a half-typed draft still counts as holding a command the bot will read as one; the accepted cost is that a draft merely mentioning the verb in prose suppresses it too, which the bot could not tell apart either. Separator is one space and no token, added only when the draft does not already end in whitespace, so the verb's own trailing space is not doubled. The menu item stays enabled: a second press is a legitimate append.

## #1357 — reply keeps both quotes and one tail

A second reply buried the first ` << ` mid-line, where the marker reads as quoted text and the answer typed at the caret belongs to the last quote only.

Per vjt's ruling, the line comes out `<a> primo <b> secondo << `. The marker is stripped only when the tail is at the END; the tail's leading space (#1235) is then exactly the separator the next quote needs. Once the operator has typed their answer the tail is mid-line and is not ours to cut — that would rewrite a human's sentence to fix our own duplication — so that line keeps two markers on purpose, per the issue's third acceptance criterion.

Replace-semantics (last swipe wins) was explicitly not dismissed, so the whole decision sits in `draftBeforeReplyQuote`: switching is that one function, not a refactor.

## `updateCompose`

Reply must REMOVE characters, which append cannot express. A `setDraft` beside the append would split one edit into two writes that disagree exactly when no composer is mounted — the strip lands, the quote does not. So the focus + iOS-scroll-short-circuit + caret-reveal dance is now parameterised by a draft transform, and `appendToCompose` is one line on top of it. `!addquote` stays on the append verb deliberately: it must not touch the composer at all for an unquotable row, and a transform callback would focus one.

## Gates

- `bun run test` — 5491 passed, 284 files (7 new arms: 4 on `!addquote`, 3 on reply).
- `bun run check` — biome + tsc + e2e tsc, rc 0.
- `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present.
- Every new arm was watched RED first: the `!addquote` four reproduced the doubled verb, the reply two reproduced the buried tail. The third reply arm (operator has typed past the tail) is green from the start by design — it is the mutant killer for an implementation that strips a tail anywhere.

## Not established

jsdom only. Both behaviours are asserted on the compose store; that a real engine shows the caret after the surviving tail is the e2e's job, and no e2e was run for this pair.

Fixes the two issues #1356 and #1357.