### PR TITLE
persistence(#1385): the rejoin snapshot takes a change, not a replacement

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43636,3 +43636,58 @@ files, and the jail never sources this one. It says `# shellcheck shell=bash`,
 which is also how `scripts/posix-parse.sh` derives its set — the gate reads
 the declared dialect, so the exclusion is a property of the file rather than
 an exception list.
+<!-- entry #1385 -->
+
+---
+
+## 2026-08-16 — #1385: the rejoin snapshot takes a change, not a replacement
+
+`network_credentials.last_joined_channels` is the set a reconnecting session
+plans its JOINs from. `Session.Server` used to write it ABSOLUTELY, from
+`Map.keys(state.members)`, on every membership mutation. After a reconnect
+that map starts EMPTY and grows one self-JOIN echo at a time, so for the
+whole restore window the value written is a strict PREFIX of the channels
+the subject is actually in.
+
+On 2026-08-16 a cold restart put that window under a second drop wave
+(`Read/Dead Error`) and the prefix became the truth: `vjt` came back with 7
+of 11 channels, `morph` with 2 of 10, and both rows stayed truncated,
+because the next reconnect planned from the truncated row, joined fewer
+channels, and re-persisted the truncation. `morph`'s row only healed when a
+human re-joined by hand.
+
+The defect is not WHEN the write happens, it is WHAT is written. Gating the
+write on "the restore is complete" was rejected: it needs a completion
+signal that a channel stuck in `in_flight_joins` (a 477 into the ChanServ
+invite retry) may never give, and a session that stops persisting entirely
+is worse than the bug. Instead the row now takes a CHANGE:
+
+    row := (row ∪ live keyset) − the channels this change removed
+
+An absent channel is merely not back yet; only a departure removes. The
+snapshot therefore still shrinks on a real `/part` or KICK — the product
+constraint that rules out any "it never shrinks" fix, because a voluntary
+part must not come back on the next rejoin. The union (rather than a pure
+delta) also keeps the write self-healing: `persist_last_joined/5` swallows
+a failed write, and the next mutation unions the live keyset back in, which
+a delta would have lost for good.
+
+**The departures are sourced from the EVENT, never from a diff of the
+previous and current keyset.** A keyset that empties for a reason other
+than leaving reads, under a diff, as "left everything" — the same defect
+with the whole row as blast radius instead of a suffix. That scenario is
+not reachable today (an upstream drop stops the session rather than
+clearing the members map in place), and the diff form indeed survived 1753
+tests unchanged. It is still the wrong shape, and it has a reachable defect
+of its own: parting a channel that is in the snapshot but not in the live
+keyset moves no keyset, so the diff form writes nothing and the channel the
+operator just dismissed is re-JOINed on the next reconnect. That path is
+what pins the event form in the suite.
+
+**Accepted cost, deliberately not engineered around:** a channel left from
+ANOTHER client while grappa is disconnected is not observable, so the row
+keeps it and the next reconnect re-JOINs it. One channel too many beats one
+lost for good. Do not build machinery on top of this.
+
+Repair of the rows already truncated in production is a separate,
+operator-owned decision — this change stops the loss, it does not undo it.

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -263,24 +263,84 @@ defmodule Grappa.Networks.Credentials do
           :ok | {:error, :not_found | Ecto.Changeset.t()}
   def update_last_joined_channels(user_id, network_id, channels)
       when is_binary(user_id) and is_integer(network_id) and is_list(channels) do
-    capped = Enum.take(channels, Credential.last_joined_channels_max())
+    case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
+      nil -> {:error, :not_found}
+      %Credential{} = cred -> write_last_joined_channels(cred, channels)
+    end
+  end
 
+  @doc """
+  GH #1385 — apply a live membership CHANGE to the rejoin snapshot rather
+  than overwriting it: the row becomes `(row ∪ joined) − departed`, capped.
+  `joined` is the session's CURRENT channel keyset, `departed` the channels
+  THIS change removed from it (self-PART / self-KICK / eager `/part`).
+
+  This is the writer `Session.Server` uses; `update_last_joined_channels/3`
+  above is the absolute setter, and a session must never reach for it. The
+  reason is the whole of #1385: after a reconnect the live keyset starts
+  EMPTY and grows one self-JOIN echo at a time, so an absolute write during
+  the restore window persists a PREFIX of the truth — and a drop inside that
+  window (measured in production on 2026-08-16, `vjt` 11 channels → 7,
+  `morph` 10 → 2) freezes the prefix as the new snapshot, which the next
+  reconnect then re-restores and re-persists. Nothing recovers the tail.
+
+  The union is what makes the restore window harmless: a channel we have not
+  re-joined YET is merely absent, and absence is not a departure. Growth
+  still works (the live keyset unions in), and the snapshot still SHRINKS on
+  a real leave, because that leave arrives as `departed`.
+
+  `departed` MUST come from the event that removed the channel, never from a
+  diff of the previous and current keyset: a keyset that empties for any
+  reason other than leaving (a future in-process connection reset — a drop
+  currently stops the session instead) reads, under a diff, as "left
+  everything", which is #1385 again through another door and losing the
+  whole row instead of a suffix.
+
+  Known accepted cost: a channel left from ANOTHER client while grappa is
+  disconnected is not observable, so the row keeps it and the next reconnect
+  re-JOINs it. One channel too many beats one lost for good.
+  """
+  @spec merge_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()], [String.t()]) ::
+          :ok | {:error, :not_found | Ecto.Changeset.t()}
+  def merge_last_joined_channels(user_id, network_id, joined, departed)
+      when is_binary(user_id) and is_integer(network_id) and is_list(joined) and
+             is_list(departed) do
     case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
       nil ->
         {:error, :not_found}
 
       %Credential{} = cred ->
