### PR TITLE
persistence(#1374): one busy-retry + immediate-transaction discipline for the write path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,8 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   old→new (broadcasting mid-migration raced a follow-on
   `Scrollback.fetch`; #373 rename-order fix). A NEW nick-keyed store MUST
   be added to this migration set or a rename silently strands its
-  old-nick rows. Boundary limit: IRC delivers a NICK only to
+  old-nick rows — the set and its one retried transaction live in
+  `Grappa.NickMigration` (#1374), not in `Session.Server`. Boundary limit: IRC delivers a NICK only to
   channel-sharing peers, so a query with someone in no shared channel
   cannot follow. **Our OWN nick keys exactly one window — the SELF
   window (`/msg <ownnick>`, GH #948) — and it has its own set** on

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43368,3 +43368,65 @@ when a reset actually happens. With `pool_size: 10` under continuous reads
 that is a real possibility, and it is the most likely reason prod's WAL was at
 168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
 the pressure and bounds the recovery; it does not promise a ceiling.
+<!-- entry #1374 -->
+
+---
+
+## 2026-08-16 — #1374: one busy-retry discipline for the write path, and what the fault seam cannot see
+
+Four findings from the 2026-08-15 review (P-S2, P-S3, P-S7, P-S8) share one
+rule, and it is the durable part of this change: **the retry goes OUTSIDE the
+transaction, the transaction goes INSIDE it, and no retry loop ever opens
+inside an already-open transaction.** `Repo.BusyRetry.run(fn ->
+Repo.immediate_transaction(fn -> … end) end)` is the only correct nesting.
+Retrying a step is not retrying a transaction; a nested retry sleeps while
+holding the enclosing transaction's connection and extends the very contention
+it waits on.
+
+Two consequences fall out. Code reached only from inside an open transaction
+needs a NON-retrying seam that RAISES, because the raise is what aborts the
+transaction and hands the retry to the enclosing engine — that is the `!`
+family (`persist!/1`, `get_or_init!/1`, `put_upload_ttl_seconds!/2`,
+`rename_muted_target!/4`). And a set of writes that must land together needs
+one owner: `Grappa.NickMigration` is now the home of the nick-rename set, a
+TOP-LEVEL boundary rather than a supervised child, so `Session` can span four
+contexts without acquiring a `Grappa.Repo` dep it deliberately lacks. The
+`query_windows_list` broadcast stays in `Session.Server` after the `:ok`
+return: it is the #373 "rename fully applied" barrier and a retried attempt
+must not re-fire it.
+
+**The write-transaction spelling is now gated statically, because it cannot be
+gated at runtime.** exqlite emits `BEGIN IMMEDIATE` only when
+`transaction_status == :idle` (`connection.ex:297-316`); nested, every mode
+collapses to `SAVEPOINT exqlite_savepoint`. Under the SQL Sandbox every test
+already runs inside a transaction, so `immediate_transaction/1` is always a
+savepoint there and no ExUnit oracle can distinguish it from `transaction/1` —
+the "put the deferred spelling back" mutant is unkillable at runtime. The
+defect is undecidable at runtime and decidable at compile time, so
+`test/grappa/repo/transaction_mode_gate_test.exs` walks the AST of `lib/**/*.ex`
+instead. Its blind spot is declared in its own moduledoc: a renaming alias
+escapes it, and a genuinely read-only transaction must say so by calling a
+`deferred_transaction/1` sibling, deliberately not written because it would be
+dead code today.
+
+**The fault-injection seam has a reach, and it is narrower than it looks.**
+`BusyRetry`'s injected fault fires only at the top of a `BusyRetry.run`
+attempt. Established by mutation, not assumed: removing the wrapper from
+`NickMigration.migrate/1` did not make the write fail, it made the write
+LAND. Three things follow, and they bound what any future test here can claim.
+A code path with no retry loop has no fault point at all, so the seam cannot
+show a raise escaping an unretried writer — that claim stays argued from
+`Repo.update/1`'s behaviour. A saturating fault fires before the first step of
+a transaction, so removing `immediate_transaction` from a retried chain leaves
+every test green: atomicity is NOT measurable in-process, and the mutant that
+should have bought it survives. And a fault cannot be aimed mid-chain, because
+a first attempt that succeeds means there is no second attempt to arm.
+
+Two review claims did not survive measurement, recorded so nobody re-derives
+them. The 2FA door does NOT answer 500 on a sustained busy; it already answers
+503, from a retry DOWNSTREAM of `TOTP.verify/3`. Its real defect was that
+`totp_last_used_step` advanced anyway, so the user paid a redeemable code for a
+degraded response. And P-S8's count was wrong in three different ways at once —
+prose said five, four were named, the file:line list held six; seven are fixed,
+including `update_visitor_last_joined_channels/3`, which the review never
+mentions and which is session-driven exactly like its user-side twin.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -775,7 +775,7 @@ defmodule Grappa.Accounts do
     * **in-transaction** — the `!` variants
       (`revoke_other_sessions_for_user!/2` and the private
       `revoke_sessions_for_user!/1`). Reached only from inside a
-      `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, where the
+      `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, where the
       enclosing engine retries the WHOLE transaction. They deliberately do
       NOT retry: a nested retry would sleep while holding the open
       transaction's connection, extending the very contention it waits on,
@@ -944,7 +944,7 @@ defmodule Grappa.Accounts do
 
   In-transaction only — every caller (TOTP enrolment/disable, the passkey
   mode transaction) already runs inside a
-  `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, so this RAISES on
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, so this RAISES on
   SQLITE_BUSY rather than retrying: the raise is what aborts the
   transaction and hands the retry to the enclosing engine. See the family
   contract on `revoke_session/1`. A caller with no such enclosure wants a
@@ -978,7 +978,7 @@ defmodule Grappa.Accounts do
           {:ok, [String.t()]} | {:error, term()}
   def confirm_totp_enrollment(user, current_session_id, secret, code, unix_seconds) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn ->
+      Repo.immediate_transaction(fn ->
         confirm_totp_transaction(user, current_session_id, secret, code, unix_seconds)
       end)
     end)
@@ -1045,7 +1045,14 @@ defmodule Grappa.Accounts do
           | {:error, :invalid_two_factor | :two_factor_replayed | :db_unavailable}
   def verify_second_factor(%User{} = user, code, unix_seconds)
       when is_binary(code) and is_integer(unix_seconds) do
-    case TOTP.verify(user, code, unix_seconds) do
+    # #1374 P-S3 — the retry belongs HERE, at the boundary, not inside
+    # `TOTP.verify/3`: the transaction is what must be retried, and it opens
+    # inside that function. Until #1374 this was the one second-factor path
+    # with no retry at all, so a transient busy raised through as a 500 at
+    # the login door where #518 promises a typed 503. The recovery-code arm
+    # below owns its OWN budget (`consume_recovery_code/2`) and is reached
+    # only after this run has returned, so the two never nest.
+    case Repo.BusyRetry.run(fn -> TOTP.verify(user, code, unix_seconds) end) do
       {:error, :two_factor_not_enabled} -> spend_recovery_code(user, code)
       result -> result
     end
@@ -1110,7 +1117,7 @@ defmodule Grappa.Accounts do
   end
 
   defp run_totp_reset(user),
-    do: Repo.BusyRetry.run(fn -> Repo.transaction(fn -> totp_reset_transaction(user) end) end)
+    do: Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> totp_reset_transaction(user) end) end)
 
   defp totp_reset_transaction(user) do
     user_query = from(u in User, where: u.id == ^user.id)
@@ -1139,7 +1146,7 @@ defmodule Grappa.Accounts do
   end
 
   defp run_passkey_reset(user) do
-    Repo.BusyRetry.run(fn -> Repo.transaction(fn -> reset_passkeys_transaction(user) end) end)
+    Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> reset_passkeys_transaction(user) end) end)
   end
 
   defp reset_passkeys_transaction(user) do
@@ -1163,7 +1170,7 @@ defmodule Grappa.Accounts do
 
   defp run_disable_totp_transaction(user, current_session_id) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn -> disable_totp_transaction(user, current_session_id) end)
+      Repo.immediate_transaction(fn -> disable_totp_transaction(user, current_session_id) end)
     end)
   end
 

--- a/lib/grappa/accounts/totp.ex
+++ b/lib/grappa/accounts/totp.ex
@@ -45,7 +45,7 @@ defmodule Grappa.Accounts.TOTP do
       when is_binary(secret) and is_binary(code) and is_integer(unix_seconds) do
     with {:ok, step} <- matching_step(secret, code, unix_seconds) do
       now = DateTime.utc_now()
-      Repo.transaction(fn -> arm(user_id, secret, step, now) end)
+      Repo.immediate_transaction(fn -> arm(user_id, secret, step, now) end)
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Grappa.Accounts.TOTP do
   @spec verify(User.t(), String.t(), integer()) :: {:ok, :totp | :recovery} | {:error, verify_error()}
   def verify(%User{id: user_id}, code, unix_seconds)
       when is_binary(code) and is_integer(unix_seconds) do
-    Repo.transaction(fn ->
+    Repo.immediate_transaction(fn ->
       user = Repo.get!(User, user_id)
 
       if is_nil(user.totp_enabled_at) or is_nil(user.totp_secret_encrypted) do

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -378,7 +378,9 @@ defmodule Grappa.Accounts.WebAuthn do
 
   defp run_mode_transaction(user, mode, current_session_id, recovery_codes) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn -> set_mode_transaction(user, mode, current_session_id, recovery_codes) end)
+      Repo.immediate_transaction(fn ->
+        set_mode_transaction(user, mode, current_session_id, recovery_codes)
+      end)
     end)
   end
 

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -182,22 +182,27 @@ defmodule Grappa.Networks.Credentials do
   path). `{:error, :not_found}` when the credential was unbound.
   """
   @spec remove_visitor_last_joined_channel(Ecto.UUID.t(), pos_integer(), String.t()) ::
-          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def remove_visitor_last_joined_channel(visitor_id, network_id, channel_name)
       when is_binary(visitor_id) and is_integer(network_id) and is_binary(channel_name) do
     canonical = Grappa.IRC.Identifier.canonical_target(channel_name)
 
-    case get_visitor_credential(visitor_id, network_id) do
-      {:ok, cred} ->
-        kept = Enum.reject(cred.last_joined_channels, &(&1 == canonical))
+    # #1374 P-S8 — web-reachable (`DELETE /networks/:slug/channels/:id`), so
+    # the terminal is the 503 door, not a drop: the operator asked for this
+    # write and must learn it did not happen.
+    Repo.BusyRetry.run(fn ->
+      case get_visitor_credential(visitor_id, network_id) do
+        {:ok, cred} ->
+          kept = Enum.reject(cred.last_joined_channels, &(&1 == canonical))
 
-        cred
-        |> Credential.last_joined_channels_changeset(kept)
-        |> Repo.update()
+          cred
+          |> Credential.last_joined_channels_changeset(kept)
+          |> Repo.update()
 
-      {:error, :not_found} ->
-        {:error, :not_found}
-    end
+        {:error, :not_found} ->
+          {:error, :not_found}
+      end
+    end)
   end
 
   @doc """
@@ -208,7 +213,7 @@ defmodule Grappa.Networks.Credentials do
   autojoin list. Returns `{:ok, credential}` or `{:error, changeset}`.
   """
   @spec remove_autojoin_channel(User.t(), Network.t(), String.t()) ::
-          {:ok, Credential.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+          {:ok, Credential.t()} | {:error, Ecto.Changeset.t() | :not_found | :db_unavailable}
   def remove_autojoin_channel(%User{} = user, %Network{} = network, channel_name)
       when is_binary(channel_name) do
     # UX-4 bucket A — canonicalise so a REST DELETE with `#Chan` in the
@@ -216,17 +221,21 @@ defmodule Grappa.Networks.Credentials do
     # Credential.changeset/2 writer normalises to).
     channel_name = Grappa.IRC.Identifier.canonical_target(channel_name)
 
-    case get_credential(user, network) do
-      {:ok, cred} ->
-        new_autojoin = Enum.reject(cred.autojoin_channels, &(&1 == channel_name))
+    # #1374 P-S8 — the user twin of `remove_visitor_last_joined_channel/3`,
+    # same web-reachable 503 door.
+    Repo.BusyRetry.run(fn ->
+      case get_credential(user, network) do
+        {:ok, cred} ->
+          new_autojoin = Enum.reject(cred.autojoin_channels, &(&1 == channel_name))
 
-        cred
-        |> Credential.changeset(%{autojoin_channels: new_autojoin})
-        |> Repo.update()
+          cred
+          |> Credential.changeset(%{autojoin_channels: new_autojoin})
+          |> Repo.update()
 
-      {:error, :not_found} ->
-        {:error, :not_found}
-    end
+        {:error, :not_found} ->
+          {:error, :not_found}
+      end
+    end)
   end
 
   @doc """
@@ -260,27 +269,40 @@ defmodule Grappa.Networks.Credentials do
   belt-and-braces guard, not the primary enforcement point.
   """
   @spec update_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_last_joined_channels(user_id, network_id, channels)
       when is_binary(user_id) and is_integer(network_id) and is_list(channels) do
     capped = Enum.take(channels, Credential.last_joined_channels_max())
 
-    case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
-      nil ->
-        {:error, :not_found}
+    # #1374 P-S8 — this fires on EVERY self-JOIN / self-PART / self-KICK, and
+    # bootstrap spawning N sessions x M autojoin channels is the correlated
+    # write burst. The call site (`Session.Server.maybe_persist_last_joined/2`)
+    # already logs a RETURNED `{:error, _}` and carries on, but a transient
+    # busy RAISED, and the raise escaped the persister closure into the
+    # GenServer. Background-DROP posture (#590): the next membership change
+    # overwrites the snapshot, so a lost one only costs the next restart its
+    # rejoin list.
+    persisted =
+      Repo.BusyRetry.run(fn ->
+        case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
+          nil ->
+            {:error, :not_found}
 
-      %Credential{} = cred ->
-        # S34: narrow changeset — this fires on every self-JOIN/PART/KICK,
-        # so it must not drag the wide `changeset/2`'s unrelated validators
-        # (`validate_password_for_auth_method`, `put_encrypted_password`,
-        # the `unique_constraint`) onto the hot path. Twin of the visitor
-        # side's `Visitor.last_joined_channels_changeset/2`.
-        changeset = Credential.last_joined_channels_changeset(cred, capped)
-
-        case Repo.update(changeset) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
+          %Credential{} = cred ->
+            # S34: narrow changeset — this fires on every self-JOIN/PART/KICK,
+            # so it must not drag the wide `changeset/2`'s unrelated validators
+            # (`validate_password_for_auth_method`, `put_encrypted_password`,
+            # the `unique_constraint`) onto the hot path. Twin of the visitor
+            # side's `Visitor.last_joined_channels_changeset/2`.
+            cred
+            |> Credential.last_joined_channels_changeset(capped)
+            |> Repo.update()
         end
+      end)
+
+    case persisted do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
     end
   end
 
@@ -301,18 +323,25 @@ defmodule Grappa.Networks.Credentials do
   to boot `:present`.
   """
   @spec update_away(Ecto.UUID.t(), pos_integer(), String.t() | nil, DateTime.t() | nil) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_away(user_id, network_id, reason, since)
       when is_binary(user_id) and is_integer(network_id) do
-    case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
-      nil ->
-        {:error, :not_found}
-
-      %Credential{} = cred ->
-        case Repo.update(Credential.away_changeset(cred, reason, since)) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
+    # #1374 P-S8 — twin of `update_last_joined_channels/3`, same posture: it
+    # fires on every away transition (including the auto-away debounce, which
+    # a WS reconnect storm drives for every session at once), and its call
+    # site (`Session.Server.call_away_persister/3`) already logs a returned
+    # error and continues. Only the RAISE was unhandled.
+    persisted =
+      Repo.BusyRetry.run(fn ->
+        case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
+          nil -> {:error, :not_found}
+          %Credential{} = cred -> Repo.update(Credential.away_changeset(cred, reason, since))
         end
+      end)
+
+    case persisted do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
     end
   end
 
@@ -331,22 +360,32 @@ defmodule Grappa.Networks.Credentials do
   semantics).
   """
   @spec update_visitor_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_visitor_last_joined_channels(visitor_id, network_id, channels)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(channels) do
     capped = Enum.take(channels, Credential.last_joined_channels_max())
 
-    case Repo.get_by(Credential, visitor_id: visitor_id, network_id: network_id) do
-      nil ->
-        {:error, :not_found}
+    # #1374 P-S8 — the visitor twin is session-driven too (injected as
+    # `last_joined_persister` by `Grappa.Visitors.SessionPlan`), so it takes
+    # the same background-DROP posture as the user side. Retrying one subject
+    # kind and not the other is the two-patterns split, and the visitor path
+    # is the one that fires under a visitor-login burst.
+    persisted =
+      Repo.BusyRetry.run(fn ->
+        case Repo.get_by(Credential, visitor_id: visitor_id, network_id: network_id) do
+          nil ->
+            {:error, :not_found}
 
-      %Credential{} = cred ->
-        changeset = Credential.last_joined_channels_changeset(cred, capped)
-
-        case Repo.update(changeset) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
+          %Credential{} = cred ->
+            cred
+            |> Credential.last_joined_channels_changeset(capped)
+            |> Repo.update()
         end
+      end)
+
+    case persisted do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
     end
   end
 

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -62,6 +62,31 @@ defmodule Grappa.NickMigration do
   disconnecting a user over, and the old-nick state it leaves behind is
   self-consistent. Before #1374 the same busy RAISED through strict
   `{:ok, _} =` binds and took the session down mid-migration.
+
+  ## The transaction earns its place PROSPECTIVELY — do not remove it
+
+  Today no test can kill a mutant that deletes `immediate_transaction/1`
+  from `migrate/1`, and that is a property of the CURRENT step list, not a
+  licence. Every step here is total on real data: the two scrollback
+  renames are `update_all`, `ReadCursor.rename_dm_peer/4` handles a
+  fold-collision by dropping the stale cursor, `QueryWindows.rename/4`
+  merges on collision and even rescues the unique-index race, and the
+  mute's changeset validates only `data` presence and the subject XOR,
+  neither of which a rename of an existing row can violate. The one
+  failure the chain admits — the enclosing retry's budget running out —
+  fires before the first step by construction. Nothing can fail in the
+  middle, so nothing can be observed rolling back.
+
+  That changes the moment the set grows, and CLAUDE.md says it WILL: "A
+  NEW nick-keyed store MUST be added to this migration set or a rename
+  silently strands its old-nick rows." A new store is under no obligation
+  to be total — the next one may carry a validation, a unique constraint,
+  or a genuine `{:error, _}` arm. On that day a half-applied identity
+  becomes reachable and this transaction is the only thing standing
+  between a rename and a window pointing at history that moved without
+  it. It is here for the step that has not been written yet, and the
+  test that will finally be able to buy it is the one that adds a
+  fallible step.
   """
 
   use Boundary,

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -1,0 +1,192 @@
+defmodule Grappa.NickMigration do
+  @moduledoc """
+  Single home of the nick-rename migration set (#1374 P-S2).
+
+  A NICK change is an identity MIGRATION, not a fold: every store keyed on
+  the old nick moves old -> new. The set is:
+
+    * `Grappa.QueryWindows.rename/4` — the window row (#373).
+    * `Grappa.Scrollback.rename_dm_peer/4` — the DM history (#373).
+    * `Grappa.ReadCursor.rename_dm_peer/4` — the DM read cursor, else the
+      migrated history reads as fully unread (#373).
+    * `Grappa.UserSettings.rename_muted_target!/4` — the per-conversation
+      mute, nick-keyed since #1038 (#1340).
+
+  and, when the nick that moved is OUR OWN, `Scrollback.rename_own_nick/4`
+  (the inbound-DM own-nick TAG, #514) plus `rename_self_window/4` and the
+  three above behind its row-count gate (#948).
+
+  ## Why the set has a module and not just a paragraph
+
+  Until #1374 the set existed as prose in CLAUDE.md ("A NEW nick-keyed store
+  MUST be added to this migration set") over a chain inlined in
+  `Grappa.Session.Server`. A new nick-keyed store was added by hoping
+  somebody read the paragraph. Here the invariant is executable: the set is
+  this module's two public verbs, and a store left out of them is visible as
+  a store this module never calls.
+
+  ## Why the transaction lives HERE
+
+  The chain spans four contexts. None of them can host the transaction
+  without owning the other three's tables — an abstraction that leaks by
+  construction. `Grappa.Session.Server`, the only caller, cannot host it
+  either: the `Grappa.Session` boundary deliberately has no `Grappa.Repo`
+  dep, and opening one to reach `immediate_transaction/1` is exactly the
+  dependency its moduledoc denies. So this is a TOP-LEVEL boundary that deps
+  the four contexts and `Repo`, called from Session — the
+  `Grappa.SpawnOrchestrator` shape (a cross-context verb, not a supervised
+  child).
+
+  ## Composition: retry OUTSIDE, transaction INSIDE, broadcast NEITHER
+
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> … end) end)`:
+
+    * **Transaction inside** — a crash or busy between two steps used to
+      strand the history under the new nick with a cursor keyed to the old
+      one (the "reads as fully unread" failure the cursor move exists to
+      prevent). All four stores move together or none does.
+    * **Retry outside** — the whole transaction is the retryable unit. Each
+      step is idempotent in the only sense that matters here: a rolled-back
+      attempt left nothing behind, so a replay starts from the same
+      pre-state. Callees reached from here are the non-retrying `!`
+      variants where the family offers one; a nested retry would sleep
+      holding the open transaction's connection.
+    * **Broadcast in NEITHER** — `query_windows_list` is the truthful
+      "rename fully applied" barrier and stays in `Session.Server`, after
+      this returns `{:ok, _}` (#373 rename-order fix). Inside the retry a
+      re-attempt could broadcast twice; inside the transaction it could
+      announce a rename that then rolled back.
+
+  Terminal on budget exhaustion is `{:error, :db_unavailable}`, which the
+  session logs and DROPs (#590 background posture) — a rename is not worth
+  disconnecting a user over, and the old-nick state it leaves behind is
+  self-consistent. Before #1374 the same busy RAISED through strict
+  `{:ok, _} =` binds and took the session down mid-migration.
+  """
+
+  use Boundary,
+    top_level?: true,
+    deps: [
+      Grappa.QueryWindows,
+      Grappa.ReadCursor,
+      Grappa.Repo,
+      Grappa.Scrollback,
+      Grappa.Subject,
+      Grappa.UserSettings
+    ]
+
+  alias Grappa.{QueryWindows, ReadCursor, Repo, Scrollback, Subject, UserSettings}
+  alias Grappa.Repo.BusyRetry
+
+  @typedoc """
+  Outcome of a peer rename. `window` is `:noop` when the peer had no query
+  window (the common case — a peer we never queried costs one indexed
+  lookup and no writes), in which case `rows` is 0. `mute` is independent
+  of both: a mute outlives the window it silenced.
+  """
+  @type peer_result :: %{
+          window: :renamed | :noop,
+          rows: non_neg_integer(),
+          mute: :renamed | :noop
+        }
+
+  @typedoc """
+  Outcome of an own-nick rename. `tag_rows` counts the inbound-DM own-nick
+  TAGs re-keyed (#514) — independent of the self window. `rows` counts the
+  SELF window's scrollback rows, and is the gate: at 0 the window, cursor
+  and mute are deliberately untouched (see `own_renamed/5`).
+  """
+  @type own_result :: %{
+          tag_rows: non_neg_integer(),
+          rows: non_neg_integer(),
+          window: :renamed | :noop,
+          mute: :renamed | :noop
+        }
+
+  @doc """
+  Migrates every store keyed on a PEER's old nick, atomically.
+
+  The window row is the gate for the history + cursor: a peer we never
+  queried has nothing to move. The mute is migrated UNCONDITIONALLY and
+  deliberately outside that gate — a mute outlives the window that was
+  muted (closing a tab does not unmute it), so gating it on the window row
+  would strand exactly the mute nobody can see to fix (#1340 K-S2).
+
+  Returns `{:error, :db_unavailable}` when the retry budget is exhausted
+  (nothing applied), or `{:error, changeset}` when the mute's settings row
+  will not validate — also nothing applied, because the transaction rolls
+  back on it rather than half-migrating an identity.
+  """
+  @spec peer_renamed(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, peer_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def peer_renamed({_, _} = subject, network_id, network_slug, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
+             is_binary(new_nick) do
+    migrate(fn ->
+      mute = rekey_mute!(subject, network_slug, old_nick, new_nick)
+
+      case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
+        {:ok, :renamed} ->
+          {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          %{window: :renamed, rows: rows, mute: mute}
+
+        {:ok, :noop} ->
+          %{window: :noop, rows: 0, mute: mute}
+      end
+    end)
+  end
+
+  @doc """
+  Migrates every store keyed on OUR OWN old nick, atomically.
+
+  Two independent migrations share the transaction. The inbound-DM own-nick
+  TAG (`tag_rows`) always moves: `Push.Triggers.dm?/2` reads it back against
+  the LIVE nick, so a stale tag silently loses a DM's badge (#514).
+
+  The SELF window (`/msg <ownnick>`, #948) moves behind its scrollback row
+  count, the inverse of the peer arm's window gate: a window standing at our
+  old nick is EITHER our self window or a leftover query with a peer who
+  bore that nick before us, and the fold-unique index makes those ONE row.
+  Only the scrollback's `sender` tells them apart, so a zero count means "no
+  self conversation here" and the window, cursor and mute stay put — the
+  cheaper of two wrongs against filing a peer's identity under our new nick.
+  """
+  @spec own_renamed(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, own_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def own_renamed({_, _} = subject, network_id, network_slug, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
+             is_binary(new_nick) do
+    migrate(fn ->
+      {:ok, tag_rows} = Scrollback.rename_own_nick(subject, network_id, old_nick, new_nick)
+      {:ok, rows} = Scrollback.rename_self_window(subject, network_id, old_nick, new_nick)
+
+      if rows > 0 do
+        :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+        {:ok, window} = QueryWindows.rename(subject, network_id, old_nick, new_nick)
+        mute = rekey_mute!(subject, network_slug, old_nick, new_nick)
+
+        %{tag_rows: tag_rows, rows: rows, window: window, mute: mute}
+      else
+        %{tag_rows: tag_rows, rows: 0, window: :noop, mute: :noop}
+      end
+    end)
+  end
+
+  # The non-retrying variant: we are already inside the enclosing engine's
+  # budget. A changeset rejection rolls the whole migration back rather than
+  # leaving an identity half-moved — the caller sees `{:error, changeset}`.
+  @spec rekey_mute!(Subject.t(), String.t(), String.t(), String.t()) :: :renamed | :noop
+  defp rekey_mute!(subject, network_slug, old_nick, new_nick) do
+    case UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick) do
+      {:ok, outcome} -> outcome
+      {:error, %Ecto.Changeset{} = changeset} -> Repo.rollback(changeset)
+    end
+  end
+
+  @spec migrate((-> result)) :: {:ok, result} | {:error, Ecto.Changeset.t() | :db_unavailable}
+        when result: peer_result() | own_result()
+  defp migrate(fun) do
+    BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)
+  end
+end

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1194,7 +1194,8 @@ defmodule Grappa.Scrollback do
   cic tabs refresh their archive section AND invalidate the in-memory
   scrollback cache for the deleted target (UX-7-B 2026-05-22).
   """
-  @spec delete_for_dm(subject(), integer(), String.t()) :: {:ok, non_neg_integer()}
+  @spec delete_for_dm(subject(), integer(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_for_dm(subject, network_id, peer)
       when is_integer(network_id) and is_binary(peer) do
     # REV-B / H17 (2026-05-22 codebase review): route through
@@ -1214,14 +1215,24 @@ defmodule Grappa.Scrollback do
     # in archive (surfaced by `list_archive/3`'s COALESCE) yet
     # `delete_for_dm` returned a silent `{:ok, 0}` and the operator's
     # "really delete" tap did nothing.
-    {count, _} =
-      Message
-      |> subject_where(subject)
-      |> where([m], m.network_id == ^network_id)
-      |> where_dm_peer(folded_peer)
-      |> Repo.delete_all()
-
-    {:ok, count}
+    # #1374 P-S8 — web-reachable (`DELETE /networks/:slug/archive`), so a
+    # transient busy degrades to the typed 503 (#518) instead of the 500 a
+    # naked `delete_all` raises. NOT `with_pool_retry/1`: that wrapper's #336
+    # contract is best-effort DURABILITY for the session's own persist path,
+    # and it swallows even a non-transient fault to keep the session up. A
+    # web write has no session to protect and must not report a purge that
+    # did not happen. Idempotent, so a retried statement is safe.
+    case BusyRetry.run(fn ->
+           {:ok,
+            Message
+            |> subject_where(subject)
+            |> where([m], m.network_id == ^network_id)
+            |> where_dm_peer(folded_peer)
+            |> Repo.delete_all()}
+         end) do
+      {:ok, {count, _}} -> {:ok, count}
+      {:error, :db_unavailable} = err -> err
+    end
   end
 
   @doc """
@@ -1532,7 +1543,8 @@ defmodule Grappa.Scrollback do
   back from upstream. cic's confirm-modal copy makes the rejoinable
   contract explicit.
   """
-  @spec delete_for_channel(subject(), integer(), String.t()) :: {:ok, non_neg_integer()}
+  @spec delete_for_channel(subject(), integer(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_for_channel(subject, network_id, channel)
       when is_integer(network_id) and is_binary(channel) do
     # REV-B / H17 (2026-05-22 codebase review): single-source the
@@ -1549,14 +1561,18 @@ defmodule Grappa.Scrollback do
     # `lower()` fragment) is the correct comparison.
     canonical = Identifier.canonical_target(channel)
 
-    {count, _} =
-      Message
-      |> subject_where(subject)
-      |> where([m], m.network_id == ^network_id)
-      |> where([m], m.channel == ^canonical)
-      |> Repo.delete_all()
-
-    {:ok, count}
+    # #1374 P-S8 — same web-reachable 503 door as `delete_for_dm/3`.
+    case BusyRetry.run(fn ->
+           {:ok,
+            Message
+            |> subject_where(subject)
+            |> where([m], m.network_id == ^network_id)
+            |> where([m], m.channel == ^canonical)
+            |> Repo.delete_all()}
+         end) do
+      {:ok, {count, _}} -> {:ok, count}
+      {:error, :db_unavailable} = err -> err
+    end
   end
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -60,10 +60,14 @@ defmodule Grappa.Session do
       # takes NO Session dep (its live-holder source is an injected fn), so no
       # Boundary cycle.
       Grappa.Net.SourceAliasManager,
+      # #1374 P-S2 — the nick-rename migration SET (and the transaction
+      # around it) lives in its own top-level boundary: it spans four
+      # contexts, and reaching `Repo.immediate_transaction/1` from here
+      # would mean a Session -> Repo dep this boundary deliberately lacks.
+      Grappa.NickMigration,
       Grappa.PubSub,
       Grappa.Push,
       Grappa.QueryWindows,
-      Grappa.ReadCursor,
       Grappa.Scrollback,
       Grappa.SessionLog,
       Grappa.Subject,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -83,8 +83,8 @@ defmodule Grappa.Session.Server do
     ChannelDirectory,
     Log,
     Mentions,
+    NickMigration,
     QueryWindows,
-    ReadCursor,
     Scrollback,
     Session,
     SessionLog,
@@ -6149,33 +6149,19 @@ defmodule Grappa.Session.Server do
   # immaterial: those are `channel=#chan, dm_with=nil` and never match the
   # DM fold, so migrating after them is a no-op interaction.
   defp apply_effects([{:peer_nick_renamed, old_nick, new_nick} | rest], state) do
-    # #1340 K-S2 — the per-conversation mute joined this set when #1038 keyed
-    # it on `(network, peer nick)`. UNCONDITIONAL, and deliberately not inside
-    # the `:renamed` arm the review proposed: the mute outlives the window
-    # that was muted (closing a tab does not unmute it), so gating on the
-    # window row would strand exactly the mute nobody can see to fix. Same
-    # reasoning, and the same placement, as the presence reset at the foot of
-    # this arm — independent stores of the moved identity, each migrated on
-    # its own terms. It sits ahead of the barrier broadcast because a rename
-    # must never be observable half-applied.
-    {:ok, _} =
-      UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
-
-    case QueryWindows.rename(
+    # #1374 P-S2 — the whole set moves inside ONE retried transaction owned by
+    # `Grappa.NickMigration` (the mute included, unconditionally: it outlives
+    # the window it silenced). What stays here is what is the SESSION's to
+    # decide — the barrier broadcast, which must fire once, after a committed
+    # migration, and never from inside a retry.
+    case NickMigration.peer_renamed(
            state.subject,
            state.network_id,
+           state.network_slug,
            old_nick,
            new_nick
          ) do
-      {:ok, :renamed} ->
-        {:ok, migrated} =
-          Scrollback.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-        # Read cursor follows too, else the migrated history reads as fully
-        # unread under the new window (no cursor row → count from 0).
-        :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-        # Broadcast LAST — the event is the "everything migrated" barrier.
+      {:ok, %{window: :renamed, rows: migrated}} ->
         :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
 
         Logger.info("query window followed peer NICK",
@@ -6184,8 +6170,19 @@ defmodule Grappa.Session.Server do
           rows_migrated: migrated
         )
 
-      {:ok, :noop} ->
+      {:ok, %{window: :noop}} ->
         :ok
+
+      {:error, reason} ->
+        # #590 background-DROP: a rename is not worth disconnecting the user
+        # over, and nothing was applied, so the old-nick state left behind is
+        # self-consistent. Pre-#1374 this was a MatchError that killed the
+        # session mid-migration.
+        Logger.warning("peer NICK migration db unavailable — session continues",
+          old_nick: old_nick,
+          new_nick: new_nick,
+          reason: inspect(reason)
+        )
     end
 
     # #378 — a rename is not a presence transition. The vacated nick draws a
@@ -6198,19 +6195,11 @@ defmodule Grappa.Session.Server do
     apply_effects(rest, reset_presence_for(state, old_nick))
   end
 
-  # #514: WE renamed. Deliberately NOT the peer arm above with the arguments
-  # swapped — for the rows #514 owns, our own nick is not a window key, so
-  # nothing moves: an inbound DM's window is `dm_with` (the peer) and its
-  # read cursor is keyed there too, both untouched by our rename. What goes
-  # stale is the own-nick TAG each inbound row carries in `channel`, which
-  # `Push.Triggers.dm?/2` compares to the LIVE nick (#498) when
-  # `Push.BadgeCount` folds the notify predicate back over history. One
-  # store, one UPDATE, no barrier.
-  #
-  # #948 then found the ONE window our own nick does key: the SELF window
-  # (`/msg <ownnick>`). `migrate_self_window/3` below handles it, and it is
-  # a genuine window-key migration with the full peer-rename set behind it
-  # — hence the barrier broadcast the tag re-key must not fire.
+  # #514 / #948: WE renamed. Deliberately NOT the peer arm above with the
+  # arguments swapped — WHAT moves differs (the inbound-DM own-nick TAG
+  # always, the SELF window only behind its row-count gate), and
+  # `Grappa.NickMigration.own_renamed/5` owns that distinction and the
+  # transaction around it.
   #
   # `state` here is the POST-route state, so `state.nick` already reads the
   # NEW nick. The arm never consults it — both nicks travel in the effect —
@@ -6221,70 +6210,43 @@ defmodule Grappa.Session.Server do
   # with `dm_with = nil`, and the migration predicate requires a non-nil
   # `dm_with`, so they can never be swept up.
   defp apply_effects([{:own_nick_renamed, old_nick, new_nick} | rest], state) do
-    {:ok, migrated} =
-      Scrollback.rename_own_nick(state.subject, state.network_id, old_nick, new_nick)
+    case NickMigration.own_renamed(
+           state.subject,
+           state.network_id,
+           state.network_slug,
+           old_nick,
+           new_nick
+         ) do
+      {:ok, result} ->
+        log_own_rename(state, old_nick, new_nick, result)
 
-    if migrated > 0 do
-      Logger.info("inbound DM rows re-keyed to our new nick",
-        old_nick: old_nick,
-        new_nick: new_nick,
-        rows_migrated: migrated
-      )
+      {:error, reason} ->
+        Logger.warning("own NICK migration db unavailable — session continues",
+          old_nick: old_nick,
+          new_nick: new_nick,
+          reason: inspect(reason)
+        )
     end
-
-    migrate_self_window(state, old_nick, new_nick)
 
     apply_effects(rest, state)
   end
 
-  # #948 — the SELF window (`/msg <ownnick>`) is the one window keyed on OUR
-  # nick, so our rename moves it exactly like #373 moves a peer's: rows,
-  # cursor, window row, then the barrier broadcast LAST.
-  #
-  # The scrollback count is the GATE, and it runs FIRST — the inversion of
-  # the #373 arm, which gates on `QueryWindows.rename/4` instead. There, the
-  # window row alone identifies the thing being renamed. Here it cannot: a
-  # window standing at our old nick is EITHER our self window or a leftover
-  # query with a peer who bore that nick before we took it, and the two are
-  # one row under the fold-unique index. Only the scrollback rows carry the
-  # `sender` that tells them apart (`Scrollback.rename_self_window/4`), so a
-  # zero count means "no self conversation here" and we touch neither the
-  # window nor the cursor — following the rename would otherwise file the
-  # peer's identity under our new nick.
-  #
-  # The gate cuts the other way too, and that is accepted rather than
-  # overlooked: a GENUINE self window whose history was purged (or which was
-  # opened and never written to) also counts zero, so its tab stays at the
-  # nick we just vacated. With no rows there is no history to strand and no
-  # evidence to decide on, and the alternative — moving every window at our
-  # old nick — is the corruption above. An empty orphan tab is the cheaper
-  # of the two wrongs.
-  @spec migrate_self_window(t(), String.t(), String.t()) :: :ok
-  defp migrate_self_window(state, old_nick, new_nick) do
-    {:ok, migrated} =
-      Scrollback.rename_self_window(state.subject, state.network_id, old_nick, new_nick)
+  # The session-side half of an own-nick migration: what an operator reads
+  # back, and the ONE broadcast. The barrier fires only when a window
+  # actually moved — `:noop` is a real state (the self window can be CLOSED
+  # while its history lives in Archive: the rows still had to follow, but
+  # announcing a window move would be a lie).
+  @spec log_own_rename(t(), String.t(), String.t(), NickMigration.own_result()) :: :ok
+  defp log_own_rename(state, old_nick, new_nick, %{tag_rows: tag_rows, rows: rows, window: window}) do
+    if tag_rows > 0 do
+      Logger.info("inbound DM rows re-keyed to our new nick",
+        old_nick: old_nick,
+        new_nick: new_nick,
+        rows_migrated: tag_rows
+      )
+    end
 
-    if migrated > 0 do
-      # Else the migrated history reads fully unread under the new key
-      # (no cursor row → `WindowCounts` counts from 0), the #373 lesson.
-      :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-      {:ok, window} = QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick)
-
-      # #1340 K-S2 — the self window's mute follows too, and INSIDE the gate,
-      # unlike the peer arm where it is unconditional. Here the row count is
-      # the only evidence that the window at our old nick is OURS; ungated,
-      # our rename would quietly re-file a mute the operator set against a
-      # peer who bore that nick before us.
-      {:ok, _} =
-        UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
-
-      # Broadcast LAST, and only when a window actually moved: the event is
-      # the truthful "rename fully applied" barrier (#373 rename-order fix).
-      # `:noop` is a real state — the self window can be CLOSED while its
-      # history lives in Archive. The rows still had to follow, or the
-      # archive entry reads as a stranded query bearing our old nick; but
-      # no window moved, so announcing one would be a lie.
+    if rows > 0 do
       if window == :renamed do
         :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
       end
@@ -6295,7 +6257,7 @@ defmodule Grappa.Session.Server do
       Logger.info("self window followed our own NICK",
         old_nick: old_nick,
         new_nick: new_nick,
-        rows_migrated: migrated,
+        rows_migrated: rows,
         window: window
       )
     end

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -292,7 +292,18 @@ if Mix.env() in [:dev, :test] do
       count = Map.get(spec, :seed_count, 0)
       sender = Map.get(spec, :seed_sender, "seed-bot")
 
-      {:ok, _} = Scrollback.delete_for_channel({:user, user.id}, cred.network_id, name)
+      # #1374 P-S8 gave the purge a `:db_unavailable` terminal. This is the
+      # e2e baseline reset: a half-drained surface poisons every following
+      # spec, so the honest move is the loud stop the moduledoc already
+      # prefers over silent retry — with the reason named, unlike the bare
+      # MatchError a strict bind would now raise.
+      case Scrollback.delete_for_channel({:user, user.id}, cred.network_id, name) do
+        {:ok, _} ->
+          :ok
+
+        {:error, :db_unavailable} ->
+          raise "subject reset: scrollback purge for #{name} found the DB saturated — baseline not clean"
+      end
 
       SubjectSession.seed_channel(user.id, cred.network_id, name, count, sender)
     end

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -639,21 +639,58 @@ defmodule Grappa.UserSettings do
           {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def rename_muted_target({_, _} = subject, network_slug, old_target, new_target)
       when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
+    do_rename_muted_target(subject, network_slug, old_target, new_target, &persist/1)
+  end
+
+  @doc """
+  In-transaction variant of `rename_muted_target/4` (#1374 P-S2).
+
+  Identical migration, one difference that is the whole contract: it does
+  NOT retry. It is reached only from inside a `Repo.BusyRetry.run(fn ->
+  Repo.immediate_transaction(…) end)` — `Grappa.NickMigration`, which owns
+  the nick-rename set — where the enclosing engine retries the WHOLE
+  transaction. A nested retry there would sleep while holding the open
+  transaction's connection, extending the very contention it waits on, and
+  would convert a raise the transaction needs into a return value. The bang
+  is the contract: a transient busy RAISES through to the caller's budget.
+
+  Mirrors the `Grappa.Accounts` revoke family's caller-facing/in-transaction
+  split (`accounts.ex`, "The family contract (#636)").
+  """
+  @spec rename_muted_target!(Subject.t(), String.t(), String.t(), String.t()) ::
+          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t()}
+  def rename_muted_target!({_, _} = subject, network_slug, old_target, new_target)
+      when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
+    do_rename_muted_target(subject, network_slug, old_target, new_target, &persist!/1)
+  end
+
+  @spec do_rename_muted_target(
+          Subject.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          (Ecto.Changeset.t() -> {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable})
+        ) :: {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp do_rename_muted_target(subject, network_slug, old_target, new_target, persist_fun) do
     old_key = Identifier.channel_key(network_slug, old_target)
     new_key = Identifier.channel_key(network_slug, new_target)
 
     if old_key == new_key do
       {:ok, :noop}
     else
-      rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key, persist_fun)
     end
   end
 
-  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) ::
-          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp rekey_muted_target(nil, _, _), do: {:ok, :noop}
+  @spec rekey_muted_target(
+          Settings.t() | nil,
+          String.t(),
+          String.t(),
+          (Ecto.Changeset.t() -> {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable})
+        ) :: {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp rekey_muted_target(nil, _, _, _), do: {:ok, :noop}
 
-  defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
+  defp rekey_muted_target(%Settings{} = settings, old_key, new_key, persist_fun) do
     prefs = Map.get(settings.data, @notification_prefs_key, %{})
     muted = if is_map(prefs), do: Map.get(prefs, "muted_targets", %{}), else: %{}
 
@@ -668,7 +705,7 @@ defmodule Grappa.UserSettings do
         next_prefs = Map.put(prefs, "muted_targets", next_muted)
         next_data = Map.put(settings.data, @notification_prefs_key, next_prefs)
 
-        case persist(Settings.changeset(settings, %{data: next_data})) do
+        case persist_fun.(Settings.changeset(settings, %{data: next_data})) do
           {:ok, _} -> {:ok, :renamed}
           {:error, _} = error -> error
         end
@@ -1302,6 +1339,14 @@ defmodule Grappa.UserSettings do
   @spec persist(Ecto.Changeset.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   defp persist(cs), do: Repo.BusyRetry.run(fn -> Repo.update(cs) end)
+
+  # #1374 P-S2 — the in-transaction twin of `persist/1`, for `!` callers
+  # already inside someone else's `BusyRetry.run(fn -> immediate_transaction`.
+  # No retry BY DESIGN: the busy must raise through so the enclosing engine
+  # can roll the transaction back and retry it whole (see
+  # `rename_muted_target!/4`).
+  @spec persist!(Ecto.Changeset.t()) :: {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  defp persist!(cs), do: Repo.update(cs)
 
   # Mirror of `Grappa.QueryWindows.conflict_target/1` — partial
   # indexes carry the predicate so the upsert must repeat it.

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -341,15 +341,34 @@ defmodule Grappa.UserSettings do
   @spec get_or_init(Subject.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def get_or_init({_, _} = subject) do
+    # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
+    # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518)
+    # at every PUT /me/settings setter (they all init through here first).
+    do_get_or_init(subject, fn op -> Repo.BusyRetry.run(op) end)
+  end
+
+  @doc """
+  In-transaction variant of `get_or_init/1` (#1374 P-S7).
+
+  Same init, no retry: reached only from inside an enclosing
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, where a
+  nested retry would sleep holding the open transaction's connection and
+  would swallow the raise the transaction needs to abort on. See the
+  family contract on `rename_muted_target!/4`.
+  """
+  @spec get_or_init!(Subject.t()) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  def get_or_init!({_, _} = subject), do: do_get_or_init(subject, fn op -> op.() end)
+
+  @spec do_get_or_init(Subject.t(), ((-> term()) -> term())) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp do_get_or_init(subject, run) do
     with :ok <- validate_subject_exists(subject) do
       attrs = Subject.put_subject_id(%{data: %{}}, subject)
       cs = Settings.changeset(%Settings{}, attrs)
 
-      # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
-      # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518)
-      # at every PUT /me/settings setter (they all init through here first).
       insert_result =
-        Repo.BusyRetry.run(fn ->
+        run.(fn ->
           Repo.insert(cs, on_conflict: :nothing, conflict_target: conflict_target(subject))
         end)
 
@@ -756,8 +775,36 @@ defmodule Grappa.UserSettings do
   @spec put_upload_ttl_seconds(Subject.t(), pos_integer() | nil) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_upload_ttl_seconds({_, _} = subject, seconds) do
+    do_put_upload_ttl_seconds(subject, seconds, &get_or_init/1, &persist/1)
+  end
+
+  @doc """
+  In-transaction variant of `put_upload_ttl_seconds/2` (#1374 P-S7).
+
+  Same write, no retry at either step. `Grappa.Visitors.create_anon/4`
+  seeds the incognito TTL as the third statement of an already-open
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`; the
+  retrying spelling ran TWO more retry loops inside that transaction,
+  each sleeping on the connection it holds — extending the very
+  contention it waits on — and each turning the busy into a return value
+  where the transaction needed the raise. See the family contract on
+  `rename_muted_target!/4`.
+  """
+  @spec put_upload_ttl_seconds!(Subject.t(), pos_integer() | nil) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  def put_upload_ttl_seconds!({_, _} = subject, seconds) do
+    do_put_upload_ttl_seconds(subject, seconds, &get_or_init!/1, &persist!/1)
+  end
+
+  @spec do_put_upload_ttl_seconds(
+          Subject.t(),
+          pos_integer() | nil,
+          (Subject.t() -> {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}),
+          (Ecto.Changeset.t() -> {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable})
+        ) :: {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp do_put_upload_ttl_seconds(subject, seconds, init_fun, persist_fun) do
     with :ok <- validate_upload_ttl_seconds(seconds, subject),
-         {:ok, settings} <- get_or_init(subject) do
+         {:ok, settings} <- init_fun.(subject) do
       merged_data =
         case seconds do
           nil -> Map.delete(settings.data, @upload_ttl_seconds_key)
@@ -765,7 +812,7 @@ defmodule Grappa.UserSettings do
         end
 
       cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+      persist_fun.(cs)
     end
   end
 

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -237,7 +237,12 @@ defmodule Grappa.Visitors do
          {:ok, _} <- seed_incognito_upload_ttl(visitor, incognito) do
       visitor
     else
-      {:error, changeset} -> Repo.rollback(changeset)
+      # #1374 P-S7 — `reason`, not `changeset`: the seed step can also fail
+      # with a plain `{:error, %Ecto.Changeset{}}` from a validation, and
+      # `create_anon/4`'s spec admits `:db_unavailable` from the enclosing
+      # engine. Naming the binding after one of the shapes invited the next
+      # reader to pattern-match `%Ecto.Changeset{}` on the rollback value.
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 
@@ -250,12 +255,19 @@ defmodule Grappa.Visitors do
   # the holder raises it up to the 72h ladder from the drawer and the server
   # leaves them be (vjt 2026-07-26). Non-incognito provisions leave the pref
   # unset and fall through to the standard 24h upload default.
+  # #1374 P-S7 — the `!` seam: this runs as the third statement of
+  # `create_anon/4`'s OPEN transaction, so it must not retry. The retrying
+  # spelling ran two nested `BusyRetry.run` loops here, each sleeping while
+  # holding the transaction's connection (extending the contention it was
+  # waiting on) and each converting the busy into a return value, which
+  # `Repo.rollback/1` then turned into a 503 WITHOUT the enclosing engine
+  # ever spending its own budget. The raise is what hands the retry up.
   @spec seed_incognito_upload_ttl(Visitor.t(), boolean()) ::
-          {:ok, term()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+          {:ok, term()} | {:error, Ecto.Changeset.t()}
   defp seed_incognito_upload_ttl(_, false), do: {:ok, :not_incognito}
 
   defp seed_incognito_upload_ttl(%Visitor{id: id}, true),
-    do: UserSettings.put_upload_ttl_seconds({:visitor, id}, @incognito_upload_ttl_seconds)
+    do: UserSettings.put_upload_ttl_seconds!({:visitor, id}, @incognito_upload_ttl_seconds)
 
   @doc """
   #211 phase 7 — resolve the visitor's `(visitor_id, network_id)`

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -947,7 +947,7 @@ defmodule Grappa.Visitors do
   mid-flight — race tolerated).
   """
   @spec update_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_last_joined_channels(visitor_id, network_id, channels)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(channels) do
     Credentials.update_visitor_last_joined_channels(visitor_id, network_id, channels)
@@ -967,7 +967,7 @@ defmodule Grappa.Visitors do
   network).
   """
   @spec remove_autojoin_channel(Visitor.t(), pos_integer(), String.t()) ::
-          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def remove_autojoin_channel(%Visitor{id: id}, network_id, channel_name)
       when is_integer(network_id) and is_binary(channel_name) do
     Credentials.remove_visitor_last_joined_channel(id, network_id, channel_name)

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -141,7 +141,7 @@ defmodule GrappaWeb.ArchiveController do
   def delete(_, _), do: {:error, :bad_request}
 
   @spec delete_for_target(String.t(), Grappa.Subject.t(), pos_integer()) ::
-          {:ok, non_neg_integer()}
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   defp delete_for_target(canonical_target, session_subject, network_id) do
     case Scrollback.target_kind(canonical_target) do
       :channel ->

--- a/test/grappa/repo/transaction_mode_gate_test.exs
+++ b/test/grappa/repo/transaction_mode_gate_test.exs
@@ -1,0 +1,89 @@
+defmodule Grappa.Repo.TransactionModeGateTest do
+  @moduledoc """
+  #1374 P-S3 — the static gate for the write-transaction contract.
+
+  `Grappa.Repo.immediate_transaction/1`'s docstring is unambiguous: "Use
+  this for every WRITE transaction." Until #1374 that contract was
+  comment-only, and seven call sites had drifted off it. Two spellings in
+  one repo is the split CLAUDE.md warns about — the next session copies
+  whichever is nearest.
+
+  ## Why the gate is STATIC and not a runtime assertion
+
+  It cannot be a runtime assertion. `exqlite`'s `handle_begin/2`
+  (`connection.ex:297-316`) emits `BEGIN IMMEDIATE` only when
+  `transaction_status == :idle`; nested, EVERY mode collapses to
+  `SAVEPOINT exqlite_savepoint`. Under the SQL Sandbox every test already
+  runs inside a transaction, so `immediate_transaction/1` is always a
+  savepoint there and no ExUnit oracle can tell it from `transaction/1`.
+  The defect is undecidable at runtime and decidable at compile time, so
+  the gate reads the source.
+
+  ## What it does and does not catch
+
+  It matches the remote-call AST `*.Repo.transaction(…)` — the spelling
+  every call site in `lib/` uses, in pipes too (the pipe's right-hand node
+  is the same call node). It does NOT catch a call routed through a
+  renaming alias (`alias Grappa.Repo, as: R; R.transaction(…)`); nothing
+  short of a compiler pass would, and no such spelling exists here. Stated
+  so the gate's reach is known rather than assumed.
+
+  A genuinely read-only transaction is still legitimate (deferred preserves
+  WAL read concurrency) — but it must SAY so at the call site. Add a
+  `Grappa.Repo.deferred_transaction/1` sibling and call that; do not reach
+  for the raw verb, which is the one whose default is the #524 trap.
+  """
+  use ExUnit.Case, async: true
+
+  # The contract's own home: `immediate_transaction/1` delegates to
+  # `transaction/2` there, which is the one place it is meant to happen.
+  @definition "lib/grappa/repo.ex"
+  @lib_glob "lib/**/*.ex"
+
+  test "no module outside Grappa.Repo opens a bare Repo.transaction" do
+    offenders =
+      @lib_glob
+      |> Path.wildcard()
+      |> Enum.reject(&(&1 == @definition))
+      |> Enum.flat_map(&scan/1)
+
+    assert offenders == [],
+           """
+           bare `Repo.transaction/1` outside #{@definition}:
+
+           #{Enum.map_join(offenders, "\n", fn {path, line} -> "  #{path}:#{line}" end)}
+
+           Every WRITE transaction takes `Grappa.Repo.immediate_transaction/1`:
+           a deferred transaction's read->write upgrade raises an IMMEDIATE
+           SQLITE_BUSY that `busy_timeout` does not cover (#524). If this one is
+           genuinely READ-ONLY, add `Grappa.Repo.deferred_transaction/1` and say
+           so at the call site.
+           """
+  end
+
+  @spec scan(Path.t()) :: [{Path.t(), pos_integer()}]
+  defp scan(path) do
+    {_ast, offenders} =
+      path
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> Macro.prewalk([], fn node, acc ->
+        case transaction_call_line(node) do
+          nil -> {node, acc}
+          line -> {node, [{path, line} | acc]}
+        end
+      end)
+
+    Enum.reverse(offenders)
+  end
+
+  # `Repo.transaction(…)` / `Grappa.Repo.transaction(…)`, however many args
+  # (a pipe leaves the call node with one fewer). `immediate_transaction`
+  # is a DIFFERENT function name and never matches here.
+  @spec transaction_call_line(Macro.t()) :: pos_integer() | nil
+  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _args}) do
+    if List.last(segments) == :Repo, do: Keyword.get(meta, :line), else: nil
+  end
+
+  defp transaction_call_line(_), do: nil
+end

--- a/test/grappa/repo/transaction_mode_gate_test.exs
+++ b/test/grappa/repo/transaction_mode_gate_test.exs
@@ -63,7 +63,7 @@ defmodule Grappa.Repo.TransactionModeGateTest do
 
   @spec scan(Path.t()) :: [{Path.t(), pos_integer()}]
   defp scan(path) do
-    {_ast, offenders} =
+    {_, offenders} =
       path
       |> File.read!()
       |> Code.string_to_quoted!()
@@ -81,7 +81,7 @@ defmodule Grappa.Repo.TransactionModeGateTest do
   # (a pipe leaves the call node with one fewer). `immediate_transaction`
   # is a DIFFERENT function name and never matches here.
   @spec transaction_call_line(Macro.t()) :: pos_integer() | nil
-  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _args}) do
+  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _}) do
     if List.last(segments) == :Repo, do: Keyword.get(meta, :line), else: nil
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3219,6 +3219,85 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
+
+    # #1374 P-S2 — the migration chain used to run bare against `Repo`, each
+    # step strictly bound (`{:ok, _} =` / `:ok =`) inside the supervised
+    # session. A transient SQLITE_BUSY therefore RAISED and took the session
+    # (and the user's connection) down, mid-migration: the exact class of the
+    # 2026-07-19 incident, and the trigger — a netsplit rejoin renaming many
+    # peers at once — is precisely the correlated write burst.
+    test "a sustained DB busy during a peer rename drops it whole and the session survives" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      slug = network.slug
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, _} =
+               put_all_muted(subject, %{"#{slug} guest87449" => %{"until" => nil}})
+
+      IRCServer.feed(server, ":Guest87449!~g@host JOIN #sniffo\r\n")
+      IRCServer.feed(server, ":Guest87449!~g@host PRIVMSG #{own} :ciao\r\n")
+
+      # #422 auto-open: waiting for the window broadcast proves the whole
+      # pre-state (window row + DM row) exists BEFORE the fault is armed, and
+      # drains the topic so a later broadcast cannot be mistaken for this one.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :query_windows_list,
+                         windows: %{^net_id => [%{target_nick: "Guest87449"}]}
+                       }
+                     },
+                     1_000
+
+      assert [pre_row] = Scrollback.fetch(subject, net_id, "Guest87449", nil, 10, own, false)
+      {:ok, _} = ReadCursor.set(subject, net_id, "Guest87449", pre_row.id)
+
+      # Saturate every retry loop this session enters from here on.
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
+      on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":Guest87449!~g@host NICK :NickTemporaneo\r\n")
+
+          # DB-free FIFO barrier: PING is answered from the SAME serial
+          # mailbox, so the PONG proves the NICK's effects have fully run.
+          # It cannot itself be starved by the armed fault (no Repo call on
+          # that path), which every DB-backed barrier here could be.
+          IRCServer.feed(server, "PING :rename-barrier\r\n")
+
+          assert {:ok, _} =
+                   IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      # The terminal is the #590 background-DROP posture, not a crash.
+      assert Process.alive?(pid)
+      assert log =~ "peer NICK migration db unavailable — session continues"
+
+      # And the drop is WHOLE: window row, DM history and read cursor all
+      # still stand at the old nick. A per-step retry would have let the
+      # earlier steps land and stranded the later ones.
+      assert [%{target_nick: "Guest87449"}] = QueryWindows.list_for_subject(subject)[net_id]
+      assert [_] = Scrollback.fetch(subject, net_id, "Guest87449", nil, 10, own, false)
+      assert Scrollback.fetch(subject, net_id, "NickTemporaneo", nil, 10, own, false) == []
+      assert %{last_read_message_id: _} = ReadCursor.get(subject, net_id, "Guest87449")
+      assert ReadCursor.get(subject, net_id, "NickTemporaneo") == nil
+
+      assert Grappa.UserSettings.get_notification_prefs(subject).muted_targets == %{
+               "#{slug} guest87449" => %{"until" => nil}
+             }
+
+      Repo.BusyRetry.disarm_faults(pid)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
   end
 
   describe "#948 — the SELF window follows OUR OWN NICK change" do

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3300,6 +3300,49 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#1374 P-S8 — the session-driven credential persisters" do
+    # `update_last_joined_channels/3` fires on every self-JOIN / self-PART /
+    # self-KICK and `update_away/4` on every away transition. Both did
+    # `Repo.get_by` + `Repo.update` with no retry: the call sites handle a
+    # RETURNED `{:error, _}` with a warning, but a transient busy RAISED and
+    # the raise escaped the persister closure into the GenServer. Bootstrap
+    # spawning N sessions x M autojoin channels is that write burst.
+    test "a sustained DB busy on the rejoin snapshot drops it and the session survives" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
+      on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+      log =
+        capture_log(fn ->
+          # A self-JOIN is the cheapest trigger: it mutates the members
+          # keyset, which is the ONLY thing that arms the snapshot write.
+          IRCServer.feed(server, ":grappa-test!~g@host JOIN #busy-room\r\n")
+
+          # DB-free FIFO barrier (see the peer-rename test): the PONG proves
+          # the JOIN was fully handled, and the armed fault cannot starve it.
+          IRCServer.feed(server, "PING :snapshot-barrier\r\n")
+          assert {:ok, _} = IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      assert Process.alive?(pid)
+      assert log =~ "last_joined_channels persist failed"
+      assert log =~ "db_unavailable"
+
+      # Dropped, not written: the credential still carries the pre-JOIN
+      # snapshot. Read through the context, never a raw Repo query.
+      {:ok, cred} = Credentials.get_credential(user, network)
+      refute "#busy-room" in cred.last_joined_channels
+
+      Repo.BusyRetry.disarm_faults(pid)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#948 — the SELF window follows OUR OWN NICK change" do
     test "a self /nick migrates the self window row, its scrollback and its read cursor" do
       {server, port} = start_server()

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -1686,4 +1686,48 @@ defmodule Grappa.UserSettingsTest do
       refute_receive {:auto_away_debounce_changed, _}, 100
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #1374 P-S7 — the in-transaction (`!`) seam
+  # ---------------------------------------------------------------------------
+
+  describe "in-transaction seam (#1374 P-S7)" do
+    # `Grappa.Visitors.create_anon/4` seeds the incognito upload TTL as the
+    # third statement of an already-open `BusyRetry.run(fn ->
+    # immediate_transaction(…) end)`. The retrying spelling ran TWO more
+    # retry loops in there — `get_or_init/1` and `persist/1` — each sleeping
+    # while holding the transaction's connection and each converting the
+    # busy into a return value that `Repo.rollback/1` then surfaced as a 503
+    # WITHOUT the enclosing engine ever spending its budget.
+    #
+    # What this measures: the `!` spelling has NO retry loop, so the armed
+    # fault (which fires only at the top of a `BusyRetry.run` attempt) has
+    # nothing to grab and the write lands; its retrying twin, on the same
+    # armed faults, degrades. That is the whole difference between the two,
+    # and it is what a mutant swapping `persist!/1` back to `persist/1`
+    # breaks.
+    #
+    # What it does NOT establish: that a REAL SQLITE_BUSY raises through to
+    # the caller's transaction. The pool_size:1 Sandbox cannot produce one
+    # (that is why the injection seam exists), and the seam reaches only
+    # code already inside a retry loop — the very thing the `!` variant
+    # lacks. The raise-through is argued from `Repo.update/1`'s own
+    # behaviour, not measured here.
+    test "the `!` setters carry no retry loop, where their twins degrade" do
+      seam_visitor = visitor_fixture()
+      twin_visitor = visitor_fixture()
+
+      Repo.BusyRetry.inject_transient_faults(10_000)
+
+      assert {:ok, %Settings{}} =
+               UserSettings.put_upload_ttl_seconds!({:visitor, seam_visitor.id}, 3_600)
+
+      assert UserSettings.get_upload_ttl_seconds({:visitor, seam_visitor.id}) == 3_600
+
+      assert {:error, :db_unavailable} =
+               UserSettings.put_upload_ttl_seconds({:visitor, twin_visitor.id}, 3_600)
+
+      assert UserSettings.get_upload_ttl_seconds({:visitor, twin_visitor.id}) == nil
+    end
+  end
 end

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -180,6 +180,32 @@ defmodule GrappaWeb.ArchiveControllerTest do
       assert slug == net.slug
     end
 
+    # #1374 P-S8 — the two archive purges were the last web-reachable
+    # scrollback writes with no retry: a transient SQLITE_BUSY raised out of
+    # `Repo.delete_all` and left the operator with a 500 where #518 promises
+    # a typed 503, on a door #523 B1's own stated scope already covered.
+    test "sustained DB busy on a purge is a typed 503, and the rows survive",
+         %{conn: conn, vjt: vjt} do
+      net = net_with_credential(vjt)
+      :ok = seed_archive_rows(vjt, net)
+
+      Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(vjt.name))
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      degraded = delete(conn, "/networks/#{net.slug}/archive/#{URI.encode_www_form("#a")}")
+
+      assert json_response(degraded, 503) == %{"error" => "db_unavailable"}
+
+      # Refused, not half-done: the rows are still there, and NO purge was
+      # announced — a broadcast here would tell every cic tab to drop a
+      # cache the server still holds.
+      remaining = Scrollback.list_archive({:user, vjt.id}, net.id, MapSet.new())
+      assert Enum.any?(remaining, &(&1.target == "#a"))
+
+      refute_received %Phoenix.Socket.Broadcast{payload: %{kind: :archive_purged}}
+    end
+
     test "query-shaped target → 204 + drops DM rows + broadcasts archive_purged",
          %{conn: conn, vjt: vjt} do
       net = net_with_credential(vjt)

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -28,6 +28,7 @@ defmodule GrappaWeb.AuthControllerTest do
   alias Grappa.Networks.Credential
   alias Grappa.PubSub.Topic
   alias Grappa.RateLimit.FailureWindow
+  alias Grappa.Repo.BusyRetry
   alias Grappa.Session.Server, as: SessionServer
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.PasskeyOrigin
@@ -274,7 +275,7 @@ defmodule GrappaWeb.AuthControllerTest do
       armed_step = Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step
       assert is_integer(armed_step)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       degraded =
         post(conn, "/auth/totp/verify", %{
@@ -700,7 +701,7 @@ defmodule GrappaWeb.AuthControllerTest do
       {_, port} = start_server()
       {_, _} = setup_visitor_network(port)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       conn = post(conn, "/auth/login", %{"identifier" => "vjt"})
 
@@ -1012,7 +1013,7 @@ defmodule GrappaWeb.AuthControllerTest do
     test "returns 503 db_unavailable when the revoke degrades, leaving the bearer live",
          %{conn: conn} do
       {_, session} = user_and_session()
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       conn =
         conn

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -246,6 +246,51 @@ defmodule GrappaWeb.AuthControllerTest do
       assert session_count() == 1
     end
 
+    # #1374 P-S3 — the 2FA door was the ONE second-factor path with no
+    # `BusyRetry` anywhere: `verify_second_factor/3` called `TOTP.verify/3`
+    # bare, and `TOTP.verify/3` is the #524 shape exactly (a `Repo.get!` READ
+    # then a conditional `update_all` WRITE inside one DEFERRED transaction).
+    # A transient busy there surfaced as an uncaught `Exqlite.Error` — a 500
+    # at the login door, where #518 promises a typed 503.
+    #
+    # The Sandbox cannot raise a real SQLITE_BUSY (pool_size 1, no
+    # self-contention), hence the seam. Armed AFTER the password step so the
+    # faults can only land on the verify request.
+    test "sustained DB busy at the TOTP door is a typed 503, not a 500", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      on_exit(fn -> clear_totp_window(user.id) end)
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      # `arm_totp/1` already spent the PREVIOUS step, so the pre-state is a
+      # non-nil step — read it rather than assume nil, or the assertion below
+      # would pass against a value the enrolment set.
+      armed_step = Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step
+      assert is_integer(armed_step)
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      degraded =
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => pending["challenge_token"],
+          "code" => code
+        })
+
+      assert json_response(degraded, 503) == %{"error" => "db_unavailable"}
+
+      # Degraded, not half-spent: no bearer, and the TOTP step was NOT
+      # consumed — the code is still redeemable once the DB frees up. A
+      # rolled-back transaction is what makes that true.
+      assert session_count() == 0
+      assert Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step == armed_step
+    end
+
     test "invalid TOTP never mints a bearer", %{conn: conn} do
       {user, password} = user_fixture_with_password()
       _ = arm_totp(user)


### PR DESCRIPTION
Four findings from the 2026-08-15 codebase review (P-S2, P-S3, P-S7, P-S8),
one commit per finding plus their reds. They share one durable rule, and it is
the part worth keeping: **the retry goes OUTSIDE the transaction, the
transaction goes INSIDE it, and no retry loop ever opens inside an already-open
transaction.**

## What landed

**P-S2 — `Grappa.NickMigration` owns the nick-rename set.** The chain ran bare
against `Repo`, step by step, each bound `{:ok, _} =` or `:ok =`, inside the
supervised session. The new module is a TOP-LEVEL boundary rather than a
supervised child (the `Grappa.SpawnOrchestrator` shape), calls only public
context APIs, and lets `Session` span four contexts without acquiring the
`Grappa.Repo` dep its boundary deliberately lacks. The `query_windows_list`
broadcast stays in `Session.Server` after the `:ok` return — it is the #373
"rename fully applied" barrier and a retried attempt must not re-fire it.
Budget exhaustion is the #590 background-DROP posture.

**P-S3 — seven `Repo.transaction/1` call sites converted, and gated.** Plus a
retry at the 2FA door, and the two `@doc` paragraphs that quoted the dead
spelling.

**P-S7 — a non-retrying `!` seam for in-transaction callers.** `get_or_init!/1`
and `put_upload_ttl_seconds!/2`, bodies parameterised rather than duplicated.
The atom reaching `Repo.rollback/1` was bound to a variable called `changeset`,
which is what it is not; it is `reason` now.

**P-S8 — seven writers brought under a retry budget.** Five in `credentials.ex`,
two in `scrollback.ex`.

## Where the review was wrong, with the measurement

**The 2FA door does NOT answer 500.** The review says a transient busy surfaces
there as a 500 where #518 promises 503. Measured at HEAD, it already answered
**503**: the retry producing it sits DOWNSTREAM of `TOTP.verify/3`. The real
defect was that `totp_last_used_step` advanced anyway — 59561585 to 59561586 in
the red — so the user paid a redeemable code for a degraded response. The
boundary retry fixes that, but the status code was never the symptom.

**P-S2's killing site is not one the review names.** The red's crash is at
`server.ex:6161`, `UserSettings.rename_muted_target/4` — the FIRST step of the
arm. That call already carried a retry loop (23 attempts over the full 300ms
budget in the log); what killed the session is that its
`{:error, :db_unavailable}` terminal was bound `{:ok, _} =`. Same defect as the
sites the review does name, different cause: not a missing retry, an exhausted
one meeting a strict match. The bare-`Repo` steps downstream were never reached.
Because the mute had to move inside the transaction, `rename_muted_target!/4`
and `persist!/1` land in the P-S2 commit — so the mechanism P-S7 asks for is a
prerequisite of P-S2, and the P-S7 commit consumes the family instead of
inventing it.

**P-S8's count is wrong three ways at once.** The prose says five, four are
named, the file:line list points at six. Counted: seven.
`update_visitor_last_joined_channels/3` is not in the review at all — it is
session-driven exactly like its user-side twin, injected as
`last_joined_persister` from `session_plan.ex:237`, and retrying one subject
kind but not the other is the split into two patterns CLAUDE.md warns about.
`update_away/4` has no visitor twin; that was checked, not assumed.

**P-S7's nesting is narrower than implied.** It fires only on incognito
provisioning — `seed_incognito_upload_ttl/2` has a `false` clause — not on every
anonymous login.

**`totp.ex:48` was converted but #524 was never open there.** Its single
production caller already runs inside the outer transaction of
`confirm_totp_enrollment/5`, so the change is inert. Converted for the contract,
not for a bug.

## Why the transaction-mode gate is STATIC

It cannot be a runtime assertion. exqlite emits `BEGIN IMMEDIATE` only when
`transaction_status == :idle` (`deps/exqlite/lib/exqlite/connection.ex:297-316`);
nested, every mode collapses to `SAVEPOINT exqlite_savepoint`. Under the SQL
Sandbox every test already runs inside a transaction, so `immediate_transaction/1`
is always a savepoint there and no ExUnit oracle distinguishes it from
`transaction/1` — the "put the deferred spelling back" mutant is unkillable at
runtime. Undecidable at runtime, decidable at compile time, so the gate walks
the AST of `lib/**/*.ex`. It is an arch test rather than a Credo check because
the repo already has that shape (`error_tokens_drift_test.exs`), while a custom
check would want `requires:` in `.credo.exs` and a module outside the app tree.
Its blind spot is in its own moduledoc: a renaming alias escapes it, and a
genuinely read-only transaction must say so via a `deferred_transaction/1`
sibling, deliberately not written because it would be dead code today.

Bought by mutation: restoring the deferred spelling at one site reddens the gate
naming exactly `lib/grappa/accounts/totp.ex:56`.

## Why atomicity is UNKILLABLE here, and why the transaction stays anyway

This is a reason, not an omission.

The mutant that removes `immediate_transaction/1` from `NickMigration.migrate/1`
**survives** — measured, and deliberately left surviving rather than masked by an
assertion that passes for another reason. Two facts explain it.

First, the fault seam has a reach narrower than it looks. `BusyRetry`'s injected
fault fires at exactly one place: `maybe_inject_fault/0` at the top of a
`BusyRetry.run/1` attempt, before `op.()` — stated in the source and confirmed by
mutation, since removing the wrapper from `migrate/1` did not make the write fail,
it made the write LAND. Counted in the post-fix code: **zero** reachable
`BusyRetry.run` calls inside the transaction body across all five steps. So there
is exactly one check per migration and it fires before the transaction opens. The
irony is that the P-S7 fix is what removed the only thing that could have fired
mid-chain.

Second — and this is the part that closes the question — **no data-driven
intermediate failure exists to arrange either.** Every step is total on real data:

* the two scrollback renames are `update_all` returning `{:ok, n}`, with no
  constraint on the updated columns to violate;
* `ReadCursor.rename_dm_peer/4` handles a fold-collision by dropping the stale
  cursor (`read_cursor.ex:675`), and wraps the update in a `try`;
* `QueryWindows.rename/4` merges on collision (`query_windows.ex:296`) and even
  rescues the unique-index race, degrading to the same merge path (`:308`);
* the mute's `Repo.rollback` (`nick_migration.ex:183`) is reachable only on a
  `Settings` changeset error, and that changeset validates `data` presence, the
  subject XOR, two `assoc_constraint`s and `unique_constraint(:user_id)` — none
  of which a rename of an EXISTING row can violate.

`own_renamed/5` is the arm where the route should have worked, because there the
mute is LAST, after four stores. It fails for the same reason: the only step that
can roll back is the only step with nothing after it to roll back.

So the single failure the chain admits is the enclosing retry's budget running
out, which fires before step one. Nothing can fail in the middle, so no rollback
can be observed, so the mutant cannot die. **The transaction stays regardless**,
and the moduledoc now says why in prospective terms: CLAUDE.md requires every NEW
nick-keyed store to join this set, a new store is under no obligation to be
total, and on the day one arrives with a validation or a constraint a
half-applied identity becomes reachable. The test that will finally buy this
transaction is the one that adds a fallible step.

## What I have not established

* **How long the P-S2 transaction holds on a large DM history.** It now wraps
  `update_all` over `messages` + `read_cursors` + `query_windows`. I have no
  honest way to measure that here, so it is declared rather than estimated.
* **That a real SQLITE_BUSY raises through the `!` variants to the caller's
  transaction.** The pool_size:1 Sandbox cannot produce one, and the injection
  seam reaches only code already inside a retry loop — precisely what the `!`
  variants lack. Argued from `Repo.update/1`'s behaviour, not measured.
* **That a raise escapes the P-S8 writers into the GenServer.** Same limit: an
  unretried writer has no fault point, so both P-S8 reds fail at HEAD by
  SUCCEEDING rather than by crashing. What they measure is the property the fix
  installs — each writer now runs under a retry budget and degrades on its own
  terms — and a mutant removing the wrapper flips each back.
* **The rest of `credentials.ex`'s write surface.** #523 B1 deferred
  `update_nick` on purpose and this does not widen past the seven. That exposure
  is declared here rather than quietly fixed.

## Test plan

- [x] `scripts/check.sh` green: 8 doctests, 60 properties, 6344 tests, 0
      failures; Dialyzer 0 errors; Credo strict clean; Sobelow no
      vulnerabilities; Doctor passed; bats green
- [x] every assertion bought by a named 1:1 mutation, each mutant verified
      applied with `grep -q` before its red was believed
- [x] one mutant deliberately left surviving, with the reason above
- [ ] integration suite — not run on this lane