### PR TITLE
#1404: three guards on the session process

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -158,6 +158,23 @@ config :grappa, :send_throttle,
   oper_capacity: 50,
   oper_refill_per_sec: 5.0
 
+# #1404 — the ceiling on answers a session emits on a STRANGER's command
+# (the CTCP VERSION / PING auto-replies). Distinct from `:send_throttle`
+# above in WHO sets the pace: that one meters the operator's own sends and
+# lives in a node-global `RateLimit.TokenBucket`; this one meters a rate
+# chosen by whoever sends the query, so the arithmetic is pure and the
+# bucket lives in the session's own state — a remote-paced path must not
+# be able to enqueue serialized calls into a node-global process.
+#
+# Same pair of numbers as the ORDINARY send drip on purpose: an answer
+# grappa emits on a stranger's command may not consume more of the
+# upstream's flood allowance than the operator's own client is allowed to.
+# One query costs an outbound frame AND a scrollback row, and one token
+# buys both — see `Grappa.Session.AutoReplyBudget`.
+config :grappa, :auto_reply_budget,
+  capacity: 5,
+  refill_per_sec: 0.5
+
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is
 # the shared OUTER gate that a flooder cannot dodge by switching surface;

--- a/config/config.exs
+++ b/config/config.exs
@@ -158,22 +158,21 @@ config :grappa, :send_throttle,
   oper_capacity: 50,
   oper_refill_per_sec: 5.0
 
-# #1404 — the ceiling on answers a session emits on a STRANGER's command
-# (the CTCP VERSION / PING auto-replies). Distinct from `:send_throttle`
-# above in WHO sets the pace: that one meters the operator's own sends and
-# lives in a node-global `RateLimit.TokenBucket`; this one meters a rate
-# chosen by whoever sends the query, so the arithmetic is pure and the
-# bucket lives in the session's own state — a remote-paced path must not
-# be able to enqueue serialized calls into a node-global process.
+# #1404 — the ORDINARY pair above has a SECOND consumer:
+# `Grappa.Session.AutoReplyBudget`, the ceiling on answers a session emits
+# on a STRANGER's command (the CTCP VERSION / PING auto-replies). It reads
+# these keys rather than owning a knob of its own, because an answer
+# emitted on a stranger's command may not consume more of the upstream's
+# allowance than the operator's own client is allowed to — so re-measuring
+# a network moves one pair of numbers, not two that drift.
 #
-# Same pair of numbers as the ORDINARY send drip on purpose: an answer
-# grappa emits on a stranger's command may not consume more of the
-# upstream's flood allowance than the operator's own client is allowed to.
-# One query costs an outbound frame AND a scrollback row, and one token
-# buys both — see `Grappa.Session.AutoReplyBudget`.
-config :grappa, :auto_reply_budget,
-  capacity: 5,
-  refill_per_sec: 0.5
+# The two differ in WHO sets the pace, and that is why the mechanisms
+# differ: `:send_throttle` meters a human through a node-global
+# `RateLimit.TokenBucket`, while the auto-reply budget is pure arithmetic
+# in the session's own state, since a remote-paced path must not be able to
+# enqueue serialized calls into a node-global process. The oper pair is
+# deliberately NOT read there: it describes a connection the ircd meters
+# loosely, which says nothing about courtesy answers.
 
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43755,3 +43755,76 @@ re-read inside when there is work — buys back a sub-millisecond, WAL-frame-fre
 lock acquisition at the price of a second SELECT on the write path and a
 duplicated "is this key muted?" predicate. Not taken; if nick-change churn ever
 shows up in the #357 write-latency counters, that is the knob.
+<!-- entry #1404a -->
+
+---
+
+## 2026-08-16 — #1404: three guards on the session process
+
+Hardening from the 2026-08-15 review. Stated at the level of the control,
+per the terms the tracking issue sets: what is guarded now, and why the
+guard has the shape it has.
+
+### A valueless message-tag carries `""`
+
+IRCv3 message-tags §3.2 gives `@foo` and `@foo=` the same absent value, so
+`Grappa.IRC.Parser` now gives them the same representation, and
+`Message.tags` narrows from `String.t() | true` to `String.t()`.
+
+The narrowing is the point, not the spelling. `NumericRouter.label_lookup/2`
+splits on `nil` versus binary; with a third inhabitant in the type that
+split was partial, and the partiality was DECLARED, so nothing could
+object to it. With the type narrowed, the two clauses cover the domain and
+the compiler can prove it — a catch-all clause would have covered the same
+ground while leaving the next consumer to rediscover the same trap.
+
+The parser test now asserts that the two spellings AGREE rather than
+pinning each to its own literal, which is the property that actually has
+to hold. Routing is pinned from a real parse: a value shape only the
+parser produces is exactly the shape a hand-built fixture never exercises.
+
+### The CTCP auto-reply has a ceiling, and it covers both costs
+
+`Grappa.Session.AutoReplyBudget` — pure token-bucket arithmetic, held in
+the session's own state. `EventRouter` emits `{:auto_reply, line, persist}`
+as ONE effect, and `Session.Server` spends one token for the pair, then
+expands it back into the ordinary `{:reply, _}` and `{:persist, _, _}`
+arms. A stranger chooses how often this path runs, and each run costs both
+an upstream frame and a row in the shared sqlite file; metering them
+separately would let the scrollback claim an answer that never went out.
+
+**Why not `RateLimit.TokenBucket`.** That bucket is right for what it
+does: it meters the SUBJECT's own sends, a human sets the pace, and a
+node-global GenServer suits a `(subject, network)` key. This path is paced
+by whoever sends the query. Routing it through a node-global process would
+let any peer on any bound network enqueue serialized work for the whole
+node — a bound that relocates a flood rather than stopping one. A
+per-sender ledger was rejected twice over: it grows a keyspace with the
+number of strangers who ask, and it does not bound the aggregate, which is
+the quantity the upstream meters.
+
+The numbers are the ORDINARY send drip of #340 rather than a pair of their
+own. An answer grappa emits on a stranger's command may not consume more
+of the upstream's allowance than the operator's own client may, and an
+operator who re-measures their network moves one pair, not two that drift.
+
+### `format_status/1` on `Session.Server`
+
+Upstream credentials are plaintext in that state for as long as the
+handshake needs them — decrypted from Cloak at boot, threaded to the wire.
+`redact: true` guards the columns, `@derive Inspect` guards `AuthFSM`,
+`filter_parameters` guards HTTP params, and none of the three is consulted
+when OTP renders a GenServer's state through `inspect/2`. `format_status/1`
+owns that door. The house `@derive {Inspect, except: …}` pattern is not
+available: this state is a bare map, not a struct.
+
+Redaction is uniform — present becomes `:redacted`, absent stays `nil`.
+The operator keeps the diagnostic that matters, and what has to stay
+current is one list of keys rather than a set of per-key value shapes.
+
+**The test asserts on the VALUE, not on the key**, walking the whole
+formatted term. This state map is a declared target for regrouping; a
+key-name assertion would keep passing after the keys moved under a nested
+struct while the guard had stopped covering them. Written this way, the
+regrouping breaks the test loudly. Two mutants pin it: a pass-through
+callback, and one key dropped from the list, which fails naming that key.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43803,10 +43803,22 @@ per-sender ledger was rejected twice over: it grows a keyspace with the
 number of strangers who ask, and it does not bound the aggregate, which is
 the quantity the upstream meters.
 
