### PR TITLE
union: #1353 name fold + #1355 WAL byte threshold + #1350 ring rotation pin

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,6 +148,29 @@ if config_env() == :prod do
 
   config :grappa, :uploads_storage_root, uploads_storage_root
 
+  # #1355 — the WAL's steady-state byte envelope. ONE number, in BYTES,
+  # feeding both PRAGMAs below, because both express a byte-shaped intent:
+  #
+  #   * `journal_size_limit` takes bytes directly.
+  #   * `wal_autocheckpoint` takes PAGES, so `Grappa.Repo.init/2` divides this
+  #     by the DB file's LIVE `page_size` before the pool opens. NEVER pin a
+  #     page count here: `docs/zfs-baseline-2026-07-31.md` moved prod from
+  #     `page_size 4096` to `65536`, and the untouched 1000-page default
+  #     silently went from ~4 MiB to ~64 MiB.
+  #
+  # 16 MiB is a TUNING CHOICE, not a measurement, argued between two bounds:
+  # SQLite's own default was ~4 MiB here before the page-size change, but a
+  # 64 KiB page makes a one-row update dirty 16× more WAL bytes, so pinning
+  # 4 MiB would checkpoint far more often in wall-clock terms than this
+  # deployment ever did. 16 MiB keeps the checkpoint cadence in the same
+  # order as the pre-ZFS one while capping the WAL an order of magnitude
+  # below the 168 MiB observed in #1355 — and it is a whole number of pages
+  # at both 4096 and 65536, so no rounding either way.
+  #
+  # Deliberately NOT an env var: it is a tuning constant, not an operator
+  # knob, and every env var carries a registry/compose/.env.example tax.
+  wal_checkpoint_bytes = 16 * 1024 * 1024
+
   # NB: `:cic_dist_root` is derived ABOVE, hoisted out of this prod block
   # (all envs except :test) since #485 — see the comment there, which
   # folds in the #526 jail-CWD knowledge that used to live here.
@@ -188,7 +211,18 @@ if config_env() == :prod do
     # Insurance against future dep upgrades; zero runtime behavior
     # change today.
     synchronous: :normal,
-    foreign_keys: :on
+    foreign_keys: :on,
+    # #1355, same "defaults are right by accident" class as the two above —
+    # except here the default stopped being right the moment the page size
+    # changed. `wal_autocheckpoint` was never set (SQLite's 1000 pages), and
+    # `journal_size_limit` defaults to -1, meaning a checkpointed WAL is
+    # RECYCLED at its high-water mark rather than truncated — which is why
+    # prod's `-wal` reached 168 MiB and stayed there. Pinning the limit to
+    # the same envelope as the checkpoint threshold means the steady-state
+    # WAL is recycled with no truncate churn (it is already at that size),
+    # while a burst-grown one comes back down at the next reset.
+    wal_checkpoint_bytes: wal_checkpoint_bytes,
+    journal_size_limit: wal_checkpoint_bytes
 
   # Every missing-secret raise routes through here (#862). The per-site
   # messages used to name `scripts/mix.sh …`, which exists in exactly ONE of

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43314,3 +43314,57 @@ window leaves the DM listener with no subscription at all, so every inbound DM
 collapses into the self window. Its root is a guard that suppresses the install
 regardless of who holds the key, not a hold never released, and closing it needs
 a precedence rule between two loops that nobody has specified — filed as #1365.
+<!-- entry #1355 -->
+
+---
+
+## 2026-08-16 — #1355: the WAL checkpoint threshold is a byte count, derived at boot
+
+**The defect was a unit mismatch that a good change walked into.**
+`PRAGMA wal_autocheckpoint` counts PAGES. The ZFS baseline
+(`docs/zfs-baseline-2026-07-31.md`) moved prod from `page_size 4096` to
+`65536` to make one SQLite page land on exactly one ZFS record — right on its
+own terms — and the untouched 1000-page default went from ~4 MiB to ~64 MiB
+as a side effect. Nothing in `config/runtime.exs` mentioned either number, so
+there was no line to review and no line to change. Measured on prod in the
+issue: a 168 MiB `-wal` that had not reset since that morning.
+
+**So the config declares BYTES and the page count is derived, never pinned.**
+`config/runtime.exs` sets `wal_checkpoint_bytes`, and `Grappa.Repo.init/2`
+divides it by the DB file's LIVE `page_size` before the pool opens. Pinning a
+page count — even a correctly re-computed one — would leave the same trap
+armed for the next person who changes the page size, which is the whole point
+of the issue and not a detail of it. The derivation rounds UP because
+`wal_autocheckpoint = 0` does not checkpoint eagerly, it disables automatic
+checkpointing outright.
+
+**The derivation site is the #506 serial pre-pool connection, reused.** That
+connection already exists and already runs before any pool connection, for the
+rollback→WAL switch; the live `page_size` is one more PRAGMA read on it, and
+`init/2` returns the config the pool is then started with. Nothing else in the
+boot sequence can see the real page size — `runtime.exs` cannot open the file,
+and a per-connection hook would re-derive the same constant N times. `:runtime`
+stays pure, as #506 requires.
+
+**`journal_size_limit` is pinned to the same envelope, and that is a
+deliberate equality.** Its `-1` default means a checkpointed WAL is recycled at
+its high-water mark rather than truncated, which is why the prod file never
+came back down. Setting it equal to the checkpoint threshold means the
+steady-state WAL is already at the limit and truncation is a no-op — no
+truncate/regrow churn — while a burst-grown WAL is cut back at the next reset.
+
+**16 MiB is a tuning choice and is argued as one, not measured.** Two bounds:
+this deployment ran its whole life at SQLite's ~4 MiB effective threshold, but
+a 64 KiB page makes a single-row update dirty 16× more WAL bytes, so pinning
+4 MiB would checkpoint far more often in wall-clock terms than it ever did.
+16 MiB sits between them, caps the WAL an order of magnitude below the
+observed 168 MiB, and is a whole number of pages at both 4096 and 65536.
+
+**What this does NOT establish.** No before/after measurement was taken — there
+is no prod DB in this worktree, and the issue's figures are vjt-claude's. And
+a passive autocheckpoint is not a guarantee: it cannot reset a WAL while a
+reader still holds an older snapshot, and `journal_size_limit` only truncates
+when a reset actually happens. With `pool_size: 10` under continuous reads
+that is a real possibility, and it is the most likely reason prod's WAL was at
+168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
+the pressure and bounds the recovery; it does not promise a ceiling.

--- a/docs/zfs-baseline-2026-07-31.md
+++ b/docs/zfs-baseline-2026-07-31.md
@@ -24,6 +24,10 @@ stays in the tree for the day someone IS authorised to run it; **it was not run.
 | ZFS `recordsize` (DB dataset) | **128K** | 64K |
 | SQLite pages per ZFS record | **32** (128K ÷ 4K) | **1** (64K ÷ 64K) |
 