-        # S34: narrow changeset — this fires on every self-JOIN/PART/KICK,
-        # so it must not drag the wide `changeset/2`'s unrelated validators
-        # (`validate_password_for_auth_method`, `put_encrypted_password`,
-        # the `unique_constraint`) onto the hot path. Twin of the visitor
-        # side's `Visitor.last_joined_channels_changeset/2`.
-        changeset = Credential.last_joined_channels_changeset(cred, capped)
+        write_last_joined_channels(cred, merge_snapshot(cred, joined, departed))
+    end
+  end
 
-        case Repo.update(changeset) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
-        end
+  # The stored row is the rejoin plan, so the LIVE keyset leads and the rows
+  # we have not re-joined yet trail it: on overflow the cap then drops the
+  # stale tail rather than a channel we are actually sitting in.
+  @spec merge_snapshot(Credential.t(), [String.t()], [String.t()]) :: [String.t()]
+  defp merge_snapshot(%Credential{last_joined_channels: stored}, joined, departed) do
+    gone = MapSet.new(departed)
+
+    (joined ++ stored)
+    |> Enum.uniq()
+    |> Enum.reject(&MapSet.member?(gone, &1))
+  end
+
+  # S34: narrow changeset — this fires on every self-JOIN/PART/KICK, so it
+  # must not drag the wide `changeset/2`'s unrelated validators
+  # (`validate_password_for_auth_method`, `put_encrypted_password`, the
+  # `unique_constraint`) onto the hot path. Twin of the visitor side's
+  # `Visitor.last_joined_channels_changeset/2`. Single Repo writer for the
+  # column — both subject kinds and both verbs (set + merge) land here, so
+  # the cap is enforced once.
+  @spec write_last_joined_channels(Credential.t(), [String.t()]) ::
+          :ok | {:error, Ecto.Changeset.t()}
+  defp write_last_joined_channels(%Credential{} = cred, channels) do
+    capped = Enum.take(channels, Credential.last_joined_channels_max())
+
+    case cred |> Credential.last_joined_channels_changeset(capped) |> Repo.update() do
+      {:ok, _} -> :ok
+      {:error, changeset} -> {:error, changeset}
     end
   end
 
@@ -334,19 +394,34 @@ defmodule Grappa.Networks.Credentials do
           :ok | {:error, :not_found | Ecto.Changeset.t()}
   def update_visitor_last_joined_channels(visitor_id, network_id, channels)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(channels) do
-    capped = Enum.take(channels, Credential.last_joined_channels_max())
+    case Repo.get_by(Credential, visitor_id: visitor_id, network_id: network_id) do
+      nil -> {:error, :not_found}
+      %Credential{} = cred -> write_last_joined_channels(cred, channels)
+    end
+  end
 
