### PR TITLE
sqlite(#1355): denominate the WAL checkpoint threshold in bytes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,6 +148,29 @@ if config_env() == :prod do
 
   config :grappa, :uploads_storage_root, uploads_storage_root
 
+  # #1355 — the WAL's steady-state byte envelope. ONE number, in BYTES,
+  # feeding both PRAGMAs below, because both express a byte-shaped intent:
+  #
+  #   * `journal_size_limit` takes bytes directly.
+  #   * `wal_autocheckpoint` takes PAGES, so `Grappa.Repo.init/2` divides this
+  #     by the DB file's LIVE `page_size` before the pool opens. NEVER pin a
+  #     page count here: `docs/zfs-baseline-2026-07-31.md` moved prod from
+  #     `page_size 4096` to `65536`, and the untouched 1000-page default
+  #     silently went from ~4 MiB to ~64 MiB.
+  #
+  # 16 MiB is a TUNING CHOICE, not a measurement, argued between two bounds:
+  # SQLite's own default was ~4 MiB here before the page-size change, but a
+  # 64 KiB page makes a one-row update dirty 16× more WAL bytes, so pinning
+  # 4 MiB would checkpoint far more often in wall-clock terms than this
+  # deployment ever did. 16 MiB keeps the checkpoint cadence in the same
+  # order as the pre-ZFS one while capping the WAL an order of magnitude
+  # below the 168 MiB observed in #1355 — and it is a whole number of pages
+  # at both 4096 and 65536, so no rounding either way.
+  #
+  # Deliberately NOT an env var: it is a tuning constant, not an operator
+  # knob, and every env var carries a registry/compose/.env.example tax.
+  wal_checkpoint_bytes = 16 * 1024 * 1024
+
   # NB: `:cic_dist_root` is derived ABOVE, hoisted out of this prod block
   # (all envs except :test) since #485 — see the comment there, which
   # folds in the #526 jail-CWD knowledge that used to live here.
@@ -188,7 +211,18 @@ if config_env() == :prod do
     # Insurance against future dep upgrades; zero runtime behavior
     # change today.
     synchronous: :normal,
-    foreign_keys: :on
+    foreign_keys: :on,
+    # #1355, same "defaults are right by accident" class as the two above —
+    # except here the default stopped being right the moment the page size
+    # changed. `wal_autocheckpoint` was never set (SQLite's 1000 pages), and
+    # `journal_size_limit` defaults to -1, meaning a checkpointed WAL is
+    # RECYCLED at its high-water mark rather than truncated — which is why
+    # prod's `-wal` reached 168 MiB and stayed there. Pinning the limit to
+    # the same envelope as the checkpoint threshold means the steady-state
+    # WAL is recycled with no truncate churn (it is already at that size),
+    # while a burst-grown one comes back down at the next reset.
+    wal_checkpoint_bytes: wal_checkpoint_bytes,
+    journal_size_limit: wal_checkpoint_bytes
 
   # Every missing-secret raise routes through here (#862). The per-site
   # messages used to name `scripts/mix.sh …`, which exists in exactly ONE of

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43271,3 +43271,57 @@ against a path it asserts absent beforehand, rather than reasoning about it.
 pending counts it OBSERVED, never "no pending migrations, nothing to do" — a
 pending count of zero is the silent regime's own signature, so a fast path
 that reports the absence of work would be reporting the defect as health.
+<!-- entry #1355 -->
+
+---
+
+## 2026-08-16 — #1355: the WAL checkpoint threshold is a byte count, derived at boot
+
+**The defect was a unit mismatch that a good change walked into.**
+`PRAGMA wal_autocheckpoint` counts PAGES. The ZFS baseline
+(`docs/zfs-baseline-2026-07-31.md`) moved prod from `page_size 4096` to
+`65536` to make one SQLite page land on exactly one ZFS record — right on its
+own terms — and the untouched 1000-page default went from ~4 MiB to ~64 MiB
+as a side effect. Nothing in `config/runtime.exs` mentioned either number, so
+there was no line to review and no line to change. Measured on prod in the
+issue: a 168 MiB `-wal` that had not reset since that morning.
+
+**So the config declares BYTES and the page count is derived, never pinned.**
+`config/runtime.exs` sets `wal_checkpoint_bytes`, and `Grappa.Repo.init/2`
+divides it by the DB file's LIVE `page_size` before the pool opens. Pinning a
+page count — even a correctly re-computed one — would leave the same trap
+armed for the next person who changes the page size, which is the whole point
+of the issue and not a detail of it. The derivation rounds UP because
+`wal_autocheckpoint = 0` does not checkpoint eagerly, it disables automatic
+checkpointing outright.
+
+**The derivation site is the #506 serial pre-pool connection, reused.** That
+connection already exists and already runs before any pool connection, for the
+rollback→WAL switch; the live `page_size` is one more PRAGMA read on it, and
+`init/2` returns the config the pool is then started with. Nothing else in the
+boot sequence can see the real page size — `runtime.exs` cannot open the file,
+and a per-connection hook would re-derive the same constant N times. `:runtime`
+stays pure, as #506 requires.
+
+**`journal_size_limit` is pinned to the same envelope, and that is a
+deliberate equality.** Its `-1` default means a checkpointed WAL is recycled at
+its high-water mark rather than truncated, which is why the prod file never
+came back down. Setting it equal to the checkpoint threshold means the
+steady-state WAL is already at the limit and truncation is a no-op — no
+truncate/regrow churn — while a burst-grown WAL is cut back at the next reset.
+
+**16 MiB is a tuning choice and is argued as one, not measured.** Two bounds:
+this deployment ran its whole life at SQLite's ~4 MiB effective threshold, but
+a 64 KiB page makes a single-row update dirty 16× more WAL bytes, so pinning
+4 MiB would checkpoint far more often in wall-clock terms than it ever did.
+16 MiB sits between them, caps the WAL an order of magnitude below the
+observed 168 MiB, and is a whole number of pages at both 4096 and 65536.
+
+**What this does NOT establish.** No before/after measurement was taken — there
+is no prod DB in this worktree, and the issue's figures are vjt-claude's. And
+a passive autocheckpoint is not a guarantee: it cannot reset a WAL while a
+reader still holds an older snapshot, and `journal_size_limit` only truncates
+when a reset actually happens. With `pool_size: 10` under continuous reads
+that is a real possibility, and it is the most likely reason prod's WAL was at
+168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
+the pressure and bounds the recovery; it does not promise a ceiling.

--- a/docs/zfs-baseline-2026-07-31.md
+++ b/docs/zfs-baseline-2026-07-31.md
@@ -24,6 +24,10 @@ stays in the tree for the day someone IS authorised to run it; **it was not run.
 | ZFS `recordsize` (DB dataset) | **128K** | 64K |
 | SQLite pages per ZFS record | **32** (128K ÷ 4K) | **1** (64K ÷ 64K) |
 
+> ⚠️ **`page_size` is not a storage-only knob — see
+> [What page_size also moves](#what-page_size-also-moves-1355) below before
+> changing it again.**
+
 Dataset `tank/bastille/jails/grappa/root` (the jail root, where the DB lives):
 
 | property | value | source |
@@ -85,6 +89,43 @@ Stated plainly so nobody over-reads it later:
   `SQLITE_BUSY` must not surface as a 500 — **not on a benchmark delta.** The
   storage migration and the busy-retry fix are two independent improvements that
   happen to touch the same symptom.
+
+---
+
+## What `page_size` also moves (#1355)
+
+**Added 2026-08-16, after the fact.** The migration above changed `page_size`
+for storage-alignment reasons and changed nothing else on purpose. It moved one
+more thing anyway, and it took two weeks and a 168 MiB WAL to notice:
+
+**`PRAGMA wal_autocheckpoint` counts PAGES, not bytes.** SQLite's default of
+1000 pages meant a passive checkpoint was attempted roughly every **4 MiB** at
+`page_size 4096`. At `65536` the same untouched default means roughly
+**64 MiB** — a 16× longer checkpoint interval, arrived at without changing a
+line of config, and precisely the opposite of the small-frequent-writes posture
+this migration was tuning for. `journal_size_limit`'s `-1` default compounded
+it: a checkpointed WAL is recycled at its high-water mark, never truncated, so
+the file only ever grew.
+
+**The cure, and the rule it leaves behind.** `config/runtime.exs` now pins the
+threshold in **BYTES** (`wal_checkpoint_bytes`, 16 MiB) alongside
+`journal_size_limit` (same value, so a burst-grown WAL comes back down), and
+`Grappa.Repo.init/2` divides it by the file's LIVE `page_size` on the #506
+serial pre-pool connection to get the page count the PRAGMA takes.
+
+> **So: never pin a page count.** Any SQLite setting denominated in pages
+> (`wal_autocheckpoint`, `cache_size` when positive, `mmap_size` interactions)
+> must be expressed in bytes and derived from the live `page_size`, or the next
+> page-size change moves it silently. `cache_size: -64_000` is already correct
+> by this rule — the negative form IS the byte form (KiB), which is why it did
+> not drift here.
+
+Numbers, and what they are not: 16 MiB is a **tuning choice argued in the
+#1355 PR**, not a measurement — no before/after was taken on prod. The
+reasoning and the limits are in `docs/DESIGN_NOTES.md` (2026-08-16, #1355),
+including the honest caveat that a passive checkpoint cannot reset a WAL while
+a reader holds an older snapshot, so the threshold bounds pressure rather than
+guaranteeing a ceiling.
 
 ---
 

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -38,23 +38,42 @@ defmodule Grappa.Repo do
   # out from under storage_up. See docs/DESIGN_NOTES.md 2026-07-31.
   @impl Ecto.Repo
   def init(context, config) do
-    if context == :supervisor, do: ensure_wal_journal!(config)
-    {:ok, config}
-  end
-
-  @spec ensure_wal_journal!(keyword()) :: :ok
-  defp ensure_wal_journal!(config) do
-    case Keyword.get(config, :database) do
-      path when is_binary(path) and path != "" and path != ":memory:" ->
-        switch_to_wal!(path, Keyword.get(config, :busy_timeout, 30_000))
-
-      _ ->
-        :ok
+    if context == :supervisor do
+      {:ok, prepare_database!(config)}
+    else
+      {:ok, config}
     end
   end
 
-  @spec switch_to_wal!(binary(), non_neg_integer()) :: :ok
-  defp switch_to_wal!(path, busy_timeout) when is_integer(busy_timeout) do
+  # Everything that must happen on ONE serial connection, before the pool (or
+  # `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) opens:
+  #
+  #   1. #506 — the rollback→WAL switch, once, so no two connections race it.
+  #   2. #1355 — read the file's LIVE `page_size`, so the byte-denominated WAL
+  #      checkpoint threshold can be turned into the page count that
+  #      `PRAGMA wal_autocheckpoint` actually takes.
+  #
+  # An in-memory or unnamed database has neither a WAL nor a meaningful page
+  # count, so it is left alone — including the `:wal_checkpoint_bytes` key,
+  # which exqlite ignores (it reads `:wal_auto_check_point`).
+  @spec prepare_database!(keyword()) :: keyword()
+  defp prepare_database!(config) do
+    case Keyword.get(config, :database) do
+      path when is_binary(path) and path != "" and path != ":memory:" ->
+        on_serial_connection!(path, Keyword.get(config, :busy_timeout, 30_000), fn conn ->
+          :ok = switch_to_wal!(conn, path)
+          derive_wal_autocheckpoint(config, page_size!(conn, path))
+        end)
+
+      _ ->
+        config
+    end
+  end
+
+  @spec on_serial_connection!(binary(), non_neg_integer(), (Exqlite.Sqlite3.db() -> result)) ::
+          result
+        when result: var
+  defp on_serial_connection!(path, busy_timeout, fun) when is_integer(busy_timeout) do
     # Mirror the pool connection's own connect path, which mkdir_p's the parent
     # (SQLITE_OPEN_CREATE does NOT create intermediary dirs) — a raw open on a
     # missing dir would otherwise fail here before we ever reach the pool.
@@ -67,28 +86,71 @@ defmodule Grappa.Repo do
       # exqlite's connect order (journal_mode before busy_timeout), the very
       # ordering that makes the per-connection switch race (#506).
       :ok = Exqlite.Sqlite3.execute(conn, "PRAGMA busy_timeout=#{busy_timeout}")
-      {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA journal_mode=WAL")
-      result = Exqlite.Sqlite3.step(conn, stmt)
-      :ok = Exqlite.Sqlite3.release(conn, stmt)
-
-      case result do
-        {:row, ["wal"]} ->
-          :ok
-
-        {:row, [other_mode]} ->
-          # PRAGMA journal_mode=WAL returns the PREVIOUS mode (no error) when the
-          # filesystem can't back WAL shared-memory (NFS/CIFS/some overlay FSes).
-          # grappa REQUIRES WAL (config/runtime.exs journal_mode: :wal + the #524
-          # BEGIN IMMEDIATE semantics), so fail LOUD over booting silently
-          # degraded — and name the cause.
-          raise "Grappa.Repo: #{path} could not switch to WAL (got #{inspect(other_mode)}) — " <>
-                  "the filesystem likely cannot back WAL shared-memory; grappa requires WAL."
-
-        other ->
-          raise "Grappa.Repo: unexpected result switching #{path} to WAL: #{inspect(other)}"
-      end
+      fun.(conn)
     after
       :ok = Exqlite.Sqlite3.close(conn)
+    end
+  end
+
+  @spec switch_to_wal!(Exqlite.Sqlite3.db(), binary()) :: :ok
+  defp switch_to_wal!(conn, path) do
+    {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA journal_mode=WAL")
+    result = Exqlite.Sqlite3.step(conn, stmt)
+    :ok = Exqlite.Sqlite3.release(conn, stmt)
+
+    case result do
+      {:row, ["wal"]} ->
+        :ok
+
+      {:row, [other_mode]} ->
+        # PRAGMA journal_mode=WAL returns the PREVIOUS mode (no error) when the
+        # filesystem can't back WAL shared-memory (NFS/CIFS/some overlay FSes).
+        # grappa REQUIRES WAL (config/runtime.exs journal_mode: :wal + the #524
+        # BEGIN IMMEDIATE semantics), so fail LOUD over booting silently
+        # degraded — and name the cause.
+        raise "Grappa.Repo: #{path} could not switch to WAL (got #{inspect(other_mode)}) — " <>
+                "the filesystem likely cannot back WAL shared-memory; grappa requires WAL."
+
+      other ->
+        raise "Grappa.Repo: unexpected result switching #{path} to WAL: #{inspect(other)}"
+    end
+  end
+
+  @spec page_size!(Exqlite.Sqlite3.db(), binary()) :: pos_integer()
+  defp page_size!(conn, path) do
+    {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA page_size")
+    result = Exqlite.Sqlite3.step(conn, stmt)
+    :ok = Exqlite.Sqlite3.release(conn, stmt)
+
+    case result do
+      {:row, [size]} when is_integer(size) and size > 0 ->
+        size
+
+      other ->
+        raise "Grappa.Repo: unexpected result reading page_size of #{path}: #{inspect(other)}"
+    end
+  end
+
+  # #1355 — `PRAGMA wal_autocheckpoint` counts PAGES; the threshold we mean is a
+  # number of BYTES, so it is divided by the file's live page size at boot. A
+  # pinned page count is exactly the defect this fixes: the ZFS baseline moved
+  # prod from `page_size 4096` to `65536` and multiplied the effective threshold
+  # by 16 without touching a line of config. Deriving keeps the BYTES fixed and
+  # lets the page count move, so the next page-size change cannot re-arm it.
+  #
+  # Rounds UP, and that matters: `wal_autocheckpoint = 0` does not checkpoint
+  # eagerly, it DISABLES automatic checkpointing outright.
+  #
+  # The exqlite option is spelled `:wal_auto_check_point` (four words) while the
+  # PRAGMA it sets is `wal_autocheckpoint` — see `Exqlite.Pragma`.
+  @spec derive_wal_autocheckpoint(keyword(), pos_integer()) :: keyword()
+  defp derive_wal_autocheckpoint(config, page_size) do
+    case Keyword.pop(config, :wal_checkpoint_bytes) do
+      {nil, config} ->
+        config
+
+      {bytes, config} when is_integer(bytes) and bytes > 0 ->
+        Keyword.put(config, :wal_auto_check_point, div(bytes + page_size - 1, page_size))
     end
   end
 

--- a/test/grappa/repo_wal_checkpoint_test.exs
+++ b/test/grappa/repo_wal_checkpoint_test.exs
@@ -1,0 +1,185 @@
+defmodule Grappa.RepoWalCheckpointTest do
+  @moduledoc """
+  #1355 — the WAL checkpoint threshold is expressed in BYTES and translated to
+  the page count `PRAGMA wal_autocheckpoint` takes by `Grappa.Repo.init/2`,
+  using the DB file's LIVE `page_size`.
+
+  The defect this pins: `wal_autocheckpoint` counts pages, so the ZFS baseline's
+  `page_size` 4096 → 65536 move (`docs/zfs-baseline-2026-07-31.md`) multiplied
+  the effective threshold by 16 without touching a line of config. A bare page
+  count leaves the same trap armed for the next page-size change; a byte
+  threshold divided by the live page size does not.
+
+  Pure unit test of the callback — no Repo/pool, no Sandbox, same shape as
+  `Grappa.RepoWalJournalTest`. `async: false`: the prod-config test mutates the
+  process-global OS env via `System.put_env`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Exqlite.Sqlite3
+
+  @runtime_exs Path.expand("../../config/runtime.exs", __DIR__)
+
+  # The prod block of `config/runtime.exs` raises on every missing secret, so a
+  # `Config.Reader` read of it needs the full mandatory set. Values are shaped
+  # only as far as the file inspects them: GRAPPA_ENCRYPTION_KEY is decoded with
+  # `Base.decode64!`, RELEASE_COOKIE must be neither blank nor the dev sentinel.
+  @prod_env %{
+    "PHX_HOST" => "grappa.example.test",
+    "DATABASE_PATH" => "/nonexistent/grappa_wal_checkpoint_test.db",
+    "SECRET_KEY_BASE" => String.duplicate("s", 64),
+    "RELEASE_COOKIE" => String.duplicate("c", 64),
+    "SECRET_SIGNING_SALT" => String.duplicate("t", 32),
+    "GRAPPA_ENCRYPTION_KEY" => Base.encode64(String.duplicate("k", 32)),
+    "VAPID_PUBLIC_KEY" => String.duplicate("p", 87),
+    "VAPID_PRIVATE_KEY" => String.duplicate("q", 43)
+  }
+
+  # A fresh database created at `page_size`, with one real table so the page
+  # size is committed to the file header (PRAGMA page_size only takes on an
+  # empty database).
+  defp db_with_page_size(page_size) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa_wal_ckpt_#{page_size}_#{System.unique_integer([:positive])}.db"
+      )
+
+    {:ok, conn} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(conn, "PRAGMA page_size=#{page_size}")
+    :ok = Sqlite3.execute(conn, "CREATE TABLE probe (x INTEGER)")
+    :ok = Sqlite3.close(conn)
+    on_exit(fn -> for suffix <- ["", "-wal", "-shm"], do: File.rm(path <> suffix) end)
+    path
+  end
+
+  defp init!(config) do
+    {:ok, config} = Grappa.Repo.init(:supervisor, config)
+    config
+  end
+
+  # `config/runtime.exs`'s `Grappa.Repo` block, read exactly as prod boot would.
+  defp prod_repo_config do
+    previous = Map.new(@prod_env, fn {name, _} -> {name, System.get_env(name)} end)
+    System.put_env(@prod_env)
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {name, nil} -> System.delete_env(name)
+        {name, value} -> System.put_env(name, value)
+      end)
+    end)
+
+    @runtime_exs
+    |> Config.Reader.read!(env: :prod)
+    |> get_in([:grappa, Grappa.Repo])
+  end
+
+  describe "byte → page derivation" do
+    test "the same byte threshold yields the same BYTES at either page size" do
+      # THE regression assertion: a bare page count would produce the same
+      # number twice and thus two thresholds 16× apart.
+      bytes = 16 * 1024 * 1024
+
+      for page_size <- [4096, 65_536] do
+        config =
+          init!(
+            database: db_with_page_size(page_size),
+            busy_timeout: 30_000,
+            wal_checkpoint_bytes: bytes
+          )
+
+        assert Keyword.fetch!(config, :wal_auto_check_point) * page_size == bytes
+      end
+    end
+
+    test "the byte-denominated key never reaches exqlite" do
+      config =
+        init!(
+          database: db_with_page_size(65_536),
+          busy_timeout: 30_000,
+          wal_checkpoint_bytes: 16 * 1024 * 1024
+        )
+
+      refute Keyword.has_key?(config, :wal_checkpoint_bytes)
+    end
+
+    test "a threshold below one page rounds UP to one, never to zero" do
+      # `wal_autocheckpoint = 0` disables automatic checkpointing outright, so
+      # a floor division here would turn a tiny threshold into no checkpoints
+      # at all — the opposite of what the number asks for.
+      config =
+        init!(
+          database: db_with_page_size(65_536),
+          busy_timeout: 30_000,
+          wal_checkpoint_bytes: 1024
+        )
+
+      assert Keyword.fetch!(config, :wal_auto_check_point) == 1
+    end
+
+    test "no threshold configured leaves exqlite's own default in force" do
+      config = init!(database: db_with_page_size(4096), busy_timeout: 30_000)
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "init(:runtime, _) derives nothing (config-lookup path stays pure)" do
+      path = db_with_page_size(65_536)
+
+      assert {:ok, config} =
+               Grappa.Repo.init(:runtime,
+                 database: path,
+                 busy_timeout: 30_000,
+                 wal_checkpoint_bytes: 16 * 1024 * 1024
+               )
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "an in-memory database is left alone" do
+      assert {:ok, config} =
+               Grappa.Repo.init(:supervisor,
+                 database: ":memory:",
+                 wal_checkpoint_bytes: 16 * 1024 * 1024
+               )
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+  end
+
+  describe "production configuration" do
+    test "prod pins the threshold in bytes and never as a page count" do
+      config = prod_repo_config()
+
+      assert Keyword.fetch!(config, :wal_checkpoint_bytes) > 0
+
+      # A `wal_auto_check_point` pinned in config IS the defect — it counts
+      # pages, so it silently changes meaning the next time page_size moves.
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "prod bounds the WAL at the same envelope it checkpoints at" do
+      # `journal_size_limit` is what makes a checkpointed WAL come back down
+      # instead of being recycled at its high-water mark (the -1 default).
+      config = prod_repo_config()
+
+      assert Keyword.fetch!(config, :journal_size_limit) ==
+               Keyword.fetch!(config, :wal_checkpoint_bytes)
+    end
+
+    test "prod's threshold is a whole number of pages at 4096 and at 65536" do
+      # Rounding up is a safety net, not the intent: the chosen constant should
+      # land on a page boundary at both the pre- and post-ZFS page size.
+      config = prod_repo_config()
+      bytes = Keyword.fetch!(config, :wal_checkpoint_bytes)
+
+      for page_size <- [4096, 65_536] do
+        derived =
+          init!(Keyword.put(config, :database, db_with_page_size(page_size)))
+
+        assert Keyword.fetch!(derived, :wal_auto_check_point) * page_size == bytes
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes the defect in #1355: `PRAGMA wal_autocheckpoint` counts **pages**, so the
ZFS baseline's `page_size` 4096 → 65536 move multiplied the effective checkpoint
threshold by 16 as a side effect, and `journal_size_limit = -1` meant the WAL
never came back down from its high-water mark.

## 🔴 This is a COLD deploy

The cure lives in `config/runtime.exs`. There is no hot path for it and no
attempt was made to invent one.

## What changed

- **`config/runtime.exs`** — one number, `wal_checkpoint_bytes = 16 MiB`, in
  BYTES, feeding both PRAGMAs. `journal_size_limit` takes bytes natively and is
  pinned to the same value.
- **`lib/grappa/repo.ex`** — `init(:supervisor, _)` reads the DB file's **live**
  `page_size` and divides, producing the page count the PRAGMA actually takes.
  It does this on the serial pre-pool connection that #506 already opens for the
  rollback→WAL switch, so no new connection and no new boot step. `:runtime`
  stays pure, as #506 requires.
- **Docs** — `docs/zfs-baseline-2026-07-31.md` gains a *What `page_size` also
  moves* section (with a pointer from the `page_size` table itself), so the
  coupling is written where the next person to change the page size will look;
  DESIGN_NOTES carries the decision record.

**A re-computed page count was rejected on purpose.** It would fix today's
number and leave the identical trap armed for the next `page_size` change,
which is the point of the issue rather than a detail of it. The invariant is:
never pin a page count; express the intent in bytes and derive.

## The rounding is load-bearing, not tidiness

The division rounds **UP**. `wal_autocheckpoint = 0` does not mean "checkpoint
constantly" — it **disables automatic checkpointing outright**. A floor division
with a large enough `page_size` and a small enough threshold would therefore
switch off the very mechanism this issue exists to repair, silently. That is the
same class of trap as the one being fixed, so it is guarded and tested rather
than assumed away.

## The number, and how it was arrived at

**16 MiB is a tuning choice, not a measurement.** I have no production DB in
this worktree; every figure in the issue is vjt-claude's, and I re-measured
none of them.

It is argued between two bounds:

- **Lower bound ~4 MiB.** That was the effective threshold here for the whole
  life of the deployment (SQLite's 1000-page default at `page_size 4096`), and
  nothing ever complained about it.
- **Why not simply restore it.** A 64 KiB page makes a single-row update dirty
  16× more WAL bytes than a 4 KiB one did. Pinning 4 MiB would therefore
  checkpoint far more often *in wall-clock terms* than this deployment has ever
  done — an over-correction in the opposite direction.
- **16 MiB** sits between them: it caps the WAL an order of magnitude below the
  168 MiB observed in the issue, keeps crash-recovery replay trivial, and is a
  whole number of pages at **both** 4096 and 65536, so the round-up never
  actually fires on the configured value.

`journal_size_limit` equal to the threshold is also deliberate: in steady state
the WAL is already at that size, so truncation is a no-op and there is no
truncate/regrow churn, while a burst-grown WAL is cut back at the next reset.

Deliberately **not** an env var — it is a tuning constant, not an operator knob,
and every env var carries the registry/compose/`.env.example` tax.

## What this does NOT establish

- **No before/after measurement.** The change is justified structurally, on the
  unit mismatch, not on a benchmark delta. Nobody should read a performance
  claim into it.
- **A lead I did not measure, flagged as a lead.** A passive autocheckpoint
  cannot reset the WAL while a reader still holds an older snapshot, and
  `journal_size_limit` only truncates when a reset actually happens. With a
  read-concurrent pool that could plausibly be part of why the observed WAL was
  much larger than the threshold alone predicts — but I did not measure it, I
  did not look at the live node, and I am attaching no numbers to it. If it
  holds up it is a separate issue, not this one.
- **Dev and test keep SQLite's default** (~4 MiB at their 4096 page size). The
  issue is prod-scoped and so is the pin.

## Gates

`scripts/check.sh` on the branch: **RC=0** — `8 doctests, 60 properties, 6322
tests, 0 failures`; Credo strict `found no issues` across 657 files; Dialyzer
`Total errors: 0`; Sobelow, doctor, deps.audit, wire-type drift gate and the
482-test bats suite all green. `mix format` produced no diff.
`scripts/design-notes-gate.sh` RC=0.

## The tests are not mirrors — measured

Nine new tests in `test/grappa/repo_wal_checkpoint_test.exs`, and two deliberate
mutants were run against them to prove they witness the defect rather than the
implementation:

| mutant | result |
|---|---|
| `div(bytes + page_size - 1, page_size)` → `div(bytes, page_size)` (drop the round-up) | **1 test, exactly 1 assertion**: `left: 0` — the value that disables checkpointing |
| the derivation → a bare `1000` (the defect itself) | **3 tests**, the load-bearing one reporting `left: 4096000, right: 16777216` — literally 4 MiB where 16 MiB was meant |

Both reverted; the tree is clean and the branch is the green source.

The decisive assertion is that the *same* config yields the *same BYTES* at both
4096 and 65536 — a bare page count produces the same number twice and therefore
two thresholds 16× apart, which is exactly the bug. A second test reads the real
prod block of `config/runtime.exs` through `Config.Reader` and fails if prod
ever pins `wal_auto_check_point` directly.