### PR TITLE
deploy: one hook set for the Docker substrate (#1384, D-S2)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43572,3 +43572,67 @@ window. And the open question from #1353 stays open: *why* a pool connection
 that did not serve the `CREATE INDEX` plans differently — schema cache or
 transaction visibility — is still unmeasured, and `pool_size: 1` remains a
 remedy whose mechanism nobody has characterised.
+<!-- entry #1384 -->
+
+---
+
+## 2026-08-16 — #1384: the Docker substrate gets one hook set, not two
+
+`infra/lib/deploy_common.sh` is the substrate-independent deploy algorithm;
+each substrate hands it a `substrate_*` hook set. The jail and the systemd
+host have one each. The Docker source substrate had TWO — fourteen functions
+in `scripts/deploy.sh` (operator, on a checkout, personal compose override,
+worktree/branch guard) and fourteen more inside `infra/docker/deploy.sh`'s
+`cmd_update` (standalone box: secrets, install/stop verbs, ownership guard).
+Review D-S2 counted seven divergences between them.
+
+**What made it a defect rather than untidiness was #1377, one day earlier.**
+That change established the `.env` + `MIX_ENV` preconditions on both PATHS of
+the operator door and structurally could not reach the twin — which had
+arrived at the same precondition by an unrelated mechanism, `set_env MIX_ENV
+prod` writing the value into `.env` at install time. A box installed by that
+driver was covered; a hand-installed one was not, because `cmd_update` checks
+only that `.env` EXISTS. compose then interpolates `${MIX_ENV:-dev}`,
+`DATABASE_PATH` follows it, and the update seeded the box's dev database while
+the live container served the prod one. Two implementations of one
+precondition: neither wrong on its own, and the divergence is the bug.
+
+**The entry points stay two; the hooks become one.** They serve different
+audiences and guard different things, so `infra/lib/deploy_docker.sh` holds
+the thirteen hooks and each door keeps what is genuinely its own: the compose
+invocation (only the operator door reads `compose.override.yaml`), the done
+banner (one of the two is bats-pinned), and the seed retry hint, which has to
+name the door the operator actually invoked.
+
+Three divergences resolved toward the safer side and are behaviour changes:
+the standalone door now migrates through `mix grappa.migrate`, gaining the
+#1348 duplicate-version audit it never had; both doors diagnose a
+non-fast-forward pull instead of dying on a bare non-zero; and the reload
+stopped probing `ps -q grappa` first — the operator door got that probe from
+`_lib.sh`'s `in_container`, while the standalone door detects a down box
+earlier and FORCES COLD, so unifying on the probe would have written the
+weaker of the two answers into both doors.
+
+**Four of the seven were deliberately left divergent, which is the part worth
+recording.** `assert_box_ownership` and `require_main_checkout` guard
+different failure modes for different audiences; `migrate_publish_env` is
+`.env` authorship and only one driver owns `.env`; `--no-pull` is a flag
+surface, and the shared hook already honours `NO_PULL` for whoever sets it.
+The seventh — "empty-array expansion" — is not a defect in either direction:
+`"$@"` and `${libargs[@]+"${libargs[@]}"}` are both correct, one for a
+pass-through and one for a built array. A drift count is a starting point,
+not a verdict.
+
+**A third `substrate_*` set survives inside `infra/docker/deploy.sh` and must
+not be folded in.** Nine of its members are `{ :; }`: a checkout-less host
+running the published image has no source to pull, build, reload or bundle
+from. That is a different substrate wearing the same interface, and merging
+it would be one data model with a type flag rather than shared behaviour.
+
+`deploy_docker.sh` is the first file under `infra/lib/` that is NOT POSIX sh.
+It takes the compose invocation as a bash array because both callers already
+have one; the POSIX rule exists so the jail's `/bin/sh` can source these
+files, and the jail never sources this one. It says `# shellcheck shell=bash`,
+which is also how `scripts/posix-parse.sh` derives its set — the gate reads
+the declared dialect, so the exclusion is a property of the file rather than
+an exception list.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2826,6 +2826,19 @@ can run them. Consumers keep their own shebangs and may use bashisms in
 their own hooks. This section is the WHY behind those files; the files
 themselves say only what they do (#1159).
 
+**A fourth file, `deploy_docker.sh`, is deliberately NOT POSIX (#1384).**
+It holds the Docker substrate's thirteen `substrate_*` hooks, shared by
+the two entry points onto that substrate — `scripts/deploy.sh` and
+`infra/docker/deploy.sh update` — and it takes the compose invocation as
+a bash ARRAY, because that is what both callers already have (the
+operator door's carries the host's `compose.override.yaml`). The POSIX
+rule exists so the jail's `/bin/sh` can source these files; the jail
+never sources this one, and nothing else on a Docker box runs `sh`. It
+declares `# shellcheck shell=bash`, which is also how
+`scripts/posix-parse.sh` derives its set — the gate reads the declared
+dialect, so the file is excluded by saying what it is rather than by an
+exception list someone has to maintain.
+
 **That claim is gated, and over a DERIVED set (#1377).**
 `scripts/posix-parse.sh` runs `dash -n` over every file under `bin/`,
 `infra/` and `scripts/` whose first line declares the sh dialect — a

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -618,91 +618,13 @@ cmd_update() {
 	DEPLOY_FEATURE_MARKER=1
 	DEPLOY_FEATURE_PREV_SHA_CARRY=1
 	DEPLOY_SEED_RETRY_HINT="${COMPOSE[*]} --profile prod run --rm grappa mix grappa.seed_themes"
-	HOT_HEALTHCHECK_RETRIES="${HOT_HEALTHCHECK_RETRIES:-30}"
-	HOT_HEALTHCHECK_SLEEP="${HOT_HEALTHCHECK_SLEEP:-1}"
-	COLD_HEALTHCHECK_RETRIES="${COLD_HEALTHCHECK_RETRIES:-120}"
-	COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
-
 	# ---- substrate hooks --------------------------------------------
-	substrate_pull() {
-		PREV_SHA="$(git rev-parse HEAD)"
-		if [ "$NO_PULL" -eq 1 ]; then
-			NEW_SHA="$PREV_SHA"
-		else
-			local branch
-			branch="$(git rev-parse --abbrev-ref HEAD)"
-			say "Pulling ${branch} (fast-forward only)"
-			git pull --ff-only || die "pull is not a fast-forward — the branch diverged. Resolve it by hand."
-			NEW_SHA="$(git rev-parse HEAD)"
-		fi
-	}
-
-	substrate_read_marker()  { cat runtime/last-deployed-sha 2>/dev/null || true; }
-	substrate_write_marker() { mkdir -p runtime; printf '%s\n' "$NEW_SHA" > runtime/last-deployed-sha; }
-	substrate_commit_exists() { git cat-file -e "$1^{commit}" >/dev/null 2>&1; }
-	substrate_changed_files() { git diff --name-only "$1..$2"; }
-
-	substrate_preflight() {
-		# Classify via Grappa.Deploy.Preflight (substrate "docker"), the
-		# same SoT every substrate uses: 0=HOT, 3=COLD, anything else is a
-		# crash the lib aborts on.
-		"${COMPOSE[@]}" run --rm --no-deps -e MIX_ENV=dev grappa \
-			mix run --no-start -e "Grappa.Deploy.Preflight.cli([\"$1\", \"$2\", \"docker\"])"
-	}
-
-	substrate_build() {
-		# Hot needs no build — compose.yaml bind-mounts ./:/app, so the
-		# pulled commit is already in place. Cold rebuilds the image.
-		[ "$MODE" = cold ] || return 0
-		say "Rebuilding the grappa image"
-		"${COMPOSE[@]}" --profile prod build grappa
-	}
-
-	substrate_reload() {
-		# The lib captures this hook's stdout as the reload response body,
-		# so pre-reload chatter MUST go to stderr or it pollutes the JSON
-		# the lib inspects.
-		say "Reloading modules in the live BEAM" >&2
-		"${COMPOSE[@]}" exec -T grappa curl -fsS -X POST http://localhost:4000/admin/reload
-	}
-
-	substrate_cic() {
-		# Build into a staging sibling and rename it in — never in place.
-		# Why: docs/OPERATIONS.md § "The Docker deploy driver
-		# (infra/docker/)" (#1020).
-		local cic_served="runtime/cicchetto-dist"
-		local cic_build_out
-		cic_build_out="$(cic_dist_docker_stage "$cic_served")"
-		# AFTER substrate_pull, so the bundle carries the version the box is
-		# moving TO — the pull may have bumped VERSION.
-		export_cic_version
-		say "Rebuilding the cicchetto bundle"
-		CIC_BUILD_OUT="$cic_build_out" "${COMPOSE[@]}" --profile prod run --rm cicchetto-build
-		cic_dist_promote "$cic_served" "$cic_build_out"
-	}
-
-	substrate_migrate() {
-		say "Syncing deps + running migrations"
-		# shellcheck disable=SC1010  # `mix do` is a mix subcommand, not shell `do`
-		"${COMPOSE[@]}" --profile prod run --rm --no-deps grappa \
-			mix do local.hex --force, local.rebar --force, deps.get
-		"${COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix ecto.migrate
-	}
-
-	substrate_seed() {
-		# The same seed cmd_install runs, on the UPGRADE path — so a
-		# built-in theme added after install actually reaches the box.
-		say "Seeding the built-in theme gallery"
-		"${COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix grappa.seed_themes
-	}
-
-	substrate_restart() {
-		"${COMPOSE[@]}" --profile prod up -d --force-recreate --no-deps --remove-orphans grappa
-	}
-
-	substrate_healthcheck() {
-		"${COMPOSE[@]}" exec -T grappa curl -fsS -o /dev/null http://localhost:4000/healthz
-	}
+	# ONE hook set for this substrate, shared with `scripts/deploy.sh`
+	# (#1384). The healthcheck knobs come with it: two doors onto one
+	# substrate must not wait for it with different patience.
+	DOCKER_COMPOSE=("${COMPOSE[@]}")
+	# shellcheck source=infra/lib/deploy_docker.sh
+	. "$REPO_ROOT/infra/lib/deploy_docker.sh"
 
 	substrate_done_banner() {
 		if [ "$MODE" = hot ]; then
@@ -720,11 +642,10 @@ EOF
 
 	# shellcheck source=infra/lib/deploy_common.sh
 	. "$REPO_ROOT/infra/lib/deploy_common.sh"
-	# The build-beside-then-swap helpers substrate_cic uses. Sourced HERE and
-	# not at the top of the file: only source mode builds a bundle, so the
-	# get.sh mirror needs no extra file.
-	# shellcheck source=infra/lib/cic_dist.sh
-	. "$REPO_ROOT/infra/lib/cic_dist.sh"
+	# cic_dist.sh (the build-beside-then-swap helpers substrate_cic uses)
+	# arrives with the shared hook set above, sourced HERE and not at the top
+	# of the file for the same reason it always was: only source mode builds
+	# a bundle, so the get.sh mirror needs neither file.
 	# Empty-array-safe expansion for bash 3.2 under `set -u`.
 	deploy_main ${libargs[@]+"${libargs[@]}"}
 }

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -1,0 +1,242 @@
+# shellcheck shell=bash
+# infra/lib/deploy_docker.sh — the Docker substrate's hook set, once (#1384).
+#
+# `infra/lib/deploy_common.sh` is the substrate-INDEPENDENT deploy algorithm:
+# pull, classify, build, then hot-reload or recreate. Each substrate supplies
+# the `substrate_*` hooks it calls. The jail and the systemd host have one
+# hook set each; the Docker source substrate had TWO, one per entry point —
+# `scripts/deploy.sh` (operator, on a checkout, with the host's personal
+# compose override and the worktree/branch guard) and `infra/docker/deploy.sh
+# update` (standalone box: secrets, install/stop verbs, ownership guard).
+#
+# Two hook sets for one substrate means the operator's outcome depends on
+# which door they walked through, and a fix applied to one silently leaves
+# the other wrong. #1377 is the worked example rather than the hypothesis: it
+# established the environment floor on both PATHS of the operator door and
+# structurally could not reach the twin, which to this day would seed a
+# hand-installed box's DEV database on every update.
+#
+# So the ENTRY POINTS stay two — they serve different audiences and guard
+# different things — and the hooks become one. What is genuinely per-consumer
+# stays per-consumer: `substrate_done_banner` (different wording for
+# different operators, one of them pinned by bats) and
+# `DEPLOY_SEED_RETRY_HINT` (the retry command must name the door the operator
+# actually invoked).
+#
+# NOT a consumer: the release-image mode further down `infra/docker/deploy.sh`.
+# It declares a third `substrate_*` set, of which nine members are `{ :; }` —
+# no pull, no build, no reload, no cic bundle, because a checkout-less host
+# running a published image has no source to do any of it with. That is a
+# DIFFERENT substrate wearing the same interface, and folding it in here
+# would be one data model with a type flag rather than shared behaviour.
+#
+# ## Contract — set these BEFORE sourcing
+#
+#   DOCKER_COMPOSE   array: the full compose invocation, e.g.
+#                    `(docker compose -f compose.yaml)` or, for a consumer
+#                    that honours the host's personal override,
+#                    `(docker compose "${COMPOSE_ARGS[@]}")`.
+#   REPO_ROOT        absolute path to the checkout (used to source cic_dist).
+#   NO_PULL          optional, 0/1 — 1 deploys the working tree as-is.
+#   die              a function that prints to stderr and exits non-zero.
+#
+# Sourcing has no side effect: the preconditions run from `substrate_pull`,
+# for the reason given there. Source it before `deploy_common.sh`.
+
+: "${NO_PULL:=0}"
+
+# The healthcheck loops. Docker's hot loop is fast/short; the cold loop is
+# long because a bind-mounted first boot recompiles `mix phx.server` (2-3
+# min). Shared, so two doors onto one substrate cannot wait for it with
+# different patience.
+HOT_HEALTHCHECK_RETRIES="${HOT_HEALTHCHECK_RETRIES:-30}"
+HOT_HEALTHCHECK_SLEEP="${HOT_HEALTHCHECK_SLEEP:-1}"
+COLD_HEALTHCHECK_RETRIES="${COLD_HEALTHCHECK_RETRIES:-120}"
+COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
+
+# The build-beside-then-swap helpers substrate_cic uses (#1020).
+# shellcheck source=infra/lib/cic_dist.sh
+. "$REPO_ROOT/infra/lib/cic_dist.sh"
+
+# ---- preconditions ---------------------------------------------------
+# Verbatim from #1377, which established them for the operator door: they
+# apply to EVERY compose invocation on BOTH paths.
+#
+# `.env` carries the prod secrets runtime.exs refuses to boot without, and
+# MIX_ENV picks the database every oneshot opens — compose.yaml derives both
+# `MIX_ENV: ${MIX_ENV:-dev}` and `DATABASE_PATH:
+# /app/runtime/grappa_${MIX_ENV:-dev}.db` from it. Neither is a property of
+# the image build, which is where the pair used to live, behind a
+# `[ "$MODE" = cold ] || return 0` that kept them off the hot path entirely.
+#
+# The twin reached the same precondition by a different mechanism —
+# `set_env MIX_ENV prod` writes it into `.env` at install time — so a box
+# installed that way was covered and a hand-installed one was not. One
+# mechanism now, for both doors.
+establish_deploy_env() {
+	if [ ! -f .env ]; then
+		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
+	fi
+
+	MIX_ENV=${MIX_ENV:-prod}
+	export MIX_ENV
+}
+
+# ---- substrate hooks -------------------------------------------------
+
+substrate_pull() {
+	# The earliest hook the lib calls, so the preconditions land here: AFTER
+	# the flag parse inside deploy_main (an unknown flag must still read as a
+	# usage error, not as a missing .env) and BEFORE the first side effect.
+	establish_deploy_env
+
+	# Pull first so the preflight diffs against what we are ABOUT to deploy.
+	# Both endpoints are RESOLVED shas — NEW_SHA goes into the marker.
+	PREV_SHA="$(git rev-parse HEAD)"
+	if [ "$NO_PULL" = 1 ]; then
+		NEW_SHA="$PREV_SHA"
+		return 0
+	fi
+	local branch
+	branch="$(git rev-parse --abbrev-ref HEAD)"
+	echo "Pulling ${branch} (fast-forward only)"
+	# A bare `git pull --ff-only` failure under `set -e` aborts with no
+	# explanation, and a diverged branch is not something an operator can
+	# read out of an exit code.
+	git pull --ff-only || die "pull is not a fast-forward — the branch diverged. Resolve it by hand."
+	NEW_SHA="$(git rev-parse HEAD)"
+}
+
+# Marker hooks — cwd is the checkout and the operator has git + fs access
+# here, so plain git/cat rather than the jail/linux run_as delegate.
+substrate_read_marker() {
+	cat runtime/last-deployed-sha 2>/dev/null || true
+}
+
+substrate_write_marker() {
+	# mkdir -p: the marker owns its dir. Do NOT assume a git checkout — a
+	# checkout-less install reuses this same write.
+	mkdir -p runtime
+	printf '%s\n' "$NEW_SHA" > runtime/last-deployed-sha
+}
+
+substrate_commit_exists() {
+	# Boolean predicate evaluated inside the lib's `base=$(...)` — suppress
+	# stdout too, for parity with the jail/linux hooks.
+	git cat-file -e "$1^{commit}" >/dev/null 2>&1
+}
+
+substrate_changed_files() {
+	git diff --name-only "$1..$2"
+}
+
+substrate_preflight() {
+	# Delegate the whole classification to Grappa.Deploy.Preflight via a
+	# oneshot mix run: halts 0 (HOT) / 3 (COLD); anything else is NOT a
+	# verdict (1=mix crash, 2=usage) and the lib aborts on it.
+	#
+	# `-e MIX_ENV=dev` is explicit and outranks the floor on purpose: the
+	# classifier is `mix run --no-start`, it starts no Repo and opens no
+	# database, and pinning it to dev lets a box with no prod build still be
+	# classified.
+	"${DOCKER_COMPOSE[@]}" run --rm --no-deps \
+		-e MIX_ENV=dev grappa \
+		mix run --no-start -e "Grappa.Deploy.Preflight.cli([\"$1\", \"$2\", \"docker\"])"
+}
+
+substrate_build() {
+	# Hot path needs no build — the pulled commit is already in the
+	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
+	# rebuilds the toolchain image.
+	[ "$MODE" = cold ] || return 0
+
+	echo "Building grappa image..."
+	"${DOCKER_COMPOSE[@]}" --profile prod build grappa
+}
+
+substrate_reload() {
+	# Hot-deploy: POST /admin/reload purges + reloads modified beams in the
+	# live BEAM. Sessions (Session.Server, IRC.Client) keep their state.
+	#
+	# The lib captures this hook's stdout as the reload response body, so
+	# pre-reload chatter MUST go to stderr or it pollutes the JSON the lib
+	# inspects.
+	# No is-it-running probe here, deliberately. The operator door used to
+	# reach this through `_lib.sh`'s `in_container`, which dies with "grappa
+	# container is not running"; the standalone door detects a down box in
+	# `assert_box_ownership` and FORCES COLD instead — bringing the box up
+	# rather than refusing. Unifying on the probe would have encoded the
+	# weaker of the two answers into both doors, so the probe goes and a hot
+	# deploy against a down box surfaces as compose's own non-zero error.
+	echo "Reloading modules in live BEAM..." >&2
+	"${DOCKER_COMPOSE[@]}" exec -T grappa curl -fsS -X POST http://localhost:4000/admin/reload
+}
+
+substrate_cic() {
+	# Refresh the cicchetto SPA dist into ./runtime/cicchetto-dist. Host
+	# bind-mount (not a named volume) so the container UID can write into a
+	# dir that already exists with the right ownership.
+	#
+	# The build lands in a STAGING sibling and is renamed into the served dir
+	# only on success — never build in place (#1020).
+	local cic_served="runtime/cicchetto-dist"
+	local cic_build_out
+	cic_build_out="$(cic_dist_docker_stage "$cic_served")"
+	# The cicchetto-build container mounts only ./cicchetto and cannot read
+	# the repo root, so the version goes through the env (#538). Derived
+	# HERE, after substrate_pull, so the bundle carries the version the box
+	# is moving TO — the pull may have bumped VERSION (#652). vite refuses to
+	# build on an empty value, so an unreadable VERSION must not reach it as
+	# a silent blank.
+	GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")" \
+		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
+	export GRAPPA_VERSION
+	echo "Building cicchetto dist..."
+	CIC_BUILD_OUT="$cic_build_out" "${DOCKER_COMPOSE[@]}" --profile prod run --rm cicchetto-build
+	# The promote plants the tracked .gitkeep into the tree that lands.
+	cic_dist_promote "$cic_served" "$cic_build_out"
+}
+
+substrate_migrate() {
+	# Sync host deps/ to mix.lock. The image is toolchain-only and the
+	# bind-mount puts deps/ + HEX_HOME on the host; a fresh checkout has
+	# neither. Idempotent + cheap when already in sync.
+	echo "Syncing hex + deps to mix.lock..."
+	# shellcheck disable=SC1010  # `mix do` is a mix subcommand, not shell `do`
+	"${DOCKER_COMPOSE[@]}" --profile prod run --rm --no-deps grappa \
+		mix do local.hex --force, local.rebar --force, deps.get
+
+	# Apply pending migrations BEFORE bringing the long-running container up:
+	# a one-shot `run` exits before Bootstrap's first DB hit can race an
+	# unapplied migration.
+	#
+	# `grappa.migrate`, not `ecto.migrate`: same migrator, same footprint
+	# (the task starts the Repo and nothing else), preceded by the #1348
+	# duplicate-version audit. `ecto.migrate` cannot carry that audit — a
+	# version claimed by two files and already applied leaves the pending set
+	# empty, so the migrator reports success having run neither file, for
+	# good.
+	echo "Running migrations..."
+	"${DOCKER_COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix grappa.migrate
+}
+
+substrate_seed() {
+	# Mirrors substrate_migrate's door. The task suppresses Bootstrap and the
+	# Endpoint, so it neither dials upstream IRC nor fights the running
+	# container for port 4000. Runs on BOTH paths — which is why the
+	# preconditions must too.
+	echo "Seeding the built-in theme gallery..."
+	"${DOCKER_COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix grappa.seed_themes
+}
+
+substrate_restart() {
+	# --no-deps avoids re-running cicchetto-build; --remove-orphans sweeps a
+	# stale grappa-nginx left by a pre-#485 two-container stack.
+	"${DOCKER_COMPOSE[@]}" --profile prod up -d --force-recreate --no-deps --remove-orphans grappa
+}
+
+substrate_healthcheck() {
+	# Probe /healthz from INSIDE the container so the check is independent of
+	# host port binding.
+	"${DOCKER_COMPOSE[@]}" exec -T grappa curl -fsS -o /dev/null http://localhost:4000/healthz
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,9 +4,12 @@
 #
 # Thin consumer of the shared deploy algorithm in
 # infra/lib/deploy_common.sh — the same lib that drives
-# infra/freebsd/deploy.sh (jail) and infra/linux/deploy.sh (systemd). This
-# script sets config, flips this substrate's feature toggles, and defines
-# the Docker-specific hooks.
+# infra/freebsd/deploy.sh (jail) and infra/linux/deploy.sh (systemd) — and,
+# since #1384, of the Docker substrate's ONE hook set in
+# infra/lib/deploy_docker.sh, shared with infra/docker/deploy.sh. This script
+# sets config, flips this substrate's feature toggles, and supplies the two
+# things that are its own: the compose invocation (with the host's personal
+# override) and the done banner.
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)" (#503).
 #
 # Cic deploys are orthogonal — scripts/deploy-cic.sh handles the Vite
@@ -21,8 +24,6 @@ set -euo pipefail
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
-# shellcheck source=infra/lib/cic_dist.sh
-. "$(dirname "$0")/../infra/lib/cic_dist.sh"
 
 # Assert main-checkout + main-branch BEFORE any side effect — the git pull
 # below mutates REPO_ROOT (#364).
@@ -40,162 +41,16 @@ DEPLOY_FEATURE_REEXEC=1
 DEPLOY_FEATURE_MARKER=1
 DEPLOY_FEATURE_PREV_SHA_CARRY=1
 DEPLOY_SEED_RETRY_HINT="scripts/mix.sh grappa.seed_themes"
-# Docker's hot healthcheck loop is fast/short; the cold loop is long
-# because a bind-mounted first boot recompiles `mix phx.server` (2-3 min).
-HOT_HEALTHCHECK_RETRIES="${HOT_HEALTHCHECK_RETRIES:-30}"
-HOT_HEALTHCHECK_SLEEP="${HOT_HEALTHCHECK_SLEEP:-1}"
-COLD_HEALTHCHECK_RETRIES="${COLD_HEALTHCHECK_RETRIES:-120}"
-COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 
 # ---- substrate hooks ------------------------------------------------
-
-# Preconditions for EVERY compose invocation this script makes, on BOTH
-# paths. They used to live inside substrate_build, behind its
-# `[ "$MODE" = cold ] || return 0`: a HOT deploy therefore reached
-# substrate_seed with no `.env` check and no MIX_ENV in the shell, compose
-# fell back to `.env` for the interpolation, and `.env.example` ships
-# `MIX_ENV=dev` — so compose.yaml resolved DATABASE_PATH to
-# `grappa_dev.db`. COLD seeded prod, HOT seeded the DEV database on the
-# same box, silently, and hot is the documented normal case (#1377 D-S3).
-#
-# `.env` carries the prod secrets runtime.exs refuses to boot without, and
-# MIX_ENV picks the database every oneshot opens — neither is a property of
-# the image build.
-establish_deploy_env() {
-	if [ ! -f .env ]; then
-		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
-	fi
-
-	MIX_ENV=${MIX_ENV:-prod}
-	export MIX_ENV
-}
-
-substrate_pull() {
-	# The earliest hook the lib calls, so the preconditions land here: AFTER
-	# the flag parse inside deploy_main (an unknown flag must still read as a
-	# usage error, not as a missing .env) and BEFORE the first side effect.
-	establish_deploy_env
-
-	# Pull first so the preflight diffs against what we are ABOUT to deploy.
-	# Both endpoints are RESOLVED shas — NEW_SHA goes into the marker.
-	PREV_SHA="$(git rev-parse HEAD)"
-	echo "Pulling latest main..."
-	git pull --ff-only
-	NEW_SHA="$(git rev-parse HEAD)"
-}
-
-# Marker hooks — cwd is REPO_ROOT and the operator has git + fs access
-# here, so plain git/cat rather than the jail/linux run_as delegate.
-substrate_read_marker() {
-	cat runtime/last-deployed-sha 2>/dev/null || true
-}
-
-substrate_write_marker() {
-	# mkdir -p: the marker owns its dir. Do NOT assume a git checkout — a
-	# checkout-less install reuses this same write.
-	mkdir -p runtime
-	printf '%s\n' "$NEW_SHA" > runtime/last-deployed-sha
-}
-
-substrate_commit_exists() {
-	# Boolean predicate evaluated inside the lib's `base=$(...)` — suppress
-	# stdout too, for parity with the jail/linux hooks.
-	git cat-file -e "$1^{commit}" >/dev/null 2>&1
-}
-
-substrate_changed_files() {
-	git diff --name-only "$1..$2"
-}
-
-substrate_preflight() {
-	# Delegate the whole classification to Grappa.Deploy.Preflight via a
-	# oneshot mix run: halts 0 (HOT) / 3 (COLD); anything else is NOT a
-	# verdict (1=mix crash, 2=usage) and the lib aborts on it.
-	docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps \
-		-e MIX_ENV=dev grappa \
-		mix run --no-start -e "Grappa.Deploy.Preflight.cli([\"$1\", \"$2\", \"docker\"])"
-}
-
-substrate_build() {
-	# Hot path needs no build — the pulled commit is already in the
-	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
-	# rebuilds the toolchain image.
-	[ "$MODE" = cold ] || return 0
-
-	echo "Building grappa image..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod build grappa
-}
-
-substrate_reload() {
-	# Hot-deploy: POST /admin/reload purges + reloads modified beams in the
-	# live BEAM. Sessions (Session.Server, IRC.Client) keep their state.
-	echo "Reloading modules in live BEAM..." >&2
-	in_container curl -fsS -X POST http://localhost:4000/admin/reload
-}
-
-substrate_cic() {
-	# Refresh cicchetto SPA dist into ./runtime/cicchetto-dist. Host
-	# bind-mount (not a named volume) so the container UID can write into a
-	# dir that already exists with the right ownership.
-	#
-	# The build lands in a STAGING sibling and is renamed into the served dir
-	# only on success — never build in place.
-	# Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)" (#1020).
-	local cic_served="runtime/cicchetto-dist"
-	local cic_build_out
-	cic_build_out="$(cic_dist_docker_stage "$cic_served")"
-	# The cicchetto-build container mounts only ./cicchetto and cannot read
-	# the repo root, so pass the version through the env (#538).
-	GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
-	export GRAPPA_VERSION
-	echo "Building cicchetto dist..."
-	CIC_BUILD_OUT="$cic_build_out" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
-	# The promote plants the tracked .gitkeep into the tree that lands.
-	cic_dist_promote "$cic_served" "$cic_build_out"
-}
-
-substrate_migrate() {
-	# Sync host deps/ to mix.lock. The image is toolchain-only and the
-	# bind-mount puts deps/ + HEX_HOME on the host; a fresh checkout has
-	# neither. Idempotent + cheap when already in sync.
-	echo "Syncing hex + deps to mix.lock..."
-	# shellcheck disable=SC1010  # `mix do` is a mix subcommand, not shell `do`
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm --no-deps grappa \
-		mix do local.hex --force, local.rebar --force, deps.get
-
-	# Apply pending migrations BEFORE bringing the long-running container up:
-	# a one-shot `run` exits before Bootstrap's first DB hit can race an
-	# unapplied migration.
-	# Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
-	# `grappa.migrate`, not `ecto.migrate`: same migrator, same footprint
-	# (the task starts the Repo and nothing else), preceded by the #1348
-	# duplicate-version audit. `ecto.migrate` cannot carry that audit —
-	# a version claimed by two files and already applied leaves the
-	# pending set empty, so the migrator reports success having run
-	# neither file, forever.
-	echo "Running migrations..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm --no-deps grappa mix grappa.migrate
-}
-
-substrate_seed() {
-	# Mirrors substrate_migrate's door. The task suppresses Bootstrap and the
-	# Endpoint, so it neither dials upstream IRC nor fights the running
-	# container for port 4000.
-	echo "Seeding the built-in theme gallery..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm --no-deps grappa mix grappa.seed_themes
-}
-
-substrate_restart() {
-	# --no-deps avoids re-running cicchetto-build; --remove-orphans sweeps a
-	# stale grappa-nginx left by a pre-#485 two-container stack.
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod up -d --force-recreate --no-deps --remove-orphans grappa
-}
-
-substrate_healthcheck() {
-	# Probe /healthz from INSIDE the container so the check is independent
-	# of host port binding.
-	in_container curl -fsS -o /dev/null http://localhost:4000/healthz
-}
+# ONE hook set for this substrate, shared with `infra/docker/deploy.sh
+# update` (#1384) — including the #1377 preconditions, which moved into it
+# unchanged. What this entry point contributes is the compose invocation:
+# `COMPOSE_ARGS` carries the host's personal `compose.override.yaml`, which
+# the standalone driver deliberately does not read.
+DOCKER_COMPOSE=(docker compose "${COMPOSE_ARGS[@]}")
+# shellcheck source=infra/lib/deploy_docker.sh
+. "$REPO_ROOT/infra/lib/deploy_docker.sh"
 
 substrate_done_banner() {
 	# Docker success wording, no [deploy] prefix — PINNED by

--- a/test/infra/cic_dist_swap_test.bats
+++ b/test/infra/cic_dist_swap_test.bats
@@ -395,9 +395,11 @@ code_of() {
 }
 
 DOCKER_LAUNCHERS=(
-    scripts/deploy.sh
     scripts/deploy-cic.sh
-    infra/docker/deploy.sh
+    # #1384 — the deploy path's compose launch lives in the ONE Docker hook
+    # set now, sourced by both scripts/deploy.sh and infra/docker/deploy.sh,
+    # so the staging + promote pair is asserted where it is written.
+    infra/lib/deploy_docker.sh
 )
 
 @test "docker: every compose launcher aims the build at a staging dir and promotes it" {

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -29,8 +29,10 @@ setup() {
 # Every launcher, as of #692. A new one belongs here AND must export.
 ROSTER=(
     scripts/bun.sh
-    scripts/deploy.sh
     scripts/deploy-cic.sh
+    # #1384 — the Docker substrate's cic launch moved out of both deploy
+    # entry points into the ONE hook set they now share.
+    infra/lib/deploy_docker.sh
     scripts/integration.sh
     scripts/testnet.sh
     infra/docker/deploy.sh

--- a/test/infra/deploy_docker_convergence_test.bats
+++ b/test/infra/deploy_docker_convergence_test.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+#
+# Bats suite for the ONE Docker hook set (#1384, review D-S2).
+#
+# Two entry points drive the Docker source substrate: `scripts/deploy.sh`
+# (operator, on a checkout, with the host's compose override) and
+# `infra/docker/deploy.sh update` (standalone box, secrets + install/stop).
+# Each used to carry its OWN 14 `substrate_*` functions, so the operator's
+# outcome depended on which door they walked through, and a fix applied to
+# one silently left the other wrong. #1377 is the worked example: it
+# established the MIX_ENV floor on both PATHS of the operator door and could
+# not reach the twin at all.
+#
+# These are the two divergences that carry a consequence rather than a
+# spelling, asserted through the TWIN — the door #1377 could not reach. The
+# operator door keeps its own suites (deploy_docker_test.bats,
+# deploy_reload_verify_test.bats); this one exists to fail when the two
+# doors stop agreeing.
+#
+# Harness mirrors deploy_docker_update_test.bats.
+
+load ../bats_helpers
+
+setup() {
+    BATS_TEST_TMPDIR="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"
+    : > "$ARGV_LOG"
+    export ARGV_LOG
+    # A second log carrying the MIX_ENV each compose invocation inherited,
+    # kept out of ARGV_LOG so it cannot widen any ordering assertion — the
+    # shape #1377 established for the operator door.
+    ENV_LOG="$BATS_TEST_TMPDIR/env.log"
+    : > "$ENV_LOG"
+    export ENV_LOG
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+
+    export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    export GIT_AUTHOR_NAME=bats GIT_AUTHOR_EMAIL=bats@example.org
+    export GIT_COMMITTER_NAME=bats GIT_COMMITTER_EMAIL=bats@example.org
+
+    UPSTREAM="$BATS_TEST_TMPDIR/upstream"
+    git init -q -b main "$UPSTREAM"
+    mkdir -p "$UPSTREAM/infra/docker" "$UPSTREAM/infra/lib" "$UPSTREAM/infra/packaging" \
+             "$UPSTREAM/runtime" "$UPSTREAM/lib"
+    cp "$REPO_SRC/infra/docker/deploy.sh" "$UPSTREAM/infra/docker/deploy.sh"
+    cp "$REPO_SRC/infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    cp "$REPO_SRC/infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
+    # The shared hook set. Copied when present so that before it exists this
+    # suite is red for the RIGHT reason — the two doors disagree — rather
+    # than for a missing file.
+    if [ -f "$REPO_SRC/infra/lib/deploy_docker.sh" ]; then
+        cp "$REPO_SRC/infra/lib/deploy_docker.sh" "$UPSTREAM/infra/lib/deploy_docker.sh"
+    fi
+    cp "$REPO_SRC/VERSION" "$UPSTREAM/VERSION"
+    cp "$REPO_SRC/infra/packaging/version.sh" "$UPSTREAM/infra/packaging/version.sh"
+    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh"
+    cat > "$UPSTREAM/compose.yaml" <<'EOF'
+services:
+  grappa:
+    container_name: grappa
+EOF
+    touch "$UPSTREAM/runtime/.gitkeep"
+    echo base > "$UPSTREAM/lib/base.txt"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "base"
+
+    export REPO_ROOT="$BATS_TEST_TMPDIR/repo"
+    git clone -q "$UPSTREAM" "$REPO_ROOT"
+
+    # THE PRE-STATE. An installed box whose .env was written BY HAND rather
+    # than by `install` — so it carries no MIX_ENV. `install` writes
+    # `set_env MIX_ENV prod` into .env, which is the twin's own mechanism for
+    # the same precondition the operator door solves by exporting; a box that
+    # never ran `install` therefore has neither. compose then interpolates
+    # `${MIX_ENV:-dev}` and every oneshot below opens grappa_dev.db.
+    cat > "$REPO_ROOT/.env" <<'EOF'
+PHX_HOST=staging.example.org
+GRAPPA_PUBLISH=127.0.0.1:3100
+EOF
+
+    export PREFLIGHT_RC=0
+    export RELOAD_FAILS=0
+    export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
+    export COLD_HEALTHCHECK_RETRIES=2 COLD_HEALTHCHECK_SLEEP=0
+    export FAKE_OWNER_DIR="$REPO_ROOT"
+    # An ambient MIX_ENV from the developer's shell would satisfy every arm
+    # below without the script having established anything.
+    unset MIX_ENV
+
+    cat > "$FAKE_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+printf 'docker %s\n' "$*" >> "$ARGV_LOG"
+printf 'MIX_ENV=%s | docker %s\n' "${MIX_ENV-<unset>}" "$*" >> "$ENV_LOG"
+if [ "$1" = inspect ]; then
+    [ -n "${FAKE_OWNER_DIR:-}" ] || exit 1
+    printf '%s\n' "$FAKE_OWNER_DIR"
+    exit 0
+fi
+case "$*" in
+    *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
+    *"run --rm cicchetto-build"*)
+        cic_out="${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "$cic_out/assets"
+        printf '<!doctype html>\n' > "$cic_out/index.html"
+        ;;
+    *"exec -T grappa curl"*reload*)
+        if [ "$RELOAD_FAILS" = "1" ]; then
+            printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'
+        else
+            printf '{"loaded":[],"failed":[]}'
+        fi
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+commit_upstream() {
+    echo "$RANDOM" > "$UPSTREAM/$1"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "change $1"
+}
+
+run_update() {
+    cd "$REPO_ROOT"
+    run "$REPO_ROOT/infra/docker/deploy.sh" update "$@"
+}
+
+# The MIX_ENV recorded for the first invocation whose argv matches.
+env_for() {
+    grep -- "$1" "$ENV_LOG" | head -1 | sed 's/ | docker.*//'
+}
+
+@test "the standalone door establishes the environment floor too, not only the operator one" {
+    refute grep -q MIX_ENV "$REPO_ROOT/.env"
+    commit_upstream lib/base.txt
+
+    run_update --force-hot
+    [ "$status" -eq 0 ]
+
+    # The hot path's one host-side oneshot that opens the database.
+    grep -q 'seed_themes' "$ARGV_LOG"
+    [ "$(env_for seed_themes)" = "MIX_ENV=prod" ]
+}
+
+@test "the standalone door's cold path establishes it as well" {
+    refute grep -q MIX_ENV "$REPO_ROOT/.env"
+    commit_upstream lib/base.txt
+
+    run_update --force-cold
+    [ "$status" -eq 0 ]
+
+    [ "$(env_for 'mix grappa.migrate')" = "MIX_ENV=prod" ]
+    [ "$(env_for seed_themes)" = "MIX_ENV=prod" ]
+}
+
+@test "both doors migrate through the audited task, not bare ecto.migrate" {
+    # `grappa.migrate` carries the #1348 duplicate-version audit;
+    # `ecto.migrate` cannot. A version claimed by two files and already
+    # applied leaves the pending set empty, so the migrator reports success
+    # having run neither file — for good. CLAUDE.md marks that regime 🔴,
+    # and the operator door has been audited since #1348 while this one was
+    # never moved with it.
+    commit_upstream lib/base.txt
+
+    run_update --force-cold
+    [ "$status" -eq 0 ]
+
+    grep -q 'mix grappa.migrate' "$ARGV_LOG"
+    refute grep -q 'mix ecto.migrate' "$ARGV_LOG"
+}
+
+@test "an explicit MIX_ENV is still a floor, not an override" {
+    commit_upstream lib/base.txt
+
+    cd "$REPO_ROOT"
+    MIX_ENV=staging run "$REPO_ROOT/infra/docker/deploy.sh" update --force-hot
+    [ "$status" -eq 0 ]
+
+    [ "$(env_for seed_themes)" = "MIX_ENV=staging" ]
+}

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -68,6 +68,9 @@ setup() {
     # #1020 — the cic build's build-beside-then-swap helper, sourced by the
     # same orchestrator. A checkout has it; the throwaway clone must too.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
+    # #1384: the Docker substrate's hook set moved into one shared lib
+    # that both deploy entry points source.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_docker.sh" "$UPSTREAM/infra/lib/deploy_docker.sh"
     # version.sh delegate → committed recorder that echoes a version.
     cat > "$UPSTREAM/infra/packaging/version.sh" <<'EOF'
 #!/bin/sh

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -45,6 +45,9 @@ setup() {
     # #1020 — the cic build's build-beside-then-swap helper, sourced by the
     # same orchestrator. A checkout has it; the throwaway clone must too.
     cp "$REPO_SRC/infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
+    # #1384: the Docker substrate's hook set moved into one shared lib
+    # that both deploy entry points source.
+    cp "$REPO_SRC/infra/lib/deploy_docker.sh" "$UPSTREAM/infra/lib/deploy_docker.sh"
     # The REAL version carrier + extractor (#538/#652): source mode derives
     # GRAPPA_VERSION from them at init so every compose call inherits it, and a
     # cic build with an empty value is refused by vite (#692).

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -50,6 +50,9 @@ setup() {
     # #1020 — the cic build's build-beside-then-swap helper, sourced by the
     # same orchestrator. A checkout has it; the throwaway clone must too.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
+    # #1384: the two Docker hook sets folded into one shared lib that
+    # deploy.sh sources — the throwaway clone must carry it too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_docker.sh" "$UPSTREAM/infra/lib/deploy_docker.sh"
     : > "$UPSTREAM/compose.yaml"
     # NB: deliberately NO runtime/.gitkeep here — git drops the empty dir,
     # so the clone has NO runtime/. This mimics a checkout-less install

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -16,7 +16,7 @@
 # Scope: guard ordering + the #526 loud-fail contract. Runs the scripts
 # against a throwaway repo + a real `git worktree add` (so _lib.sh derives
 # a genuine SRC_ROOT!=REPO_ROOT), with `docker` stubbed on PATH. Asserts
-# the guard fires before the side-effect echo ("Pulling latest main..." /
+# the guard fires before the side-effect echo ("Pulling <branch> (fast-forward only)" /
 # "Building cicchetto dist..."), AND that deploy-cic.sh treats an empty
 # (HTTP 204) bundle-hash response as a hard failure — see #526: the server
 # built the bundle but resolved the wrong CIC_DIST_ROOT, could not read
@@ -56,6 +56,9 @@ setup() {
     # top — before the guards these cases are about. Missing it would kill them
     # for the wrong reason.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$MAIN/infra/lib/cic_dist.sh"
+    # #1384: the two Docker hook sets folded into one shared lib that
+    # deploy.sh sources — the throwaway clone must carry it too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_docker.sh" "$MAIN/infra/lib/deploy_docker.sh"
     # #538/#652 — deploy-cic.sh (and deploy.sh's cold path) derive the cic
     # version from the repo-root VERSION file via infra/packaging/version.sh.
     # The fixture needs both the script and a VERSION file to derive from, or
@@ -114,7 +117,7 @@ EOF
     run "$WT/scripts/deploy.sh" --force-hot
     [ "$status" -ne 0 ]
     [[ "$output" == *"worktree"* ]]
-    [[ "$output" != *"Pulling latest main"* ]]
+    [[ "$output" != *"fast-forward only"* ]]
 }
 
 @test "deploy.sh from the main checkout passes the worktree guard" {
@@ -122,7 +125,7 @@ EOF
     run "$MAIN/scripts/deploy.sh" --force-hot
     # Reaching the pull echo proves the guard did not over-fire on main
     # (the pull itself then fails — the throwaway repo has no upstream).
-    [[ "$output" == *"Pulling latest main"* ]]
+    [[ "$output" == *"fast-forward only"* ]]
     [[ "$output" != *"worktree"* ]]
 }
 
@@ -132,7 +135,7 @@ EOF
     run "$MAIN/scripts/deploy.sh" --force-hot
     [ "$status" -ne 0 ]
     [[ "$output" == *"branch"* ]]
-    [[ "$output" != *"Pulling latest main"* ]]
+    [[ "$output" != *"fast-forward only"* ]]
 }
 
 # --- deploy-cic.sh -----------------------------------------------------------


### PR DESCRIPTION
## What

`infra/lib/deploy_common.sh` is the substrate-independent deploy algorithm, and each substrate hands it a `substrate_*` hook set. The jail and the systemd host have one each. The Docker source substrate had **two** — fourteen functions in `scripts/deploy.sh` and fourteen more inside `infra/docker/deploy.sh`'s `cmd_update` — so an operator's outcome depended on which entry point they walked through.

This gives that substrate one hook set (`infra/lib/deploy_docker.sh`, 13 hooks) and leaves the two entry points in place: they serve different audiences and guard different things. Each keeps what is genuinely its own — the compose invocation (only the operator door reads `compose.override.yaml`), the done banner, and the seed retry hint.

## Why it is not untidiness

#1377 established the `.env` + `MIX_ENV` preconditions on both *paths* of the operator door and structurally could not reach the twin, which had arrived at the same precondition by an unrelated mechanism (`set_env MIX_ENV prod`, written into `.env` at install time). A box installed by that driver was covered; a hand-installed one was not, and every update then ran its database oneshots against the dev database while the live container served the prod one. Two implementations of one precondition — the divergence is the defect.

## Behaviour changes (three, all toward the safer side)

- the standalone door migrates through `mix grappa.migrate`, gaining the #1348 duplicate-version audit it never had;
- both doors diagnose a non-fast-forward pull instead of dying on a bare non-zero exit;
- the reload no longer probes `ps -q grappa` first. The operator door inherited that probe from `_lib.sh`'s `in_container`; the standalone door detects a down box earlier and forces COLD, bringing it up rather than refusing, so unifying on the probe would have written the weaker answer into both doors.

## Left divergent on purpose

`assert_box_ownership` vs `require_main_checkout` (different failure modes, different audiences); `migrate_publish_env` (`.env` authorship, and only one driver owns `.env`); `--no-pull` (a flag surface — the shared hook already honours `NO_PULL`). The seventh measured divergence, "empty-array expansion", is not a defect in either direction.

The third `substrate_*` set inside `infra/docker/deploy.sh` also stays: nine of its members are `{ :; }` because a checkout-less host running the published image has no source to pull, build, reload or bundle from. Different substrate, same interface.

Production (the FreeBSD bastille jail) is a different substrate and is untouched.

## Test plan

- [x] New suite `test/infra/deploy_docker_convergence_test.bats` drives the standalone door — the one #1377 could not reach — and was **red before the change** on three of four arms: the floor missing on its hot path, missing on its cold path, and `ecto.migrate` instead of the audited task. The fourth arm (an explicit `MIX_ENV` must survive as a floor, not be overridden) is a control and was green throughout.
- [x] Full bats set green: **496 passing, 0 failing** (`scripts/bats.sh test/infra/ test/scripts/ test/bin/`).
- [x] `scripts/posix-parse.sh` green — the new file declares `# shellcheck shell=bash` and is excluded by the derived set rather than by an exception list.
- [x] Both cic launcher rosters follow the code: the compose launch is now asserted where it is written.
- [ ] Not run: `scripts/check.sh` (no lane allocated) and any real deploy.