+  @doc """
+  GH #1385 — visitor twin of `merge_last_joined_channels/4`, keyed on
+  `(visitor_id, network_id)`. Same verb, same reasons, and the visitor needs
+  it MORE: with no operator-bound `autojoin_channels` to merge against, the
+  snapshot is the visitor's ENTIRE rejoin source, so a truncated write is
+  the whole loss with nothing to fall back on.
+  """
+  @spec merge_visitor_last_joined_channels(
+          Ecto.UUID.t(),
+          pos_integer(),
+          [String.t()],
+          [String.t()]
+        ) :: :ok | {:error, :not_found | Ecto.Changeset.t()}
+  def merge_visitor_last_joined_channels(visitor_id, network_id, joined, departed)
+      when is_binary(visitor_id) and is_integer(network_id) and is_list(joined) and
+             is_list(departed) do
     case Repo.get_by(Credential, visitor_id: visitor_id, network_id: network_id) do
       nil ->
         {:error, :not_found}
 
       %Credential{} = cred ->
-        changeset = Credential.last_joined_channels_changeset(cred, capped)
-
-        case Repo.update(changeset) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
-        end
+        write_last_joined_channels(cred, merge_snapshot(cred, joined, departed))
     end
   end
 

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -139,12 +139,14 @@ defmodule Grappa.Networks.SessionPlan do
         Credentials.commit_registration_password(user.id, cred.network_id, password)
       end,
       # CP22 cluster B (channel-client-polish #14, B-restart) — opaque
-      # closure that forwards `Map.keys(state.members)` snapshots to
-      # the per-credential `last_joined_channels` column. Wraps the
-      # (user_id, network_id) pair so Session.Server stays
-      # boundary-clean (Networks deps Session, not the reverse).
-      last_joined_persister: fn channels ->
-        Credentials.update_last_joined_channels(user.id, cred.network_id, channels)
+      # closure that forwards membership CHANGES (`Map.keys(state.members)`
+      # plus the channels the change removed) to the per-credential
+      # `last_joined_channels` column. Wraps the (user_id, network_id) pair
+      # so Session.Server stays boundary-clean (Networks deps Session, not
+      # the reverse). #1385 turned the write from an overwrite into a merge:
+      # the keyset alone cannot distinguish "not restored yet" from "left".
+      last_joined_persister: fn channels, departed ->
+        Credentials.merge_last_joined_channels(user.id, cred.network_id, channels, departed)
       end,
       # GH #417 — persist/restore the EXPLICIT away across crash / respawn /
       # upstream reconnect (user-only; the visitor plan omits both). The

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -343,20 +343,26 @@ defmodule Grappa.Session.Server do
 
   @typedoc """
   CP22 cluster B (channel-client-polish #14, B-restart) — opaque
-  callback that persists the current `Map.keys(state.members)` snapshot
-  so a graceful or crash restart can rehydrate the channel list at boot.
+  callback that persists a channels-list CHANGE so a graceful or crash
+  restart can rehydrate the channel list at boot. First argument is the
+  current `Map.keys(state.members)` keyset, second the channels THIS
+  change removed from it.
 
   Boundary-clean: Session.Server cannot reference `Grappa.Networks`
   directly (the cycle is banned — Networks already deps Session for
   stop_session calls on /disconnect). The callback wraps a closure
   that knows the (user_id, network_id) pair and forwards to
-  `Grappa.Networks.Credentials.update_last_joined_channels/3`.
+  `Grappa.Networks.Credentials.merge_last_joined_channels/4`.
   Returns `:ok` on success or `{:error, reason}`; Session.Server logs
-  failures but does not retry — the next channels-list mutation
-  overwrites, and a missing snapshot only forces the next restart to
-  fall back to operator autojoin.
+  failures but does not retry — the next channels-list mutation unions
+  the live keyset back in, and a missing snapshot only forces the next
+  restart to fall back to operator autojoin.
+
+  #1385 — the two arguments exist because the keyset ALONE cannot tell
+  "not restored yet" from "left": both read as absent. The departures
+  therefore travel separately, sourced from the event that caused them.
   """
