### PR TITLE
cic(#1341): release the DM-listener own-nick topic, gated on ownership

### DIFF
--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -4232,3 +4232,155 @@ describe("subscribe — own nick after a rename (#1340 C-S1)", () => {
     expect(rail.railWhoisFor("freenode", "zelda2")).toBeUndefined();
   });
 });
+
+// #1341 — the DM-listener must RELEASE the own-nick topic it holds when the
+// own nick moves, and must release only what it took.
+//
+// The loops in `subscribe.ts` dedup on `joined.has(key)`, and the DM-listener's
+// key is the own nick. A rename therefore mints a NEW key while the retired one
+// stays in `joined` with a live Channel on it. That is not a duplicate-delivery
+// bug — `Persistor.persist_and_broadcast` derives the topic from the row's
+// single `channel` value, so a row still reaches exactly one topic. It is a
+// SHADOW: when a peer later takes the retired nick, our own outbound `/msg`
+// echo is broadcast on that peer's topic (`server.ex` persists the outbound row
+// with `channel: <folded target>`), the retired subscription is still sitting on
+// it, and `ensureQueryTopicJoined` short-circuits on `joined.has(key)` so the
+// correct channel handler is never installed. The DM-listener handler re-keys on
+// the SENDER, so the line we sent to that peer surfaces in our own self window.
+//
+// The release is gated on OWNERSHIP, never on the key: a query window opened
+// while we wore a different nick can legitimately hold the very key we are
+// retiring (second test), and tearing it down would sever a live conversation.
+describe("subscribe — the DM listener releases its own-nick topic on a rename (#1341)", () => {
+  const boot = async (ownNick: string, peers: () => string[]) => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const api = await import("../lib/api");
+    vi.mocked(api.listNetworks).mockResolvedValue([
+      { id: 1, slug: "freenode", nick: ownNick, inserted_at: "x", updated_at: "y" },
+    ]);
+    const qw = await import("../lib/queryWindows");
+    vi.mocked(qw.queryWindowsByNetwork).mockImplementation(() => ({
+      1: peers().map((targetNick) => ({ targetNick, openedAt: "2026-08-16T00:00:00Z" })),
+    }));
+    await usePerTopicChannels();
+    const store = await loadStores();
+    const socket = await import("../lib/socket");
+    await vi.waitFor(() => {
+      expect(socket.joinChannel).toHaveBeenCalled();
+    });
+    return { store, socket };
+  };
+
+  // Deliver a row the way the socket does: to EVERY live Channel sitting on
+  // that topic. A Channel that was `.leave()`d is off the socket and gets
+  // nothing. Returns the scrollback buckets the row landed in — the routing
+  // outcome, which is what the operator sees.
+  const deliverOnTopic = async (
+    socket: typeof import("../lib/socket"),
+    topic: string,
+    row: { id: number; sender: string },
+  ) => {
+    const calls = vi.mocked(socket.joinChannel).mock.calls;
+    const payload = {
+      kind: "message",
+      message: {
+        id: row.id,
+        network: "freenode",
+        channel: topic,
+        server_time: row.id,
+        kind: "privmsg",
+        sender: row.sender,
+        body: "body",
+        meta: {},
+      },
+    };
+    calls.forEach((call, i) => {
+      if (call[2] !== topic) return;
+      const mock = perTopicChannels[i];
+      if (mock === undefined || mock.left) return;
+      for (const on of mock.on.mock.calls) {
+        if (on[0] === "event") (on[1] as (p: unknown) => void)(payload);
+      }
+    });
+    const scrollback = await import("../lib/scrollback");
+    return Object.entries(scrollback.scrollbackByChannel())
+      .filter(([, rows]) => (rows as { id: number }[]).some((r) => r.id === row.id))
+      .map(([key]) => key)
+      .sort();
+  };
+
+  it("our outbound echo to a peer who took our retired nick lands in that peer's window", async () => {
+    const [peers, setPeers] = createSignal<string[]>([]);
+    const { store, socket } = await boot("alice", peers);
+    await vi.waitFor(() => {
+      expect(socket.joinChannel).toHaveBeenCalledWith(
+        "alice",
+        "freenode",
+        "alice",
+        expect.any(Function),
+      );
+    });
+
+    store.mutateNetworkNick(1, "zelda");
+    await vi.waitFor(() => {
+      expect(socket.joinChannel).toHaveBeenCalledWith(
+        "alice",
+        "freenode",
+        "zelda",
+        expect.any(Function),
+      );
+    });
+
+    // A peer takes the nick we just retired and we `/msg` them: the server
+    // opens the query window and broadcasts our echo on that peer's topic.
+    // Barrier: the query-windows loop has re-run against the new list. True in
+    // both worlds — the loop runs either way, it is what it does with the key
+    // that differs — so the routing assertion below is what fails, not this.
+    const qw = await import("../lib/queryWindows");
+    const readsBefore = vi.mocked(qw.queryWindowsByNetwork).mock.calls.length;
+    setPeers(["alice"]);
+    await vi.waitFor(() => {
+      expect(vi.mocked(qw.queryWindowsByNetwork).mock.calls.length).toBeGreaterThan(readsBefore);
+    });
+
+    const landed = await deliverOnTopic(socket, "alice", { id: 1341, sender: "zelda" });
+    expect(landed).toEqual([channelKey("freenode", "alice")]);
+  });
+
+  it("a query window holding the key we are retiring keeps its subscription", async () => {
+    // We are `bob` and hold an open query with the peer `alice`, so the key
+    // `freenode alice` belongs to the query loop, not to us. We then take the
+    // nick `alice` and rename away from it — the retired own-nick key is now
+    // one we never joined. Releasing by key would sever that conversation.
+    const [peers] = createSignal<string[]>(["alice"]);
+    const { store, socket } = await boot("bob", peers);
+    await vi.waitFor(() => {
+      expect(socket.joinChannel).toHaveBeenCalledWith(
+        "alice",
+        "freenode",
+        "alice",
+        expect.any(Function),
+      );
+    });
+
+    store.mutateNetworkNick(1, "alice");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    store.mutateNetworkNick(1, "zelda");
+    await vi.waitFor(() => {
+      expect(socket.joinChannel).toHaveBeenCalledWith(
+        "alice",
+        "freenode",
+        "zelda",
+        expect.any(Function),
+      );
+    });
+
+    const landed = await deliverOnTopic(socket, "alice", { id: 1342, sender: "carol" });
+    expect(landed).toEqual([channelKey("freenode", "alice")]);
+  });
+});

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -147,6 +147,11 @@ moduleRoot(() => {
   // per query topic, so subscribe-before-send awaits the SAME ack the loop
   // drives (no double-join). Cleared on identity rotation alongside `joined`.
   const queryJoinAcks = new Map<ChannelKey, Promise<void>>();
+  // #1341 — per-network provenance for the DM-listener loop: the own-nick key
+  // THIS loop joined. `joined` is keyed by topic with no record of who took it,
+  // so without this the retiring loop cannot tell its own subscription from a
+  // query window that happens to sit on the same key.
+  const dmListenerKeys = new Map<string, ChannelKey>();
 
   createEffect(
     on(token, (t, prev) => {
@@ -154,6 +159,7 @@ moduleRoot(() => {
         for (const ch of joined.values()) ch.leave();
         joined.clear();
         queryJoinAcks.clear();
+        dmListenerKeys.clear();
       }
     }),
   );
@@ -1090,6 +1096,17 @@ moduleRoot(() => {
   // The pre-fix fallback to `displayNick(u)` (= user.name) silently
   // subscribed to the WRONG topic when account-name differed from the
   // IRC nick — see api.ts moduledoc + cic H3.
+  //
+  // #1341 — the key moves with the nick, so a rename mints a new one and the
+  // retired key would stay in `joined` with a live Channel on it. That is not
+  // duplicate delivery (a row carries one `channel`, so it reaches one topic)
+  // but a SHADOW: once a peer takes the retired nick, our outbound echo to them
+  // is broadcast on that key, `ensureQueryTopicJoined` short-circuits on
+  // `joined.has(key)` and never installs the channel handler, and this handler
+  // re-keys on the sender — so the line lands in our own self window.
+  // `dmListenerKeys` records what THIS loop joined, per network, so the release
+  // is gated on ownership: a query window opened while we wore another nick can
+  // legitimately hold the key we are retiring, and leaving by key would sever it.
   createEffect(() => {
     const t = token();
     const u = user();
@@ -1101,6 +1118,12 @@ moduleRoot(() => {
       const ownNick = ownNickForNetwork(net, u);
       if (!ownNick) continue;
       const key = channelKey(net.slug, ownNick);
+      const held = dmListenerKeys.get(net.slug);
+      if (held !== undefined && held !== key) {
+        joined.get(held)?.leave();
+        joined.delete(held);
+        dmListenerKeys.delete(net.slug);
+      }
       if (joined.has(key)) continue;
       const phx = joinChannel(userName, net.slug, ownNick, (reply) => {
         applyJoinReplyAndSeed(net.slug, ownNick, reply);
@@ -1144,6 +1167,7 @@ moduleRoot(() => {
       });
       installDmListenerHandler(phx, net.slug, net.id, ownNick);
       joined.set(key, phx);
+      dmListenerKeys.set(net.slug, key);
     }
   });
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43271,3 +43271,46 @@ against a path it asserts absent beforehand, rather than reasoning about it.
 pending counts it OBSERVED, never "no pending migrations, nothing to do" — a
 pending count of zero is the silent regime's own signature, so a fast path
 that reports the absence of work would be reporting the defect as health.
+<!-- entry #1341 -->
+
+---
+
+## 2026-08-16 — #1341: the DM listener releases the own-nick topic it took, gated on ownership
+
+CLAUDE.md's rename-migration set (#373 for a peer, #948 for our own nick) says a
+new nick-keyed store must join that set or a rename strands its old-nick rows.
+cic's WS subscription map is such a store and was not in it: the DM-listener
+topic is keyed on the own nick, so `own_nick_changed` minted a new key and left
+the retired one in `joined` with a live Channel on it.
+
+Measured before the fix rather than assumed. The hold is one topic per DISTINCT
+nick the session ever wore — four, five, six, seven keys at zero, one, two,
+three renames, and a rename BACK to a nick already held adds none. It is NOT
+duplicate delivery: `Persistor.persist_and_broadcast` derives the topic from the
+row's single `channel`, so a row reaches exactly one topic, and `joined` admits
+one subscription per topic. The user-visible failure is a SHADOW. Once a peer
+takes the retired nick, our outbound `/msg` to them is broadcast on that peer's
+topic (the outbound row persists with `channel: <folded target>`),
+`ensureQueryTopicJoined` short-circuits on `joined.has(key)` and never installs
+the channel handler, and the retired DM-listener handler re-keys on the sender —
+so the line we sent surfaces in our own self window. That is what the pin
+asserts; the key count is diagnostics.
+
+The release is gated on OWNERSHIP, never on the key, and that came from a
+measurement too. With an open query at `alice` while we wore `bob`, taking
+`alice` and then renaming away leaves a retired own-nick key that the query loop
+holds and the DM listener never joined; leaving by key would sever a live
+conversation. `dmListenerKeys` records, per network, what THIS loop joined —
+`joined` is keyed by topic and carries no record of who took it, so the
+provenance was missing state, not duplicated state.
+
+**Not established.** All of it is vitest against the socket mock; the two
+broadcast shapes were pinned by reading the server's broadcast sites, not
+observed on a real stack. Whether the retired subscriptions survive a phoenix.js
+auto-rejoin is unmeasured. The handler probe discriminates by which scrollback
+bucket a row lands in, not by inspecting closure identity. And the mirror defect
+is UNCOVERED on purpose: renaming INTO a nick that already has an open query
+window leaves the DM listener with no subscription at all, so every inbound DM
+collapses into the self window. Its root is a guard that suppresses the install
+regardless of who holds the key, not a hold never released, and closing it needs
+a precedence rule between two loops that nobody has specified — filed as #1365.


### PR DESCRIPTION
Fixes the leak in #1341 by releasing the DM-listener's own-nick topic when the own nick moves, gated on ownership.

## What was measured, before anything was written

The issue asked for the mechanism to be treated as read, not established. Two things were uncharacterised; both were measured against the real `joined` map (via the `__cic_joinedTopicKeys` seam) rather than reasoned from the source.

**The hold is one topic per DISTINCT nick the session ever wore**, not one per rename. Displacement: 4, 5, 6, 7 joined keys at 0, 1, 2, 3 renames — and a fourth rename *back* to a nick already held leaves the count at 7. The retired Channel is never `.leave()`d and keeps its handler.

**It is not duplicate delivery.** `Persistor.persist_and_broadcast` derives the broadcast topic from the row's single `channel` value, so a row reaches exactly one topic, and `joined` admits one subscription per topic. There is no second subscriber to double a notification.

**The user-visible failure is a shadow.** Once a peer takes the retired nick and we `/msg` them, the outbound row persists with `channel: <folded target>` and is broadcast on that peer's topic — which the retired subscription is still sitting on. `ensureQueryTopicJoined` short-circuits on `joined.has(key)`, so the correct channel handler is never installed, and the retired DM-listener handler re-keys on the *sender*: the line we sent to that peer surfaces in our own self window. Measured at the scrollback store: the row landed in `freenode zelda` instead of `freenode alice`.

## The shape of the fix, and why

`dmListenerKeys` records, per network, the key **this loop** joined; on a rename the loop leaves and deletes only that key.

The release is gated on ownership rather than on the key because the two can come apart, and that was measured too: with an open query at `alice` while we wore `bob`, taking `alice` and then renaming away leaves a retired own-nick key that the *query* loop holds and the DM listener never joined. Leaving by key would sever a live conversation.

`joined` is `Map<key, Channel>` with no record of who took a key, so this provenance is missing state, not duplicated state.

Reading the own nick live instead of capturing it at `installDmListenerHandler` was rejected: what suppresses the correct handler is the `joined.has(key)` short circuit, so a live read would still route the row through the wrong listener *and* would leave the monotonic set intact. Only removing the key restores the correct path.

## Tests

Two, and each was bought with a mutant that kills exactly one of them:

- *outbound echo lands in the peer's window* — the route, which is what the operator sees, not the key count. Red before the fix on the routing assertion itself (`['freenode zelda']` vs `['freenode alice']`), with a barrier that is true in both worlds so the failure cannot be the barrier. Killed by the mutant "release removed"; survives "ownership gate dropped".
- *a query window holding the key we are retiring keeps its subscription* — killed by the mutant "record the key even when we did not join it" (the row then lands nowhere, the conversation having been severed); survives "release removed".

Delivery is modelled the way the socket does it — to every live Channel on the topic — so a stale subscription that still delivers shows up as an extra bucket rather than being invisible.

## What this does NOT cover, and why

The mirror defect is left uncovered **on purpose** and filed as #1365: renaming *into* a nick that already has an open query window leaves the DM listener with no subscription at all, so every inbound DM from anybody collapses into the self window. Its root is different — a guard that suppresses the install regardless of who holds the key, rather than a hold that is never released — and closing it requires a precedence rule between the query-windows loop and the DM-listener loop that nobody has specified. Minting that protocol inside a bugfix would leave it unreviewed and edges close to cic originating state.

Measured while scoping it: the same defect is **not** present at boot. With the self window (`/msg <ownnick>`, #948) already open at our own nick, the query loop skips it via the own-nick guard, exactly one join is made, and a probe row re-keys on the sender. The guard protects the nick we wear *now*; the rename is what moves the identity onto a key already joined as a peer.

## What I have not established

- All of it is vitest against the socket mock. The server-side broadcast shape was pinned by **reading**, not observed on a real stack: `handle_persisting_send` folds the outbound target into `key` (`lib/grappa/session/server.ex:3890`), the attrs carry `channel: key`, and `Persistor.persist_and_broadcast` broadcasts on `Topic.channel(…, attrs.channel)` (`lib/grappa/session/persistor.ex:81`).
- **No server-side pin was found for that invariant**, and that is itself a finding rather than an omission on this branch. There is no ExUnit test that sends an outbound PRIVMSG to a mixed-case non-service target and asserts the persisted/broadcast `channel` is the folded one. The nearest candidates each miss it: the only mixed-case outbound test targets `NickServ` and asserts *no* row and *no* broadcast (`test/grappa_web/controllers/messages_controller_outbound_test.exs:837`); the DM outbound test uses an all-lowercase target, which cannot tell folded from raw (`:588`); the channel-fold property persists under the already-canonical form on purpose — "write side has already canonicalised" (`test/grappa/scrollback_test.exs:3283`); and `test/grappa/irc/client_test.exs:214` pins the *wire* framing, where the target stays RAW by design (#537). So the CLAUDE.md channel-key invariant is unguarded on the outbound persist/broadcast path. Not fixed here — this branch touches no Elixir.
- Whether the retired subscriptions survive a phoenix.js auto-rejoin after a reconnect is **unmeasured**.
- "The server still holds the subscription" is **inferred** from `.leave()` never being called, not observed on a live socket.
- The handler probe discriminates a channel handler from a DM-listener handler by **which scrollback bucket a row lands in**, not by inspecting closure identity.

## Gates

Run from this worktree, on the final rebased base (`68dbaba2`), RCs read from the log:

- `bun run check` (biome + `tsc --noEmit` + e2e tsconfig) — RC=0, 0 TS errors
- `bun run test` — 284 files, 5493 tests, RC=0
- `scripts/design-notes-gate.sh` — RC=0, `1 new entry heading(s), separator and marker present`
- branch contribution `--numstat` pinned to a file before the rebase and diffed after: identical, additions unchanged and deletions zero
- 0 Elixir files touched, so no Credo/Dialyzer surface

## Deploy

**HOT, cic-only** — verified, not assumed: the branch touches 0 `.ex`/`.exs` files, no `VERSION`, no `mix.exs`, no migrations, and `scripts/deploy-m42.sh:52` labels the `--cic` path "cic bundle (hot — no BEAM restart)".
