### PR TITLE
settings(#1375): hold the read and the write of `data` in one transaction

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43691,3 +43691,67 @@ lost for good. Do not build machinery on top of this.
 
 Repair of the rows already truncated in production is a separate,
 operator-owned decision — this change stops the loss, it does not undo it.
+<!-- entry #1375 -->
+
+---
+
+## 2026-08-16 — #1375: one write path for the settings blob, and what a one-connection harness can prove about a race
+
+`user_settings.data` is a single JSON column, so a setter that reads the blob,
+merges its key and writes it back necessarily writes the WHOLE column. Nine
+setters spelled that read-modify-write pair by hand, plus
+`rename_muted_target/4`, so two writers touching completely DIFFERENT keys both
+read the same snapshot, both write a full replacement, and the second commit
+drops the first's key — with `{:ok, _}` on both sides and nothing in the logs.
+
+The durable rule is the one the module now states in its moduledoc: **there is
+exactly ONE writer, `update_data/2`, and it holds the read and the write in a
+single `Repo.immediate_transaction/1`.** A new setter that spells its own pair
+reintroduces the defect for its own key. The nesting is #1374's — retry
+OUTSIDE, transaction INSIDE — which is why the row init inside it is the
+non-retrying `get_or_init!/1`: a retry loop opened inside an open transaction
+sleeps on the connection it holds.
+
+### The interleave was reproduced, not argued
+
+Ecto's per-query telemetry (`[:grappa, :repo, :query]`, the event
+`Grappa.DbLatency` already folds) runs its handlers SYNCHRONOUSLY in the
+process that issued the query. A handler that blocks on the writer's
+`user_settings` SELECT therefore suspends it exactly between its read and its
+write, with no seam in production code and no sleep-and-hope — the second
+writer is signalled from inside that window.
+`test/grappa/user_settings_concurrency_test.exs` drives the pair the issue
+names as reachable in production (`put_last_client_prefix64/2` fires from
+`Vhosts.record_client_source/2` on every client connect, in the socket's own
+process and its own connection of the ten, while a settings-drawer PUT runs in
+another). Unfixed, the key written in the window comes back `nil`.
+
+### What the harness substitutes, and what it therefore cannot buy
+
+In production the serialisation comes from SQLite's file-level write lock: the
+second `BEGIN IMMEDIATE` waits out `busy_timeout` and its read then sees the
+first writer's commit. The Sandbox has ONE connection (`config/test.exs`,
+`pool_size: 1`), so in the test the second writer blocks on the checkout the
+open transaction holds. Same serialisation, different lock.
+
+So these tests prove the read and the write are ONE transaction — removing the
+transaction kills exactly one assertion in each of them — and they do NOT prove
+the `:immediate` spelling of it. That was measured, not assumed: with
+`Repo.transaction/1` in place of `Repo.immediate_transaction/1` both tests stay
+green, because nested under the Sandbox every mode is a `SAVEPOINT` (the same
+blind spot #1374 records for its own conversions, and the reason its gate on
+the spelling is a static AST walk rather than an ExUnit oracle). The
+`:immediate` spelling here rests on `Repo.immediate_transaction/1`'s own
+contract (#524: a deferred transaction's read→write upgrade raises a
+`SQLITE_BUSY` that `busy_timeout` does not cover), not on anything this branch
+measured.
+
+### Accepted cost
+
+`rename_muted_target/4` now opens a write transaction even when it turns out to
+have nothing to migrate, and it is called once per peer NICK change per live
+session. The alternative — decide on a read taken OUTSIDE the transaction and
+re-read inside when there is work — buys back a sub-millisecond, WAL-frame-free
+lock acquisition at the price of a second SELECT on the write path and a
+duplicated "is this key muted?" predicate. Not taken; if nick-change churn ever
+shows up in the #357 write-latency counters, that is the knob.

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -25,12 +25,27 @@ defmodule Grappa.UserSettings do
 
   ## Access model
 
-  - **Writers** use `get_or_init/1` first (which creates the row on
-    first access), then a typed accessor (`set_highlight_patterns/2`).
+  - **Writers** call a typed setter (`set_highlight_patterns/2`), which
+    routes through the ONE private write path, `update_data/2`.
   - **Readers** use typed accessors directly (`get_highlight_patterns/1`),
     which return safe defaults (`[]`, `nil`, etc.) when no row exists.
     Readers do NOT auto-create the row — side-effect-free reads are
     observable-stable and don't pollute the DB with empty rows.