-  @type last_joined_persister :: ([String.t()] -> :ok | {:error, term()})
+  @type last_joined_persister :: ([String.t()], [String.t()] -> :ok | {:error, term()})
 
   @typedoc """
   GH #581 — opaque reader the visitor `SessionPlan` injects so
@@ -2912,7 +2918,11 @@ defmodule Grappa.Session.Server do
     # snapshot went stale: a visitor's parted channel kept surfacing in
     # `GET /channels` (its autojoin source IS this snapshot) and both subjects
     # rejoined the parted channel on the next reconnect.
-    maybe_persist_last_joined(prev, state)
+    #
+    # #1385 — the operator's own `/part` IS the departure event for this path
+    # (there is no upstream echo to wait for, and `cleanup_local` above may
+    # not even have moved the keyset), so the channel travels as `departed`.
+    maybe_persist_last_joined(prev, state, [key])
 
     case Client.send_part(state.client, channel, reason) do
       :ok ->
@@ -3726,7 +3736,7 @@ defmodule Grappa.Session.Server do
         # AWAY confirmation) still flow.
         {:cont, next_state, effects} = EventRouter.route(msg, persist_state)
         final_state = effects |> apply_effects(next_state) |> prune_seeded_channels()
-        maybe_broadcast_channels_changed(state, final_state)
+        maybe_broadcast_channels_changed(state, final_state, departed_channels(effects, state))
         on_own_nick_change(state, final_state)
         {:noreply, final_state}
     end
@@ -5024,7 +5034,7 @@ defmodule Grappa.Session.Server do
   defp delegate(msg, state) do
     {:cont, derived_state, effects} = EventRouter.route(msg, state)
     next_state = effects |> apply_effects(derived_state) |> prune_seeded_channels()
-    maybe_broadcast_channels_changed(state, next_state)
+    maybe_broadcast_channels_changed(state, next_state, departed_channels(effects, state))
     on_own_nick_change(state, next_state)
     # #623 — a self-NICK arrives as a :nick command → this delegate path (never
     # the numeric path). Feed the recover FSM `:nick_observed` when our nick
@@ -5046,13 +5056,33 @@ defmodule Grappa.Session.Server do
     %{state | seeded_channels: MapSet.intersection(state.seeded_channels, member_keys)}
   end
 
-  @spec maybe_broadcast_channels_changed(t(), t()) :: :ok
-  defp maybe_broadcast_channels_changed(prev, next) do
+  @spec maybe_broadcast_channels_changed(t(), t(), [String.t()]) :: :ok
+  defp maybe_broadcast_channels_changed(prev, next, departed) do
     if channels_keyset(prev) != channels_keyset(next) do
       broadcast_channels_changed(next)
     end
 
-    maybe_persist_last_joined(prev, next)
+    maybe_persist_last_joined(prev, next, departed)
+  end
+
+  # #1385 — the departures this batch of effects carries, folded to the
+  # members-map key space. `:parted` and `:kicked` are emitted by EventRouter
+  # ONLY for ourselves (a peer's PART/KICK is a scrollback row and leaves the
+  # keyset alone), so they ARE the leave set.
+  #
+  # This is deliberately sourced from the EVENTS and not from a diff of the
+  # previous and current keyset. A diff reads any keyset that empties as
+  # "left everything" — today a drop stops the session instead of clearing
+  # the map in place, so the two agree, but the day one does not the diff
+  # form deletes the entire snapshot. That is #1385 with a bigger blast
+  # radius, and the shape that prevents it costs nothing.
+  @spec departed_channels([EventRouter.effect()], t()) :: [String.t()]
+  defp departed_channels(effects, state) do
+    Enum.flat_map(effects, fn
+      {:parted, channel} -> [fold_key(state, channel)]
+      {:kicked, channel, _, _} -> [fold_key(state, channel)]
+      _ -> []
+    end)
   end
 
   # CP22 cluster B (channel-client-polish #14, B-restart) — persist the
@@ -5061,19 +5091,32 @@ defmodule Grappa.Session.Server do
   # restart rehydrates the right window list. The keyset is the only field
   # that affects rejoin; one Repo write per channels-list mutation (a typical
   # session sees a handful per hour). Failure logged but NOT fatal
-  # (`persist_last_joined/4`): the next mutation overwrites, and a missing
-  # snapshot only forces the next restart to fall back to operator autojoin.
+  # (`persist_last_joined/5`): the next mutation unions the live keyset back
+  # in, and a missing snapshot only forces the next restart to fall back to
+  # operator autojoin.
   #
   # #87 (2026-06-26) — SINGLE persister call site, shared with the explicit
   # `handle_cast({:send_part, _})` leave path. Both the organic
   # membership-change path and the eager-PART path converge here, so the
   # snapshot stays consistent regardless of which one fired.
-  @spec maybe_persist_last_joined(t(), t()) :: :ok
-  defp maybe_persist_last_joined(prev, next) do
+  #
+  # #1385 — the WRITE is a merge on the far side (row ∪ keyset − departed),
+  # so what travels is the change, not a replacement. `departed` alone is
+  # enough to fire it: the eager-PART of a channel we were never live in
+  # does not move the keyset, but it IS a leave and must reach the row.
+  @spec maybe_persist_last_joined(t(), t(), [String.t()]) :: :ok
+  defp maybe_persist_last_joined(prev, next, departed) do
     next_keys = channels_keyset(next)
 
-    if channels_keyset(prev) != next_keys do
-      :ok = persist_last_joined(prev.subject, prev.network_id, next_keys, prev.last_joined_persister)
+    if departed != [] or channels_keyset(prev) != next_keys do
+      :ok =
+        persist_last_joined(
+          prev.subject,
+          prev.network_id,
+          next_keys,
+          departed,
+          prev.last_joined_persister
+        )
     end
 
     :ok
@@ -5113,12 +5156,18 @@ defmodule Grappa.Session.Server do
     :ok = Broadcaster.to_user(state, Wire.archive_changed_payload(state.network_slug))
   end
 
-  @spec persist_last_joined(Grappa.Session.subject(), pos_integer(), [String.t()], last_joined_persister() | nil) :: :ok
-  defp persist_last_joined(_, _, _, nil), do: :ok
+  @spec persist_last_joined(
+          Grappa.Session.subject(),
+          pos_integer(),
+          [String.t()],
+          [String.t()],
+          last_joined_persister() | nil
+        ) :: :ok
+  defp persist_last_joined(_, _, _, _, nil), do: :ok
 
-  defp persist_last_joined(_, _, channels, fun)
-       when is_function(fun, 1) do
-    case fun.(channels) do
+  defp persist_last_joined(_, _, channels, departed, fun)
+       when is_function(fun, 2) do
+    case fun.(channels, departed) do
       :ok ->
         :ok
 

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -942,6 +942,22 @@ defmodule Grappa.Visitors do
   end
 
   @doc """
