### PR TITLE
test(#1350): pin the fail-over ring rotation past the exponent knee

### DIFF
--- a/lib/grappa/session/backoff.ex
+++ b/lib/grappa/session/backoff.ex
@@ -359,6 +359,19 @@ defmodule Grappa.Session.Backoff do
   @spec cap_ms() :: unquote(@cap_ms)
   def cap_ms, do: @cap_ms
 
+  @doc """
+  The exponent clamp — the knee of the curve. From failure count
+  `max_exponent() + 1` on, every further failure yields the same capped
+  wait.
+
+  Public for the same reason as `base_ms/0` and `cap_ms/0`: the #1350
+  consumer pin walks the fail-over ring PAST this point, and a test that
+  hardcoded the knee would keep passing below it the day the tuning
+  moves.
+  """
+  @spec max_exponent() :: unquote(@max_exponent)
+  def max_exponent, do: @max_exponent
+
   @doc false
   @spec entries() :: [entry()]
   def entries do

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -46,6 +46,17 @@ defmodule Grappa.NetworksTest do
 
   # #93 — builds the `{host, enabled}` list as an ascending-priority ring,
   # binds `user` to it and resolves the spawn-door plan.
+  # Shared by the two fail-over ring describes (#93 below the exponent
+  # knee, #1350 past it). `Backoff` is an application-wide singleton with
+  # no sandbox, so the counter has to be evicted per test.
+  defp ring_ctx do
+    user = user_fixture()
+    net = network_fixture()
+    on_exit(fn -> Backoff.forget({:user, user.id}) end)
+
+    {:ok, user: user, net: net}
+  end
+
   defp bind_ring(user, net, hosts) do
     Enum.each(Enum.with_index(hosts, 1), fn {{host, enabled}, priority} ->
       {:ok, _} =
@@ -60,6 +71,14 @@ defmodule Grappa.NetworksTest do
       })
 
     user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
+  end
+
+  # The endpoint ring as `pick_server!/2` indexes it — `list_servers/1`
+  # returns the `(priority, id)` order the picker sorts by, so the
+  # expected fail-over walk is derived from production, not transcribed
+  # from the fixture's insertion order.
+  defp enabled_ring(net) do
+    net |> Servers.list_servers() |> Enum.filter(& &1.enabled) |> Enum.map(& &1.host)
   end
 
   describe "find_or_create_network/1" do
@@ -1829,11 +1848,7 @@ defmodule Grappa.NetworksTest do
   # per-server state to keep in sync.
   describe "SessionPlan fail-over ring (#93)" do
     setup do
-      user = user_fixture()
-      net = network_fixture()
-      on_exit(fn -> Backoff.forget({:user, user.id}) end)
-
-      {:ok, user: user, net: net}
+      ring_ctx()
     end
 
     test "each recorded failure advances the plan to the next enabled server", ctx do
@@ -1895,6 +1910,93 @@ defmodule Grappa.NetworksTest do
 
       assert {:ok, plan} = user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
       assert plan.host == "primary"
