### PR TITLE
deploy(#1348): refuse a migration version claimed by two files, at every door that migrates

### DIFF
--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -456,6 +456,13 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // token the server can emit and the switch is exhaustive by
       // construction. Copy stays operator-shaped, not reassuring.
       return "The server needs a full restart to apply a database change.";
+    case "duplicate_migration_versions":
+      // #1348 — 409 from the same loopback-gated POST /admin/reload, so
+      // this string is likewise unreachable from a browser and exists
+      // because the union is exhaustive. Deliberately NOT the sibling's
+      // copy: a restart is what the other token asks for and the wrong
+      // move for this one, which needs the duplicate resolved in the repo.
+      return "Two migration files claim the same version; nothing was applied.";
     case "client_token_scope":
       // #1196 — 403 for a per-client token on a credential-management
       // route. cic authenticates with a browser session, so this arm is

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1553,6 +1553,7 @@ export const S_ErrorTokensRestErrorToken = {
     { l: "internal" },
     { l: "session_plan_resolve_failed" },
     { l: "contract_migrations_pending" },
+    { l: "duplicate_migration_versions" },
     { l: "invalid_message" },
     { l: "anon_collision" },
     { l: "nick_in_use" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1543,6 +1543,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "internal",
   "session_plan_resolve_failed",
   "contract_migrations_pending",
+  "duplicate_migration_versions",
   "invalid_message",
   "anon_collision",
   "nick_in_use",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43193,3 +43193,81 @@ and a transform callback would focus one.
 **Not established:** jsdom only. Both behaviours are asserted on the compose
 STORE; that a real engine shows the caret after the surviving tail is the
 e2e's job and no e2e was run for this pair.
+<!-- entry #1348 -->
+
+---
+
+## 2026-08-16 — #1348: the duplicate no pending count can see, gated at the doors instead of the preflight
+
+#1343 gated migration FILENAMES, which catches a duplicated version before it
+is applied. It cannot catch the regime CLAUDE.md marks as the dangerous one:
+once the duplicated version is IN `schema_migrations`, both files leave the
+pending set, `ensure_no_duplication!([])` answers `:ok`, the run reports
+SUCCESS, and neither migration ever runs again. A gate that counts pending
+files sees zero — which is exactly what a healthy deploy sees too.
+
+**The deploy preflight cannot host this gate, and the reason is structural.**
+All three substrates invoke the classifier with `mix run --no-start`
+(`scripts/deploy.sh`, `infra/freebsd/deploy.sh`, `infra/linux/deploy.sh`), so
+`Grappa.Deploy.Preflight.cli/1` runs with no application started and no Repo.
+It cannot read `schema_migrations` at all. The issue asked for "a preflight
+that compares version sets"; what it gets is the same comparison hung off
+every door that migrates, where a pool is live by construction. `Preflight`
+stays pure and git-only.
+
+**Six doors, three call sites, one rule.** `Grappa.HotReload.migrate_and_reload/2`
+(hot, every substrate, behind `POST /admin/reload`); `Grappa.Release.migrate/0`
+(the jail's cold deploy, the published image's boot-time migrate from #867,
+and the `grappa migrate` operator verb — all three reach it through
+`eval`); and `mix grappa.migrate` (Docker cold, native-Linux cold, and the
+first-install migration in `infra/linux/install.sh`). Adding a seventh door
+means calling the audit from it; there is no ambient hook that would catch it
+for you.
+
+**The collector is `Ecto.Migrator.migrations/1`**, which already fuses disk
+and `schema_migrations` into `[{:up | :down, version, name}]` — a duplicated
+version simply appears twice. No hand-rolled glob, no raw SQL, no re-derived
+convention.
+
+**What is deliberately NOT reported: the third `comm` column.** A version in
+`schema_migrations` with no file on disk is real and observable, but only by
+recognising the literal `"** FILE NOT FOUND **"` that Ecto's
+`collect_migrations/2` writes into the name field. Coupling a gate to another
+project's internal string means the day it changes the report silently goes
+to zero — a gate that lies by omission is worse than an absent one. It was
+also the wrong shape for a refusal: a legitimate deploy-backwards, or an old
+migration squashed away, would brick every subsequent deploy.
+
+**`mix grappa.migrate` starts nothing.** `docs/OPERATIONS.md` requires any mix
+task run against a live host on the systemd substrate to go through
+`Mix.Tasks.Grappa.Boot`, and that rule is about the APP START — it suppresses
+`Grappa.Bootstrap` and `GrappaWeb.Endpoint` so nothing dials IRC or fights
+port 4000. The migrate door has always sat outside it: `mix ecto.migrate`
+starts the Repo and nothing else, which is why `substrate_migrate` has run it
+bare against a live host since the substrate existed. The new task keeps that
+regime exactly — `app.config`, then the audit and the migrator inside
+`Ecto.Migrator.with_repo/2`. Routing it through `Boot` would ADD an app boot
+to the cold path of the one substrate whose documented pathology is a boot
+that kills the BEAM; routing it through `Grappa.Release` is forbidden by name
+in the same section. Starting NOTHING satisfies the rule's reason more
+strictly than starting everything with two children suppressed.
+
+**A 409 now has two causes that need opposite moves.** The hot deploy's
+`curl -f` discards the response body, so the line `deploy_common.sh` prints is
+all the operator gets, and it named only the contract-migration cause with
+"run a cold deploy". A duplicated version is a repo defect a cold deploy walks
+straight back into. Both causes are named now, and the second says plainly
+that a cold deploy will not help.
+
+**The first-install door was measured, not assumed.** At
+`infra/linux/install.sh`'s `6/11 first migration` the database file does not
+exist yet — `DATABASE_PATH` was written into the env moments earlier. The
+audit is fine with that: its only DB touch is `Ecto.Migrator.migrations/1`,
+which creates `schema_migrations` through the same door the migrator opens a
+line later, on a file sqlite creates on open. The test drives the audit
+against a path it asserts absent beforehand, rather than reasoning about it.
+
+**Log honesty on the passing arm.** The audit's `:ok` reports the applied and
+pending counts it OBSERVED, never "no pending migrations, nothing to do" — a
+pending count of zero is the silent regime's own signature, so a fast path
+that reports the absence of work would be reporting the defect as health.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3532,7 +3532,7 @@ pins the outcomes (#441); the reasons follow.
   finished file is 0644 with every secret readable by anyone on the box.
   Pinned by "the finished env file is 0640, not the tmp+mv default (#441)".
 
-### Migrations run `mix ecto.migrate`, never the release's `eval`
+### Migrations run a mix task, never the release's `eval`
 
 **On this substrate the packaged release's `eval` / `remote` / `rpc`
 crash the BEAM at kernel boot** — even for a trivial `eval '1 + 1'`.
@@ -3548,19 +3548,32 @@ hypotheses and the console fallback are in `infra/linux/README.md`
 "Day-2 operations".
 
 So `install.sh` and `deploy.sh` (`substrate_migrate` and
-`substrate_seed` both) drive the plain **mix task** instead — viable
+`substrate_seed` both) drive a plain **mix task** instead — viable
 here precisely because this substrate keeps the whole mix/asdf toolchain
 around permanently, unlike a minimal prod container, and consistent with
-what Docker already does (§ "Hot vs cold deploy": Docker via `mix
-ecto.migrate`, the jail via `Grappa.Release.migrate()`). Do not "restore
-symmetry" with the jail by routing these through the release.
+what Docker already does (§ "Hot vs cold deploy": Docker and Linux via
+`mix grappa.migrate`, the jail via `Grappa.Release.migrate()`). Do not
+"restore symmetry" with the jail by routing these through the release.
 
-**Any mix task run against a LIVE host on this substrate must go through
-`Mix.Tasks.Grappa.Boot`.** It suppresses both `Grappa.Bootstrap` and
-`GrappaWeb.Endpoint`, so the task neither opens upstream IRC connections
-for every bound network nor fights the running daemon for port 4000
-(`:eaddrinuse`). That is what makes seeding safe on a HOT deploy, which
-is the entire point of seeding on one.
+**Any mix task that STARTS THE APP against a LIVE host on this substrate
+must go through `Mix.Tasks.Grappa.Boot`.** It suppresses both
+`Grappa.Bootstrap` and `GrappaWeb.Endpoint`, so the task neither opens
+upstream IRC connections for every bound network nor fights the running
+daemon for port 4000 (`:eaddrinuse`). That is what makes seeding safe on
+a HOT deploy, which is the entire point of seeding on one.
+
+The rule is about the APP START, not about the words "mix task", and the
+migrate door has always sat outside it: `mix ecto.migrate` starts the
+Repo and nothing else — no Bootstrap to connect, no Endpoint to bind —
+which is why `substrate_migrate` has run it bare against a live host
+since this substrate existed. `mix grappa.migrate` (#1348) keeps exactly
+that regime: `app.config`, the duplicate-version audit and the migrator,
+all inside `Ecto.Migrator.with_repo/2`, with no
+`Application.ensure_all_started/1` anywhere. Satisfying the rule's
+reason by starting NOTHING is stricter than satisfying it by starting
+everything with two children suppressed — so do not "tidy" that task
+onto `Boot`, it would ADD an app boot to the cold path of the substrate
+whose documented pathology is a boot that kills the BEAM.
 
 ### deploy.sh — what is Linux-specific
 
@@ -4194,11 +4207,19 @@ it.
   `/home/grappa/grappa/runtime/`.
 - **Migrations**: standard Ecto.
   - Write migration in `priv/repo/migrations/<timestamp>_<name>.exs`.
-  - Dev: `scripts/mix.sh ecto.migrate`.
+  - Dev: `scripts/mix.sh grappa.migrate`. The same migrator plus the
+    #1348 audit — and a long-lived dev database is precisely where a
+    duplicated version goes silent, because the version is already
+    applied there long before anyone deploys it.
   - Deploys: the preflight classifies ANY new migration file as COLD
     (Class 5 — there is no in-reload migrate until #41 lands). The
-    cold paths run it: Docker via `mix ecto.migrate`, the jail via
-    `Grappa.Release.migrate()` before `service grappa restart`.
+    cold paths run it: Docker and native Linux via `mix grappa.migrate`,
+    the jail via `Grappa.Release.migrate()` before `service grappa
+    restart`. Every one of those doors — plus the hot
+    `POST /admin/reload`, the published image's boot entrypoint and the
+    `grappa migrate` operator verb — runs the #1348 duplicate-version
+    audit first, and refuses rather than migrate past a version claimed
+    by two files.
     Never `--force-hot` past a new migration — the DML is skipped
     and the code reads defaults (the uploads-2 key-rename would have
     silently reverted tuned caps this way).

--- a/infra/lib/deploy_common.sh
+++ b/infra/lib/deploy_common.sh
@@ -324,7 +324,12 @@ _deploy_hot() {
 		# failed and NOTHING about why. Name both live causes.
 		deploy_error "POST /admin/reload failed"
 		printf '[deploy]   the daemon is down/unreachable, OR it refused the hot reload\n' >&2
-		printf '[deploy]   (HTTP 409 = a pending migration is CONTRACT → run a cold deploy)\n' >&2
+		# Since #1348 a 409 has two causes and they need OPPOSITE moves,
+		# so naming only the first sends the operator to restart
+		# production for a defect a restart walks straight back into.
+		printf '[deploy]   HTTP 409, cause 1: a pending migration is CONTRACT → run a cold deploy\n' >&2
+		printf '[deploy]   HTTP 409, cause 2: two files claim one migration version — a\n' >&2
+		printf '[deploy]   cold deploy will not help, the duplicate must be resolved in the repo\n' >&2
 		exit 1
 	fi
 

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -134,13 +134,17 @@ substrate_cic() {
 }
 
 substrate_migrate() {
-	# Plain `mix ecto.migrate`, not release eval — the packaged release's
-	# eval boot path crashes the BEAM on this substrate (see install.sh).
+	# A mix task, not release eval — the packaged release's eval boot path
+	# crashes the BEAM on this substrate (see install.sh). `grappa.migrate`
+	# rather than `ecto.migrate` since #1348: it runs the same migrator with
+	# the same footprint (Repo started, nothing else — no Endpoint, no
+	# Bootstrap, so it stays safe against the live host) and adds the
+	# duplicate-version audit that `ecto.migrate` structurally cannot carry.
 	deploy_log "migrate"
 	run_as_grappa "
 		set -a; . '${ENV_FILE}'; set +a
 		export MIX_ENV=prod
-		mix ecto.migrate
+		mix grappa.migrate
 	"
 }
 

--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -211,17 +211,26 @@ mkdir -p "${REPO_ROOT}/runtime/uploads"
 chown -R "${GRAPPA_USER}:${GRAPPA_USER}" "${REPO_ROOT}/runtime"
 
 say "6/11 first migration"
-# Plain `mix ecto.migrate`, NOT `release.sh eval 'Grappa.Release.migrate()'`:
-# the packaged release's eval/remote/rpc boot path crashes the BEAM on this
-# substrate (systemd's own `bin/grappa start` is unaffected). This host keeps
-# the full mix toolchain, so nothing is lost by not using it.
+# A mix task, NOT `release.sh eval 'Grappa.Release.migrate()'`: the packaged
+# release's eval/remote/rpc boot path crashes the BEAM on this substrate
+# (systemd's own `bin/grappa start` is unaffected). This host keeps the full
+# mix toolchain, so nothing is lost by not using it.
 # Why: docs/OPERATIONS.md § "Native Linux and the cloud one-click box (infra/linux/, infra/cloud/)".
+#
+# `grappa.migrate` carries the #1348 duplicate-version audit. The database
+# file does NOT exist yet at this point — DATABASE_PATH was written into the
+# env a few lines up and only `runtime/` was created — and the audit is fine
+# with that: its one DB touch is `Ecto.Migrator.migrations/1`, which creates
+# `schema_migrations` through the very door the migrator opens a moment
+# later, on a file sqlite creates on open. Measured, not assumed:
+# `test/grappa/migrations/duplicate_version_gate_test.exs` drives the audit
+# against a database file it asserts absent beforehand.
 run_as_grappa "
 	${asdf_path_export}
 	set -a; . '${ENV_FILE}'; set +a
 	export MIX_ENV=prod
 	cd '${REPO_ROOT}'
-	mix ecto.migrate
+	mix grappa.migrate
 "
 
 say "7/11 seed built-in themes"

--- a/lib/grappa/deploy/migration_audit.ex
+++ b/lib/grappa/deploy/migration_audit.ex
@@ -1,0 +1,169 @@
+defmodule Grappa.Deploy.MigrationAudit do
+  @moduledoc """
+  Refuses to migrate past a version claimed by two files (#1348).
+
+  ## The regime this exists for
+
+  A duplicated migration version has three regimes, measured in Ecto's own
+  source. On a fresh database it raises `Ecto.MigrationError` — loud, fine.
+  On the hot preflight it dies on a `[path] = Path.wildcard(…)` match. And
+  on a database that has **already applied** that version, both files drop
+  out of the pending set, `ensure_no_duplication!([])` answers `:ok`, the
+  run reports SUCCESS, and neither migration ever runs — permanently, since
+  the version is already in `schema_migrations`.
+
+  The third is the one production hits, and no count can see it: a pending
+  count of zero is exactly what it produces, and exactly what a healthy
+  deploy produces. So this compares version SETS, and the passing arm
+  reports the counts it OBSERVED rather than announcing an absence of work.
+
+  ## Why it does not live in `Grappa.Deploy.Preflight`
+
+  Every substrate invokes the classifier with `mix run --no-start`, so
+  `Preflight.cli/1` has no application started and no Repo — it cannot read
+  `schema_migrations` at all. The gate therefore hangs off the doors that
+  migrate, where a pool is live by construction: `check/1` for a caller that
+  reports a refusal (the hot handler), `check!/1` for one whose refusal is a
+  non-zero exit (`Grappa.Release.migrate/0`, `mix grappa.migrate`).
+
+  ## What it deliberately does not report
+
+  A version in `schema_migrations` with no file on disk is real, but
+  separating it out means recognising the literal `"** FILE NOT FOUND **"`
+  that `Ecto.Migrator.collect_migrations/2` writes into the name field. A
+  gate coupled to another project's internal string goes silently to zero
+  the day that string changes, and a gate that lies by omission is worse
+  than an absent one. See DESIGN_NOTES 2026-08-16.
+  """
+
+  use Boundary, top_level?: true
+
+  require Logger
+
+  @typedoc "One row of `Ecto.Migrator.migrations/1`: status, version, name."
+  @type status :: {:up | :down, non_neg_integer(), String.t()}
+
+  @typedoc """
+  One version claimed by more than one file. `applied` distinguishes the
+  silent regime (true — neither file will ever run) from the loud one
+  (false — the migrator would raise on the next run).
+  """
+  @type duplicate :: %{
+          version: non_neg_integer(),
+          files: [String.t()],
+          applied: boolean()
+        }
+
+  @typedoc "What the passing arm OBSERVED, for an honest log line."
+  @type summary :: %{applied: non_neg_integer(), pending: non_neg_integer()}
+
+  @doc """
+  The rule, over a merged `Ecto.Migrator.migrations/1` table.
+
+  `{:ok, summary}` when no version is claimed twice, `{:error, duplicates}`
+  otherwise — oldest version first, and each duplicate's files sorted, so
+  the refusal reads the same regardless of the order Ecto handed the rows
+  over (it reverses the applied ones).
+  """
+  @spec audit([status()]) :: {:ok, summary()} | {:error, [duplicate()]}
+  def audit(statuses) when is_list(statuses) do
+    case duplicates(statuses) do
+      [] -> {:ok, summarise(statuses)}
+      duplicates -> {:error, duplicates}
+    end
+  end
+
+  @doc """
+  Audit `repo`'s migration set, logging what it observed either way.
+
+  Returns `:ok` or `{:error, duplicates}` for a caller that turns a refusal
+  into a response rather than an exit.
+  """
+  @spec check(module()) :: :ok | {:error, [duplicate()]}
+  def check(repo) when is_atom(repo) do
+    case repo |> Ecto.Migrator.migrations() |> audit() do
+      {:ok, summary} ->
+        Logger.info(
+          "migration audit: #{summary.applied} versions applied, #{summary.pending} pending, " <>
+            "no version claimed by two files"
+        )
+
+        :ok
+
+      {:error, duplicates} ->
+        Logger.error("migration audit refused the migrate — #{describe(duplicates)}")
+        {:error, duplicates}
+    end
+  end
+
+  @doc """
+  `check/1` for a caller whose refusal is a non-zero exit: raises naming the
+  version, both files and the directory they sit in.
+  """
+  @spec check!(module()) :: :ok
+  def check!(repo) when is_atom(repo) do
+    case check(repo) do
+      :ok ->
+        :ok
+
+      {:error, duplicates} ->
+        raise "refusing to migrate — #{describe(duplicates)} " <>
+                "(migrations directory: #{Ecto.Migrator.migrations_path(repo)})"
+    end
+  end
+
+  @doc """
+  The refusal in words: every duplicate names its version, ALL its files,
+  and which of the two regimes it is in.
+  """
+  @spec describe([duplicate()]) :: String.t()
+  def describe(duplicates) when is_list(duplicates) do
+    Enum.map_join(duplicates, " ", &describe_one/1)
+  end
+
+  defp describe_one(%{version: version, files: files, applied: applied}) do
+    "migration version #{version} is claimed by #{length(files)} files " <>
+      "(#{Enum.join(files, ", ")})" <> regime(applied)
+  end
+
+  # The whole point of the distinction: one of these is fixed by fixing the
+  # repo, the other is ALSO fixed by fixing the repo but looks like success
+  # until someone goes looking for a table that was never created.
+  defp regime(true) do
+    ", and that version is already applied, so NEITHER file will ever run: " <>
+      "both leave the pending set and the migrator reports success having run nothing"
+  end
+
+  defp regime(false) do
+    ", and that version is not yet applied, so the migrator would raise on the next run"
+  end
+
+  defp duplicates(statuses) do
+    statuses
+    |> Enum.group_by(fn {_, version, _} -> version end)
+    |> Enum.filter(fn {_, claims} -> length(claims) > 1 end)
+    |> Enum.sort_by(fn {version, _} -> version end)
+    |> Enum.map(&duplicate/1)
+  end
+
+  defp duplicate({version, claims}) do
+    %{
+      version: version,
+      applied: Enum.any?(claims, &match?({:up, _, _}, &1)),
+      files: claims |> Enum.map(&basename/1) |> Enum.sort()
+    }
+  end
+
+  # `Ecto.Migrator.migrations/1` drops the path and keeps the name, so this
+  # inverts the basename parse Ecto itself did (`extract_migration_info/1`
+  # reads `Path.basename` and nothing else). The directory is named
+  # separately, by `check!/1`.
+  defp basename({_, version, name}), do: "#{version}_#{name}.exs"
+
+  defp summarise(statuses) do
+    %{
+      applied: Enum.count(statuses, &match?({:up, _, _}, &1)),
+      pending: Enum.count(statuses, &match?({:down, _, _}, &1))
+    }
+  end
+end

--- a/lib/grappa/deploy/migration_audit.ex
+++ b/lib/grappa/deploy/migration_audit.ex
@@ -26,14 +26,21 @@ defmodule Grappa.Deploy.MigrationAudit do
   reports a refusal (the hot handler), `check!/1` for one whose refusal is a
   non-zero exit (`Grappa.Release.migrate/0`, `mix grappa.migrate`).
 
-  ## What it deliberately does not report
+  ## The third column: reported, never refused
 
-  A version in `schema_migrations` with no file on disk is real, but
-  separating it out means recognising the literal `"** FILE NOT FOUND **"`
-  that `Ecto.Migrator.collect_migrations/2` writes into the name field. A
-  gate coupled to another project's internal string goes silently to zero
-  the day that string changes, and a gate that lies by omission is worse
-  than an absent one. See DESIGN_NOTES 2026-08-16.
+  A version in `schema_migrations` that no file on disk claims is reported
+  and nothing more. It is a set DIFFERENCE — applied versions minus the
+  versions the directory carries — so nothing here reads the
+  `"** FILE NOT FOUND **"` placeholder `Ecto.Migrator.collect_migrations/2`
+  writes for such a row; a gate coupled to another project's internal
+  string goes silently to zero the day that string changes.
+
+  It does not refuse because a database ahead of the code is also a
+  legitimate rollback, and a deploy from an older checkout: refusing there
+  would block a valid operation at every door. It is not silent because
+  staying silent is what turned one foreign migration in a shared test
+  database into three unrelated tests raising on an index nobody declared
+  (2026-08-15). See DESIGN_NOTES 2026-08-16.
   """
 
   use Boundary, top_level?: true
@@ -54,21 +61,38 @@ defmodule Grappa.Deploy.MigrationAudit do
           applied: boolean()
         }
 
-  @typedoc "What the passing arm OBSERVED, for an honest log line."
-  @type summary :: %{applied: non_neg_integer(), pending: non_neg_integer()}
+  @typedoc """
+  What the passing arm OBSERVED, for an honest log line.
+
+  `applied_without_file` is the third column of the comparison: versions
+  recorded in `schema_migrations` that no file on disk claims. It is
+  REPORTED, never refused — a database ahead of the code is also a
+  legitimate rollback, or a deploy from an older checkout.
+  """
+  @type summary :: %{
+          applied: non_neg_integer(),
+          pending: non_neg_integer(),
+          applied_without_file: [non_neg_integer()]
+        }
 
   @doc """
-  The rule, over a merged `Ecto.Migrator.migrations/1` table.
+  The rule, over a merged `Ecto.Migrator.migrations/1` table and the
+  versions of the files actually on disk.
 
   `{:ok, summary}` when no version is claimed twice, `{:error, duplicates}`
   otherwise — oldest version first, and each duplicate's files sorted, so
   the refusal reads the same regardless of the order Ecto handed the rows
   over (it reverses the applied ones).
+
+  `disk_versions` is a second OBSERVATION, not a derivation: the merged
+  table cannot be split back into its two sides without reading the
+  placeholder name Ecto writes for a fileless version, and coupling to
+  another project's internal string is what this module refuses to do.
   """
-  @spec audit([status()]) :: {:ok, summary()} | {:error, [duplicate()]}
-  def audit(statuses) when is_list(statuses) do
+  @spec audit([status()], [non_neg_integer()]) :: {:ok, summary()} | {:error, [duplicate()]}
+  def audit(statuses, disk_versions) when is_list(statuses) and is_list(disk_versions) do
     case duplicates(statuses) do
-      [] -> {:ok, summarise(statuses)}
+      [] -> {:ok, summarise(statuses, disk_versions)}
       duplicates -> {:error, duplicates}
     end
   end
@@ -81,11 +105,11 @@ defmodule Grappa.Deploy.MigrationAudit do
   """
   @spec check(module()) :: :ok | {:error, [duplicate()]}
   def check(repo) when is_atom(repo) do
-    case repo |> Ecto.Migrator.migrations() |> audit() do
+    case audit(Ecto.Migrator.migrations(repo), disk_versions(repo)) do
       {:ok, summary} ->
         Logger.info(
           "migration audit: #{summary.applied} versions applied, #{summary.pending} pending, " <>
-            "no version claimed by two files"
+            "no version claimed by two files" <> orphans(summary.applied_without_file)
         )
 
         :ok
@@ -138,6 +162,29 @@ defmodule Grappa.Deploy.MigrationAudit do
     ", and that version is not yet applied, so the migrator would raise on the next run"
   end
 
+  # The versions the DIRECTORY claims, read the way Ecto reads them: the
+  # leading integer of each basename. Same gesture as
+  # `Grappa.HotReload.pending_migration_files/1`, and pinned by the #1343
+  # filename gate, which refuses any migration Ecto could not parse.
+  defp disk_versions(repo) do
+    repo
+    |> Ecto.Migrator.migrations_path()
+    |> Path.join("*.exs")
+    |> Path.wildcard()
+    |> Enum.map(&(&1 |> Path.basename() |> Integer.parse() |> elem(0)))
+  end
+
+  # Never silent, never a refusal: a database ahead of the code is a
+  # legitimate rollback as often as it is a mistake, and the operator is
+  # the one who can tell which. Saying nothing is what cost an hour on
+  # 2026-08-15 (DESIGN_NOTES).
+  defp orphans([]), do: ""
+
+  defp orphans(versions) do
+    ", and #{length(versions)} applied with NO migration file on disk " <>
+      "(#{Enum.join(versions, ", ")}) — a rollback, an older checkout, or a foreign migration"
+  end
+
   defp duplicates(statuses) do
     statuses
     |> Enum.group_by(fn {_, version, _} -> version end)
@@ -160,10 +207,16 @@ defmodule Grappa.Deploy.MigrationAudit do
   # separately, by `check!/1`.
   defp basename({_, version, name}), do: "#{version}_#{name}.exs"
 
-  defp summarise(statuses) do
+  defp summarise(statuses, disk_versions) do
+    applied =
+      for {:up, version, _} <- statuses, into: MapSet.new() do
+        version
+      end
+
     %{
       applied: Enum.count(statuses, &match?({:up, _, _}, &1)),
-      pending: Enum.count(statuses, &match?({:down, _, _}, &1))
+      pending: Enum.count(statuses, &match?({:down, _, _}, &1)),
+      applied_without_file: applied |> MapSet.difference(MapSet.new(disk_versions)) |> Enum.sort()
     }
   end
 end

--- a/lib/grappa/hot_reload.ex
+++ b/lib/grappa/hot_reload.ex
@@ -53,8 +53,7 @@ defmodule Grappa.HotReload do
     deps: [Grappa.Deploy.MigrationAudit, Grappa.Deploy.Preflight, Grappa.Repo],
     exports: []
 
-  alias Grappa.Deploy.MigrationAudit
-  alias Grappa.Deploy.Preflight
+  alias Grappa.Deploy.{MigrationAudit, Preflight}
 
   @typedoc "Per-module failure: soft-purge refusal or load error."
   @type failure :: {module(), :old_code_in_use | term()}

--- a/lib/grappa/hot_reload.ex
+++ b/lib/grappa/hot_reload.ex
@@ -48,8 +48,12 @@ defmodule Grappa.HotReload do
   retry, or schedule a cold window).
   """
 
-  use Boundary, top_level?: true, deps: [Grappa.Deploy.Preflight, Grappa.Repo], exports: []
+  use Boundary,
+    top_level?: true,
+    deps: [Grappa.Deploy.MigrationAudit, Grappa.Deploy.Preflight, Grappa.Repo],
+    exports: []
 
+  alias Grappa.Deploy.MigrationAudit
   alias Grappa.Deploy.Preflight
 
   @typedoc "Per-module failure: soft-purge refusal or load error."
@@ -65,10 +69,15 @@ defmodule Grappa.HotReload do
         }
 
   @typedoc """
-  Refusal to hot-deploy: the named migration files are pending and at
-  least one of their ops is contract (or unprovable). Nothing ran.
+  Refusal to migrate. Either the named migration files are pending and at
+  least one of their ops is contract (or unprovable), or a version is
+  claimed by two files (#1348). Nothing ran, in both cases — and the two
+  need OPPOSITE operator moves: the first is what a cold deploy is for,
+  the second is a repo defect a cold deploy walks straight back into.
   """
-  @type refusal :: {:contract_migrations, [Path.t()]}
+  @type refusal ::
+          {:contract_migrations, [Path.t()]}
+          | {:duplicate_migration_versions, [MigrationAudit.duplicate()]}
 
   @doc """
   Apply pending migrations on the live pool, THEN reload modules (#41).
@@ -132,6 +141,18 @@ defmodule Grappa.HotReload do
   @spec migrate_and_reload(module(), (-> result())) ::
           {:ok, migrate_result()} | {:error, refusal()}
   def migrate_and_reload(repo, reload_fn) when is_atom(repo) and is_function(reload_fn, 0) do
+    # The audit runs FIRST, and not only because a duplicate is the worse
+    # defect: `pending_migration_files/1` below matches `[path] =
+    # Path.wildcard(…)` per pending version, so a duplicate that is still
+    # PENDING would blow up there as a MatchError. Auditing first turns
+    # that crash into a refusal that names the two files.
+    case MigrationAudit.check(repo) do
+      :ok -> migrate_expand_only(repo, reload_fn)
+      {:error, duplicates} -> {:error, {:duplicate_migration_versions, duplicates}}
+    end
+  end
+
+  defp migrate_expand_only(repo, reload_fn) do
     case contract_migrations(repo) do
       [] ->
         migrated = Ecto.Migrator.run(repo, :up, all: true)

--- a/lib/grappa/release.ex
+++ b/lib/grappa/release.ex
@@ -42,9 +42,17 @@ defmodule Grappa.Release do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Grappa.Repo, Grappa.Themes, Grappa.Vault],
+    deps: [
+      Grappa.Accounts,
+      Grappa.Deploy.MigrationAudit,
+      Grappa.Networks,
+      Grappa.Repo,
+      Grappa.Themes,
+      Grappa.Vault
+    ],
     exports: [CLI]
 
+  alias Grappa.Deploy.MigrationAudit
   alias Grappa.Release.CLI
   alias Grappa.Themes
 
@@ -63,7 +71,16 @@ defmodule Grappa.Release do
     start_vault!()
 
     for repo <- repos() do
-      case Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true)) do
+      # The audit is INSIDE the callback because that is the only place the
+      # pool is up — `with_repo/2` starts the repo around the fun and stops
+      # it after. It raises rather than returns: the deploy scripts read the
+      # exit code, and `_deploy_cold` aborts before the seed and the restart.
+      migrate = fn repo ->
+        MigrationAudit.check!(repo)
+        Ecto.Migrator.run(repo, :up, all: true)
+      end
+
+      case Ecto.Migrator.with_repo(repo, migrate) do
         {:ok, _, _} -> :ok
         {:error, reason} -> raise "migration failed: #{inspect(reason)}"
       end

--- a/lib/grappa_web/controllers/admin_controller.ex
+++ b/lib/grappa_web/controllers/admin_controller.ex
@@ -7,7 +7,7 @@ defmodule GrappaWeb.AdminController do
   Delegates to `Grappa.HotReload.migrate_and_reload/0`, which applies
   pending migrations on the already-open `Grappa.Repo` pool and only
   THEN reloads modules (GH #41 — see that function for why the order is
-  load-bearing and why it refuses a pending contract migration). Two
+  load-bearing and why it refuses a pending contract migration). Three
   outcomes join the pre-#41 one:
 
     * `409` `%{"error" => "contract_migrations_pending", "migrations" =>
@@ -17,6 +17,11 @@ defmodule GrappaWeb.AdminController do
       suppresses this body, so the deploy script can only report that
       the POST failed, not why — `infra/lib/deploy_common.sh` names both
       possibilities rather than guessing one.
+    * `409` `%{"error" => "duplicate_migration_versions", "duplicates" =>
+      [%{"version" => v, "files" => [...], "applied" => bool}, ...]}` —
+      two files claim one version (#1348); nothing ran. Same status, but
+      the OPPOSITE next move: a cold deploy migrates through the same
+      defect, so the repo has to be fixed first.
     * a raising migration is NOT rescued: it 5xxes, the transaction
       rolls back, and no module is reloaded.
 
@@ -140,6 +145,15 @@ defmodule GrappaWeb.AdminController do
         conn
         |> put_status(:conflict)
         |> json(%{error: "contract_migrations_pending", migrations: files})
+
+      {:error, {:duplicate_migration_versions, duplicates}} ->
+        # Also 409, and also nothing ran — but the operator's next move
+        # is the OPPOSITE one (#1348). A cold deploy walks straight back
+        # into a version claimed by two files, so the body names them
+        # and the deploy script's printed hint says so out loud.
+        conn
+        |> put_status(:conflict)
+        |> json(%{error: "duplicate_migration_versions", duplicates: duplicates})
     end
   end
 

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -138,6 +138,10 @@ defmodule GrappaWeb.ErrorTokens do
           # pending migration is contract, so the hot deploy is refused
           # and nothing ran — see Grappa.HotReload.migrate_and_reload/0.
           | :contract_migrations_pending
+          # Operator-facing, same endpoint, same "nothing ran" — but the
+          # OPPOSITE next move (#1348): two files claim one migration
+          # version, and a cold deploy migrates through the same defect.
+          | :duplicate_migration_versions
           | :invalid_message
           | :anon_collision
           | :nick_in_use

--- a/lib/mix/tasks/grappa.migrate.ex
+++ b/lib/mix/tasks/grappa.migrate.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Grappa.Migrate do
+  @shortdoc "Run pending Ecto migrations, refusing a duplicated version first"
+
+  @moduledoc """
+  The cold-deploy migrate door for the substrates that keep Mix around —
+  Docker (`scripts/deploy.sh`), native Linux (`infra/linux/deploy.sh` and
+  its first install) — replacing a bare `mix ecto.migrate` (#1348).
+
+  ## Why a task instead of `ecto.migrate`
+
+  `ecto.migrate` cannot carry the duplicate-version audit, and the audit is
+  not optional: a version claimed by two files that is already applied
+  leaves the pending set EMPTY, so the migrator reports success having run
+  neither file, forever. See `Grappa.Deploy.MigrationAudit`.
+
+  ## Why it starts nothing
+
+  Deliberately NOT `Mix.Tasks.Grappa.Boot.start_app_silent/0`, which the
+  other `grappa.*` tasks use. That helper exists to keep a task that needs
+  the APP from opening upstream IRC connections or binding port 4000
+  against a live host; a migrate needs neither the app nor those
+  suppressions, and `mix ecto.migrate` has run bare against a live host on
+  these substrates since they existed. Starting nothing satisfies that
+  rule's reason more strictly than starting everything with two children
+  suppressed — and it keeps an app boot off the cold path of the substrate
+  whose documented pathology is a boot that kills the BEAM
+  (`docs/OPERATIONS.md` § "Migrations run a mix task, never the release's
+  `eval`").
+
+  `mix app.config` is still needed, and for the reason
+  `Mix.Tasks.Grappa.Boot` records: a bare `Ecto.Migrator` call does not
+  evaluate `config/runtime.exs` on its own, and under `MIX_ENV=prod` the
+  database path exists only there.
+
+  Both the audit and the migrator run through `Grappa.Release.migrate/0`,
+  so this substrate and the jail share one implementation rather than two
+  that can drift — the same posture `Grappa.Release.seed_themes/0` takes
+  with `mix grappa.seed_themes`.
+
+  ## Usage
+
+      scripts/mix.sh grappa.migrate
+  """
+
+  use Boundary, top_level?: true, deps: [Grappa.Release]
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_) do
+    Mix.Task.run("app.config")
+    Grappa.Release.migrate()
+  end
+end

--- a/priv/repo/duplicate_version_smoke/README.md
+++ b/priv/repo/duplicate_version_smoke/README.md
@@ -1,0 +1,32 @@
+# `duplicate_version_smoke` — two files claiming ONE version, on purpose
+
+`migrations/` here is the `priv` of `Grappa.DuplicateVersionSmokeRepo`,
+the scratch repo `test/grappa/migrations/duplicate_version_gate_test.exs`
+starts against a temp sqlite file. Both files claim version
+`20200101000001`, which is the #1044 / #1038 collision reproduced: two
+branches naming one version under different basenames, which git fuses
+without a conflict marker.
+
+The duplication is the fixture. Do not "fix" it — the gate under test
+(`Grappa.Deploy.MigrationAudit`, #1348) exists to refuse exactly this,
+and it has to be refused at every door that migrates: the hot handler,
+`Grappa.Release.migrate/0`, and `mix grappa.migrate`.
+
+Neither file is ever compiled or applied. `Ecto.Migrator.migrations/1`
+parses the BASENAME and nothing else (`extract_migration_info/1`), so
+the bodies exist only so the directory is not lying about what it holds.
+
+## Why under `priv/repo/`, and why the project's own gates ignore it
+
+The same two constraints that put `hot_migrate_smoke` here — see
+`../hot_migrate_smoke/README.md` for the measurement:
+`Ecto.Migrator.migrations_path/1` resolves under `priv/`, and
+`scripts/_lib.sh` bind-mounts `priv/repo` alone, so a sibling
+`priv/duplicate_version_smoke/` would silently resolve to main's tree
+from every worktree.
+
+Nothing else sees these files. `test/infra/migration_version_test.bats`
+(the #1343 filename gate) globs `priv/repo/migrations` only, so this
+deliberate duplicate does not trip it. `Grappa.Deploy.Preflight`
+classifies `priv/repo/migrations/` only, so touching a file here does
+not force a COLD deploy either.

--- a/priv/repo/duplicate_version_smoke/migrations/20200101000001_first_claim_on_the_version.exs
+++ b/priv/repo/duplicate_version_smoke/migrations/20200101000001_first_claim_on_the_version.exs
@@ -1,0 +1,17 @@
+defmodule Grappa.DuplicateVersionSmoke.Migrations.FirstClaimOnTheVersion do
+  @moduledoc """
+  Fixture 1 of 2 for `test/grappa/migrations/duplicate_version_gate_test.exs`.
+  Never compiled, never applied — see `../README.md`.
+
+  Half of a deliberate version collision. The sibling
+  `20200101000001_second_claim_on_the_version.exs` claims the same
+  number, which is what #1044 and #1038 did to `20260810120000`.
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:first_claim_rows) do
+      add :label, :string
+    end
+  end
+end

--- a/priv/repo/duplicate_version_smoke/migrations/20200101000001_second_claim_on_the_version.exs
+++ b/priv/repo/duplicate_version_smoke/migrations/20200101000001_second_claim_on_the_version.exs
@@ -1,0 +1,17 @@
+defmodule Grappa.DuplicateVersionSmoke.Migrations.SecondClaimOnTheVersion do
+  @moduledoc """
+  Fixture 2 of 2 for `test/grappa/migrations/duplicate_version_gate_test.exs`.
+  Never compiled, never applied — see `../README.md`.
+
+  The other half of the collision. On a database that has already
+  applied `20200101000001`, BOTH files leave the pending set and neither
+  ever runs — the silent regime #1348 closes.
+  """
+  use Ecto.Migration
+
+  def change do
+    create table(:second_claim_rows) do
+      add :label, :string
+    end
+  end
+end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -148,8 +148,14 @@ substrate_migrate() {
 	# a one-shot `run` exits before Bootstrap's first DB hit can race an
 	# unapplied migration.
 	# Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
+	# `grappa.migrate`, not `ecto.migrate`: same migrator, same footprint
+	# (the task starts the Repo and nothing else), preceded by the #1348
+	# duplicate-version audit. `ecto.migrate` cannot carry that audit —
+	# a version claimed by two files and already applied leaves the
+	# pending set empty, so the migrator reports success having run
+	# neither file, forever.
 	echo "Running migrations..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm --no-deps grappa mix ecto.migrate
+	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm --no-deps grappa mix grappa.migrate
 }
 
 substrate_seed() {

--- a/test/grappa/deploy/migration_audit_test.exs
+++ b/test/grappa/deploy/migration_audit_test.exs
@@ -50,12 +50,23 @@ defmodule Grappa.Deploy.MigrationAuditTest do
     end
 
     test "reports EVERY duplicated version, not just the first, oldest first" do
-      statuses = [
-        {:down, 20_260_811_130_000, "add_notes"},
-        {:down, 20_260_811_130_000, "add_labels"},
-        {:up, @collided, "add_mute"},
-        {:up, @collided, "add_peer"}
-      ]
+      # The filler is not padding. `duplicates/1` groups by version, and an
+      # Erlang map holds ≤32 keys as a flatmap, which enumerates in TERM
+      # order — so a two-version input comes out ascending whether or not
+      # anything sorted it, and the ordering claim would be bought by the
+      # runtime rather than by the code. Past 32 keys the map is a hashmap
+      # and enumeration order is unspecified. Production is ~86 migrations,
+      # so this is also the realistic size.
+      filler = for v <- 1..40, do: {:up, 20_250_000_000_000 + v, "filler_#{v}"}
+
+      statuses =
+        filler ++
+          [
+            {:down, 20_260_811_130_000, "add_notes"},
+            {:down, 20_260_811_130_000, "add_labels"},
+            {:up, @collided, "add_mute"},
+            {:up, @collided, "add_peer"}
+          ]
 
       assert {:error, duplicates} = MigrationAudit.audit(statuses)
       assert Enum.map(duplicates, & &1.version) == [@collided, 20_260_811_130_000]

--- a/test/grappa/deploy/migration_audit_test.exs
+++ b/test/grappa/deploy/migration_audit_test.exs
@@ -1,0 +1,104 @@
+defmodule Grappa.Deploy.MigrationAuditTest do
+  @moduledoc """
+  The pure half of #1348: the rule that reads a merged
+  `Ecto.Migrator.migrations/1` table and refuses a duplicated version.
+
+  The regime under test is the one CLAUDE.md marks dangerous, and it is
+  invisible to every count: when the duplicated version is ALREADY
+  applied, both files leave the pending set, `ensure_no_duplication!([])`
+  answers `:ok`, the migrate reports success, and neither file ever runs
+  again. A gate that counts pending files sees zero — which is exactly
+  what a healthy deploy also sees. So the input here is deliberately a
+  set with NOTHING pending.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Deploy.MigrationAudit
+
+  # The real collision that filed #1044 / #1038: two branches claiming
+  # one version under different basenames, which git fuses silently.
+  @collided 20_260_810_120_000
+
+  describe "audit/1" do
+    test "refuses an already-applied duplicate, with nothing pending" do
+      # The two colliding rows arrive in DESCENDING name order, which is
+      # what `Ecto.Migrator.migrations/1` actually hands over for an
+      # applied pair (`pending_in_direction(_, _, :down)` reverses). The
+      # refusal has to read the same either way, so the files come back
+      # sorted rather than in arrival order.
+      statuses = [
+        {:up, 20_260_425_000_000, "init"},
+        {:up, @collided, "add_peer_to_mutes"},
+        {:up, @collided, "add_mute_to_user_settings"}
+      ]
+
+      assert {:error, [duplicate]} = MigrationAudit.audit(statuses)
+      assert duplicate.version == @collided
+      assert duplicate.applied
+
+      assert duplicate.files == [
+               "20260810120000_add_mute_to_user_settings.exs",
+               "20260810120000_add_peer_to_mutes.exs"
+             ]
+    end
+
+    test "refuses a duplicate that is still pending, and says it is pending" do
+      statuses = [{:down, @collided, "add_mute"}, {:down, @collided, "add_peer"}]
+
+      assert {:error, [duplicate]} = MigrationAudit.audit(statuses)
+      refute duplicate.applied
+    end
+
+    test "reports EVERY duplicated version, not just the first, oldest first" do
+      statuses = [
+        {:down, 20_260_811_130_000, "add_notes"},
+        {:down, 20_260_811_130_000, "add_labels"},
+        {:up, @collided, "add_mute"},
+        {:up, @collided, "add_peer"}
+      ]
+
+      assert {:error, duplicates} = MigrationAudit.audit(statuses)
+      assert Enum.map(duplicates, & &1.version) == [@collided, 20_260_811_130_000]
+    end
+
+    test "passes a clean set, reporting the applied and pending counts it observed" do
+      statuses = [
+        {:up, 20_260_425_000_000, "init"},
+        {:up, 20_260_504_013_318, "tighten_session_client_id_format"},
+        {:down, 20_260_811_130_000, "add_notes"}
+      ]
+
+      assert {:ok, %{applied: 2, pending: 1}} = MigrationAudit.audit(statuses)
+    end
+
+    test "passes an empty set — a fresh database is not a fault" do
+      assert {:ok, %{applied: 0, pending: 0}} = MigrationAudit.audit([])
+    end
+  end
+
+  describe "describe/1" do
+    test "names the version and BOTH files of every duplicate" do
+      duplicates = [
+        %{
+          version: @collided,
+          applied: true,
+          files: ["20260810120000_add_mute.exs", "20260810120000_add_peer.exs"]
+        }
+      ]
+
+      message = MigrationAudit.describe(duplicates)
+
+      assert message =~ "20260810120000"
+      assert message =~ "20260810120000_add_mute.exs"
+      assert message =~ "20260810120000_add_peer.exs"
+    end
+
+    test "an applied duplicate says neither file will ever run" do
+      applied = MigrationAudit.describe([%{version: @collided, applied: true, files: ["a", "b"]}])
+      pending = MigrationAudit.describe([%{version: @collided, applied: false, files: ["a", "b"]}])
+
+      assert applied =~ "already applied"
+      refute pending =~ "already applied"
+    end
+  end
+end

--- a/test/grappa/deploy/migration_audit_test.exs
+++ b/test/grappa/deploy/migration_audit_test.exs
@@ -32,7 +32,9 @@ defmodule Grappa.Deploy.MigrationAuditTest do
         {:up, @collided, "add_mute_to_user_settings"}
       ]
 
-      assert {:error, [duplicate]} = MigrationAudit.audit(statuses)
+      disk = [20_260_425_000_000, @collided, @collided]
+
+      assert {:error, [duplicate]} = MigrationAudit.audit(statuses, disk)
       assert duplicate.version == @collided
       assert duplicate.applied
 
@@ -45,7 +47,7 @@ defmodule Grappa.Deploy.MigrationAuditTest do
     test "refuses a duplicate that is still pending, and says it is pending" do
       statuses = [{:down, @collided, "add_mute"}, {:down, @collided, "add_peer"}]
 
-      assert {:error, [duplicate]} = MigrationAudit.audit(statuses)
+      assert {:error, [duplicate]} = MigrationAudit.audit(statuses, [@collided, @collided])
       refute duplicate.applied
     end
 
@@ -68,7 +70,9 @@ defmodule Grappa.Deploy.MigrationAuditTest do
             {:up, @collided, "add_peer"}
           ]
 
-      assert {:error, duplicates} = MigrationAudit.audit(statuses)
+      disk = Enum.map(statuses, fn {_, version, _} -> version end)
+
+      assert {:error, duplicates} = MigrationAudit.audit(statuses, disk)
       assert Enum.map(duplicates, & &1.version) == [@collided, 20_260_811_130_000]
     end
 
@@ -79,11 +83,43 @@ defmodule Grappa.Deploy.MigrationAuditTest do
         {:down, 20_260_811_130_000, "add_notes"}
       ]
 
-      assert {:ok, %{applied: 2, pending: 1}} = MigrationAudit.audit(statuses)
+      disk = [20_260_425_000_000, 20_260_504_013_318, 20_260_811_130_000]
+
+      assert {:ok, %{applied: 2, pending: 1, applied_without_file: []}} =
+               MigrationAudit.audit(statuses, disk)
     end
 
     test "passes an empty set — a fresh database is not a fault" do
-      assert {:ok, %{applied: 0, pending: 0}} = MigrationAudit.audit([])
+      assert {:ok, %{applied: 0, pending: 0, applied_without_file: []}} =
+               MigrationAudit.audit([], [])
+    end
+
+    test "REPORTS a version applied with no file on disk, and does not refuse it" do
+      # The case that cost two people an hour on 2026-08-15: a shared test
+      # database carrying another branch's migration. `20260815210238` was
+      # in `schema_migrations` with no file in this checkout, and nothing
+      # said so — the symptom was three unrelated tests raising
+      # Ecto.ConstraintError on an index no one here declared.
+      #
+      # It REPORTS rather than refuses because a database ahead of the code
+      # is also a legitimate rollback, and a deploy from an older checkout.
+      # Refusing there would block a valid operation at three doors.
+      #
+      # The name is deliberately Ecto's own placeholder, to show it is not
+      # read: this is a set difference over versions, applied MINUS
+      # on-disk, so nothing here depends on that literal.
+      statuses = [
+        {:up, 20_260_425_000_000, "init"},
+        {:up, 20_260_815_210_238, "** FILE NOT FOUND **"},
+        {:down, 20_260_811_130_000, "add_notes"}
+      ]
+
+      # `add_notes` is on disk and NOT applied — the opposite direction.
+      # Subtracting the wrong way round would report it instead.
+      disk = [20_260_425_000_000, 20_260_811_130_000]
+
+      assert {:ok, summary} = MigrationAudit.audit(statuses, disk)
+      assert summary.applied_without_file == [20_260_815_210_238]
     end
   end
 

--- a/test/grappa/migrations/duplicate_version_gate_test.exs
+++ b/test/grappa/migrations/duplicate_version_gate_test.exs
@@ -1,0 +1,203 @@
+defmodule Grappa.DuplicateVersionSmokeRepo do
+  use Ecto.Repo,
+    otp_app: :grappa,
+    adapter: Ecto.Adapters.SQLite3
+end
+
+defmodule Grappa.FreshInstallSmokeRepo do
+  @moduledoc """
+  A second scratch repo, never supervised: `Ecto.Migrator.with_repo/2`
+  starts it, which is the shape `infra/linux/install.sh`'s first migration
+  runs in — no app, no pool, no database file yet.
+  """
+  use Ecto.Repo,
+    otp_app: :grappa,
+    adapter: Ecto.Adapters.SQLite3
+end
+
+defmodule Grappa.Migrations.DuplicateVersionGateTest do
+  @moduledoc """
+  #1348 at the three doors that migrate, driven against a **live
+  supervised pool on a real sqlite file** whose `schema_migrations`
+  already holds the duplicated version.
+
+  That "already holds" is the whole scenario, not set dressing. It is
+  the regime CLAUDE.md marks dangerous and the one no count can see:
+  both files leave the pending set, `ensure_no_duplication!([])` answers
+  `:ok`, the migrate reports success, and neither file ever runs again.
+  The first test here measures that emptiness directly, so the rest are
+  not asserting against a scenario that quietly stopped reproducing.
+
+  The fixture set is `priv/repo/duplicate_version_smoke/migrations` —
+  two files claiming `20200101000001`, owned by this test and never
+  applied to `Grappa.Repo`. See that directory's README.
+
+  Doors, in the order a deploy meets them:
+
+    * HOT, every substrate — `Grappa.HotReload.migrate_and_reload/2`,
+      reached by `POST /admin/reload`.
+    * COLD, jail — `Grappa.Release.migrate/0`.
+    * COLD, docker + linux — `mix grappa.migrate`, which drives the very
+      same `Grappa.Release.migrate/0`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Grappa.DuplicateVersionSmokeRepo, as: SmokeRepo
+  alias Grappa.FreshInstallSmokeRepo, as: FreshRepo
+  alias Grappa.HotReload
+
+  @fixture_priv "priv/repo/duplicate_version_smoke"
+
+  @collided 20_200_101_000_001
+  @first_file "20200101000001_first_claim_on_the_version.exs"
+  @second_file "20200101000001_second_claim_on_the_version.exs"
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa-duplicate-version-#{System.unique_integer([:positive])}.db"
+      )
+
+    # An explicit `priv` is what makes `Ecto.Migrator.migrations_path/1`
+    # — the function the production code under test calls — resolve to
+    # the fixture set instead of the project's own. Same reasoning as
+    # `hot_deploy_migrate_test.exs`; that file's setup comment carries
+    # the measurement.
+    Application.put_env(:grappa, SmokeRepo,
+      database: path,
+      priv: @fixture_priv,
+      pool_size: 2,
+      busy_timeout: 30_000,
+      foreign_keys: :on
+    )
+
+    start_supervised!(SmokeRepo)
+
+    # Creates `schema_migrations`, then records the collided version as
+    # applied WITHOUT running either file — which is precisely what a
+    # host looks like after one of the two landed and the other arrived
+    # in a later merge.
+    _ = Ecto.Migrator.migrated_versions(SmokeRepo)
+
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO schema_migrations (version, inserted_at) VALUES (?, datetime('now'))",
+      [@collided]
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:grappa, SmokeRepo)
+      File.rm(path)
+      File.rm(path <> "-shm")
+      File.rm(path <> "-wal")
+    end)
+
+    %{path: path}
+  end
+
+  defp with_ecto_repos(repos, fun) do
+    previous = Application.fetch_env!(:grappa, :ecto_repos)
+    Application.put_env(:grappa, :ecto_repos, repos)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:grappa, :ecto_repos, previous)
+    end
+  end
+
+  test "the scenario reproduces: the duplicate is applied and NOTHING is pending" do
+    statuses = Ecto.Migrator.migrations(SmokeRepo)
+
+    assert Enum.filter(statuses, &match?({:down, _, _}, &1)) == []
+    assert length(Enum.filter(statuses, &match?({:up, @collided, _}, &1))) == 2
+  end
+
+  test "the HOT door refuses, naming the version and both files" do
+    test_pid = self()
+
+    reload_probe = fn ->
+      send(test_pid, :reloaded)
+      %{reloaded: [], failed: []}
+    end
+
+    assert {:error, {:duplicate_migration_versions, [duplicate]}} =
+             HotReload.migrate_and_reload(SmokeRepo, reload_probe)
+
+    assert duplicate.version == @collided
+    assert duplicate.files == [@first_file, @second_file]
+  end
+
+  test "the HOT door refuses having done NOTHING — the reload never runs" do
+    test_pid = self()
+
+    reload_probe = fn ->
+      send(test_pid, :reloaded)
+      %{reloaded: [], failed: []}
+    end
+
+    assert {:error, _} = HotReload.migrate_and_reload(SmokeRepo, reload_probe)
+    refute_received :reloaded
+  end
+
+  test "the jail COLD door raises out of Grappa.Release.migrate/0" do
+    with_ecto_repos([SmokeRepo], fn ->
+      error = assert_raise RuntimeError, fn -> Grappa.Release.migrate() end
+
+      assert error.message =~ "20200101000001"
+      assert error.message =~ @first_file
+      assert error.message =~ @second_file
+    end)
+  end
+
+  test "the docker/linux COLD door raises out of mix grappa.migrate" do
+    with_ecto_repos([SmokeRepo], fn ->
+      error = assert_raise RuntimeError, fn -> Mix.Tasks.Grappa.Migrate.run([]) end
+
+      assert error.message =~ "20200101000001"
+    end)
+  end
+
+  test "the first-install door: the audit runs against a database file that does not exist yet" do
+    # `infra/linux/install.sh`'s `6/11 first migration` runs before any
+    # database file exists — DATABASE_PATH was written into the env a few
+    # lines earlier. This measures that precondition instead of reasoning
+    # about it: the audit's one DB touch creates `schema_migrations`
+    # through the same door the migrator opens a moment later, on a file
+    # sqlite creates on open.
+    path =
+      Path.join(System.tmp_dir!(), "grappa-fresh-install-#{System.unique_integer([:positive])}.db")
+
+    Application.put_env(:grappa, FreshRepo,
+      database: path,
+      priv: @fixture_priv,
+      pool_size: 2,
+      busy_timeout: 30_000,
+      foreign_keys: :on
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:grappa, FreshRepo)
+      File.rm(path)
+      File.rm(path <> "-shm")
+      File.rm(path <> "-wal")
+    end)
+
+    # The pre-state, asserted before the gesture: without this the test
+    # could be measuring a database some earlier case left behind.
+    refute File.exists?(path)
+
+    with_ecto_repos([FreshRepo], fn ->
+      # It reaches the duplicate — which is the fixture's whole content —
+      # rather than failing to open, and it says the version is NOT yet
+      # applied, because on a fresh file nothing is.
+      error = assert_raise RuntimeError, fn -> Grappa.Release.migrate() end
+
+      assert error.message =~ "not yet applied"
+    end)
+
+    assert File.exists?(path)
+  end
+end

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -91,7 +91,7 @@ EOF
     #   compose run … mix run --no-start → preflight oneshot, honors PREFLIGHT_RC
     #   compose exec … curl … reload     → reload JSON (clean, or failing when
     #                                      $RELOAD_FAILS=1)
-    #   everything else (build, run cicchetto-build, deps.get, ecto.migrate,
+    #   everything else (build, run cicchetto-build, deps.get, grappa.migrate,
     #   up -d, exec … curl … healthz)    → succeed silently
     cat > "$FAKE_DIR/docker" <<'EOF'
 #!/bin/sh
@@ -242,13 +242,13 @@ run_deploy() {
     grep -q "build grappa" "$ARGV_LOG"
     grep -q "cicchetto-build" "$ARGV_LOG"
     grep -q "deps.get" "$ARGV_LOG"
-    grep -q "ecto.migrate" "$ARGV_LOG"
+    grep -q "grappa.migrate" "$ARGV_LOG"
     grep -q "up -d --force-recreate" "$ARGV_LOG"
 
     build_line=$(grep -n "build grappa" "$ARGV_LOG" | head -1 | cut -d: -f1)
     cic_line=$(grep -n "cicchetto-build" "$ARGV_LOG" | head -1 | cut -d: -f1)
     deps_line=$(grep -n "deps.get" "$ARGV_LOG" | head -1 | cut -d: -f1)
-    mig_line=$(grep -n "ecto.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
+    mig_line=$(grep -n "grappa.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
     up_line=$(grep -n "up -d --force-recreate" "$ARGV_LOG" | head -1 | cut -d: -f1)
     [ "$build_line" -lt "$cic_line" ]
     [ "$cic_line" -lt "$deps_line" ]

--- a/test/infra/deploy_linux_test.bats
+++ b/test/infra/deploy_linux_test.bats
@@ -76,6 +76,7 @@ EOF
     export HEALTHCHECK_RETRIES=2 HEALTHCHECK_SLEEP=0
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
+    export RELOAD_HTTP_FAILS=0
     # #440: SEED_RC injects a failing seed task (a busy DB, a bad payload —
     # all the same shape from out here). Default 0 so every other test's
     # seed succeeds and the warn-path assertions below are the only ones
@@ -130,12 +131,22 @@ EOF
 
     # curl: reload POST answers clean (or failing, gated by $RELOAD_FAILS);
     # healthcheck answers 200 (curl -f success).
+    #
+    # $RELOAD_HTTP_FAILS is a DIFFERENT failure from $RELOAD_FAILS and the
+    # distinction is the point: RELOAD_FAILS is a 200 reporting per-module
+    # failures IN-BAND, while RELOAD_HTTP_FAILS is a non-2xx, on which
+    # `curl -f` exits non-zero and discards the body — the branch where the
+    # deploy knows the POST failed and nothing about why, so its printed
+    # guess is all the operator gets. Nothing exercised that branch before
+    # #1348.
     cat > "$FAKE_DIR/curl" <<'EOF'
 #!/bin/sh
 printf 'curl %s\n' "$*" >> "$ARGV_LOG"
 case "$*" in
     *"-X POST"*reload*)
-        if [ "$RELOAD_FAILS" = "1" ]; then
+        if [ "$RELOAD_HTTP_FAILS" = "1" ]; then
+            exit 22
+        elif [ "$RELOAD_FAILS" = "1" ]; then
             printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'
         else
             printf '{"loaded":[],"failed":[]}'
@@ -224,6 +235,24 @@ run_deploy() {
     refute grep -q "systemctl" "$ARGV_LOG"   # hot path never restarts
 }
 
+@test "a non-2xx reload names BOTH 409 causes, and says which one a cold deploy fixes (#1348)" {
+    # `curl -f` threw the body away, so these printed lines are the whole
+    # of what the operator learns. Since #1348 a 409 has two causes and
+    # they need OPPOSITE moves: a pending CONTRACT migration is what a
+    # cold deploy is for, while a duplicated version is a repo defect a
+    # cold deploy walks straight back into. Naming only the first sends
+    # the operator to restart production for nothing.
+    export RELOAD_HTTP_FAILS=1
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"CONTRACT"* ]]
+    [[ "$output" == *"duplicate"* ]]
+    [[ "$output" == *"cold deploy will not"* ]]
+    [ ! -f "$REPO_ROOT/runtime/last-deployed-sha" ]
+}
+
 @test "hot reload reporting per-module failures aborts non-zero, no marker" {
     export RELOAD_FAILS=1
     commit_upstream lib/base.txt > /dev/null
@@ -254,13 +283,13 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     grep -q "cic_build.sh" "$ARGV_LOG"
-    grep -q "mix ecto.migrate" "$ARGV_LOG"
+    grep -q "mix grappa.migrate" "$ARGV_LOG"
     grep -q "install_systemd.sh" "$ARGV_LOG"
     grep -q "systemctl stop grappa" "$ARGV_LOG"
     grep -q "systemctl start grappa" "$ARGV_LOG"
 
     cic_line=$(grep -n "cic_build.sh" "$ARGV_LOG" | head -1 | cut -d: -f1)
-    mig_line=$(grep -n "mix ecto.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
+    mig_line=$(grep -n "mix grappa.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
     unit_line=$(grep -n "install_systemd.sh" "$ARGV_LOG" | head -1 | cut -d: -f1)
     stop_line=$(grep -n "systemctl stop grappa" "$ARGV_LOG" | head -1 | cut -d: -f1)
     start_line=$(grep -n "systemctl start grappa" "$ARGV_LOG" | head -1 | cut -d: -f1)
@@ -415,7 +444,7 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
 
-    mig_line=$(grep -n "mix ecto.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
+    mig_line=$(grep -n "mix grappa.migrate" "$ARGV_LOG" | head -1 | cut -d: -f1)
     seed_line=$(grep -n "mix grappa.seed_themes" "$ARGV_LOG" | head -1 | cut -d: -f1)
     stop_line=$(grep -n "systemctl stop grappa" "$ARGV_LOG" | head -1 | cut -d: -f1)
     [ -n "$mig_line" ]


### PR DESCRIPTION
Closes the first item of #1348. **The other two were already fixed on `main`** and are not reimplemented here — measured, and commented on the issue:

* `Preflight.module_to_path/1` hardcoding `lib/grappa/` was fixed by e5ca387e, which also added `LongLivedModulesMembershipTest` to hold every candidate module to the mapping.
* `Grappa.Net.SourceAliasManager` was added to the CLAUDE.md tree by bc7b755b.

## The defect

#1343 gated migration FILENAMES, which catches a duplicate before it is applied. It cannot catch the regime CLAUDE.md marks as the dangerous one: once the duplicated version is in `schema_migrations`, both files leave the pending set, `ensure_no_duplication!([])` answers `:ok`, the run reports SUCCESS, and neither migration ever runs again. A gate that counts pending files sees zero — which is exactly what a healthy deploy sees.

## Why this is not in the deploy preflight

The issue asked for "a preflight that compares version sets". It cannot live there: all three substrates invoke the classifier with `mix run --no-start` (`scripts/deploy.sh:90`, `infra/freebsd/deploy.sh:111`, `infra/linux/deploy.sh:101`), so `Preflight.cli/1` has no application started and no Repo, and cannot read `schema_migrations` at all. `Preflight` stays pure and git-only; the comparison hangs off the doors that migrate, where a pool is live by construction.

## Six doors, three call sites

| door | call | refusal |
|---|---|---|
| hot reload, every substrate | `HotReload.migrate_and_reload/2` | `{:error, refusal}` → 409, nothing ran |
| jail cold deploy, published-image boot migrate (#867), `grappa migrate` operator verb | `Grappa.Release.migrate/0` | raises → non-zero exit → `_deploy_cold` aborts before seed and restart |
| Docker cold, Linux cold, Linux first install | `mix grappa.migrate` → the same `Release.migrate/0` | as above |

The audit runs BEFORE the contract check in the hot handler, and not only because a duplicate is worse: `pending_migration_files/1` matches `[path] = Path.wildcard(…)` per pending version, so a still-pending duplicate would blow up there as a MatchError instead of a refusal.

## The third column

A version applied with no file on disk is **reported, never refused** — a database ahead of the code is also a legitimate rollback or a deploy from an older checkout. It is a set difference (applied minus on-disk), so nothing reads Ecto's `"** FILE NOT FOUND **"` placeholder. This was added after the branch hit the case for real: a foreign migration in the shared test database surfaced as three unrelated tests raising on an index nobody here declared.

## `mix grappa.migrate` starts nothing

`docs/OPERATIONS.md` required any mix task on a live host to go through `Mix.Tasks.Grappa.Boot`. That rule is about the APP START (no IRC, no port 4000), and the migrate door has always sat outside it — `substrate_migrate` has run `ecto.migrate` bare against a live host since the substrate existed. The task keeps that regime: `app.config`, then audit and migrator inside `with_repo/2`, no `ensure_all_started`. The doc is precised at the source rather than caveat-walled. Routing it through `Boot` would add an app boot to the cold path of the substrate whose documented pathology is a boot that kills the BEAM.

## The 409 hint would have lied twice

`curl -f` discards the response body, so `deploy_common.sh`'s printed line is all the operator gets, and it named only the contract cause with "run a cold deploy" — the wrong move for a duplicate, which a cold deploy walks straight back into. Both causes are named now. That branch had **no bats coverage at all** (the stub `curl` always exited 0, so `RELOAD_FAILS` only ever exercised the in-band 200) and now has a knob of its own.

## Evidence

* `scripts/check.sh`: **RC=0** — credo clean, doctor passed, 8 doctests / 60 properties / **6313 tests, 0 failures**, both generated wire twins in sync.
* Full `scripts/bats.sh` set: green.
* `scripts/bun.sh run check` rc 0; `run test` 5484 passed.
* Every assertion bought by mutation, 1:1. Two findings worth naming:
  * the "oldest first" assertion was initially bought by the RUNTIME, not the code — an Erlang map under 32 keys is a flatmap and enumerates in term order, so the sort was a no-op at fixture size. Refixtured to 40 versions (production is ~86), where deleting the sort now kills that assertion and only it.
  * an earlier mutation round on the third column was **void** and was redone: the harness restores with `git checkout --`, and the file was not yet committed. The harness now verifies the mutant was actually applied before trusting a red.
* Three tests failing on the shared test database were traced to a foreign migration (`20260815210238`, `users_folded_name_index`) applied by another branch, proven by displacement: the same three files on the same code, isolated substrate, 76 tests 0 failures.

## Not covered

`infra/linux/install.sh`'s migrate line has **no witness**: `install_linux_test.bats` stops at the env-file stage (#441 scope) and never reaches step `6/11`, and extending that harness is its own job. A source grep is not a witness, so none was added. The residual risk of the one-word change is a typo in the task name, which fails the install loudly rather than silently. The precondition that door depends on — no database file exists yet — IS measured, by a test that asserts the path absent before the gesture.

## Two doors that came for free, named explicitly

Gating `Grappa.Release.migrate/0` turned out to cover more than the jail's cold deploy, because two other callers reach it through `eval`:

* `infra/docker/release-entrypoint.sh` — the published image's boot-time migration (#867). On a bare `docker run <image> start` there is no mix, no checkout and no deploy script inside the image, so this is the operator's only migrate door there.
* `infra/packaging/grappa-wrapper.sh:52` — the `grappa migrate` operator verb, which is sugar for `eval 'Grappa.Release.migrate()'`.

So the audit reaches **six doors through three call sites**, not four through three. Neither of those two needed a line changed.
