### PR TITLE
accounts(#1353): make the account name an identity key that folds

### DIFF
--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -83,6 +83,7 @@ defmodule Grappa.Accounts do
       Grappa.Accounts.Revocations,
       Grappa.Ecto.Like,
       Grappa.EncryptedBinary,
+      Grappa.IRC,
       Grappa.Repo,
       Grappa.Visitors.Visitor
     ],
@@ -92,9 +93,11 @@ defmodule Grappa.Accounts do
 
   alias Grappa.Accounts.{Passkey, RecoveryCodes, Revocations, Session, TOTP, TOTPRecoveryCode, User}
   alias Grappa.Ecto.Like
+  alias Grappa.IRC.Identifier
   alias Grappa.Repo
   alias Grappa.Visitors.Visitor
 
+  require Identifier
   require Logger
 
   @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
@@ -106,10 +109,11 @@ defmodule Grappa.Accounts do
   Creates a user from `name` + plaintext `password`.
 
   Validation lives in `User.changeset/2`; uniqueness on `name` is
-  enforced by both the changeset's `unique_constraint/2` and the
-  `users_name_index` DB index — concurrent inserts that race the
-  in-process check still surface `{:error, changeset}` on the second
-  insert.
+  enforced by the changeset's two `unique_constraint/2` calls and the
+  two DB indexes behind them — `users_name_index` (byte-exact) and
+  `users_folded_name_index` (ASCII fold, #1353) — so concurrent inserts
+  that race the in-process check still surface `{:error, changeset}` on
+  the second insert, whichever spelling it used.
   """
   @spec create_user(%{required(:name) => String.t(), required(:password) => String.t()}) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
@@ -131,7 +135,7 @@ defmodule Grappa.Accounts do
           {:ok, User.t()} | {:error, :invalid_credentials}
   def get_user_by_credentials(name, password)
       when is_binary(name) and is_binary(password) do
-    case Repo.get_by(User, name: name) do
+    case Repo.one(by_folded_name(name)) do
       %User{} = user ->
         with :ok <- verify_password(user, password), do: {:ok, user}
 
@@ -316,13 +320,16 @@ defmodule Grappa.Accounts do
   end
 
   @doc """
-  Fetches a user by `name`. Raises `Ecto.NoResultsError` on miss.
+  Fetches a user by `name`, case-insensitively. Raises
+  `Ecto.NoResultsError` on miss.
 
   Used by the operator-side mix tasks where a typo in `--user`
   should fail loudly with a stack trace, not silently no-op.
   """
   @spec get_user_by_name!(String.t()) :: User.t()
-  def get_user_by_name!(name) when is_binary(name), do: Repo.get_by!(User, name: name)
+  def get_user_by_name!(name) when is_binary(name) do
+    Repo.one!(by_folded_name(name))
+  end
 
   @doc """
   Typed-nil sibling of `get_user_by_name!/1` — fetches a user by `name`,
@@ -333,13 +340,32 @@ defmodule Grappa.Accounts do
   bare login identifier classifies as an IRC nick, this decides whether
   it ALSO names an existing account (→ route to the account credential,
   never a silently-provisioned guest) or not (→ visitor path). Matches
-  the case-sensitive `name`-key semantics of `get_user_by_credentials/2`
-  so the two account lookups can never disagree on what "an account
-  named X" is — account names are the account key, a distinct namespace
-  from the ASCII-folded IRC nick.
+  the `name`-key semantics of `get_user_by_credentials/2` so the two
+  account lookups can never disagree on what "an account named X" is.
+
+  #1353 — that shared semantics is now the ASCII fold. An account name
+  is an identity KEY, and this schema folds identity keys at the MATCH
+  while storing them raw for display (#121/#525), so `vjt` and `VJT`
+  name one account here exactly as they name one nick on the wire. The
+  `users_folded_name_index` is what makes that true of the table as
+  well as of this reader.
   """
   @spec get_user_by_name(String.t()) :: User.t() | nil
-  def get_user_by_name(name) when is_binary(name), do: Repo.get_by(User, name: name)
+  def get_user_by_name(name) when is_binary(name) do
+    Repo.one(by_folded_name(name))
+  end
+
+  # The single folded-name query the three account readers share. Folds
+  # the INPUT in Elixir (`canonical_target/1`) and the COLUMN in SQL
+  # (`nick_fold/1`, the byte-pinned `lower()`), which is the expression
+  # `users_folded_name_index` is built on — so this is an index lookup,
+  # not a scan.
+  @spec by_folded_name(String.t()) :: Ecto.Query.t()
+  defp by_folded_name(name) do
+    folded = Identifier.canonical_target(name)
+
+    from(u in User, where: Identifier.nick_fold(u.name) == ^folded)
+  end
 
   @doc """
   Toggle the operator-authorization `is_admin` bit on `user`. The M

--- a/lib/grappa/accounts/user.ex
+++ b/lib/grappa/accounts/user.ex
@@ -75,7 +75,22 @@ defmodule Grappa.Accounts.User do
     |> validate_length(:name, min: 1, max: 64)
     |> validate_format(:name, @name_format, message: "must start with a letter, then alphanumeric/_/-")
     |> validate_length(:password, min: 8, max: 256)
+    # Measured #1353: removing this line reddens NO test, because SQLite
+    # names the folded index first when an exact duplicate violates both.
+    # It stays anyway — which index a conflict reports is index-resolution
+    # order, not a contract, so a later migration that recreates the two
+    # in another order would put the byte-exact violation back on this
+    # line, and without it that violation escapes as a raise instead of a
+    # changeset error. One declaration per index, not one per observed
+    # message.
     |> unique_constraint(:name)
+    # #1353 — the folded index is the one that decides identity: it is
+    # what makes `vjt` and `VJT` one account rather than two. Named
+    # explicitly because ecto derives its default constraint name from
+    # the COLUMN, which reaches `users_name_index` only; without this the
+    # folded violation would surface as an `Ecto.ConstraintError` raise
+    # instead of a changeset error.
+    |> unique_constraint(:name, name: :users_folded_name_index)
     |> put_password_hash()
   end
 

--- a/lib/grappa/test_support/subject_provision.ex
+++ b/lib/grappa/test_support/subject_provision.ex
@@ -56,13 +56,12 @@ if Mix.env() in [:dev, :test] do
       deps: [
         Grappa.Accounts,
         Grappa.Networks,
-        Grappa.Repo,
         Grappa.TestSupport.SubjectSession
       ]
 
     import Grappa.TestSupport.SubjectSession, only: [measure: 1]
 
-    alias Grappa.{Accounts, Networks, Repo, TestSupport.SubjectSession}
+    alias Grappa.{Accounts, Networks, TestSupport.SubjectSession}
 
     require Logger
 
@@ -223,7 +222,7 @@ if Mix.env() in [:dev, :test] do
     """
     @spec teardown!(String.t()) :: :ok | {:error, :user_not_found | :last_admin}
     def teardown!(name) when is_binary(name) do
-      case Repo.get_by(Accounts.User, name: name) do
+      case Accounts.get_user_by_name(name) do
         nil ->
           {:error, :user_not_found}
 

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -179,7 +179,7 @@ if Mix.env() in [:dev, :test] do
     """
     @spec reset!(String.t(), reset_opts()) :: {:ok, phases()} | {:error, reset_error()}
     def reset!(user_name, opts) when is_binary(user_name) and is_map(opts) do
-      case Repo.get_by(Accounts.User, name: user_name) do
+      case Accounts.get_user_by_name(user_name) do
         nil -> {:error, :user_not_found}
         %Accounts.User{} = user -> do_reset(user, opts)
       end

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -368,12 +368,16 @@ defmodule GrappaWeb.AuthController do
   # next attempt). A name with NO matching account routes to the visitor
   # path exactly as before, so anonymous IRC still works.
   #
-  # Account names are matched the ACCOUNT way — the case-sensitive
-  # `Accounts.get_user_by_name/1`, the SAME `name` key
-  # `mode1_login/3` + `get_user_by_credentials/2` use — NOT the ASCII
-  # nick fold (#121/#525). Account name is the account key, a namespace distinct from
-  # the IRC nick; folding it here would diverge from the email branch and
-  # fork what "the account named X" means across the two login doors.
+  # Account names are matched the ACCOUNT way — `Accounts.get_user_by_name/1`,
+  # the SAME `name` key `mode1_login/3` + `get_user_by_credentials/2` use.
+  #
+  # #1353 — that key folds. An account name is an identity KEY, and this
+  # schema folds identity keys at the MATCH while keeping the stored
+  # spelling for display (#121/#525), so `vjt` and `VJT` reach one
+  # account here just as they reach one nick on the wire. The fold lives
+  # in the CONTEXT reader, not at this branch, which is what keeps the
+  # two login doors saying the same thing about "the account named X":
+  # the email branch resolves its local part through the same function.
   @spec nick_login(
           Plug.Conn.t(),
           String.t(),

--- a/priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs
+++ b/priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs
@@ -1,0 +1,96 @@
+defmodule Grappa.Repo.Migrations.AddFoldedNameIndexToUsers do
+  @moduledoc """
+  #1353 — `users.name` is an identity KEY, so it folds like every other
+  identity key in this schema: a UNIQUE expression index on
+  `lower(name)`, with the column left RAW for display (the #121/#525
+  key/display split, already carried by `network_credentials`,
+  `query_windows` and `notify_entries`).
+
+  The byte-exact `users_name_index` from `20260426000000` stays. It is
+  implied by the folded one, and dropping it in the same migration that
+  adds a stricter one buys nothing while removing the fallback if this
+  index is ever rolled back.
+
+  ## The fold is plain `lower()`
+
+  `Grappa.Accounts.User`'s `@name_format` admits
+  `[a-zA-Z][a-zA-Z0-9_-]*` and nothing else, so the entire legal charset
+  is ASCII and `lower()` is byte-for-byte `Identifier.canonical_target/1`
+  over it. The expression MUST stay character-identical to
+  `Grappa.IRC.Identifier.nick_fold_sql/1` or SQLite will not use the
+  index. Inlined rather than called: migrations stay self-contained,
+  since they run under a possibly-truncated code load order.
+
+  ## A collision REFUSES the migration — it does not resolve it
+
+  The sibling folded-index migrations (`20260628100000`,
+  `20260711131000`) collapse case-variant duplicates by deleting the
+  losers before creating the index. That is right for a visitor
+  credential: it is disposable, and the next login re-provisions it. It
+  is wrong here. Two rows in `users` are two ACCOUNTS, each with a
+  password, sessions, credentials, scrollback and themes hanging off it.
+  Merging them silently would be data loss the operator never asked for
+  and cannot see afterwards, and choosing a survivor is not a decision
+  this file is entitled to make.
+
+  So the check runs FIRST and raises, naming every colliding spelling,
+  and the index is never created. The operator renames one side and runs
+  the deploy again — an operator-action failure taking the loud path,
+  the same posture as `Grappa.Networks.NoServerError`.
+
+  ## Cold deploy
+
+  A new migration: the hot path skips `ecto.migrate`, so this rides a
+  COLD window.
+  """
+  use Ecto.Migration
+
+  # The ASCII fold of `name`, in pure SQL. Written out rather than
+  # derived so the literal is in the source where the #525 fold pin in
+  # `Grappa.IRC.IdentifierTest` can compare it against
+  # `Identifier.nick_fold_sql("name")` — one byte of drift reddens there.
+  @folded_name "lower(name)"
+
+  def up do
+    refuse_on_collisions()
+
+    create unique_index(:users, [@folded_name], name: :users_folded_name_index)
+  end
+
+  def down do
+    drop unique_index(:users, [@folded_name], name: :users_folded_name_index)
+  end
+
+  # Every group of two or more accounts whose names differ only by case.
+  # Raising here aborts the migration with the table untouched.
+  defp refuse_on_collisions do
+    %{rows: rows} =
+      repo().query!("""
+      SELECT group_concat(name, ', ')
+      FROM users
+      GROUP BY #{@folded_name}
+      HAVING COUNT(*) > 1
+      ORDER BY #{@folded_name}
+      """)
+
+    case rows do
+      [] ->
+        :ok
+
+      collisions ->
+        groups = Enum.map_join(collisions, "\n  ", fn [names] -> names end)
+
+        raise """
+        Cannot make users.name case-insensitively unique: \
+        #{length(collisions)} group(s) of accounts differ only by case.
+
+          #{groups}
+
+        Each group is more than one account, with its own password,
+        sessions, credentials and scrollback. This migration will not
+        choose which one survives: rename all but one member of each
+        group, then run the deploy again.
+        """
+    end
+  end
+end

--- a/test/grappa/accounts_test.exs
+++ b/test/grappa/accounts_test.exs
@@ -33,6 +33,19 @@ defmodule Grappa.AccountsTest do
       assert "has already been taken" in errors_on(cs).name
     end
 
+    test "rejects a name that differs from an existing one only by case (#1353)" do
+      # One account per folded name: the folded unique index is what makes
+      # `vjt` and `VJT` the same account rather than two, and the
+      # changeset carries that index's name so the violation arrives as a
+      # changeset error rather than an `Ecto.ConstraintError`.
+      assert {:ok, _} = Accounts.create_user(%{name: "Dup-Case", password: @password})
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Accounts.create_user(%{name: "dup-case", password: @password})
+
+      assert "has already been taken" in errors_on(cs).name
+    end
+
     test "rejects a too-short password" do
       assert {:error, %Ecto.Changeset{} = cs} =
                Accounts.create_user(%{name: "vjt", password: "short"})
@@ -173,16 +186,47 @@ defmodule Grappa.AccountsTest do
                nil
     end
 
-    # Account names are the account key — a distinct namespace from the
-    # ASCII-folded IRC nick. The lookup is case-SENSITIVE (plain
-    # `Repo.get_by(User, name:)`), the SAME semantics
-    # `get_user_by_credentials/2` uses, so the two account lookups can
-    # never disagree on what "the account named X" is (the #404 dispatch
-    # relies on this).
-    test "is case-sensitive (does NOT nick-fold the name)" do
-      {:ok, _} = Accounts.create_user(%{name: "CaseAcct", password: @password})
-      assert %User{name: "CaseAcct"} = Accounts.get_user_by_name("CaseAcct")
-      assert Accounts.get_user_by_name("caseacct") == nil
+    # #1353 — the account name is an identity KEY, so it folds like every
+    # other identity key in the schema, and the row keeps its raw
+    # spelling for display. This arm replaces one that pinned the
+    # opposite ("is case-sensitive"): the property that test was
+    # protecting — the two account lookups never disagree about what "the
+    # account named X" is — is unchanged and asserted directly below;
+    # only the fold moved, and it moved for both of them at once.
+    test "resolves a case-variant spelling to the same account (#1353)" do
+      {:ok, user} = Accounts.create_user(%{name: "CaseAcct", password: @password})
+
+      assert %User{id: id, name: "CaseAcct"} = Accounts.get_user_by_name("caseacct")
+      assert id == user.id
+      assert %User{id: ^id} = Accounts.get_user_by_name("CASEACCT")
+      assert %User{id: ^id} = Accounts.get_user_by_name("CaseAcct")
+    end
+
+    test "the display spelling is the one the account was created with (#1353)" do
+      # Folding is a MATCH, never a write: the column stays raw so the
+      # operator sees the name they chose.
+      {:ok, _} = Accounts.create_user(%{name: "MixedCase", password: @password})
+
+      assert %User{name: "MixedCase"} = Accounts.get_user_by_name("mixedcase")
+    end
+
+    test "get_user_by_name!/1 folds the same way (#1353)" do
+      {:ok, user} = Accounts.create_user(%{name: "BangAcct", password: @password})
+
+      assert %User{id: id} = Accounts.get_user_by_name!("bangacct")
+      assert id == user.id
+    end
+
+    test "the two account lookups agree on what the account named X is (#1353)" do
+      # The #404 dispatch reads `get_user_by_name/1` to decide which door
+      # a bare identifier takes, and `get_user_by_credentials/2` then
+      # authenticates it. A spelling that resolves for one and not the
+      # other would route an account holder to the wrong door.
+      {:ok, user} = Accounts.create_user(%{name: "AgreeAcct", password: @password})
+
+      assert %User{id: id} = Accounts.get_user_by_name("agreeacct")
+      assert {:ok, %User{id: ^id}} = Accounts.get_user_by_credentials("agreeacct", @password)
+      assert id == user.id
     end
   end
 

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -821,6 +821,10 @@ defmodule Grappa.IRC.IdentifierTest do
     # literals stay tied to nick_fold_sql/1.
     @refold_migration "priv/repo/migrations/20260729120000_refold_identifiers_ascii.exs"
 
+    # #1353 added a live folded index the re-fold migration predates, so
+    # it carries its own copy of the fold literal and needs its own pin.
+    @folded_name_migration "priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs"
+
     # Pre-#525 migrations legitimately embed the rfc1459 four-replace fold
     # (correct when written; #525 supersedes their LIVE indexes). The
     # re-fold migration's own down/0 restores the rfc1459 indexes as its
@@ -850,6 +854,18 @@ defmodule Grappa.IRC.IdentifierTest do
         assert String.contains?(source, Identifier.nick_fold_sql(col)),
                "#{@refold_migration} is missing #{Identifier.nick_fold_sql(col)}"
       end
+    end
+
+    test "the #1353 folded-name index embeds the ASCII fold from nick_fold_sql/1" do
+      source = File.read!(@folded_name_migration)
+
+      # The whole attribute line, not the bare expression: that migration
+      # spells `lower(name)` in its moduledoc too, so a pin on the
+      # expression alone would survive a drift in the index itself.
+      expected = ~s(@folded_name "#{Identifier.nick_fold_sql("name")}")
+
+      assert String.contains?(source, expected),
+             "#{@folded_name_migration} is missing #{expected}"
     end
 
     test "no migration newer than the #525 re-fold reintroduces the rfc1459 fold" do

--- a/test/grappa/migrations/add_folded_name_index_to_users_test.exs
+++ b/test/grappa/migrations/add_folded_name_index_to_users_test.exs
@@ -1,0 +1,201 @@
+defmodule Grappa.FoldedNameMigrationSmokeRepo do
+  use Ecto.Repo,
+    otp_app: :grappa,
+    adapter: Ecto.Adapters.SQLite3
+end
+
+defmodule Grappa.Migrations.AddFoldedNameIndexToUsersTest do
+  @moduledoc """
+  #1353 — the folded-name unique index on `users`, and the refusal that
+  guards it.
+
+  The sibling folded-index migrations resolve a case-variant duplicate by
+  deleting the losers. This one must NOT: two `users` rows are two
+  accounts, so the migration refuses and names them instead. That refusal
+  is the arm below that matters — it is the whole difference from the
+  precedent it otherwise copies, and a later author "harmonising" this
+  migration with its siblings would turn a loud stop into silent data
+  loss.
+
+  Runs against a REAL migrated database on disk (same harness as
+  `Grappa.Migrations.AddUserTotpTest`) rather than the sandbox, because
+  what is under test is the migration itself: the raise before any DDL,
+  and the index that exists afterwards.
+
+  `async: false` — owns a repo process and a temp DB file.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Grappa.FoldedNameMigrationSmokeRepo, as: SmokeRepo
+  alias Grappa.IRC.Identifier
+
+  @previous_version 20_260_813_074_128
+  @folded_name_version 20_260_815_210_238
+
+  @timestamp "2026-01-01T00:00:00.000000Z"
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa-folded-name-migration-#{System.unique_integer([:positive])}.db"
+      )
+
+    Application.put_env(:grappa, SmokeRepo,
+      database: path,
+      # ONE connection, because the planner arm below asks SQLite which
+      # index it picks and that answer is per-connection: measured at
+      # pool_size 2, a checkout that did not serve the CREATE INDEX plans
+      # the same query as a full scan, so the arm flipped run to run on
+      # nothing but which connection the pool handed out.
+      pool_size: 1,
+      busy_timeout: 30_000,
+      foreign_keys: :on
+    )
+
+    start_supervised!(SmokeRepo)
+    migrations_path = Application.app_dir(:grappa, "priv/repo/migrations")
+
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @previous_version, log: false)
+
+    on_exit(fn ->
+      Application.delete_env(:grappa, SmokeRepo)
+      File.rm(path)
+      File.rm(path <> "-shm")
+      File.rm(path <> "-wal")
+    end)
+
+    %{migrations_path: migrations_path}
+  end
+
+  test "applies to a database whose account names already fold apart", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    insert_user!("22222222-2222-4222-8222-222222222222", "someone-else")
+    before = names()
+
+    assert [@folded_name_version] =
+             Ecto.Migrator.run(SmokeRepo, migrations_path, :up,
+               to: @folded_name_version,
+               log: false
+             )
+
+    assert "users_folded_name_index" in index_names()
+
+    # Every row survives with its spelling intact: the fold is a MATCH,
+    # never a rewrite.
+    assert names() == before
+  end
+
+  test "the index is derived from nick_fold_sql/1, and the folded lookup rides it", %{
+    migrations_path: migrations_path
+  } do
+    # `Accounts.by_folded_name/1` folds the column with the same
+    # `Identifier` source this predicate is built from, and the comment
+    # on it claims the result is an index lookup. Ask SQLite instead of
+    # deriving it: a fold that drifts from the indexed expression still
+    # returns the right row, silently, by reading every account.
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @folded_name_version, log: false)
+
+    # TWO arms, because `SCAN users` cannot carry two causes: SQLite says
+    # it both when the indexed expression has drifted away from the
+    # query's fold and when the index is right but the planner passed it
+    # over. This arm reads the expression SQLite actually stored, so a
+    # drift reddens HERE — which leaves the plan arm below a statement
+    # about the planner alone, and a red one names which of the two broke.
+    assert index_sql("users_folded_name_index") =~ "(#{Identifier.nick_fold_sql("name")})"
+
+    %{rows: rows} =
+      SQL.query!(
+        SmokeRepo,
+        "EXPLAIN QUERY PLAN SELECT id FROM users WHERE #{Identifier.nick_fold_sql("name")} = ?",
+        ["vjt"]
+      )
+
+    plan = rows |> List.flatten() |> Enum.filter(&is_binary/1) |> Enum.join(" ")
+
+    assert plan =~ "users_folded_name_index", "planner chose: #{plan}"
+    refute plan =~ "SCAN"
+  end
+
+  test "the index refuses a second account whose name differs only by case", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @folded_name_version, log: false)
+
+    assert_raise Exqlite.Error, fn ->
+      insert_user!("33333333-3333-4333-8333-333333333333", "VJT")
+    end
+  end
+
+  test "a pre-existing case collision refuses the migration and names the rows", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    insert_user!("22222222-2222-4222-8222-222222222222", "VJT")
+    insert_user!("44444444-4444-4444-8444-444444444444", "solo")
+    before = names()
+
+    error =
+      assert_raise RuntimeError, fn ->
+        Ecto.Migrator.run(SmokeRepo, migrations_path, :up,
+          to: @folded_name_version,
+          log: false
+        )
+      end
+
+    # The operator has to know WHICH accounts to rename, so both
+    # spellings are in the message and the uninvolved one is not.
+    assert error.message =~ "vjt"
+    assert error.message =~ "VJT"
+    refute error.message =~ "solo"
+
+    # Nothing was created and nothing was deleted: the refusal happens
+    # before any DDL, and the accounts are still both there for the
+    # operator to choose between.
+    refute "users_folded_name_index" in index_names()
+    assert names() == before
+  end
+
+  defp insert_user!(id, name) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO users (id, name, password_hash, is_admin, inserted_at, updated_at) VALUES (?,?,?,?,?,?)",
+      [id, name, "hash", 0, @timestamp, @timestamp]
+    )
+  end
+
+  # The CREATE INDEX text SQLite kept for `name`, which is where a drift
+  # between the migration's expression and `nick_fold_sql/1` shows up as
+  # data rather than as a planner mood.
+  defp index_sql(name) do
+    %{rows: rows} =
+      SQL.query!(
+        SmokeRepo,
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+        [name]
+      )
+
+    case rows do
+      [[sql]] -> sql
+      [] -> flunk("no index named #{name}")
+    end
+  end
+
+  defp index_names do
+    %{rows: rows} =
+      SQL.query!(SmokeRepo, "SELECT name FROM sqlite_master WHERE type = 'index'", [])
+
+    List.flatten(rows)
+  end
+
+  defp names do
+    %{rows: rows} = SQL.query!(SmokeRepo, "SELECT name FROM users ORDER BY name", [])
+    List.flatten(rows)
+  end
+end

--- a/test/grappa/test_support/subject_provision_test.exs
+++ b/test/grappa/test_support/subject_provision_test.exs
@@ -81,6 +81,18 @@ defmodule Grappa.TestSupport.SubjectProvisionTest do
       assert {:error, :user_not_found} = SubjectProvision.teardown!("nobody-by-that-name")
     end
 
+    test "a case-variant spelling of the name tears down the same subject (#1353)" do
+      # This resolves the account the same way every other account reader
+      # does: the name is an identity key, so the teardown a spec asks for
+      # cannot depend on how the harness capitalised it.
+      user = user_fixture(name: unique_name())
+      typed = String.upcase(user.name)
+      refute typed == user.name
+
+      assert :ok = SubjectProvision.teardown!(typed)
+      assert Accounts.get_user_by_name(user.name) == nil
+    end
+
     test "removes the user, its credential and everything keyed to it" do
       user = user_fixture(name: unique_name())
       network = network_fixture()

--- a/test/grappa/test_support/subject_reset_test.exs
+++ b/test/grappa/test_support/subject_reset_test.exs
@@ -68,6 +68,17 @@ defmodule Grappa.TestSupport.SubjectResetTest do
       assert Notify.list({:user, user.id}, network.id) == []
     end
 
+    test "a case-variant spelling of the name resets the same subject (#1353)", %{
+      user: user,
+      network: network
+    } do
+      typed = String.upcase(user.name)
+      refute typed == user.name
+
+      assert {:ok, _} = SubjectReset.reset!(typed, %{})
+      assert ReadCursor.get({:user, user.id}, network.id, "#bofh") == nil
+    end
+
     test "does not touch other users", %{user: user, network: network} do
       other = user_fixture(name: "other-test-reset-#{System.unique_integer([:positive])}")
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -543,6 +543,38 @@ defmodule GrappaWeb.AuthControllerTest do
       assert is_nil(session.revoked_at)
     end
 
+    test "a case-variant spelling of the account name takes the account door (#1353)",
+         %{conn: conn} do
+      # The dispatch asks `Accounts.get_user_by_name/1` which door this
+      # identifier belongs to, and the account name is an identity key,
+      # so the answer does not depend on how the holder capitalised it.
+      # No visitor network is configured in this describe, so the visitor
+      # door is not merely unlikely here — it is unreachable, and the 200
+      # below could not come from it.
+      {user, password} = user_fixture_with_password()
+      typed = String.upcase(user.name)
+
+      # The fixture picks the stored spelling, so pin the pre-state: if a
+      # future fixture name were already upper-case this test would still
+      # pass while asserting nothing.
+      refute typed == user.name
+
+      body =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/auth/login", %{"identifier" => typed, "password" => password})
+        |> json_response(200)
+
+      assert body["subject"]["kind"] == "user"
+      assert body["subject"]["id"] == user.id
+      # The envelope carries the STORED spelling, not the typed one.
+      assert body["subject"]["name"] == user.name
+
+      session = Repo.get(Session, body["token"])
+      assert session.user_id == user.id
+      assert is_nil(session.visitor_id)
+    end
+
     test "bare account name + wrong password → 401 invalid_credentials, no guest provisioned",
          %{conn: conn} do
       {user, _} = user_fixture_with_password()


### PR DESCRIPTION
## What changes

`users.name` names an account, and this schema folds identity keys at the MATCH
while storing them raw for display (#121/#525) — the pattern `network_credentials`,
`query_windows` and `notify_entries` already carry. The account name now carries it
too: `vjt` and `VJT` name ONE account, exactly as they name one nick on the wire.

Both halves move together:

- `users_folded_name_index` is a UNIQUE expression index on `lower(name)` — the same
  byte-pinned `lower()` that `Identifier.nick_fold_sql/1` emits, so the #525 fold pin
  now covers this migration too and one byte of drift reddens there rather than
  silently costing the index.
- The three account readers share one folded query, so the table and its readers
  cannot drift apart.
- The changeset names the new index explicitly, since ecto derives a constraint name
  from the column and would otherwise let the folded violation escape as an
  `Ecto.ConstraintError` instead of a changeset error.
- The column stays raw: the login envelope still returns the spelling the account was
  created with.

The two byte-exact readers in `test_support` move in the same commit — half a
migration leaves two patterns in the tree, and the next reader copies whichever is
closer.

## A pre-existing collision refuses the migration

The sibling folded-index migrations delete the losers, which is right for a visitor
credential and wrong for an account: two rows here are two accounts with their own
passwords, sessions, credentials and scrollback, and choosing a survivor is not a
decision a migration is entitled to make. This one raises and names the groups; the
operator renames one side and runs the deploy again.

We measured **7 accounts and zero collisions** — but that is measured on our
deployment, not on all of them. A self-hosted instance has never been measured by
anyone, which is exactly why the migration refuses loudly instead of resolving.

## Deploy class

🔵 **COLD.** This carries a migration, so it does not ride the hot batch.

## Verification

- Full `scripts/check.sh` green: Credo strict, Dialyzer, Doctor, Sobelow,
  `deps.audit`, the ExUnit suite and the bats set.
- The migration test pins the index two ways — first the SQL SQLite actually kept for
  it, read back from `sqlite_master`, then the query plan — and fails loudly if the
  index is absent. A plan assertion alone is not diagnostic: it reads the same whether
  the expression drifted or the planner simply declined a correct index. Run 3/3
  stable.
- Mutation-tested: drift in the index expression kills the source pin and the planner
  pin as two disjoint deaths; the folded `unique_constraint` and the migration's
  refusal each have an exact killing assertion; the two `test_support` readers are 1:1.

## Not established here

The migration has only ever run against a temp-file smoke repo, never against a
database of production size.
