### PR TITLE
cic(#1358): stop the frame seam from moving the focused composer

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -657,17 +657,32 @@ const ComposeBox: Component<Props> = (props) => {
           visual: aria-hidden, because a live region that changes on every
           keystroke is noise, and the thing worth ANNOUNCING (the draft will
           split) is the polite seam line below. */}
-      <Show when={frameCountdown()} keyed>
-        {(label) => (
-          <p
-            class="compose-box-frame-countdown"
-            data-testid="compose-frame-countdown"
-            aria-hidden="true"
-          >
-            {label}
-          </p>
-        )}
-      </Show>
+      {/* #1358 — the slot is ALWAYS mounted; only its content comes and goes.
+          The countdown used to be a bare `Show` among the root fragment's
+          children, and when it arrived in the same flush the split warning
+          left — the draft shrinking back under the frame limit — Solid
+          reconciled the fragment by DETACHING the <form> and re-attaching it
+          after the new sibling. The focused textarea rode along, and a
+          detached element loses the focus with nobody calling blur(): on iOS
+          that closes the keyboard mid-edit. A stable parent keeps the
+          appear/disappear inside this slot, where the form is not a sibling.
+          Measured in ComposeBoxFrameSeam.test.tsx over all eight seam
+          transitions; only that one moved the form, and only downward.
+          The node identity of the textarea is NOT the oracle — Solid handed
+          back the same node object across the move, focus already gone. */}
+      <div class="compose-box-frame-countdown-slot">
+        <Show when={frameCountdown()} keyed>
+          {(label) => (
+            <p
+              class="compose-box-frame-countdown"
+              data-testid="compose-frame-countdown"
+              aria-hidden="true"
+            >
+              {label}
+            </p>
+          )}
+        </Show>
+      </div>
       <form
         class={`compose-box${greyed() ? " compose-box-greyed" : ""}`}
         onSubmit={(e) => {

--- a/cicchetto/src/__tests__/ComposeBoxFrameSeam.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBoxFrameSeam.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #1358 — the iOS SYMPTOM is the keyboard closing as a draft shrinks back
+// under the single-frame limit. The MECHANISM under it is DOM node movement:
+// a focused element that leaves the DOM loses the focus in EVERY browser,
+// with nobody calling `blur()`. Solid's reconciliation is plain
+// `removeChild`/`insertBefore` on the same nodes in every DOM, so the
+// mechanism is measurable in jsdom and is measured here; only the keyboard
+// consequence needs a device, and vjt has already measured that one.
+//
+// Its own file, not a block in ComposeBox.test.tsx: that file mocks
+// `../lib/compose` wholesale, so the draft there is a constant and the seams
+// cannot be CROSSED — and the crossing is the entire subject. Here the
+// compose store, the frame budget and the ISUPPORT table are the real ones,
+// and the draft moves the way a thumb moves it: `input` on the textarea.
+//
+// Only `../lib/networks` is stubbed, and only `networkBySlug`: the view looks
+// the published budget up under a network id, and that store is fed by an
+// HTTP resource.
+vi.mock("../lib/networks", async () => {
+  const actual = await vi.importActual<typeof import("../lib/networks")>("../lib/networks");
+  return {
+    ...actual,
+    networkBySlug: (slug: string) => ({
+      kind: "user" as const,
+      id: NETWORK_ID,
+      slug,
+      nick: "vjt",
+      inserted_at: "",
+      updated_at: "",
+      connection_state: "connected",
+      connection_state_reason: null,
+      connection_state_changed_at: null,
+    }),
+  };
+});
+
+import ComposeBox from "../ComposeBox";
+import { channelKey } from "../lib/channelKey";
+import { setDraft } from "../lib/compose";
+import { frameBudgetForTarget } from "../lib/frameBudget";
+import { DEFAULT_ISUPPORT, seedIsupport } from "../lib/isupport";
+
+const NETWORK_ID = 7;
+const SLUG = "azzurra";
+const CHANNEL = "#a";
+const FRAME_BUDGET_BASE = 393;
+
+const BUDGET = frameBudgetForTarget(FRAME_BUDGET_BASE, CHANNEL) as number;
+
+// Drafts sized off the production budget, never off a literal. A single `x`
+// run holds no space to break on, so the split is the plain byte cut.
+const room = (bytes: number) => "x".repeat(BUDGET - bytes);
+const over = (bytes: number) => "x".repeat(BUDGET + bytes);
+
+const countdownOf = (root: ParentNode) =>
+  root.querySelector("[data-testid=compose-frame-countdown]");
+const splitWarningOf = (root: ParentNode) => root.querySelector(".compose-box-warning");
+
+// What is on the seam, as a pair of booleans: the countdown above the form,
+// the split warning below it.
+const seamsUp = (root: ParentNode) => ({
+  countdown: countdownOf(root) !== null,
+  warning: splitWarningOf(root) !== null,
+});
+
+type Crossing = {
+  label: string;
+  from: string;
+  to: string;
+  before: { countdown: boolean; warning: boolean };
+  after: { countdown: boolean; warning: boolean };
+};
+
+// Every transition the two seams can make, not just the one vjt's thumb
+// found. The bug is a property of how the root fragment reconciles, so the
+// invariant is stated over the whole class: NO seam transition may move the
+// composer out from under the focus.
+const CROSSINGS: Crossing[] = [
+  {
+    label: "countdown appears, no split on either side",
+    from: room(200),
+    to: room(3),
+    before: { countdown: false, warning: false },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "countdown value changes inside the band (its <p> is keyed)",
+    from: room(3),
+    to: room(2),
+    before: { countdown: true, warning: false },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "countdown disappears, no split on either side",
+    from: room(3),
+    to: room(200),
+    before: { countdown: true, warning: false },
+    after: { countdown: false, warning: false },
+  },
+  {
+    label: "up over the limit: countdown out above, warning in below",
+    from: room(3),
+    to: over(1),
+    before: { countdown: true, warning: false },
+    after: { countdown: false, warning: true },
+  },
+  {
+    label: "down under the limit: warning out below, countdown in above",
+    from: over(1),
+    to: room(3),
+    before: { countdown: false, warning: true },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "split warning appears alone, out of the countdown band",
+    from: room(200),
+    to: over(1),
+    before: { countdown: false, warning: false },
+    after: { countdown: false, warning: true },
+  },
+  {
+    label: "split warning disappears alone, out of the countdown band",
+    from: over(1),
+    to: room(200),
+    before: { countdown: false, warning: true },
+    after: { countdown: false, warning: false },
+  },
+  {
+    label: "split warning text changes, two frames to three",
+    from: over(1),
+    to: over(BUDGET),
+    before: { countdown: false, warning: true },
+    after: { countdown: false, warning: true },
+  },
+];
+
+describe("#1358 — no frame-seam transition may unmount the focused composer", () => {
+  beforeEach(() => {
+    seedIsupport(NETWORK_ID, { ...DEFAULT_ISUPPORT, frameBudgetBase: FRAME_BUDGET_BASE });
+    setDraft(channelKey(SLUG, CHANNEL), "");
+  });
+
+  for (const crossing of CROSSINGS) {
+    it(`keeps the focus: ${crossing.label}`, () => {
+      setDraft(channelKey(SLUG, CHANNEL), crossing.from);
+      const { container } = render(() => <ComposeBox networkSlug={SLUG} channelName={CHANNEL} />);
+
+      const textarea = container.querySelector("textarea");
+      if (textarea === null) throw new Error("no composer textarea rendered");
+      const form = container.querySelector("form");
+      if (form === null) throw new Error("no composer form rendered");
+      textarea.focus();
+
+      // Pre-state, asserted rather than assumed: the seams really are where
+      // this row says they are and the focus really is on the box. Without
+      // it a row could pass having crossed nothing.
+      expect(seamsUp(container)).toEqual(crossing.before);
+      expect(document.activeElement).toBe(textarea);
+
+      // The gesture: one `input`, the way a keystroke or a deletion reports.
+      // The form is watched across it, because Solid can hand the same node
+      // object back after having detached and re-attached it — node identity
+      // alone is a blind oracle here (measured: same node, focus gone).
+      let formDetached = false;
+      const observer = new MutationObserver(() => {});
+      observer.observe(container, { childList: true, subtree: true });
+      fireEvent.input(textarea, { target: { value: crossing.to } });
+      for (const record of observer.takeRecords()) {
+        for (const node of Array.from(record.removedNodes)) {
+          if (node === form || node.contains(form)) formDetached = true;
+        }
+      }
+      observer.disconnect();
+
+      // The crossing really happened.
+      expect(seamsUp(container)).toEqual(crossing.after);
+
+      // The measurement. The focus is the oracle that matters — a detached
+      // and re-attached composer keeps its node identity and loses the
+      // keyboard — and the detach is reported alongside it so a red says
+      // WHY, not just that.
+      expect({ formDetached, focused: document.activeElement === textarea }).toEqual({
+        formDetached: false,
+        focused: true,
+      });
+    });
+  }
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43368,3 +43368,73 @@ when a reset actually happens. With `pool_size: 10` under continuous reads
 that is a real possibility, and it is the most likely reason prod's WAL was at
 168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
 the pressure and bounds the recovery; it does not promise a ceiling.
+<!-- entry #1358 -->
+
+---
+
+## 2026-08-16 — #1358: a seam sibling moved the composer, and node identity is a blind oracle
+
+vjt's report was an iOS one: deleting characters from a draft that is over the
+single-frame limit closes the keyboard as the draft crosses back under it. The
+mechanism underneath is not iOS and not a `blur()` — nothing in `ComposeBox`
+calls one. `ComposeBox`'s root is a fragment whose children are, in order: the
+byte countdown, the `<form>`, the uploads block, the greyed line, the feedback
+seam. Crossing the limit DOWNWARD flips two of those in the same flush — the
+split warning leaves below the form, the countdown arrives above it — and
+Solid reconciled that by DETACHING the form and re-attaching it after the new
+sibling. The focused textarea rode along inside it, and a detached element
+loses the focus in every engine, with nobody calling anything.
+
+**Measured, not reasoned: one transition out of eight.** `MutationObserver`
+over the container, the gesture a single `input` on the textarea, the compose
+store and frame budget the real ones. The countdown appearing, changing value
+inside the band or disappearing on its own: clean. The split warning
+appearing, disappearing or changing its text on its own: clean. The crossing
+UPWARD — countdown out above, warning in below: clean. Only the DOWNWARD
+crossing moves the form, which is exactly the direction a deleting thumb
+travels, and exactly why the report named deletion.
+
+**The node-identity oracle the issue proposed is a FALSE NEGATIVE.** Across
+that transition Solid hands back the SAME `<textarea>` and the SAME `<form>`
+object: an assert that the node did not change passes while the keyboard is
+already gone. The oracle is `document.activeElement`, and the detach is worth
+reporting beside it so a red says why. This generalises past this box — for
+any "did my focus survive the re-render" question, node identity answers a
+different question than the one being asked.
+
+**cic unit tests have a real DOM, and this class of bug is measurable there.**
+`vitest.config.ts` runs `environment: "jsdom"`, and jsdom resets
+`document.activeElement` to `<body>` when the focused node leaves the document.
+Solid reconciles with plain `removeChild`/`insertBefore` on the same nodes in
+every DOM, so the movement and the focus loss are both engine-independent and
+neither needs a browser or a device. Only the keyboard consequence is iOS's,
+and that half stays vjt's device-verify. An issue that says a DOM measurement
+needs e2e is describing the host it was written on, not this repo.
+
+**The fix is a stable parent, not a stable node count.** The `Show` now sits
+inside an always-mounted `div`, so the appear/disappear happens where the form
+is not a sibling. Two alternatives were measured and rejected. An
+always-mounted `<p>` whose text merely empties — the shape the issue suggested
+— also measures clean, but the defect is the identity of the node in the slot
+rather than the number of slots, and that shape additionally changes an
+unrelated observable contract ("hidden means the node is absent"), costing two
+green assertions elsewhere; the slot leaves the component's observable
+behaviour identical except for the bug. A `fallback` on the existing `Show` is
+WORSE, and measurably so: it breaks the upward crossing too, because swapping
+the node in the slot is the very thing that relocates the form.
+
+**Re-focusing after the fact stays forbidden.** It papers over a DOM move
+instead of preventing it, and it fights the UX-6-D `preventScroll` history in
+`composeAppend.ts`.
+
+**The empty slot is layout-inert, checked rather than assumed.** An
+always-mounted child consumes a `gap` even at zero height, which would be a
+permanent phantom space above the box. Its only parent is `.drop-upload-zone`
+(both `ComposeBox` mount sites are inside it), `display:flex;
+flex-direction:column` with no `gap` or `row-gap`, and `themes/default.css` —
+the one stylesheet — carries no `:empty` rule anywhere. The slot therefore
+needs no CSS rule and has none.
+
+**Not established:** that the slot is visually inert in a real engine (the
+check above is static), and the detach-to-keyboard chain on iOS, which remains
+vjt's device measurement.


### PR DESCRIPTION
## What was measured

vjt's report (#1358) is iOS: deleting characters from a draft that is over the
single-frame limit closes the keyboard as the draft crosses back under it. The
mechanism is not iOS. `ComposeBox`'s root is a fragment; the byte countdown is
a sibling ABOVE the `<form>`, the split warning a sibling BELOW it. Crossing
the limit downward flips both in the same flush, and Solid reconciled that by
**detaching the form and re-attaching it** after the new sibling. The focused
textarea rode along inside it, and a detached element loses the focus in every
engine with nobody calling `blur()` — which is why no `blur()` is findable in
the source.

Traced with a `MutationObserver` over the container:

```
REMOVED: FORM   (with the focused textarea inside)
ADDED:   P      (the countdown arrives above)
REMOVED: P      (the split warning leaves below)
ADDED:   FORM   (the SAME node object goes back)
```

### One transition out of eight, and it is the reported one

| transition | form detached | focus kept |
|---|---|---|
| countdown appears / changes value / disappears, alone | no | yes |
| split warning appears / disappears / changes text, alone | no | yes |
| **up** over the limit (countdown out above, warning in below) | no | yes |
| **down** under the limit (warning out below, countdown in above) | **yes** | **no** |

Asymmetric, and the asymmetry matches the report: a deleting thumb travels
downward.

### Two premises in the issue were wrong

- **"jsdom is broken here and cic tests run `--environment node`" is false for
  this repo.** `cicchetto/vitest.config.ts:14` sets `environment: "jsdom"`, and
  jsdom resets `document.activeElement` to `<body>` when the focused node
  leaves the document. Solid reconciles with plain `removeChild`/`insertBefore`
  in every DOM, so the movement and the focus loss are engine-independent.
  **No e2e, no browser and no device were needed to measure this.**
- **The issue's oracle (1) — "the textarea is the SAME node object before and
  after" — is a FALSE NEGATIVE.** Measured: across that transition Solid hands
  back the same `<textarea>` and the same `<form>`, so an identity assert
  passes with the keyboard already gone. The oracle is `document.activeElement`;
  the detach is reported beside it so a red says why.

## The change

`ComposeBoxFrameSeam.test.tsx` — its own file, because `ComposeBox.test.tsx`
mocks `lib/compose` wholesale, so the draft there is a constant and the seams
cannot be *crossed*, which is the entire subject. Here the compose store, the
frame budget and the ISUPPORT table are real; only `networkBySlug` is stubbed.
The invariant is stated over the **class** — no seam transition may unmount the
focused composer — so all eight rows are pinned, not just the reported gesture.
Each row asserts its pre-state before the gesture, so a row cannot pass having
crossed nothing. Committed red first (7 green, 1 red on the downward crossing).

`ComposeBox.tsx` — the countdown `Show` now sits inside an always-mounted
`div`, so the appear/disappear happens where the form is not a sibling.

### Alternatives measured and rejected

- **An always-mounted `<p>` whose text merely empties** (the issue's
  suggestion): also clean on all eight, but the defect is the identity of the
  node in the slot, not the number of slots — and this shape additionally
  changes an unrelated observable contract ("hidden means the node is absent"),
  turning two currently-green assertions in `ComposeBox.test.tsx` red. The slot
  leaves observable behaviour identical except for the bug.
- **A `fallback` on the existing `Show`**: measurably WORSE — it breaks the
  upward crossing too, because swapping the node in the slot is the very thing
  that relocates the form.
- **Re-focusing after the fact**: not attempted. It papers over a DOM move
  instead of preventing it and fights the UX-6-D `preventScroll` history
  (`composeAppend.ts:26`).

### The empty slot consumes no gap — checked, not assumed

An always-mounted child consumes a flex/grid `gap` even at zero height, which
would be a permanent phantom space above the box. Both `ComposeBox` mount sites
are inside `DropUploadZone`, so the fragment's only parent is
`.drop-upload-zone` (`themes/default.css:1394`): `display:flex;
flex-direction:column`, **no `gap`, no `row-gap`**. That file is the only
stylesheet in the codebase and contains **no `:empty` rule anywhere**. The slot
therefore carries no CSS rule and needs none.

## Gates

- `scripts/bun.sh run test` — **5499/5499 green**, 285 files, including the
  eight new rows. Zero churn on existing assertions.
- `scripts/bun.sh run check` (biome + `tsc --noEmit` over `src` and `e2e`) — RC 0.
- `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present.
- No Elixir, no `VERSION`, no `mix.exs`, no migrations touched, so no server
  gate applies.

**Deploy class: cic bundle only** (`scripts/deploy-m42.sh --cic`) — verified,
not asserted: `git diff --name-only origin/main...HEAD` is two files under
`cicchetto/` and one under `docs/`. A server hot-reload would not ship this at
all.

## What this does NOT establish

- **That the slot is visually inert in a real engine.** The gap/`:empty` check
  above is static; no browser was driven (and none can be driven from this
  host).
- **The detach-to-keyboard chain on iOS.** What is established here is that the
  form is detached and the focus is lost. That this is what closes vjt's
  keyboard remains **vjt's device-verify**, still owed.