-The numbers are the ORDINARY send drip of #340 rather than a pair of their
-own. An answer grappa emits on a stranger's command may not consume more
-of the upstream's allowance than the operator's own client may, and an
-operator who re-measures their network moves one pair, not two that drift.
+The numbers are READ FROM `:send_throttle` — the ORDINARY pair — rather
+than duplicated into a knob of their own. An answer grappa emits on a
+stranger's command may not consume more of the upstream's allowance than
+the operator's own client may, and sharing the config key makes that a
+property of the code instead of a promise in a comment: re-measuring a
+network moves one pair, not two that drift. The oper pair is deliberately
+not read there; it describes a connection the ircd meters loosely, which
+says nothing about courtesy answers.
+
+The module exposes no accessor for either number, and the tests read the
+same config keys. A function returning a compile-time constant cannot
+carry a spec that is both general and true under `:underspecs` — the
+success typing is the literal — and the alternative, pinning the spec to
+today's literal the way `Grappa.Protocol` does, is only correct there
+because that constant is not configurable. Here it would break the build
+of an operator who retunes the pair.
 
 ### `format_status/1` on `Session.Server`
 

--- a/lib/grappa/irc/message.ex
+++ b/lib/grappa/irc/message.ex
@@ -72,7 +72,7 @@ defmodule Grappa.IRC.Message do
           | {:numeric, 1..999}
           | {:unknown, String.t()}
 