+  GH #1385 — the visitor session's rejoin-snapshot writer: applies a
+  membership CHANGE (`joined` keyset, `departed` channels) instead of
+  overwriting, so a drop inside the restore window cannot freeze the
+  partial keyset as the whole snapshot. Delegates to
+  `Credentials.merge_visitor_last_joined_channels/4`; the reasoning lives
+  there.
+  """
+  @spec merge_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()], [String.t()]) ::
+          :ok | {:error, :not_found | Ecto.Changeset.t()}
+  def merge_last_joined_channels(visitor_id, network_id, joined, departed)
+      when is_binary(visitor_id) and is_integer(network_id) and is_list(joined) and
+             is_list(departed) do
+    Credentials.merge_visitor_last_joined_channels(visitor_id, network_id, joined, departed)
+  end
+
+  @doc """
   #211 phase 4c — PER-NETWORK visitor "dismiss channel": remove
   `channel_name` from the `(visitor_id, network_id)` Credential's
   `last_joined_channels` rejoin list.

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -230,12 +230,15 @@ defmodule Grappa.Visitors.SessionPlan do
       # session's `network.id` so an accreted network-B session persists to
       # B's credential. A concurrent unbind between snapshot write and Repo
       # round-trip surfaces as `{:error, :not_found}` inside
-      # `update_last_joined_channels/3`, which `Session.Server`'s logger
+      # `merge_last_joined_channels/4`, which `Session.Server`'s logger
       # swallows non-fatally. The read side (`base_plan` +
       # `resolve/2`) already reads `cred.last_joined_channels` per-network,
-      # so write + read are now symmetric per-network.
-      last_joined_persister: fn channels ->
-        Visitors.update_last_joined_channels(visitor.id, network.id, channels)
+      # so write + read are now symmetric per-network. #1385 — the write
+      # MERGES the change into the row instead of overwriting it, and the
+      # visitor has no `autojoin_channels` to fall back on, so a truncated
+      # write here loses the whole rejoin source.
+      last_joined_persister: fn channels, departed ->
+        Visitors.merge_last_joined_channels(visitor.id, network.id, channels, departed)
       end,
       # #581 — the "recover my identity" secret SOURCE. Session.Server cannot
       # statically alias Networks/Visitors (Boundary cycle — Visitors deps

--- a/test/grappa/networks/last_joined_channels_test.exs
+++ b/test/grappa/networks/last_joined_channels_test.exs
@@ -159,6 +159,105 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     end
   end
 
