### PR TITLE
infra(#1377): fix the hot-path MIX_ENV asymmetry, derive the POSIX gate, refuse D-S5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ CONTAINER_GID=1000
 # Mix environment switch. `dev` for local hacking, `prod` for the
 # deploy.sh stack. Phoenix expects an atom without the leading colon
 # when read from env vars (just `prod`).
+#
+# NOTE: compose interpolates this into BOTH `MIX_ENV` and `DATABASE_PATH`
+# (`grappa_${MIX_ENV:-dev}.db`), so the value below picks which database
+# every container and oneshot opens. `scripts/deploy.sh` exports
+# `MIX_ENV=prod` for its own invocations and the shell wins over this
+# file (#1377 D-S3) — but a hand-driven `docker compose --profile prod
+# …` on a prod box inherits exactly what is written here. Set it to
+# `prod` on any box that is not a dev laptop.
 MIX_ENV=dev
 
 # Host port publish for the grappa container. #485 dropped the in-stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,24 +160,21 @@ jobs:
         # convention. Needs the fetch-depth: 0 above.
         run: scripts/design-notes-gate.sh
 
-      - name: POSIX-parse the shared deploy lib + its sh consumers (#503)
+      - name: POSIX-parse the sh-dialect scripts (#503, derived by #1377)
         # A DIFFERENT property from the lint above, with a different tool:
-        # the shared deploy lib (infra/lib/deploy_common.sh) must stay strict
-        # POSIX sh so dash can run it as the FreeBSD jail's /bin/sh. dash -n
-        # parses; shellcheck lints. A reintroduced bashism in the shared
-        # algorithm fails here instead of silently breaking the jail deploy —
+        # the shared deploy lib (infra/lib/deploy_common.sh) and its sh
+        # consumers must stay strict POSIX so dash can run them as the FreeBSD
+        # jail's /bin/sh. dash -n parses; shellcheck lints. A reintroduced
+        # bashism fails here instead of silently breaking the jail deploy —
         # the copy-paste-drift class #503 exists to kill.
         #
-        # Still a hand-written list, deliberately: #441 derived the SHELLCHECK
-        # set, and this one is not the same question — "which files must parse
-        # under dash" is a claim about where they run, and the honest
-        # derivation for it is a separate piece of work.
-        run: |
-          dash -n infra/lib/deploy_common.sh
-          dash -n infra/freebsd/deploy.sh
-          dash -n infra/docker/assert-abi-lockstep.sh
-          dash -n infra/docker/release-entrypoint.sh
-          dash -n infra/docker/get.sh
+        # The set is DERIVED, like the shellcheck one (#441). The hand list
+        # this replaced covered five of the twenty-eight files that declare
+        # the sh dialect, missing two of the three POSIX libs under
+        # infra/lib/ and all twelve jail rails; the derivation reads each
+        # file's own line-1 declaration instead of keeping a second copy of
+        # it. Covered by test/infra/posix_parse_gate_test.bats.
+        run: scripts/posix-parse.sh
 
       - name: Cloud provider-door drift-guard (#665)
         # Prove every provider door (infra/aws today, infra/terraform later)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43368,3 +43368,72 @@ when a reset actually happens. With `pool_size: 10` under continuous reads
 that is a real possibility, and it is the most likely reason prod's WAL was at
 168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
 the pressure and bounds the recovery; it does not promise a ceiling.
+<!-- entry #1377 -->
+
+---
+
+## 2026-08-16 — #1377: a precondition inside a mode-gated hook is a per-mode precondition
+
+Bucket I of the 2026-08-15 codebase review — D-S3 (HIGH), D-S4, D-S5. Two were
+real. The third had been closed the same day the review was written, which is
+its own lesson about reading a review as a document rather than as a
+measurement.
+
+**D-S3, and the shape worth keeping.** `scripts/deploy.sh` held its `.env`
+check and its `MIX_ENV=${MIX_ENV:-prod}; export MIX_ENV` inside
+`substrate_build` — a hook the shared library calls on BOTH paths, but which
+opens with `[ "$MODE" = cold ] || return 0`. So both lines ran on cold and
+neither on hot, and nothing complained, because the hot path did not fail: it
+diverged. `docker compose` falls back to `.env` for a variable absent from the
+shell, `.env.example` ships `MIX_ENV=dev` uncommented, and `compose.yaml`
+derives `DATABASE_PATH` from that same variable — so the theme seed opened
+`grappa_dev.db` on a box whose cold deploys had always opened `grappa_prod.db`.
+Measured against the real files, not inferred from them: `docker compose
+--env-file .env.example --profile prod config` resolves `MIX_ENV: dev` +
+`/app/runtime/grappa_dev.db` with no shell `MIX_ENV`, and `prod` +
+`grappa_prod.db` with `MIX_ENV=prod` exported.
+
+The durable rule is not "hoist that check". It is that **a precondition placed
+inside a mode-guarded hook quietly becomes a per-mode precondition**, and the
+resulting bug is silent by construction: the mode that keeps the precondition
+is the one that would have failed loudly, so the mode that loses it is the one
+nobody hears about. Preconditions belong at the first hook the shared algorithm
+calls. File scope was rejected on ordering: the library parses flags inside
+`deploy_main`, so a check above that turns an unknown flag into a
+missing-`.env` error. The top of `substrate_pull` is after the parse and before
+the first side effect, which is the whole of what the placement has to satisfy.
+
+**D-S4 — a hand list is a snapshot, twice over.** The `dash -n` step in
+`ci.yml` named five paths and covered five of the twenty-eight files that
+declare the sh dialect on line 1, missing two of the three `infra/lib/` libs
+this log already calls strict POSIX. Its comment defended the list because "the
+honest derivation for it is a separate piece of work" — the derivation is a
+dozen lines, and it is #441's, one dialect down: read the dialect declaration
+each file already carries for shellcheck instead of keeping a second copy of
+it. Recorded because it will be tempting again: the argument that a set is
+"a claim about where files run, not about what they are" is exactly the
+argument that lets a snapshot outlive its accuracy.
+
+Worth knowing before trusting that gate: `dash -n` checks GRAMMAR. `arr=(a b)`
+is a syntax error to it, `[[ 1 == 1 ]]` and `local x` are not — they parse as
+ordinary commands and fail only when they run. shellcheck in `sh` dialect
+(SC3xxx) is what covers that half, over the same files. Neither gate is a
+superset of the other.
+
+**D-S5 — refused, with the mutation as the evidence.** The finding says no gate
+holds the four `oven/bun:1` transcriptions to one digest. One does:
+`test/infra/base_image_digest_pin_test.bats` grew it in #1343, landed
+2026-08-15, commit subject naming D-S5. A zeroed digest in `scripts/bun.sh`
+fails it. What the mutation did surface is that the report named the family and
+dumped the tokens — and the four tokens are textually identical, so it proved a
+divergence while leaving the reader to grep for which surface moved. It now
+lists the matching `path:line` refs instead.
+
+**What this does NOT establish.** Nothing here was exercised on a real Docker
+substrate: the D-S3 chain is proven by `docker compose config` (client-side
+interpolation, no daemon) plus a bats run against a stubbed `docker`, and no
+container was started, no seed was run, and no `grappa_prod.db` was written.
+The claim that the hot path now seeds prod rests on the shell exporting
+`MIX_ENV=prod` before the oneshot, which the suite observes directly; the step
+from there to the database file is compose's, and is evidenced by its own
+`config` output rather than by a deploy.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -979,6 +979,21 @@ gate. Note that the in-file `# shellcheck source=` directives are part
 of the gate, not decoration; a comment sweep is exactly the operation
 that deletes them.
 
+### `scripts/posix-parse.sh` — the same idea, one dialect down (#1377)
+
+**A different property, a different tool: shellcheck lints, `dash -n`
+parses.** Files that run as the FreeBSD jail's `/bin/sh` must be strict
+POSIX, and this gate is the interpreter itself agreeing. Same derivation
+discipline as its sibling above, one question narrower — membership is
+the file's own line-1 dialect declaration (`#!/bin/sh`-family shebang,
+or a `# shellcheck shell=sh` directive), which is the answer each file
+already gives shellcheck. Twenty-eight files today; the `ci.yml` hand
+list it replaced named five and missed, among others, two of the three
+POSIX libs under `infra/lib/`. `--list` prints the set. A missing `dash`
+is a hard `exit 1`, same doctrine as the missing-docker branch above.
+See § "The shared deploy library (infra/lib/)" for what the gate is
+protecting and for what `dash -n` does NOT catch.
+
 ### `scripts/quickstart*.sh` — deprecated shims (#503)
 
 The three quickstart scripts (`quickstart.sh`, `-update.sh`, `-stop.sh`)
@@ -2810,6 +2825,17 @@ bash arrays, no `[[ ]]`, no `local` — so the FreeBSD jail's `/bin/sh`
 can run them. Consumers keep their own shebangs and may use bashisms in
 their own hooks. This section is the WHY behind those files; the files
 themselves say only what they do (#1159).
+
+**That claim is gated, and over a DERIVED set (#1377).**
+`scripts/posix-parse.sh` runs `dash -n` over every file under `bin/`,
+`infra/` and `scripts/` whose first line declares the sh dialect — a
+`#!/bin/sh`-family shebang, or the `# shellcheck shell=sh` directive
+these three libs use in place of one. Twenty-eight files today; the
+hand-written list in `ci.yml` it replaced named five, and two of the
+three libs above were not among them. `dash -n` checks GRAMMAR only
+(`arr=(a b)` is a syntax error; `[[ ]]` and `local` parse fine and fail
+at run time) — shellcheck's sh dialect, over the same files, is what
+covers the rest.
 
 **Why a shared library exists at all: the 2026-06-11 outage.** Before
 #503 each substrate had its own near-identical deploy script, and the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -604,6 +604,18 @@ itself. **The preflight hook's stdout contract:** it prints `→ <kind>:
 (HOT) / 3 (COLD); anything else is not a verdict and the library aborts
 on it.
 
+**`.env` and `MIX_ENV` are established for BOTH paths, in
+`establish_deploy_env` (#1377).** They used to live inside
+`substrate_build`, which returns early on hot — so a hot deploy reached
+the theme seed with no `MIX_ENV` in the shell, compose fell back to
+`.env` for the interpolation, and `.env.example` ships `MIX_ENV=dev`:
+cold seeded `grappa_prod.db`, hot seeded `grappa_dev.db` on the same
+box, silently. The function runs at the top of `substrate_pull` — the
+earliest hook, so it lands after the library's flag parse (an unknown
+flag still reads as a usage error) and before the first side effect.
+Consequence for operators: a box with no `.env` now fails the same way
+on hot as it always did on cold.
+
 **Hot deploys are the normal case.** `git pull` plus `POST
 /admin/reload` swaps modules in the live BEAM with no restart, and
 sessions (`Session.Server`, `IRC.Client`) keep their state. What cannot

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,7 +49,33 @@ COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 
 # ---- substrate hooks ------------------------------------------------
 
+# Preconditions for EVERY compose invocation this script makes, on BOTH
+# paths. They used to live inside substrate_build, behind its
+# `[ "$MODE" = cold ] || return 0`: a HOT deploy therefore reached
+# substrate_seed with no `.env` check and no MIX_ENV in the shell, compose
+# fell back to `.env` for the interpolation, and `.env.example` ships
+# `MIX_ENV=dev` — so compose.yaml resolved DATABASE_PATH to
+# `grappa_dev.db`. COLD seeded prod, HOT seeded the DEV database on the
+# same box, silently, and hot is the documented normal case (#1377 D-S3).
+#
+# `.env` carries the prod secrets runtime.exs refuses to boot without, and
+# MIX_ENV picks the database every oneshot opens — neither is a property of
+# the image build.
+establish_deploy_env() {
+	if [ ! -f .env ]; then
+		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
+	fi
+
+	MIX_ENV=${MIX_ENV:-prod}
+	export MIX_ENV
+}
+
 substrate_pull() {
+	# The earliest hook the lib calls, so the preconditions land here: AFTER
+	# the flag parse inside deploy_main (an unknown flag must still read as a
+	# usage error, not as a missing .env) and BEFORE the first side effect.
+	establish_deploy_env
+
 	# Pull first so the preflight diffs against what we are ABOUT to deploy.
 	# Both endpoints are RESOLVED shas — NEW_SHA goes into the marker.
 	PREV_SHA="$(git rev-parse HEAD)"
@@ -95,13 +121,6 @@ substrate_build() {
 	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
 	# rebuilds the toolchain image.
 	[ "$MODE" = cold ] || return 0
-
-	if [ ! -f .env ]; then
-		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
-	fi
-
-	MIX_ENV=${MIX_ENV:-prod}
-	export MIX_ENV
 
 	echo "Building grappa image..."
 	docker compose "${COMPOSE_ARGS[@]}" --profile prod build grappa

--- a/scripts/posix-parse.sh
+++ b/scripts/posix-parse.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/posix-parse.sh — the POSIX-sh PARSE gate, over a DERIVED file set.
+#
+# Usage:
+#   scripts/posix-parse.sh          # parse everything, exit non-zero on a finding
+#   scripts/posix-parse.sh --list   # print the derived set and exit
+#
+# A DIFFERENT property from scripts/shellcheck.sh, with a different tool:
+# that gate lints, `dash -n` parses. Files that run under the FreeBSD jail's
+# /bin/sh must stay strict POSIX, and a reintroduced bashism in one of them
+# must fail here rather than silently break a jail deploy — the copy-paste
+# drift class #503 exists to kill.
+#
+# The file set is DERIVED, never hand-listed (#1377 D-S4). The hand list this
+# replaced named five paths and covered five of the twenty-eight files that
+# declare the sh dialect — including only one of the three POSIX libs under
+# infra/lib/ that docs/OPERATIONS.md calls out, and none of the twelve
+# infra/freebsd/jail_*.sh rails.
+#
+# Membership rule, deliberately mechanical: a regular file under `bin/`,
+# `infra/` or `scripts/` whose FIRST LINE declares the sh (or dash) dialect —
+# a `#!/bin/sh`-family shebang, or the `# shellcheck shell=sh` directive the
+# sourced libs use in place of a shebang. That is the same question the
+# scripts each already answer for shellcheck; this gate just reads the answer
+# instead of keeping a second copy of it. A file that says nothing about its
+# dialect is not swept in: `dash -n` on a bash script reports syntax errors
+# for valid code, and the pressure would be to shrink the set.
+#
+# What this catches, measured: GRAMMAR. `arr=(a b c)` and `<<<` are syntax
+# errors to dash; `[[ 1 == 1 ]]` and `local x` are NOT — they parse as
+# ordinary commands and only fail when they RUN. shellcheck's sh dialect
+# (SC3xxx) is what covers that half, over the same files, which is why the
+# two gates are complementary rather than one being a superset.
+#
+# Exit 0 = every derived script parses. Exit 1 = a parse error, or dash
+# missing (a gate that silently skips itself is worse than no gate).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+readonly PARSE_ROOTS=(bin infra scripts)
+
+# Line 1 declares the sh dialect: shebang, or shellcheck directive.
+is_sh_dialect() {
+	local first_line
+	# A binary or empty file simply has no first line to read.
+	IFS= read -r first_line < "$1" 2>/dev/null || return 1
+	[[ $first_line =~ ^#!.*[[:space:]/](sh|dash)([[:space:]]|$) ]] && return 0
+	[[ $first_line =~ ^#[[:space:]]*shellcheck([[:space:]]|.*[[:space:]])shell=(sh|dash)([[:space:]]|$) ]]
+}
+
+derive_set() {
+	local path
+	while IFS= read -r path; do
+		if is_sh_dialect "$path"; then printf '%s\n' "$path"; fi
+	done < <(find "${PARSE_ROOTS[@]}" -type f | sort)
+}
+
+mapfile -t SCRIPTS < <(derive_set)
+
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+	echo "posix-parse.sh: derived an EMPTY file set — the roots moved, or find failed" >&2
+	exit 1
+fi
+
+if [ "${1:-}" = "--list" ]; then
+	printf '%s\n' "${SCRIPTS[@]}"
+	exit 0
+fi
+
+if ! command -v dash >/dev/null 2>&1; then
+	echo "posix-parse.sh: dash is required (it is the POSIX sh this gate parses with)" >&2
+	exit 1
+fi
+
+echo "posix-parse.sh: dash -n over ${#SCRIPTS[@]} derived sh-dialect scripts under ${PARSE_ROOTS[*]}"
+
+# Parse every file before reporting: one bashism must not hide the next.
+# `dash -n` names the offending file itself, on stderr.
+failed=0
+for script in "${SCRIPTS[@]}"; do
+	dash -n "$script" || failed=$((failed + 1))
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo "posix-parse.sh: $failed file(s) are NOT POSIX sh — see the dash errors above" >&2
+	exit 1
+fi

--- a/test/infra/base_image_digest_pin_test.bats
+++ b/test/infra/base_image_digest_pin_test.bats
@@ -87,7 +87,13 @@ pinned_tokens() {
         [ "$refs" -ge 2 ] && multi_ref_families=$((multi_ref_families + 1))
 
         if [ "$(printf '%s\n' "$digests" | grep -c .)" -gt 1 ]; then
+            # Name the FILES, not just the family (#1377). The four oven/bun:1
+            # references are textually identical, so a report of "these two
+            # digests disagree" leaves the reader to grep for which of four
+            # surfaces was bumped and which were not — and the whole point of
+            # the failure is that they are easy to miss one at a time.
             conflicts="${conflicts}${family}: $(printf '%s' "$digests" | tr '\n' ' ')
+$(matched_refs | grep -F -- "$family@sha256:" | sed 's/^/    /')
 "
         fi
     done
@@ -103,7 +109,6 @@ pinned_tokens() {
     [ -z "$conflicts" ] || {
         echo "DIVERGENT digests for the same image:tag — bump every surface together (#1343):" >&2
         printf '%s' "$conflicts" >&2
-        printf '%s\n' "$(pinned_tokens | sort)" >&2
         return 1
     }
 }

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -41,6 +41,12 @@ setup() {
     ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"
     : > "$ARGV_LOG"
     export ARGV_LOG
+    # A SECOND log, carrying the MIX_ENV each compose invocation inherited.
+    # Separate from ARGV_LOG on purpose: every ordering assertion below greps
+    # that file by line number, so the env must not widen those lines.
+    ENV_LOG="$BATS_TEST_TMPDIR/env.log"
+    : > "$ENV_LOG"
+    export ENV_LOG
     export HOME="$BATS_TEST_TMPDIR/home"
     mkdir -p "$HOME"
 
@@ -79,6 +85,13 @@ EOF
     git -C "$REPO_ROOT" config user.name "bats"
 
     # ---- env the script needs ------------------------------------------
+    # The default fixture is an INSTALLED box: since #1377 every path
+    # requires .env, not just cold. The two cases about its absence remove
+    # it again.
+    make_env
+    # An ambient MIX_ENV from the developer's shell would satisfy the D-S3
+    # cases without the script having established anything.
+    unset MIX_ENV
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -96,6 +109,7 @@ EOF
     cat > "$FAKE_DIR/docker" <<'EOF'
 #!/bin/sh
 printf 'docker %s\n' "$*" >> "$ARGV_LOG"
+printf 'MIX_ENV=%s | docker %s\n' "${MIX_ENV-<unset>}" "$*" >> "$ENV_LOG"
 case "$*" in
     *"ps -q grappa"*)  echo fakecid ;;
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
@@ -181,7 +195,6 @@ run_deploy() {
 }
 
 @test "--force-cold skips preflight and cold-deploys" {
-    make_env
     run_deploy --force-cold
     [ "$status" -eq 0 ]
     refute grep -q "run --no-start" "$ARGV_LOG"
@@ -225,7 +238,7 @@ run_deploy() {
 @test "cold path requires a .env file" {
     export PREFLIGHT_RC=3
     commit_upstream lib/base.txt > /dev/null
-    # no make_env
+    rm -f "$REPO_ROOT/.env"
 
     run_deploy
     [ "$status" -ne 0 ]
@@ -234,7 +247,6 @@ run_deploy() {
 
 @test "cold path order: build -> cicchetto-build -> deps.get -> migrate -> up -> healthcheck" {
     export PREFLIGHT_RC=3
-    make_env
     commit_upstream lib/base.txt > /dev/null
 
     run_deploy
@@ -268,7 +280,6 @@ run_deploy() {
 
 @test "cold deploy writes the completed-deploy marker as final step" {
     export PREFLIGHT_RC=3
-    make_env
     new="$(commit_upstream lib/base.txt)"
 
     run_deploy
@@ -337,4 +348,56 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     [[ "$output" == *"re-exec"* ]]
+}
+
+# --- #1377 D-S3: MIX_ENV is established for BOTH paths, not just cold --------
+#
+# `substrate_build` used to own the `.env` check and the
+# `MIX_ENV=${MIX_ENV:-prod}; export MIX_ENV` line, behind an early
+# `[ "$MODE" = cold ] || return 0`. So a HOT deploy reached `substrate_seed`
+# with MIX_ENV unset in the shell, compose fell back to `.env`, and
+# `.env.example` ships `MIX_ENV=dev` uncommented — measured against the real
+# compose.yaml, `docker compose --env-file .env.example config` then resolves
+# `DATABASE_PATH: /app/runtime/grappa_dev.db`. COLD seeded prod, HOT seeded
+# dev, and hot is the documented normal case.
+#
+# The env each compose invocation inherited is recorded in ENV_LOG by the
+# same stub that writes ARGV_LOG.
+
+# The MIX_ENV the seed oneshot inherited: `MIX_ENV=prod`, or `MIX_ENV=<unset>`.
+seed_mix_env() {
+    grep 'grappa.seed_themes' "$ENV_LOG" | head -1 | cut -d' ' -f1
+}
+
+@test "hot path: the seed oneshot carries MIX_ENV=prod, not the .env default (#1377 D-S3)" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    grep -q "grappa.seed_themes" "$ARGV_LOG"      # the seed really ran
+    [ "$(seed_mix_env)" = "MIX_ENV=prod" ] || {
+        echo "hot seed ran with $(seed_mix_env) — compose falls back to .env (grappa_dev.db)" >&2
+        return 1
+    }
+}
+
+@test "cold path: the seed oneshot carries MIX_ENV=prod too (#1377 D-S3)" {
+    export PREFLIGHT_RC=3
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    [ "$(seed_mix_env)" = "MIX_ENV=prod" ]
+}
+
+@test "hot path refuses to start without a .env, same as cold (#1377 D-S3)" {
+    # The check is path-independent now: every compose oneshot this script
+    # runs — reload, seed, healthcheck — reads .env for the prod secrets.
+    commit_upstream lib/base.txt > /dev/null
+    rm -f "$REPO_ROOT/.env"
+
+    run_deploy --force-hot
+    [ "$status" -ne 0 ]
+    [[ "$output" == *".env"* ]]
+    refute grep -q "docker" "$ARGV_LOG"           # died before any side effect
 }

--- a/test/infra/posix_parse_gate_test.bats
+++ b/test/infra/posix_parse_gate_test.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+#
+# scripts/posix-parse.sh — the DERIVED POSIX-sh parse gate (#1377 D-S4).
+#
+# The thing under test is the derivation, not dash. The hand-written list in
+# ci.yml named five paths and covered five of the twenty-eight files that
+# declare the sh dialect: it missed two of the three POSIX libs under
+# infra/lib/ (docs/OPERATIONS.md calls all three POSIX, and both misses carry
+# `# shellcheck shell=sh` on line 1, in the same directory as the one it did
+# name), the twelve infra/freebsd/jail_*.sh rails, and infra/packaging/version.sh.
+#
+# So these cases pin three properties:
+#
+#   1. the RULE — membership follows from the file's own line-1 dialect
+#      declaration, exercised in a sandbox tree so a new file can actually be
+#      added and observed;
+#   2. the REAL set — the specific files the old list forgot are in it now;
+#   3. that the gate BITES — a bashism in a newly covered file makes it fail,
+#      naming that file. A gate nobody has watched fail is not a gate.
+#
+# `--list` is used for the membership cases: they are about WHICH files the
+# gate covers. Case 3 runs the real thing, so it needs dash — which is also
+# what CI and the jail run, and what the gate refuses to proceed without.
+
+load ../bats_helpers
+
+setup() {
+    GATE="$BATS_TEST_DIRNAME/../../scripts/posix-parse.sh"
+    CI_YML="$BATS_TEST_DIRNAME/../../.github/workflows/ci.yml"
+
+    # A sandbox repo with the same three roots, and the gate copied in: the
+    # script derives its own root from BASH_SOURCE, so the copy enumerates
+    # the sandbox and a case can add a file and see what happens.
+    SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra/lib" "$SANDBOX/scripts"
+    cp "$GATE" "$SANDBOX/scripts/posix-parse.sh"
+    chmod +x "$SANDBOX/scripts/posix-parse.sh"
+    SANDBOX_GATE="$SANDBOX/scripts/posix-parse.sh"
+    # One valid member, so a case about EXCLUSION reads the exclusion and not
+    # the empty-set refusal. (The gate itself is bash and stays out of its own
+    # set, so without this the sandbox can hold only non-members.) The
+    # empty-set case removes the roots and therefore this too.
+    printf '#!/bin/sh\ntrue\n' > "$SANDBOX/infra/lib/canary.sh"
+}
+
+@test "a NEW script with an sh shebang joins the set (#1377)" {
+    printf '#!/bin/sh\ntrue\n' > "$SANDBOX/infra/lib/newrail.sh"
+    printf '#!/usr/bin/env sh\ntrue\n' > "$SANDBOX/bin/another"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/lib/newrail.sh"* ]]
+    [[ "$output" == *"bin/another"* ]]
+}
+
+@test "a NEW sourced lib declaring shell=sh on line 1 joins the set (#1377)" {
+    # This is the shape the hand list missed twice over: infra/lib/beam_wait.sh
+    # and infra/lib/cic_dist.sh are sourced, so they have no shebang at all —
+    # the directive IS the dialect declaration.
+    printf '# shellcheck shell=sh\ntrue\n' > "$SANDBOX/infra/lib/helpers.sh"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/lib/helpers.sh"* ]]
+}
+
+@test "bash-dialect and dialect-less files stay OUT (#1377)" {
+    # dash -n reports syntax errors for perfectly valid bash, so sweeping
+    # these in would make the gate fail on files it has no claim over — and
+    # the pressure would be to shrink the set back to a hand list.
+    printf '#!/usr/bin/env bash\narr=(a b)\n' > "$SANDBOX/scripts/basher.sh"
+    printf '# shellcheck shell=bash\narr=(a b)\n' > "$SANDBOX/infra/lib/_bashlib.sh"
+    printf '# grappa — nginx config\nserver { }\n' > "$SANDBOX/infra/lib/nginx.conf"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    refute grep -q 'basher.sh' <<<"$output"
+    refute grep -q '_bashlib.sh' <<<"$output"
+    refute grep -q 'nginx.conf' <<<"$output"
+}
+
+@test "an empty derived set fails loud instead of passing vacuously (#1377)" {
+    # A gate that parses nothing and exits 0 is the failure mode that hides a
+    # moved directory or a broken find.
+    rm -rf "${SANDBOX:?}/bin" "${SANDBOX:?}/infra"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra"
+    mkdir -p "$SANDBOX/tools"
+    cp "$GATE" "$SANDBOX/tools/gate.sh"
+    chmod +x "$SANDBOX/tools/gate.sh"
+    rm -f "$SANDBOX/scripts/posix-parse.sh"
+
+    run "$SANDBOX/tools/gate.sh" --list
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"EMPTY file set"* ]]
+}
+
+@test "a bashism in a covered file fails the gate, naming the file (#1377)" {
+    # The mutation that buys the gate. An ARRAY, not `[[ ]]`: dash -n checks
+    # GRAMMAR, and `[[ 1 == 1 ]]` parses as an ordinary command (it fails when
+    # it runs, and shellcheck's SC3xxx is what catches it). The array is a
+    # syntax error, which is what this tool is for.
+    printf '# shellcheck shell=sh\narr=(a b c)\n' > "$SANDBOX/infra/lib/regressed.sh"
+
+    run "$SANDBOX_GATE"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"infra/lib/regressed.sh"* ]]
+}
+
+@test "the real set covers what the hand-written list forgot (#1377)" {
+    # The five-path list in ci.yml before #1377 named none of these.
+    run "$GATE" --list
+
+    [ "$status" -eq 0 ]
+    # Two of the three infra/lib POSIX libs, in the same directory as the one
+    # it did name, with the same line-1 declaration.
+    [[ "$output" == *"infra/lib/beam_wait.sh"* ]]
+    [[ "$output" == *"infra/lib/cic_dist.sh"* ]]
+    # The jail rails the jail's /bin/sh actually runs, and the version
+    # delegate every deploy wrapper shells out to.
+    [[ "$output" == *"infra/freebsd/jail_mix.sh"* ]]
+    [[ "$output" == *"infra/freebsd/jail_db_query.sh"* ]]
+    [[ "$output" == *"infra/packaging/version.sh"* ]]
+    # An extensionless one, which a `*.sh` glob would have missed.
+    [[ "$output" == *"infra/freebsd/rc.d/grappa"* ]]
+    # And it still covers every path the old list did name.
+    [[ "$output" == *"infra/lib/deploy_common.sh"* ]]
+    [[ "$output" == *"infra/freebsd/deploy.sh"* ]]
+    [[ "$output" == *"infra/docker/assert-abi-lockstep.sh"* ]]
+    [[ "$output" == *"infra/docker/release-entrypoint.sh"* ]]
+    [[ "$output" == *"infra/docker/get.sh"* ]]
+}
+
+@test "ci.yml runs the derived gate and names no dash paths (#1377)" {
+    # The regression this guards is not "the step disappeared" — it is someone
+    # re-adding `dash -n <some new file>` beside the derived run. That reads
+    # like extra care and quietly restores the two-sources-of-truth state this
+    # change exists to end.
+    grep -q 'scripts/posix-parse.sh' "$CI_YML"
+
+    refute grep -nE '^[[:space:]]+dash[[:space:]]+-n[[:space:]]' "$CI_YML"
+}

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -65,6 +65,11 @@ setup() {
     git -C "$REPO" config user.email test@grappa.local
     git -C "$REPO" config user.name "bats"
 
+    # #1377: the hot path requires .env too now (establish_deploy_env, at the
+    # top of substrate_pull). These cases are about the reload contract, so
+    # the box they run against is an installed one.
+    echo "SECRET_KEY_BASE=x" > "$REPO/.env"
+
     # Fast healthcheck loop for tests (prod defaults stay in the script).
     export HOT_HEALTHCHECK_RETRIES=3 HOT_HEALTHCHECK_SLEEP=0
 

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -66,6 +66,11 @@ setup() {
     printf '9.9.9\n' > "$MAIN/VERSION"
     printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' > "$MAIN/mix.exs"
     : > "$MAIN/compose.yaml"
+    # #1377: deploy.sh requires .env on BOTH paths now, checked at the top of
+    # substrate_pull. Without it the positive case below would die before the
+    # pull echo it reads as "the guard did not over-fire" — for the wrong
+    # reason.
+    echo "SECRET_KEY_BASE=x" > "$MAIN/.env"
     touch "$MAIN/runtime/.gitkeep"
     echo base > "$MAIN/lib/base.ex"
     git -C "$MAIN" add -A


### PR DESCRIPTION
Bucket I (infra-simplify) of the 2026-08-15 codebase review: D-S3 (HIGH), D-S4, D-S5.
Two were real. D-S5 was already closed the day the review was written, and is refused
here with evidence rather than implemented.

## D-S3 — `scripts/deploy.sh` seeded the DEV database on a HOT deploy

The chain was demonstrated before anything was changed, leg by leg:

- `substrate_build` opens with `[ "$MODE" = cold ] || return 0`, and owned both the
  `.env` check and `MIX_ENV=${MIX_ENV:-prod}; export MIX_ENV` — so on hot neither ran.
- `deploy_common.sh` reaches `substrate_seed` on the hot path
  (`_deploy_hot` → `_deploy_seed`), a fresh `docker compose … run --rm grappa mix
  grappa.seed_themes`.
- With no shell `MIX_ENV`, compose interpolates from `.env`. Measured against the real
  files with the real compose.yaml:

  ```
  $ docker compose -f compose.yaml --env-file .env.example --profile prod config | grep -E 'MIX_ENV|DATABASE_PATH'
        DATABASE_PATH: /app/runtime/grappa_dev.db
        MIX_ENV: dev
  $ MIX_ENV=prod docker compose … config | grep -E 'MIX_ENV|DATABASE_PATH'
        DATABASE_PATH: /app/runtime/grappa_prod.db
        MIX_ENV: prod
  ```

So cold seeded prod, hot seeded dev, on the same box, silently — and hot is the
documented normal case.

**Fix.** Both preconditions move into `establish_deploy_env`, called from the top of
`substrate_pull`. Not from file scope: the library parses flags inside `deploy_main`,
so a check above that turns an unknown flag into a missing-`.env` error. The top of
the first hook is after the parse and before the first side effect, which is all the
placement has to satisfy.

**Red first.** The bats `docker` stub grew a second log carrying the `MIX_ENV` each
compose invocation inherited. Before the fix the new hot case reports
`hot seed ran with MIX_ENV=<unset>`; the cold twin was already green, which is the
asymmetry stated as a test.

**Operator-visible change:** a box with no `.env` now fails on hot exactly as it always
did on cold. Three sibling bats suites drove hot deploys against a fixture with no
`.env`; they now provision one, because their subject is the reload contract and the
worktree guard, not the absence of `.env`.

`.env.example` keeps `MIX_ENV=dev` (the registry drift test wants the key present, and
compose defaults to `dev` anyway, so commenting it out would de-trap nothing) and names
the residual hazard instead: a hand-driven `docker compose --profile prod …` inherits
whatever is written there, since only `deploy.sh` exports over it. Verified that the
declared-key set of `.env.example` is byte-identical in membership before and after
(33 keys, no delta).

## D-S4 — the POSIX gate covered 5 of 28

Counted, not estimated: 28 files under `bin/`, `infra/`, `scripts/` declare the sh
dialect on line 1; the `dash -n` step named 5. Missing: `infra/lib/beam_wait.sh` and
`infra/lib/cic_dist.sh` (two of the three libs `docs/OPERATIONS.md` calls strict POSIX,
same directory and same `# shellcheck shell=sh` line 1 as the one it did name), all
twelve `infra/freebsd/jail_*.sh` rails, `infra/packaging/version.sh`, `bin/start.sh`,
the packaging scriptlets, and the extensionless `infra/freebsd/rc.d/grappa`.

`scripts/posix-parse.sh` derives the set from each file's own line-1 declaration —
the same answer the file already gives shellcheck, so there is no second copy of the
dialect to drift. Same shape as `scripts/shellcheck.sh`: `--list`, an empty-set refusal,
and a hard exit when the tool is missing rather than a silent skip. All 28 parse clean
today, so the widening lands green.

**The gate is bought by mutation.** With `arr=(a b c)` appended to
`infra/lib/cic_dist.sh` — a file the old list did not name — it exits 1 with
`infra/lib/cic_dist.sh: 91: Syntax error: "(" unexpected`. The bats suite pins the same
thing in a sandbox, plus the membership rule, the exclusions, the empty-set refusal, and
that `ci.yml` runs the script and names no `dash -n` paths (that last assertion matches
five lines of the pre-change `ci.yml`, so it is not vacuous).

**Measured limit, stated in the script and the docs:** `dash -n` checks GRAMMAR.
`arr=(a b)` is a syntax error to it; `[[ 1 == 1 ]]` and `local x` are not — they parse
as ordinary commands and fail only when they run. shellcheck's `sh` dialect (SC3xxx)
covers that half, over the same files. Neither gate subsumes the other, and the review's
note that the `dash -n` list is "largely redundant" holds only for the half shellcheck
sees.

## D-S5 — refused

The finding says the four `oven/bun:1` transcriptions have no equality gate. They do:
`test/infra/base_image_digest_pin_test.bats:69` grew one in `1fb0bffd`,
`test(#1343): hold every copy of an image:tag to one digest (D-S5)`, landed 2026-08-15
— the same day the review was written. Verified by mutation, not by reading: a zeroed
digest in `scripts/bun.sh` fails the case with `DIVERGENT digests for the same
image:tag`.

The mutation did surface a smaller gap the finding did not raise. The failure printed
the family and then dumped every pinned token, and the four `oven/bun:1` tokens are
textually identical — so it proved a divergence and left the reader to grep for which of
four surfaces moved. It now prints the matching `path:line:content` refs for the
conflicting family; the same mutation on `.github/workflows/ci.yml:348` now names all
four, with the odd one out on its own line.

## Gates

- `scripts/bats.sh` (full set): 492 ok, rc=0
- `scripts/shellcheck.sh`: rc=0 (75 derived scripts)
- `scripts/posix-parse.sh`: rc=0 (28 derived scripts)
- `scripts/design-notes-gate.sh`: rc=0, `1 new entry heading(s), separator and marker present`
- Contribution `--numstat` pinned to a file across the rebase onto `origin/main`; both
  sides identical (additions unchanged, deletions zero on `docs/DESIGN_NOTES.md`).

## What I have not established

- **Nothing ran on a real Docker substrate.** No container was started, no seed was run,
  no `grappa_prod.db` was written. The D-S3 chain rests on two separate measurements —
  `docker compose config` (client-side interpolation, no daemon) for the
  `.env` → `DATABASE_PATH` leg, and bats against a stubbed `docker` for the
  "the seed oneshot inherits `MIX_ENV=prod`" leg. I did not join them in one live run.
- **The jail and systemd substrates were not exercised.** The D-S4 widening asserts that
  28 files *parse* under dash; it says nothing about whether they *run* correctly there,
  and `dash -n` would not catch it if they did not (see the grammar-vs-runtime limit
  above).
- **No Elixir gate was run** — this branch has no COMPILE lane. The only Elixir test that
  reads a file I touched is `test/grappa/config/env_registry_drift_test.exs` (`.env.example`);
  I proved its `env_file_decls` key set is unchanged by re-implementing that regex over
  both revisions, which is an argument, not a run of the test.
- **The `.env.example` residual hazard is documented, not closed.** A hand-driven
  `docker compose --profile prod up` on a prod box still opens `grappa_dev.db` unless the
  operator edits that value. Closing it would mean changing compose's default, which
  breaks plain dev `docker compose up`; that trade was not mine to make here.
- **The bun-digest report change is only proven for a two-digest conflict** in one family.
  A three-way divergence would print all refs the same way, but I did not construct one.