+    end
+  end
+
+  # #1350 — #1349 bounded the backoff EXPONENT and left the stored count
+  # deliberately UNCLAMPED, because that same count is the fail-over ring
+  # ordinal. #1349 pinned that consequence at the counter (`failure_count/2`
+  # still answers 1_025 after 1_025 failures); this pins it where it is
+  # load-bearing — at the respawn door, past the knee, where the wait has
+  # stopped growing and the endpoint must NOT stop moving with it. The
+  # #93 tests above all sit BELOW the knee.
+  #
+  # The first test is the anti-vacuity witness for the second: it fixes
+  # that the count the walk derives really does sit on the flat part of
+  # the curve. Split into two tests so each dies on its own mutant
+  # instead of shadowing the other.
+  describe "SessionPlan fail-over ring past the exponent knee (#1350)" do
+    setup do
+      ring_ctx()
+    end
+
+    # One-sided on purpose: the ±25% jitter windows of the last rung below
+    # the knee and the cap overlap at the production tuning, so "not yet
+    # capped one failure earlier" is not assertable without a flake.
+    test "the knee the walk derives is where the wait has flattened at the cap", ctx do
+      %{user: user, net: net} = ctx
+      cap = Backoff.cap_ms()
+      jitter = trunc(cap * 0.25)
+
+      for _ <- 1..(Backoff.max_exponent() + 1) do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+      end
+
+      ms = Backoff.wait_ms({:user, user.id}, net.id)
+
+      assert ms >= cap - jitter
+      assert ms <= cap + jitter
+    end
+
+    test "the endpoint keeps advancing once the wait has flattened", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      ring = enabled_ring(net)
+      # A full ring PAST the flattening point, so the tail of the walk is
+      # entirely on the flat part of the curve.
+      walk = Backoff.max_exponent() + 1 + length(ring)
+
+      walked =
+        for _ <- 1..walk do
+          :ok = Backoff.record_failure({:user, user.id}, net.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      # `list_servers/1` returns the same `(priority, id)` order
+      # `pick_server!/2` indexes, so the walk is that order cycled — the
+      # Nth failure is ring position N, one past the primary.
+      expected = ring |> Stream.cycle() |> Stream.drop(1) |> Enum.take(walk)
+
+      assert walked == expected
+    end
+
+    # The count whose pre-#1349 `:math.pow/2` exponent overflowed the
+    # double. Nothing the test computes can put it below a knee, so this
+    # claim rests on no derivation of its own — the price is that it can
+    # only assert the ring's SHAPE (every endpoint visited once per
+    # revolution), not its phase.
+    @overflow_count 1_025
+
+    test "the ring still advances at the count that used to raise badarith", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      ring = enabled_ring(net)
+
+      for _ <- 1..(@overflow_count - length(ring)) do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+      end
+
+      walked =
+        for _ <- 1..length(ring) do
+          :ok = Backoff.record_failure({:user, user.id}, net.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      assert Enum.sort(walked) == Enum.sort(ring)
     end
   end
 

--- a/test/grappa/visitors/session_plan_test.exs
+++ b/test/grappa/visitors/session_plan_test.exs
@@ -111,6 +111,35 @@ defmodule Grappa.Visitors.SessionPlanTest do
       assert second.host == "secondary"
     end
 
+    # #1350 — the visitor half of the past-the-knee pin (the user half
+    # lives in `Grappa.NetworksTest`, which also witnesses that
+    # `max_exponent/0` is where the wait flattens). Two respawn doors read
+    # the same unclamped counter, so a write-side clamp would freeze both;
+    # pinning one door would leave the other free to regress alone.
+    test "refresh_plan keeps walking the ring past the exponent knee (#1350)" do
+      {network, _} = network_with_server(slug: "azzurra", port: 6667, host: "primary")
+      {:ok, _} = Servers.add_server(network, %{host: "secondary", port: 6667, priority: 9})
+      {:ok, _} = Servers.add_server(network, %{host: "tertiary", port: 6667, priority: 10})
+      {:ok, visitor} = Visitors.find_or_provision_anon("vjt-knee", "azzurra", "1.2.3.4")
+      on_exit(fn -> Backoff.forget({:visitor, visitor.id}) end)
+
+      assert {:ok, plan} = SessionPlan.resolve(visitor, network)
+
+      ring = network |> Servers.list_servers() |> Enum.filter(& &1.enabled) |> Enum.map(& &1.host)
+      walk = Backoff.max_exponent() + 1 + length(ring)
+
+      walked =
+        for _ <- 1..walk do
+          :ok = Backoff.record_failure({:visitor, visitor.id}, network.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      expected = ring |> Stream.cycle() |> Stream.drop(1) |> Enum.take(walk)
+
+      assert walked == expected
+    end
+
     # CP24 bucket E lifecycle/S1: visitor plans carry a `credential_failer`
     # callback that expires the row on K-line / permanent SASL.
     test "plan injects credential_failer that expires the visitor on call" do


### PR DESCRIPTION
## What this pins

#1349 bounded the backoff **exponent** and deliberately left the stored failure
count unclamped, because that same count is the ordinal both respawn doors hand
to `Servers.pick_server!/2`. It pinned that consequence **at the counter** —
`failure_count/2` still answers `1_025` after 1_025 failures — but never at the
consumer, where a write-side clamp actually hurts: a multi-server network nailed
to one dead endpoint for as long as the outage lasts.

Every pre-existing #93 ring test records 1–4 failures. The knee sits at 5 in the
test tuning. So nothing in the suite failed if the ring froze exactly where the
wait flattens.

## The change

* `Backoff.max_exponent/0` — a read-only accessor on an attribute that already
  existed, joining `base_ms/0` and `cap_ms/0`, which are public for the same
  reason. No behaviour change, no bypass path, no optional parameter. A test
  carrying its own literal for the knee would keep passing *below* it the day
  the curve is retuned, which is the silent pass this pin exists to prevent.
* Four tests. T1 witnesses that the derived knee is really where the wait
  flattens; T2 walks the user respawn door across it and asserts the endpoint
  still advances; T3 does the same at the count whose pre-#1349 `:math.pow/2`
  exponent overflowed its double; T4 is the visitor door's walk past the knee.
* `ring_ctx/0` extracts the per-test `Backoff` eviction the #93 describe already
  did — the singleton has no sandbox.

The expected walk is derived from `list_servers/1` (the same `(priority, id)`
order the picker indexes), not transcribed from the fixture.

## Mutation evidence

Baseline 150 tests / 0 failures, re-printed green after the last round. Every
mutant was verified present in the source before its red was believed; each
round restored the file and asserted an empty porcelain. Every mutant keeps the
mutated binding **used**, because the suite runs `--warnings-as-errors` and a
dead variable paints a red that is not the mutant.

| mutant | tally | reds |
|---|---|---|
| M1 ring frozen at position 0 | 11 F / 139 P | T2, T3, T4 + 8 pre-existing |
| M2 the knee seam lies (`max_exponent/0` → 0) | **1 F / 149 P** | **T1 only** |
| M3 counter clamped at write | 4 F / 146 P | T2, T3, T4 + #1349's counter test |
| M4 user door stops reading the counter | 6 F / 144 P | T2, T3 + 4 pre-existing; **T4 green** |
| M5 visitor door stops reading the counter | 2 F / 148 P | **T4** + 1 pre-existing; T2/T3 green |
| M6 ring order flipped on BOTH sides | 11 F / 139 P | **none of T1–T4** |
| M7 counter restarts at the knee | 4 F / 146 P | T1, T2, T4; **T3 green** |
| M8 ring ordinal saturates at 20 | **1 F / 149 P** | **T3 only** |

M4/M5 are the pair that earns pinning both doors: each leaves the other door's
test green.

M1–M7 and their expected reds were **pre-registered before the run**. M1–M7 then
showed that no mutant killed T3 alone — every mutant that killed T3 also killed
T2 — so T3's independent value was argued in prose and unearned by measurement.
**M8 was pre-registered too, after reading M1–M7 and before running it**: it
saturates the ring ordinal at a high but finite value, which is the mistake
#1349 refused to make at the counter, relocated to the picker. Predicted T3 only;
observed T3 only.

No test here is covered by a sibling: T1 is isolated by M2, T3 by M8, T2 is
separated from T3 by M7, T4 from the user-door tests by M5.

### The prediction that was wrong

The verdict was pre-registered before the lane. Under M3 — the write-side clamp,
i.e. exactly the regression #1349 refused to risk — the #93 tests were predicted
red. **They all stayed green.** Obvious in hindsight: #93 records 1–4 failures
and the clamp sits at 5.

That wrong prediction is the measurement that #1350's gap was real. Before this
branch, the only net under M3 was #1349's assertion **at the counter**; at the
consumer there was nothing.

## Declared limit: the ordering claim is borrowed (M6)

Flipping the ring order in `list_servers/1` **and** `pick_server!/2` in the same
round leaves all four new tests **green** — the 11 reds are pre-existing tests
that name hosts literally.

This is accepted and declared, not closed. The pin's subject is the ring's
**rotation past the knee**, not the server **order**; deriving the expected walk
from production buys immunity to drift at the price of being order-agnostic, and
the coordinated flip is already caught by another net. The ordering claim lives
in `list_servers/1 returns servers ordered by (priority asc, id asc)` and
`returns the lowest-priority enabled server, ties broken by id`.

Smaller blind spot, same class: every #1350 fixture ring is fully enabled, so a
mutant dropping the `enabled` filter from the picker would be invisible here.
`a disabled server is not a ring position` covers it, below the knee.

## Gates

`scripts/check.sh` green on the rebased tree — 8 doctests, 60 properties, 6317
tests, 0 failures, with format, Credo, Sobelow and Dialyzer in the same run. The
gate was taken **after** the rebase onto current `main`, so it covers the tree
that would be merged rather than the base the work started on.

Worth recording, because it cost a wrong diagnosis first: the initial run came
back with 3 reds, all on duplicate-user-name constraints
(`users_folded_name_index` raised while the changeset declares only
`users_name_index`). That index exists in **no migration on this branch** — the
shared test database carried 87 applied migrations with a max version this
branch does not ship. Moving the database aside (not deleting it) and re-running
the same three files on a regenerated one gave 81 tests / 0 failures, and the
regenerated database matched this branch exactly. Contamination of a shared
substrate, not a defect here — established by displacement rather than asserted.

## Not established

* T1's witness is **one-sided**: the ±25% jitter windows of the last rung below
  the knee and of the cap overlap, so "not yet capped one failure earlier" is
  not assertable without a flake.
* T3 asserts the ring's **shape** (every endpoint once per revolution), not its
  phase — M7 is the mutant that walks through that gap, and T2 is what catches
  it.
* No integration suite was run on this branch; CI is the arbiter there.
* No `DESIGN_NOTES.md` entry: #1349's entry already records the rationale this
  branch relies on (the counter stays unclamped because it is the ring ordinal).
  This branch changes no decision — it buys the evidence for one already taken.

## Deploy

**HOT**, and checked rather than assumed: each of the three changed paths was
matched against `Grappa.Deploy.Preflight`'s COLD predicates — `mix.exs`/
`mix.lock`, `lib/grappa/application.ex`, the Docker image set, the jail `rc.d`
script, the systemd unit, `priv/repo/migrations/*`, nginx, `config/*.exs`,
`VERSION`. None matches on any substrate, so the classifier yields `{:hot, []}`.