-  @type tags :: %{optional(String.t()) => String.t() | true}
+  @type tags :: %{optional(String.t()) => String.t()}
 
   @type t :: %__MODULE__{
           tags: tags(),
@@ -139,21 +139,24 @@ defmodule Grappa.IRC.Message do
 
   @doc """
   Returns the value of an IRCv3 message-tag, or `nil` when the tag is
-  absent. Tag-only entries (`@account` with no `=`) yield `true`.
+  absent. A tag-only entry (`@account`, no `=`) yields `""`, the same as
+  `@account=` — IRCv3 message-tags §3.2 gives both an absent value, so a
+  consumer never has to branch on which spelling arrived.
 
   Centralised accessor so consumers do not poke at the `tags` map
   directly — keeps the storage shape (today: a `%{String.t() => ...}`
   map; tomorrow: maybe a struct with normalized vendor-prefix keys) an
   implementation detail of this module.
   """
-  @spec tag(t(), String.t()) :: String.t() | true | nil
+  @spec tag(t(), String.t()) :: String.t() | nil
   def tag(%__MODULE__{tags: tags}, key) when is_binary(key), do: Map.get(tags, key)
 
   @doc """
   Returns the value of an IRCv3 message-tag, or `default` when absent.
-  Tag-only entries (`@account` with no `=`) yield `true`.
+  A tag-only entry (`@account`, no `=`) yields `""`, not the default —
+  the tag IS present, it just carries no value.
   """
-  @spec tag(t(), String.t(), default) :: String.t() | true | default when default: term()
+  @spec tag(t(), String.t(), default) :: String.t() | default when default: term()
   def tag(%__MODULE__{tags: tags}, key, default) when is_binary(key),
     do: Map.get(tags, key, default)
 end

--- a/lib/grappa/irc/parser.ex
+++ b/lib/grappa/irc/parser.ex
@@ -194,10 +194,15 @@ defmodule Grappa.IRC.Parser do
     |> Map.new(&parse_tag/1)
   end
 
+  # A tag with no `=` and a tag with an empty value are the SAME thing per
+  # IRCv3 message-tags §3.2 — both carry an absent value — so both yield
+  # `""`. The alternative (a boolean for the first form) would make the tag
+  # map heterogeneous, which costs every consumer a value-shape branch it
+  # has no domain reason to write; the type below is the enforcement.
   defp parse_tag(entry) do
     case String.split(entry, "=", parts: 2) do
       [key, value] -> {key, unescape_tag_value(value)}
-      [key] -> {key, true}
+      [key] -> {key, ""}
     end
   end
 

--- a/lib/grappa/session/auto_reply_budget.ex
+++ b/lib/grappa/session/auto_reply_budget.ex
@@ -38,14 +38,16 @@ defmodule Grappa.Session.AutoReplyBudget do
   behaviour testable without sleeping.
   """
 
-  # Deliberately the ORDINARY send drip of #340 (`config :grappa,
-  # :send_throttle`), not a number of its own: an answer grappa emits on a
-  # stranger's command may not consume more of the upstream's allowance
-  # than the operator's own client is allowed to consume. Tying the two
-  # together also means an operator who re-measures their network's
-  # allowance moves one pair of numbers, not two that drift.
-  @capacity Application.compile_env(:grappa, [:auto_reply_budget, :capacity], 5)
-  @refill_per_sec Application.compile_env(:grappa, [:auto_reply_budget, :refill_per_sec], 0.5)
+  # READ FROM `:send_throttle`, not from a knob of this module's own. An
+  # answer grappa emits on a stranger's command may not consume more of the
+  # upstream's allowance than the operator's own client is allowed to
+  # consume — and an operator who re-measures their network's allowance
+  # should move one pair of numbers, not two that drift. Sharing the source
+  # makes that a property of the code rather than a promise in a comment.
+  # The ORDINARY pair specifically: the oper pair belongs to a connection
+  # the ircd meters loosely, which says nothing about courtesy answers.
+  @capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:send_throttle, :refill_per_sec], 0.5)
 
   @typedoc """
   Remaining tokens plus the monotonic stamp they were computed at.
@@ -79,17 +81,4 @@ defmodule Grappa.Session.AutoReplyBudget do
       {:error, :rate_limited, %{tokens: refilled, last_ms: now_ms}}
     end
   end
-
-  @doc """
-  The configured burst allowance — exposed so a test states the ceiling by
-  reading it rather than by re-typing the number.
-  """
-  @spec capacity() :: pos_integer()
-  def capacity, do: @capacity
-
-  @doc """
-  The configured sustained refill rate, in tokens per second.
-  """
-  @spec refill_per_sec() :: number()
-  def refill_per_sec, do: @refill_per_sec
 end

--- a/lib/grappa/session/auto_reply_budget.ex
+++ b/lib/grappa/session/auto_reply_budget.ex
@@ -1,0 +1,95 @@
+defmodule Grappa.Session.AutoReplyBudget do
+  @moduledoc """
+  The ceiling on UNSOLICITED outbound answers one session emits on remote
+  command — today the CTCP VERSION / PING auto-replies.
+
+  Two quantities are bounded by the same token, because one query produces
+  both: a line to the upstream socket, and a visibility row in the shared
+  sqlite file. Metering only the line would leave the writes uncapped;
+  metering them separately would let the scrollback claim an answer that
+  never went out.
+
+  ## Why this is not the #340 bucket
+
+  `Grappa.RateLimit.TokenBucket` meters the SUBJECT's own sends. A human
+  paces those, the key is `(subject, network)`, and a node-global
+  GenServer is the right home for it.
+
+  This budget meters answers a STRANGER paces. Sending a remote-paced path
+  through a node-global process hands every peer on every bound network
+  the ability to enqueue a serialized call for the whole node — a bound
+  that relocates the flood rather than stopping it. So the arithmetic is
+  pure and the bucket lives in the state of the session that owns it: no
+  shared process, no shared table, and — the reason a per-sender ledger
+  was rejected too — no keyspace that grows with the number of strangers
+  who ask. A per-sender bound would also miss the aggregate, which is the
+  quantity the upstream actually meters.
+
+  ## Shape
+
+  Lazy refill, no timer: `tokens + elapsed_s * refill`, capped at
+  `capacity`, computed on access. This mirrors `TokenBucket`'s model
+  deliberately — same arithmetic, different home. A fresh budget starts
+  FULL, so a session that has answered nothing answers the first query
+  immediately.
+
+  `now_ms` is supplied by the caller (`System.monotonic_time(:millisecond)`
+  in production) rather than read here, which is what makes refill
+  behaviour testable without sleeping.
+  """
+
+  # Deliberately the ORDINARY send drip of #340 (`config :grappa,
+  # :send_throttle`), not a number of its own: an answer grappa emits on a
+  # stranger's command may not consume more of the upstream's allowance
+  # than the operator's own client is allowed to consume. Tying the two
+  # together also means an operator who re-measures their network's
+  # allowance moves one pair of numbers, not two that drift.
+  @capacity Application.compile_env(:grappa, [:auto_reply_budget, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:auto_reply_budget, :refill_per_sec], 0.5)
+
+  @typedoc """
+  Remaining tokens plus the monotonic stamp they were computed at.
+  """
+  @type t :: %{tokens: float(), last_ms: integer()}
+
+  @doc """
+  A full budget stamped at `now_ms`.
+  """
+  @spec new(integer()) :: t()
+  def new(now_ms) when is_integer(now_ms) do
+    %{tokens: @capacity * 1.0, last_ms: now_ms}
+  end
+
+  @doc """
+  Refill for the elapsed time, then try to consume one token.
+
+  `{:ok, budget}` when a token was available and consumed;
+  `{:error, :rate_limited, budget}` when it was not. Both arms return the
+  refilled budget — a denied take still advances the clock, so the next
+  call refills from here instead of re-crediting the same interval.
+  """
+  @spec take(t(), integer()) :: {:ok, t()} | {:error, :rate_limited, t()}
+  def take(%{tokens: tokens, last_ms: last_ms}, now_ms) when is_integer(now_ms) do
+    elapsed_s = (now_ms - last_ms) / 1000
+    refilled = min(@capacity * 1.0, tokens + elapsed_s * @refill_per_sec)
+
+    if refilled >= 1.0 do
+      {:ok, %{tokens: refilled - 1.0, last_ms: now_ms}}
+    else
+      {:error, :rate_limited, %{tokens: refilled, last_ms: now_ms}}
+    end
+  end
+
+  @doc """
+  The configured burst allowance — exposed so a test states the ceiling by
+  reading it rather than by re-typing the number.
+  """
+  @spec capacity() :: pos_integer()
+  def capacity, do: @capacity
+
+  @doc """
+  The configured sustained refill rate, in tokens per second.
+  """
+  @spec refill_per_sec() :: number()
+  def refill_per_sec, do: @refill_per_sec
+end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -10,6 +10,7 @@ defmodule Grappa.Session.EventRouter do
       @type effect ::
               {:persist, kind, persist_attrs}    -- write a Scrollback row
               | {:reply, iodata()}                -- send a line upstream
+              | {:auto_reply, iodata(), persist}   -- both, or neither, under a ceiling
               | {:topic_changed, channel, topic_entry()}
               | {:channel_modes_changed, channel, channel_mode_entry()}
               | {:members_seeded, channel, members} -- 366 RPL_ENDOFNAMES landed; carries snapshot
@@ -197,6 +198,8 @@ defmodule Grappa.Session.EventRouter do
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
           | {:reply, iodata()}
+          | {:auto_reply, iodata(),
+             {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
           | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}
           | {:topic_changed, String.t(), topic_entry()}
@@ -442,15 +445,21 @@ defmodule Grappa.Session.EventRouter do
   # responses MUST go via NOTICE (not PRIVMSG) to the SENDER's nick to
   # prevent reply loops between two responsive bots.
   #
-  # Two effects:
-  #   1. {:reply, line}    — outbound NOTICE response. Client.send_line
-  #      guarantees CRLF at the transport boundary (see ensure_crlf/1
-  #      in irc/client.ex), so callers don't need to remember.
+  # ONE effect carrying two, `{:auto_reply, line, persist}`:
+  #   1. the outbound NOTICE response. Client.send_line guarantees CRLF at
+  #      the transport boundary (see ensure_crlf/1 in irc/client.ex), so
+  #      callers don't need to remember.
   #   2. {:persist, :notice, attrs} — visible scrollback row in the DM
   #      window for the sender, so cic shows "alice queried grappa for
   #      VERSION" instead of silently consuming the CTCP. CTCP framing
   #      stripped from body for readability; the notice kind matches the
   #      outbound reply (also a NOTICE), pairing query + answer visually.
+  #
+  # They travel as one effect rather than two because the ceiling in
+  # `Session.Server` (`AutoReplyBudget`) must decide for the pair: a row
+  # saying the query was answered, next to a line that was never sent, is
+  # worse than neither. The rate at which this arm can fire is chosen by
+  # whoever sends the query, not by the operator — hence a ceiling at all.
   defp do_route(%Message{command: :privmsg, params: [target, body]} = msg, state)
        when is_binary(target) and is_binary(body) and
               binary_part(body, 0, 1) == <<0x01>> do
@@ -494,7 +503,7 @@ defmodule Grappa.Session.EventRouter do
         {state2, persist_eff} =
           build_persist(state, :notice, dm_channel, sender, notice_body, sender_meta(msg))
 
-        {:cont, state2, [{:reply, reply}, persist_eff]}
+        {:cont, state2, [{:auto_reply, reply, persist_eff}]}
 
       {"PING", _} ->
         # Answered in its own function, not inline: this clause was at
@@ -2899,7 +2908,7 @@ defmodule Grappa.Session.EventRouter do
         sender_meta(msg)
       )
 
-    {:cont, state2, [{:reply, reply}, persist_eff]}
+    {:cont, state2, [{:auto_reply, reply, persist_eff}]}
   end
 
   # #591 — the typed CTCP meta for a persisted row whose body is a CTCP frame,

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -198,8 +198,7 @@ defmodule Grappa.Session.EventRouter do
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
           | {:reply, iodata()}
-          | {:auto_reply, iodata(),
-             {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
+          | {:auto_reply, iodata(), {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
           | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}
           | {:topic_changed, String.t(), topic_entry()}

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1669,7 +1669,7 @@ defmodule Grappa.Session.Server do
   defp redact_key(key, state) do
     case Map.get(state, key) do
       nil -> state
-      _held -> Map.put(state, key, :redacted)
+      _ -> Map.put(state, key, :redacted)
     end
   end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1631,6 +1631,46 @@ defmodule Grappa.Session.Server do
   # dead code post-boundary-fix and removed per
   # `feedback_no_silent_drops_closed` (a safety net that catches an
   # impossible exception silently absorbs the next class of bug).
+  # The state map carries upstream credentials in PLAINTEXT for as long as
+  # the handshake needs them — that is the design (they are decrypted from
+  # Cloak at boot and threaded to the wire), and every existing protection
+  # stops one layer short of a crash report: the schema columns are
+  # `redact: true`, `AuthFSM` derives `Inspect`, `filter_parameters` covers
+  # HTTP params. None of them is consulted when OTP formats a dying
+  # GenServer, which prints `State:` through `inspect/2`.
+  #
+  # `@derive {Inspect, except: …}` is the house pattern and is NOT
+  # available here: this state is a bare map, not a struct. `format_status/1`
+  # is the callback that owns the same question for a GenServer.
+  #
+  # Redaction is uniform — present ⇒ `:redacted`, absent stays `nil` — so
+  # the operator keeps the one diagnostic that matters (was a secret held
+  # at crash time) and the list below stays a list of KEYS, with no
+  # per-key value shapes to keep in step.
+  @redacted_state_keys [
+    :pending_auth,
+    :pending_password,
+    :pending_registration_secret,
+    :perform_list,
+    :oper_pass
+  ]
+
+  @impl GenServer
+  def format_status(status) do
+    Map.update(status, :state, nil, fn
+      state when is_map(state) ->
+        Enum.reduce(@redacted_state_keys, state, fn key, acc ->
+          case Map.get(acc, key) do
+            nil -> acc
+            _ -> Map.put(acc, key, :redacted)
+          end
+        end)
+
+      other ->
+        other
+    end)
+  end
+
   @impl GenServer
   def terminate(reason, state)
       when reason == :shutdown or (is_tuple(reason) and elem(reason, 0) == :shutdown) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1656,19 +1656,21 @@ defmodule Grappa.Session.Server do
   ]
 
   @impl GenServer
-  def format_status(status) do
-    Map.update(status, :state, nil, fn
-      state when is_map(state) ->
-        Enum.reduce(@redacted_state_keys, state, fn key, acc ->
-          case Map.get(acc, key) do
-            nil -> acc
-            _ -> Map.put(acc, key, :redacted)
-          end
-        end)
+  def format_status(status), do: Map.update(status, :state, nil, &redact_secrets/1)
 
-      other ->
-        other
-    end)
+  @spec redact_secrets(term()) :: term()
+  defp redact_secrets(state) when is_map(state) do
+    Enum.reduce(@redacted_state_keys, state, &redact_key/2)
+  end
+
+  defp redact_secrets(other), do: other
+
+  @spec redact_key(atom(), map()) :: map()
+  defp redact_key(key, state) do
+    case Map.get(state, key) do
+      nil -> state
+      _held -> Map.put(state, key, :redacted)
+    end
   end
 
   @impl GenServer

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -98,6 +98,7 @@ defmodule Grappa.Session.Server do
   alias Grappa.Scrollback.Wire
 
   alias Grappa.Session.{
+    AutoReplyBudget,
     AwayState,
     Backoff,
     Broadcaster,
@@ -594,6 +595,11 @@ defmodule Grappa.Session.Server do
           # on …" line.
           channels_created: %{String.t() => DateTime.t()},
           userhost_cache: EventRouter.userhost_cache(),
+          # The ceiling on answers this session emits on a stranger's
+          # command (CTCP VERSION/PING). Read with a `Map.get` default so a
+          # process hot-reloaded across the field's introduction answers
+          # instead of KeyError-crashing (the #216 contract).
+          auto_reply_budget: AutoReplyBudget.t(),
           # CP15 B1 + cluster #6 extraction: per-channel window state
           # bundle (states + failure_reasons + failure_numerics +
           # kicked_meta in one struct). Sibling to `members` —
@@ -1204,6 +1210,7 @@ defmodule Grappa.Session.Server do
       channel_modes: %{},
       channels_created: %{},
       userhost_cache: %{},
+      auto_reply_budget: AutoReplyBudget.new(System.monotonic_time(:millisecond)),
       window_state: WindowState.new(),
       in_flight_joins: %{},
       awaiting_invite: MapSet.new(),
@@ -6009,6 +6016,39 @@ defmodule Grappa.Session.Server do
     end
 
     apply_effects(rest, state)
+  end
+
+  # An answer emitted on a STRANGER's command (CTCP VERSION / PING), under
+  # a ceiling. Whoever sends the query chooses the rate, and each one costs
+  # an outbound frame plus a row in the shared sqlite file — two quantities
+  # nothing else on this path bounds, since `RateLimit.TokenBucket` and
+  # `RequestBudget` both meter the SUBJECT's own sends at the web edge.
+  #
+  # Allowed ⇒ expand back into the two ordinary effects, so the line still
+  # leaves through the one `{:reply, _}` door and the row through the one
+  # `{:persist, _, _}` door. Denied ⇒ drop BOTH: the pair travels together
+  # precisely so the scrollback can never claim an answer that never went
+  # out. Not logged per drop — a log line per dropped query would restore
+  # the write amplification the ceiling exists to remove.
+  # `Map.get`/`Map.put`, not `state.field`/`%{state | field}`: a process
+  # hot-reloaded across this field's introduction has no such key, and the
+  # #216 contract is that it answers rather than KeyError-crashes. A fresh
+  # (full) budget is the honest default — it has emitted nothing this
+  # incarnation can account for.
+  defp apply_effects([{:auto_reply, line, persist_eff} | rest], state) do
+    now_ms = System.monotonic_time(:millisecond)
+    budget = Map.get_lazy(state, :auto_reply_budget, fn -> AutoReplyBudget.new(now_ms) end)
+
+    case AutoReplyBudget.take(budget, now_ms) do
+      {:ok, spent} ->
+        apply_effects(
+          [{:reply, line}, persist_eff | rest],
+          Map.put(state, :auto_reply_budget, spent)
+        )
+
+      {:error, :rate_limited, spent} ->
+        apply_effects(rest, Map.put(state, :auto_reply_budget, spent))
+    end
   end
 
   defp apply_effects([{:reply, line} | rest], state) do

--- a/test/grappa/irc/message_test.exs
+++ b/test/grappa/irc/message_test.exs
@@ -62,9 +62,13 @@ defmodule Grappa.IRC.MessageTest do
       assert Message.tag(msg, "account") == nil
     end
 
-    test "tag/2 returns true for tag-only entries (no = in the wire form)" do
-      msg = %Message{command: :privmsg, tags: %{"draft/typing" => true}}
-      assert Message.tag(msg, "draft/typing") == true
+    # `""` and not `nil`: the tag IS present. A consumer distinguishing
+    # "absent" from "present but valueless" must be able to, and the only
+    # thing that carries that distinction is the nil/binary split.
+    test "tag/2 returns \"\" for tag-only entries (no = in the wire form)" do
+      msg = %Message{command: :privmsg, tags: %{"draft/typing" => ""}}
+      assert Message.tag(msg, "draft/typing") == ""
+      refute Message.tag(msg, "draft/typing") == nil
     end
 
     test "tag/3 returns the default when the tag is absent" do

--- a/test/grappa/irc/parser_test.exs
+++ b/test/grappa/irc/parser_test.exs
@@ -193,11 +193,12 @@ defmodule Grappa.IRC.ParserTest do
                Parser.parse("@time=2026-04-25T12:00:00.000Z;account=vjt :vjt!~vjt@host PRIVMSG #x :hi")
     end
 
-    test "tag without value (key-only): value is `true`" do
-      assert {:ok, %Message{tags: %{"foo" => true}}} = Parser.parse("@foo PING :x")
-    end
-
-    test "tag with empty value (key=): value is empty string" do
+    # IRCv3 message-tags §3.2 gives `@foo` and `@foo=` the same absent
+    # value, so the parser gives them the same representation. Asserted as
+    # one pair rather than two independent cases: the property is that the
+    # two spellings AGREE, and two separate literals would let one drift.
+    test "tag without value (key-only) parses identically to an empty value" do
+      assert {:ok, %Message{tags: %{"foo" => ""}}} = Parser.parse("@foo PING :x")
       assert {:ok, %Message{tags: %{"foo" => ""}}} = Parser.parse("@foo= PING :x")
     end
 

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -1,0 +1,80 @@
+defmodule Grappa.Session.AutoReplyBudgetTest do
+  @moduledoc """
+  Unit tests for `Grappa.Session.AutoReplyBudget`.
+
+  Every case supplies its own monotonic stamp, so refill is exercised by
+  arithmetic rather than by sleeping — the reason `take/2` takes `now_ms`
+  at all.
+
+  The ceiling is read from the module (`capacity/0`, `refill_per_sec/0`)
+  rather than re-typed here: a test that hardcodes 5 keeps passing after an
+  operator lowers the configured burst to 1, which is the one change these
+  tests exist to notice.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.AutoReplyBudget
+
+  @t0 1_000_000
+
+  defp drain(budget, 0, _now), do: budget
+
+  defp drain(budget, n, now) when n > 0 do
+    {:ok, next} = AutoReplyBudget.take(budget, now)
+    drain(next, n - 1, now)
+  end
+
+  describe "take/2" do
+    test "a fresh budget answers the first query immediately" do
+      assert {:ok, _} = AutoReplyBudget.take(AutoReplyBudget.new(@t0), @t0)
+    end
+
+    test "the burst is exactly `capacity` takes, and the next one is refused" do
+      capacity = AutoReplyBudget.capacity()
+
+      drained = drain(AutoReplyBudget.new(@t0), capacity, @t0)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(drained, @t0)
+    end
+
+    test "a refused take consumes nothing — it stays refused at the same instant" do
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+
+      {:error, :rate_limited, after_first} = AutoReplyBudget.take(drained, @t0)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(after_first, @t0)
+    end
+
+    test "one token's worth of elapsed time buys exactly one more answer" do
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+
+      {:ok, spent} = AutoReplyBudget.take(drained, @t0 + one_token_ms)
+
+      # The second take at the SAME instant is what proves the refill
+      # credited one token and not the whole bucket.
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(spent, @t0 + one_token_ms)
+    end
+
+    test "refill is capped at capacity — an idle century does not buy a bigger burst" do
+      century_ms = 100 * 365 * 24 * 60 * 60 * 1000
+
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      recovered = drain(drained, AutoReplyBudget.capacity(), @t0 + century_ms)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(recovered, @t0 + century_ms)
+    end
+
+    test "a refused take still advances the clock, so the interval is not credited twice" do
+      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+
+      # Refused mid-interval: the partial refill is banked and stamped.
+      {:error, :rate_limited, mid} = AutoReplyBudget.take(drained, @t0 + div(one_token_ms, 2))
+
+      # Had the denial NOT re-stamped, the full interval would be credited
+      # again here and this second half-interval would buy a whole token.
+      assert {:ok, _} = AutoReplyBudget.take(mid, @t0 + one_token_ms)
+    end
+  end
+end

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -17,7 +17,7 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
 
   @t0 1_000_000
 
-  defp drain(budget, 0, _now), do: budget
+  defp drain(budget, 0, _), do: budget
 
   defp drain(budget, n, now) when n > 0 do
     {:ok, next} = AutoReplyBudget.take(budget, now)

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -6,16 +6,20 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
   arithmetic rather than by sleeping — the reason `take/2` takes `now_ms`
   at all.
 
-  The ceiling is read from the module (`capacity/0`, `refill_per_sec/0`)
-  rather than re-typed here: a test that hardcodes 5 keeps passing after an
-  operator lowers the configured burst to 1, which is the one change these
-  tests exist to notice.
+  The ceiling is read from the SAME config keys the module reads, never
+  re-typed: a test that hardcodes 5 keeps passing after an operator lowers
+  the configured burst to 1, which is the one change these tests exist to
+  notice. The module exposes no accessor for them on purpose — a function
+  returning a compile-time constant cannot carry a spec that is both
+  general and true under `:underspecs`.
   """
   use ExUnit.Case, async: true
 
   alias Grappa.Session.AutoReplyBudget
 
   @t0 1_000_000
+  @capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:send_throttle, :refill_per_sec], 0.5)
 
   defp drain(budget, 0, _), do: budget
 
@@ -30,15 +34,13 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     end
 
     test "the burst is exactly `capacity` takes, and the next one is refused" do
-      capacity = AutoReplyBudget.capacity()
-
-      drained = drain(AutoReplyBudget.new(@t0), capacity, @t0)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       assert {:error, :rate_limited, _} = AutoReplyBudget.take(drained, @t0)
     end
 
     test "a refused take consumes nothing — it stays refused at the same instant" do
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       {:error, :rate_limited, after_first} = AutoReplyBudget.take(drained, @t0)
 
@@ -46,8 +48,8 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     end
 
     test "one token's worth of elapsed time buys exactly one more answer" do
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
-      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
+      one_token_ms = ceil(1000 / @refill_per_sec)
 
       {:ok, spent} = AutoReplyBudget.take(drained, @t0 + one_token_ms)
 
@@ -59,15 +61,15 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     test "refill is capped at capacity — an idle century does not buy a bigger burst" do
       century_ms = 100 * 365 * 24 * 60 * 60 * 1000
 
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
-      recovered = drain(drained, AutoReplyBudget.capacity(), @t0 + century_ms)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
+      recovered = drain(drained, @capacity, @t0 + century_ms)
 
       assert {:error, :rate_limited, _} = AutoReplyBudget.take(recovered, @t0 + century_ms)
     end
 
     test "a refused take still advances the clock, so the interval is not credited twice" do
-      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      one_token_ms = ceil(1000 / @refill_per_sec)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       # Refused mid-interval: the partial refill is banked and stamped.
       {:error, :rate_limited, mid} = AutoReplyBudget.take(drained, @t0 + div(one_token_ms, 2))

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -503,7 +503,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       # RFC 2812 + CTCP spec: response goes via NOTICE (NOT PRIVMSG) to
@@ -593,7 +593,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "PING 1753776000123", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, _, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01PING 1753776000123\x01"
@@ -615,7 +615,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "PING", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, _}]} =
+      assert {:cont, _, [{:auto_reply, line, {:persist, :notice, _}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01PING\x01"
@@ -633,7 +633,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION", 0x01>>
       m = msg(:privmsg, ["#italia", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) =~ "NOTICE alice :"
@@ -649,7 +649,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION ", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, _}, {:persist, :notice, _}]} =
+      assert {:cont, ^state, [{:auto_reply, _, {:persist, :notice, _}}]} =
                EventRouter.route(m, state)
     end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -13,6 +13,7 @@ defmodule Grappa.Session.NumericRouterTest do
   use ExUnitProperties
 
   alias Grappa.IRC.{JoinFailure, Message}
+  alias Grappa.IRC.Parser
   alias Grappa.Session.NumericRouter
 
   # ---------------------------------------------------------------------------
@@ -1081,6 +1082,20 @@ defmodule Grappa.Session.NumericRouterTest do
 
       state =
         state(labels_pending: %{"abc" => %{kind: :channel, target: "#other"}})
+
+      assert {:channel, "#sniffo"} = NumericRouter.route(m, state)
+    end
+
+    # Routed from a REAL parse, not a hand-built `%Message{}`: the value a
+    # bare `@label` (no `=`) carries is the parser's answer, and this test
+    # exists to pin that the whole chain is total for it. Every numeric
+    # enters `route/2` through the label lookup, so a value shape the lookup
+    # cannot match makes the FIRST numeric of a connection unroutable —
+    # which is the property under test, not the tag's spelling.
+    test "a valueless `@label` on the wire still routes by params" do
+      {:ok, m} = Parser.parse("@label :irc.example.org 404 vjt #sniffo :Cannot send")
+
+      state = state(labels_pending: %{"abc" => %{kind: :channel, target: "#other"}})
 
       assert {:channel, "#sniffo"} = NumericRouter.route(m, state)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1153,7 +1153,7 @@ defmodule Grappa.Session.ServerTest do
 
     defp secret_needles do
       Enum.map(@secrets, fn
-        {_, {needle, _deadline}} -> needle
+        {_, {needle, _}} -> needle
         {_, needle} -> needle
       end)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -33,7 +33,17 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.IRC.Message
   alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
-  alias Grappa.Session.{AwayState, Backoff, GhostRecovery, ISupport, RecoverIdentity, Server, WindowState}
+  alias Grappa.Session.{
+    AutoReplyBudget,
+    AwayState,
+    Backoff,
+    GhostRecovery,
+    ISupport,
+    RecoverIdentity,
+    Server,
+    WindowState
+  }
+
   alias Grappa.SessionStateHelpers
   alias Grappa.WindowCounts.PushSource
 
@@ -91,6 +101,23 @@ defmodule Grappa.Session.ServerTest do
   defp await_handshake(server) do
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
     :ok
+  end
+
+  # Poll until the fake ircd has seen `target` CTCP PING answers, or the
+  # deadline passes — a condition, not a sleep. Returns whatever the last
+  # sample was so the caller asserts on a number rather than on a timeout.
+  defp await_ctcp_ping_answers(server, target) do
+    await_ctcp_ping_answers(server, target, System.monotonic_time(:millisecond) + 2_000)
+  end
+
+  defp await_ctcp_ping_answers(server, target, deadline) do
+    seen = Enum.count(IRCServer.sent_lines(server), &String.contains?(&1, "\x01PING"))
+
+    cond do
+      seen >= target -> seen
+      System.monotonic_time(:millisecond) >= deadline -> seen
+      true -> await_ctcp_ping_answers(server, target, deadline)
+    end
   end
 
   # #543 INC-6 — a full synthetic connect plan (no `refresh_plan`, so the
@@ -2720,6 +2747,83 @@ defmodule Grappa.Session.ServerTest do
 
       assert Enum.any?(entries, &(&1.target_nick == "bob"))
       assert QueryWindows.open?({:user, user.id}, net_id, "bob")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1404 — the auto-answer is paced by whoever asks, and each answer
+    # costs an outbound frame AND a row in the shared sqlite file. Both are
+    # bounded by ONE budget, so the two counts must move together: a row
+    # claiming the query was answered, beside a line that never went out,
+    # would be a worse outcome than dropping the pair.
+    #
+    # The oracle is the RATIO, not an absolute — `capacity` is a config
+    # knob, so it is read from the module rather than retyped, and the
+    # assertion is that answers are strictly fewer than queries. Refill is
+    # one token per two seconds, so a burst fed in one go cannot earn a
+    # second helping while the feed is in flight; `sent + 1` absorbs at
+    # most one token of slack should the box be slow enough to cross it.
+    test "#1404 a burst of peer CTCP queries is answered under a ceiling, line and row together" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      # The per-channel topic, not the user topic: these rows land at
+      # `channel = own_nick` (the DM-shaped key an inbound query takes), and
+      # a `:message` broadcast rides the channel topic.
+      :ok =
+        Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      capacity = AutoReplyBudget.capacity()
+      queries = capacity * 4
+
+      for n <- 1..queries do
+        IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01PING #{n}\x01\r\n")
+      end
+
+      # Barrier, and the reason it is a plain PRIVMSG rather than a
+      # `:sys.get_state/1`: the queries are still in flight through the
+      # IRCServer → socket → Client hop when the feed loop returns, so a
+      # round-trip to the session proves only that ITS mailbox is empty.
+      # The session routes inbound in arrival order and persists after each
+      # one, so the broadcast for a marker fed LAST is a durable witness
+      # that every query ahead of it was already routed — answered or
+      # dropped. `assert_receive` matches anywhere in the mailbox, so the
+      # visibility rows queued ahead of the marker do not hide it.
+      marker = "burst drained"
+      IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :#{marker}\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :message, message: %{body: ^marker}}
+                     },
+                     5_000
+
+      # Counted straight off the table rather than through `fetch/7`: the
+      # quantity under test is "how many rows did the flood write", and a
+      # read path with its own windowing and own-nick semantics would put a
+      # second thing between the assertion and the answer.
+      rows =
+        Grappa.Scrollback.Message
+        |> Ecto.Query.where(
+          [m],
+          m.network_id == ^network.id and m.body == "CTCP PING query → answered"
+        )
+        |> Repo.aggregate(:count)
+
+      assert rows > 0, "the ceiling must bound the courtesy answer, not remove it"
+      assert rows < queries, "every query was answered — nothing bounded the burst"
+      assert rows <= capacity + 1
+
+      # The rows are final at this point; the outbound frames may still be
+      # crossing the loopback socket, so converge on the count rather than
+      # sampling it once. Equality is the property under test — one budget
+      # buys both, so a wire count that never reaches the row count is the
+      # failure this waits to expose.
+      assert await_ctcp_ping_answers(server, rows) == rows,
+             "the visibility row and the outbound line must not diverge"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -33,6 +33,7 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.IRC.Message
   alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
+
   alias Grappa.Session.{
     AutoReplyBudget,
     AwayState,

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -35,7 +35,6 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.Networks.{Credentials, SessionPlan}
 
   alias Grappa.Session.{
-    AutoReplyBudget,
     AwayState,
     Backoff,
     GhostRecovery,
@@ -2829,6 +2828,9 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # Read from the same config key the budget module reads, never retyped.
+    @auto_reply_capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+
     # #1404 — the auto-answer is paced by whoever asks, and each answer
     # costs an outbound frame AND a row in the shared sqlite file. Both are
     # bounded by ONE budget, so the two counts must move together: a row
@@ -2854,8 +2856,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       :ok = await_handshake(server)
 
-      capacity = AutoReplyBudget.capacity()
-      queries = capacity * 4
+      queries = @auto_reply_capacity * 4
 
       for n <- 1..queries do
         IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01PING #{n}\x01\r\n")
@@ -2893,7 +2894,7 @@ defmodule Grappa.Session.ServerTest do
 
       assert rows > 0, "the ceiling must bound the courtesy answer, not remove it"
       assert rows < queries, "every query was answered — nothing bounded the burst"
-      assert rows <= capacity + 1
+      assert rows <= @auto_reply_capacity + 1
 
       # The rows are final at this point; the outbound frames may still be
       # crossing the loopback socket, so converge on the count rather than

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1128,6 +1128,83 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "format_status/1 — upstream credentials never reach a status dump" do
+    # The upstream credentials are plaintext in this state by design: they
+    # are decrypted from Cloak at boot and threaded to the wire. Everything
+    # that protects them elsewhere — `redact: true` on the columns,
+    # `@derive Inspect` on AuthFSM, `filter_parameters` on HTTP params —
+    # stops before OTP formats a dying process, which prints the state
+    # through `inspect/2`. `format_status/1` is the callback that owns
+    # that door, and `:sys.get_status/1` routes through the very same one.
+    #
+    # The oracle is deliberately the VALUE, not the key: it inspects the
+    # whole formatted term and asks whether the secret is anywhere in it.
+    # That is what keeps the test honest across a state-map regrouping —
+    # move these keys under a nested struct and a key-name assertion would
+    # still pass while the guard had quietly stopped covering them.
+    @secrets %{
+      pending_password: "ns-plaintext-must-not-print",
+      oper_pass: "oper-plaintext-must-not-print",
+      pending_registration_secret: "register-plaintext-must-not-print",
+      perform_list: "PRIVMSG NickServ :IDENTIFY perform-plaintext-must-not-print",
+      pending_auth: {"rendezvous-plaintext-must-not-print", 123_456}
+    }
+
+    defp secret_needles do
+      Enum.map(@secrets, fn
+        {_, {needle, _deadline}} -> needle
+        {_, needle} -> needle
+      end)
+    end
+
+    defp deep_inspect(term) do
+      inspect(term, limit: :infinity, printable_limit: :infinity, structs: false)
+    end
+
+    test "every credential-bearing state key is redacted in the status dump" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      :sys.replace_state(pid, &Map.merge(&1, @secrets))
+
+      # Pre-state: without this the refute below would pass on a session
+      # that never held a secret in the first place.
+      raw = deep_inspect(:sys.get_state(pid))
+
+      for needle <- secret_needles() do
+        assert raw =~ needle, "planting failed — #{needle} is not in the live state"
+      end
+
+      dumped = deep_inspect(:sys.get_status(pid))
+
+      for needle <- secret_needles() do
+        refute dumped =~ needle, "#{needle} reached a status dump"
+      end
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "absent stays absent — redaction does not invent a secret that was never held" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      status = Server.format_status(%{state: :sys.get_state(pid)})
+
+      # A session that holds no oper password must not read as one that
+      # holds a redacted one: `nil` is a diagnostic, and flattening it into
+      # `:redacted` would tell the operator the opposite of the truth.
+      assert status.state.oper_pass == nil
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "terminate/2 — clean QUIT on supervisor shutdown" do
     # When the BEAM stops (SIGTERM, Application.stop, scripts/deploy.sh
     # recreating the container), the SessionSupervisor takes each


### PR DESCRIPTION
First slice of #1404. Three items, all on `Session.Server`'s inbound path.

**These land first and on their own.** Two of them sit on doors the
2026-08-15 architecture review already has buckets for, and the issue's
sequencing note asks that the hardening not travel inside the structural
change:

- the outbound-reply arm the review's `E outbound-door` bucket proposes to
  replace with a single `send_outbound/2`;
- the state map the `A session-decomposition` bucket proposes to regroup —
  the redaction test is written against VALUES, not key names, precisely so
  that regrouping breaks it loudly rather than quietly stepping around it.

The third is not door-sharing; it is the trigger the second one answers,
and splitting them would ship half a chain.

## What is guarded now

- **A valueless IRCv3 message-tag carries `""`**, the value the spec gives
  it, and the tag type narrows to `String.t()`. The consumer that splits on
  `nil` versus binary is now total by construction rather than by a
  catch-all clause.
- **The CTCP VERSION/PING auto-reply has a ceiling**, and one token buys
  both of its costs — the upstream frame and the scrollback row — because
  a row claiming an answer that never went out is worse than neither. The
  arithmetic is pure and lives in the session's own state; the reasoning
  for not reusing the node-global bucket is in the commit and in
  DESIGN_NOTES.
- **`format_status/1` keeps upstream credentials out of a status dump.**
  The house `@derive Inspect` pattern is unavailable here (bare map, not a
  struct), so this is the callback that owns the same question.

## Gates

- `scripts/check.sh` green on the branch.
- Every guard has a mutant that was RUN, not predicted — six in all. Two
  of them corrected me: one exposed a test measuring the wrong thing, and
  one showed a divergence assertion was never being reached.
- Integration CI has not been run from here; that gate is outstanding
  before any merge.