### PR TITLE
e2e(#1336): instruments slice — an absence that proves its stimulus, a barrier that waits for the effect

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1148,6 +1148,30 @@ export async function closeSettings(page: Page): Promise<void> {
 // test meaningful: on desktop `.shell-members` is the permanent rail and never
 // leaves the viewport. That is not a new constraint — the backdrop this clicks
 // exists only on mobile.
+//
+// MEASURED, webkit-iphone-15, 10/10 repeats, clocked from the backdrop click
+// (untracked probe: a rAF sampler armed BEFORE the click recording the drawer's
+// `getBoundingClientRect().left`, its `getAnimations().length` and the `.open`
+// class, against a driver-side stamp of when the barrier returned):
+//
+//   * `.open` disappears at t = 44–67 ms;
+//   * the drawer's box is fully past the right edge at t = 238–263 ms, and the
+//     transition reports finished at t = 254–285 ms;
+//   * this barrier returns at t = 441–490 ms.
+//
+// So the margin between "the barrier lets go" and "the drawer stops covering
+// the tap point" is −207…−193 ms on the class (ALWAYS negative — the caller is
+// free to tap while the panel is still over it, and only the driver's own
+// ~200 ms of latency usually covered the gap, which is exactly why the same sha
+// passed and failed) and +193…+230 ms here (always positive).
+//
+// The #1050 worry does not materialise: `getBoundingClientRect` was measured
+// there reporting the settled transform early, and IntersectionObserver could
+// have done the same. It does not — but note what is and is not proven. The
+// 441–490 ms is when the ASSERTION RETURNED, which is an upper bound on when
+// its condition was satisfied; the IO callback itself was not instrumented. The
+// claim earned here is operational, and it is the one that matters: the
+// earliest a caller can act is ~178 ms after the drawer is provably clear.
 export async function closeMembersDrawer(page: Page): Promise<void> {
   await page.locator(".shell-drawer-backdrop.open").click({ position: { x: 20, y: 200 } });
   await expect(page.locator(".shell-members")).not.toBeInViewport({ timeout: 5_000 });

--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1121,9 +1121,36 @@ export async function closeSettings(page: Page): Promise<void> {
 // which is timing-flaky on WebKit. `.click()` fires the synthetic
 // click directly via DevTools — same end-state effect, no synthesis
 // race. Verified across UX-6-A scroll spec + UX-4-Z journey spec.
+// #1336 (#1155) — the wait is `not.toBeInViewport` on the drawer ITSELF, not
+// `.shell-members.open` count→0. Same idiom, same reason, as `closeSettings`
+// above: the drawer stays MOUNTED and closing only strips `.open`, which
+// STARTS a 200ms `transform: translateX(100%)` slide (`default.css` ~:7469),
+// so the class is gone at the slide's BEGINNING and the panel keeps covering
+// the tap point for the rest of it.
+//
+// Measured on `ux-5-bt-narrow-chrome-compression.spec.ts:124`
+// (webkit-iphone-15, run 31325751959 attempt 2 — the same sha passed on
+// attempt 1, `workers: 1`, `retries: 0`): class gone at 18:17:56.09, the next
+// tap dispatched at 18:17:56.297 at (355, 31) — inside the drawer's 288px box
+// on a 393px viewport — and 10 ms later the SERVER logged
+// `HANDLED open_query_window target_nick="m9b-grappa"`. The touch aimed at the
+// topic-bar hamburger was received by a members row, which opens a query and
+// switches focus; a DM window has no members drawer, so the assertion waited
+// out its 5 s on a `.shell-members.open` that could never exist again. The
+// barrier and the hazard are the same order of magnitude — ~196 ms of driver
+// latency against a 200 ms animation — so the margin is zero by construction.
+//
+// Playwright cannot see this on its own: its "visible, enabled and stable"
+// check runs on the TARGET's box, and the hamburger never moves. The thing
+// moving is the drawer on top of it.
+//
+// Every caller is a mobile `@webkit` spec, which is what makes the viewport
+// test meaningful: on desktop `.shell-members` is the permanent rail and never
+// leaves the viewport. That is not a new constraint — the backdrop this clicks
+// exists only on mobile.
 export async function closeMembersDrawer(page: Page): Promise<void> {
   await page.locator(".shell-drawer-backdrop.open").click({ position: { x: 20, y: 200 } });
-  await expect(page.locator(".shell-members.open")).toHaveCount(0, { timeout: 5_000 });
+  await expect(page.locator(".shell-members")).not.toBeInViewport({ timeout: 5_000 });
 }
 
 // #473 — reach the grouped ArchiveModal (viewport-aware), the SINGLE archive

--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -36,6 +36,8 @@
 
 import { type BrowserContext, expect, type Page } from "@playwright/test";
 import { openSettingsSection } from "./cicchettoPage";
+import { assertMessagePersisted } from "./grappaApi";
+import { assertNoPushAfterStimulus } from "./pushAbsence";
 
 const PUSH_CATCHER_URL = process.env.E2E_PUSH_CATCHER_URL ?? "http://push-catcher:3000";
 
@@ -318,17 +320,88 @@ export async function awaitPushDelivery(
 }
 
 /**
- * Asserts NO deliveries have landed for `id` by the end of `windowMs`.
- * Used by dedup + prefs-whitelist specs where the absence of a push
- * is the contract (focused-window suppress; unmatched channel skip).
+ * The message whose push must NOT arrive — and the proof it reached
+ * grappa in the first place.
+ *
+ * `window` is the REST scrollback segment the row is readable under:
+ * the channel name for a channel message, the PEER's nick for a peer
+ * DM (the CP14-B3 aggregation shape — probing our own nick hits the
+ * own-nick narrowing path and misses peer-originated DMs).
+ */
+export type PushStimulus = {
+  token: string;
+  networkSlug: string;
+  window: string;
+  sender: string;
+  body: string;
+};
+
+/**
+ * Asserts NO deliveries have landed for `id` by the end of `windowMs`,
+ * AFTER proving that the message whose push is forbidden actually
+ * reached grappa. Used by the suppress/mute specs where the absence of
+ * a push is the contract (focused-window suppress; unmatched channel
+ * skip; muted conversation).
+ *
+ * The stimulus is a REQUIRED argument, not a convention: #1152 measured
+ * a peer DM that never arrived at all (a ghost-nick collision sent it to
+ * a name nobody was registered under), and on an absence assertion that
+ * is a silent pass — no message, no trigger, no push, contract
+ * "satisfied" without the suppression ever being exercised. Making the
+ * proof part of the signature is what stops the next spec author from
+ * omitting it. Rationale + the unit-tested core: `pushAbsence.ts`.
  *
  * windowMs is intentionally short (default 1.5s) — Sender's hot path
  * is fire-and-forget but the eval+POST round-trip is sub-100ms when
  * it does fire, so a 1.5s window catches everything that *would*
  * have fired without dragging the suite. Pass a higher window only
- * if a real regression demonstrates a slower path.
+ * if a real regression demonstrates a slower path. It is now clocked
+ * from the delivery proof rather than from the call, so it can no
+ * longer expire before the push it forbids could have fired.
  */
-export async function assertNoPushDelivery(id: string, windowMs = 1_500): Promise<void> {
+export async function assertNoPushDelivery(
+  id: string,
+  stimulus: PushStimulus,
+  windowMs = 1_500,
+): Promise<void> {
+  await assertNoPushAfterStimulus(
+    {
+      stimulusDelivered: () =>
+        assertMessagePersisted({
+          token: stimulus.token,
+          networkSlug: stimulus.networkSlug,
+          channel: stimulus.window,
+          sender: stimulus.sender,
+          body: stimulus.body,
+        }),
+      deliveryCount: async () => {
+        const res = await fetch(`${PUSH_CATCHER_URL}/received/${encodeURIComponent(id)}`);
+        if (!res.ok) return 0;
+        return ((await res.json()) as CatcherResponse).deliveries.length;
+      },
+    },
+    {
+      id,
+      stimulus: `<${stimulus.sender}> "${stimulus.body}" → ${stimulus.window}`,
+      windowMs,
+      pollMs: 100,
+    },
+  );
+}
+
+/**
+ * Asserts an id NOBODY ever sent to stays empty — the push-catcher
+ * partitioning check, not a suppression check.
+ *
+ * Deliberately NOT the same door as `assertNoPushDelivery`: there is no
+ * stimulus to prove here, because the whole point is that no message was
+ * ever addressed to this id. Its positive control is the real delivery
+ * the same test already awaited on the id under test — a Sender that
+ * fanned out to every known endpoint would land on both. Uniforming this
+ * onto the barriered signature would mean inventing a stimulus that does
+ * not exist, which is how an honest assertion becomes a decorative one.
+ */
+export async function assertNoPushDeliveryOnUnusedId(id: string, windowMs = 1_500): Promise<void> {
   const deadline = Date.now() + windowMs;
   while (Date.now() < deadline) {
     const res = await fetch(`${PUSH_CATCHER_URL}/received/${encodeURIComponent(id)}`);
@@ -336,7 +409,7 @@ export async function assertNoPushDelivery(id: string, windowMs = 1_500): Promis
       const body = (await res.json()) as CatcherResponse;
       if (body.deliveries.length > 0) {
         throw new Error(
-          `assertNoPushDelivery: expected zero, saw ${body.deliveries.length} for id=${id}`,
+          `assertNoPushDeliveryOnUnusedId: expected zero, saw ${body.deliveries.length} for id=${id}`,
         );
       }
     }

--- a/cicchetto/e2e/fixtures/pushAbsence.test.ts
+++ b/cicchetto/e2e/fixtures/pushAbsence.test.ts
@@ -1,0 +1,96 @@
+// #1336 — the absence assertion is the instrument seven push specs are judged
+// by, so it has to be able to FAIL for the right reason. Runs under the cic
+// vitest project (same reason, same shape as `scrollGesture.test.ts` and
+// `whoisWait.test.ts`): the logic is deliberately free of `fetch`, so it is
+// provable without a testnet.
+//
+// The case that matters is the one MEASURED on #1152: the peer's DM never
+// reached grappa at all (0 occurrences of the peer nick in a 240 MB
+// `grappa-test.log` that carried 135 902 message INSERTs, so the instrument
+// was sound). On the POSITIVE spec that event was a loud 5 s timeout. On an
+// absence assertion the very same event is a silent PASS — the suppression
+// under test is never exercised, and nobody finds out.
+
+import { describe, expect, it } from "vitest";
+import { assertNoPushAfterStimulus, type PushAbsenceProbes } from "./pushAbsence";
+
+const SPEC = { id: "964-device-row", stimulus: "<n964-dmer> hi → s0ddba11", pollMs: 1 };
+
+// A catcher whose delivery count walks the given script, one entry per read.
+// The last entry repeats, so a script models "…and stays that way".
+function fakeProbes(
+  counts: readonly number[],
+  opts: { stimulus?: () => Promise<void> } = {},
+): { calls: string[]; probes: PushAbsenceProbes } {
+  const calls: string[] = [];
+  let reads = 0;
+  return {
+    calls,
+    probes: {
+      stimulusDelivered: async () => {
+        calls.push("stimulus");
+        if (opts.stimulus) await opts.stimulus();
+      },
+      deliveryCount: async () => {
+        const value = counts[Math.min(reads, counts.length - 1)] ?? 0;
+        reads += 1;
+        calls.push(`count:${value}`);
+        return value;
+      },
+    },
+  };
+}
+
+async function failureOf(assertion: Promise<unknown>): Promise<string> {
+  try {
+    await assertion;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected the assertion to reject, but it resolved");
+}
+
+describe("#1336 — assertNoPushAfterStimulus", () => {
+  it("proves the stimulus reached grappa BEFORE it opens the absence window", async () => {
+    const { calls, probes } = fakeProbes([0]);
+    await assertNoPushAfterStimulus(probes, { ...SPEC, windowMs: 5 });
+    // `calls[0]`, deliberately not `indexOf("stimulus") < indexOf("count:")`.
+    // The first draft of this witness SURVIVED the mutant that deletes the
+    // proof outright: `indexOf` answers -1 for a call that never happened, and
+    // -1 is less than 0, so "never asked" read as "asked first". A witness
+    // satisfied by the absence of the thing it witnesses is the very defect
+    // this module exists to refuse.
+    expect(calls[0]).toBe("stimulus");
+  });
+
+  it("REJECTS when the stimulus never reached grappa — the silence would prove nothing", async () => {
+    const { probes } = fakeProbes([0], {
+      stimulus: () => Promise.reject(new Error("assertMessagePersisted: timeout after 5000ms")),
+    });
+    expect(await failureOf(assertNoPushAfterStimulus(probes, { ...SPEC, windowMs: 5 }))).toContain(
+      "never reached grappa",
+    );
+  });
+
+  it("fails on a delivery that lands LATE inside the window", async () => {
+    // Two, so an off-by-one `> 1` guard cannot be what catches this one.
+    const { probes } = fakeProbes([0, 0, 0, 2]);
+    expect(
+      await failureOf(assertNoPushAfterStimulus(probes, { ...SPEC, windowMs: 200 })),
+    ).toContain("saw 2");
+  });
+
+  it("fails on a SINGLE delivery", async () => {
+    const { probes } = fakeProbes([1]);
+    expect(await failureOf(assertNoPushAfterStimulus(probes, { ...SPEC, windowMs: 5 }))).toContain(
+      "saw 1",
+    );
+  });
+
+  it("resolves when the stimulus landed and nothing was pushed", async () => {
+    const { probes } = fakeProbes([0]);
+    await expect(
+      assertNoPushAfterStimulus(probes, { ...SPEC, windowMs: 5 }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/cicchetto/e2e/fixtures/pushAbsence.ts
+++ b/cicchetto/e2e/fixtures/pushAbsence.ts
@@ -1,0 +1,78 @@
+// #1336 (#1117 + #1152) — an absence that can only pass for the right reason.
+//
+// Seven specs in the push/mute family assert that NO push was delivered, and
+// each one's stimulus is a bare `peer.privmsg(...)` — fire-and-forget, with no
+// barrier that the message ever reached grappa. Measured on #1152: it does not
+// always. On run 31324253590 the peer's DM went to a nick nobody was
+// registered under (a 7 ms teardown/reconnect left bahamut holding the ghost,
+// and grappa's #604 reconcile correctly adopted `vjt-grappa_`), and the peer
+// nick appears ZERO times in that run's 240 MB `grappa-test.log` — a log
+// carrying 135 902 message INSERTs, so the instrument was sound and the
+// absence was real.
+//
+// On the POSITIVE spec that event is a loud 5 s `awaitPushDelivery` timeout.
+// On the six negative ones the SAME event is a silent green: no message, no
+// trigger, no push, assertion satisfied. The suppression under test is never
+// exercised. That is the difference between "the apparatus was on" and "the
+// stimulus was delivered" — every one of those specs proves the first (a real
+// delivery elsewhere in the test), none proved the second.
+//
+// So the contract here is: prove the stimulus reached grappa, THEN watch for
+// silence — and fail, naming the stimulus, when the proof cannot be had. The
+// order is load-bearing in both directions. A window opened before the message
+// lands can expire before the push it is meant to forbid could ever have
+// fired, which is a second way to pass without observing anything.
+//
+// Free of `fetch` by construction (the caller adapts the push-catcher and the
+// scrollback REST view to `PushAbsenceProbes`) for the reason `whoisWait.ts`
+// gives: the instrument a claim is judged by has to be provable itself.
+
+export type PushAbsenceProbes = {
+  // Resolves once the stimulus is provably in grappa's scrollback; rejects
+  // with the reason when it is not.
+  stimulusDelivered(): Promise<void>;
+  // Deliveries the push-catcher has recorded for the subscription so far.
+  deliveryCount(): Promise<number>;
+};
+
+export type PushAbsenceSpec = {
+  // Push-catcher subscription id the silence is asserted over.
+  readonly id: string;
+  // Human-readable stimulus, quoted back on failure so the reader sees WHICH
+  // message was supposed to arrive.
+  readonly stimulus: string;
+  // How long silence must hold, clocked from the delivery proof.
+  readonly windowMs: number;
+  readonly pollMs: number;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function assertNoPushAfterStimulus(
+  probes: PushAbsenceProbes,
+  spec: PushAbsenceSpec,
+): Promise<void> {
+  const { id, stimulus, windowMs, pollMs } = spec;
+
+  try {
+    await probes.stimulusDelivered();
+  } catch (cause) {
+    throw new Error(
+      `assertNoPushAfterStimulus: the stimulus never reached grappa, so the absence of a push ` +
+        `for id=${id} proves nothing — ${stimulus}\n  cause: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+    );
+  }
+
+  const deadline = Date.now() + windowMs;
+  while (Date.now() < deadline) {
+    const count = await probes.deliveryCount();
+    if (count > 0) {
+      throw new Error(
+        `assertNoPushAfterStimulus: expected zero, saw ${count} for id=${id} — ${stimulus}`,
+      );
+    }
+    await sleep(pollMs);
+  }
+}

--- a/cicchetto/e2e/tests/issue1038-mute-is-per-network.spec.ts
+++ b/cicchetto/e2e/tests/issue1038-mute-is-per-network.spec.ts
@@ -200,8 +200,19 @@ test("a mute made on one network leaves the same channel on the other still push
     await setPageVisibility(page, false);
 
     // Arm 1 — a MENTION on the MUTED network. Silent.
-    peerA.privmsg(SHARED_CHANNEL, `${OWN_NICK}: you will not hear this one`);
-    await assertNoPushDelivery(SUB_ID, 1_500);
+    const mutedBody = `${OWN_NICK}: you will not hear this one`;
+    peerA.privmsg(SHARED_CHANNEL, mutedBody);
+    await assertNoPushDelivery(
+      SUB_ID,
+      {
+        token: user.token,
+        networkSlug: MUTE1038_NETWORK_A,
+        window: SHARED_CHANNEL,
+        sender: peerA.nick,
+        body: mutedBody,
+      },
+      1_500,
+    );
 
     // Arm 2 — the identical mention, same channel NAME, other network. This is
     // the assertion the pre-#1038 key fails: with a network-blind mute the

--- a/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
+++ b/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
@@ -130,8 +130,19 @@ test("a one-hour snooze picked from the rail silences the channel and says how l
 
     // Negative arm — a MENTION inside the snoozed hour. The server compares the
     // integer this client wrote against its own clock and holds the push.
-    peer.privmsg(SNOOZED_CHANNEL, `${specNick()}: not for the next hour`);
-    await assertNoPushDelivery(SUB_ID, 1_500);
+    const snoozedBody = `${specNick()}: not for the next hour`;
+    peer.privmsg(SNOOZED_CHANNEL, snoozedBody);
+    await assertNoPushDelivery(
+      SUB_ID,
+      {
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        window: SNOOZED_CHANNEL,
+        sender: peer.nick,
+        body: snoozedBody,
+      },
+      1_500,
+    );
 
     // Positive arm — the same shape in the unmuted sibling, so the negative arm
     // cannot be passing because push broke outright.

--- a/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
+++ b/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
@@ -106,8 +106,19 @@ test("a muted channel swallows even a direct mention, while its unmuted sibling 
     await setPageVisibility(page, false);
 
     // Negative arm — a MENTION in the muted channel. Pre-#866 this pushed.
-    peer.privmsg(MUTED_CHANNEL, `${specNick()}: you will not hear this`);
-    await assertNoPushDelivery(SUB_ID, 1_500);
+    const mutedBody = `${specNick()}: you will not hear this`;
+    peer.privmsg(MUTED_CHANNEL, mutedBody);
+    await assertNoPushDelivery(
+      SUB_ID,
+      {
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        window: MUTED_CHANNEL,
+        sender: peer.nick,
+        body: mutedBody,
+      },
+      1_500,
+    );
 
     // Positive arm — the same mention shape in the unmuted sibling. This is
     // what keeps the negative arm from passing because push broke outright.

--- a/cicchetto/e2e/tests/push-focus-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-focus-suppression.spec.ts
@@ -69,8 +69,15 @@ test("server delivers push once the window is blurred though still on-screen, su
     // matches #182's visible case). setPageFocus blocks until WSPresence
     // acked present=true, so the DM can't race the focus update.
     await setPageFocus(page, true);
-    peer.privmsg(specNick(), "you are looking at the app — no toast please");
-    await assertNoPushDelivery(SUB_ID);
+    const focusedBody = "you are looking at the app — no toast please";
+    peer.privmsg(specNick(), focusedBody);
+    await assertNoPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: focusedBody,
+    });
 
     // Phase 2 — visible but BLURRED (still on-screen, keyboard focus lost).
     // #192: presence is now false → the server MUST deliver. Pre-fix this
@@ -86,8 +93,15 @@ test("server delivers push once the window is blurred though still on-screen, su
     // Phase 3 — REFOCUS (still visible) → suppression restored.
     await resetPushCatcher();
     await setPageFocus(page, true);
-    peer.privmsg(specNick(), "back in focus — suppress again");
-    await assertNoPushDelivery(SUB_ID);
+    const refocusedBody = "back in focus — suppress again";
+    peer.privmsg(specNick(), refocusedBody);
+    await assertNoPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: refocusedBody,
+    });
   } finally {
     await peer.disconnect("#192 focus-suppression done");
   }

--- a/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
@@ -66,8 +66,15 @@ test("server suppresses push while a device reports visible, delivers once hidde
     // whole fan-out; push-catcher sees nothing. setPageVisibility blocks
     // until WSPresence has acked visible=true, so the DM can't race it.
     await setPageVisibility(page, true);
-    peer.privmsg(specNick(), "you are looking at the app — no toast please");
-    await assertNoPushDelivery(SUB_ID);
+    const visibleBody = "you are looking at the app — no toast please";
+    peer.privmsg(specNick(), visibleBody);
+    await assertNoPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: visibleBody,
+    });
 
     // Phase 2 — device HIDDEN (backgrounded). The server MUST now deliver.
     await resetPushCatcher();

--- a/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
+++ b/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
@@ -108,8 +108,19 @@ test("notification_prefs whitelist: messages in allow-list push, messages elsewh
     // Negative path FIRST — peer talks in OTHER, no mention. No push
     // expected because: channel_messages_all=false, channel_mentions=false,
     // channel_messages_only doesn't include #b5-other.
-    peer.privmsg(OTHER_CHANNEL, "small talk in other");
-    await assertNoPushDelivery(SUB_ID, 1_500);
+    const otherBody = "small talk in other";
+    peer.privmsg(OTHER_CHANNEL, otherBody);
+    await assertNoPushDelivery(
+      SUB_ID,
+      {
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        window: OTHER_CHANNEL,
+        sender: peer.nick,
+        body: otherBody,
+      },
+      1_500,
+    );
 
     // Positive path — peer talks in ALLOW, no mention. Push expected
     // because channel_messages_only includes #b5-allow.

--- a/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
@@ -36,7 +36,7 @@ import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
-  assertNoPushDelivery,
+  assertNoPushDeliveryOnUnusedId,
   awaitPushDelivery,
   enablePushFromSettings,
   expectRfc8291Delivery,
@@ -116,12 +116,17 @@ test("channel mention while push-enabled fires Sender → push-catcher receives 
     // path includes the per-spec id we minted.
     // (verified by push-catcher partitioning by id; recurrence here
     // would only show up as zero deliveries on the WRONG id, which
-    // is a stronger negative caught by assertNoPushDelivery below.)
+    // is a stronger negative caught by the unused-id check below.)
 
     // Negative cross-check: a never-used id sees zero deliveries —
     // proves push-catcher partitioning + Sender targeting (no
     // accidental fan-out to all known endpoints).
-    await assertNoPushDelivery("channel-mention-unrelated");
+    //
+    // #1336 — deliberately NOT the barriered `assertNoPushDelivery`. There is
+    // no stimulus to prove for an id nobody ever sent to; its positive control
+    // is the real delivery on SUB_ID above, which a fan-out bug would have
+    // duplicated here.
+    await assertNoPushDeliveryOnUnusedId("channel-mention-unrelated");
   } finally {
     await peer.disconnect("B5 channel-mention done");
     await partChannel(vjt.token, NETWORK_SLUG, TARGET_CHANNEL).catch(() => {});


### PR DESCRIPTION
## Summary

The instruments slice of #1336 — the four reports the epic groups as "barriers
and samplers that do not straddle what they claim to": #1155, #1119, #1117,
#1152.

The first job was to measure whether those four are one mechanism or several,
because the epic's body proposes "a shared helper that proves its own
liveness". They are **not** one. Two commits here; the measurement below is why
there are two and not four, and not one.

## The measurement: three mechanisms, and one of them is already dead

Static measurement of the four sites on `origin/main` @ `68dbaba2`, against the
chain every instrument depends on — pre-state → stimulus → effect →
observation.

| report | broken link | state on `68dbaba2` |
|---|---|---|
| #1119 | the pre-state was never captured before the stimulus | **already cured** |
| #1155 | the effect is awaited on a PROXY that fires at its START | open — 1 fixture site, 4 caller specs |
| #1117 + #1152 | the absence is unfalsifiable: nothing proves the thing whose absence is asserted could have been observed | open — 3 + 7 sites |

Each breaks a different link, so no single helper can serve them. What IS shared
is the discipline, not the code: an instrument must be able to fail for the
right reason. The same conclusion the gesture slice (#1339) reached from the
other end.

### #1119 is closed, and the epic's own table is stale on that row

`waitForProbeBaseline` landed in `e825cbea` (2026-08-14, *after* the report was
filed) and takes the sampler's baseline frame before the perturbation is
dispatched. Verified by sha, not by reading the issue: `e825cbea` is an ancestor
of `origin/main` **and of the `v1.2.0` tag** — so the cure is not merely on main,
it has shipped. Nothing in this PR touches it. Recorded here because the row in
#1336's table still describes it as open, and the next reader deserves to know
before spending a lane on it.

## Commit 1 — `#1117` and `#1152` are the same defect, and the push family is where it lives

#1117 filed three negative assertions with no positive control. #1152 filed a
push spec that timed out non-deterministically. They are the same defect seen
from two sides.

`assertNoPushDelivery` had eight call sites. Seven assert the absence of a push
for a specific `peer.privmsg(...)` — fire-and-forget, with **no barrier that the
message ever reached grappa**. On #1152's run `31324253590` it did not: a 7 ms
teardown/reconnect left bahamut holding the ghost nick, grappa's #604 reconcile
correctly adopted `vjt-grappa_`, and the peer's DM went to a name nobody was
registered under. The peer nick appears ZERO times in that run's 240 MB
`grappa-test.log` — a log carrying 135 902 message INSERTs, so the instrument
was sound and the absence was real.

On the POSITIVE spec that event is a loud 5 s timeout. On the negative ones the
SAME event is a silent green: no message, no trigger, no push, contract
"satisfied" with the suppression never exercised. The positive spec is the
accidental positive control that revealed the class.

Measured honestly, because it is what keeps this a finding rather than an alarm:
**all seven tests DO contain a real delivery elsewhere**, so each proves the
peer→grappa→push path was live at some point during the test. **None proved that
the specific message whose push must be absent ever arrived.** That is the
difference between "the apparatus was on" and "the stimulus was delivered", and
only the second one makes the silence mean something.

So the stimulus is now a **required argument, not a convention**: a caller cannot
invoke the absence without naming the message, and the helper fails — naming it —
when the proof cannot be had. The window is also clocked FROM the proof rather
than from the call, which closes a second way to pass without observing
anything: a window opened before the message lands can expire before the push it
forbids could ever have fired.

### The eighth call site is deliberately kept out

`channel-mention-unrelated` is a partition check on an id nobody ever sent to.
There is no stimulus to prove, and its positive control is the real delivery the
same test already awaited on the id under test — a Sender that fanned out to
every known endpoint would have landed on both. Forcing it onto the barriered
signature would mean inventing a stimulus that does not exist, which is how an
honest assertion becomes a decorative one. It gets its own door,
`assertNoPushDeliveryOnUnusedId`, whose name says which contract it serves.

### Deliberately NOT fixed

#1152's other spec-side defect — addressing the subject by `specNick()`, the
REQUESTED nick, rather than the live registered one. The barrier's whole job is
to turn that failure from a silent green into a named red. Repairing the address
in the same change would delete the evidence before anyone sees it.

## Commit 2 — `closeMembersDrawer` waits for the drawer to LEAVE

#1155's barrier awaits `.shell-members.open` count→0. The drawer stays mounted
and closing only strips `.open`, which STARTS a 200 ms
`transform: translateX(100%)` slide — so the barrier releases at the BEGINNING
of the animation and the panel keeps covering the tap point for the rest of it.

Measured on `ux-5-bt-narrow-chrome-compression.spec.ts:124` (webkit-iphone-15,
run `31325751959` attempt 2; the same sha passed on attempt 1, `workers: 1`,
`retries: 0`, nothing concurrent): class gone at 18:17:56.09, next tap dispatched
at 18:17:56.297 at (355, 31) — inside the drawer's 288 px box on a 393 px
viewport — and 10 ms later the SERVER logged
`HANDLED open_query_window target_nick="m9b-grappa"`. The touch aimed at the
topic-bar hamburger was received by a members row, which opens a query and
switches focus; a DM window has no members drawer, so `.shell-members.open`
never existed again and the assertion spent its full 5 s.

**No new idiom.** This is `closeSettings`'s close-side wait —
`await expect(drawer).not.toBeInViewport()` — a few lines up in the same file,
applied to the drawer this helper closes. That file already carries the
mechanism three times: `closeSettings` (with the "count→0 returns at the slide's
START" comment), `openMembersDrawer` (`toBeInViewport({ratio: 1})`, "the instant
it stops moving under the next click"), and `openAdminConsole`, which narrates
the same 200 ms hazard and how it was removed structurally.
`closeMembersDrawer` was the last drawer door still waiting on the class.

The locator drops `.open` deliberately: the class is what disappears first, so a
viewport test keyed to it would assert about a locator that matches nothing.
Every caller is a mobile `@webkit` spec, which is what makes the viewport test
meaningful — on desktop `.shell-members` is the permanent rail. Not a new
constraint: the backdrop this helper clicks exists only on mobile.

## The witness that survived its own mutant

Worth more than any green in this PR, and it is the epic's own disease found
inside the instrument written to cure it.

The ordering witness was first written as
`expect(calls.indexOf("stimulus")).toBeLessThan(calls.findIndex(isCount))`.
`indexOf` answers **-1** for a call that never happened, and **-1 is less than
0** — so "the proof was never demanded" read as "the proof was demanded first".
The mutant that deletes the proof outright killed 1 test instead of the 2 that
were predicted, and the surviving one was the very assertion claiming to cover
the ordering.

It now asserts `calls[0]`, with the trap written down beside it. A witness
satisfied by the absence of the thing it witnesses is exactly what #1336 exists
to refuse.

## Mutation, one mutant at a time

| mutant | tests killed |
|---|---|
| the stimulus proof is never demanded | **2** |
| the stimulus rejection is swallowed | 1 |
| `count > 0` becomes `count > 1` | 1 |
| one poll instead of the whole window | 1 |
| the window opens BEFORE the proof | 1 |

The logic is free of `fetch` by construction (`pushAbsence.ts`; the caller adapts
the push-catcher and the scrollback REST view), for the reason `whoisWait.ts`
gives: the instrument a claim is judged by has to be provable itself. TDD, red
read by name: `Failed to resolve import "./pushAbsence" from
"e2e/fixtures/pushAbsence.test.ts"`.

## The in-situ positive control

A green suite does not show the barrier does anything, so the barrier was made
to fail on purpose — by reproducing #1152's MEASURED failure rather than a
lookalike. `push-foreground-suppression`'s peer DMs `${specNick()}-ghost`, a
nick nobody is registered under: bahamut answers the peer 401, irc-framework
ignores it, and grappa never sees the message. Two arms, same injected stimulus,
differing only in the absence idiom.

| arm | idiom at the call site | result |
|---|---|---|
| A | the pre-#1336 bare absence poll | **1 passed (14.1 s)** |
| B | the #1336 barriered assert | **1 failed** |

Arm B names it:

```
Error: assertNoPushAfterStimulus: the stimulus never reached grappa, so the
absence of a push for id=foreground-suppression proves nothing —
<fg-suppressor> "you are looking at the app — no toast please" → fg-suppressor
```

Arm A's green is the point of the exercise: it re-exhibits, on demand, the exact
state the old idiom passed on. Arm A's helper is not a stand-in — it is the old
function's body, unchanged, now living under the honest name
`assertNoPushDeliveryOnUnusedId`.

## The #1155 barrier, measured

webkit-iphone-15, 10/10 repeats, clocked from the backdrop click. Untracked
probe: a rAF sampler armed BEFORE the click (the #1119 lesson applied to the
probe itself) recording the drawer's `left`, `getAnimations().length` and the
`.open` class, against a driver-side stamp of the barrier's return.

| instant | t (ms from click) |
|---|---|
| `.open` disappears — the OLD barrier's release | 44–67 |
| the drawer's box is fully past the right edge | 238–263 |
| the transition reports finished | 254–285 |
| `not.toBeInViewport` returns | 441–490 |

Margin between "the barrier lets go" and "the drawer stops covering the tap
point": **−207…−193 ms on the class, +193…+230 ms on the conversion.** Every
repeat, both signs consistent.

The negative number is #1155's mechanism quantified. The class releases roughly
a fifth of a second before the panel is out of the way, and what usually saved
the suite was the driver's own ~200 ms of latency happening to cover the gap —
not a margin, a coincidence holding two comparable quantities apart. Which is
why one sha passed on attempt 1 and failed on attempt 2.

## Gates

- **8 push/mute specs, chromium — 8 passed (49.3 s), RC=0.** The seven converted
  call sites plus `push-trigger-channel-mention`; `push-964-device-row` (#1152's
  own spec, unmodified here) ran alongside and passed. Nothing turned red, which
  is why the control above exists.
- `scripts/bun.sh run check` — **RC=0** (biome + tsc over `src` AND `e2e`), after
  every commit.
- `scripts/bun.sh run test` — **5496 passed / 285 files**, RC=0.

Not run: the full `scripts/integration.sh`. This is a targeted set on the specs
this PR touches, not the ship gate.

## What I have NOT established

- **That IntersectionObserver reports honestly mid-transition.** 441–490 ms is
  when the ASSERTION RETURNED — an upper bound on when its condition was
  satisfied. The IO callback itself was not instrumented. What is established is
  operational and is what #1155 needs: the earliest a caller can act is ~178 ms
  after the drawer is provably clear.
- **That the conversion fixes #1155's red.** The natural failure was never
  reproduced — it is a ~1-in-many on a hosted runner. What is shown is that the
  barrier no longer releases while the panel covers the tap point.
- **Whether the ghost-nick trigger behind #1152 still fires post-#1078.** Per-spec
  subjects removed the nick recycling that gave that run 612 opportunities; the
  structural gap survives, the trigger's current rate is unmeasured. The eight
  specs passing here says nothing about it: on this host the stimulus arrived
  every time.
- **The three original #1117 sites are untouched** — `issue160-virtual-tab-no-cursor`,
  `channel-directory`, `ux-5-bu-unread-focus`. They are the same mechanism in cic
  HTTP recorders rather than in the push family, and they were not part of this
  slice's ruling. One of them carries a boundary worth a decision before anyone
  starts: `channel-directory`'s recorder is keyed on the `$list` messages path, so
  a positive control **on the same predicate is impossible** — provoking it means
  provoking the very request the assertion forbids. A weaker control (record all
  `/messages`, assert the `$list` subset empty and the total non-zero) proves the
  listener is attached, not that the exact predicate would match. I have not
  judged that acceptable.
- **No rates.** Nothing here estimates how often any of this fires.
