### PR TITLE
auth(#1387): the share-link redeem door joins the house failure window

### DIFF
--- a/cicchetto/src/AdminEventsTab.tsx
+++ b/cicchetto/src/AdminEventsTab.tsx
@@ -219,7 +219,7 @@ function renderEvent(ev: WireAdminEvent): string {
       return `${ev.user_name} unbound from ${ev.network_slug}${actorSuffix(ev.actor_user_name)}`;
     case "login_throttled":
       // S6 — a credential door's brute-force gate tripped for this source
-      // IP. Seven windows across five doors share this event, so the door
+      // IP. Eight windows across six doors share this event, so the door
       // and the key that crossed are what make it actionable: the fine key
       // says one account is being hammered from that address, the ceiling
       // says the address is spraying across accounts. Both are additive —

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -417,6 +417,7 @@ export const ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR = [
   "totp_login",
   "passkey_recovery",
   "passkey_login_options",
+  "share_token_consume",
 ] as const;
 export type AdminEventsWireLoginThrottleDoor =
   (typeof ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR)[number];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44406,3 +44406,40 @@ accept. Refusals are logged per occurrence: the volume is bounded by
 whatever rate upstream lets a sender INVITE at, and it rotates, whereas the
 alternative is an operator who never learns that invitations are being
 turned away.
+<!-- entry #1387 -->
+
+---
+
+## 2026-08-16 — #1387: the share-link redeem door joins the house credential policy
+
+`POST /auth/share/consume` is unauthenticated by design — the signed one-shot
+link IS the credential — and it was the last credential-adjacent door standing
+outside the per-source-address failure window the rest of them share. It now
+runs that window, with the house numbers adopted unchanged: ten failures per
+address per fifteen minutes, the same values its siblings carry. A freshly
+invented number would have been the only thing left on this door to justify.
+
+The window is read before the link is, so a shut door answers 429 identically
+whatever the body held, and costs the server no verification work. That is the
+same placement the sibling doors use — ahead of the expensive compare rather
+than after it.
+
+**Only a link this server cannot have issued loads the window.** Every other
+refusal here describes a link that WAS ours: already redeemed, run out, or
+outliving the identity behind it. Those are the shapes an honest holder
+produces — the second click, the client retrying its own request — and
+charging them would shut the door on precisely the person it exists for while
+bounding nothing an attacker could have reproduced. A well-formed link the
+signature does not vouch for is the same case as a malformed one and needs no
+separate rule.
+
+The crossing failure carries the sibling doors' exactly-once operator signal,
+naming this door and the per-address key that shut; the refusals that follow
+stay silent, so a spray cannot flood the admin ring with its own rejections.
+`:share_token_consume` therefore joins the `login_throttled` door enum — an
+additive widening the client already tolerates by construction, since a build
+that predates a door value keeps the alert and drops only the attribution.
+
+Out of scope by ruling: `:passkey_login_options` charges on success as well as
+failure, because the abuse it bounds is ceremony allocation rather than
+guessing. It stays exactly as it is.

--- a/lib/grappa/admin_events/wire.ex
+++ b/lib/grappa/admin_events/wire.ex
@@ -417,13 +417,15 @@ defmodule Grappa.AdminEvents.Wire do
           | :totp_login
           | :passkey_recovery
           | :passkey_login_options
+          | :share_token_consume
 
   @login_throttle_doors [
     :mode1_login,
     :visitor_login,
     :totp_login,
     :passkey_recovery,
-    :passkey_login_options
+    :passkey_login_options,
+    :share_token_consume
   ]
 
   @typedoc """
@@ -443,7 +445,7 @@ defmodule Grappa.AdminEvents.Wire do
   rejections.
 
   `door` + `scope` + `source_ip` together name the exact
-  `FailureWindow` row that crossed; without them seven windows would
+  `FailureWindow` row that crossed; without them eight windows would
   render as one indistinguishable line. Both are `optional` and a client
   MUST tolerate their absence: the ring is mirrored to disk and reloaded
   at boot (#215 Option B), so after this upgrade the Events tab still

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -82,7 +82,9 @@ defmodule GrappaWeb.ShareTokenController do
     * `:share_token_expired` → 410 Gone
     * `:share_token_consumed` → 410 Gone
 
-  Reused: `:client_token_scope` → 403 (#1353 — the mint takes a full
+  Reused: `:too_many_attempts` → 429 (#1387 — the redeem door under the
+  house per-address failure window, answering exactly as the other
+  credential doors do), `:client_token_scope` → 403 (#1353 — the mint takes a full
   session; the route's `:full_session` pipeline and
   `GrappaWeb.ShareToken.mint/2` answer with the same atom, so one body
   covers both), `:forbidden` (an incognito visitor trying to mint — #363),
@@ -95,8 +97,18 @@ defmodule GrappaWeb.ShareTokenController do
   alias Grappa.{Accounts, AdminEvents, ShareTokens, Visitors}
   alias Grappa.Accounts.User
   alias Grappa.AdminEvents.Wire, as: EventsWire
+  alias Grappa.RateLimit.FailureWindow
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.{AuthJSON, RemoteIP, ShareToken, Subject}
+
+  # #1387 — the redeem door runs the house credential policy: a FAILURE
+  # window per source address, the same shape and the same numbers its
+  # sibling doors run. It is the last credential-adjacent door that stood
+  # outside that policy, and the values are adopted unchanged precisely
+  # so there is nothing here left to justify separately.
+  @throttle_bucket :share_token_consume
+  @throttle_max_failures 10
+  @throttle_window_ms :timer.minutes(15)
 
   @doc """
   `POST /me/share-token` — self-mint for the calling subject.
@@ -197,6 +209,8 @@ defmodule GrappaWeb.ShareTokenController do
   `POST /auth/share/consume` — unauthenticated, body `{token}`.
 
   Flow (claim-then-release, #593):
+    0. The house failure window for the source address (#1387) → 429
+       once it is shut, ahead of every step below.
     1. Validate body shape (token present + binary) → 400 otherwise.
     2. `ShareToken.verify/1` → 401 on bad signature or on a payload
        that is not a known subject tag, 410 on TTL elapsed. The
@@ -226,6 +240,7 @@ defmodule GrappaWeb.ShareTokenController do
           Plug.Conn.t()
           | {:error,
              :bad_request
+             | :too_many_attempts
              | :unauthorized
              | :share_token_expired
              | :share_token_consumed
@@ -233,7 +248,10 @@ defmodule GrappaWeb.ShareTokenController do
              | :db_unavailable
              | Ecto.Changeset.t()}
   def consume(conn, %{"token" => token}) when is_binary(token) and token != "" do
-    with {:ok, subject} <- ShareToken.verify(token),
+    ip = format_ip(conn)
+
+    with :ok <- check_window(ip),
+         {:ok, subject} <- verify_token(token, ip),
          :ok <- mark_consumed(token) do
       # The one-shot claim is now HELD by this request (mark_consumed
       # returned :ok — we won any race). #593 — every failure past this
@@ -242,11 +260,12 @@ defmodule GrappaWeb.ShareTokenController do
       # #518) leaves the link usable instead of silently dead.
       mint_session(conn, token, subject)
     else
-      # Pre-consume rejects (bad signature / expired / lost the one-shot
-      # race → :share_token_consumed). NOTHING to release here: either no
-      # claim was taken, or the claim belongs to the WINNING request —
-      # releasing it would resurrect a token that already minted a
-      # session (dead-link → double-redemption, a worse bug).
+      # Pre-consume rejects (window shut / bad signature / expired / lost
+      # the one-shot race → :share_token_consumed). NOTHING to release
+      # here: either no claim was taken, or the claim belongs to the
+      # WINNING request — releasing it would resurrect a token that
+      # already minted a session (dead-link → double-redemption, a
+      # worse bug).
       {:error, reason} -> reject(reason)
     end
   end
@@ -292,12 +311,69 @@ defmodule GrappaWeb.ShareTokenController do
     end
   end
 
-  # The closed set of rejection reasons — pre-consume (bad sig / expired /
-  # lost the one-shot race) and post-consume (visitor reaped / saturated
-  # mint / mint changeset). Typed over a bare `atom()` per CLAUDE.md's
-  # closed-set rule.
+  # #1387 — the window is read BEFORE anything else this action does, so
+  # a shut door costs the server no signature work and the caller no
+  # further information: the answer is the same 429 whatever was in the
+  # body. Its sibling doors place the check the same way, ahead of the
+  # expensive compare rather than after it.
+  @spec check_window(String.t() | nil) :: :ok | {:error, :too_many_attempts}
+  defp check_window(ip) do
+    case FailureWindow.check(@throttle_bucket, ip, @throttle_max_failures) do
+      :ok -> :ok
+      {:error, :limited} -> {:error, :too_many_attempts}
+    end
+  end
+
+  # The ONE charging site (#1387). `ShareToken.verify/1` answers
+  # `:unauthorized` for a signature that does not hold and for a payload
+  # this branch cannot route — one condition, not two, since neither can
+  # have come from a link this server issued. That is the shape worth
+  # bounding, and it is the only outcome of this action a caller can
+  # reach by trying.
+  #
+  # Every other refusal describes a link that WAS ours — already
+  # redeemed, run out, or outliving the identity behind it. Those are
+  # the shapes an honest holder produces on their own second click, and
+  # charging them would shut the door on precisely the person it exists
+  # for while costing an attacker nothing they could have reproduced.
+  @spec verify_token(String.t(), String.t() | nil) ::
+          {:ok, ShareToken.subject()} | {:error, :unauthorized | :share_token_expired}
+  defp verify_token(token, ip) do
+    case ShareToken.verify(token) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, :share_token_expired} = err ->
+        err
+
+      {:error, :unauthorized} = err ->
+        :ok = charge_window(ip)
+        err
+    end
+  end
+
+  # Record the failure and, on the crossing one ONLY, tell the operator
+  # which door and which key shut — the sibling doors' exactly-once
+  # signal. Emitting on every subsequent refusal would let a spray flood
+  # the admin ring with its own rejections.
+  @spec charge_window(String.t() | nil) :: :ok
+  defp charge_window(ip) do
+    count = FailureWindow.record_failure(@throttle_bucket, ip, @throttle_window_ms)
+
+    if count == @throttle_max_failures do
+      AdminEvents.record(EventsWire.login_throttled(@throttle_bucket, :ip, ip, count, @throttle_window_ms))
+    end
+
+    :ok
+  end
+
+  # The closed set of rejection reasons — the shut window, pre-consume
+  # (bad sig / expired / lost the one-shot race) and post-consume
+  # (visitor reaped / saturated mint / mint changeset). Typed over a bare
+  # `atom()` per CLAUDE.md's closed-set rule.
   @typep reject_reason ::
-           :unauthorized
+           :too_many_attempts
+           | :unauthorized
            | :share_token_expired
            | :share_token_consumed
            | :not_found

--- a/test/grappa/admin_events/wire_test.exs
+++ b/test/grappa/admin_events/wire_test.exs
@@ -101,6 +101,12 @@ defmodule Grappa.AdminEvents.WireTest do
       assert event.scope == :ip_account
     end
 
+    test "the share-link redeem door is in the closed set (#1387)" do
+      event = Wire.login_throttled(:share_token_consume, :ip, "203.0.113.7", 10, 900_000)
+      assert event.door == :share_token_consume
+      assert event.scope == :ip
+    end
+
     test "refuses a door outside the closed set" do
       assert_raise FunctionClauseError, fn ->
         Wire.login_throttled(:not_a_door, :ip, "203.0.113.7", 10, 900_000)

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -23,6 +23,11 @@ defmodule GrappaWeb.ShareTokenControllerTest do
     * subject row deleted between mint and consume → 404 not_found
     * missing token param → 400 bad_request
 
+  Consume side, house failure window (#1387):
+    * past the per-IP limit → 429, before the link is read
+    * a spent / expired / orphaned link → never loads the window
+    * the crossing → one `:login_throttled` naming this door
+
   Wire shape (mint):
     %{token: "<signed>", expires_at: "<ISO8601 UTC>"}
 
@@ -40,6 +45,8 @@ defmodule GrappaWeb.ShareTokenControllerTest do
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, ShareTokens}
+  alias Grappa.PubSub.Topic
+  alias Grappa.RateLimit.FailureWindow
   alias Grappa.Repo.BusyRetry
   alias GrappaWeb.ShareToken
 
@@ -412,6 +419,127 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       assert Phoenix.ConnTest.build_conn()
              |> post("/auth/share/consume", %{"token" => token})
              |> json_response(410) == %{"error" => "share_token_consumed"}
+    end
+  end
+
+  # ----- consume-throttle helpers (#1387) — module level; ExUnit forbids
+  # defp inside describe. Each test below gets its OWN source address:
+  # the window is per-IP, so a distinct address isolates one test's
+  # counter from the sibling describes (all on 127.0.0.1) and from any
+  # file sharing the process-wide ETS table.
+  defp with_ip(conn, d), do: %{conn | remote_ip: {10, 67, 0, d}}
+
+  defp consume_invalid(conn, d) do
+    conn |> with_ip(d) |> post("/auth/share/consume", %{"token" => "not-a-signed-token"})
+  end
+
+  defp consume(conn, d, token) do
+    conn |> with_ip(d) |> post("/auth/share/consume", %{"token" => token})
+  end
+
+  defp minted_for_new_visitor do
+    visitor = visitor_fixture()
+    {:ok, {token, _}} = ShareToken.mint({:visitor, visitor.id}, :web)
+    {visitor, token}
+  end
+
+  describe "POST /auth/share/consume — house failure window (#1387)" do
+    # Clear only THIS door's rows for the addresses used below. Wiping
+    # the whole table (the sibling files' idiom) would reach into a
+    # concurrently running file's window, and this file is `async: true`.
+    setup do
+      for d <- 1..6, do: :ok = FailureWindow.clear(:share_token_consume, "10.67.0.#{d}")
+      :ok
+    end
+
+    test "past the limit the address is refused before the link is even read", %{conn: conn} do
+      {_, token} = minted_for_new_visitor()
+
+      for _ <- 1..10 do
+        assert json_response(consume_invalid(conn, 1), 401) == %{"error" => "unauthorized"}
+      end
+
+      # The check precedes verification: a GENUINE link presented from the
+      # same address is refused without being read.
+      assert json_response(consume(conn, 1, token), 429) == %{"error" => "too_many_attempts"}
+
+      # And the refusal did not spend it — the window is a property of the
+      # address, never of the link, so another address still redeems.
+      assert Phoenix.ConnTest.build_conn()
+             |> consume(2, token)
+             |> json_response(200)
+    end
+
+    test "a spent link retried from the same address never loads the window", %{conn: conn} do
+      # The honest double click, and the PWA that retries its own request.
+      # Charging that shape locks out precisely the legitimate holder.
+      {_, token} = minted_for_new_visitor()
+      assert json_response(consume(conn, 3, token), 200)
+
+      for _ <- 1..12 do
+        assert json_response(consume(conn, 3, token), 410) == %{"error" => "share_token_consumed"}
+      end
+
+      # Nothing was charged: the address still has its whole window, so an
+      # unreadable token gets a first-failure answer rather than a refusal.
+      assert json_response(consume_invalid(conn, 3), 401) == %{"error" => "unauthorized"}
+    end
+
+    test "a link that has run out never loads the window", %{conn: conn} do
+      visitor = visitor_fixture()
+
+      token =
+        Phoenix.Token.sign(GrappaWeb.Endpoint, @salt, {:visitor, visitor.id},
+          signed_at: System.system_time(:second) - @max_age_seconds - 60
+        )
+
+      for _ <- 1..12 do
+        assert json_response(consume(conn, 4, token), 410) == %{"error" => "share_token_expired"}
+      end
+
+      assert json_response(consume_invalid(conn, 4), 401) == %{"error" => "unauthorized"}
+    end
+
+    test "a link whose subject is gone never loads the window", %{conn: conn} do
+      # The signature held, so the holder is not guessing at anything: the
+      # row went away underneath a real link. That is the reaper's timing,
+      # not the caller's conduct.
+      {visitor, token} = minted_for_new_visitor()
+      :ok = Grappa.Visitors.delete(visitor.id)
+
+      for _ <- 1..12 do
+        assert json_response(consume(conn, 5, token), 404) == %{"error" => "not_found"}
+      end
+
+      assert json_response(consume_invalid(conn, 5), 401) == %{"error" => "unauthorized"}
+    end
+
+    test "crossing the limit names this door to the operator, exactly once", %{conn: conn} do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.admin_events())
+
+      for _ <- 1..10, do: consume_invalid(conn, 6)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "grappa:admin:events",
+                       payload: %{
+                         kind: :login_throttled,
+                         door: :share_token_consume,
+                         scope: :ip,
+                         source_ip: "10.67.0.6",
+                         failures: 10
+                       }
+                     },
+                     500
+
+      # The rejections that follow must not re-emit, or a spray floods the
+      # admin stream with its own refusals. Matched on THIS door so a
+      # concurrent file's throttle can't answer for it.
+      _ = consume_invalid(conn, 6)
+
+      refute_receive %Phoenix.Socket.Broadcast{
+                       payload: %{kind: :login_throttled, door: :share_token_consume}
+                     },
+                     200
     end
   end
 


### PR DESCRIPTION
## What this does

`POST /auth/share/consume` is unauthenticated by design — the signed one-shot
link IS the credential — and it was the last credential-adjacent door standing
outside the per-source-address failure window the rest of them share. It now
runs that window, with the house numbers adopted unchanged: **ten failures per
address per fifteen minutes**, the same values its siblings carry. Inventing a
number here would have left this door the only one with something of its own
to justify.

The window is read before the link is, so a shut door answers the same 429
whatever the body held and costs the server no verification work — the
placement the sibling doors already use.

**Only a link this server cannot have issued loads the window.** Every other
refusal describes a link that WAS ours: already redeemed, run out, or
outliving the identity behind it. Those are the shapes an honest holder
produces on their own second click, and charging them would shut the door on
precisely the person it exists for.

The crossing failure carries the sibling doors' exactly-once operator signal,
so `:share_token_consume` joins the `login_throttled` door enum. The widening
is additive: a client that predates the value keeps the alert and drops only
the attribution it cannot name. That is the whole cic-side change — the door
renders as a label, so no per-door copy was needed.

`:passkey_login_options` is ruled out of scope and stays as it is.

## Tests

Written first. Two of the five were RED before the change; the other three
state what must NOT happen, so each was measured against its own mutant:

| Mutant (one line, at the site named) | Test killed |
| --- | --- |
| charge on a link that ran out | `a link that has run out never loads the window` |
| charge on a link already redeemed | `a spent link retried from the same address never loads the window` |
| charge on a link whose subject is gone | `a link whose subject is gone never loads the window` |

Each mutant killed exactly one test, and the right one — 1 failure of 33 in
all three runs.

## Gates

- `scripts/check.sh` — RC=0 (format, Credo, Dialyzer, Sobelow, doctor, bats;
  8 doctests, 60 properties, 6345 tests, 0 failures)
- `scripts/bun.sh run check` / `run build` / `run test` — RC=0 each
  (5506 cic tests). Run because the wire enum widened.
- `scripts/design-notes-gate.sh` — 1 new entry, separator + marker present
- STACK / integration not requested: no client-facing shape change beyond a
  generated enum member the client already tolerates, and the surface is a
  429 the FallbackController and cic already render for five other doors.