+
+  ## One write path, because a JSON blob loses concurrent writes (#1375)
+
+  `data` is a single column. Every setter necessarily REPLACES it whole, so
+  a read-modify-write pair that straddles another writer's commit drops that
+  writer's key — two writers touching completely DIFFERENT keys, last one
+  wins, no error anywhere. That is not hypothetical: `put_last_client_prefix64/2`
+  fires from `Grappa.Vhosts.record_client_source/2` on every client connect,
+  in the socket's own process and its own pool connection, while the settings
+  drawer PUTs from another.
+
+  So there is exactly ONE writer here — `update_data/2` — and it holds the
+  read and the write in a single `Repo.immediate_transaction/1`. A new
+  setter MUST go through it; a second read-modify-write pair spelled by
+  hand reintroduces the defect for its own key.
 
   ## String-key invariant
 
@@ -341,15 +356,29 @@ defmodule Grappa.UserSettings do
   @spec get_or_init(Subject.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def get_or_init({_, _} = subject) do
+    # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
+    # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518).
+    do_get_or_init(subject, fn op -> Repo.BusyRetry.run(op) end)
+  end
+
+  # In-transaction twin of `get_or_init/1` (#1375): the row init as the first
+  # statement of `update_data/2`'s transaction. NO retry of its own — the
+  # enclosing `BusyRetry.run/1` retries the WHOLE transaction, and a nested
+  # retry would sleep holding the open transaction's connection, extending the
+  # very contention it waits on. The bang is that contract: a transient busy
+  # RAISES through to the enclosing budget instead of becoming a return value.
+  @spec get_or_init!(Subject.t()) :: {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  defp get_or_init!(subject), do: do_get_or_init(subject, fn op -> op.() end)
+
+  @spec do_get_or_init(Subject.t(), ((-> term()) -> term())) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp do_get_or_init(subject, run) do
     with :ok <- validate_subject_exists(subject) do
       attrs = Subject.put_subject_id(%{data: %{}}, subject)
       cs = Settings.changeset(%Settings{}, attrs)
 
-      # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
-      # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518)
-      # at every PUT /me/settings setter (they all init through here first).
       insert_result =
-        Repo.BusyRetry.run(fn ->
+        run.(fn ->
           Repo.insert(cs, on_conflict: :nothing, conflict_target: conflict_target(subject))
         end)
 
@@ -440,11 +469,8 @@ defmodule Grappa.UserSettings do
   @spec set_highlight_patterns(Subject.t(), [String.t()]) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def set_highlight_patterns({_, _} = subject, patterns) when is_list(patterns) do
-    with :ok <- validate_patterns(patterns, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, "highlight_patterns", patterns)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_patterns(patterns, subject) do
+      update_data(subject, &Map.put(&1, "highlight_patterns", patterns))
     end
   end
 
@@ -584,11 +610,9 @@ defmodule Grappa.UserSettings do
   @spec put_notification_prefs(Subject.t(), notification_prefs()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_notification_prefs({_, _} = subject, prefs) when is_map(prefs) do
-    with {:ok, normalized} <- validate_and_normalize_prefs(prefs, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @notification_prefs_key, stringify_prefs(normalized))
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_prefs(prefs, subject) do
+      stringified = stringify_prefs(normalized)
+      update_data(subject, &Map.put(&1, @notification_prefs_key, stringified))
     end
   end
 
@@ -645,13 +669,17 @@ defmodule Grappa.UserSettings do
     if old_key == new_key do
       {:ok, :noop}
     else
-      rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      # Same `data` blob, same lost-update hazard as the setters (#1375), so
+      # the same frame — but NOT `update_data/2`: a rename must never CREATE
+      # the row, and it reports which of the two things it did.
+      write_transaction(fn ->
+        rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      end)
     end
   end
 
-  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) ::
-          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp rekey_muted_target(nil, _, _), do: {:ok, :noop}
+  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) :: :renamed | :noop
+  defp rekey_muted_target(nil, _, _), do: :noop
 
   defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
     prefs = Map.get(settings.data, @notification_prefs_key, %{})
@@ -659,19 +687,16 @@ defmodule Grappa.UserSettings do
 
     case is_map(muted) and Map.has_key?(muted, old_key) do
       false ->
-        {:ok, :noop}
+        :noop
 
       true ->
         {entry, without_old} = Map.pop(muted, old_key)
         # put_new, not put: the destination's own entry wins the collision.
         next_muted = Map.put_new(without_old, new_key, entry)
         next_prefs = Map.put(prefs, "muted_targets", next_muted)
-        next_data = Map.put(settings.data, @notification_prefs_key, next_prefs)
 
-        case persist(Settings.changeset(settings, %{data: next_data})) do
-          {:ok, _} -> {:ok, :renamed}
-          {:error, _} = error -> error
-        end
+        _ = write_data!(settings, Map.put(settings.data, @notification_prefs_key, next_prefs))
+        :renamed
     end
   end
 
@@ -719,16 +744,8 @@ defmodule Grappa.UserSettings do
   @spec put_upload_ttl_seconds(Subject.t(), pos_integer() | nil) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_upload_ttl_seconds({_, _} = subject, seconds) do
-    with :ok <- validate_upload_ttl_seconds(seconds, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        case seconds do
-          nil -> Map.delete(settings.data, @upload_ttl_seconds_key)
-          n -> Map.put(settings.data, @upload_ttl_seconds_key, n)
-        end
-
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_upload_ttl_seconds(seconds, subject) do
+      update_data(subject, &put_or_delete(&1, @upload_ttl_seconds_key, seconds))
     end
   end
 
@@ -822,20 +839,12 @@ defmodule Grappa.UserSettings do
   def put_auto_away_debounce_seconds({_, _} = subject, value, subject_label)
       when is_binary(subject_label) do
     with :ok <- validate_auto_away_debounce_seconds(value, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        case value do
-          nil -> Map.delete(settings.data, @auto_away_debounce_seconds_key)
-          :disabled -> Map.put(settings.data, @auto_away_debounce_seconds_key, 0)
-          n -> Map.put(settings.data, @auto_away_debounce_seconds_key, n)
-        end
-
-      cs = Settings.changeset(settings, %{data: merged_data})
-
-      with {:ok, saved} <- persist(cs) do
-        :ok = broadcast_auto_away_debounce(value, subject_label)
-        {:ok, saved}
-      end
+         {:ok, saved} <- update_data(subject, &put_auto_away_debounce(&1, value)) do
+      # AFTER the transaction returned, never inside it: a retried attempt
+      # (`BusyRetry` wraps `update_data/2`'s transaction) would re-announce a
+      # change that had been rolled back.
+      :ok = broadcast_auto_away_debounce(value, subject_label)
+      {:ok, saved}
     end
   end
 
@@ -866,6 +875,15 @@ defmodule Grappa.UserSettings do
         Wire.auto_away_debounce_changed(value)
       )
   end
+
+  # Write-side twin of `decode_auto_away_debounce/1`: `:disabled` is the `0`
+  # sentinel on the JSON side, `nil` clears the key back to the server default.
+  @spec put_auto_away_debounce(map(), auto_away_debounce()) :: map()
+  defp put_auto_away_debounce(data, :disabled),
+    do: Map.put(data, @auto_away_debounce_seconds_key, 0)
+
+  defp put_auto_away_debounce(data, value),
+    do: put_or_delete(data, @auto_away_debounce_seconds_key, value)
 
   @spec decode_auto_away_debounce(term()) :: auto_away_debounce()
   defp decode_auto_away_debounce(0), do: :disabled
@@ -940,11 +958,8 @@ defmodule Grappa.UserSettings do
   @spec put_vhost_selection(Subject.t(), [String.t()]) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_vhost_selection({_, _} = subject, addresses) when is_list(addresses) do
-    with :ok <- validate_vhost_selection(addresses, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @vhost_selection_key, addresses)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_vhost_selection(addresses, subject) do
+      update_data(subject, &Map.put(&1, @vhost_selection_key, addresses))
     end
   end
 
@@ -1001,11 +1016,8 @@ defmodule Grappa.UserSettings do
   @spec put_last_client_prefix64(Subject.t(), String.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_last_client_prefix64({_, _} = subject, hex) when is_binary(hex) do
-    with :ok <- validate_base16(hex, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @last_client_prefix64_key, hex)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_base16(hex, subject) do
+      update_data(subject, &Map.put(&1, @last_client_prefix64_key, hex))
     end
   end
 
@@ -1080,20 +1092,14 @@ defmodule Grappa.UserSettings do
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_theme_pair({_, _} = subject, light_id, dark_id) do
     with :ok <- validate_theme_pointer(light_id, subject, :active_theme_id),
-         :ok <- validate_theme_pointer(dark_id, subject, :dark_theme_id),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        settings.data
+         :ok <- validate_theme_pointer(dark_id, subject, :dark_theme_id) do
+      update_data(subject, fn data ->
+        data
         |> put_or_delete(@active_theme_id_key, light_id)
         |> put_or_delete(@dark_theme_id_key, dark_id)
-
-      persist(Settings.changeset(settings, %{data: merged_data}))
+      end)
     end
   end
-
-  # Merge helper: a positive id is stored, a nil clears the key.
-  defp put_or_delete(data, key, nil), do: Map.delete(data, key)
-  defp put_or_delete(data, key, id), do: Map.put(data, key, id)
 
   @spec validate_theme_pointer(term(), Subject.t(), atom()) :: :ok | {:error, Ecto.Changeset.t()}
   defp validate_theme_pointer(nil, _, _), do: :ok
@@ -1192,11 +1198,8 @@ defmodule Grappa.UserSettings do
   @spec set_aliases(Subject.t(), %{optional(String.t()) => term()}) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def set_aliases({_, _} = subject, aliases) when is_map(aliases) do
-    with {:ok, normalized} <- validate_and_normalize_aliases(aliases, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @aliases_key, normalized)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_aliases(aliases, subject) do
+      update_data(subject, &Map.put(&1, @aliases_key, normalized))
     end
   end
 
@@ -1282,11 +1285,8 @@ defmodule Grappa.UserSettings do
   @spec put_display_prefs(Subject.t(), map()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_display_prefs({_, _} = subject, prefs) when is_map(prefs) do
-    with {:ok, normalized} <- validate_and_normalize_display_prefs(prefs, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @display_prefs_key, normalized)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_display_prefs(prefs, subject) do
+      update_data(subject, &Map.put(&1, @display_prefs_key, normalized))
     end
   end
 
@@ -1294,14 +1294,51 @@ defmodule Grappa.UserSettings do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # #523 — the single write choke point for every setter. Rides out a transient
-  # SQLITE_BUSY on the `user_settings` UPDATE; sustained saturation degrades to
-  # `{:error, :db_unavailable}` → a clean 503 (#518) at the PUT /me/settings
-  # family instead of a 500 raise. `Repo.update/1` returns exactly the
-  # `{:ok, _} | {:error, changeset}` shape `BusyRetry.run/1` expects.
-  @spec persist(Ecto.Changeset.t()) ::
+  # #1375 — the single write path for every `data` key. `fun` receives the
+  # CURRENT `data` map and returns the next one; it must be pure, because a
+  # `BusyRetry` retry replays the whole transaction and therefore replays it.
+  #
+  # Read and write are ONE `BEGIN IMMEDIATE` transaction (see the moduledoc):
+  # SQLite serialises writers at the file level, so a concurrent writer waits
+  # for this commit and then reads the merged blob, instead of overwriting it
+  # from a snapshot taken before it.
+  @spec update_data(Subject.t(), (map() -> map())) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp persist(cs), do: Repo.BusyRetry.run(fn -> Repo.update(cs) end)
+  defp update_data(subject, fun) do
+    write_transaction(fn ->
+      case get_or_init!(subject) do
+        {:ok, settings} -> write_data!(settings, fun.(settings.data))
+        {:error, cs} -> Repo.rollback(cs)
+      end
+    end)
+  end
+
+  # The retry goes OUTSIDE the transaction and the transaction INSIDE it — the
+  # `Grappa.Visitors.create_anon/4` nesting. A retry loop opened inside an
+  # already-open transaction would sleep while holding that transaction's
+  # connection, extending the very contention it waits on. #523's degrade
+  # contract is unchanged: sustained saturation still surfaces as
+  # `{:error, :db_unavailable}` → a clean 503 (#518) at PUT /me/settings.
+  @typep write_result :: Settings.t() | :renamed | :noop
+  @spec write_transaction((-> write_result())) ::
+          {:ok, write_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp write_transaction(fun), do: Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)
+
+  # The module's only `Repo.update`. In-transaction by construction, so a
+  # changeset error ROLLS BACK rather than returning into a half-applied
+  # transaction; `write_transaction/1` surfaces it as `{:error, changeset}`.
+  @spec write_data!(Settings.t(), map()) :: Settings.t()
+  defp write_data!(settings, data) do
+    case Repo.update(Settings.changeset(settings, %{data: data})) do
+      {:ok, saved} -> saved
+      {:error, cs} -> Repo.rollback(cs)
+    end
+  end
+
+  # Merge helper: a value is stored, a nil clears the key.
+  @spec put_or_delete(map(), String.t(), term()) :: map()
+  defp put_or_delete(data, key, nil), do: Map.delete(data, key)
+  defp put_or_delete(data, key, value), do: Map.put(data, key, value)
 
   # Mirror of `Grappa.QueryWindows.conflict_target/1` — partial
   # indexes carry the predicate so the upsert must repeat it.

--- a/test/grappa/user_settings_concurrency_test.exs
+++ b/test/grappa/user_settings_concurrency_test.exs
@@ -1,0 +1,127 @@
+defmodule Grappa.UserSettingsConcurrencyTest do
+  @moduledoc """
+  #1375 — two writers, two DIFFERENT `data` keys, neither write lost.
+
+  `user_settings.data` is one JSON column, so every setter writes it WHOLE.
+  A setter that reads the blob, merges its key and writes it back drops any
+  key another writer committed in between — silently, with `{:ok, _}` on both
+  sides. The pair driven here is the pair the issue names as reachable in
+  production: `put_last_client_prefix64/2` fires from
+  `Grappa.Vhosts.record_client_source/2` on every client connect, in the
+  socket's own process, while a settings-drawer PUT runs in another.
+
+  ## How the interleave is forced
+
+  Ecto's per-query telemetry (`[:grappa, :repo, :query]`, the event
+  `Grappa.DbLatency` already folds) runs its handlers SYNCHRONOUSLY in the
+  process that issued the query. Attaching a handler that blocks on the
+  writer's `user_settings` SELECT therefore suspends it exactly between its
+  read and its write — no production code has a test seam in it, and there is
+  no sleep-and-hope: the second writer is signalled from inside that window.
+
+  ## What the harness substitutes, and what it therefore cannot buy
+
+  In production the two writers hold two of the pool's ten connections and
+  the serialisation comes from SQLite's file-level write lock: the second
+  `BEGIN IMMEDIATE` waits out `busy_timeout` and its read then sees the first
+  writer's commit. The Sandbox has ONE connection (`config/test.exs`,
+  `pool_size: 1`), so here the second writer blocks on the checkout the open
+  transaction holds. Same serialisation, different lock — which is why these
+  tests prove that the read and the write are ONE transaction, and do NOT
+  prove the `:immediate` spelling of it. That distinction is invisible at
+  runtime under the Sandbox (nested, every mode is a `SAVEPOINT`) and both
+  tests stay green with `Repo.transaction/1` — measured, not assumed.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{Accounts, UserSettings}
+  alias Grappa.IRC.Identifier
+  alias Grappa.UserSettings.Settings
+
+  @handler_id {__MODULE__, :pause_between_read_and_write}
+
+  # How long the paused writer waits for the other one. Reached only when the
+  # other writer is BLOCKED (the fixed shape), so it is a per-test cost, not a
+  # timing guess: generous on purpose, because a window too short to let an
+  # UNGUARDED writer commit would turn the defect green.
+  @peer_grace_ms 1_000
+
+  defp user_fixture do
+    name = "us-conc-#{System.unique_integer([:positive])}"
+    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
+    user
+  end
+
+  # Spawns the second writer, then arms the pause. `peer_write` runs only once
+  # the paused writer has read, and the pause ends as soon as it reports back.
+  defp interleave(subject, peer_write) do
+    parent = self()
+
+    peer =
+      spawn(fn ->
+        receive do
+          :go -> send(parent, {:peer_done, peer_write.(subject)})
+        end
+      end)
+
+    Ecto.Adapters.SQL.Sandbox.allow(Grappa.Repo, parent, peer)
+
+    :telemetry.attach(
+      @handler_id,
+      [:grappa, :repo, :query],
+      # `:telemetry` handler args: event, measurements, metadata, config.
+      fn _, _, meta, _ ->
+        if self() == parent and meta[:source] == "user_settings" and
+             String.starts_with?(meta[:query] || "", "SELECT") and
+             Process.get(@handler_id) == nil do
+          Process.put(@handler_id, :fired)
+          send(peer, :go)
+
+          receive do
+            {:peer_done, _} = landed -> send(parent, landed)
+          after
+            @peer_grace_ms -> :ok
+          end
+        end
+      end,
+      nil
+    )
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach(@handler_id) end)
+  end
+
+  defp write_prefix(subject), do: UserSettings.put_last_client_prefix64(subject, "AABB")
+
+  test "a setter does not drop a key another writer commits between its read and its write" do
+    user = user_fixture()
+    subject = {:user, user.id}
+    {:ok, _} = UserSettings.get_or_init(subject)
+
+    interleave(subject, &write_prefix/1)
+
+    assert {:ok, %Settings{}} = UserSettings.set_highlight_patterns(subject, ["ciao"])
+    assert_receive {:peer_done, {:ok, %Settings{}}}, 2_000
+
+    assert UserSettings.get_highlight_patterns(subject) == ["ciao"]
+    assert UserSettings.get_last_client_prefix64(subject) == "AABB"
+  end
+
+  test "a mute rename does not drop a key another writer commits between its read and its write" do
+    user = user_fixture()
+    subject = {:user, user.id}
+
+    muted = %{Identifier.channel_key("azzurra", "old") => %{"until" => nil}}
+    prefs = Map.put(UserSettings.default_notification_prefs(), :muted_targets, muted)
+
+    {:ok, _} = UserSettings.put_notification_prefs(subject, prefs)
+
+    interleave(subject, &write_prefix/1)
+
+    assert {:ok, :renamed} = UserSettings.rename_muted_target(subject, "azzurra", "old", "new")
+    assert_receive {:peer_done, {:ok, %Settings{}}}, 2_000
+
+    renamed = UserSettings.get_notification_prefs(subject).muted_targets
+    assert Map.has_key?(renamed, Identifier.channel_key("azzurra", "new"))
+    assert UserSettings.get_last_client_prefix64(subject) == "AABB"
+  end
+end


### PR DESCRIPTION
Refs #1375.

## The defect

`user_settings.data` is one JSON column, so every setter writes it whole. Nine
setters plus `rename_muted_target/4` spelled the read-modify-write pair by hand:
two writers touching **different** keys both read the same snapshot and both
wrote a full replacement, so the second commit dropped the first's key — with
`{:ok, _}` on both sides and nothing in the logs.

Not theory. `put_last_client_prefix64/2` fires from
`Vhosts.record_client_source/2` on every client connect, in the socket's own
process and its own connection of the ten (`pool_size: 10`,
`config/runtime.exs:187`), while a settings-drawer PUT runs in another.

## The fix

Exactly one writer — `update_data/2` — holding the read and the write in a
single `Repo.immediate_transaction/1`, with the `BusyRetry` budget wrapping it
from **outside** (#1374's nesting). The init inside it is the non-retrying
`get_or_init!/1` for the same reason: a retry loop opened inside an open
transaction sleeps on the connection it holds. #523's degrade contract
(`{:error, :db_unavailable}` → 503) is unchanged, and the helper deletes eight
copies of the merge idiom.

`rename_muted_target/4` is in scope too — same blob, same hazard. It does not go
through `update_data/2` (a rename must never CREATE the row, and it reports
which of the two things it did) but shares the same `write_transaction/1` frame.

## Evidence

The interleave is **reproduced**, not argued. Ecto's per-query telemetry
(`[:grappa, :repo, :query]`) runs its handlers synchronously in the querying
process, so a handler that blocks on the writer's `user_settings` SELECT
suspends it exactly between its read and its write — no seam in production code
and no sleep-and-hope. Unfixed, the key written in that window reads back `nil`.

Mutants run, not predicted:

| mutant | result |
|---|---|
| drop the transaction (`BusyRetry.run(fn -> {:ok, fun.()} end)`) | **both tests red**, each on exactly one assertion (`get_last_client_prefix64` → `nil`) |
| `Repo.transaction/1` instead of `Repo.immediate_transaction/1` | **green — survives** |

The second one is the declared blind spot, and it is declared in the test's own
moduledoc: with one Sandbox connection (`config/test.exs`, `pool_size: 1`) the
second writer blocks on the *checkout* the open transaction holds, not on
SQLite's file-level write lock, and nested under the Sandbox every transaction
mode is a `SAVEPOINT`. These tests buy "the read and the write are ONE
transaction"; they do **not** buy the `:immediate` spelling, which rests on
`Repo.immediate_transaction/1`'s own #524 contract.

`scripts/check.sh` green end to end: 8 doctests, 60 properties, 6351 tests, 0
failures; dialyzer `Total errors: 0`; credo strict, sobelow, bats all pass.

## Overlaps with #1378 (PR of #1374, w2, held)

Landing order is w1 first, #1378 rebases after. Four of the five hunks #1378 has
in `lib/grappa/user_settings.ex` land on lines this PR rewrites; details in the
thread.