+> ⚠️ **`page_size` is not a storage-only knob — see
+> [What page_size also moves](#what-page_size-also-moves-1355) below before
+> changing it again.**
+
 Dataset `tank/bastille/jails/grappa/root` (the jail root, where the DB lives):
 
 | property | value | source |
@@ -85,6 +89,43 @@ Stated plainly so nobody over-reads it later:
   `SQLITE_BUSY` must not surface as a 500 — **not on a benchmark delta.** The
   storage migration and the busy-retry fix are two independent improvements that
   happen to touch the same symptom.
+
+---
+
+## What `page_size` also moves (#1355)
+
+**Added 2026-08-16, after the fact.** The migration above changed `page_size`
+for storage-alignment reasons and changed nothing else on purpose. It moved one
+more thing anyway, and it took two weeks and a 168 MiB WAL to notice:
+
+**`PRAGMA wal_autocheckpoint` counts PAGES, not bytes.** SQLite's default of
+1000 pages meant a passive checkpoint was attempted roughly every **4 MiB** at
+`page_size 4096`. At `65536` the same untouched default means roughly
+**64 MiB** — a 16× longer checkpoint interval, arrived at without changing a
+line of config, and precisely the opposite of the small-frequent-writes posture
+this migration was tuning for. `journal_size_limit`'s `-1` default compounded
+it: a checkpointed WAL is recycled at its high-water mark, never truncated, so
+the file only ever grew.
+
+**The cure, and the rule it leaves behind.** `config/runtime.exs` now pins the
+threshold in **BYTES** (`wal_checkpoint_bytes`, 16 MiB) alongside
+`journal_size_limit` (same value, so a burst-grown WAL comes back down), and
+`Grappa.Repo.init/2` divides it by the file's LIVE `page_size` on the #506
+serial pre-pool connection to get the page count the PRAGMA takes.
+
+> **So: never pin a page count.** Any SQLite setting denominated in pages
+> (`wal_autocheckpoint`, `cache_size` when positive, `mmap_size` interactions)
+> must be expressed in bytes and derived from the live `page_size`, or the next
+> page-size change moves it silently. `cache_size: -64_000` is already correct
+> by this rule — the negative form IS the byte form (KiB), which is why it did
+> not drift here.
+
+Numbers, and what they are not: 16 MiB is a **tuning choice argued in the
+#1355 PR**, not a measurement — no before/after was taken on prod. The
+reasoning and the limits are in `docs/DESIGN_NOTES.md` (2026-08-16, #1355),
+including the honest caveat that a passive checkpoint cannot reset a WAL while
+a reader holds an older snapshot, so the threshold bounds pressure rather than
+guaranteeing a ceiling.
 
 ---
 

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -83,6 +83,7 @@ defmodule Grappa.Accounts do
       Grappa.Accounts.Revocations,
       Grappa.Ecto.Like,
       Grappa.EncryptedBinary,
+      Grappa.IRC,
       Grappa.Repo,
       Grappa.Visitors.Visitor
     ],
@@ -92,9 +93,11 @@ defmodule Grappa.Accounts do
 
   alias Grappa.Accounts.{Passkey, RecoveryCodes, Revocations, Session, TOTP, TOTPRecoveryCode, User}
   alias Grappa.Ecto.Like
+  alias Grappa.IRC.Identifier
   alias Grappa.Repo
   alias Grappa.Visitors.Visitor
 
+  require Identifier
   require Logger
 
   @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
@@ -106,10 +109,11 @@ defmodule Grappa.Accounts do
   Creates a user from `name` + plaintext `password`.
 
   Validation lives in `User.changeset/2`; uniqueness on `name` is
-  enforced by both the changeset's `unique_constraint/2` and the
-  `users_name_index` DB index — concurrent inserts that race the
-  in-process check still surface `{:error, changeset}` on the second
-  insert.
+  enforced by the changeset's two `unique_constraint/2` calls and the
+  two DB indexes behind them — `users_name_index` (byte-exact) and
+  `users_folded_name_index` (ASCII fold, #1353) — so concurrent inserts
+  that race the in-process check still surface `{:error, changeset}` on
+  the second insert, whichever spelling it used.
   """
   @spec create_user(%{required(:name) => String.t(), required(:password) => String.t()}) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
@@ -131,7 +135,7 @@ defmodule Grappa.Accounts do
           {:ok, User.t()} | {:error, :invalid_credentials}
   def get_user_by_credentials(name, password)
       when is_binary(name) and is_binary(password) do
-    case Repo.get_by(User, name: name) do
+    case Repo.one(by_folded_name(name)) do
       %User{} = user ->
         with :ok <- verify_password(user, password), do: {:ok, user}
 
@@ -316,13 +320,16 @@ defmodule Grappa.Accounts do
   end
 
   @doc """
-  Fetches a user by `name`. Raises `Ecto.NoResultsError` on miss.
+  Fetches a user by `name`, case-insensitively. Raises
+  `Ecto.NoResultsError` on miss.
 
   Used by the operator-side mix tasks where a typo in `--user`
   should fail loudly with a stack trace, not silently no-op.
   """
   @spec get_user_by_name!(String.t()) :: User.t()
-  def get_user_by_name!(name) when is_binary(name), do: Repo.get_by!(User, name: name)
+  def get_user_by_name!(name) when is_binary(name) do
+    Repo.one!(by_folded_name(name))
+  end
 
   @doc """
   Typed-nil sibling of `get_user_by_name!/1` — fetches a user by `name`,
@@ -333,13 +340,32 @@ defmodule Grappa.Accounts do
   bare login identifier classifies as an IRC nick, this decides whether
   it ALSO names an existing account (→ route to the account credential,
   never a silently-provisioned guest) or not (→ visitor path). Matches
-  the case-sensitive `name`-key semantics of `get_user_by_credentials/2`
-  so the two account lookups can never disagree on what "an account
-  named X" is — account names are the account key, a distinct namespace
-  from the ASCII-folded IRC nick.
+  the `name`-key semantics of `get_user_by_credentials/2` so the two
+  account lookups can never disagree on what "an account named X" is.
+
+  #1353 — that shared semantics is now the ASCII fold. An account name
+  is an identity KEY, and this schema folds identity keys at the MATCH
+  while storing them raw for display (#121/#525), so `vjt` and `VJT`
+  name one account here exactly as they name one nick on the wire. The
+  `users_folded_name_index` is what makes that true of the table as
+  well as of this reader.
   """
   @spec get_user_by_name(String.t()) :: User.t() | nil
-  def get_user_by_name(name) when is_binary(name), do: Repo.get_by(User, name: name)
+  def get_user_by_name(name) when is_binary(name) do
+    Repo.one(by_folded_name(name))
+  end
+
+  # The single folded-name query the three account readers share. Folds
+  # the INPUT in Elixir (`canonical_target/1`) and the COLUMN in SQL
+  # (`nick_fold/1`, the byte-pinned `lower()`), which is the expression
+  # `users_folded_name_index` is built on — so this is an index lookup,
+  # not a scan.
+  @spec by_folded_name(String.t()) :: Ecto.Query.t()
+  defp by_folded_name(name) do
+    folded = Identifier.canonical_target(name)
+
+    from(u in User, where: Identifier.nick_fold(u.name) == ^folded)
+  end
 
   @doc """
   Toggle the operator-authorization `is_admin` bit on `user`. The M

--- a/lib/grappa/accounts/user.ex
+++ b/lib/grappa/accounts/user.ex
@@ -75,7 +75,22 @@ defmodule Grappa.Accounts.User do
     |> validate_length(:name, min: 1, max: 64)
     |> validate_format(:name, @name_format, message: "must start with a letter, then alphanumeric/_/-")
     |> validate_length(:password, min: 8, max: 256)
+    # Measured #1353: removing this line reddens NO test, because SQLite
+    # names the folded index first when an exact duplicate violates both.
+    # It stays anyway — which index a conflict reports is index-resolution
+    # order, not a contract, so a later migration that recreates the two
+    # in another order would put the byte-exact violation back on this
+    # line, and without it that violation escapes as a raise instead of a
+    # changeset error. One declaration per index, not one per observed
+    # message.
     |> unique_constraint(:name)
+    # #1353 — the folded index is the one that decides identity: it is
+    # what makes `vjt` and `VJT` one account rather than two. Named
+    # explicitly because ecto derives its default constraint name from
+    # the COLUMN, which reaches `users_name_index` only; without this the
+    # folded violation would surface as an `Ecto.ConstraintError` raise
+    # instead of a changeset error.
+    |> unique_constraint(:name, name: :users_folded_name_index)
     |> put_password_hash()
   end
 

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -38,23 +38,42 @@ defmodule Grappa.Repo do
   # out from under storage_up. See docs/DESIGN_NOTES.md 2026-07-31.
   @impl Ecto.Repo
   def init(context, config) do
-    if context == :supervisor, do: ensure_wal_journal!(config)
-    {:ok, config}
-  end
-
-  @spec ensure_wal_journal!(keyword()) :: :ok
-  defp ensure_wal_journal!(config) do
-    case Keyword.get(config, :database) do
-      path when is_binary(path) and path != "" and path != ":memory:" ->
-        switch_to_wal!(path, Keyword.get(config, :busy_timeout, 30_000))
-
-      _ ->
-        :ok
+    if context == :supervisor do
+      {:ok, prepare_database!(config)}
+    else
+      {:ok, config}
     end
   end
 
-  @spec switch_to_wal!(binary(), non_neg_integer()) :: :ok
-  defp switch_to_wal!(path, busy_timeout) when is_integer(busy_timeout) do
+  # Everything that must happen on ONE serial connection, before the pool (or
+  # `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) opens:
+  #
+  #   1. #506 — the rollback→WAL switch, once, so no two connections race it.
+  #   2. #1355 — read the file's LIVE `page_size`, so the byte-denominated WAL
+  #      checkpoint threshold can be turned into the page count that
+  #      `PRAGMA wal_autocheckpoint` actually takes.
+  #
+  # An in-memory or unnamed database has neither a WAL nor a meaningful page
+  # count, so it is left alone — including the `:wal_checkpoint_bytes` key,
+  # which exqlite ignores (it reads `:wal_auto_check_point`).
+  @spec prepare_database!(keyword()) :: keyword()
+  defp prepare_database!(config) do
+    case Keyword.get(config, :database) do
+      path when is_binary(path) and path != "" and path != ":memory:" ->
+        on_serial_connection!(path, Keyword.get(config, :busy_timeout, 30_000), fn conn ->
+          :ok = switch_to_wal!(conn, path)
+          derive_wal_autocheckpoint(config, page_size!(conn, path))
+        end)
+
+      _ ->
+        config
+    end
+  end
+
+  @spec on_serial_connection!(binary(), non_neg_integer(), (Exqlite.Sqlite3.db() -> result)) ::
+          result
+        when result: var
+  defp on_serial_connection!(path, busy_timeout, fun) when is_integer(busy_timeout) do
     # Mirror the pool connection's own connect path, which mkdir_p's the parent
     # (SQLITE_OPEN_CREATE does NOT create intermediary dirs) — a raw open on a
     # missing dir would otherwise fail here before we ever reach the pool.
@@ -67,28 +86,71 @@ defmodule Grappa.Repo do
       # exqlite's connect order (journal_mode before busy_timeout), the very
       # ordering that makes the per-connection switch race (#506).
       :ok = Exqlite.Sqlite3.execute(conn, "PRAGMA busy_timeout=#{busy_timeout}")
-      {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA journal_mode=WAL")
-      result = Exqlite.Sqlite3.step(conn, stmt)
-      :ok = Exqlite.Sqlite3.release(conn, stmt)
-
-      case result do
-        {:row, ["wal"]} ->
-          :ok
-
-        {:row, [other_mode]} ->
-          # PRAGMA journal_mode=WAL returns the PREVIOUS mode (no error) when the
-          # filesystem can't back WAL shared-memory (NFS/CIFS/some overlay FSes).
-          # grappa REQUIRES WAL (config/runtime.exs journal_mode: :wal + the #524
-          # BEGIN IMMEDIATE semantics), so fail LOUD over booting silently
-          # degraded — and name the cause.
-          raise "Grappa.Repo: #{path} could not switch to WAL (got #{inspect(other_mode)}) — " <>
-                  "the filesystem likely cannot back WAL shared-memory; grappa requires WAL."
-
-        other ->
-          raise "Grappa.Repo: unexpected result switching #{path} to WAL: #{inspect(other)}"
-      end
+      fun.(conn)
     after
       :ok = Exqlite.Sqlite3.close(conn)
+    end
+  end
+
+  @spec switch_to_wal!(Exqlite.Sqlite3.db(), binary()) :: :ok
+  defp switch_to_wal!(conn, path) do
+    {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA journal_mode=WAL")
+    result = Exqlite.Sqlite3.step(conn, stmt)
+    :ok = Exqlite.Sqlite3.release(conn, stmt)
+
+    case result do
+      {:row, ["wal"]} ->
+        :ok
+
+      {:row, [other_mode]} ->
+        # PRAGMA journal_mode=WAL returns the PREVIOUS mode (no error) when the
+        # filesystem can't back WAL shared-memory (NFS/CIFS/some overlay FSes).
+        # grappa REQUIRES WAL (config/runtime.exs journal_mode: :wal + the #524
+        # BEGIN IMMEDIATE semantics), so fail LOUD over booting silently
+        # degraded — and name the cause.
+        raise "Grappa.Repo: #{path} could not switch to WAL (got #{inspect(other_mode)}) — " <>
+                "the filesystem likely cannot back WAL shared-memory; grappa requires WAL."
+
+      other ->
+        raise "Grappa.Repo: unexpected result switching #{path} to WAL: #{inspect(other)}"
+    end
+  end
+
+  @spec page_size!(Exqlite.Sqlite3.db(), binary()) :: pos_integer()
+  defp page_size!(conn, path) do
+    {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA page_size")
+    result = Exqlite.Sqlite3.step(conn, stmt)
+    :ok = Exqlite.Sqlite3.release(conn, stmt)
+
+    case result do
+      {:row, [size]} when is_integer(size) and size > 0 ->
+        size
+
+      other ->
+        raise "Grappa.Repo: unexpected result reading page_size of #{path}: #{inspect(other)}"
+    end
+  end
+
+  # #1355 — `PRAGMA wal_autocheckpoint` counts PAGES; the threshold we mean is a
+  # number of BYTES, so it is divided by the file's live page size at boot. A
+  # pinned page count is exactly the defect this fixes: the ZFS baseline moved
+  # prod from `page_size 4096` to `65536` and multiplied the effective threshold
+  # by 16 without touching a line of config. Deriving keeps the BYTES fixed and
+  # lets the page count move, so the next page-size change cannot re-arm it.
+  #
+  # Rounds UP, and that matters: `wal_autocheckpoint = 0` does not checkpoint
+  # eagerly, it DISABLES automatic checkpointing outright.
+  #
+  # The exqlite option is spelled `:wal_auto_check_point` (four words) while the
+  # PRAGMA it sets is `wal_autocheckpoint` — see `Exqlite.Pragma`.
+  @spec derive_wal_autocheckpoint(keyword(), pos_integer()) :: keyword()
+  defp derive_wal_autocheckpoint(config, page_size) do
+    case Keyword.pop(config, :wal_checkpoint_bytes) do
+      {nil, config} ->
+        config
+
+      {bytes, config} when is_integer(bytes) and bytes > 0 ->
+        Keyword.put(config, :wal_auto_check_point, div(bytes + page_size - 1, page_size))
     end
   end
 

--- a/lib/grappa/session/backoff.ex
+++ b/lib/grappa/session/backoff.ex
@@ -359,6 +359,19 @@ defmodule Grappa.Session.Backoff do
   @spec cap_ms() :: unquote(@cap_ms)
   def cap_ms, do: @cap_ms
 
+  @doc """
+  The exponent clamp — the knee of the curve. From failure count
+  `max_exponent() + 1` on, every further failure yields the same capped
+  wait.
+
+  Public for the same reason as `base_ms/0` and `cap_ms/0`: the #1350
+  consumer pin walks the fail-over ring PAST this point, and a test that
+  hardcoded the knee would keep passing below it the day the tuning
+  moves.
+  """
+  @spec max_exponent() :: unquote(@max_exponent)
+  def max_exponent, do: @max_exponent
+
   @doc false
   @spec entries() :: [entry()]
   def entries do

--- a/lib/grappa/test_support/subject_provision.ex
+++ b/lib/grappa/test_support/subject_provision.ex
@@ -56,13 +56,12 @@ if Mix.env() in [:dev, :test] do
       deps: [
         Grappa.Accounts,
         Grappa.Networks,
-        Grappa.Repo,
         Grappa.TestSupport.SubjectSession
       ]
 
     import Grappa.TestSupport.SubjectSession, only: [measure: 1]
 
-    alias Grappa.{Accounts, Networks, Repo, TestSupport.SubjectSession}
+    alias Grappa.{Accounts, Networks, TestSupport.SubjectSession}
 
     require Logger
 
@@ -223,7 +222,7 @@ if Mix.env() in [:dev, :test] do
     """
     @spec teardown!(String.t()) :: :ok | {:error, :user_not_found | :last_admin}
     def teardown!(name) when is_binary(name) do
-      case Repo.get_by(Accounts.User, name: name) do
+      case Accounts.get_user_by_name(name) do
         nil ->
           {:error, :user_not_found}
 

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -179,7 +179,7 @@ if Mix.env() in [:dev, :test] do
     """
     @spec reset!(String.t(), reset_opts()) :: {:ok, phases()} | {:error, reset_error()}
     def reset!(user_name, opts) when is_binary(user_name) and is_map(opts) do
-      case Repo.get_by(Accounts.User, name: user_name) do
+      case Accounts.get_user_by_name(user_name) do
         nil -> {:error, :user_not_found}
         %Accounts.User{} = user -> do_reset(user, opts)
       end

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -368,12 +368,16 @@ defmodule GrappaWeb.AuthController do
   # next attempt). A name with NO matching account routes to the visitor
   # path exactly as before, so anonymous IRC still works.
   #
-  # Account names are matched the ACCOUNT way — the case-sensitive
-  # `Accounts.get_user_by_name/1`, the SAME `name` key
-  # `mode1_login/3` + `get_user_by_credentials/2` use — NOT the ASCII
-  # nick fold (#121/#525). Account name is the account key, a namespace distinct from
-  # the IRC nick; folding it here would diverge from the email branch and
-  # fork what "the account named X" means across the two login doors.
+  # Account names are matched the ACCOUNT way — `Accounts.get_user_by_name/1`,
+  # the SAME `name` key `mode1_login/3` + `get_user_by_credentials/2` use.
+  #
+  # #1353 — that key folds. An account name is an identity KEY, and this
+  # schema folds identity keys at the MATCH while keeping the stored
+  # spelling for display (#121/#525), so `vjt` and `VJT` reach one
+  # account here just as they reach one nick on the wire. The fold lives
+  # in the CONTEXT reader, not at this branch, which is what keeps the
+  # two login doors saying the same thing about "the account named X":
+  # the email branch resolves its local part through the same function.
   @spec nick_login(
           Plug.Conn.t(),
           String.t(),

--- a/priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs
+++ b/priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs
@@ -1,0 +1,96 @@
+defmodule Grappa.Repo.Migrations.AddFoldedNameIndexToUsers do
+  @moduledoc """
+  #1353 — `users.name` is an identity KEY, so it folds like every other
+  identity key in this schema: a UNIQUE expression index on
+  `lower(name)`, with the column left RAW for display (the #121/#525
+  key/display split, already carried by `network_credentials`,
+  `query_windows` and `notify_entries`).
+
+  The byte-exact `users_name_index` from `20260426000000` stays. It is
+  implied by the folded one, and dropping it in the same migration that
+  adds a stricter one buys nothing while removing the fallback if this
+  index is ever rolled back.
+
+  ## The fold is plain `lower()`
+
+  `Grappa.Accounts.User`'s `@name_format` admits
+  `[a-zA-Z][a-zA-Z0-9_-]*` and nothing else, so the entire legal charset
+  is ASCII and `lower()` is byte-for-byte `Identifier.canonical_target/1`
+  over it. The expression MUST stay character-identical to
+  `Grappa.IRC.Identifier.nick_fold_sql/1` or SQLite will not use the
+  index. Inlined rather than called: migrations stay self-contained,
+  since they run under a possibly-truncated code load order.
+
+  ## A collision REFUSES the migration — it does not resolve it
+
+  The sibling folded-index migrations (`20260628100000`,
+  `20260711131000`) collapse case-variant duplicates by deleting the
+  losers before creating the index. That is right for a visitor
+  credential: it is disposable, and the next login re-provisions it. It
+  is wrong here. Two rows in `users` are two ACCOUNTS, each with a
+  password, sessions, credentials, scrollback and themes hanging off it.
+  Merging them silently would be data loss the operator never asked for
+  and cannot see afterwards, and choosing a survivor is not a decision
+  this file is entitled to make.
+
+  So the check runs FIRST and raises, naming every colliding spelling,
+  and the index is never created. The operator renames one side and runs
+  the deploy again — an operator-action failure taking the loud path,
+  the same posture as `Grappa.Networks.NoServerError`.
+
+  ## Cold deploy
+
+  A new migration: the hot path skips `ecto.migrate`, so this rides a
+  COLD window.
+  """
+  use Ecto.Migration
+
+  # The ASCII fold of `name`, in pure SQL. Written out rather than
+  # derived so the literal is in the source where the #525 fold pin in
+  # `Grappa.IRC.IdentifierTest` can compare it against
+  # `Identifier.nick_fold_sql("name")` — one byte of drift reddens there.
+  @folded_name "lower(name)"
+
+  def up do
+    refuse_on_collisions()
+
+    create unique_index(:users, [@folded_name], name: :users_folded_name_index)
+  end
+
+  def down do
+    drop unique_index(:users, [@folded_name], name: :users_folded_name_index)
+  end
+
+  # Every group of two or more accounts whose names differ only by case.
+  # Raising here aborts the migration with the table untouched.
+  defp refuse_on_collisions do
+    %{rows: rows} =
+      repo().query!("""
+      SELECT group_concat(name, ', ')
+      FROM users
+      GROUP BY #{@folded_name}
+      HAVING COUNT(*) > 1
+      ORDER BY #{@folded_name}
+      """)
+
+    case rows do
+      [] ->
+        :ok
+
+      collisions ->
+        groups = Enum.map_join(collisions, "\n  ", fn [names] -> names end)
+
+        raise """
+        Cannot make users.name case-insensitively unique: \
+        #{length(collisions)} group(s) of accounts differ only by case.
+
+          #{groups}
+
+        Each group is more than one account, with its own password,
+        sessions, credentials and scrollback. This migration will not
+        choose which one survives: rename all but one member of each
+        group, then run the deploy again.
+        """
+    end
+  end
+end

--- a/test/grappa/accounts_test.exs
+++ b/test/grappa/accounts_test.exs
@@ -33,6 +33,19 @@ defmodule Grappa.AccountsTest do
       assert "has already been taken" in errors_on(cs).name
     end
 
+    test "rejects a name that differs from an existing one only by case (#1353)" do
+      # One account per folded name: the folded unique index is what makes
+      # `vjt` and `VJT` the same account rather than two, and the
+      # changeset carries that index's name so the violation arrives as a
+      # changeset error rather than an `Ecto.ConstraintError`.
+      assert {:ok, _} = Accounts.create_user(%{name: "Dup-Case", password: @password})
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Accounts.create_user(%{name: "dup-case", password: @password})
+
+      assert "has already been taken" in errors_on(cs).name
+    end
+
     test "rejects a too-short password" do
       assert {:error, %Ecto.Changeset{} = cs} =
                Accounts.create_user(%{name: "vjt", password: "short"})
@@ -173,16 +186,47 @@ defmodule Grappa.AccountsTest do
                nil
     end
 
-    # Account names are the account key — a distinct namespace from the
-    # ASCII-folded IRC nick. The lookup is case-SENSITIVE (plain
-    # `Repo.get_by(User, name:)`), the SAME semantics
-    # `get_user_by_credentials/2` uses, so the two account lookups can
-    # never disagree on what "the account named X" is (the #404 dispatch
-    # relies on this).
-    test "is case-sensitive (does NOT nick-fold the name)" do
-      {:ok, _} = Accounts.create_user(%{name: "CaseAcct", password: @password})
-      assert %User{name: "CaseAcct"} = Accounts.get_user_by_name("CaseAcct")
-      assert Accounts.get_user_by_name("caseacct") == nil
+    # #1353 — the account name is an identity KEY, so it folds like every
+    # other identity key in the schema, and the row keeps its raw
+    # spelling for display. This arm replaces one that pinned the
+    # opposite ("is case-sensitive"): the property that test was
+    # protecting — the two account lookups never disagree about what "the
+    # account named X" is — is unchanged and asserted directly below;
+    # only the fold moved, and it moved for both of them at once.
+    test "resolves a case-variant spelling to the same account (#1353)" do
+      {:ok, user} = Accounts.create_user(%{name: "CaseAcct", password: @password})
+
+      assert %User{id: id, name: "CaseAcct"} = Accounts.get_user_by_name("caseacct")
+      assert id == user.id
+      assert %User{id: ^id} = Accounts.get_user_by_name("CASEACCT")
+      assert %User{id: ^id} = Accounts.get_user_by_name("CaseAcct")
+    end
+
+    test "the display spelling is the one the account was created with (#1353)" do
+      # Folding is a MATCH, never a write: the column stays raw so the
+      # operator sees the name they chose.
+      {:ok, _} = Accounts.create_user(%{name: "MixedCase", password: @password})
+
+      assert %User{name: "MixedCase"} = Accounts.get_user_by_name("mixedcase")
+    end
+
+    test "get_user_by_name!/1 folds the same way (#1353)" do
+      {:ok, user} = Accounts.create_user(%{name: "BangAcct", password: @password})
+
+      assert %User{id: id} = Accounts.get_user_by_name!("bangacct")
+      assert id == user.id
+    end
+
+    test "the two account lookups agree on what the account named X is (#1353)" do
+      # The #404 dispatch reads `get_user_by_name/1` to decide which door
+      # a bare identifier takes, and `get_user_by_credentials/2` then
+      # authenticates it. A spelling that resolves for one and not the
+      # other would route an account holder to the wrong door.
+      {:ok, user} = Accounts.create_user(%{name: "AgreeAcct", password: @password})
+
+      assert %User{id: id} = Accounts.get_user_by_name("agreeacct")
+      assert {:ok, %User{id: ^id}} = Accounts.get_user_by_credentials("agreeacct", @password)
+      assert id == user.id
     end
   end
 

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -821,6 +821,10 @@ defmodule Grappa.IRC.IdentifierTest do
     # literals stay tied to nick_fold_sql/1.
     @refold_migration "priv/repo/migrations/20260729120000_refold_identifiers_ascii.exs"
 
+    # #1353 added a live folded index the re-fold migration predates, so
+    # it carries its own copy of the fold literal and needs its own pin.
+    @folded_name_migration "priv/repo/migrations/20260815210238_add_folded_name_index_to_users.exs"
+
     # Pre-#525 migrations legitimately embed the rfc1459 four-replace fold
     # (correct when written; #525 supersedes their LIVE indexes). The
     # re-fold migration's own down/0 restores the rfc1459 indexes as its
@@ -850,6 +854,18 @@ defmodule Grappa.IRC.IdentifierTest do
         assert String.contains?(source, Identifier.nick_fold_sql(col)),
                "#{@refold_migration} is missing #{Identifier.nick_fold_sql(col)}"
       end
+    end
+
+    test "the #1353 folded-name index embeds the ASCII fold from nick_fold_sql/1" do
+      source = File.read!(@folded_name_migration)
+
+      # The whole attribute line, not the bare expression: that migration
+      # spells `lower(name)` in its moduledoc too, so a pin on the
+      # expression alone would survive a drift in the index itself.
+      expected = ~s(@folded_name "#{Identifier.nick_fold_sql("name")}")
+
+      assert String.contains?(source, expected),
+             "#{@folded_name_migration} is missing #{expected}"
     end
 
     test "no migration newer than the #525 re-fold reintroduces the rfc1459 fold" do

--- a/test/grappa/migrations/add_folded_name_index_to_users_test.exs
+++ b/test/grappa/migrations/add_folded_name_index_to_users_test.exs
@@ -1,0 +1,201 @@
+defmodule Grappa.FoldedNameMigrationSmokeRepo do
+  use Ecto.Repo,
+    otp_app: :grappa,
+    adapter: Ecto.Adapters.SQLite3
+end
+
+defmodule Grappa.Migrations.AddFoldedNameIndexToUsersTest do
+  @moduledoc """
+  #1353 — the folded-name unique index on `users`, and the refusal that
+  guards it.
+
+  The sibling folded-index migrations resolve a case-variant duplicate by
+  deleting the losers. This one must NOT: two `users` rows are two
+  accounts, so the migration refuses and names them instead. That refusal
+  is the arm below that matters — it is the whole difference from the
+  precedent it otherwise copies, and a later author "harmonising" this
+  migration with its siblings would turn a loud stop into silent data
+  loss.
+
+  Runs against a REAL migrated database on disk (same harness as
+  `Grappa.Migrations.AddUserTotpTest`) rather than the sandbox, because
+  what is under test is the migration itself: the raise before any DDL,
+  and the index that exists afterwards.
+
+  `async: false` — owns a repo process and a temp DB file.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Grappa.FoldedNameMigrationSmokeRepo, as: SmokeRepo
+  alias Grappa.IRC.Identifier
+
+  @previous_version 20_260_813_074_128
+  @folded_name_version 20_260_815_210_238
+
+  @timestamp "2026-01-01T00:00:00.000000Z"
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa-folded-name-migration-#{System.unique_integer([:positive])}.db"
+      )
+
+    Application.put_env(:grappa, SmokeRepo,
+      database: path,
+      # ONE connection, because the planner arm below asks SQLite which
+      # index it picks and that answer is per-connection: measured at
+      # pool_size 2, a checkout that did not serve the CREATE INDEX plans
+      # the same query as a full scan, so the arm flipped run to run on
+      # nothing but which connection the pool handed out.
+      pool_size: 1,
+      busy_timeout: 30_000,
+      foreign_keys: :on
+    )
+
+    start_supervised!(SmokeRepo)
+    migrations_path = Application.app_dir(:grappa, "priv/repo/migrations")
+
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @previous_version, log: false)
+
+    on_exit(fn ->
+      Application.delete_env(:grappa, SmokeRepo)
+      File.rm(path)
+      File.rm(path <> "-shm")
+      File.rm(path <> "-wal")
+    end)
+
+    %{migrations_path: migrations_path}
+  end
+
+  test "applies to a database whose account names already fold apart", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    insert_user!("22222222-2222-4222-8222-222222222222", "someone-else")
+    before = names()
+
+    assert [@folded_name_version] =
+             Ecto.Migrator.run(SmokeRepo, migrations_path, :up,
+               to: @folded_name_version,
+               log: false
+             )
+
+    assert "users_folded_name_index" in index_names()
+
+    # Every row survives with its spelling intact: the fold is a MATCH,
+    # never a rewrite.
+    assert names() == before
+  end
+
+  test "the index is derived from nick_fold_sql/1, and the folded lookup rides it", %{
+    migrations_path: migrations_path
+  } do
+    # `Accounts.by_folded_name/1` folds the column with the same
+    # `Identifier` source this predicate is built from, and the comment
+    # on it claims the result is an index lookup. Ask SQLite instead of
+    # deriving it: a fold that drifts from the indexed expression still
+    # returns the right row, silently, by reading every account.
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @folded_name_version, log: false)
+
+    # TWO arms, because `SCAN users` cannot carry two causes: SQLite says
+    # it both when the indexed expression has drifted away from the
+    # query's fold and when the index is right but the planner passed it
+    # over. This arm reads the expression SQLite actually stored, so a
+    # drift reddens HERE — which leaves the plan arm below a statement
+    # about the planner alone, and a red one names which of the two broke.
+    assert index_sql("users_folded_name_index") =~ "(#{Identifier.nick_fold_sql("name")})"
+
+    %{rows: rows} =
+      SQL.query!(
+        SmokeRepo,
+        "EXPLAIN QUERY PLAN SELECT id FROM users WHERE #{Identifier.nick_fold_sql("name")} = ?",
+        ["vjt"]
+      )
+
+    plan = rows |> List.flatten() |> Enum.filter(&is_binary/1) |> Enum.join(" ")
+
+    assert plan =~ "users_folded_name_index", "planner chose: #{plan}"
+    refute plan =~ "SCAN"
+  end
+
+  test "the index refuses a second account whose name differs only by case", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+
+    Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @folded_name_version, log: false)
+
+    assert_raise Exqlite.Error, fn ->
+      insert_user!("33333333-3333-4333-8333-333333333333", "VJT")
+    end
+  end
+
+  test "a pre-existing case collision refuses the migration and names the rows", %{
+    migrations_path: migrations_path
+  } do
+    insert_user!("11111111-1111-4111-8111-111111111111", "vjt")
+    insert_user!("22222222-2222-4222-8222-222222222222", "VJT")
+    insert_user!("44444444-4444-4444-8444-444444444444", "solo")
+    before = names()
+
+    error =
+      assert_raise RuntimeError, fn ->
+        Ecto.Migrator.run(SmokeRepo, migrations_path, :up,
+          to: @folded_name_version,
+          log: false
+        )
+      end
+
+    # The operator has to know WHICH accounts to rename, so both
+    # spellings are in the message and the uninvolved one is not.
+    assert error.message =~ "vjt"
+    assert error.message =~ "VJT"
+    refute error.message =~ "solo"
+
+    # Nothing was created and nothing was deleted: the refusal happens
+    # before any DDL, and the accounts are still both there for the
+    # operator to choose between.
+    refute "users_folded_name_index" in index_names()
+    assert names() == before
+  end
+
+  defp insert_user!(id, name) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO users (id, name, password_hash, is_admin, inserted_at, updated_at) VALUES (?,?,?,?,?,?)",
+      [id, name, "hash", 0, @timestamp, @timestamp]
+    )
+  end
+
+  # The CREATE INDEX text SQLite kept for `name`, which is where a drift
+  # between the migration's expression and `nick_fold_sql/1` shows up as
+  # data rather than as a planner mood.
+  defp index_sql(name) do
+    %{rows: rows} =
+      SQL.query!(
+        SmokeRepo,
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+        [name]
+      )
+
+    case rows do
+      [[sql]] -> sql
+      [] -> flunk("no index named #{name}")
+    end
+  end
+
+  defp index_names do
+    %{rows: rows} =
+      SQL.query!(SmokeRepo, "SELECT name FROM sqlite_master WHERE type = 'index'", [])
+
+    List.flatten(rows)
+  end
+
+  defp names do
+    %{rows: rows} = SQL.query!(SmokeRepo, "SELECT name FROM users ORDER BY name", [])
+    List.flatten(rows)
+  end
+end

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -46,6 +46,17 @@ defmodule Grappa.NetworksTest do
 
   # #93 — builds the `{host, enabled}` list as an ascending-priority ring,
   # binds `user` to it and resolves the spawn-door plan.
+  # Shared by the two fail-over ring describes (#93 below the exponent
+  # knee, #1350 past it). `Backoff` is an application-wide singleton with
+  # no sandbox, so the counter has to be evicted per test.
+  defp ring_ctx do
+    user = user_fixture()
+    net = network_fixture()
+    on_exit(fn -> Backoff.forget({:user, user.id}) end)
+
+    {:ok, user: user, net: net}
+  end
+
   defp bind_ring(user, net, hosts) do
     Enum.each(Enum.with_index(hosts, 1), fn {{host, enabled}, priority} ->
       {:ok, _} =
@@ -60,6 +71,14 @@ defmodule Grappa.NetworksTest do
       })
 
     user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
+  end
+
+  # The endpoint ring as `pick_server!/2` indexes it — `list_servers/1`
+  # returns the `(priority, id)` order the picker sorts by, so the
+  # expected fail-over walk is derived from production, not transcribed
+  # from the fixture's insertion order.
+  defp enabled_ring(net) do
+    net |> Servers.list_servers() |> Enum.filter(& &1.enabled) |> Enum.map(& &1.host)
   end
 
   describe "find_or_create_network/1" do
@@ -1829,11 +1848,7 @@ defmodule Grappa.NetworksTest do
   # per-server state to keep in sync.
   describe "SessionPlan fail-over ring (#93)" do
     setup do
-      user = user_fixture()
-      net = network_fixture()
-      on_exit(fn -> Backoff.forget({:user, user.id}) end)
-
-      {:ok, user: user, net: net}
+      ring_ctx()
     end
 
     test "each recorded failure advances the plan to the next enabled server", ctx do
@@ -1895,6 +1910,93 @@ defmodule Grappa.NetworksTest do
 
       assert {:ok, plan} = user |> Credentials.get_credential!(net) |> SessionPlan.resolve()
       assert plan.host == "primary"
+    end
+  end
+
+  # #1350 — #1349 bounded the backoff EXPONENT and left the stored count
+  # deliberately UNCLAMPED, because that same count is the fail-over ring
+  # ordinal. #1349 pinned that consequence at the counter (`failure_count/2`
+  # still answers 1_025 after 1_025 failures); this pins it where it is
+  # load-bearing — at the respawn door, past the knee, where the wait has
+  # stopped growing and the endpoint must NOT stop moving with it. The
+  # #93 tests above all sit BELOW the knee.
+  #
+  # The first test is the anti-vacuity witness for the second: it fixes
+  # that the count the walk derives really does sit on the flat part of
+  # the curve. Split into two tests so each dies on its own mutant
+  # instead of shadowing the other.
+  describe "SessionPlan fail-over ring past the exponent knee (#1350)" do
+    setup do
+      ring_ctx()
+    end
+
+    # One-sided on purpose: the ±25% jitter windows of the last rung below
+    # the knee and the cap overlap at the production tuning, so "not yet
+    # capped one failure earlier" is not assertable without a flake.
+    test "the knee the walk derives is where the wait has flattened at the cap", ctx do
+      %{user: user, net: net} = ctx
+      cap = Backoff.cap_ms()
+      jitter = trunc(cap * 0.25)
+
+      for _ <- 1..(Backoff.max_exponent() + 1) do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+      end
+
+      ms = Backoff.wait_ms({:user, user.id}, net.id)
+
+      assert ms >= cap - jitter
+      assert ms <= cap + jitter
+    end
+
+    test "the endpoint keeps advancing once the wait has flattened", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      ring = enabled_ring(net)
+      # A full ring PAST the flattening point, so the tail of the walk is
+      # entirely on the flat part of the curve.
+      walk = Backoff.max_exponent() + 1 + length(ring)
+
+      walked =
+        for _ <- 1..walk do
+          :ok = Backoff.record_failure({:user, user.id}, net.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      # `list_servers/1` returns the same `(priority, id)` order
+      # `pick_server!/2` indexes, so the walk is that order cycled — the
+      # Nth failure is ring position N, one past the primary.
+      expected = ring |> Stream.cycle() |> Stream.drop(1) |> Enum.take(walk)
+
+      assert walked == expected
+    end
+
+    # The count whose pre-#1349 `:math.pow/2` exponent overflowed the
+    # double. Nothing the test computes can put it below a knee, so this
+    # claim rests on no derivation of its own — the price is that it can
+    # only assert the ring's SHAPE (every endpoint visited once per
+    # revolution), not its phase.
+    @overflow_count 1_025
+
+    test "the ring still advances at the count that used to raise badarith", ctx do
+      %{user: user, net: net} = ctx
+      assert {:ok, plan} = bind_ring(user, net, [{"primary", true}, {"secondary", true}, {"tertiary", true}])
+
+      ring = enabled_ring(net)
+
+      for _ <- 1..(@overflow_count - length(ring)) do
+        :ok = Backoff.record_failure({:user, user.id}, net.id)
+      end
+
+      walked =
+        for _ <- 1..length(ring) do
+          :ok = Backoff.record_failure({:user, user.id}, net.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      assert Enum.sort(walked) == Enum.sort(ring)
     end
   end
 

--- a/test/grappa/repo_wal_checkpoint_test.exs
+++ b/test/grappa/repo_wal_checkpoint_test.exs
@@ -1,0 +1,185 @@
+defmodule Grappa.RepoWalCheckpointTest do
+  @moduledoc """
+  #1355 — the WAL checkpoint threshold is expressed in BYTES and translated to
+  the page count `PRAGMA wal_autocheckpoint` takes by `Grappa.Repo.init/2`,
+  using the DB file's LIVE `page_size`.
+
+  The defect this pins: `wal_autocheckpoint` counts pages, so the ZFS baseline's
+  `page_size` 4096 → 65536 move (`docs/zfs-baseline-2026-07-31.md`) multiplied
+  the effective threshold by 16 without touching a line of config. A bare page
+  count leaves the same trap armed for the next page-size change; a byte
+  threshold divided by the live page size does not.
+
+  Pure unit test of the callback — no Repo/pool, no Sandbox, same shape as
+  `Grappa.RepoWalJournalTest`. `async: false`: the prod-config test mutates the
+  process-global OS env via `System.put_env`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Exqlite.Sqlite3
+
+  @runtime_exs Path.expand("../../config/runtime.exs", __DIR__)
+
+  # The prod block of `config/runtime.exs` raises on every missing secret, so a
+  # `Config.Reader` read of it needs the full mandatory set. Values are shaped
+  # only as far as the file inspects them: GRAPPA_ENCRYPTION_KEY is decoded with
+  # `Base.decode64!`, RELEASE_COOKIE must be neither blank nor the dev sentinel.
+  @prod_env %{
+    "PHX_HOST" => "grappa.example.test",
+    "DATABASE_PATH" => "/nonexistent/grappa_wal_checkpoint_test.db",
+    "SECRET_KEY_BASE" => String.duplicate("s", 64),
+    "RELEASE_COOKIE" => String.duplicate("c", 64),
+    "SECRET_SIGNING_SALT" => String.duplicate("t", 32),
+    "GRAPPA_ENCRYPTION_KEY" => Base.encode64(String.duplicate("k", 32)),
+    "VAPID_PUBLIC_KEY" => String.duplicate("p", 87),
+    "VAPID_PRIVATE_KEY" => String.duplicate("q", 43)
+  }
+
+  # A fresh database created at `page_size`, with one real table so the page
+  # size is committed to the file header (PRAGMA page_size only takes on an
+  # empty database).
+  defp db_with_page_size(page_size) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa_wal_ckpt_#{page_size}_#{System.unique_integer([:positive])}.db"
+      )
+
+    {:ok, conn} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(conn, "PRAGMA page_size=#{page_size}")
+    :ok = Sqlite3.execute(conn, "CREATE TABLE probe (x INTEGER)")
+    :ok = Sqlite3.close(conn)
+    on_exit(fn -> for suffix <- ["", "-wal", "-shm"], do: File.rm(path <> suffix) end)
+    path
+  end
+
+  defp init!(config) do
+    {:ok, config} = Grappa.Repo.init(:supervisor, config)
+    config
+  end
+
+  # `config/runtime.exs`'s `Grappa.Repo` block, read exactly as prod boot would.
+  defp prod_repo_config do
+    previous = Map.new(@prod_env, fn {name, _} -> {name, System.get_env(name)} end)
+    System.put_env(@prod_env)
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {name, nil} -> System.delete_env(name)
+        {name, value} -> System.put_env(name, value)
+      end)
+    end)
+
+    @runtime_exs
+    |> Config.Reader.read!(env: :prod)
+    |> get_in([:grappa, Grappa.Repo])
+  end
+
+  describe "byte → page derivation" do
+    test "the same byte threshold yields the same BYTES at either page size" do
+      # THE regression assertion: a bare page count would produce the same
+      # number twice and thus two thresholds 16× apart.
+      bytes = 16 * 1024 * 1024
+
+      for page_size <- [4096, 65_536] do
+        config =
+          init!(
+            database: db_with_page_size(page_size),
+            busy_timeout: 30_000,
+            wal_checkpoint_bytes: bytes
+          )
+
+        assert Keyword.fetch!(config, :wal_auto_check_point) * page_size == bytes
+      end
+    end
+
+    test "the byte-denominated key never reaches exqlite" do
+      config =
+        init!(
+          database: db_with_page_size(65_536),
+          busy_timeout: 30_000,
+          wal_checkpoint_bytes: 16 * 1024 * 1024
+        )
+
+      refute Keyword.has_key?(config, :wal_checkpoint_bytes)
+    end
+
+    test "a threshold below one page rounds UP to one, never to zero" do
+      # `wal_autocheckpoint = 0` disables automatic checkpointing outright, so
+      # a floor division here would turn a tiny threshold into no checkpoints
+      # at all — the opposite of what the number asks for.
+      config =
+        init!(
+          database: db_with_page_size(65_536),
+          busy_timeout: 30_000,
+          wal_checkpoint_bytes: 1024
+        )
+
+      assert Keyword.fetch!(config, :wal_auto_check_point) == 1
+    end
+
+    test "no threshold configured leaves exqlite's own default in force" do
+      config = init!(database: db_with_page_size(4096), busy_timeout: 30_000)
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "init(:runtime, _) derives nothing (config-lookup path stays pure)" do
+      path = db_with_page_size(65_536)
+
+      assert {:ok, config} =
+               Grappa.Repo.init(:runtime,
+                 database: path,
+                 busy_timeout: 30_000,
+                 wal_checkpoint_bytes: 16 * 1024 * 1024
+               )
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "an in-memory database is left alone" do
+      assert {:ok, config} =
+               Grappa.Repo.init(:supervisor,
+                 database: ":memory:",
+                 wal_checkpoint_bytes: 16 * 1024 * 1024
+               )
+
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+  end
+
+  describe "production configuration" do
+    test "prod pins the threshold in bytes and never as a page count" do
+      config = prod_repo_config()
+
+      assert Keyword.fetch!(config, :wal_checkpoint_bytes) > 0
+
+      # A `wal_auto_check_point` pinned in config IS the defect — it counts
+      # pages, so it silently changes meaning the next time page_size moves.
+      refute Keyword.has_key?(config, :wal_auto_check_point)
+    end
+
+    test "prod bounds the WAL at the same envelope it checkpoints at" do
+      # `journal_size_limit` is what makes a checkpointed WAL come back down
+      # instead of being recycled at its high-water mark (the -1 default).
+      config = prod_repo_config()
+
+      assert Keyword.fetch!(config, :journal_size_limit) ==
+               Keyword.fetch!(config, :wal_checkpoint_bytes)
+    end
+
+    test "prod's threshold is a whole number of pages at 4096 and at 65536" do
+      # Rounding up is a safety net, not the intent: the chosen constant should
+      # land on a page boundary at both the pre- and post-ZFS page size.
+      config = prod_repo_config()
+      bytes = Keyword.fetch!(config, :wal_checkpoint_bytes)
+
+      for page_size <- [4096, 65_536] do
+        derived =
+          init!(Keyword.put(config, :database, db_with_page_size(page_size)))
+
+        assert Keyword.fetch!(derived, :wal_auto_check_point) * page_size == bytes
+      end
+    end
+  end
+end

--- a/test/grappa/test_support/subject_provision_test.exs
+++ b/test/grappa/test_support/subject_provision_test.exs
@@ -81,6 +81,18 @@ defmodule Grappa.TestSupport.SubjectProvisionTest do
       assert {:error, :user_not_found} = SubjectProvision.teardown!("nobody-by-that-name")
     end
 
+    test "a case-variant spelling of the name tears down the same subject (#1353)" do
+      # This resolves the account the same way every other account reader
+      # does: the name is an identity key, so the teardown a spec asks for
+      # cannot depend on how the harness capitalised it.
+      user = user_fixture(name: unique_name())
+      typed = String.upcase(user.name)
+      refute typed == user.name
+
+      assert :ok = SubjectProvision.teardown!(typed)
+      assert Accounts.get_user_by_name(user.name) == nil
+    end
+
     test "removes the user, its credential and everything keyed to it" do
       user = user_fixture(name: unique_name())
       network = network_fixture()

--- a/test/grappa/test_support/subject_reset_test.exs
+++ b/test/grappa/test_support/subject_reset_test.exs
@@ -68,6 +68,17 @@ defmodule Grappa.TestSupport.SubjectResetTest do
       assert Notify.list({:user, user.id}, network.id) == []
     end
 
+    test "a case-variant spelling of the name resets the same subject (#1353)", %{
+      user: user,
+      network: network
+    } do
+      typed = String.upcase(user.name)
+      refute typed == user.name
+
+      assert {:ok, _} = SubjectReset.reset!(typed, %{})
+      assert ReadCursor.get({:user, user.id}, network.id, "#bofh") == nil
+    end
+
     test "does not touch other users", %{user: user, network: network} do
       other = user_fixture(name: "other-test-reset-#{System.unique_integer([:positive])}")
 

--- a/test/grappa/visitors/session_plan_test.exs
+++ b/test/grappa/visitors/session_plan_test.exs
@@ -111,6 +111,35 @@ defmodule Grappa.Visitors.SessionPlanTest do
       assert second.host == "secondary"
     end
 
+    # #1350 — the visitor half of the past-the-knee pin (the user half
+    # lives in `Grappa.NetworksTest`, which also witnesses that
+    # `max_exponent/0` is where the wait flattens). Two respawn doors read
+    # the same unclamped counter, so a write-side clamp would freeze both;
+    # pinning one door would leave the other free to regress alone.
+    test "refresh_plan keeps walking the ring past the exponent knee (#1350)" do
+      {network, _} = network_with_server(slug: "azzurra", port: 6667, host: "primary")
+      {:ok, _} = Servers.add_server(network, %{host: "secondary", port: 6667, priority: 9})
+      {:ok, _} = Servers.add_server(network, %{host: "tertiary", port: 6667, priority: 10})
+      {:ok, visitor} = Visitors.find_or_provision_anon("vjt-knee", "azzurra", "1.2.3.4")
+      on_exit(fn -> Backoff.forget({:visitor, visitor.id}) end)
+
+      assert {:ok, plan} = SessionPlan.resolve(visitor, network)
+
+      ring = network |> Servers.list_servers() |> Enum.filter(& &1.enabled) |> Enum.map(& &1.host)
+      walk = Backoff.max_exponent() + 1 + length(ring)
+
+      walked =
+        for _ <- 1..walk do
+          :ok = Backoff.record_failure({:visitor, visitor.id}, network.id)
+          assert {:ok, fresh} = plan.refresh_plan.()
+          fresh.host
+        end
+
+      expected = ring |> Stream.cycle() |> Stream.drop(1) |> Enum.take(walk)
+
+      assert walked == expected
+    end
+
     # CP24 bucket E lifecycle/S1: visitor plans carry a `credential_failer`
     # callback that expires the row on K-line / permanent SASL.
     test "plan injects credential_failer that expires the visitor on call" do

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -543,6 +543,38 @@ defmodule GrappaWeb.AuthControllerTest do
       assert is_nil(session.revoked_at)
     end
 
+    test "a case-variant spelling of the account name takes the account door (#1353)",
+         %{conn: conn} do
+      # The dispatch asks `Accounts.get_user_by_name/1` which door this
+      # identifier belongs to, and the account name is an identity key,
+      # so the answer does not depend on how the holder capitalised it.
+      # No visitor network is configured in this describe, so the visitor
+      # door is not merely unlikely here — it is unreachable, and the 200
+      # below could not come from it.
+      {user, password} = user_fixture_with_password()
+      typed = String.upcase(user.name)
+
+      # The fixture picks the stored spelling, so pin the pre-state: if a
+      # future fixture name were already upper-case this test would still
+      # pass while asserting nothing.
+      refute typed == user.name
+
+      body =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/auth/login", %{"identifier" => typed, "password" => password})
+        |> json_response(200)
+
+      assert body["subject"]["kind"] == "user"
+      assert body["subject"]["id"] == user.id
+      # The envelope carries the STORED spelling, not the typed one.
+      assert body["subject"]["name"] == user.name
+
+      session = Repo.get(Session, body["token"])
+      assert session.user_id == user.id
+      assert is_nil(session.visitor_id)
+    end
+
     test "bare account name + wrong password → 401 invalid_credentials, no guest provisioned",
          %{conn: conn} do
       {user, _} = user_fixture_with_password()


### PR DESCRIPTION
Replay of three branches onto one base, gated **once, together**.

## Why a union and not three merges

Each of #1364, #1369 and #1367 was green **against a different, older base**, and none was
ever gated alongside the others. Textual non-overlap is not semantic independence, and the
interaction here is concrete: #1364 carries a **migration**, and #1369 rewrites
`Grappa.Repo.init/2`, which runs the PRAGMA setup on the serial pre-pool connection at boot —
exactly where a migration lands. #1367 is in because it is no longer fast-forwardable after
main moved past its rebase; rebasing it would buy a second full gate for no added confidence.

This is a **replay, not a merge**: each branch was cherry-picked over **its own merge-base**,
so the shas are new.

## What is in it

| issue | commits | shape |
|---|---|---|
| #1353 | `5a5d80c0` | account name becomes an identity key that folds; carries migration `20260815210238_add_folded_name_index_to_users` |
| #1355 | `df5eb44b` | WAL checkpoint threshold denominated in bytes, derived at boot from the live `page_size` |
| #1350 | `e7d9f974`, `4d93ce38` | `Backoff.max_exponent/0` read-only seam + the fail-over ring rotation pin past the knee |

## Migration version

Re-checked against `origin/main` **as of this push**, not against the base each branch was cut
from. Last migration on main is `20260813074128_add_provider_to_push_subscriptions`; the one
carried here is `20260815210238`, strictly past it, and the branch holds no duplicate version —
so the #1348 duplicate-version refusal that landed in #1363 does not fire.

## Gate

One whole `scripts/check.sh` on the union tree, working tree clean before and after.

- `mix test`: **6338 tests, 60 properties, 8 doctests, 0 failures**
- Credo strict: `5918 mods/funs, found no issues` over 658 files
- Dialyzer: `Total errors: 0` — `done (passed successfully)`
- `mix deps.audit`: `No vulnerabilities found` (`hex.audit` cowboy/cowlib advisories are
  advisory-only per #149)
- Sobelow: no Medium-or-above
- bats: 482 ok, 0 not ok
- `scripts/design-notes-gate.sh`: `rc=0`

`docs/DESIGN_NOTES.md` numstat was pinned to a file before the gate and re-diffed after:
**54 additions, 0 deletions**, unchanged, and equal to the exact sum of the entries carried
(only #1355 appends one). Not 51 — the union driver did not eat a separator.

### One red on the first run, not reproduced

Run 1 came back `rc=1` with a single failure out of the same 6338:
`Grappa.SessionLogPersistenceTest` "prune keeps only the newest `retention` rows on disk",
`Repo.aggregate(Event, :count)` read **4** against an expected **3**.

That is **#1334**, and specifically the second, latent mode that issue predicted from source
without ever observing: a foreign persist that *succeeds* lands inside the spec's transaction
after its `Repo.delete_all(Event)`. The spec attaches a VM-global telemetry handler bound to
the singleton `Grappa.SessionLog` and `Sandbox.allow`s it on its own connection, so any session
alive anywhere in the VM writes into this test. The intruder is named in the test's own captured
output — `user=vjt-145732 network=sl-145860 … event=disconnected`, a session leaked from
`lifecycle_log_integration_test.exs` (the only producer of `sl-` slugs) dying on `econnrefused`
mid-test. Six emits, retention 3, prune leaves 3, the foreign row lands after: 4.

Verdict was written down before the rerun. Run 2 on the byte-identical tree: `rc=0`, same 6338
collected. Not attributable to this branch — the union touches neither `session_log.ex`, nor
`session/server.ex`, nor either spec; the only file it changes on the persist path is
`repo.ex`, and that change is confined to `context == :supervisor`, i.e. boot. **No frequency is
claimed**: one observation plus one non-reproduction is not a rate. Evidence archived on #1334.

## Deploy

**COLD** — migration plus `config/runtime.exs`. Deliberate: one session drop instead of two.

Replaces #1364, #1369 and #1367; the replay rewrote their shas, so GitHub will not close them
from here.