### PR TITLE
perf(#1372): restore the unread aggregate's covering index, and un-blind the pin

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43368,3 +43368,68 @@ when a reset actually happens. With `pool_size: 10` under continuous reads
 that is a real possibility, and it is the most likely reason prod's WAL was at
 168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
 the pressure and bounds the recovery; it does not promise a ceiling.
+<!-- entry #1372 -->
+
+---
+
+## 2026-08-16 — #1372: the unread aggregate lost its covering index, and the pin that should have caught it was blind
+
+`Scrollback.count_after_split/6` is the query behind the cold-load `/me` seed
+and the per-channel join reply (`WindowCounts.snapshot/7`). #393 shipped two
+covering index families for it on 2026-07-25 — `kind` at the tail so the
+content-vs-event GROUP BY could be answered without touching the table —
+because the non-covering form was the prod incident of that morning: its
+migration moduledoc records 80ms → 5-7ms, ~15x.
+
+Four and six days later #532 A and #576 added `exclude_own_authored/3` to the
+same aggregate. The predicate reads `lower(sender)` and
+`json_extract(meta, '$.new_nick')`, neither of which was in any index on
+`messages`, so SQLite went back to one table row-fetch per post-cursor row.
+Neither entry mentions an index, a covering property or an EXPLAIN.
+
+**The finding that outlived the fix is the pin.** The 2026-08-15 review read
+this as "no covering pin exists". One did — three of them, asserting
+`USING COVERING INDEX` — and they were green throughout. They EXPLAINed a
+LOCAL REBUILD of the aggregate that passed `own_nick: nil`, and at nil
+`exclude_own_authored/3` is the identity clause, so the predicate that caused
+the regression never entered the pinned SQL. Measured on one 650k-row corpus,
+same channel, same cursor: the pinned shape reads 1,676 page fetches and says
+COVERING; the production shape reads 175,576 and does not. A pin on a branch
+production does not take is worse than no pin, because it reports safety. The
+cure is not a second pin beside it: the plan is now read off the SQL the
+production function actually emits, captured from `[:grappa, :repo, :query]`
+telemetry, so no second copy of the query exists to drift. Rule for any future
+plan pin: **EXPLAIN what production emitted, never what the test can rebuild.**
+
+**Why widening, and not seek-and-subtract.** Both shapes were measured on the
+same corpus before either was written. Appending the two expressions to the
+four existing indexes restores COVERING (175,576 → 1,886 page fetches, 93x,
+identical results) at **no measurable INSERT cost** — widening an entry adds no
+b-tree. Counting own-authored rows as a second seek and subtracting costs
+**+37% on INSERT**, because it adds four new b-trees to the highest-write-rate
+table in the codebase; and it is not a subtraction but inclusion-exclusion
+across three seeks, since a case-only self-rename matches both arms of the
+disjunction. Dearer and more fragile, for a read that is already served.
+Widening alone with `lower(sender)` was also measured: it does NOT restore
+COVERING. Both expressions are load-bearing.
+
+The four dead `dm_with` indexes (P-S4) are dropped in the same PR rather than
+deferred, because that is what makes the write side a net win: the pair is 25%
+faster on INSERT and 22% smaller in index bytes than main is today, where the
+widening alone is merely neutral. An 11-shape plan sweep confirms nothing else
+regresses, and that the four dropped indexes served no production read — the
+only thing referencing them was a pair of tests EXPLAINing the
+`(channel = ? OR dm_with = ?)` disjunction #393 deleted from production, the
+same defect class as the blind pin.
+
+**Not established.** There is no prod copy on this lane; the corpus is
+synthetic and its distributions — notably the ~4% own-`sender` share — are
+chosen, not observed. Page fetches are reported instead of milliseconds
+precisely because they are deterministic and host-independent; the wall-clock
+figures are warm macOS, not the m42 jail, and cold-cache timing is unmeasured.
+Local `CREATE INDEX` is 0.51-0.66s per index at 650k rows, but #393's own prod
+record of 1.6-2.6s per index at 654k rows is the better predictor for the COLD
+window. And the open question from #1353 stays open: *why* a pool connection
+that did not serve the `CREATE INDEX` plans differently — schema cache or
+transaction visibility — is still unmeasured, and `pool_size: 1` remains a
+remedy whose mechanism nobody has characterised.

--- a/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
+++ b/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
@@ -75,11 +75,28 @@ defmodule Grappa.Repo.Migrations.AddOwnAuthoredExprsToMessagesCoveringIndexes do
 
   ## Deploy
 
-  New migration file — Preflight Class 5 forces **COLD**. The four
-  `CREATE INDEX` builds took 2.6s in total over 650k rows locally (per-index
-  split in the PR body); they share one migration transaction, so schedule
-  off a traffic peak. Expand-class: no schema-shape change, so the running
-  old code is unaffected by the added index columns.
+  New migration file — Preflight Class 5 forces **COLD**. All four
+  `CREATE INDEX` builds share ONE migration transaction, so the number that
+  sizes the window is that transaction, not the per-index split.
+
+  Measured on a corpus built at prod's ACTUAL row count (1,943,545 rows —
+  vjt read it off the jail 2026-08-16; #393's 654k is three weeks stale and
+  three times too small), fresh copy per rep so none inherits the previous
+  page cache: **9.55 / 9.66 / 9.85 s** for this migration's `up/0`, and
+  9.72-10.14 s for it plus the P-S4 drop back to back. 2.99x the rows cost
+  3.24x the time, which is the mild superlinearity a sort-dominated build
+  should show.
+
+  That is a LOCAL number. Scaled by the host ratio #393 recorded for the same
+  operation on the same table (prod 1.6-2.0s per channel index and
+  2.442/2.570s per DM index at 654k, against 0.52-0.69s locally at 650k —
+  a 3-4.5x factor, and conservative because those indexes were NARROWER than
+  these), prod should land around **30-45 seconds** for the migrate step.
+  Nobody has measured an index build on prod's substrate at 1.9M rows; this
+  is an explicit extrapolation, not an observation.
+
+  Expand-class: no schema-shape change, so the running old code is unaffected
+  by the added index columns.
 
   See DESIGN_NOTES 2026-08-16.
   """

--- a/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
+++ b/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
@@ -1,0 +1,226 @@
+defmodule Grappa.Repo.Migrations.AddOwnAuthoredExprsToMessagesCoveringIndexes do
+  @moduledoc """
+  #1372 P-S1 — restore the COVERING property #393 shipped for the
+  `count_after_split/6` aggregate, which #532 A and #576 defeated.
+
+  ## What broke
+
+  #393 (2026-07-25) put `kind` at the tail of both covering families
+  precisely so the content-vs-event GROUP BY could be answered from the
+  index with no table touch — its moduledoc records the prod measurement,
+  80ms → 5-7ms, ~15x, on the query behind that day's incident.
+
+  Four and six days later `exclude_own_authored/3` was added to the SAME
+  aggregate (#532 A presence, #576 content). It reads two things that were
+  in NO index on `messages`: `lower(sender)` and
+  `json_extract(meta, '$.new_nick')`. So SQLite went back to seeking
+  `(subject, network_id, channel, id > ?)` on the index and then fetching
+  the table row for EVERY post-cursor row to evaluate them — the exact
+  shape #393 measured as the incident. The worst window is the one that
+  matters: a channel whose read cursor is far behind, which is what the
+  cold-load `/me` seed and the per-channel join reply both route through
+  (`WindowCounts.snapshot/7`).
+
+  ## The measurement this migration is built on
+
+  650k rows, prod-shaped distribution, no `ANALYZE` (prod has no
+  `sqlite_stat*` and the app never runs it, so the planner must be measured
+  on default estimates), channel window of 103,209 post-cursor rows, SQL
+  captured verbatim off `[:grappa, :repo, :query]` rather than rebuilt:
+
+      before   SEARCH … USING INDEX …channel_id_kind_index          175,576 page fetches
+      after    SEARCH … USING COVERING INDEX …channel_id_kind_index   1,886 page fetches
+
+  93x fewer page fetches, identical results. Page fetches rather than
+  wall-clock on purpose: they are deterministic and host-independent, and
+  the 14x ratio on page MISSES (23,427 → 1,885) lands on the same ~15x
+  #393 recorded from an entirely independent measurement.
+
+  Both expressions are load-bearing — widening with `lower(sender)` alone
+  was measured and does NOT restore COVERING.
+
+  ## Why widen, and not seek-and-subtract
+
+  The alternative shape was to count own-authored rows as a second seek on
+  a `sender`-leading index and subtract. Measured on the same corpus, it
+  costs **+37% on INSERT** (0.67s vs 0.48s for 50k rows, 3 reps) because it
+  adds four NEW b-trees to the highest-write-rate table in the codebase,
+  where widening an existing entry by two short values adds none —
+  **no measurable insert cost at all** (0.48/0.49/0.48s against a
+  0.48/0.50/0.50s baseline). It is also not a subtraction: the predicate is
+  a disjunction whose arms overlap (a case-only self-rename matches BOTH
+  `sender` and `new_nick`), so it needs inclusion-exclusion across three
+  seeks, each reproducing the GROUP BY bucketing, to replace one query.
+  Dearer and more fragile, for a read that is already served.
+
+  Index size grows 348 MB → 373 MB (+7.2%) at 650k rows. The sibling
+  commit that drops the four dead `dm_with` indexes (#1372 P-S4) more than
+  pays that back: together they are 25% FASTER on INSERT and 22% smaller
+  than today.
+
+  ## Byte-identity is load-bearing, as ever
+
+  The DM expression MUST stay character-identical to
+  `Identifier.nick_fold_sql/1` applied to `COALESCE(dm_with, channel)`, and
+  the `sender` fold to the same function applied to `sender`, or SQLite
+  silently stops recognising the query as index-eligible — no error, just
+  the old per-row fetch. Inlined here because migrations run before `lib/`
+  is loaded (same reason as `20260725120000`); `ScrollbackTest`'s two-arm
+  pin guards both literals plus the `$.new_nick` JSON path.
+
+  Whitespace and the table alias may differ between this DDL and the
+  emitted query (`json_extract(m0."meta", '$.new_nick')`) — SQLite matches
+  indexed expressions after parsing, not textually, and that was measured,
+  not assumed. The JSON PATH may not differ.
+
+  ## Deploy
+
+  New migration file — Preflight Class 5 forces **COLD**. The four
+  `CREATE INDEX` builds took 2.6s in total over 650k rows locally (per-index
+  split in the PR body); they share one migration transaction, so schedule
+  off a traffic peak. Expand-class: no schema-shape change, so the running
+  old code is unaffected by the added index columns.
+
+  See DESIGN_NOTES 2026-08-16.
+  """
+  use Ecto.Migration
+
+  # The ASCII fold, pure SQL. MUST stay character-identical to
+  # `Grappa.IRC.Identifier.nick_fold_sql/1` (#525 narrowed it from the
+  # rfc1459 four-`replace()` form to plain `lower()`).
+  defp fold(col), do: "lower(#{col})"
+
+  # The `meta.new_nick` half of `exclude_own_authored/3`. No lib-side SSOT
+  # exists — it is an Ecto `fragment` at `scrollback.ex:724`/`:740` — so the
+  # pin test carries the guard.
+  defp new_nick, do: "json_extract(meta, '$.new_nick')"
+
+  def up do
+    # (A) channel family
+    drop index(:messages, ["user_id", "network_id", "channel", "id", "kind"],
+          name: :messages_user_id_network_id_channel_id_kind_index
+        )
+
+    create index(
+             :messages,
+             ["user_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+             name: :messages_user_id_network_id_channel_id_kind_index
+           )
+
+    drop index(:messages, ["visitor_id", "network_id", "channel", "id", "kind"],
+          name: :messages_visitor_id_network_id_channel_id_kind_index
+        )
+
+    create index(
+             :messages,
+             ["visitor_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+             name: :messages_visitor_id_network_id_channel_id_kind_index
+           )
+
+    # (B) DM folded-COALESCE family
+    drop index(
+           :messages,
+           ["user_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+           name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             [
+               "user_id",
+               "network_id",
+               fold("COALESCE(dm_with, channel)"),
+               "id",
+               "kind",
+               fold("sender"),
+               new_nick()
+             ],
+             name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           ["visitor_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+           name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             [
+               "visitor_id",
+               "network_id",
+               fold("COALESCE(dm_with, channel)"),
+               "id",
+               "kind",
+               fold("sender"),
+               new_nick()
+             ],
+             name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+  end
+
+  def down do
+    # Back to the #393 shape: same four names, without the two trailing
+    # expressions. The aggregate returns to a per-row table fetch — that is
+    # what `down` means here, and the pin test reddens on it, correctly.
+    drop index(
+           :messages,
+           ["user_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+           name: :messages_user_id_network_id_channel_id_kind_index
+         )
+
+    create index(:messages, ["user_id", "network_id", "channel", "id", "kind"],
+             name: :messages_user_id_network_id_channel_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           ["visitor_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+           name: :messages_visitor_id_network_id_channel_id_kind_index
+         )
+
+    create index(:messages, ["visitor_id", "network_id", "channel", "id", "kind"],
+             name: :messages_visitor_id_network_id_channel_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           [
+             "user_id",
+             "network_id",
+             fold("COALESCE(dm_with, channel)"),
+             "id",
+             "kind",
+             fold("sender"),
+             new_nick()
+           ],
+           name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             ["user_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+             name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           [
+             "visitor_id",
+             "network_id",
+             fold("COALESCE(dm_with, channel)"),
+             "id",
+             "kind",
+             fold("sender"),
+             new_nick()
+           ],
+           name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             ["visitor_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+             name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+  end
+end

--- a/priv/repo/migrations/20260816014915_drop_dead_messages_dm_with_indexes.exs
+++ b/priv/repo/migrations/20260816014915_drop_dead_messages_dm_with_indexes.exs
@@ -1,0 +1,92 @@
+defmodule Grappa.Repo.Migrations.DropDeadMessagesDmWithIndexes do
+  @moduledoc """
+  #1372 P-S4 — drop four indexes on `messages` that no read can use.
+
+  ## What they were for, and why nothing needs them
+
+      (user_id|visitor_id, network_id, dm_with, server_time)   20260508132130
+      (user_id|visitor_id, network_id, dm_with, id)            20260722202612
+
+  `20260722202612`'s own moduledoc states the purpose of the `id` twins: they
+  exist for symmetry, "so the `dm_with=?` arm … is index-seekable". Three days
+  later #393 DELETED that arm — `where_dm_peer/2` collapsed the OR-disjunction
+  into the single folded equality `lower(COALESCE(dm_with, channel)) = ?`.
+
+  There is no bare `m.dm_with == ^…` predicate left anywhere in `lib/`: every
+  reference is `nick_fold(dm_with)` or `nick_fold(COALESCE(dm_with, channel))`,
+  and a plain B-tree on the RAW column cannot seek either — `dm_with` is stored
+  case-preserved (the #372 nick display rule), so every match folds. #393
+  applied exactly this reasoning when it dropped the sibling
+  `..._channel_id_index` composites; it simply did not extend it to the
+  `dm_with` family.
+
+  ## Measured, not just grepped
+
+  An 11-shape `EXPLAIN QUERY PLAN` sweep over the `messages` read shapes
+  (channel fetch, DM fetch, both `fetch_after`, both `count_after_split`, both
+  content tails, the `list_archive` GROUP BY, `delete_for_dm`, and the
+  `server_time` page) on a 650k-row prod-shaped corpus: **every plan is
+  byte-identical with these four present and with them dropped.** Nothing was
+  using them.
+
+  What they DO cost is write amplification on the highest-write-rate table in
+  the codebase — four B-tree entries maintained on every scrollback INSERT.
+  Dropping them: 50k single-row INSERTs go 0.50/0.50/0.48s → 0.35/0.36/0.36s,
+  and `messages` index bytes 348 MB → 246 MB. Paired with the sibling commit
+  that widens the covering families (#1372 P-S1, which is write-neutral on its
+  own), the two together are **25% faster on INSERT and 22% smaller than main
+  is today**.
+
+  ## Scope
+
+  The two `messages_archive_*_idx` from `20260522073826` are deliberately NOT
+  touched: DESIGN_NOTES 17317-17332 records their #372 staleness and a
+  deliberate KEEP, so they are a documented deferral, not a new finding.
+
+  `down/0` recreates all four, so the decision is reversible — but it recreates
+  a cost with no reader, which is the point of dropping them.
+
+  New migration file — Preflight Class 5 forces **COLD**. Contract-class
+  (removes structure), but nothing reads it, which is what the sweep
+  establishes.
+
+  See DESIGN_NOTES 2026-08-16.
+  """
+  use Ecto.Migration
+
+  def up do
+    drop index(:messages, ["user_id", "network_id", "dm_with", "server_time"],
+          name: :messages_user_id_network_id_dm_with_server_time_index
+        )
+
+    drop index(:messages, ["visitor_id", "network_id", "dm_with", "server_time"],
+          name: :messages_visitor_id_network_id_dm_with_server_time_index
+        )
+
+    drop index(:messages, ["user_id", "network_id", "dm_with", "id"],
+          name: :messages_user_id_network_id_dm_with_id_index
+        )
+
+    drop index(:messages, ["visitor_id", "network_id", "dm_with", "id"],
+          name: :messages_visitor_id_network_id_dm_with_id_index
+        )
+  end
+
+  def down do
+    create index(:messages, ["user_id", "network_id", "dm_with", "server_time"],
+             name: :messages_user_id_network_id_dm_with_server_time_index
+           )
+
+    create index(:messages, ["visitor_id", "network_id", "dm_with", "server_time"],
+             name: :messages_visitor_id_network_id_dm_with_server_time_index
+           )
+
+    create index(:messages, ["user_id", "network_id", "dm_with", "id"],
+             name: :messages_user_id_network_id_dm_with_id_index
+           )
+
+    create index(:messages, ["visitor_id", "network_id", "dm_with", "id"],
+             name: :messages_visitor_id_network_id_dm_with_id_index
+           )
+  end
+end

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -1881,88 +1881,36 @@ defmodule Grappa.ScrollbackTest do
       assert Enum.map(alice_page, & &1.body) == ["to alice"]
     end
 
-    # Codebase review 2026-05-08 H1: the original CP14 B3 index
-    # `(network_id, dm_with, server_time)` had no leading subject
-    # column, so the OR arm of channel_or_dm_where/2 walked rows for
-    # every user/visitor on the network sharing that peer name and
-    # post-filtered by `subject_where/2`. The fix replaces it with two
-    # subject-leading composites that mirror the channel-side shape:
+    # #1372 P-S4 — the two `EXPLAIN QUERY PLAN` tests that used to sit here
+    # pinned a query production no longer runs. They hand-wrote
+    # `(channel = ? OR dm_with = ?)`, the two-arm disjunction #393 DELETED from
+    # `where_dm_peer/2` when it collapsed the DM match to the single folded
+    # `lower(COALESCE(dm_with, channel)) = ?`. Their `acceptable` name lists
+    # were the four `dm_with` indexes this commit drops, so they were the only
+    # thing left in the repo referencing them — a test keeping an index alive
+    # for a reader that no longer exists. Same defect class as the blind
+    # covering pin two commits back: an EXPLAIN of a locally rebuilt query.
     #
-    #   * (user_id, network_id, dm_with, server_time)
-    #   * (visitor_id, network_id, dm_with, server_time)
-    #
-    # These tests pin the SQLite query planner's choice so the
-    # subject-leading shape can never silently regress to a slow
-    # cross-subject scan. EXPLAIN QUERY PLAN is the only observable
-    # signal that the index leadership matters; functional output is
-    # identical either way.
-    #
-    # REV-B / H18 (2026-05-22 codebase review): the regression
-    # invariant is "subject-LEADING", not "this specific index name".
-    # The new REV-B covering index (`messages_archive_user_idx` on
-    # `(user_id, network_id, COALESCE(dm_with, channel), server_time)`)
-    # is ALSO subject-leading; SQLite's planner may pick it for the
-    # DM-fetch OR-shape because the COALESCE column matches BOTH OR
-    # arms in a single walk. Either choice preserves the H1
-    # invariant — the `refute` against the subject-less
-    # `messages_network_id_dm_with_server_time_index` is the
-    # invariant; the asserted name list permits the planner to pick
-    # the more selective subject-leading composite.
-    test "EXPLAIN QUERY PLAN: user-side DM fetch picks a subject-leading composite",
-         %{user: user, network: net} do
-      {:ok, %{rows: rows}} =
-        Repo.query("""
-        EXPLAIN QUERY PLAN
-        SELECT * FROM messages
-        WHERE user_id = '#{user.id}'
-          AND network_id = #{net.id}
-          AND (channel = 'peer' OR dm_with = 'peer')
-        ORDER BY server_time DESC, id DESC
-        LIMIT 50
-        """)
+    # Their invariant SURVIVES, asserted against the real query instead: the
+    # #393 B describe below pins that the production DM read seeks a
+    # SUBJECT-LEADING index (`messages_<subject>_id_network_id_dm_coalesce_…`)
+    # and refutes the network-wide scan. That IS the 2026-05-08 H1 rule — no
+    # cross-subject walk — measured on the predicate production emits. The
+    # deleted tests also `refute`d
+    # `messages_network_id_dm_with_server_time_index`, an index absent from
+    # every migration, so that arm had already gone vacuous.
+    test "the four dead dm_with indexes are dropped" do
+      names = messages_index_names()
 
-      plan_text = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
-
-      acceptable = [
-        "messages_user_id_network_id_dm_with_server_time_index",
-        "messages_archive_user_idx"
-      ]
-
-      assert Enum.any?(acceptable, &String.contains?(plan_text, &1)),
-             "expected dm_with arm to use a subject-leading composite (#{Enum.join(acceptable, " OR ")}), got plan:\n#{plan_text}"
-
-      refute plan_text =~ "messages_network_id_dm_with_server_time_index",
-             "old subject-less index must NOT be used:\n#{plan_text}"
-    end
-
-    test "EXPLAIN QUERY PLAN: visitor-side DM fetch picks a subject-leading composite",
-         %{network: net} do
-      {:ok, visitor} =
-        Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
-
-      {:ok, %{rows: rows}} =
-        Repo.query("""
-        EXPLAIN QUERY PLAN
-        SELECT * FROM messages
-        WHERE visitor_id = '#{visitor.id}'
-          AND network_id = #{net.id}
-          AND (channel = 'peer' OR dm_with = 'peer')
-        ORDER BY server_time DESC, id DESC
-        LIMIT 50
-        """)
-
-      plan_text = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
-
-      acceptable = [
-        "messages_visitor_id_network_id_dm_with_server_time_index",
-        "messages_archive_visitor_idx"
-      ]
-
-      assert Enum.any?(acceptable, &String.contains?(plan_text, &1)),
-             "expected dm_with arm to use a subject-leading composite (#{Enum.join(acceptable, " OR ")}), got plan:\n#{plan_text}"
-
-      refute plan_text =~ "messages_network_id_dm_with_server_time_index",
-             "old subject-less index must NOT be used:\n#{plan_text}"
+      for idx <- ~w(
+            messages_user_id_network_id_dm_with_server_time_index
+            messages_visitor_id_network_id_dm_with_server_time_index
+            messages_user_id_network_id_dm_with_id_index
+            messages_visitor_id_network_id_dm_with_id_index
+          ) do
+        refute idx in names,
+               "#{idx} is write amplification with no reader: every `dm_with` predicate in lib/ folds the column, and a plain B-tree on the raw column cannot seek a folded match"
+      end
     end
   end
 
@@ -3621,13 +3569,22 @@ defmodule Grappa.ScrollbackTest do
 
       # #393 dropped the two `..._channel_id` composites in favour of the
       # `..._channel_id_kind` covering supersets (same prefix, `kind` at the
-      # tail). The `dm_with` id-twins are unchanged. Either the composite OR
-      # its covering superset satisfies the CP29 R-2 no-sort invariant.
+      # tail). Either the composite OR its covering superset satisfies the
+      # CP29 R-2 no-sort invariant.
+      #
+      # #1372 P-S4 — the DM half named the `..._dm_with_id` twins. Those are
+      # dropped: they index the RAW column, and since #393 collapsed the DM
+      # match to `lower(COALESCE(dm_with, channel)) = ?` no read can seek
+      # them. The invariant itself is untouched — a table rebuild must still
+      # leave the DM id-cursor read seekable and sort-free — so it now names
+      # the index that ACTUALLY serves it, the folded-COALESCE covering pair.
+      # Measured: the DM `fetch_after` shape plans
+      # `SEARCH … (… AND <expr>=? AND id>?)` on exactly these.
       for idx <- [
             "messages_visitor_id_network_id_channel_id_kind_index",
             "messages_user_id_network_id_channel_id_kind_index",
-            "messages_visitor_id_network_id_dm_with_id_index",
-            "messages_user_id_network_id_dm_with_id_index"
+            "messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index",
+            "messages_user_id_network_id_dm_coalesce_fold_id_kind_index"
           ] do
         assert idx in names,
                "#{idx} missing — CP29 R-2-class drift (a table-rebuild migration " <>

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -120,16 +120,60 @@ defmodule Grappa.ScrollbackTest do
   # respective `..._id_kind` index (kind at the tail = no per-row table
   # fetch). `kind` is read by the GROUP BY, so a covering plan requires it in
   # the index — this is the regression guard for the kind-at-tail claim.
-  defp count_split_query(subject, net, target) do
-    ck = Message.content_kinds()
+  #
+  # #1372 — this used to REBUILD the aggregate here. That local copy is what
+  # blinded the pin: it called `channel_or_dm_where(target, nil)`, and at
+  # `own_nick = nil` `exclude_own_authored/3` is the identity clause
+  # (`scrollback.ex:718`), so the predicate #532 A and #576 later bolted onto
+  # the production query never entered the pinned SQL. The pin went on
+  # asserting COVERING against a shape production had stopped running, and
+  # stayed green straight through the regression it existed to catch. So the
+  # plan is now taken off the query the production function ACTUALLY emits,
+  # captured from Ecto's own telemetry — there is no second copy left to
+  # drift. Verified result- and byte-identical to the deleted local rebuild
+  # at (own_nick: nil, hide_presence: false) before it was removed.
+  defp count_split_plan(subject, net, target, own_nick) do
+    {sql, params} =
+      capture_one_query(fn ->
+        Scrollback.count_after_split(subject, net.id, target, 0, own_nick, false)
+      end)
 
-    Message
-    |> subject_filter(subject)
-    |> where([m], m.network_id == ^net.id)
-    |> Scrollback.channel_or_dm_where(target, nil)
-    |> where([m], m.id > ^0)
-    |> group_by([m], fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.kind in ^ck))
-    |> select([m], {fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.kind in ^ck), count(m.id)})
+    {:ok, %{rows: rows}} = Repo.query("EXPLAIN QUERY PLAN " <> sql, params)
+    rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
+  end
+
+  # Returns the single `{sql, params}` Ecto emitted while `fun` ran. Ecto
+  # publishes `[:grappa, :repo, :query]` synchronously in the caller process,
+  # so the capture needs no synchronisation. Matching on ONE query is part of
+  # the contract: if `count_after_split/6` ever becomes multi-statement, this
+  # raises instead of silently pinning whichever statement came last.
+  defp capture_one_query(fun) do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:grappa, :repo, :query],
+      fn _, _, meta, _ -> send(test_pid, {ref, meta.query, meta.params}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach({__MODULE__, ref})
+    end
+
+    [captured] = drain_queries(ref, [])
+    captured
+  end
+
+  defp drain_queries(ref, acc) do
+    receive do
+      {^ref, sql, params} -> drain_queries(ref, [{sql, params} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
   end
 
   # #393 — messages index name list + a single index's committed DDL.
@@ -2010,7 +2054,7 @@ defmodule Grappa.ScrollbackTest do
       # COVERING — no per-row table fetch (the exact 432ms DM bug #393 fixed).
       # This is the DM twin of the channel COVERING assertion; it regresses
       # loudly if `kind` is ever dropped from the coalesce index tail.
-      plan = explain_plan(count_split_query({:user, user.id}, net, "peer"))
+      plan = count_split_plan({:user, user.id}, net, "peer", nil)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_dm_coalesce_fold_id_kind_index",
              "expected the DM count_after_split covered by the coalesce kind index, got:\n#{plan}"
@@ -2170,7 +2214,7 @@ defmodule Grappa.ScrollbackTest do
 
     test "channel count_after_split is served by the COVERING kind index (no table fetch)",
          %{user: user, network: net} do
-      plan = explain_plan(count_split_query({:user, user.id}, net, "#linux"))
+      plan = count_split_plan({:user, user.id}, net, "#linux", nil)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_channel_id_kind_index",
              "expected count_after_split channel query covered by the kind index, got:\n#{plan}"
@@ -2180,7 +2224,7 @@ defmodule Grappa.ScrollbackTest do
          %{network: net} do
       {:ok, visitor} = Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
 
-      plan = explain_plan(count_split_query({:visitor, visitor.id}, net, "#linux"))
+      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", nil)
 
       assert plan =~ "USING COVERING INDEX messages_visitor_id_network_id_channel_id_kind_index",
              "expected visitor count_after_split channel query covered by the kind index, got:\n#{plan}"

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -30,6 +30,29 @@ defmodule Grappa.ScrollbackTest do
 
   defp uniq, do: System.unique_integer([:positive])
 
+  # #1372 — the `meta.new_nick` half of `exclude_own_authored/3`, as it is
+  # spelled in the covering-index DDL. The `sender` half has a lib-side SSOT
+  # (`Identifier.nick_fold_sql/1`); this one does not — it lives as an Ecto
+  # `fragment` (`scrollback.ex:724`, `:740`), and a migration cannot call into
+  # `lib/`. So the migration inlines it and THIS attribute is the guard, the
+  # same posture #393 took for its folded-COALESCE literal.
+  #
+  # Whitespace and the table alias may differ between the index DDL and the
+  # emitted query (`json_extract(m0."meta", '$.new_nick')`): SQLite matches
+  # indexed expressions after parsing, not textually. Measured — an index
+  # written without the space still yields COVERING for the aliased query.
+  # What may NOT differ is the JSON PATH: change `$.new_nick` on either side
+  # and the index silently stops applying.
+  @new_nick_index_expr "json_extract(meta, '$.new_nick')"
+
+  # #1372 — the own nick the covering pins pass to `count_after_split/6`. It
+  # MUST be non-nil and MUST NOT equal the target: nil short-circuits
+  # `exclude_own_authored/3` to the identity clause (the blind spot this issue
+  # is about), and a target equal to it takes the #576 self-window branch,
+  # which strips presence only. Either would pin a shape the cold `/me` seed
+  # and the per-channel join reply do not take.
+  @own_nick "vjt"
+
   defp sample(user, network, i, overrides \\ %{}) do
     Map.merge(
       %{
@@ -1998,6 +2021,21 @@ defmodule Grappa.ScrollbackTest do
       end
     end
 
+    # #1372 arm 1 of 2 — the DM twin of the channel DDL arm. Same split, same
+    # reason: this one names the missing expression, the plan test names the
+    # lost COVERING.
+    test "the DM covering indexes carry both exclude_own_authored/3 expressions" do
+      for idx <- @dm_coalesce_index_names do
+        ddl = index_ddl(idx)
+
+        assert ddl =~ Identifier.nick_fold_sql("sender"),
+               "#{idx} lost the folded `sender` expression — the DM aggregate falls back to a per-row table fetch:\n#{ddl}"
+
+        assert ddl =~ @new_nick_index_expr,
+               "#{idx} lost the `#{@new_nick_index_expr}` expression — same fallback:\n#{ddl}"
+      end
+    end
+
     test "user-side DM read SEEKS the folded COALESCE value on the covering index",
          %{user: user, network: net} do
       plan = explain_plan(folded_dm_read_query({:user, user.id}, net, "peer"))
@@ -2054,7 +2092,7 @@ defmodule Grappa.ScrollbackTest do
       # COVERING — no per-row table fetch (the exact 432ms DM bug #393 fixed).
       # This is the DM twin of the channel COVERING assertion; it regresses
       # loudly if `kind` is ever dropped from the coalesce index tail.
-      plan = count_split_plan({:user, user.id}, net, "peer", nil)
+      plan = count_split_plan({:user, user.id}, net, "peer", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_dm_coalesce_fold_id_kind_index",
              "expected the DM count_after_split covered by the coalesce kind index, got:\n#{plan}"
@@ -2198,11 +2236,33 @@ defmodule Grappa.ScrollbackTest do
   # via `create_if_not_exists`. dev/test/CI create them normally — these
   # assertions hold in BOTH states.
   describe "#393 A — channel unread-count covering index" do
+    @channel_covering_index_names ~w(
+      messages_user_id_network_id_channel_id_kind_index
+      messages_visitor_id_network_id_channel_id_kind_index
+    )
+
     test "the two channel+id+kind covering indexes exist on messages" do
       names = messages_index_names()
 
       assert "messages_user_id_network_id_channel_id_kind_index" in names
       assert "messages_visitor_id_network_id_channel_id_kind_index" in names
+    end
+
+    # #1372, arm 1 of 2 — the DDL SQLite actually stored. Arm 2 (below) reads
+    # the plan. Split deliberately: a plan assertion alone cannot say WHICH of
+    # the two expressions went missing, and "not COVERING" is the same message
+    # whether an expression drifted or the planner merely passed the index
+    # over. This arm names the expression; that one names the lost COVERING.
+    test "the channel covering indexes carry both exclude_own_authored/3 expressions" do
+      for idx <- @channel_covering_index_names do
+        ddl = index_ddl(idx)
+
+        assert ddl =~ Identifier.nick_fold_sql("sender"),
+               "#{idx} lost the folded `sender` expression — the aggregate falls back to a per-row table fetch:\n#{ddl}"
+
+        assert ddl =~ @new_nick_index_expr,
+               "#{idx} lost the `#{@new_nick_index_expr}` expression — same fallback:\n#{ddl}"
+      end
     end
 
     test "the two now-redundant channel+id composites are dropped" do
@@ -2214,7 +2274,7 @@ defmodule Grappa.ScrollbackTest do
 
     test "channel count_after_split is served by the COVERING kind index (no table fetch)",
          %{user: user, network: net} do
-      plan = count_split_plan({:user, user.id}, net, "#linux", nil)
+      plan = count_split_plan({:user, user.id}, net, "#linux", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_channel_id_kind_index",
              "expected count_after_split channel query covered by the kind index, got:\n#{plan}"
@@ -2224,7 +2284,7 @@ defmodule Grappa.ScrollbackTest do
          %{network: net} do
       {:ok, visitor} = Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
 
-      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", nil)
+      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_visitor_id_network_id_channel_id_kind_index",
              "expected visitor count_after_split channel query covered by the kind index, got:\n#{plan}"


### PR DESCRIPTION
Bucket B of the 2026-08-15 review: P-S1 (the unread aggregate lost its covering
index) and P-S4 (four dead indexes on the same table). P-S5 is deliberately not
here — it is a lost update on `user_settings.data`, another table, no index
dimension; the orchestrator is filing it separately.

## The finding that outlived the fix

P-S1 closes with *"the absence of such a pin is what let this through."* **The
pin existed, and it was green.** Three of them, asserting `USING COVERING
INDEX` — at `66759042:test/grappa/scrollback_test.exs:2013`, `:2173` and
`:2183` (line numbers as of the branch point, since this PR moves them).

They EXPLAINed `count_split_query/3` (`66759042:…:123`) — a **local rebuild**
of the aggregate, not the production query — and it passed `own_nick: nil` to
`channel_or_dm_where/3`. At nil, `exclude_own_authored/3` is the identity
clause (`lib/grappa/scrollback.ex:711`, unchanged here), so the predicate
#532 A and #576 added
never entered the pinned SQL. The pin asserted COVERING against a shape
production had stopped running and stayed green straight through the regression
it existed to catch.

Measured on one corpus, same channel, same cursor, 103,209 post-cursor rows:

| shape | plan | page fetches |
|---|---|---|
| `own_nick = nil` — what the pin asserted | **COVERING** INDEX | **1,676** |
| `own_nick = "vjt"` — what production runs | INDEX, no COVERING | **175,576** |

A pin on a branch production does not take is worse than no pin: it reports
safety. So it is not fixed by adding a second pin beside it — the plan is now
read off the SQL the production function emits, captured from
`[:grappa, :repo, :query]` telemetry, and the local rebuild is deleted. There
is no second copy left to drift.

The same defect class shows up twice more in the same file and both are cleaned
up here: two tests EXPLAINing the `(channel = ? OR dm_with = ?)` disjunction
#393 deleted from production, which were the only remaining readers of the four
indexes P-S4 drops.

## Method

No prod copy on this lane, so one was built: the real migrated DDL from
`runtime/grappa_dev.db` (13 indexes on `messages`), loaded with 650k synthetic
rows — 20 channels zipf-skewed, `#linux` heaviest at 103,209 rows on the busy
network; 192 peers plus the own nick at ~4% of `sender`; a realistic kind mix;
10% DM rows split inbound/outbound the way `Session.Server` persists them;
`meta.new_nick` on `nick_change` with 5% renaming *to* the own nick; ids
interleaved across channels so a channel's rows are contiguous in the index and
**scattered in the table**, which is where the whole cost lives.

**No `ANALYZE`** — verified absent from `lib/ priv/ scripts/ config/`, and no
`sqlite_stat*` in any runtime DB, so prod plans on default estimates and the
bench must too.

The primary metric is **page fetches**, not milliseconds: deterministic and
host-independent. The SQL is the real emitted statement, captured off
telemetry, not transcribed.

## P-S1 — the fix, and the shape that lost

Widen both covering families with `lower(sender)` and
`json_extract(meta, '$.new_nick')`:

- **Read:** 175,576 → 1,886 page fetches (**93x**), identical results
  (52112/46620 both sides). Page *misses* 23,427 → 1,885 is **14x**, which
  lands on the same ~15x #393 recorded from a completely independent
  measurement.
- **Write — the half that decides it**, on the highest-write-rate table in the
  codebase. 50k single-row INSERTs, 3 reps:

  | variant | insert | `messages` index bytes |
  |---|---|---|
  | main today | 0.50 / 0.50 / 0.48 s | 348 MB |
  | + widen (P-S1) | 0.48 / 0.49 / 0.48 s | 373 MB |
  | + widen + drop (P-S1 + P-S4) | **0.37 / 0.37 / 0.37 s** | **271 MB** |
  | drop alone (P-S4) | 0.35 / 0.36 / 0.36 s | 246 MB |

  Widening four existing entries adds no b-tree, so it costs nothing
  measurable. **The alternative — count own-authored rows as a second seek on a
  `sender`-leading index and subtract — costs +37% on INSERT** (0.67/0.67/0.68 s),
  because it adds four new b-trees. It is also not a subtraction: the predicate
  is a disjunction whose arms overlap (a case-only self-rename matches both), so
  it needs inclusion–exclusion across three seeks, each reproducing the GROUP BY
  bucketing, to replace one query. Dearer and more fragile.
- Widening with `lower(sender)` **alone** was measured and does **not** restore
  COVERING. Both expressions are load-bearing.

## P-S4 — measured dead, not just grepped

An 11-shape `EXPLAIN QUERY PLAN` sweep (channel fetch, DM fetch, both
`fetch_after`, both `count_after_split`, both content tails, `list_archive`
GROUP BY, `delete_for_dm`, `server_time` page) across main / widened /
widened+dropped:

- **No shape regresses.** Every plan is byte-identical across the three
  variants except the two `count_after_split` arms, which go `INDEX` →
  `COVERING INDEX`.
- **widened+dropped is identical to widened on all 11** — nothing was using the
  four dropped indexes.

The two `messages_archive_*_idx` are deliberately untouched: DESIGN_NOTES
17317-17332 records their #372 staleness and a deliberate KEEP.

## The pin, and how each assertion was bought

Two arms, because a plan assertion alone cannot say *which* expression went
missing, and "not COVERING" reads identically whether an expression drifted or
the planner merely passed a good index over (the #1353/#1355 shape). Arm 1 is
the DDL SQLite stored; arm 2 is the plan.

Every mutant restored afterwards, `git status` empty, baseline reprinted green
(`1 property, 181 tests, 0 failures`) at both ends:

| mutant | tally | reddens |
|---|---|---|
| **M1** index: JSON path `$.new_nick`→`$.newnick` | 181 tests, **5 failures** | 2 DDL arms + 3 plan arms |
| **M2** index: `fold("sender")`→`fold("id")` | 181 tests, **5 failures** | 2 DDL arms + 3 plan arms |
| **M3** *query*: JSON path drifts, index untouched | 181 tests, **3 failures** | **plan arms ONLY — DDL arms green** |
| **M4** *query*: fold `m.body` instead of `m.sender` | 181 tests, **5 failures** | 3 plan arms + 2 behavioural tests |

**Honest reading of that table.** M1 and M2 each kill two assertions, because
an index-side drift necessarily costs COVERING — the DDL arm implies the plan
arm on that class. The house rule says a mutant that kills two means the pair
needs rethinking, so **M3 is the one that answers it**: a query-side drift away
from a perfectly good index reddens the plan arms while the DDL arms stay
green. That is a real regression class the DDL arm cannot see, so the arms are
complementary, not redundant — and on the index-side class the DDL arm is what
names *which* expression died. M4 additionally shows the `#532 A`/`#576`
behavioural tests are not asleep.

**A trap worth naming:** M1 and M2 initially *survived*. `mix test` runs
`ecto.migrate`, which only applies **pending** migrations — so editing a
migration whose version is already in `schema_migrations` is a silent no-op and
an index-side mutant never takes effect. CI is unaffected (fresh DB per run);
locally the harness has to drop the DB between rounds. A harness without that
step would have reported these assertions bought when they were not.

## Deploy — COLD, and how long the window is

Two new migration files, Preflight Class 5. All four `CREATE INDEX` builds
share ONE transaction, so the transaction is what sizes the window, not the
per-index split.

**Measured at prod's actual row count.** The first pass of this used a 650k
corpus because that is what #393 recorded. That number is three weeks stale and
three times too small: vjt read prod on 2026-08-16 — **`messages` = 1,943,545
rows, DB 1.53 GB**. So the corpus was rebuilt at 1,943,545 rows (1.23 GB; prod
is larger because it carries the other tables and the archive indexes) and
re-measured, fresh copy per rep so no rep inherits the previous page cache:

| | rep 1 | rep 2 | rep 3 |
|---|---|---|---|
| **P-S1 `up/0`** — 4 drop + 4 create, 1 txn | 9.66 s | 9.55 s | 9.85 s |
| P-S4 `up/0` — 4 drop, 1 txn | 0.09 s | 0.08 s | 0.09 s |
| **both back to back — the real migrate step** | 10.14 s | 9.72 s | 9.72 s |

Per-CREATE at 1.9M: `user_channel` 2.16-2.31 s · `visitor_channel` 1.63-1.74 s ·
`user_dm` 2.28-2.32 s · `visitor_dm` 1.73-1.78 s. Internal consistency check:
2.99x the rows cost 3.24x the time (2.9 s → 9.7 s), the mild superlinearity a
sort-dominated build should show.

**Prod estimate — EXPLICITLY DERIVED, not observed.** The above is a macOS/APFS
laptop; prod is a FreeBSD bastille jail on ZFS. The scaling factor is #393's own
prod record for the same operation on the same table: 1.6-2.0 s per channel
index and 2.442/2.570 s per DM index at 654k rows, against 0.52-0.69 s locally
at 650k — a **3-4.5x host factor**, and conservative, because #393's indexes
were NARROWER than these (5 columns vs 7). Applying it to the measured 9.7 s:

> **expect roughly 30-45 seconds for the COLD migrate step on m42.**

This supersedes an earlier "order of 10 seconds" in this PR's history, which was
derived from the stale 654k figure. **Nobody has measured an index build on
prod's substrate at 1.9M rows** — the row count is observed, the local build is
observed, the host factor is borrowed from #393, and the product of the last two
is an extrapolation.

Not measured: the WAL commit cost. The transaction writes the four new indexes
into the WAL before committing, and #1355 has just changed the checkpoint
threshold. On a COLD deploy the BEAM is down, so at least concurrent write load
is genuinely absent rather than merely unmodelled.

The widen is expand-class (no schema-shape change, running old code unaffected);
the drop is contract-class but has no reader, which is what the sweep
establishes.

## What I did NOT establish

- **No prod copy.** Distributions are chosen, not observed. The ~4%
  own-`sender` share moves the absolute numbers; it does not move whether the
  plan is COVERING.
- **Wall-clock is not prod's** — warm macOS/APFS, no pool contention, no
  FreeBSD jail. Cold-cache timing is unmeasured (`purge` needs sudo); the
  23,427 page misses stand as the proxy for the I/O the incident was made of.
- **#1353's open question stays open.** Why a pool connection that did not
  serve the `CREATE INDEX` plans differently — schema cache or transaction
  visibility — is still unmeasured. `config/test.exs` is already `pool_size: 1`
  for the Sandbox-serialisation reason, which happens to satisfy the
  plan-stability need too; I have not re-derived the mechanism and am not
  claiming it.
- **`ReadCursor.own_authored_dynamic/2`** (`read_cursor.ex:483`) is the same
  predicate shape against the same table, flagged by the review as the same
  defect class and explicitly out of P-S1's scope. It plausibly benefits from
  these same widened indexes — **I did not measure it**, and nothing here
  claims it is fixed.
- Prod's real cursor-lag distribution. The cold `/me` seed is the worst case by
  construction; how far behind a typical cursor sits, I don't know.
- Three `users_folded_name_index` failures appeared in the full suite on the
  **shared** test DB while this branch was based on `66759042`. Established as
  contamination, not assumed: the index was in no migration on this branch, it
  came from `w1-1353-name-fold`, and the full suite under an isolated cache and
  DB (`GRAPPA_CACHE_ID`) was **6315 tests, 0 failures**. #1353 has since landed
  on main, so after the rebase the branch carries that migration legitimately
  and the three tests pass on any DB. Recorded because the *reasoning* is what
  matters here: a red naming something you never touched is a contamination
  suspect before it is a defect.
