### PR TITLE
union(#1377 #1358 #1372): replay three DESIGN_NOTES-colliding branches onto one gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ CONTAINER_GID=1000
 # Mix environment switch. `dev` for local hacking, `prod` for the
 # deploy.sh stack. Phoenix expects an atom without the leading colon
 # when read from env vars (just `prod`).
+#
+# NOTE: compose interpolates this into BOTH `MIX_ENV` and `DATABASE_PATH`
+# (`grappa_${MIX_ENV:-dev}.db`), so the value below picks which database
+# every container and oneshot opens. `scripts/deploy.sh` exports
+# `MIX_ENV=prod` for its own invocations and the shell wins over this
+# file (#1377 D-S3) — but a hand-driven `docker compose --profile prod
+# …` on a prod box inherits exactly what is written here. Set it to
+# `prod` on any box that is not a dev laptop.
 MIX_ENV=dev
 
 # Host port publish for the grappa container. #485 dropped the in-stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,24 +160,21 @@ jobs:
         # convention. Needs the fetch-depth: 0 above.
         run: scripts/design-notes-gate.sh
 
-      - name: POSIX-parse the shared deploy lib + its sh consumers (#503)
+      - name: POSIX-parse the sh-dialect scripts (#503, derived by #1377)
         # A DIFFERENT property from the lint above, with a different tool:
-        # the shared deploy lib (infra/lib/deploy_common.sh) must stay strict
-        # POSIX sh so dash can run it as the FreeBSD jail's /bin/sh. dash -n
-        # parses; shellcheck lints. A reintroduced bashism in the shared
-        # algorithm fails here instead of silently breaking the jail deploy —
+        # the shared deploy lib (infra/lib/deploy_common.sh) and its sh
+        # consumers must stay strict POSIX so dash can run them as the FreeBSD
+        # jail's /bin/sh. dash -n parses; shellcheck lints. A reintroduced
+        # bashism fails here instead of silently breaking the jail deploy —
         # the copy-paste-drift class #503 exists to kill.
         #
-        # Still a hand-written list, deliberately: #441 derived the SHELLCHECK
-        # set, and this one is not the same question — "which files must parse
-        # under dash" is a claim about where they run, and the honest
-        # derivation for it is a separate piece of work.
-        run: |
-          dash -n infra/lib/deploy_common.sh
-          dash -n infra/freebsd/deploy.sh
-          dash -n infra/docker/assert-abi-lockstep.sh
-          dash -n infra/docker/release-entrypoint.sh
-          dash -n infra/docker/get.sh
+        # The set is DERIVED, like the shellcheck one (#441). The hand list
+        # this replaced covered five of the twenty-eight files that declare
+        # the sh dialect, missing two of the three POSIX libs under
+        # infra/lib/ and all twelve jail rails; the derivation reads each
+        # file's own line-1 declaration instead of keeping a second copy of
+        # it. Covered by test/infra/posix_parse_gate_test.bats.
+        run: scripts/posix-parse.sh
 
       - name: Cloud provider-door drift-guard (#665)
         # Prove every provider door (infra/aws today, infra/terraform later)

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -657,17 +657,32 @@ const ComposeBox: Component<Props> = (props) => {
           visual: aria-hidden, because a live region that changes on every
           keystroke is noise, and the thing worth ANNOUNCING (the draft will
           split) is the polite seam line below. */}
-      <Show when={frameCountdown()} keyed>
-        {(label) => (
-          <p
-            class="compose-box-frame-countdown"
-            data-testid="compose-frame-countdown"
-            aria-hidden="true"
-          >
-            {label}
-          </p>
-        )}
-      </Show>
+      {/* #1358 — the slot is ALWAYS mounted; only its content comes and goes.
+          The countdown used to be a bare `Show` among the root fragment's
+          children, and when it arrived in the same flush the split warning
+          left — the draft shrinking back under the frame limit — Solid
+          reconciled the fragment by DETACHING the <form> and re-attaching it
+          after the new sibling. The focused textarea rode along, and a
+          detached element loses the focus with nobody calling blur(): on iOS
+          that closes the keyboard mid-edit. A stable parent keeps the
+          appear/disappear inside this slot, where the form is not a sibling.
+          Measured in ComposeBoxFrameSeam.test.tsx over all eight seam
+          transitions; only that one moved the form, and only downward.
+          The node identity of the textarea is NOT the oracle — Solid handed
+          back the same node object across the move, focus already gone. */}
+      <div class="compose-box-frame-countdown-slot">
+        <Show when={frameCountdown()} keyed>
+          {(label) => (
+            <p
+              class="compose-box-frame-countdown"
+              data-testid="compose-frame-countdown"
+              aria-hidden="true"
+            >
+              {label}
+            </p>
+          )}
+        </Show>
+      </div>
       <form
         class={`compose-box${greyed() ? " compose-box-greyed" : ""}`}
         onSubmit={(e) => {

--- a/cicchetto/src/__tests__/ComposeBoxFrameSeam.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBoxFrameSeam.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #1358 — the iOS SYMPTOM is the keyboard closing as a draft shrinks back
+// under the single-frame limit. The MECHANISM under it is DOM node movement:
+// a focused element that leaves the DOM loses the focus in EVERY browser,
+// with nobody calling `blur()`. Solid's reconciliation is plain
+// `removeChild`/`insertBefore` on the same nodes in every DOM, so the
+// mechanism is measurable in jsdom and is measured here; only the keyboard
+// consequence needs a device, and vjt has already measured that one.
+//
+// Its own file, not a block in ComposeBox.test.tsx: that file mocks
+// `../lib/compose` wholesale, so the draft there is a constant and the seams
+// cannot be CROSSED — and the crossing is the entire subject. Here the
+// compose store, the frame budget and the ISUPPORT table are the real ones,
+// and the draft moves the way a thumb moves it: `input` on the textarea.
+//
+// Only `../lib/networks` is stubbed, and only `networkBySlug`: the view looks
+// the published budget up under a network id, and that store is fed by an
+// HTTP resource.
+vi.mock("../lib/networks", async () => {
+  const actual = await vi.importActual<typeof import("../lib/networks")>("../lib/networks");
+  return {
+    ...actual,
+    networkBySlug: (slug: string) => ({
+      kind: "user" as const,
+      id: NETWORK_ID,
+      slug,
+      nick: "vjt",
+      inserted_at: "",
+      updated_at: "",
+      connection_state: "connected",
+      connection_state_reason: null,
+      connection_state_changed_at: null,
+    }),
+  };
+});
+
+import ComposeBox from "../ComposeBox";
+import { channelKey } from "../lib/channelKey";
+import { setDraft } from "../lib/compose";
+import { frameBudgetForTarget } from "../lib/frameBudget";
+import { DEFAULT_ISUPPORT, seedIsupport } from "../lib/isupport";
+
+const NETWORK_ID = 7;
+const SLUG = "azzurra";
+const CHANNEL = "#a";
+const FRAME_BUDGET_BASE = 393;
+
+const BUDGET = frameBudgetForTarget(FRAME_BUDGET_BASE, CHANNEL) as number;
+
+// Drafts sized off the production budget, never off a literal. A single `x`
+// run holds no space to break on, so the split is the plain byte cut.
+const room = (bytes: number) => "x".repeat(BUDGET - bytes);
+const over = (bytes: number) => "x".repeat(BUDGET + bytes);
+
+const countdownOf = (root: ParentNode) =>
+  root.querySelector("[data-testid=compose-frame-countdown]");
+const splitWarningOf = (root: ParentNode) => root.querySelector(".compose-box-warning");
+
+// What is on the seam, as a pair of booleans: the countdown above the form,
+// the split warning below it.
+const seamsUp = (root: ParentNode) => ({
+  countdown: countdownOf(root) !== null,
+  warning: splitWarningOf(root) !== null,
+});
+
+type Crossing = {
+  label: string;
+  from: string;
+  to: string;
+  before: { countdown: boolean; warning: boolean };
+  after: { countdown: boolean; warning: boolean };
+};
+
+// Every transition the two seams can make, not just the one vjt's thumb
+// found. The bug is a property of how the root fragment reconciles, so the
+// invariant is stated over the whole class: NO seam transition may move the
+// composer out from under the focus.
+const CROSSINGS: Crossing[] = [
+  {
+    label: "countdown appears, no split on either side",
+    from: room(200),
+    to: room(3),
+    before: { countdown: false, warning: false },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "countdown value changes inside the band (its <p> is keyed)",
+    from: room(3),
+    to: room(2),
+    before: { countdown: true, warning: false },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "countdown disappears, no split on either side",
+    from: room(3),
+    to: room(200),
+    before: { countdown: true, warning: false },
+    after: { countdown: false, warning: false },
+  },
+  {
+    label: "up over the limit: countdown out above, warning in below",
+    from: room(3),
+    to: over(1),
+    before: { countdown: true, warning: false },
+    after: { countdown: false, warning: true },
+  },
+  {
+    label: "down under the limit: warning out below, countdown in above",
+    from: over(1),
+    to: room(3),
+    before: { countdown: false, warning: true },
+    after: { countdown: true, warning: false },
+  },
+  {
+    label: "split warning appears alone, out of the countdown band",
+    from: room(200),
+    to: over(1),
+    before: { countdown: false, warning: false },
+    after: { countdown: false, warning: true },
+  },
+  {
+    label: "split warning disappears alone, out of the countdown band",
+    from: over(1),
+    to: room(200),
+    before: { countdown: false, warning: true },
+    after: { countdown: false, warning: false },
+  },
+  {
+    label: "split warning text changes, two frames to three",
+    from: over(1),
+    to: over(BUDGET),
+    before: { countdown: false, warning: true },
+    after: { countdown: false, warning: true },
+  },
+];
+
+describe("#1358 — no frame-seam transition may unmount the focused composer", () => {
+  beforeEach(() => {
+    seedIsupport(NETWORK_ID, { ...DEFAULT_ISUPPORT, frameBudgetBase: FRAME_BUDGET_BASE });
+    setDraft(channelKey(SLUG, CHANNEL), "");
+  });
+
+  for (const crossing of CROSSINGS) {
+    it(`keeps the focus: ${crossing.label}`, () => {
+      setDraft(channelKey(SLUG, CHANNEL), crossing.from);
+      const { container } = render(() => <ComposeBox networkSlug={SLUG} channelName={CHANNEL} />);
+
+      const textarea = container.querySelector("textarea");
+      if (textarea === null) throw new Error("no composer textarea rendered");
+      const form = container.querySelector("form");
+      if (form === null) throw new Error("no composer form rendered");
+      textarea.focus();
+
+      // Pre-state, asserted rather than assumed: the seams really are where
+      // this row says they are and the focus really is on the box. Without
+      // it a row could pass having crossed nothing.
+      expect(seamsUp(container)).toEqual(crossing.before);
+      expect(document.activeElement).toBe(textarea);
+
+      // The gesture: one `input`, the way a keystroke or a deletion reports.
+      // The form is watched across it, because Solid can hand the same node
+      // object back after having detached and re-attached it — node identity
+      // alone is a blind oracle here (measured: same node, focus gone).
+      let formDetached = false;
+      const observer = new MutationObserver(() => {});
+      observer.observe(container, { childList: true, subtree: true });
+      fireEvent.input(textarea, { target: { value: crossing.to } });
+      for (const record of observer.takeRecords()) {
+        for (const node of Array.from(record.removedNodes)) {
+          if (node === form || node.contains(form)) formDetached = true;
+        }
+      }
+      observer.disconnect();
+
+      // The crossing really happened.
+      expect(seamsUp(container)).toEqual(crossing.after);
+
+      // The measurement. The focus is the oracle that matters — a detached
+      // and re-attached composer keeps its node identity and loses the
+      // keyboard — and the detach is reported alongside it so a red says
+      // WHY, not just that.
+      expect({ formDetached, focused: document.activeElement === textarea }).toEqual({
+        formDetached: false,
+        focused: true,
+      });
+    });
+  }
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43368,3 +43368,72 @@ when a reset actually happens. With `pool_size: 10` under continuous reads
 that is a real possibility, and it is the most likely reason prod's WAL was at
 168 MiB rather than the ~64 MiB the threshold alone predicts. The change lowers
 the pressure and bounds the recovery; it does not promise a ceiling.
+<!-- entry #1377 -->
+
+---
+
+## 2026-08-16 — #1377: a precondition inside a mode-gated hook is a per-mode precondition
+
+Bucket I of the 2026-08-15 codebase review — D-S3 (HIGH), D-S4, D-S5. Two were
+real. The third had been closed the same day the review was written, which is
+its own lesson about reading a review as a document rather than as a
+measurement.
+
+**D-S3, and the shape worth keeping.** `scripts/deploy.sh` held its `.env`
+check and its `MIX_ENV=${MIX_ENV:-prod}; export MIX_ENV` inside
+`substrate_build` — a hook the shared library calls on BOTH paths, but which
+opens with `[ "$MODE" = cold ] || return 0`. So both lines ran on cold and
+neither on hot, and nothing complained, because the hot path did not fail: it
+diverged. `docker compose` falls back to `.env` for a variable absent from the
+shell, `.env.example` ships `MIX_ENV=dev` uncommented, and `compose.yaml`
+derives `DATABASE_PATH` from that same variable — so the theme seed opened
+`grappa_dev.db` on a box whose cold deploys had always opened `grappa_prod.db`.
+Measured against the real files, not inferred from them: `docker compose
+--env-file .env.example --profile prod config` resolves `MIX_ENV: dev` +
+`/app/runtime/grappa_dev.db` with no shell `MIX_ENV`, and `prod` +
+`grappa_prod.db` with `MIX_ENV=prod` exported.
+
+The durable rule is not "hoist that check". It is that **a precondition placed
+inside a mode-guarded hook quietly becomes a per-mode precondition**, and the
+resulting bug is silent by construction: the mode that keeps the precondition
+is the one that would have failed loudly, so the mode that loses it is the one
+nobody hears about. Preconditions belong at the first hook the shared algorithm
+calls. File scope was rejected on ordering: the library parses flags inside
+`deploy_main`, so a check above that turns an unknown flag into a
+missing-`.env` error. The top of `substrate_pull` is after the parse and before
+the first side effect, which is the whole of what the placement has to satisfy.
+
+**D-S4 — a hand list is a snapshot, twice over.** The `dash -n` step in
+`ci.yml` named five paths and covered five of the twenty-eight files that
+declare the sh dialect on line 1, missing two of the three `infra/lib/` libs
+this log already calls strict POSIX. Its comment defended the list because "the
+honest derivation for it is a separate piece of work" — the derivation is a
+dozen lines, and it is #441's, one dialect down: read the dialect declaration
+each file already carries for shellcheck instead of keeping a second copy of
+it. Recorded because it will be tempting again: the argument that a set is
+"a claim about where files run, not about what they are" is exactly the
+argument that lets a snapshot outlive its accuracy.
+
+Worth knowing before trusting that gate: `dash -n` checks GRAMMAR. `arr=(a b)`
+is a syntax error to it, `[[ 1 == 1 ]]` and `local x` are not — they parse as
+ordinary commands and fail only when they run. shellcheck in `sh` dialect
+(SC3xxx) is what covers that half, over the same files. Neither gate is a
+superset of the other.
+
+**D-S5 — refused, with the mutation as the evidence.** The finding says no gate
+holds the four `oven/bun:1` transcriptions to one digest. One does:
+`test/infra/base_image_digest_pin_test.bats` grew it in #1343, landed
+2026-08-15, commit subject naming D-S5. A zeroed digest in `scripts/bun.sh`
+fails it. What the mutation did surface is that the report named the family and
+dumped the tokens — and the four tokens are textually identical, so it proved a
+divergence while leaving the reader to grep for which surface moved. It now
+lists the matching `path:line` refs instead.
+
+**What this does NOT establish.** Nothing here was exercised on a real Docker
+substrate: the D-S3 chain is proven by `docker compose config` (client-side
+interpolation, no daemon) plus a bats run against a stubbed `docker`, and no
+container was started, no seed was run, and no `grappa_prod.db` was written.
+The claim that the hot path now seeds prod rests on the shell exporting
+`MIX_ENV=prod` before the oneshot, which the suite observes directly; the step
+from there to the database file is compose's, and is evidenced by its own
+`config` output rather than by a deploy.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43507,3 +43507,68 @@ needs no CSS rule and has none.
 **Not established:** that the slot is visually inert in a real engine (the
 check above is static), and the detach-to-keyboard chain on iOS, which remains
 vjt's device measurement.
+<!-- entry #1372 -->
+
+---
+
+## 2026-08-16 — #1372: the unread aggregate lost its covering index, and the pin that should have caught it was blind
+
+`Scrollback.count_after_split/6` is the query behind the cold-load `/me` seed
+and the per-channel join reply (`WindowCounts.snapshot/7`). #393 shipped two
+covering index families for it on 2026-07-25 — `kind` at the tail so the
+content-vs-event GROUP BY could be answered without touching the table —
+because the non-covering form was the prod incident of that morning: its
+migration moduledoc records 80ms → 5-7ms, ~15x.
+
+Four and six days later #532 A and #576 added `exclude_own_authored/3` to the
+same aggregate. The predicate reads `lower(sender)` and
+`json_extract(meta, '$.new_nick')`, neither of which was in any index on
+`messages`, so SQLite went back to one table row-fetch per post-cursor row.
+Neither entry mentions an index, a covering property or an EXPLAIN.
+
+**The finding that outlived the fix is the pin.** The 2026-08-15 review read
+this as "no covering pin exists". One did — three of them, asserting
+`USING COVERING INDEX` — and they were green throughout. They EXPLAINed a
+LOCAL REBUILD of the aggregate that passed `own_nick: nil`, and at nil
+`exclude_own_authored/3` is the identity clause, so the predicate that caused
+the regression never entered the pinned SQL. Measured on one 650k-row corpus,
+same channel, same cursor: the pinned shape reads 1,676 page fetches and says
+COVERING; the production shape reads 175,576 and does not. A pin on a branch
+production does not take is worse than no pin, because it reports safety. The
+cure is not a second pin beside it: the plan is now read off the SQL the
+production function actually emits, captured from `[:grappa, :repo, :query]`
+telemetry, so no second copy of the query exists to drift. Rule for any future
+plan pin: **EXPLAIN what production emitted, never what the test can rebuild.**
+
+**Why widening, and not seek-and-subtract.** Both shapes were measured on the
+same corpus before either was written. Appending the two expressions to the
+four existing indexes restores COVERING (175,576 → 1,886 page fetches, 93x,
+identical results) at **no measurable INSERT cost** — widening an entry adds no
+b-tree. Counting own-authored rows as a second seek and subtracting costs
+**+37% on INSERT**, because it adds four new b-trees to the highest-write-rate
+table in the codebase; and it is not a subtraction but inclusion-exclusion
+across three seeks, since a case-only self-rename matches both arms of the
+disjunction. Dearer and more fragile, for a read that is already served.
+Widening alone with `lower(sender)` was also measured: it does NOT restore
+COVERING. Both expressions are load-bearing.
+
+The four dead `dm_with` indexes (P-S4) are dropped in the same PR rather than
+deferred, because that is what makes the write side a net win: the pair is 25%
+faster on INSERT and 22% smaller in index bytes than main is today, where the
+widening alone is merely neutral. An 11-shape plan sweep confirms nothing else
+regresses, and that the four dropped indexes served no production read — the
+only thing referencing them was a pair of tests EXPLAINing the
+`(channel = ? OR dm_with = ?)` disjunction #393 deleted from production, the
+same defect class as the blind pin.
+
+**Not established.** There is no prod copy on this lane; the corpus is
+synthetic and its distributions — notably the ~4% own-`sender` share — are
+chosen, not observed. Page fetches are reported instead of milliseconds
+precisely because they are deterministic and host-independent; the wall-clock
+figures are warm macOS, not the m42 jail, and cold-cache timing is unmeasured.
+Local `CREATE INDEX` is 0.51-0.66s per index at 650k rows, but #393's own prod
+record of 1.6-2.6s per index at 654k rows is the better predictor for the COLD
+window. And the open question from #1353 stays open: *why* a pool connection
+that did not serve the `CREATE INDEX` plans differently — schema cache or
+transaction visibility — is still unmeasured, and `pool_size: 1` remains a
+remedy whose mechanism nobody has characterised.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43437,3 +43437,73 @@ The claim that the hot path now seeds prod rests on the shell exporting
 `MIX_ENV=prod` before the oneshot, which the suite observes directly; the step
 from there to the database file is compose's, and is evidenced by its own
 `config` output rather than by a deploy.
+<!-- entry #1358 -->
+
+---
+
+## 2026-08-16 — #1358: a seam sibling moved the composer, and node identity is a blind oracle
+
+vjt's report was an iOS one: deleting characters from a draft that is over the
+single-frame limit closes the keyboard as the draft crosses back under it. The
+mechanism underneath is not iOS and not a `blur()` — nothing in `ComposeBox`
+calls one. `ComposeBox`'s root is a fragment whose children are, in order: the
+byte countdown, the `<form>`, the uploads block, the greyed line, the feedback
+seam. Crossing the limit DOWNWARD flips two of those in the same flush — the
+split warning leaves below the form, the countdown arrives above it — and
+Solid reconciled that by DETACHING the form and re-attaching it after the new
+sibling. The focused textarea rode along inside it, and a detached element
+loses the focus in every engine, with nobody calling anything.
+
+**Measured, not reasoned: one transition out of eight.** `MutationObserver`
+over the container, the gesture a single `input` on the textarea, the compose
+store and frame budget the real ones. The countdown appearing, changing value
+inside the band or disappearing on its own: clean. The split warning
+appearing, disappearing or changing its text on its own: clean. The crossing
+UPWARD — countdown out above, warning in below: clean. Only the DOWNWARD
+crossing moves the form, which is exactly the direction a deleting thumb
+travels, and exactly why the report named deletion.
+
+**The node-identity oracle the issue proposed is a FALSE NEGATIVE.** Across
+that transition Solid hands back the SAME `<textarea>` and the SAME `<form>`
+object: an assert that the node did not change passes while the keyboard is
+already gone. The oracle is `document.activeElement`, and the detach is worth
+reporting beside it so a red says why. This generalises past this box — for
+any "did my focus survive the re-render" question, node identity answers a
+different question than the one being asked.
+
+**cic unit tests have a real DOM, and this class of bug is measurable there.**
+`vitest.config.ts` runs `environment: "jsdom"`, and jsdom resets
+`document.activeElement` to `<body>` when the focused node leaves the document.
+Solid reconciles with plain `removeChild`/`insertBefore` on the same nodes in
+every DOM, so the movement and the focus loss are both engine-independent and
+neither needs a browser or a device. Only the keyboard consequence is iOS's,
+and that half stays vjt's device-verify. An issue that says a DOM measurement
+needs e2e is describing the host it was written on, not this repo.
+
+**The fix is a stable parent, not a stable node count.** The `Show` now sits
+inside an always-mounted `div`, so the appear/disappear happens where the form
+is not a sibling. Two alternatives were measured and rejected. An
+always-mounted `<p>` whose text merely empties — the shape the issue suggested
+— also measures clean, but the defect is the identity of the node in the slot
+rather than the number of slots, and that shape additionally changes an
+unrelated observable contract ("hidden means the node is absent"), costing two
+green assertions elsewhere; the slot leaves the component's observable
+behaviour identical except for the bug. A `fallback` on the existing `Show` is
+WORSE, and measurably so: it breaks the upward crossing too, because swapping
+the node in the slot is the very thing that relocates the form.
+
+**Re-focusing after the fact stays forbidden.** It papers over a DOM move
+instead of preventing it, and it fights the UX-6-D `preventScroll` history in
+`composeAppend.ts`.
+
+**The empty slot is layout-inert, checked rather than assumed.** An
+always-mounted child consumes a `gap` even at zero height, which would be a
+permanent phantom space above the box. Its only parent is `.drop-upload-zone`
+(both `ComposeBox` mount sites are inside it), `display:flex;
+flex-direction:column` with no `gap` or `row-gap`, and `themes/default.css` —
+the one stylesheet — carries no `:empty` rule anywhere. The slot therefore
+needs no CSS rule and has none.
+
+**Not established:** that the slot is visually inert in a real engine (the
+check above is static), and the detach-to-keyboard chain on iOS, which remains
+vjt's device measurement.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -979,6 +979,21 @@ gate. Note that the in-file `# shellcheck source=` directives are part
 of the gate, not decoration; a comment sweep is exactly the operation
 that deletes them.
 
+### `scripts/posix-parse.sh` — the same idea, one dialect down (#1377)
+
+**A different property, a different tool: shellcheck lints, `dash -n`
+parses.** Files that run as the FreeBSD jail's `/bin/sh` must be strict
+POSIX, and this gate is the interpreter itself agreeing. Same derivation
+discipline as its sibling above, one question narrower — membership is
+the file's own line-1 dialect declaration (`#!/bin/sh`-family shebang,
+or a `# shellcheck shell=sh` directive), which is the answer each file
+already gives shellcheck. Twenty-eight files today; the `ci.yml` hand
+list it replaced named five and missed, among others, two of the three
+POSIX libs under `infra/lib/`. `--list` prints the set. A missing `dash`
+is a hard `exit 1`, same doctrine as the missing-docker branch above.
+See § "The shared deploy library (infra/lib/)" for what the gate is
+protecting and for what `dash -n` does NOT catch.
+
 ### `scripts/quickstart*.sh` — deprecated shims (#503)
 
 The three quickstart scripts (`quickstart.sh`, `-update.sh`, `-stop.sh`)
@@ -2810,6 +2825,17 @@ bash arrays, no `[[ ]]`, no `local` — so the FreeBSD jail's `/bin/sh`
 can run them. Consumers keep their own shebangs and may use bashisms in
 their own hooks. This section is the WHY behind those files; the files
 themselves say only what they do (#1159).
+
+**That claim is gated, and over a DERIVED set (#1377).**
+`scripts/posix-parse.sh` runs `dash -n` over every file under `bin/`,
+`infra/` and `scripts/` whose first line declares the sh dialect — a
+`#!/bin/sh`-family shebang, or the `# shellcheck shell=sh` directive
+these three libs use in place of one. Twenty-eight files today; the
+hand-written list in `ci.yml` it replaced named five, and two of the
+three libs above were not among them. `dash -n` checks GRAMMAR only
+(`arr=(a b)` is a syntax error; `[[ ]]` and `local` parse fine and fail
+at run time) — shellcheck's sh dialect, over the same files, is what
+covers the rest.
 
 **Why a shared library exists at all: the 2026-06-11 outage.** Before
 #503 each substrate had its own near-identical deploy script, and the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -604,6 +604,18 @@ itself. **The preflight hook's stdout contract:** it prints `→ <kind>:
 (HOT) / 3 (COLD); anything else is not a verdict and the library aborts
 on it.
 
+**`.env` and `MIX_ENV` are established for BOTH paths, in
+`establish_deploy_env` (#1377).** They used to live inside
+`substrate_build`, which returns early on hot — so a hot deploy reached
+the theme seed with no `MIX_ENV` in the shell, compose fell back to
+`.env` for the interpolation, and `.env.example` ships `MIX_ENV=dev`:
+cold seeded `grappa_prod.db`, hot seeded `grappa_dev.db` on the same
+box, silently. The function runs at the top of `substrate_pull` — the
+earliest hook, so it lands after the library's flag parse (an unknown
+flag still reads as a usage error) and before the first side effect.
+Consequence for operators: a box with no `.env` now fails the same way
+on hot as it always did on cold.
+
 **Hot deploys are the normal case.** `git pull` plus `POST
 /admin/reload` swaps modules in the live BEAM with no restart, and
 sessions (`Session.Server`, `IRC.Client`) keep their state. What cannot

--- a/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
+++ b/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
@@ -75,11 +75,28 @@ defmodule Grappa.Repo.Migrations.AddOwnAuthoredExprsToMessagesCoveringIndexes do
 
   ## Deploy
 
-  New migration file — Preflight Class 5 forces **COLD**. The four
-  `CREATE INDEX` builds took 2.6s in total over 650k rows locally (per-index
-  split in the PR body); they share one migration transaction, so schedule
-  off a traffic peak. Expand-class: no schema-shape change, so the running
-  old code is unaffected by the added index columns.
+  New migration file — Preflight Class 5 forces **COLD**. All four
+  `CREATE INDEX` builds share ONE migration transaction, so the number that
+  sizes the window is that transaction, not the per-index split.
+
+  Measured on a corpus built at prod's ACTUAL row count (1,943,545 rows —
+  vjt read it off the jail 2026-08-16; #393's 654k is three weeks stale and
+  three times too small), fresh copy per rep so none inherits the previous
+  page cache: **9.55 / 9.66 / 9.85 s** for this migration's `up/0`, and
+  9.72-10.14 s for it plus the P-S4 drop back to back. 2.99x the rows cost
+  3.24x the time, which is the mild superlinearity a sort-dominated build
+  should show.
+
+  That is a LOCAL number. Scaled by the host ratio #393 recorded for the same
+  operation on the same table (prod 1.6-2.0s per channel index and
+  2.442/2.570s per DM index at 654k, against 0.52-0.69s locally at 650k —
+  a 3-4.5x factor, and conservative because those indexes were NARROWER than
+  these), prod should land around **30-45 seconds** for the migrate step.
+  Nobody has measured an index build on prod's substrate at 1.9M rows; this
+  is an explicit extrapolation, not an observation.
+
+  Expand-class: no schema-shape change, so the running old code is unaffected
+  by the added index columns.
 
   See DESIGN_NOTES 2026-08-16.
   """

--- a/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
+++ b/priv/repo/migrations/20260816013504_add_own_authored_exprs_to_messages_covering_indexes.exs
@@ -1,0 +1,226 @@
+defmodule Grappa.Repo.Migrations.AddOwnAuthoredExprsToMessagesCoveringIndexes do
+  @moduledoc """
+  #1372 P-S1 — restore the COVERING property #393 shipped for the
+  `count_after_split/6` aggregate, which #532 A and #576 defeated.
+
+  ## What broke
+
+  #393 (2026-07-25) put `kind` at the tail of both covering families
+  precisely so the content-vs-event GROUP BY could be answered from the
+  index with no table touch — its moduledoc records the prod measurement,
+  80ms → 5-7ms, ~15x, on the query behind that day's incident.
+
+  Four and six days later `exclude_own_authored/3` was added to the SAME
+  aggregate (#532 A presence, #576 content). It reads two things that were
+  in NO index on `messages`: `lower(sender)` and
+  `json_extract(meta, '$.new_nick')`. So SQLite went back to seeking
+  `(subject, network_id, channel, id > ?)` on the index and then fetching
+  the table row for EVERY post-cursor row to evaluate them — the exact
+  shape #393 measured as the incident. The worst window is the one that
+  matters: a channel whose read cursor is far behind, which is what the
+  cold-load `/me` seed and the per-channel join reply both route through
+  (`WindowCounts.snapshot/7`).
+
+  ## The measurement this migration is built on
+
+  650k rows, prod-shaped distribution, no `ANALYZE` (prod has no
+  `sqlite_stat*` and the app never runs it, so the planner must be measured
+  on default estimates), channel window of 103,209 post-cursor rows, SQL
+  captured verbatim off `[:grappa, :repo, :query]` rather than rebuilt:
+
+      before   SEARCH … USING INDEX …channel_id_kind_index          175,576 page fetches
+      after    SEARCH … USING COVERING INDEX …channel_id_kind_index   1,886 page fetches
+
+  93x fewer page fetches, identical results. Page fetches rather than
+  wall-clock on purpose: they are deterministic and host-independent, and
+  the 14x ratio on page MISSES (23,427 → 1,885) lands on the same ~15x
+  #393 recorded from an entirely independent measurement.
+
+  Both expressions are load-bearing — widening with `lower(sender)` alone
+  was measured and does NOT restore COVERING.
+
+  ## Why widen, and not seek-and-subtract
+
+  The alternative shape was to count own-authored rows as a second seek on
+  a `sender`-leading index and subtract. Measured on the same corpus, it
+  costs **+37% on INSERT** (0.67s vs 0.48s for 50k rows, 3 reps) because it
+  adds four NEW b-trees to the highest-write-rate table in the codebase,
+  where widening an existing entry by two short values adds none —
+  **no measurable insert cost at all** (0.48/0.49/0.48s against a
+  0.48/0.50/0.50s baseline). It is also not a subtraction: the predicate is
+  a disjunction whose arms overlap (a case-only self-rename matches BOTH
+  `sender` and `new_nick`), so it needs inclusion-exclusion across three
+  seeks, each reproducing the GROUP BY bucketing, to replace one query.
+  Dearer and more fragile, for a read that is already served.
+
+  Index size grows 348 MB → 373 MB (+7.2%) at 650k rows. The sibling
+  commit that drops the four dead `dm_with` indexes (#1372 P-S4) more than
+  pays that back: together they are 25% FASTER on INSERT and 22% smaller
+  than today.
+
+  ## Byte-identity is load-bearing, as ever
+
+  The DM expression MUST stay character-identical to
+  `Identifier.nick_fold_sql/1` applied to `COALESCE(dm_with, channel)`, and
+  the `sender` fold to the same function applied to `sender`, or SQLite
+  silently stops recognising the query as index-eligible — no error, just
+  the old per-row fetch. Inlined here because migrations run before `lib/`
+  is loaded (same reason as `20260725120000`); `ScrollbackTest`'s two-arm
+  pin guards both literals plus the `$.new_nick` JSON path.
+
+  Whitespace and the table alias may differ between this DDL and the
+  emitted query (`json_extract(m0."meta", '$.new_nick')`) — SQLite matches
+  indexed expressions after parsing, not textually, and that was measured,
+  not assumed. The JSON PATH may not differ.
+
+  ## Deploy
+
+  New migration file — Preflight Class 5 forces **COLD**. The four
+  `CREATE INDEX` builds took 2.6s in total over 650k rows locally (per-index
+  split in the PR body); they share one migration transaction, so schedule
+  off a traffic peak. Expand-class: no schema-shape change, so the running
+  old code is unaffected by the added index columns.
+
+  See DESIGN_NOTES 2026-08-16.
+  """
+  use Ecto.Migration
+
+  # The ASCII fold, pure SQL. MUST stay character-identical to
+  # `Grappa.IRC.Identifier.nick_fold_sql/1` (#525 narrowed it from the
+  # rfc1459 four-`replace()` form to plain `lower()`).
+  defp fold(col), do: "lower(#{col})"
+
+  # The `meta.new_nick` half of `exclude_own_authored/3`. No lib-side SSOT
+  # exists — it is an Ecto `fragment` at `scrollback.ex:724`/`:740` — so the
+  # pin test carries the guard.
+  defp new_nick, do: "json_extract(meta, '$.new_nick')"
+
+  def up do
+    # (A) channel family
+    drop index(:messages, ["user_id", "network_id", "channel", "id", "kind"],
+          name: :messages_user_id_network_id_channel_id_kind_index
+        )
+
+    create index(
+             :messages,
+             ["user_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+             name: :messages_user_id_network_id_channel_id_kind_index
+           )
+
+    drop index(:messages, ["visitor_id", "network_id", "channel", "id", "kind"],
+          name: :messages_visitor_id_network_id_channel_id_kind_index
+        )
+
+    create index(
+             :messages,
+             ["visitor_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+             name: :messages_visitor_id_network_id_channel_id_kind_index
+           )
+
+    # (B) DM folded-COALESCE family
+    drop index(
+           :messages,
+           ["user_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+           name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             [
+               "user_id",
+               "network_id",
+               fold("COALESCE(dm_with, channel)"),
+               "id",
+               "kind",
+               fold("sender"),
+               new_nick()
+             ],
+             name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           ["visitor_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+           name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             [
+               "visitor_id",
+               "network_id",
+               fold("COALESCE(dm_with, channel)"),
+               "id",
+               "kind",
+               fold("sender"),
+               new_nick()
+             ],
+             name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+  end
+
+  def down do
+    # Back to the #393 shape: same four names, without the two trailing
+    # expressions. The aggregate returns to a per-row table fetch — that is
+    # what `down` means here, and the pin test reddens on it, correctly.
+    drop index(
+           :messages,
+           ["user_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+           name: :messages_user_id_network_id_channel_id_kind_index
+         )
+
+    create index(:messages, ["user_id", "network_id", "channel", "id", "kind"],
+             name: :messages_user_id_network_id_channel_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           ["visitor_id", "network_id", "channel", "id", "kind", fold("sender"), new_nick()],
+           name: :messages_visitor_id_network_id_channel_id_kind_index
+         )
+
+    create index(:messages, ["visitor_id", "network_id", "channel", "id", "kind"],
+             name: :messages_visitor_id_network_id_channel_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           [
+             "user_id",
+             "network_id",
+             fold("COALESCE(dm_with, channel)"),
+             "id",
+             "kind",
+             fold("sender"),
+             new_nick()
+           ],
+           name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             ["user_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+             name: :messages_user_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+
+    drop index(
+           :messages,
+           [
+             "visitor_id",
+             "network_id",
+             fold("COALESCE(dm_with, channel)"),
+             "id",
+             "kind",
+             fold("sender"),
+             new_nick()
+           ],
+           name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+         )
+
+    create index(
+             :messages,
+             ["visitor_id", "network_id", fold("COALESCE(dm_with, channel)"), "id", "kind"],
+             name: :messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index
+           )
+  end
+end

--- a/priv/repo/migrations/20260816014915_drop_dead_messages_dm_with_indexes.exs
+++ b/priv/repo/migrations/20260816014915_drop_dead_messages_dm_with_indexes.exs
@@ -1,0 +1,92 @@
+defmodule Grappa.Repo.Migrations.DropDeadMessagesDmWithIndexes do
+  @moduledoc """
+  #1372 P-S4 — drop four indexes on `messages` that no read can use.
+
+  ## What they were for, and why nothing needs them
+
+      (user_id|visitor_id, network_id, dm_with, server_time)   20260508132130
+      (user_id|visitor_id, network_id, dm_with, id)            20260722202612
+
+  `20260722202612`'s own moduledoc states the purpose of the `id` twins: they
+  exist for symmetry, "so the `dm_with=?` arm … is index-seekable". Three days
+  later #393 DELETED that arm — `where_dm_peer/2` collapsed the OR-disjunction
+  into the single folded equality `lower(COALESCE(dm_with, channel)) = ?`.
+
+  There is no bare `m.dm_with == ^…` predicate left anywhere in `lib/`: every
+  reference is `nick_fold(dm_with)` or `nick_fold(COALESCE(dm_with, channel))`,
+  and a plain B-tree on the RAW column cannot seek either — `dm_with` is stored
+  case-preserved (the #372 nick display rule), so every match folds. #393
+  applied exactly this reasoning when it dropped the sibling
+  `..._channel_id_index` composites; it simply did not extend it to the
+  `dm_with` family.
+
+  ## Measured, not just grepped
+
+  An 11-shape `EXPLAIN QUERY PLAN` sweep over the `messages` read shapes
+  (channel fetch, DM fetch, both `fetch_after`, both `count_after_split`, both
+  content tails, the `list_archive` GROUP BY, `delete_for_dm`, and the
+  `server_time` page) on a 650k-row prod-shaped corpus: **every plan is
+  byte-identical with these four present and with them dropped.** Nothing was
+  using them.
+
+  What they DO cost is write amplification on the highest-write-rate table in
+  the codebase — four B-tree entries maintained on every scrollback INSERT.
+  Dropping them: 50k single-row INSERTs go 0.50/0.50/0.48s → 0.35/0.36/0.36s,
+  and `messages` index bytes 348 MB → 246 MB. Paired with the sibling commit
+  that widens the covering families (#1372 P-S1, which is write-neutral on its
+  own), the two together are **25% faster on INSERT and 22% smaller than main
+  is today**.
+
+  ## Scope
+
+  The two `messages_archive_*_idx` from `20260522073826` are deliberately NOT
+  touched: DESIGN_NOTES 17317-17332 records their #372 staleness and a
+  deliberate KEEP, so they are a documented deferral, not a new finding.
+
+  `down/0` recreates all four, so the decision is reversible — but it recreates
+  a cost with no reader, which is the point of dropping them.
+
+  New migration file — Preflight Class 5 forces **COLD**. Contract-class
+  (removes structure), but nothing reads it, which is what the sweep
+  establishes.
+
+  See DESIGN_NOTES 2026-08-16.
+  """
+  use Ecto.Migration
+
+  def up do
+    drop index(:messages, ["user_id", "network_id", "dm_with", "server_time"],
+          name: :messages_user_id_network_id_dm_with_server_time_index
+        )
+
+    drop index(:messages, ["visitor_id", "network_id", "dm_with", "server_time"],
+          name: :messages_visitor_id_network_id_dm_with_server_time_index
+        )
+
+    drop index(:messages, ["user_id", "network_id", "dm_with", "id"],
+          name: :messages_user_id_network_id_dm_with_id_index
+        )
+
+    drop index(:messages, ["visitor_id", "network_id", "dm_with", "id"],
+          name: :messages_visitor_id_network_id_dm_with_id_index
+        )
+  end
+
+  def down do
+    create index(:messages, ["user_id", "network_id", "dm_with", "server_time"],
+             name: :messages_user_id_network_id_dm_with_server_time_index
+           )
+
+    create index(:messages, ["visitor_id", "network_id", "dm_with", "server_time"],
+             name: :messages_visitor_id_network_id_dm_with_server_time_index
+           )
+
+    create index(:messages, ["user_id", "network_id", "dm_with", "id"],
+             name: :messages_user_id_network_id_dm_with_id_index
+           )
+
+    create index(:messages, ["visitor_id", "network_id", "dm_with", "id"],
+             name: :messages_visitor_id_network_id_dm_with_id_index
+           )
+  end
+end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,7 +49,33 @@ COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 
 # ---- substrate hooks ------------------------------------------------
 
+# Preconditions for EVERY compose invocation this script makes, on BOTH
+# paths. They used to live inside substrate_build, behind its
+# `[ "$MODE" = cold ] || return 0`: a HOT deploy therefore reached
+# substrate_seed with no `.env` check and no MIX_ENV in the shell, compose
+# fell back to `.env` for the interpolation, and `.env.example` ships
+# `MIX_ENV=dev` — so compose.yaml resolved DATABASE_PATH to
+# `grappa_dev.db`. COLD seeded prod, HOT seeded the DEV database on the
+# same box, silently, and hot is the documented normal case (#1377 D-S3).
+#
+# `.env` carries the prod secrets runtime.exs refuses to boot without, and
+# MIX_ENV picks the database every oneshot opens — neither is a property of
+# the image build.
+establish_deploy_env() {
+	if [ ! -f .env ]; then
+		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
+	fi
+
+	MIX_ENV=${MIX_ENV:-prod}
+	export MIX_ENV
+}
+
 substrate_pull() {
+	# The earliest hook the lib calls, so the preconditions land here: AFTER
+	# the flag parse inside deploy_main (an unknown flag must still read as a
+	# usage error, not as a missing .env) and BEFORE the first side effect.
+	establish_deploy_env
+
 	# Pull first so the preflight diffs against what we are ABOUT to deploy.
 	# Both endpoints are RESOLVED shas — NEW_SHA goes into the marker.
 	PREV_SHA="$(git rev-parse HEAD)"
@@ -95,13 +121,6 @@ substrate_build() {
 	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
 	# rebuilds the toolchain image.
 	[ "$MODE" = cold ] || return 0
-
-	if [ ! -f .env ]; then
-		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
-	fi
-
-	MIX_ENV=${MIX_ENV:-prod}
-	export MIX_ENV
 
 	echo "Building grappa image..."
 	docker compose "${COMPOSE_ARGS[@]}" --profile prod build grappa

--- a/scripts/posix-parse.sh
+++ b/scripts/posix-parse.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/posix-parse.sh — the POSIX-sh PARSE gate, over a DERIVED file set.
+#
+# Usage:
+#   scripts/posix-parse.sh          # parse everything, exit non-zero on a finding
+#   scripts/posix-parse.sh --list   # print the derived set and exit
+#
+# A DIFFERENT property from scripts/shellcheck.sh, with a different tool:
+# that gate lints, `dash -n` parses. Files that run under the FreeBSD jail's
+# /bin/sh must stay strict POSIX, and a reintroduced bashism in one of them
+# must fail here rather than silently break a jail deploy — the copy-paste
+# drift class #503 exists to kill.
+#
+# The file set is DERIVED, never hand-listed (#1377 D-S4). The hand list this
+# replaced named five paths and covered five of the twenty-eight files that
+# declare the sh dialect — including only one of the three POSIX libs under
+# infra/lib/ that docs/OPERATIONS.md calls out, and none of the twelve
+# infra/freebsd/jail_*.sh rails.
+#
+# Membership rule, deliberately mechanical: a regular file under `bin/`,
+# `infra/` or `scripts/` whose FIRST LINE declares the sh (or dash) dialect —
+# a `#!/bin/sh`-family shebang, or the `# shellcheck shell=sh` directive the
+# sourced libs use in place of a shebang. That is the same question the
+# scripts each already answer for shellcheck; this gate just reads the answer
+# instead of keeping a second copy of it. A file that says nothing about its
+# dialect is not swept in: `dash -n` on a bash script reports syntax errors
+# for valid code, and the pressure would be to shrink the set.
+#
+# What this catches, measured: GRAMMAR. `arr=(a b c)` and `<<<` are syntax
+# errors to dash; `[[ 1 == 1 ]]` and `local x` are NOT — they parse as
+# ordinary commands and only fail when they RUN. shellcheck's sh dialect
+# (SC3xxx) is what covers that half, over the same files, which is why the
+# two gates are complementary rather than one being a superset.
+#
+# Exit 0 = every derived script parses. Exit 1 = a parse error, or dash
+# missing (a gate that silently skips itself is worse than no gate).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+readonly PARSE_ROOTS=(bin infra scripts)
+
+# Line 1 declares the sh dialect: shebang, or shellcheck directive.
+is_sh_dialect() {
+	local first_line
+	# A binary or empty file simply has no first line to read.
+	IFS= read -r first_line < "$1" 2>/dev/null || return 1
+	[[ $first_line =~ ^#!.*[[:space:]/](sh|dash)([[:space:]]|$) ]] && return 0
+	[[ $first_line =~ ^#[[:space:]]*shellcheck([[:space:]]|.*[[:space:]])shell=(sh|dash)([[:space:]]|$) ]]
+}
+
+derive_set() {
+	local path
+	while IFS= read -r path; do
+		if is_sh_dialect "$path"; then printf '%s\n' "$path"; fi
+	done < <(find "${PARSE_ROOTS[@]}" -type f | sort)
+}
+
+mapfile -t SCRIPTS < <(derive_set)
+
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+	echo "posix-parse.sh: derived an EMPTY file set — the roots moved, or find failed" >&2
+	exit 1
+fi
+
+if [ "${1:-}" = "--list" ]; then
+	printf '%s\n' "${SCRIPTS[@]}"
+	exit 0
+fi
+
+if ! command -v dash >/dev/null 2>&1; then
+	echo "posix-parse.sh: dash is required (it is the POSIX sh this gate parses with)" >&2
+	exit 1
+fi
+
+echo "posix-parse.sh: dash -n over ${#SCRIPTS[@]} derived sh-dialect scripts under ${PARSE_ROOTS[*]}"
+
+# Parse every file before reporting: one bashism must not hide the next.
+# `dash -n` names the offending file itself, on stderr.
+failed=0
+for script in "${SCRIPTS[@]}"; do
+	dash -n "$script" || failed=$((failed + 1))
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo "posix-parse.sh: $failed file(s) are NOT POSIX sh — see the dash errors above" >&2
+	exit 1
+fi

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -1881,88 +1881,36 @@ defmodule Grappa.ScrollbackTest do
       assert Enum.map(alice_page, & &1.body) == ["to alice"]
     end
 
-    # Codebase review 2026-05-08 H1: the original CP14 B3 index
-    # `(network_id, dm_with, server_time)` had no leading subject
-    # column, so the OR arm of channel_or_dm_where/2 walked rows for
-    # every user/visitor on the network sharing that peer name and
-    # post-filtered by `subject_where/2`. The fix replaces it with two
-    # subject-leading composites that mirror the channel-side shape:
+    # #1372 P-S4 — the two `EXPLAIN QUERY PLAN` tests that used to sit here
+    # pinned a query production no longer runs. They hand-wrote
+    # `(channel = ? OR dm_with = ?)`, the two-arm disjunction #393 DELETED from
+    # `where_dm_peer/2` when it collapsed the DM match to the single folded
+    # `lower(COALESCE(dm_with, channel)) = ?`. Their `acceptable` name lists
+    # were the four `dm_with` indexes this commit drops, so they were the only
+    # thing left in the repo referencing them — a test keeping an index alive
+    # for a reader that no longer exists. Same defect class as the blind
+    # covering pin two commits back: an EXPLAIN of a locally rebuilt query.
     #
-    #   * (user_id, network_id, dm_with, server_time)
-    #   * (visitor_id, network_id, dm_with, server_time)
-    #
-    # These tests pin the SQLite query planner's choice so the
-    # subject-leading shape can never silently regress to a slow
-    # cross-subject scan. EXPLAIN QUERY PLAN is the only observable
-    # signal that the index leadership matters; functional output is
-    # identical either way.
-    #
-    # REV-B / H18 (2026-05-22 codebase review): the regression
-    # invariant is "subject-LEADING", not "this specific index name".
-    # The new REV-B covering index (`messages_archive_user_idx` on
-    # `(user_id, network_id, COALESCE(dm_with, channel), server_time)`)
-    # is ALSO subject-leading; SQLite's planner may pick it for the
-    # DM-fetch OR-shape because the COALESCE column matches BOTH OR
-    # arms in a single walk. Either choice preserves the H1
-    # invariant — the `refute` against the subject-less
-    # `messages_network_id_dm_with_server_time_index` is the
-    # invariant; the asserted name list permits the planner to pick
-    # the more selective subject-leading composite.
-    test "EXPLAIN QUERY PLAN: user-side DM fetch picks a subject-leading composite",
-         %{user: user, network: net} do
-      {:ok, %{rows: rows}} =
-        Repo.query("""
-        EXPLAIN QUERY PLAN
-        SELECT * FROM messages
-        WHERE user_id = '#{user.id}'
-          AND network_id = #{net.id}
-          AND (channel = 'peer' OR dm_with = 'peer')
-        ORDER BY server_time DESC, id DESC
-        LIMIT 50
-        """)
+    # Their invariant SURVIVES, asserted against the real query instead: the
+    # #393 B describe below pins that the production DM read seeks a
+    # SUBJECT-LEADING index (`messages_<subject>_id_network_id_dm_coalesce_…`)
+    # and refutes the network-wide scan. That IS the 2026-05-08 H1 rule — no
+    # cross-subject walk — measured on the predicate production emits. The
+    # deleted tests also `refute`d
+    # `messages_network_id_dm_with_server_time_index`, an index absent from
+    # every migration, so that arm had already gone vacuous.
+    test "the four dead dm_with indexes are dropped" do
+      names = messages_index_names()
 
-      plan_text = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
-
-      acceptable = [
-        "messages_user_id_network_id_dm_with_server_time_index",
-        "messages_archive_user_idx"
-      ]
-
-      assert Enum.any?(acceptable, &String.contains?(plan_text, &1)),
-             "expected dm_with arm to use a subject-leading composite (#{Enum.join(acceptable, " OR ")}), got plan:\n#{plan_text}"
-
-      refute plan_text =~ "messages_network_id_dm_with_server_time_index",
-             "old subject-less index must NOT be used:\n#{plan_text}"
-    end
-
-    test "EXPLAIN QUERY PLAN: visitor-side DM fetch picks a subject-leading composite",
-         %{network: net} do
-      {:ok, visitor} =
-        Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
-
-      {:ok, %{rows: rows}} =
-        Repo.query("""
-        EXPLAIN QUERY PLAN
-        SELECT * FROM messages
-        WHERE visitor_id = '#{visitor.id}'
-          AND network_id = #{net.id}
-          AND (channel = 'peer' OR dm_with = 'peer')
-        ORDER BY server_time DESC, id DESC
-        LIMIT 50
-        """)
-
-      plan_text = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
-
-      acceptable = [
-        "messages_visitor_id_network_id_dm_with_server_time_index",
-        "messages_archive_visitor_idx"
-      ]
-
-      assert Enum.any?(acceptable, &String.contains?(plan_text, &1)),
-             "expected dm_with arm to use a subject-leading composite (#{Enum.join(acceptable, " OR ")}), got plan:\n#{plan_text}"
-
-      refute plan_text =~ "messages_network_id_dm_with_server_time_index",
-             "old subject-less index must NOT be used:\n#{plan_text}"
+      for idx <- ~w(
+            messages_user_id_network_id_dm_with_server_time_index
+            messages_visitor_id_network_id_dm_with_server_time_index
+            messages_user_id_network_id_dm_with_id_index
+            messages_visitor_id_network_id_dm_with_id_index
+          ) do
+        refute idx in names,
+               "#{idx} is write amplification with no reader: every `dm_with` predicate in lib/ folds the column, and a plain B-tree on the raw column cannot seek a folded match"
+      end
     end
   end
 
@@ -3621,13 +3569,22 @@ defmodule Grappa.ScrollbackTest do
 
       # #393 dropped the two `..._channel_id` composites in favour of the
       # `..._channel_id_kind` covering supersets (same prefix, `kind` at the
-      # tail). The `dm_with` id-twins are unchanged. Either the composite OR
-      # its covering superset satisfies the CP29 R-2 no-sort invariant.
+      # tail). Either the composite OR its covering superset satisfies the
+      # CP29 R-2 no-sort invariant.
+      #
+      # #1372 P-S4 — the DM half named the `..._dm_with_id` twins. Those are
+      # dropped: they index the RAW column, and since #393 collapsed the DM
+      # match to `lower(COALESCE(dm_with, channel)) = ?` no read can seek
+      # them. The invariant itself is untouched — a table rebuild must still
+      # leave the DM id-cursor read seekable and sort-free — so it now names
+      # the index that ACTUALLY serves it, the folded-COALESCE covering pair.
+      # Measured: the DM `fetch_after` shape plans
+      # `SEARCH … (… AND <expr>=? AND id>?)` on exactly these.
       for idx <- [
             "messages_visitor_id_network_id_channel_id_kind_index",
             "messages_user_id_network_id_channel_id_kind_index",
-            "messages_visitor_id_network_id_dm_with_id_index",
-            "messages_user_id_network_id_dm_with_id_index"
+            "messages_visitor_id_network_id_dm_coalesce_fold_id_kind_index",
+            "messages_user_id_network_id_dm_coalesce_fold_id_kind_index"
           ] do
         assert idx in names,
                "#{idx} missing — CP29 R-2-class drift (a table-rebuild migration " <>

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -120,16 +120,60 @@ defmodule Grappa.ScrollbackTest do
   # respective `..._id_kind` index (kind at the tail = no per-row table
   # fetch). `kind` is read by the GROUP BY, so a covering plan requires it in
   # the index — this is the regression guard for the kind-at-tail claim.
-  defp count_split_query(subject, net, target) do
-    ck = Message.content_kinds()
+  #
+  # #1372 — this used to REBUILD the aggregate here. That local copy is what
+  # blinded the pin: it called `channel_or_dm_where(target, nil)`, and at
+  # `own_nick = nil` `exclude_own_authored/3` is the identity clause
+  # (`scrollback.ex:718`), so the predicate #532 A and #576 later bolted onto
+  # the production query never entered the pinned SQL. The pin went on
+  # asserting COVERING against a shape production had stopped running, and
+  # stayed green straight through the regression it existed to catch. So the
+  # plan is now taken off the query the production function ACTUALLY emits,
+  # captured from Ecto's own telemetry — there is no second copy left to
+  # drift. Verified result- and byte-identical to the deleted local rebuild
+  # at (own_nick: nil, hide_presence: false) before it was removed.
+  defp count_split_plan(subject, net, target, own_nick) do
+    {sql, params} =
+      capture_one_query(fn ->
+        Scrollback.count_after_split(subject, net.id, target, 0, own_nick, false)
+      end)
 
-    Message
-    |> subject_filter(subject)
-    |> where([m], m.network_id == ^net.id)
-    |> Scrollback.channel_or_dm_where(target, nil)
-    |> where([m], m.id > ^0)
-    |> group_by([m], fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.kind in ^ck))
-    |> select([m], {fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.kind in ^ck), count(m.id)})
+    {:ok, %{rows: rows}} = Repo.query("EXPLAIN QUERY PLAN " <> sql, params)
+    rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
+  end
+
+  # Returns the single `{sql, params}` Ecto emitted while `fun` ran. Ecto
+  # publishes `[:grappa, :repo, :query]` synchronously in the caller process,
+  # so the capture needs no synchronisation. Matching on ONE query is part of
+  # the contract: if `count_after_split/6` ever becomes multi-statement, this
+  # raises instead of silently pinning whichever statement came last.
+  defp capture_one_query(fun) do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:grappa, :repo, :query],
+      fn _, _, meta, _ -> send(test_pid, {ref, meta.query, meta.params}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach({__MODULE__, ref})
+    end
+
+    [captured] = drain_queries(ref, [])
+    captured
+  end
+
+  defp drain_queries(ref, acc) do
+    receive do
+      {^ref, sql, params} -> drain_queries(ref, [{sql, params} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
   end
 
   # #393 — messages index name list + a single index's committed DDL.
@@ -2010,7 +2054,7 @@ defmodule Grappa.ScrollbackTest do
       # COVERING — no per-row table fetch (the exact 432ms DM bug #393 fixed).
       # This is the DM twin of the channel COVERING assertion; it regresses
       # loudly if `kind` is ever dropped from the coalesce index tail.
-      plan = explain_plan(count_split_query({:user, user.id}, net, "peer"))
+      plan = count_split_plan({:user, user.id}, net, "peer", nil)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_dm_coalesce_fold_id_kind_index",
              "expected the DM count_after_split covered by the coalesce kind index, got:\n#{plan}"
@@ -2170,7 +2214,7 @@ defmodule Grappa.ScrollbackTest do
 
     test "channel count_after_split is served by the COVERING kind index (no table fetch)",
          %{user: user, network: net} do
-      plan = explain_plan(count_split_query({:user, user.id}, net, "#linux"))
+      plan = count_split_plan({:user, user.id}, net, "#linux", nil)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_channel_id_kind_index",
              "expected count_after_split channel query covered by the kind index, got:\n#{plan}"
@@ -2180,7 +2224,7 @@ defmodule Grappa.ScrollbackTest do
          %{network: net} do
       {:ok, visitor} = Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
 
-      plan = explain_plan(count_split_query({:visitor, visitor.id}, net, "#linux"))
+      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", nil)
 
       assert plan =~ "USING COVERING INDEX messages_visitor_id_network_id_channel_id_kind_index",
              "expected visitor count_after_split channel query covered by the kind index, got:\n#{plan}"

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -30,6 +30,29 @@ defmodule Grappa.ScrollbackTest do
 
   defp uniq, do: System.unique_integer([:positive])
 
+  # #1372 — the `meta.new_nick` half of `exclude_own_authored/3`, as it is
+  # spelled in the covering-index DDL. The `sender` half has a lib-side SSOT
+  # (`Identifier.nick_fold_sql/1`); this one does not — it lives as an Ecto
+  # `fragment` (`scrollback.ex:724`, `:740`), and a migration cannot call into
+  # `lib/`. So the migration inlines it and THIS attribute is the guard, the
+  # same posture #393 took for its folded-COALESCE literal.
+  #
+  # Whitespace and the table alias may differ between the index DDL and the
+  # emitted query (`json_extract(m0."meta", '$.new_nick')`): SQLite matches
+  # indexed expressions after parsing, not textually. Measured — an index
+  # written without the space still yields COVERING for the aliased query.
+  # What may NOT differ is the JSON PATH: change `$.new_nick` on either side
+  # and the index silently stops applying.
+  @new_nick_index_expr "json_extract(meta, '$.new_nick')"
+
+  # #1372 — the own nick the covering pins pass to `count_after_split/6`. It
+  # MUST be non-nil and MUST NOT equal the target: nil short-circuits
+  # `exclude_own_authored/3` to the identity clause (the blind spot this issue
+  # is about), and a target equal to it takes the #576 self-window branch,
+  # which strips presence only. Either would pin a shape the cold `/me` seed
+  # and the per-channel join reply do not take.
+  @own_nick "vjt"
+
   defp sample(user, network, i, overrides \\ %{}) do
     Map.merge(
       %{
@@ -1998,6 +2021,21 @@ defmodule Grappa.ScrollbackTest do
       end
     end
 
+    # #1372 arm 1 of 2 — the DM twin of the channel DDL arm. Same split, same
+    # reason: this one names the missing expression, the plan test names the
+    # lost COVERING.
+    test "the DM covering indexes carry both exclude_own_authored/3 expressions" do
+      for idx <- @dm_coalesce_index_names do
+        ddl = index_ddl(idx)
+
+        assert ddl =~ Identifier.nick_fold_sql("sender"),
+               "#{idx} lost the folded `sender` expression — the DM aggregate falls back to a per-row table fetch:\n#{ddl}"
+
+        assert ddl =~ @new_nick_index_expr,
+               "#{idx} lost the `#{@new_nick_index_expr}` expression — same fallback:\n#{ddl}"
+      end
+    end
+
     test "user-side DM read SEEKS the folded COALESCE value on the covering index",
          %{user: user, network: net} do
       plan = explain_plan(folded_dm_read_query({:user, user.id}, net, "peer"))
@@ -2054,7 +2092,7 @@ defmodule Grappa.ScrollbackTest do
       # COVERING — no per-row table fetch (the exact 432ms DM bug #393 fixed).
       # This is the DM twin of the channel COVERING assertion; it regresses
       # loudly if `kind` is ever dropped from the coalesce index tail.
-      plan = count_split_plan({:user, user.id}, net, "peer", nil)
+      plan = count_split_plan({:user, user.id}, net, "peer", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_dm_coalesce_fold_id_kind_index",
              "expected the DM count_after_split covered by the coalesce kind index, got:\n#{plan}"
@@ -2198,11 +2236,33 @@ defmodule Grappa.ScrollbackTest do
   # via `create_if_not_exists`. dev/test/CI create them normally — these
   # assertions hold in BOTH states.
   describe "#393 A — channel unread-count covering index" do
+    @channel_covering_index_names ~w(
+      messages_user_id_network_id_channel_id_kind_index
+      messages_visitor_id_network_id_channel_id_kind_index
+    )
+
     test "the two channel+id+kind covering indexes exist on messages" do
       names = messages_index_names()
 
       assert "messages_user_id_network_id_channel_id_kind_index" in names
       assert "messages_visitor_id_network_id_channel_id_kind_index" in names
+    end
+
+    # #1372, arm 1 of 2 — the DDL SQLite actually stored. Arm 2 (below) reads
+    # the plan. Split deliberately: a plan assertion alone cannot say WHICH of
+    # the two expressions went missing, and "not COVERING" is the same message
+    # whether an expression drifted or the planner merely passed the index
+    # over. This arm names the expression; that one names the lost COVERING.
+    test "the channel covering indexes carry both exclude_own_authored/3 expressions" do
+      for idx <- @channel_covering_index_names do
+        ddl = index_ddl(idx)
+
+        assert ddl =~ Identifier.nick_fold_sql("sender"),
+               "#{idx} lost the folded `sender` expression — the aggregate falls back to a per-row table fetch:\n#{ddl}"
+
+        assert ddl =~ @new_nick_index_expr,
+               "#{idx} lost the `#{@new_nick_index_expr}` expression — same fallback:\n#{ddl}"
+      end
     end
 
     test "the two now-redundant channel+id composites are dropped" do
@@ -2214,7 +2274,7 @@ defmodule Grappa.ScrollbackTest do
 
     test "channel count_after_split is served by the COVERING kind index (no table fetch)",
          %{user: user, network: net} do
-      plan = count_split_plan({:user, user.id}, net, "#linux", nil)
+      plan = count_split_plan({:user, user.id}, net, "#linux", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_user_id_network_id_channel_id_kind_index",
              "expected count_after_split channel query covered by the kind index, got:\n#{plan}"
@@ -2224,7 +2284,7 @@ defmodule Grappa.ScrollbackTest do
          %{network: net} do
       {:ok, visitor} = Grappa.Visitors.find_or_provision_anon("v-#{uniq()}", net.slug, "1.2.3.4")
 
-      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", nil)
+      plan = count_split_plan({:visitor, visitor.id}, net, "#linux", @own_nick)
 
       assert plan =~ "USING COVERING INDEX messages_visitor_id_network_id_channel_id_kind_index",
              "expected visitor count_after_split channel query covered by the kind index, got:\n#{plan}"

--- a/test/infra/base_image_digest_pin_test.bats
+++ b/test/infra/base_image_digest_pin_test.bats
@@ -87,7 +87,13 @@ pinned_tokens() {
         [ "$refs" -ge 2 ] && multi_ref_families=$((multi_ref_families + 1))
 
         if [ "$(printf '%s\n' "$digests" | grep -c .)" -gt 1 ]; then
+            # Name the FILES, not just the family (#1377). The four oven/bun:1
+            # references are textually identical, so a report of "these two
+            # digests disagree" leaves the reader to grep for which of four
+            # surfaces was bumped and which were not — and the whole point of
+            # the failure is that they are easy to miss one at a time.
             conflicts="${conflicts}${family}: $(printf '%s' "$digests" | tr '\n' ' ')
+$(matched_refs | grep -F -- "$family@sha256:" | sed 's/^/    /')
 "
         fi
     done
@@ -103,7 +109,6 @@ pinned_tokens() {
     [ -z "$conflicts" ] || {
         echo "DIVERGENT digests for the same image:tag — bump every surface together (#1343):" >&2
         printf '%s' "$conflicts" >&2
-        printf '%s\n' "$(pinned_tokens | sort)" >&2
         return 1
     }
 }

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -41,6 +41,12 @@ setup() {
     ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"
     : > "$ARGV_LOG"
     export ARGV_LOG
+    # A SECOND log, carrying the MIX_ENV each compose invocation inherited.
+    # Separate from ARGV_LOG on purpose: every ordering assertion below greps
+    # that file by line number, so the env must not widen those lines.
+    ENV_LOG="$BATS_TEST_TMPDIR/env.log"
+    : > "$ENV_LOG"
+    export ENV_LOG
     export HOME="$BATS_TEST_TMPDIR/home"
     mkdir -p "$HOME"
 
@@ -79,6 +85,13 @@ EOF
     git -C "$REPO_ROOT" config user.name "bats"
 
     # ---- env the script needs ------------------------------------------
+    # The default fixture is an INSTALLED box: since #1377 every path
+    # requires .env, not just cold. The two cases about its absence remove
+    # it again.
+    make_env
+    # An ambient MIX_ENV from the developer's shell would satisfy the D-S3
+    # cases without the script having established anything.
+    unset MIX_ENV
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -96,6 +109,7 @@ EOF
     cat > "$FAKE_DIR/docker" <<'EOF'
 #!/bin/sh
 printf 'docker %s\n' "$*" >> "$ARGV_LOG"
+printf 'MIX_ENV=%s | docker %s\n' "${MIX_ENV-<unset>}" "$*" >> "$ENV_LOG"
 case "$*" in
     *"ps -q grappa"*)  echo fakecid ;;
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
@@ -181,7 +195,6 @@ run_deploy() {
 }
 
 @test "--force-cold skips preflight and cold-deploys" {
-    make_env
     run_deploy --force-cold
     [ "$status" -eq 0 ]
     refute grep -q "run --no-start" "$ARGV_LOG"
@@ -225,7 +238,7 @@ run_deploy() {
 @test "cold path requires a .env file" {
     export PREFLIGHT_RC=3
     commit_upstream lib/base.txt > /dev/null
-    # no make_env
+    rm -f "$REPO_ROOT/.env"
 
     run_deploy
     [ "$status" -ne 0 ]
@@ -234,7 +247,6 @@ run_deploy() {
 
 @test "cold path order: build -> cicchetto-build -> deps.get -> migrate -> up -> healthcheck" {
     export PREFLIGHT_RC=3
-    make_env
     commit_upstream lib/base.txt > /dev/null
 
     run_deploy
@@ -268,7 +280,6 @@ run_deploy() {
 
 @test "cold deploy writes the completed-deploy marker as final step" {
     export PREFLIGHT_RC=3
-    make_env
     new="$(commit_upstream lib/base.txt)"
 
     run_deploy
@@ -337,4 +348,56 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     [[ "$output" == *"re-exec"* ]]
+}
+
+# --- #1377 D-S3: MIX_ENV is established for BOTH paths, not just cold --------
+#
+# `substrate_build` used to own the `.env` check and the
+# `MIX_ENV=${MIX_ENV:-prod}; export MIX_ENV` line, behind an early
+# `[ "$MODE" = cold ] || return 0`. So a HOT deploy reached `substrate_seed`
+# with MIX_ENV unset in the shell, compose fell back to `.env`, and
+# `.env.example` ships `MIX_ENV=dev` uncommented — measured against the real
+# compose.yaml, `docker compose --env-file .env.example config` then resolves
+# `DATABASE_PATH: /app/runtime/grappa_dev.db`. COLD seeded prod, HOT seeded
+# dev, and hot is the documented normal case.
+#
+# The env each compose invocation inherited is recorded in ENV_LOG by the
+# same stub that writes ARGV_LOG.
+
+# The MIX_ENV the seed oneshot inherited: `MIX_ENV=prod`, or `MIX_ENV=<unset>`.
+seed_mix_env() {
+    grep 'grappa.seed_themes' "$ENV_LOG" | head -1 | cut -d' ' -f1
+}
+
+@test "hot path: the seed oneshot carries MIX_ENV=prod, not the .env default (#1377 D-S3)" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    grep -q "grappa.seed_themes" "$ARGV_LOG"      # the seed really ran
+    [ "$(seed_mix_env)" = "MIX_ENV=prod" ] || {
+        echo "hot seed ran with $(seed_mix_env) — compose falls back to .env (grappa_dev.db)" >&2
+        return 1
+    }
+}
+
+@test "cold path: the seed oneshot carries MIX_ENV=prod too (#1377 D-S3)" {
+    export PREFLIGHT_RC=3
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    [ "$(seed_mix_env)" = "MIX_ENV=prod" ]
+}
+
+@test "hot path refuses to start without a .env, same as cold (#1377 D-S3)" {
+    # The check is path-independent now: every compose oneshot this script
+    # runs — reload, seed, healthcheck — reads .env for the prod secrets.
+    commit_upstream lib/base.txt > /dev/null
+    rm -f "$REPO_ROOT/.env"
+
+    run_deploy --force-hot
+    [ "$status" -ne 0 ]
+    [[ "$output" == *".env"* ]]
+    refute grep -q "docker" "$ARGV_LOG"           # died before any side effect
 }

--- a/test/infra/posix_parse_gate_test.bats
+++ b/test/infra/posix_parse_gate_test.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+#
+# scripts/posix-parse.sh — the DERIVED POSIX-sh parse gate (#1377 D-S4).
+#
+# The thing under test is the derivation, not dash. The hand-written list in
+# ci.yml named five paths and covered five of the twenty-eight files that
+# declare the sh dialect: it missed two of the three POSIX libs under
+# infra/lib/ (docs/OPERATIONS.md calls all three POSIX, and both misses carry
+# `# shellcheck shell=sh` on line 1, in the same directory as the one it did
+# name), the twelve infra/freebsd/jail_*.sh rails, and infra/packaging/version.sh.
+#
+# So these cases pin three properties:
+#
+#   1. the RULE — membership follows from the file's own line-1 dialect
+#      declaration, exercised in a sandbox tree so a new file can actually be
+#      added and observed;
+#   2. the REAL set — the specific files the old list forgot are in it now;
+#   3. that the gate BITES — a bashism in a newly covered file makes it fail,
+#      naming that file. A gate nobody has watched fail is not a gate.
+#
+# `--list` is used for the membership cases: they are about WHICH files the
+# gate covers. Case 3 runs the real thing, so it needs dash — which is also
+# what CI and the jail run, and what the gate refuses to proceed without.
+
+load ../bats_helpers
+
+setup() {
+    GATE="$BATS_TEST_DIRNAME/../../scripts/posix-parse.sh"
+    CI_YML="$BATS_TEST_DIRNAME/../../.github/workflows/ci.yml"
+
+    # A sandbox repo with the same three roots, and the gate copied in: the
+    # script derives its own root from BASH_SOURCE, so the copy enumerates
+    # the sandbox and a case can add a file and see what happens.
+    SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra/lib" "$SANDBOX/scripts"
+    cp "$GATE" "$SANDBOX/scripts/posix-parse.sh"
+    chmod +x "$SANDBOX/scripts/posix-parse.sh"
+    SANDBOX_GATE="$SANDBOX/scripts/posix-parse.sh"
+    # One valid member, so a case about EXCLUSION reads the exclusion and not
+    # the empty-set refusal. (The gate itself is bash and stays out of its own
+    # set, so without this the sandbox can hold only non-members.) The
+    # empty-set case removes the roots and therefore this too.
+    printf '#!/bin/sh\ntrue\n' > "$SANDBOX/infra/lib/canary.sh"
+}
+
+@test "a NEW script with an sh shebang joins the set (#1377)" {
+    printf '#!/bin/sh\ntrue\n' > "$SANDBOX/infra/lib/newrail.sh"
+    printf '#!/usr/bin/env sh\ntrue\n' > "$SANDBOX/bin/another"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/lib/newrail.sh"* ]]
+    [[ "$output" == *"bin/another"* ]]
+}
+
+@test "a NEW sourced lib declaring shell=sh on line 1 joins the set (#1377)" {
+    # This is the shape the hand list missed twice over: infra/lib/beam_wait.sh
+    # and infra/lib/cic_dist.sh are sourced, so they have no shebang at all —
+    # the directive IS the dialect declaration.
+    printf '# shellcheck shell=sh\ntrue\n' > "$SANDBOX/infra/lib/helpers.sh"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/lib/helpers.sh"* ]]
+}
+
+@test "bash-dialect and dialect-less files stay OUT (#1377)" {
+    # dash -n reports syntax errors for perfectly valid bash, so sweeping
+    # these in would make the gate fail on files it has no claim over — and
+    # the pressure would be to shrink the set back to a hand list.
+    printf '#!/usr/bin/env bash\narr=(a b)\n' > "$SANDBOX/scripts/basher.sh"
+    printf '# shellcheck shell=bash\narr=(a b)\n' > "$SANDBOX/infra/lib/_bashlib.sh"
+    printf '# grappa — nginx config\nserver { }\n' > "$SANDBOX/infra/lib/nginx.conf"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    refute grep -q 'basher.sh' <<<"$output"
+    refute grep -q '_bashlib.sh' <<<"$output"
+    refute grep -q 'nginx.conf' <<<"$output"
+}
+
+@test "an empty derived set fails loud instead of passing vacuously (#1377)" {
+    # A gate that parses nothing and exits 0 is the failure mode that hides a
+    # moved directory or a broken find.
+    rm -rf "${SANDBOX:?}/bin" "${SANDBOX:?}/infra"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra"
+    mkdir -p "$SANDBOX/tools"
+    cp "$GATE" "$SANDBOX/tools/gate.sh"
+    chmod +x "$SANDBOX/tools/gate.sh"
+    rm -f "$SANDBOX/scripts/posix-parse.sh"
+
+    run "$SANDBOX/tools/gate.sh" --list
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"EMPTY file set"* ]]
+}
+
+@test "a bashism in a covered file fails the gate, naming the file (#1377)" {
+    # The mutation that buys the gate. An ARRAY, not `[[ ]]`: dash -n checks
+    # GRAMMAR, and `[[ 1 == 1 ]]` parses as an ordinary command (it fails when
+    # it runs, and shellcheck's SC3xxx is what catches it). The array is a
+    # syntax error, which is what this tool is for.
+    printf '# shellcheck shell=sh\narr=(a b c)\n' > "$SANDBOX/infra/lib/regressed.sh"
+
+    run "$SANDBOX_GATE"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"infra/lib/regressed.sh"* ]]
+}
+
+@test "the real set covers what the hand-written list forgot (#1377)" {
+    # The five-path list in ci.yml before #1377 named none of these.
+    run "$GATE" --list
+
+    [ "$status" -eq 0 ]
+    # Two of the three infra/lib POSIX libs, in the same directory as the one
+    # it did name, with the same line-1 declaration.
+    [[ "$output" == *"infra/lib/beam_wait.sh"* ]]
+    [[ "$output" == *"infra/lib/cic_dist.sh"* ]]
+    # The jail rails the jail's /bin/sh actually runs, and the version
+    # delegate every deploy wrapper shells out to.
+    [[ "$output" == *"infra/freebsd/jail_mix.sh"* ]]
+    [[ "$output" == *"infra/freebsd/jail_db_query.sh"* ]]
+    [[ "$output" == *"infra/packaging/version.sh"* ]]
+    # An extensionless one, which a `*.sh` glob would have missed.
+    [[ "$output" == *"infra/freebsd/rc.d/grappa"* ]]
+    # And it still covers every path the old list did name.
+    [[ "$output" == *"infra/lib/deploy_common.sh"* ]]
+    [[ "$output" == *"infra/freebsd/deploy.sh"* ]]
+    [[ "$output" == *"infra/docker/assert-abi-lockstep.sh"* ]]
+    [[ "$output" == *"infra/docker/release-entrypoint.sh"* ]]
+    [[ "$output" == *"infra/docker/get.sh"* ]]
+}
+
+@test "ci.yml runs the derived gate and names no dash paths (#1377)" {
+    # The regression this guards is not "the step disappeared" — it is someone
+    # re-adding `dash -n <some new file>` beside the derived run. That reads
+    # like extra care and quietly restores the two-sources-of-truth state this
+    # change exists to end.
+    grep -q 'scripts/posix-parse.sh' "$CI_YML"
+
+    refute grep -nE '^[[:space:]]+dash[[:space:]]+-n[[:space:]]' "$CI_YML"
+}

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -65,6 +65,11 @@ setup() {
     git -C "$REPO" config user.email test@grappa.local
     git -C "$REPO" config user.name "bats"
 
+    # #1377: the hot path requires .env too now (establish_deploy_env, at the
+    # top of substrate_pull). These cases are about the reload contract, so
+    # the box they run against is an installed one.
+    echo "SECRET_KEY_BASE=x" > "$REPO/.env"
+
     # Fast healthcheck loop for tests (prod defaults stay in the script).
     export HOT_HEALTHCHECK_RETRIES=3 HOT_HEALTHCHECK_SLEEP=0
 

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -66,6 +66,11 @@ setup() {
     printf '9.9.9\n' > "$MAIN/VERSION"
     printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' > "$MAIN/mix.exs"
     : > "$MAIN/compose.yaml"
+    # #1377: deploy.sh requires .env on BOTH paths now, checked at the top of
+    # substrate_pull. Without it the positive case below would die before the
+    # pull echo it reads as "the guard did not over-fire" — for the wrong
+    # reason.
+    echo "SECRET_KEY_BASE=x" > "$MAIN/.env"
     touch "$MAIN/runtime/.gitkeep"
     echo base > "$MAIN/lib/base.ex"
     git -C "$MAIN" add -A


### PR DESCRIPTION
## What this is

A **replayed union** of three open branches, gated as one set rather than three:

- **#1377** — `.env` + `MIX_ENV` established on both deploy paths (D-S3), the POSIX-parse
  set derived instead of hand-listed (D-S4), and the digest gate naming the offending file
  when two digests diverge (D-S5).
- **#1358** — the frame seam no longer moves the focused composer; the frame countdown gets
  an always-mounted slot.
- **#1372** — the unread aggregate's covering index restored, four dead `dm_with` indexes on
  `messages` dropped, and the covering pin taken off the query production actually emits.

Each branch's commits were cherry-picked over its **own merge-base**, in order
#1377 → #1358 → #1372. Nothing was squashed or rewritten in content; only the shas differ
from the source branches.

## Why one PR instead of three

All three touch `docs/DESIGN_NOTES.md`. Merging any one of them makes the other two
CONFLICTING, and a CONFLICTING PR runs **zero** CI — so three separate greens would have
decayed to one green plus two unmeasured branches the moment the first one landed. One
branch, one gate, one green over the set that actually ships together.

Outside `DESIGN_NOTES` the three do not overlap: no two of them touch the same file, and
every file's changed-line count on this branch equals its count on the source branch.

## DESIGN_NOTES

All three entries are kept, each with its own `<!-- entry #NNNN -->` marker and `---`
separator. Additions on the union are the exact sum of the three sources
(69 + 70 + 65 = **204**), deletions **0** — no entry and no separator was eaten in the
replay. `scripts/design-notes-gate.sh` passes.

## Deploy shape

**COLD** — #1372 ships two migrations
(`20260816013504_add_own_authored_exprs_to_messages_covering_indexes`,
`20260816014915_drop_dead_messages_dm_with_indexes`). The rest is hot-compatible.

## Scope note

A fourth branch (#1374, the busy-retry / immediate-transaction work) was replayed into an
earlier version of this union and then **removed**: its own integration run is red, and one
of the two reds is suspect to it, so it is held back to be measured on its own rather than
folded into a green here. This branch contains none of it.

## Source PRs

#1380, #1371, #1376 stay open and are closed by hand after this lands — the replay rewrites
their shas, so GitHub cannot see them as merged.