+  # GH #1385 — the writer `Session.Server` actually uses. The setter above
+  # stays as the seed/reset primitive; a SESSION reaching for it is the
+  # defect this describe exists to prevent, because the live keyset is a
+  # strict prefix of the truth for the whole restore window.
+  describe "Credentials.merge_last_joined_channels/4" do
+    test "a live keyset short of the snapshot leaves the snapshot whole" do
+      {_, _, cred} = setup_credential()
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b #c))
+
+      assert :ok =
+               Credentials.merge_last_joined_channels(
+                 cred.user_id,
+                 cred.network_id,
+                 ["#a"],
+                 []
+               )
+
+      assert reload(cred).last_joined_channels == ~w(#a #b #c)
+    end
+
+    test "an EMPTY live keyset does not empty the snapshot" do
+      {_, _, cred} = setup_credential()
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b))
+
+      assert :ok = Credentials.merge_last_joined_channels(cred.user_id, cred.network_id, [], [])
+
+      assert reload(cred).last_joined_channels == ~w(#a #b)
+    end
+
+    test "a departure shrinks the snapshot" do
+      {_, _, cred} = setup_credential()
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b))
+
+      assert :ok =
+               Credentials.merge_last_joined_channels(
+                 cred.user_id,
+                 cred.network_id,
+                 ["#b"],
+                 ["#a"]
+               )
+
+      assert reload(cred).last_joined_channels == ["#b"]
+    end
+
+    test "a departure from a channel we were not live in still shrinks it" do
+      {_, _, cred} = setup_credential()
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #stale))
+
+      assert :ok =
+               Credentials.merge_last_joined_channels(
+                 cred.user_id,
+                 cred.network_id,
+                 ["#a"],
+                 ["#stale"]
+               )
+
+      assert reload(cred).last_joined_channels == ["#a"]
+    end
+
+    test "a channel joined for the first time is appended ahead of the stale tail" do
+      {_, _, cred} = setup_credential()
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ["#old"])
+
+      assert :ok =
+               Credentials.merge_last_joined_channels(
+                 cred.user_id,
+                 cred.network_id,
+                 ~w(#new #old),
+                 []
+               )
+
+      assert reload(cred).last_joined_channels == ~w(#new #old)
+    end
+
+    test "on overflow the cap drops the not-yet-rejoined tail, not the live keyset" do
+      {_, _, cred} = setup_credential()
+      stale = for n <- 1..200, do: "#stale-" <> String.pad_leading(Integer.to_string(n), 3, "0")
+      :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, stale)
+
+      assert :ok =
+               Credentials.merge_last_joined_channels(
+                 cred.user_id,
+                 cred.network_id,
+                 ["#live"],
+                 []
+               )
+
+      merged = reload(cred).last_joined_channels
+      assert length(merged) == 200
+      assert hd(merged) == "#live"
+      refute "#stale-200" in merged
+    end
+
+    test "{:error, :not_found} for unknown (user, network)" do
+      assert {:error, :not_found} =
+               Credentials.merge_last_joined_channels(Ecto.UUID.generate(), 999_999, ["#x"], [])
+    end
+  end
+
   describe "Credential.changeset/2 schema-level cap (H15, REV-D)" do
     # H15: defensive schema-level cap. The context helper
     # `update_last_joined_channels/3` truncates before building the

--- a/test/grappa/session/rejoin_snapshot_test.exs
+++ b/test/grappa/session/rejoin_snapshot_test.exs
@@ -19,7 +19,7 @@ defmodule Grappa.Session.RejoinSnapshotTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.IRCServer
+  alias Grappa.{IRCServer, Session}
   alias Grappa.Networks.{Credentials, SessionPlan}
   alias Grappa.PubSub.Topic
 
@@ -81,6 +81,27 @@ defmodule Grappa.Session.RejoinSnapshotTest do
     :ok = await_first_echo_persisted(server, user, pid)
 
     assert Credentials.get_credential!(user, network).last_joined_channels == @snapshot
+
+    :ok = GenServer.stop(pid, :normal, 1_000)
+  end
+
+  # The discriminator between sourcing the departures from the EVENT and
+  # diffing the keyset. `#c` is in the snapshot and NOT live (its JOIN never
+  # came back), so parting it moves no keyset at all: a diff sees nothing
+  # removed, writes nothing, and the channel the operator just left survives
+  # in the row to be re-JOINed on the next reconnect.
+  test "parting a channel we are not live in still drops it from the snapshot" do
+    %{server: server, user: user, network: network, pid: pid} = restoring_session()
+
+    :ok = await_first_echo_persisted(server, user, pid)
+
+    :ok = Session.send_part({:user, user.id}, network.id, "#c", nil)
+
+    # The cast persists BEFORE it puts PART on the wire, so the line is the
+    # write barrier.
+    {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PART #c\r\n"), 1_000)
+
+    assert Credentials.get_credential!(user, network).last_joined_channels == ~w(#a #b)
 
     :ok = GenServer.stop(pid, :normal, 1_000)
   end

--- a/test/grappa/session/rejoin_snapshot_test.exs
+++ b/test/grappa/session/rejoin_snapshot_test.exs
@@ -1,0 +1,100 @@
+defmodule Grappa.Session.RejoinSnapshotTest do
+  @moduledoc """
+  GH #1385 — `network_credentials.last_joined_channels` is the rejoin
+  snapshot: the set a reconnecting session plans its JOINs from
+  (`SessionPlan.merge_autojoin/2`). During the restore window that follows
+  a reconnect the live keyset (`state.members`) starts EMPTY and grows one
+  self-JOIN echo at a time, so any snapshot derived from it is a strict
+  PREFIX of the truth until the last echo lands.
+
+  These tests pin the two halves of the production loss measured on
+  2026-08-16: the prefix must not be persisted over the complete snapshot,
+  and a session that dies mid-restore must still plan the complete set on
+  its next boot.
+
+  `async: false` — `Grappa.SessionRegistry` / `SessionSupervisor` /
+  `Grappa.PubSub` are singletons.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.IRCServer
+  alias Grappa.Networks.{Credentials, SessionPlan}
+  alias Grappa.PubSub.Topic
+
+  @snapshot ["#a", "#b", "#c"]
+
+  defp start_server do
+    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {server, IRCServer.port(server)}
+  end
+
+  # A session mid-restore: the credential carries the complete pre-drop
+  # snapshot, the three planned JOINs are on the wire, and NOT ONE self-JOIN
+  # echo has come back yet. This is the exact state the `Read/Dead Error`
+  # wave of 2026-08-16 04:40 interrupted.
+  defp restoring_session do
+    {server, port} = start_server()
+    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+    {network, _} =
+      network_with_server(port: port, slug: "rj-#{System.unique_integer([:positive])}")
+
+    _ = credential_fixture(user, network, %{autojoin_channels: []})
+    :ok = Credentials.update_last_joined_channels(user.id, network.id, @snapshot)
+
+    pid = start_session_for(user, network)
+    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+    Enum.each(@snapshot, fn channel ->
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "JOIN " <> channel <> "\r\n"), 1_000)
+    end)
+
+    # Pre-state: the row still holds the COMPLETE set at the moment the
+    # restore window opens. Anything that shrinks it from here is this
+    # window's doing, not the fixture's.
+    assert Credentials.get_credential!(user, network).last_joined_channels == @snapshot
+
+    %{server: server, user: user, network: network, pid: pid}
+  end
+
+  # The persist runs in the same `handle_info` as the `channels_changed`
+  # broadcast, immediately AFTER it. So the broadcast alone is not a write
+  # barrier — a `:sys.get_state/1` call, serialized behind that same
+  # handle_info, is.
+  defp await_first_echo_persisted(server, user, pid) do
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+    IRCServer.feed(server, ":grappa-test!u@h JOIN :#a\r\n")
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "event", payload: %{kind: :channels_changed}},
+                   1_000
+
+    _ = :sys.get_state(pid)
+    :ok
+  end
+
+  test "one restored channel does not overwrite the snapshot with the prefix" do
+    %{server: server, user: user, network: network, pid: pid} = restoring_session()
+
+    :ok = await_first_echo_persisted(server, user, pid)
+
+    assert Credentials.get_credential!(user, network).last_joined_channels == @snapshot
+
+    :ok = GenServer.stop(pid, :normal, 1_000)
+  end
+
+  test "a session that dies mid-restore still plans the full set on its next boot" do
+    %{server: server, user: user, network: network, pid: pid} = restoring_session()
+
+    :ok = await_first_echo_persisted(server, user, pid)
+
+    # The drop. Whatever the snapshot said at this instant is what every
+    # subsequent reconnect restores — the permanence half of #1385.
+    :ok = GenServer.stop(pid, :normal, 1_000)
+
+    {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+    assert plan.autojoin_channels == @snapshot
+  end
+end


### PR DESCRIPTION
## What broke

`network_credentials.last_joined_channels` is the set a reconnecting session plans its
JOINs from. `Session.Server` wrote it **absolutely**, from `Map.keys(state.members)`, on
every membership mutation. After a reconnect that map starts EMPTY and grows one
self-JOIN echo at a time, so for the whole restore window the value written is a strict
**prefix** of the channels the subject is actually in.

A drop inside that window freezes the prefix as the snapshot. The next reconnect plans
from the truncated row, joins fewer channels, and re-persists the truncation. Nothing
restores the tail. Measured in production on 2026-08-16: `vjt` 11 channels → 7, `morph`
10 → 2, permanent until a human re-joined by hand (#1385).

## The line

The defect is not WHEN the write happens, it is WHAT is written:

```
row := (row ∪ live keyset) − the channels this change removed
```

An absent channel is merely not back yet; only a **departure** removes. So the restore
window is harmless and the snapshot still SHRINKS on a real `/part` or KICK — the
product constraint that rules out any "it never shrinks" fix. The union rather than a
pure delta also keeps the write self-healing: a swallowed persist error is repaired by
the next mutation, which a delta would have lost for good.

Gating the write on "the restore is complete" was rejected: it needs a completion signal
that a channel stuck in `in_flight_joins` (a 477 into the ChanServ invite retry) may
never give, and a session that stops persisting entirely is worse than the bug.

`departed` is sourced from the **event** that removed the channel (the self-only
`:parted` / `:kicked` effects, plus the eager `/part` cast), never from a diff of the
previous and current keyset.

## How the mechanism was bought

The issue proposed the mechanism without proving it. Measured instead, on `0a650e82`:

| | before fix | after |
|---|---|---|
| session mid-restore, 1 of 3 JOIN echoes back → persisted row | `["#a"]` | `["#a","#b","#c"]` |
| plan resolved for the NEXT boot after the drop | `["#a"]` | `["#a","#b","#c"]` |

Both are the issue's own shape, including the permanence half.

## The event-vs-diff distinction, and what it cost to buy

The diff form **survived 1753 tests** (session / networks / visitors /
channels-controller, 0 failures), so the distinction was argument-only at first. The
scenario that motivates the event form — a connection reset emptying the keyset in place
— is **not reachable**: a drop stops the session (`server.ex`,
`handle_info({:EXIT, client_pid, reason})` → `{:stop, {:client_exit, reason}}`) and it
respawns with `members: %{}` from `init/1`, so no persist ever runs on an emptied keyset.

The two forms DO diverge on a path production walks: **parting a channel that is in the
snapshot but not in the live keyset**. The keyset does not move, so the diff form
computes no departure, writes nothing, and the channel the operator just dismissed is
re-JOINed on the next reconnect. That test fails under the diff mutant
(`["#a","#b","#c"]` vs `["#a","#b"]`) and is the only one of the three that does — one
mutant, one assertion. Write barrier is the `PART #c` line on the wire, which the cast
emits after the persist.

## What is NOT established

- **My first reading of `server.ex` was on a stale tree** — the main checkout at
  `d86d1439`, 1271 lines behind this branch's base. Sanitised by re-reading on the
  branch and diffing the function across both revisions: `maybe_persist_last_joined` is
  byte-identical between them, so the diagnosis survives — but it was asserted before it
  was proven.
- **The `Read/Dead Error` wave itself is out of scope.** Whether it was upstream
  flood/throttle or a grappa-side reconnect storm is untouched here; this change is only
  about the snapshot surviving it correctly.
- **Repair of the rows already truncated in production is not done** and is not this
  PR's call. The change stops the loss, it does not undo it.
- **Visitors are not measured, only reasoned.** Their plan has no operator
  `autojoin_channels` to merge against, so a truncated write is strictly worse for them;
  the twin writer is fixed symmetrically, but no visitor case was reproduced.
- **Accepted cost, deliberately not engineered around:** a channel left from ANOTHER
  client while grappa is disconnected is unobservable, so the row keeps it and the next
  reconnect re-JOINs it. One channel too many beats one lost for good.
- **`update_last_joined_channels/3` survives as the seed/reset primitive** and now has
  no production caller. Deleting it means rewriting the existing cap / canonicalisation
  pins, which did not belong inside a data-loss hotfix — follow-up, not oversight.
