### PR TITLE
persistence(#1374): re-land #1375 with a probe on the write lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,8 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   old→new (broadcasting mid-migration raced a follow-on
   `Scrollback.fetch`; #373 rename-order fix). A NEW nick-keyed store MUST
   be added to this migration set or a rename silently strands its
-  old-nick rows. Boundary limit: IRC delivers a NICK only to
+  old-nick rows — the set and its one retried transaction live in
+  `Grappa.NickMigration` (#1374), not in `Session.Server`. Boundary limit: IRC delivers a NICK only to
   channel-sharing peers, so a query with someone in no shared channel
   cannot follow. **Our OWN nick keys exactly one window — the SELF
   window (`/msg <ownnick>`, GH #948) — and it has its own set** on

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43746,15 +43746,46 @@ contract (#524: a deferred transaction's read→write upgrade raises a
 `SQLITE_BUSY` that `busy_timeout` does not cover), not on anything this branch
 measured.
 
-### Accepted cost
+### Accepted cost — and the knob, turned the same day (#1374)
 
-`rename_muted_target/4` now opens a write transaction even when it turns out to
+`rename_muted_target/4` opens a write transaction even when it turns out to
 have nothing to migrate, and it is called once per peer NICK change per live
 session. The alternative — decide on a read taken OUTSIDE the transaction and
-re-read inside when there is work — buys back a sub-millisecond, WAL-frame-free
-lock acquisition at the price of a second SELECT on the write path and a
-duplicated "is this key muted?" predicate. Not taken; if nick-change churn ever
-shows up in the #357 write-latency counters, that is the knob.
+re-read inside when there is work — was declined here at "a sub-millisecond,
+WAL-frame-free lock acquisition", against the price of a second SELECT on the
+write path and a duplicated "is this key muted?" predicate, with the condition
+stated: *if nick-change churn ever shows up, that is the knob*.
+
+**The knob has been turned, and the paragraph above is superseded rather than
+merely qualified.** What the evidence refutes is the QUANTITY, not the
+reasoning. Per-call cost is the wrong unit here: one NICK fans out to every
+session sharing a channel, every one of them reaches this setter, and they
+queue for the same single writer — so the regime is concurrent, and the price
+of one acquisition does not describe it. The duplicated-predicate half of the
+objection is answered by not duplicating: `muted_prefs/2` is now the ONE "is
+this key muted?" question, shared between the probe outside the transaction and
+the rewrite inside it, which is also what keeps the two from drifting onto
+different notions of "nothing to migrate". The second-SELECT half stands and is
+paid deliberately: when the key IS muted the row is read twice.
+
+Two things are established, and they are not the same thing.
+
+**That the lock is taken to migrate nothing.** Measured, not argued:
+`NickMigrationTest` counts transaction-control statements off Ecto's per-query
+telemetry and reports `["begin"]` for a rename of a peer with no query window
+and no mute. That is a defect in its own terms and is the whole of what
+justifies the probe.
+
+**That this commit, as it first landed, turned CI red.** Historical fact, on
+the only venue that reproduces: on `83d90cb1` the `integration` job went red
+four runs out of four, three of them on `issue458-presence-page-yield`; its
+parent was green four runs in a row; and reverting this commit (#1414) restored
+green. The revert is why the commit above is a re-land rather than an original
+landing.
+
+**What is NOT established is that the probe cures that red.** It is not
+measured, and local reproduction argues against being able to measure it here:
+see the venue limitation in the #1374 entry below.
 <!-- entry #1374 -->
 
 ---

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43755,3 +43755,65 @@ re-read inside when there is work — buys back a sub-millisecond, WAL-frame-fre
 lock acquisition at the price of a second SELECT on the write path and a
 duplicated "is this key muted?" predicate. Not taken; if nick-change churn ever
 shows up in the #357 write-latency counters, that is the knob.
+<!-- entry #1374 -->
+
+---
+
+## 2026-08-16 — #1374: one busy-retry discipline for the write path, and what the fault seam cannot see
+
+Four findings from the 2026-08-15 review (P-S2, P-S3, P-S7, P-S8) share one
+rule, and it is the durable part of this change: **the retry goes OUTSIDE the
+transaction, the transaction goes INSIDE it, and no retry loop ever opens
+inside an already-open transaction.** `Repo.BusyRetry.run(fn ->
+Repo.immediate_transaction(fn -> … end) end)` is the only correct nesting.
+Retrying a step is not retrying a transaction; a nested retry sleeps while
+holding the enclosing transaction's connection and extends the very contention
+it waits on.
+
+Two consequences fall out. Code reached only from inside an open transaction
+needs a NON-retrying seam that RAISES, because the raise is what aborts the
+transaction and hands the retry to the enclosing engine — that is the `!`
+family (`persist!/1`, `get_or_init!/1`, `put_upload_ttl_seconds!/2`,
+`rename_muted_target!/4`). And a set of writes that must land together needs
+one owner: `Grappa.NickMigration` is now the home of the nick-rename set, a
+TOP-LEVEL boundary rather than a supervised child, so `Session` can span four
+contexts without acquiring a `Grappa.Repo` dep it deliberately lacks. The
+`query_windows_list` broadcast stays in `Session.Server` after the `:ok`
+return: it is the #373 "rename fully applied" barrier and a retried attempt
+must not re-fire it.
+
+**The write-transaction spelling is now gated statically, because it cannot be
+gated at runtime.** exqlite emits `BEGIN IMMEDIATE` only when
+`transaction_status == :idle` (`connection.ex:297-316`); nested, every mode
+collapses to `SAVEPOINT exqlite_savepoint`. Under the SQL Sandbox every test
+already runs inside a transaction, so `immediate_transaction/1` is always a
+savepoint there and no ExUnit oracle can distinguish it from `transaction/1` —
+the "put the deferred spelling back" mutant is unkillable at runtime. The
+defect is undecidable at runtime and decidable at compile time, so
+`test/grappa/repo/transaction_mode_gate_test.exs` walks the AST of `lib/**/*.ex`
+instead. Its blind spot is declared in its own moduledoc: a renaming alias
+escapes it, and a genuinely read-only transaction must say so by calling a
+`deferred_transaction/1` sibling, deliberately not written because it would be
+dead code today.
+
+**The fault-injection seam has a reach, and it is narrower than it looks.**
+`BusyRetry`'s injected fault fires only at the top of a `BusyRetry.run`
+attempt. Established by mutation, not assumed: removing the wrapper from
+`NickMigration.migrate/1` did not make the write fail, it made the write
+LAND. Three things follow, and they bound what any future test here can claim.
+A code path with no retry loop has no fault point at all, so the seam cannot
+show a raise escaping an unretried writer — that claim stays argued from
+`Repo.update/1`'s behaviour. A saturating fault fires before the first step of
+a transaction, so removing `immediate_transaction` from a retried chain leaves
+every test green: atomicity is NOT measurable in-process, and the mutant that
+should have bought it survives. And a fault cannot be aimed mid-chain, because
+a first attempt that succeeds means there is no second attempt to arm.
+
+Two review claims did not survive measurement, recorded so nobody re-derives
+them. The 2FA door does NOT answer 500 on a sustained busy; it already answers
+503, from a retry DOWNSTREAM of `TOTP.verify/3`. Its real defect was that
+`totp_last_used_step` advanced anyway, so the user paid a redeemable code for a
+degraded response. And P-S8's count was wrong in three different ways at once —
+prose said five, four were named, the file:line list held six; seven are fixed,
+including `update_visitor_last_joined_channels/3`, which the review never
+mentions and which is session-driven exactly like its user-side twin.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43804,7 +43804,7 @@ it waits on.
 Two consequences fall out. Code reached only from inside an open transaction
 needs a NON-retrying seam that RAISES, because the raise is what aborts the
 transaction and hands the retry to the enclosing engine — that is the `!`
-family (`persist!/1`, `get_or_init!/1`, `put_upload_ttl_seconds!/2`,
+family (`get_or_init!/1`, `put_upload_ttl_seconds!/2`,
 `rename_muted_target!/4`). And a set of writes that must land together needs
 one owner: `Grappa.NickMigration` is now the home of the nick-rename set, a
 TOP-LEVEL boundary rather than a supervised child, so `Session` can span four
@@ -43848,3 +43848,61 @@ degraded response. And P-S8's count was wrong in three different ways at once �
 prose said five, four were named, the file:line list held six; seven are fixed,
 including `update_visitor_last_joined_channels/3`, which the review never
 mentions and which is session-driven exactly like its user-side twin.
+
+### Two gates, one predicate: do not take the write lock to migrate nothing
+
+A peer NICK fans out to every session sharing a channel, and almost none of
+them hold a window or a mute for that peer. Both stores are now probed before
+anything opens a transaction for them: `QueryWindows.exists?/3` for the window,
+`muted_prefs/2` for the mute. Neither probe is a second formulation of its
+store's question — each IS the question the write then asks, shared with it, so
+the cheap path and the authoritative path cannot drift onto different notions
+of "nothing to migrate". Neither probe is trusted for the write either: the
+transaction re-reads, and only that read decides what is written. A store that
+appears between probe and frame is equally invisible to a `SELECT` taken inside
+the transaction, so nothing is made less atomic; at worst a transaction opens
+that turns out to have nothing in it, which is the cost being removed
+everywhere else.
+
+The mute still migrates UNCONDITIONALLY (#1340): the probe decides whether a
+TRANSACTION is needed, never whether the MIGRATION is. With no window the mute
+is the only store that can move, and an unmuted key has nothing to move at all,
+so here the two questions coincide.
+
+The bang variants deliberately do not probe. They run inside the caller's open
+transaction, where the lock is already held, so a probe would cost a read and
+buy nothing.
+
+### The venue limitation — a green on a workstation is not an acquittal
+
+That the lock is taken to migrate nothing is measured, deterministically, by
+`NickMigrationTest` off Ecto's per-query telemetry. **That removing it cures
+any end-to-end red is NOT measured, and the attempt to measure it locally
+failed.**
+
+The signature originally chased — `fault=busy_locked`, a dropped scrollback row
+under the #336 never-crash contract, a rename landing tens of seconds behind
+its assertion window — appeared only while an unrelated ExUnit suite happened
+to be running from ANOTHER worktree on the same host. On a quiet host the
+unfixed tree passed 10/10 with zero occurrences of all three signatures. Under
+a deliberately generated load it passed 10/10 again, with zero, even though
+that load was HEAVIER by loadavg: band 4.86–9.12 against a 3.2–4.7 floor.
+
+The likely reason is worth recording, because it will mislead the next person
+the same way: **loadavg measures the CPU run queue, not contention on SQLite's
+single writer.** The generated load was more pressure of a different kind —
+different `_build`, different mix container, different disk access pattern.
+Nothing here rules the defect out; it says this venue cannot show it, and that
+a green measured here must not be read as an acquittal.
+
+Five arms were run and three discarded, recorded so the two surviving greens
+are not mistaken for the whole attempt: one where a neighbour's suite ran
+during the unfixed arm and its heavy phase fell outside the comparison arm's
+window (a time-varying neighbour on sequential arms can manufacture a
+differential from nothing); its comparison arm, for the same reason; and a
+first controlled-load attempt whose generator ran from the tree under
+measurement, so the load differed between arms by construction.
+
+The venue that does reproduce is a contended CI runner, and what it has
+established is about #1375 rather than about the probe — see the re-land note
+in that entry above.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43691,3 +43691,67 @@ lost for good. Do not build machinery on top of this.
 
 Repair of the rows already truncated in production is a separate,
 operator-owned decision — this change stops the loss, it does not undo it.
+<!-- entry #1375 -->
+
+---
+
+## 2026-08-16 — #1375: one write path for the settings blob, and what a one-connection harness can prove about a race
+
+`user_settings.data` is a single JSON column, so a setter that reads the blob,
+merges its key and writes it back necessarily writes the WHOLE column. Nine
+setters spelled that read-modify-write pair by hand, plus
+`rename_muted_target/4`, so two writers touching completely DIFFERENT keys both
+read the same snapshot, both write a full replacement, and the second commit
+drops the first's key — with `{:ok, _}` on both sides and nothing in the logs.
+
+The durable rule is the one the module now states in its moduledoc: **there is
+exactly ONE writer, `update_data/2`, and it holds the read and the write in a
+single `Repo.immediate_transaction/1`.** A new setter that spells its own pair
+reintroduces the defect for its own key. The nesting is #1374's — retry
+OUTSIDE, transaction INSIDE — which is why the row init inside it is the
+non-retrying `get_or_init!/1`: a retry loop opened inside an open transaction
+sleeps on the connection it holds.
+
+### The interleave was reproduced, not argued
+
+Ecto's per-query telemetry (`[:grappa, :repo, :query]`, the event
+`Grappa.DbLatency` already folds) runs its handlers SYNCHRONOUSLY in the
+process that issued the query. A handler that blocks on the writer's
+`user_settings` SELECT therefore suspends it exactly between its read and its
+write, with no seam in production code and no sleep-and-hope — the second
+writer is signalled from inside that window.
+`test/grappa/user_settings_concurrency_test.exs` drives the pair the issue
+names as reachable in production (`put_last_client_prefix64/2` fires from
+`Vhosts.record_client_source/2` on every client connect, in the socket's own
+process and its own connection of the ten, while a settings-drawer PUT runs in
+another). Unfixed, the key written in the window comes back `nil`.
+
+### What the harness substitutes, and what it therefore cannot buy
+
+In production the serialisation comes from SQLite's file-level write lock: the
+second `BEGIN IMMEDIATE` waits out `busy_timeout` and its read then sees the
+first writer's commit. The Sandbox has ONE connection (`config/test.exs`,
+`pool_size: 1`), so in the test the second writer blocks on the checkout the
+open transaction holds. Same serialisation, different lock.
+
+So these tests prove the read and the write are ONE transaction — removing the
+transaction kills exactly one assertion in each of them — and they do NOT prove
+the `:immediate` spelling of it. That was measured, not assumed: with
+`Repo.transaction/1` in place of `Repo.immediate_transaction/1` both tests stay
+green, because nested under the Sandbox every mode is a `SAVEPOINT` (the same
+blind spot #1374 records for its own conversions, and the reason its gate on
+the spelling is a static AST walk rather than an ExUnit oracle). The
+`:immediate` spelling here rests on `Repo.immediate_transaction/1`'s own
+contract (#524: a deferred transaction's read→write upgrade raises a
+`SQLITE_BUSY` that `busy_timeout` does not cover), not on anything this branch
+measured.
+
+### Accepted cost
+
+`rename_muted_target/4` now opens a write transaction even when it turns out to
+have nothing to migrate, and it is called once per peer NICK change per live
+session. The alternative — decide on a read taken OUTSIDE the transaction and
+re-read inside when there is work — buys back a sub-millisecond, WAL-frame-free
+lock acquisition at the price of a second SELECT on the write path and a
+duplicated "is this key muted?" predicate. Not taken; if nick-change churn ever
+shows up in the #357 write-latency counters, that is the knob.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -775,7 +775,7 @@ defmodule Grappa.Accounts do
     * **in-transaction** — the `!` variants
       (`revoke_other_sessions_for_user!/2` and the private
       `revoke_sessions_for_user!/1`). Reached only from inside a
-      `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, where the
+      `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, where the
       enclosing engine retries the WHOLE transaction. They deliberately do
       NOT retry: a nested retry would sleep while holding the open
       transaction's connection, extending the very contention it waits on,
@@ -944,7 +944,7 @@ defmodule Grappa.Accounts do
 
   In-transaction only — every caller (TOTP enrolment/disable, the passkey
   mode transaction) already runs inside a
-  `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, so this RAISES on
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, so this RAISES on
   SQLITE_BUSY rather than retrying: the raise is what aborts the
   transaction and hands the retry to the enclosing engine. See the family
   contract on `revoke_session/1`. A caller with no such enclosure wants a
@@ -978,7 +978,7 @@ defmodule Grappa.Accounts do
           {:ok, [String.t()]} | {:error, term()}
   def confirm_totp_enrollment(user, current_session_id, secret, code, unix_seconds) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn ->
+      Repo.immediate_transaction(fn ->
         confirm_totp_transaction(user, current_session_id, secret, code, unix_seconds)
       end)
     end)
@@ -1045,7 +1045,14 @@ defmodule Grappa.Accounts do
           | {:error, :invalid_two_factor | :two_factor_replayed | :db_unavailable}
   def verify_second_factor(%User{} = user, code, unix_seconds)
       when is_binary(code) and is_integer(unix_seconds) do
-    case TOTP.verify(user, code, unix_seconds) do
+    # #1374 P-S3 — the retry belongs HERE, at the boundary, not inside
+    # `TOTP.verify/3`: the transaction is what must be retried, and it opens
+    # inside that function. Until #1374 this was the one second-factor path
+    # with no retry at all, so a transient busy raised through as a 500 at
+    # the login door where #518 promises a typed 503. The recovery-code arm
+    # below owns its OWN budget (`consume_recovery_code/2`) and is reached
+    # only after this run has returned, so the two never nest.
+    case Repo.BusyRetry.run(fn -> TOTP.verify(user, code, unix_seconds) end) do
       {:error, :two_factor_not_enabled} -> spend_recovery_code(user, code)
       result -> result
     end
@@ -1110,7 +1117,7 @@ defmodule Grappa.Accounts do
   end
 
   defp run_totp_reset(user),
-    do: Repo.BusyRetry.run(fn -> Repo.transaction(fn -> totp_reset_transaction(user) end) end)
+    do: Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> totp_reset_transaction(user) end) end)
 
   defp totp_reset_transaction(user) do
     user_query = from(u in User, where: u.id == ^user.id)
@@ -1139,7 +1146,7 @@ defmodule Grappa.Accounts do
   end
 
   defp run_passkey_reset(user) do
-    Repo.BusyRetry.run(fn -> Repo.transaction(fn -> reset_passkeys_transaction(user) end) end)
+    Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> reset_passkeys_transaction(user) end) end)
   end
 
   defp reset_passkeys_transaction(user) do
@@ -1163,7 +1170,7 @@ defmodule Grappa.Accounts do
 
   defp run_disable_totp_transaction(user, current_session_id) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn -> disable_totp_transaction(user, current_session_id) end)
+      Repo.immediate_transaction(fn -> disable_totp_transaction(user, current_session_id) end)
     end)
   end
 

--- a/lib/grappa/accounts/totp.ex
+++ b/lib/grappa/accounts/totp.ex
@@ -45,7 +45,7 @@ defmodule Grappa.Accounts.TOTP do
       when is_binary(secret) and is_binary(code) and is_integer(unix_seconds) do
     with {:ok, step} <- matching_step(secret, code, unix_seconds) do
       now = DateTime.utc_now()
-      Repo.transaction(fn -> arm(user_id, secret, step, now) end)
+      Repo.immediate_transaction(fn -> arm(user_id, secret, step, now) end)
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Grappa.Accounts.TOTP do
   @spec verify(User.t(), String.t(), integer()) :: {:ok, :totp | :recovery} | {:error, verify_error()}
   def verify(%User{id: user_id}, code, unix_seconds)
       when is_binary(code) and is_integer(unix_seconds) do
-    Repo.transaction(fn ->
+    Repo.immediate_transaction(fn ->
       user = Repo.get!(User, user_id)
 
       if is_nil(user.totp_enabled_at) or is_nil(user.totp_secret_encrypted) do

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -378,7 +378,9 @@ defmodule Grappa.Accounts.WebAuthn do
 
   defp run_mode_transaction(user, mode, current_session_id, recovery_codes) do
     Repo.BusyRetry.run(fn ->
-      Repo.transaction(fn -> set_mode_transaction(user, mode, current_session_id, recovery_codes) end)
+      Repo.immediate_transaction(fn ->
+        set_mode_transaction(user, mode, current_session_id, recovery_codes)
+      end)
     end)
   end
 

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -182,22 +182,27 @@ defmodule Grappa.Networks.Credentials do
   path). `{:error, :not_found}` when the credential was unbound.
   """
   @spec remove_visitor_last_joined_channel(Ecto.UUID.t(), pos_integer(), String.t()) ::
-          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def remove_visitor_last_joined_channel(visitor_id, network_id, channel_name)
       when is_binary(visitor_id) and is_integer(network_id) and is_binary(channel_name) do
     canonical = Grappa.IRC.Identifier.canonical_target(channel_name)
 
-    case get_visitor_credential(visitor_id, network_id) do
-      {:ok, cred} ->
-        kept = Enum.reject(cred.last_joined_channels, &(&1 == canonical))
+    # #1374 P-S8 — web-reachable (`DELETE /networks/:slug/channels/:id`), so
+    # the terminal is the 503 door, not a drop: the operator asked for this
+    # write and must learn it did not happen.
+    Repo.BusyRetry.run(fn ->
+      case get_visitor_credential(visitor_id, network_id) do
+        {:ok, cred} ->
+          kept = Enum.reject(cred.last_joined_channels, &(&1 == canonical))
 
-        cred
-        |> Credential.last_joined_channels_changeset(kept)
-        |> Repo.update()
+          cred
+          |> Credential.last_joined_channels_changeset(kept)
+          |> Repo.update()
 
-      {:error, :not_found} ->
-        {:error, :not_found}
-    end
+        {:error, :not_found} ->
+          {:error, :not_found}
+      end
+    end)
   end
 
   @doc """
@@ -208,7 +213,7 @@ defmodule Grappa.Networks.Credentials do
   autojoin list. Returns `{:ok, credential}` or `{:error, changeset}`.
   """
   @spec remove_autojoin_channel(User.t(), Network.t(), String.t()) ::
-          {:ok, Credential.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+          {:ok, Credential.t()} | {:error, Ecto.Changeset.t() | :not_found | :db_unavailable}
   def remove_autojoin_channel(%User{} = user, %Network{} = network, channel_name)
       when is_binary(channel_name) do
     # UX-4 bucket A — canonicalise so a REST DELETE with `#Chan` in the
@@ -216,17 +221,21 @@ defmodule Grappa.Networks.Credentials do
     # Credential.changeset/2 writer normalises to).
     channel_name = Grappa.IRC.Identifier.canonical_target(channel_name)
 
-    case get_credential(user, network) do
-      {:ok, cred} ->
-        new_autojoin = Enum.reject(cred.autojoin_channels, &(&1 == channel_name))
+    # #1374 P-S8 — the user twin of `remove_visitor_last_joined_channel/3`,
+    # same web-reachable 503 door.
+    Repo.BusyRetry.run(fn ->
+      case get_credential(user, network) do
+        {:ok, cred} ->
+          new_autojoin = Enum.reject(cred.autojoin_channels, &(&1 == channel_name))
 
-        cred
-        |> Credential.changeset(%{autojoin_channels: new_autojoin})
-        |> Repo.update()
+          cred
+          |> Credential.changeset(%{autojoin_channels: new_autojoin})
+          |> Repo.update()
 
-      {:error, :not_found} ->
-        {:error, :not_found}
-    end
+        {:error, :not_found} ->
+          {:error, :not_found}
+      end
+    end)
   end
 
   @doc """
@@ -260,7 +269,7 @@ defmodule Grappa.Networks.Credentials do
   belt-and-braces guard, not the primary enforcement point.
   """
   @spec update_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_last_joined_channels(user_id, network_id, channels)
       when is_binary(user_id) and is_integer(network_id) and is_list(channels) do
     case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
@@ -301,7 +310,7 @@ defmodule Grappa.Networks.Credentials do
   re-JOINs it. One channel too many beats one lost for good.
   """
   @spec merge_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()], [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def merge_last_joined_channels(user_id, network_id, joined, departed)
       when is_binary(user_id) and is_integer(network_id) and is_list(joined) and
              is_list(departed) do
@@ -333,14 +342,30 @@ defmodule Grappa.Networks.Credentials do
   # `Visitor.last_joined_channels_changeset/2`. Single Repo writer for the
   # column — both subject kinds and both verbs (set + merge) land here, so
   # the cap is enforced once.
+  #
+  # #1374 P-S8 — the WRITE rides `BusyRetry.run/1`. This fires on EVERY
+  # self-JOIN / self-PART / self-KICK, and bootstrap spawning N sessions x M
+  # autojoin channels is the correlated write burst. The call site
+  # (`Session.Server.maybe_persist_last_joined/2`) already logs a RETURNED
+  # `{:error, _}` and carries on, but a transient busy RAISED, and the raise
+  # escaped the persister closure into the GenServer. Background-DROP posture
+  # (#590): the next membership change overwrites the snapshot, so a lost one
+  # only costs the next restart its rejoin list. #1385 made this the single
+  # writer, so the retry lands here ONCE and covers both subject kinds and
+  # both verbs — where #1374 originally had to repeat it per public setter.
   @spec write_last_joined_channels(Credential.t(), [String.t()]) ::
-          :ok | {:error, Ecto.Changeset.t()}
+          :ok | {:error, Ecto.Changeset.t() | :db_unavailable}
   defp write_last_joined_channels(%Credential{} = cred, channels) do
     capped = Enum.take(channels, Credential.last_joined_channels_max())
 
-    case cred |> Credential.last_joined_channels_changeset(capped) |> Repo.update() do
+    write =
+      Repo.BusyRetry.run(fn ->
+        cred |> Credential.last_joined_channels_changeset(capped) |> Repo.update()
+      end)
+
+    case write do
       {:ok, _} -> :ok
-      {:error, changeset} -> {:error, changeset}
+      {:error, _} = err -> err
     end
   end
 
@@ -361,18 +386,25 @@ defmodule Grappa.Networks.Credentials do
   to boot `:present`.
   """
   @spec update_away(Ecto.UUID.t(), pos_integer(), String.t() | nil, DateTime.t() | nil) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_away(user_id, network_id, reason, since)
       when is_binary(user_id) and is_integer(network_id) do
-    case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
-      nil ->
-        {:error, :not_found}
-
-      %Credential{} = cred ->
-        case Repo.update(Credential.away_changeset(cred, reason, since)) do
-          {:ok, _} -> :ok
-          {:error, changeset} -> {:error, changeset}
+    # #1374 P-S8 — twin of `update_last_joined_channels/3`, same posture: it
+    # fires on every away transition (including the auto-away debounce, which
+    # a WS reconnect storm drives for every session at once), and its call
+    # site (`Session.Server.call_away_persister/3`) already logs a returned
+    # error and continues. Only the RAISE was unhandled.
+    persisted =
+      Repo.BusyRetry.run(fn ->
+        case Repo.get_by(Credential, user_id: user_id, network_id: network_id) do
+          nil -> {:error, :not_found}
+          %Credential{} = cred -> Repo.update(Credential.away_changeset(cred, reason, since))
         end
+      end)
+
+    case persisted do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
     end
   end
 
@@ -391,7 +423,7 @@ defmodule Grappa.Networks.Credentials do
   semantics).
   """
   @spec update_visitor_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_visitor_last_joined_channels(visitor_id, network_id, channels)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(channels) do
     case Repo.get_by(Credential, visitor_id: visitor_id, network_id: network_id) do
@@ -412,7 +444,7 @@ defmodule Grappa.Networks.Credentials do
           pos_integer(),
           [String.t()],
           [String.t()]
-        ) :: :ok | {:error, :not_found | Ecto.Changeset.t()}
+        ) :: :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def merge_visitor_last_joined_channels(visitor_id, network_id, joined, departed)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(joined) and
              is_list(departed) do

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -62,6 +62,31 @@ defmodule Grappa.NickMigration do
   disconnecting a user over, and the old-nick state it leaves behind is
   self-consistent. Before #1374 the same busy RAISED through strict
   `{:ok, _} =` binds and took the session down mid-migration.
+
+  ## The transaction earns its place PROSPECTIVELY — do not remove it
+
+  Today no test can kill a mutant that deletes `immediate_transaction/1`
+  from `migrate/1`, and that is a property of the CURRENT step list, not a
+  licence. Every step here is total on real data: the two scrollback
+  renames are `update_all`, `ReadCursor.rename_dm_peer/4` handles a
+  fold-collision by dropping the stale cursor, `QueryWindows.rename/4`
+  merges on collision and even rescues the unique-index race, and the
+  mute's changeset validates only `data` presence and the subject XOR,
+  neither of which a rename of an existing row can violate. The one
+  failure the chain admits — the enclosing retry's budget running out —
+  fires before the first step by construction. Nothing can fail in the
+  middle, so nothing can be observed rolling back.
+
+  That changes the moment the set grows, and CLAUDE.md says it WILL: "A
+  NEW nick-keyed store MUST be added to this migration set or a rename
+  silently strands its old-nick rows." A new store is under no obligation
+  to be total — the next one may carry a validation, a unique constraint,
+  or a genuine `{:error, _}` arm. On that day a half-applied identity
+  becomes reachable and this transaction is the only thing standing
+  between a rename and a window pointing at history that moved without
+  it. It is here for the step that has not been written yet, and the
+  test that will finally be able to buy it is the one that adds a
+  fallible step.
   """
 
   use Boundary,

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -158,22 +158,30 @@ defmodule Grappa.NickMigration do
       when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
              is_binary(new_nick) do
     if QueryWindows.exists?(subject, network_id, old_nick) do
-      migrate(fn ->
-        mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
-
-        case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
-          {:ok, :renamed} ->
-            {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
-            :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
-            %{window: :renamed, rows: rows, mute: mute}
-
-          {:ok, :noop} ->
-            %{window: :noop, rows: 0, mute: mute}
-        end
-      end)
+      windowed_peer_renamed(subject, network_id, network_slug, old_nick, new_nick)
     else
       windowless_peer_renamed(subject, network_slug, old_nick, new_nick)
     end
+  end
+
+  # The migration path proper, unchanged by the #1378 gate that now guards it:
+  # same transaction, same retry, same order across the four stores.
+  @spec windowed_peer_renamed(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, peer_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp windowed_peer_renamed(subject, network_id, network_slug, old_nick, new_nick) do
+    migrate(fn ->
+      mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
+
+      case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
+        {:ok, :renamed} ->
+          {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          %{window: :renamed, rows: rows, mute: mute}
+
+        {:ok, :noop} ->
+          %{window: :noop, rows: 0, mute: mute}
+      end
+    end)
   end
 
   # #1378 — a peer we never queried is the OVERWHELMING case: IRC delivers a

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -57,6 +57,16 @@ defmodule Grappa.NickMigration do
       re-attempt could broadcast twice; inside the transaction it could
       announce a rename that then rolled back.
 
+  **And NEITHER is entered when there is nothing to migrate (#1378).**
+  `peer_renamed/5` probes `QueryWindows.exists?/3` first: with no window the
+  mute is the only store that can move, and this four-store transaction is
+  skipped (the mute setter keeps one of its own — see
+  `windowless_peer_renamed/4`). That is not an optimisation — an unconditional
+  `BEGIN IMMEDIATE` took SQLite's single write lock once per session per peer
+  rename to do nothing, and under channel fan-out the sessions raced each
+  other into `busy_locked`. See `windowless_peer_renamed/4` for the race
+  argument and for why `own_renamed/5` keeps its unconditional transaction.
+
   Terminal on budget exhaustion is `{:error, :db_unavailable}`, which the
   session logs and DROPs (#590 background posture) — a rename is not worth
   disconnecting a user over, and the old-nick state it leaves behind is
@@ -147,19 +157,69 @@ defmodule Grappa.NickMigration do
   def peer_renamed({_, _} = subject, network_id, network_slug, old_nick, new_nick)
       when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
              is_binary(new_nick) do
-    migrate(fn ->
-      mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
+    if QueryWindows.exists?(subject, network_id, old_nick) do
+      migrate(fn ->
+        mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
 
-      case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
-        {:ok, :renamed} ->
-          {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
-          :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
-          %{window: :renamed, rows: rows, mute: mute}
+        case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
+          {:ok, :renamed} ->
+            {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
+            :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+            %{window: :renamed, rows: rows, mute: mute}
 
-        {:ok, :noop} ->
-          %{window: :noop, rows: 0, mute: mute}
-      end
-    end)
+          {:ok, :noop} ->
+            %{window: :noop, rows: 0, mute: mute}
+        end
+      end)
+    else
+      windowless_peer_renamed(subject, network_slug, old_nick, new_nick)
+    end
+  end
+
+  # #1378 — a peer we never queried is the OVERWHELMING case: IRC delivers a
+  # NICK for every channel-sharing peer, so one rename fans out to every
+  # session in the channel, and almost none of them hold a window for it.
+  # Without the gate above each of those opened `BEGIN IMMEDIATE`, taking the
+  # RESERVED lock on SQLite's single writer to migrate nothing — measured on
+  # the #458 e2e as four sessions racing per rename, `busy_locked` for the
+  # full 1500ms budget, a dropped scrollback row and a session stalled ~33s
+  # behind its inbound stream.
+  #
+  # With no window, the mute is the ONLY store that can move, so this path
+  # takes the caller-facing `rename_muted_target/4` and skips the four-store
+  # transaction. It does NOT skip a transaction altogether, and saying so
+  # would be the log-honesty failure CLAUDE.md names: #1375 put a
+  # `BEGIN IMMEDIATE` inside that setter, because one `Repo.update` of the
+  # `data` blob is a read-modify-write pair that silently drops a concurrent
+  # writer's key. So what this gate removes is the transaction spanning
+  # `QueryWindows.rename/4` plus two `update_all`s — a much shorter hold of
+  # the RESERVED lock, not no hold. Whether the residue still reproduces the
+  # #458 profile is NOT established by the measurement quoted above, which
+  # was taken before #1375 landed. The migration path proper is untouched —
+  # same transaction, same retry, same order.
+  #
+  # The probe is a READ taken outside any transaction, and that is safe in
+  # the only direction that matters. If it sees a window that is gone by the
+  # time the transaction runs, we opened one transaction too many — the cost
+  # we used to pay unconditionally. It cannot skip a migration that was
+  # needed: a window CREATED after the probe is equally invisible to a
+  # `rename/4` running inside the transaction, whose own `SELECT` would have
+  # missed it just the same, so the stranded-window window is not widened by
+  # a microsecond. The transaction buys atomicity across the four stores, not
+  # mutual exclusion against a window opened later.
+  #
+  # `own_renamed/5` deliberately keeps its unconditional transaction: its
+  # first step (`Scrollback.rename_own_nick/4`) is an `update_all` whose
+  # row count cannot be known without running it, so a probe there would
+  # cost what it saves — and our own nick moves once per `/nick`, not once
+  # per peer per session.
+  @spec windowless_peer_renamed(Subject.t(), String.t(), String.t(), String.t()) ::
+          {:ok, peer_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp windowless_peer_renamed(subject, network_slug, old_nick, new_nick) do
+    case UserSettings.rename_muted_target(subject, network_slug, old_nick, new_nick) do
+      {:ok, mute} -> {:ok, %{window: :noop, rows: 0, mute: mute}}
+      {:error, _} = err -> err
+    end
   end
 
   @doc """

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -195,16 +195,14 @@ defmodule Grappa.NickMigration do
   #
   # With no window, the mute is the ONLY store that can move, so this path
   # takes the caller-facing `rename_muted_target/4` and skips the four-store
-  # transaction. It does NOT skip a transaction altogether, and saying so
-  # would be the log-honesty failure CLAUDE.md names: #1375 put a
-  # `BEGIN IMMEDIATE` inside that setter, because one `Repo.update` of the
-  # `data` blob is a read-modify-write pair that silently drops a concurrent
-  # writer's key. So what this gate removes is the transaction spanning
-  # `QueryWindows.rename/4` plus two `update_all`s — a much shorter hold of
-  # the RESERVED lock, not no hold. Whether the residue still reproduces the
-  # #458 profile is NOT established by the measurement quoted above, which
-  # was taken before #1375 landed. The migration path proper is untouched —
-  # same transaction, same retry, same order.
+  # transaction. That setter has a `BEGIN IMMEDIATE` of its own since #1375 —
+  # one `Repo.update` of the `data` blob is a read-modify-write pair that
+  # silently drops a concurrent writer's key — so for a while this gate only
+  # made the lock hold SHORTER. It carries its own probe now, on the same
+  # discipline as the one here: with nothing muted under the old key it opens
+  # no transaction either, and a peer nobody muted costs two indexed reads and
+  # no lock. The migration path proper is untouched — same transaction, same
+  # retry, same order.
   #
   # The probe is a READ taken outside any transaction, and that is safe in
   # the only direction that matters. If it sees a window that is gone by the

--- a/lib/grappa/nick_migration.ex
+++ b/lib/grappa/nick_migration.ex
@@ -1,0 +1,181 @@
+defmodule Grappa.NickMigration do
+  @moduledoc """
+  Single home of the nick-rename migration set (#1374 P-S2).
+
+  A NICK change is an identity MIGRATION, not a fold: every store keyed on
+  the old nick moves old -> new. The set is:
+
+    * `Grappa.QueryWindows.rename/4` — the window row (#373).
+    * `Grappa.Scrollback.rename_dm_peer/4` — the DM history (#373).
+    * `Grappa.ReadCursor.rename_dm_peer/4` — the DM read cursor, else the
+      migrated history reads as fully unread (#373).
+    * `Grappa.UserSettings.rename_muted_target!/4` — the per-conversation
+      mute, nick-keyed since #1038 (#1340).
+
+  and, when the nick that moved is OUR OWN, `Scrollback.rename_own_nick/4`
+  (the inbound-DM own-nick TAG, #514) plus `rename_self_window/4` and the
+  three above behind its row-count gate (#948).
+
+  ## Why the set has a module and not just a paragraph
+
+  Until #1374 the set existed as prose in CLAUDE.md ("A NEW nick-keyed store
+  MUST be added to this migration set") over a chain inlined in
+  `Grappa.Session.Server`. A new nick-keyed store was added by hoping
+  somebody read the paragraph. Here the invariant is executable: the set is
+  this module's two public verbs, and a store left out of them is visible as
+  a store this module never calls.
+
+  ## Why the transaction lives HERE
+
+  The chain spans four contexts. None of them can host the transaction
+  without owning the other three's tables — an abstraction that leaks by
+  construction. `Grappa.Session.Server`, the only caller, cannot host it
+  either: the `Grappa.Session` boundary deliberately has no `Grappa.Repo`
+  dep, and opening one to reach `immediate_transaction/1` is exactly the
+  dependency its moduledoc denies. So this is a TOP-LEVEL boundary that deps
+  the four contexts and `Repo`, called from Session — the
+  `Grappa.SpawnOrchestrator` shape (a cross-context verb, not a supervised
+  child).
+
+  ## Composition: retry OUTSIDE, transaction INSIDE, broadcast NEITHER
+
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fn -> … end) end)`:
+
+    * **Transaction inside** — a crash or busy between two steps used to
+      strand the history under the new nick with a cursor keyed to the old
+      one (the "reads as fully unread" failure the cursor move exists to
+      prevent). All four stores move together or none does.
+    * **Retry outside** — the whole transaction is the retryable unit. Each
+      step is idempotent in the only sense that matters here: a rolled-back
+      attempt left nothing behind, so a replay starts from the same
+      pre-state. Callees reached from here are the non-retrying `!`
+      variants where the family offers one; a nested retry would sleep
+      holding the open transaction's connection.
+    * **Broadcast in NEITHER** — `query_windows_list` is the truthful
+      "rename fully applied" barrier and stays in `Session.Server`, after
+      this returns `{:ok, _}` (#373 rename-order fix). Inside the retry a
+      re-attempt could broadcast twice; inside the transaction it could
+      announce a rename that then rolled back.
+
+  Terminal on budget exhaustion is `{:error, :db_unavailable}`, which the
+  session logs and DROPs (#590 background posture) — a rename is not worth
+  disconnecting a user over, and the old-nick state it leaves behind is
+  self-consistent. Before #1374 the same busy RAISED through strict
+  `{:ok, _} =` binds and took the session down mid-migration.
+  """
+
+  use Boundary,
+    top_level?: true,
+    deps: [
+      Grappa.QueryWindows,
+      Grappa.ReadCursor,
+      Grappa.Repo,
+      Grappa.Scrollback,
+      Grappa.Subject,
+      Grappa.UserSettings
+    ]
+
+  alias Grappa.{QueryWindows, ReadCursor, Repo, Scrollback, Subject, UserSettings}
+  alias Grappa.Repo.BusyRetry
+
+  @typedoc """
+  Outcome of a peer rename. `window` is `:noop` when the peer had no query
+  window (the common case — a peer we never queried costs one indexed
+  lookup and no writes), in which case `rows` is 0. `mute` is independent
+  of both: a mute outlives the window it silenced.
+  """
+  @type peer_result :: %{
+          window: :renamed | :noop,
+          rows: non_neg_integer(),
+          mute: :renamed | :noop
+        }
+
+  @typedoc """
+  Outcome of an own-nick rename. `tag_rows` counts the inbound-DM own-nick
+  TAGs re-keyed (#514) — independent of the self window. `rows` counts the
+  SELF window's scrollback rows, and is the gate: at 0 the window, cursor
+  and mute are deliberately untouched (see `own_renamed/5`).
+  """
+  @type own_result :: %{
+          tag_rows: non_neg_integer(),
+          rows: non_neg_integer(),
+          window: :renamed | :noop,
+          mute: :renamed | :noop
+        }
+
+  @doc """
+  Migrates every store keyed on a PEER's old nick, atomically.
+
+  The window row is the gate for the history + cursor: a peer we never
+  queried has nothing to move. The mute is migrated UNCONDITIONALLY and
+  deliberately outside that gate — a mute outlives the window that was
+  muted (closing a tab does not unmute it), so gating it on the window row
+  would strand exactly the mute nobody can see to fix (#1340 K-S2).
+
+  Returns `{:error, :db_unavailable}` when the retry budget is exhausted
+  (nothing applied), or `{:error, changeset}` when the mute's settings row
+  will not validate — also nothing applied, because the transaction rolls
+  back on it rather than half-migrating an identity.
+  """
+  @spec peer_renamed(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, peer_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def peer_renamed({_, _} = subject, network_id, network_slug, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
+             is_binary(new_nick) do
+    migrate(fn ->
+      mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
+
+      case QueryWindows.rename(subject, network_id, old_nick, new_nick) do
+        {:ok, :renamed} ->
+          {:ok, rows} = Scrollback.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+          %{window: :renamed, rows: rows, mute: mute}
+
+        {:ok, :noop} ->
+          %{window: :noop, rows: 0, mute: mute}
+      end
+    end)
+  end
+
+  @doc """
+  Migrates every store keyed on OUR OWN old nick, atomically.
+
+  Two independent migrations share the transaction. The inbound-DM own-nick
+  TAG (`tag_rows`) always moves: `Push.Triggers.dm?/2` reads it back against
+  the LIVE nick, so a stale tag silently loses a DM's badge (#514).
+
+  The SELF window (`/msg <ownnick>`, #948) moves behind its scrollback row
+  count, the inverse of the peer arm's window gate: a window standing at our
+  old nick is EITHER our self window or a leftover query with a peer who
+  bore that nick before us, and the fold-unique index makes those ONE row.
+  Only the scrollback's `sender` tells them apart, so a zero count means "no
+  self conversation here" and the window, cursor and mute stay put — the
+  cheaper of two wrongs against filing a peer's identity under our new nick.
+  """
+  @spec own_renamed(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, own_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  def own_renamed({_, _} = subject, network_id, network_slug, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(network_slug) and is_binary(old_nick) and
+             is_binary(new_nick) do
+    migrate(fn ->
+      {:ok, tag_rows} = Scrollback.rename_own_nick(subject, network_id, old_nick, new_nick)
+      {:ok, rows} = Scrollback.rename_self_window(subject, network_id, old_nick, new_nick)
+
+      if rows > 0 do
+        :ok = ReadCursor.rename_dm_peer(subject, network_id, old_nick, new_nick)
+        {:ok, window} = QueryWindows.rename(subject, network_id, old_nick, new_nick)
+        mute = UserSettings.rename_muted_target!(subject, network_slug, old_nick, new_nick)
+
+        %{tag_rows: tag_rows, rows: rows, window: window, mute: mute}
+      else
+        %{tag_rows: tag_rows, rows: 0, window: :noop, mute: :noop}
+      end
+    end)
+  end
+
+  @spec migrate((-> result)) :: {:ok, result} | {:error, Ecto.Changeset.t() | :db_unavailable}
+        when result: peer_result() | own_result()
+  defp migrate(fun) do
+    BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)
+  end
+end

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -282,14 +282,40 @@ defmodule Grappa.QueryWindows do
     end
   end
 
+  @doc """
+  Does `subject` hold a DM window whose `target_nick` folds to `nick`?
+
+  The read half of `rename/4`'s own gate, exposed because a caller needs to
+  know whether a rename has anything to move BEFORE paying for the machinery
+  that would move it — `Grappa.NickMigration.peer_renamed/5` opens a write
+  transaction only when this answers true (#1378).
+
+  Folds `nick` like every other nick KEY (#121/#537), so the caller passes
+  the RAW nick off the wire.
+  """
+  @spec exists?(Subject.t(), integer(), String.t()) :: boolean()
+  def exists?({_, _} = subject, network_id, nick)
+      when is_integer(network_id) and is_binary(nick) do
+    subject
+    |> window_query(network_id, Identifier.canonical_target(nick))
+    |> Repo.exists?()
+  end
+
+  # The one folded-nick window predicate. `rename/4`'s two gates and
+  # `exists?/3` all derive from it, so the probe a caller makes is BY
+  # CONSTRUCTION the same question the rename then asks.
+  @spec window_query(Subject.t(), integer(), String.t()) :: Ecto.Query.t()
+  defp window_query(subject, network_id, folded_nick) do
+    Window
+    |> Subject.subject_where(subject)
+    |> where([w], w.network_id == ^network_id)
+    |> where([w], Identifier.nick_fold(w.target_nick) == ^folded_nick)
+  end
+
   @spec do_rename(Subject.t(), integer(), String.t(), String.t(), String.t()) ::
           {:ok, :renamed | :noop}
   defp do_rename(subject, network_id, folded_old, folded_new, new_nick) do
-    old_query =
-      Window
-      |> Subject.subject_where(subject)
-      |> where([w], w.network_id == ^network_id)
-      |> where([w], Identifier.nick_fold(w.target_nick) == ^folded_old)
+    old_query = window_query(subject, network_id, folded_old)
 
     if Repo.exists?(old_query) do
       if new_window_exists?(subject, network_id, folded_new) do
@@ -325,10 +351,8 @@ defmodule Grappa.QueryWindows do
 
   @spec new_window_exists?(Subject.t(), integer(), String.t()) :: boolean()
   defp new_window_exists?(subject, network_id, folded_new) do
-    Window
-    |> Subject.subject_where(subject)
-    |> where([w], w.network_id == ^network_id)
-    |> where([w], Identifier.nick_fold(w.target_nick) == ^folded_new)
+    subject
+    |> window_query(network_id, folded_new)
     |> Repo.exists?()
   end
 

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1194,7 +1194,8 @@ defmodule Grappa.Scrollback do
   cic tabs refresh their archive section AND invalidate the in-memory
   scrollback cache for the deleted target (UX-7-B 2026-05-22).
   """
-  @spec delete_for_dm(subject(), integer(), String.t()) :: {:ok, non_neg_integer()}
+  @spec delete_for_dm(subject(), integer(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_for_dm(subject, network_id, peer)
       when is_integer(network_id) and is_binary(peer) do
     # REV-B / H17 (2026-05-22 codebase review): route through
@@ -1214,14 +1215,24 @@ defmodule Grappa.Scrollback do
     # in archive (surfaced by `list_archive/3`'s COALESCE) yet
     # `delete_for_dm` returned a silent `{:ok, 0}` and the operator's
     # "really delete" tap did nothing.
-    {count, _} =
-      Message
-      |> subject_where(subject)
-      |> where([m], m.network_id == ^network_id)
-      |> where_dm_peer(folded_peer)
-      |> Repo.delete_all()
-
-    {:ok, count}
+    # #1374 P-S8 — web-reachable (`DELETE /networks/:slug/archive`), so a
+    # transient busy degrades to the typed 503 (#518) instead of the 500 a
+    # naked `delete_all` raises. NOT `with_pool_retry/1`: that wrapper's #336
+    # contract is best-effort DURABILITY for the session's own persist path,
+    # and it swallows even a non-transient fault to keep the session up. A
+    # web write has no session to protect and must not report a purge that
+    # did not happen. Idempotent, so a retried statement is safe.
+    case BusyRetry.run(fn ->
+           {:ok,
+            Message
+            |> subject_where(subject)
+            |> where([m], m.network_id == ^network_id)
+            |> where_dm_peer(folded_peer)
+            |> Repo.delete_all()}
+         end) do
+      {:ok, {count, _}} -> {:ok, count}
+      {:error, :db_unavailable} = err -> err
+    end
   end
 
   @doc """
@@ -1532,7 +1543,8 @@ defmodule Grappa.Scrollback do
   back from upstream. cic's confirm-modal copy makes the rejoinable
   contract explicit.
   """
-  @spec delete_for_channel(subject(), integer(), String.t()) :: {:ok, non_neg_integer()}
+  @spec delete_for_channel(subject(), integer(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_for_channel(subject, network_id, channel)
       when is_integer(network_id) and is_binary(channel) do
     # REV-B / H17 (2026-05-22 codebase review): single-source the
@@ -1549,14 +1561,18 @@ defmodule Grappa.Scrollback do
     # `lower()` fragment) is the correct comparison.
     canonical = Identifier.canonical_target(channel)
 
-    {count, _} =
-      Message
-      |> subject_where(subject)
-      |> where([m], m.network_id == ^network_id)
-      |> where([m], m.channel == ^canonical)
-      |> Repo.delete_all()
-
-    {:ok, count}
+    # #1374 P-S8 — same web-reachable 503 door as `delete_for_dm/3`.
+    case BusyRetry.run(fn ->
+           {:ok,
+            Message
+            |> subject_where(subject)
+            |> where([m], m.network_id == ^network_id)
+            |> where([m], m.channel == ^canonical)
+            |> Repo.delete_all()}
+         end) do
+      {:ok, {count, _}} -> {:ok, count}
+      {:error, :db_unavailable} = err -> err
+    end
   end
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -60,10 +60,14 @@ defmodule Grappa.Session do
       # takes NO Session dep (its live-holder source is an injected fn), so no
       # Boundary cycle.
       Grappa.Net.SourceAliasManager,
+      # #1374 P-S2 — the nick-rename migration SET (and the transaction
+      # around it) lives in its own top-level boundary: it spans four
+      # contexts, and reaching `Repo.immediate_transaction/1` from here
+      # would mean a Session -> Repo dep this boundary deliberately lacks.
+      Grappa.NickMigration,
       Grappa.PubSub,
       Grappa.Push,
       Grappa.QueryWindows,
-      Grappa.ReadCursor,
       Grappa.Scrollback,
       Grappa.SessionLog,
       Grappa.Subject,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -83,8 +83,8 @@ defmodule Grappa.Session.Server do
     ChannelDirectory,
     Log,
     Mentions,
+    NickMigration,
     QueryWindows,
-    ReadCursor,
     Scrollback,
     Session,
     SessionLog,
@@ -6198,33 +6198,19 @@ defmodule Grappa.Session.Server do
   # immaterial: those are `channel=#chan, dm_with=nil` and never match the
   # DM fold, so migrating after them is a no-op interaction.
   defp apply_effects([{:peer_nick_renamed, old_nick, new_nick} | rest], state) do
-    # #1340 K-S2 — the per-conversation mute joined this set when #1038 keyed
-    # it on `(network, peer nick)`. UNCONDITIONAL, and deliberately not inside
-    # the `:renamed` arm the review proposed: the mute outlives the window
-    # that was muted (closing a tab does not unmute it), so gating on the
-    # window row would strand exactly the mute nobody can see to fix. Same
-    # reasoning, and the same placement, as the presence reset at the foot of
-    # this arm — independent stores of the moved identity, each migrated on
-    # its own terms. It sits ahead of the barrier broadcast because a rename
-    # must never be observable half-applied.
-    {:ok, _} =
-      UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
-
-    case QueryWindows.rename(
+    # #1374 P-S2 — the whole set moves inside ONE retried transaction owned by
+    # `Grappa.NickMigration` (the mute included, unconditionally: it outlives
+    # the window it silenced). What stays here is what is the SESSION's to
+    # decide — the barrier broadcast, which must fire once, after a committed
+    # migration, and never from inside a retry.
+    case NickMigration.peer_renamed(
            state.subject,
            state.network_id,
+           state.network_slug,
            old_nick,
            new_nick
          ) do
-      {:ok, :renamed} ->
-        {:ok, migrated} =
-          Scrollback.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-        # Read cursor follows too, else the migrated history reads as fully
-        # unread under the new window (no cursor row → count from 0).
-        :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-        # Broadcast LAST — the event is the "everything migrated" barrier.
+      {:ok, %{window: :renamed, rows: migrated}} ->
         :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
 
         Logger.info("query window followed peer NICK",
@@ -6233,8 +6219,19 @@ defmodule Grappa.Session.Server do
           rows_migrated: migrated
         )
 
-      {:ok, :noop} ->
+      {:ok, %{window: :noop}} ->
         :ok
+
+      {:error, reason} ->
+        # #590 background-DROP: a rename is not worth disconnecting the user
+        # over, and nothing was applied, so the old-nick state left behind is
+        # self-consistent. Pre-#1374 this was a MatchError that killed the
+        # session mid-migration.
+        Logger.warning("peer NICK migration db unavailable — session continues",
+          old_nick: old_nick,
+          new_nick: new_nick,
+          reason: inspect(reason)
+        )
     end
 
     # #378 — a rename is not a presence transition. The vacated nick draws a
@@ -6247,19 +6244,11 @@ defmodule Grappa.Session.Server do
     apply_effects(rest, reset_presence_for(state, old_nick))
   end
 
-  # #514: WE renamed. Deliberately NOT the peer arm above with the arguments
-  # swapped — for the rows #514 owns, our own nick is not a window key, so
-  # nothing moves: an inbound DM's window is `dm_with` (the peer) and its
-  # read cursor is keyed there too, both untouched by our rename. What goes
-  # stale is the own-nick TAG each inbound row carries in `channel`, which
-  # `Push.Triggers.dm?/2` compares to the LIVE nick (#498) when
-  # `Push.BadgeCount` folds the notify predicate back over history. One
-  # store, one UPDATE, no barrier.
-  #
-  # #948 then found the ONE window our own nick does key: the SELF window
-  # (`/msg <ownnick>`). `migrate_self_window/3` below handles it, and it is
-  # a genuine window-key migration with the full peer-rename set behind it
-  # — hence the barrier broadcast the tag re-key must not fire.
+  # #514 / #948: WE renamed. Deliberately NOT the peer arm above with the
+  # arguments swapped — WHAT moves differs (the inbound-DM own-nick TAG
+  # always, the SELF window only behind its row-count gate), and
+  # `Grappa.NickMigration.own_renamed/5` owns that distinction and the
+  # transaction around it.
   #
   # `state` here is the POST-route state, so `state.nick` already reads the
   # NEW nick. The arm never consults it — both nicks travel in the effect —
@@ -6270,70 +6259,43 @@ defmodule Grappa.Session.Server do
   # with `dm_with = nil`, and the migration predicate requires a non-nil
   # `dm_with`, so they can never be swept up.
   defp apply_effects([{:own_nick_renamed, old_nick, new_nick} | rest], state) do
-    {:ok, migrated} =
-      Scrollback.rename_own_nick(state.subject, state.network_id, old_nick, new_nick)
+    case NickMigration.own_renamed(
+           state.subject,
+           state.network_id,
+           state.network_slug,
+           old_nick,
+           new_nick
+         ) do
+      {:ok, result} ->
+        log_own_rename(state, old_nick, new_nick, result)
 
-    if migrated > 0 do
-      Logger.info("inbound DM rows re-keyed to our new nick",
-        old_nick: old_nick,
-        new_nick: new_nick,
-        rows_migrated: migrated
-      )
+      {:error, reason} ->
+        Logger.warning("own NICK migration db unavailable — session continues",
+          old_nick: old_nick,
+          new_nick: new_nick,
+          reason: inspect(reason)
+        )
     end
-
-    migrate_self_window(state, old_nick, new_nick)
 
     apply_effects(rest, state)
   end
 
-  # #948 — the SELF window (`/msg <ownnick>`) is the one window keyed on OUR
-  # nick, so our rename moves it exactly like #373 moves a peer's: rows,
-  # cursor, window row, then the barrier broadcast LAST.
-  #
-  # The scrollback count is the GATE, and it runs FIRST — the inversion of
-  # the #373 arm, which gates on `QueryWindows.rename/4` instead. There, the
-  # window row alone identifies the thing being renamed. Here it cannot: a
-  # window standing at our old nick is EITHER our self window or a leftover
-  # query with a peer who bore that nick before we took it, and the two are
-  # one row under the fold-unique index. Only the scrollback rows carry the
-  # `sender` that tells them apart (`Scrollback.rename_self_window/4`), so a
-  # zero count means "no self conversation here" and we touch neither the
-  # window nor the cursor — following the rename would otherwise file the
-  # peer's identity under our new nick.
-  #
-  # The gate cuts the other way too, and that is accepted rather than
-  # overlooked: a GENUINE self window whose history was purged (or which was
-  # opened and never written to) also counts zero, so its tab stays at the
-  # nick we just vacated. With no rows there is no history to strand and no
-  # evidence to decide on, and the alternative — moving every window at our
-  # old nick — is the corruption above. An empty orphan tab is the cheaper
-  # of the two wrongs.
-  @spec migrate_self_window(t(), String.t(), String.t()) :: :ok
-  defp migrate_self_window(state, old_nick, new_nick) do
-    {:ok, migrated} =
-      Scrollback.rename_self_window(state.subject, state.network_id, old_nick, new_nick)
+  # The session-side half of an own-nick migration: what an operator reads
+  # back, and the ONE broadcast. The barrier fires only when a window
+  # actually moved — `:noop` is a real state (the self window can be CLOSED
+  # while its history lives in Archive: the rows still had to follow, but
+  # announcing a window move would be a lie).
+  @spec log_own_rename(t(), String.t(), String.t(), NickMigration.own_result()) :: :ok
+  defp log_own_rename(state, old_nick, new_nick, %{tag_rows: tag_rows, rows: rows, window: window}) do
+    if tag_rows > 0 do
+      Logger.info("inbound DM rows re-keyed to our new nick",
+        old_nick: old_nick,
+        new_nick: new_nick,
+        rows_migrated: tag_rows
+      )
+    end
 
-    if migrated > 0 do
-      # Else the migrated history reads fully unread under the new key
-      # (no cursor row → `WindowCounts` counts from 0), the #373 lesson.
-      :ok = ReadCursor.rename_dm_peer(state.subject, state.network_id, old_nick, new_nick)
-
-      {:ok, window} = QueryWindows.rename(state.subject, state.network_id, old_nick, new_nick)
-
-      # #1340 K-S2 — the self window's mute follows too, and INSIDE the gate,
-      # unlike the peer arm where it is unconditional. Here the row count is
-      # the only evidence that the window at our old nick is OURS; ungated,
-      # our rename would quietly re-file a mute the operator set against a
-      # peer who bore that nick before us.
-      {:ok, _} =
-        UserSettings.rename_muted_target(state.subject, state.network_slug, old_nick, new_nick)
-
-      # Broadcast LAST, and only when a window actually moved: the event is
-      # the truthful "rename fully applied" barrier (#373 rename-order fix).
-      # `:noop` is a real state — the self window can be CLOSED while its
-      # history lives in Archive. The rows still had to follow, or the
-      # archive entry reads as a stranded query bearing our old nick; but
-      # no window moved, so announcing one would be a lie.
+    if rows > 0 do
       if window == :renamed do
         :ok = QueryWindows.broadcast_windows_list(state.subject, state.subject_label)
       end
@@ -6344,7 +6306,7 @@ defmodule Grappa.Session.Server do
       Logger.info("self window followed our own NICK",
         old_nick: old_nick,
         new_nick: new_nick,
-        rows_migrated: migrated,
+        rows_migrated: rows,
         window: window
       )
     end

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -292,7 +292,18 @@ if Mix.env() in [:dev, :test] do
       count = Map.get(spec, :seed_count, 0)
       sender = Map.get(spec, :seed_sender, "seed-bot")
 
-      {:ok, _} = Scrollback.delete_for_channel({:user, user.id}, cred.network_id, name)
+      # #1374 P-S8 gave the purge a `:db_unavailable` terminal. This is the
+      # e2e baseline reset: a half-drained surface poisons every following
+      # spec, so the honest move is the loud stop the moduledoc already
+      # prefers over silent retry — with the reason named, unlike the bare
+      # MatchError a strict bind would now raise.
+      case Scrollback.delete_for_channel({:user, user.id}, cred.network_id, name) do
+        {:ok, _} ->
+          :ok
+
+        {:error, :db_unavailable} ->
+          raise "subject reset: scrollback purge for #{name} found the DB saturated — baseline not clean"
+      end
 
       SubjectSession.seed_channel(user.id, cred.network_id, name, count, sender)
     end

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -665,17 +665,21 @@ defmodule Grappa.UserSettings do
           {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def rename_muted_target({_, _} = subject, network_slug, old_target, new_target)
       when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
-    case rekey_pair(network_slug, old_target, new_target) do
-      nil ->
-        {:ok, :noop}
-
-      {old_key, new_key} ->
-        # Same `data` blob, same lost-update hazard as the setters (#1375), so
-        # the same frame — but NOT `update_data/2`: a rename must never CREATE
-        # the row, and it reports which of the two things it did.
-        write_transaction(fn ->
-          rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
-        end)
+    # Two ways to have nothing to migrate, one answer: the spellings fold to one
+    # key, or the old key is not muted. Only past both does this take a frame —
+    # #1378, do not take SQLite's single write lock to migrate nothing.
+    with {old_key, new_key} <- rekey_pair(network_slug, old_target, new_target),
+         true <- muted_key?(subject, old_key) do
+      # Same `data` blob, same lost-update hazard as the setters (#1375), so the
+      # same frame — but NOT `update_data/2`: a rename must never CREATE the
+      # row, and it reports which of the two things it did. The probe's read is
+      # NOT trusted for the write: `rekey_muted_target/3` re-reads inside the
+      # transaction and is the only thing that decides what gets written.
+      write_transaction(fn ->
+        rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      end)
+    else
+      _ -> {:ok, :noop}
     end
   end
 
@@ -719,17 +723,12 @@ defmodule Grappa.UserSettings do
   end
 
   @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) :: :renamed | :noop
-  defp rekey_muted_target(nil, _, _), do: :noop
-
-  defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
-    prefs = Map.get(settings.data, @notification_prefs_key, %{})
-    muted = if is_map(prefs), do: Map.get(prefs, "muted_targets", %{}), else: %{}
-
-    case is_map(muted) and Map.has_key?(muted, old_key) do
-      false ->
+  defp rekey_muted_target(settings, old_key, new_key) do
+    case muted_prefs(settings, old_key) do
+      nil ->
         :noop
 
-      true ->
+      {prefs, muted} ->
         {entry, without_old} = Map.pop(muted, old_key)
         # put_new, not put: the destination's own entry wins the collision.
         next_muted = Map.put_new(without_old, new_key, entry)
@@ -739,6 +738,33 @@ defmodule Grappa.UserSettings do
         :renamed
     end
   end
+
+  # The ONE "is this key muted?" question. `rename_muted_target/4`'s probe asks
+  # it OUTSIDE the transaction to decide whether to open one; `rekey_muted_target/3`
+  # asks it again INSIDE to decide what to write. Sharing the predicate is what
+  # makes the probe safe — #1378's discipline for `QueryWindows.exists?/3`, that
+  # the cheap question be BY CONSTRUCTION the question the write then asks, so
+  # the two cannot drift onto different notions of "nothing to migrate".
+  #
+  # Returns the two maps the rewrite needs, because deciding and locating are
+  # the same traversal; `nil` IS the answer "no".
+  @spec muted_prefs(Settings.t() | nil, String.t()) :: {map(), map()} | nil
+  defp muted_prefs(nil, _), do: nil
+
+  defp muted_prefs(%Settings{} = settings, key) do
+    prefs = Map.get(settings.data, @notification_prefs_key, %{})
+    muted = if is_map(prefs), do: Map.get(prefs, "muted_targets", %{}), else: %{}
+
+    if is_map(muted) and Map.has_key?(muted, key), do: {prefs, muted}, else: nil
+  end
+
+  # The probe. Costs one indexed SELECT on the write path, which is the price
+  # of not taking the write lock in the common case — a peer NICK fans out to
+  # every session sharing a channel and almost none of them mute that peer.
+  # Deliberately NOT used by `rename_muted_target!/4`: inside a transaction the
+  # lock is already held, so the probe there would buy nothing and cost a read.
+  @spec muted_key?(Subject.t(), String.t()) :: boolean()
+  defp muted_key?(subject, key), do: muted_prefs(fetch_existing_or_nil(subject), key) != nil
 
   # ---------------------------------------------------------------------------
   # upload_ttl_seconds accessors (UX-4 bucket M, 2026-05-19)

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -357,16 +357,18 @@ defmodule Grappa.UserSettings do
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def get_or_init({_, _} = subject) do
     # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
-    # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518).
+    # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518)
+    # at every PUT /me/settings setter (they all init through here first).
     do_get_or_init(subject, fn op -> Repo.BusyRetry.run(op) end)
   end
 
   # In-transaction twin of `get_or_init/1` (#1375): the row init as the first
-  # statement of `update_data/2`'s transaction. NO retry of its own — the
-  # enclosing `BusyRetry.run/1` retries the WHOLE transaction, and a nested
-  # retry would sleep holding the open transaction's connection, extending the
-  # very contention it waits on. The bang is that contract: a transient busy
-  # RAISES through to the enclosing budget instead of becoming a return value.
+  # statement of `update_data!/2`, which runs inside a transaction whichever
+  # door it came through. NO retry of its own — the enclosing `BusyRetry.run/1`
+  # retries the WHOLE transaction, and a nested retry would sleep holding the
+  # open transaction's connection, extending the very contention it waits on.
+  # The bang is that contract: a transient busy RAISES through to the enclosing
+  # budget instead of becoming a return value.
   @spec get_or_init!(Subject.t()) :: {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
   defp get_or_init!(subject), do: do_get_or_init(subject, fn op -> op.() end)
 
@@ -784,6 +786,30 @@ defmodule Grappa.UserSettings do
   def put_upload_ttl_seconds({_, _} = subject, seconds) do
     with :ok <- validate_upload_ttl_seconds(seconds, subject) do
       update_data(subject, &put_or_delete(&1, @upload_ttl_seconds_key, seconds))
+    end
+  end
+
+  @doc """
+  In-transaction variant of `put_upload_ttl_seconds/2` (#1374 P-S7).
+
+  Same write, MINUS the frame. `Grappa.Visitors.create_anon/4` seeds the
+  incognito TTL as the third statement of an already-open
+  `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(…) end)`, so it must
+  bring neither half of its own: the retrying spelling ran TWO more retry
+  loops inside that transaction, each sleeping on the connection it holds —
+  extending the very contention it waits on — and each turning the busy into
+  a return value where the transaction needed the raise. See the family
+  contract on `rename_muted_target!/4`.
+
+  Keeps the `{:ok, _}` wrapper its twin has, unlike `rename_muted_target!/4`:
+  the error arm here is REACHABLE without a rollback, because
+  `validate_upload_ttl_seconds/2` rejects before the DB is touched at all.
+  """
+  @spec put_upload_ttl_seconds!(Subject.t(), pos_integer() | nil) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  def put_upload_ttl_seconds!({_, _} = subject, seconds) do
+    with :ok <- validate_upload_ttl_seconds(seconds, subject) do
+      {:ok, update_data!(subject, &put_or_delete(&1, @upload_ttl_seconds_key, seconds))}
     end
   end
 
@@ -1342,13 +1368,19 @@ defmodule Grappa.UserSettings do
   # from a snapshot taken before it.
   @spec update_data(Subject.t(), (map() -> map())) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp update_data(subject, fun) do
-    write_transaction(fn ->
-      case get_or_init!(subject) do
-        {:ok, settings} -> write_data!(settings, fun.(settings.data))
-        {:error, cs} -> Repo.rollback(cs)
-      end
-    end)
+  defp update_data(subject, fun), do: write_transaction(fn -> update_data!(subject, fun) end)
+
+  # The write path MINUS the frame, for a caller already inside one (#1374
+  # P-S7: `Grappa.Visitors.create_anon/4`). Splitting it here rather than
+  # giving the `!` seam its own body is what keeps the two doors honest — a
+  # future key added to `update_data/2` cannot be missing from the seam,
+  # because there is only the one body to add it to.
+  @spec update_data!(Subject.t(), (map() -> map())) :: Settings.t()
+  defp update_data!(subject, fun) do
+    case get_or_init!(subject) do
+      {:ok, settings} -> write_data!(settings, fun.(settings.data))
+      {:error, cs} -> Repo.rollback(cs)
+    end
   end
 
   # The retry goes OUTSIDE the transaction and the transaction INSIDE it — the

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -663,19 +663,57 @@ defmodule Grappa.UserSettings do
           {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def rename_muted_target({_, _} = subject, network_slug, old_target, new_target)
       when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
+    case rekey_pair(network_slug, old_target, new_target) do
+      nil ->
+        {:ok, :noop}
+
+      {old_key, new_key} ->
+        # Same `data` blob, same lost-update hazard as the setters (#1375), so
+        # the same frame — but NOT `update_data/2`: a rename must never CREATE
+        # the row, and it reports which of the two things it did.
+        write_transaction(fn ->
+          rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+        end)
+    end
+  end
+
+  @doc """
+  In-transaction variant of `rename_muted_target/4` (#1374 P-S2).
+
+  Identical migration, one difference that is the whole contract: NO frame.
+  It is reached only from inside a `Repo.BusyRetry.run(fn ->
+  Repo.immediate_transaction(…) end)` — `Grappa.NickMigration`, which owns
+  the nick-rename set — where the enclosing engine already holds both halves
+  and retries the WHOLE transaction. A nested retry there would sleep while
+  holding the open transaction's connection, extending the very contention it
+  waits on; a nested `immediate_transaction/1` would collapse to a savepoint
+  and buy nothing.
+
+  It returns the bare outcome, not `{:ok, outcome}`: in a transaction a
+  changeset rejection is `Repo.rollback/1` (see `write_data!/2`), so there is
+  no error arm left for a tuple to carry. The caller sees the rejection as
+  its own `Repo.immediate_transaction/1` returning `{:error, changeset}`.
+
+  Mirrors the `Grappa.Accounts` revoke family's caller-facing/in-transaction
+  split (`accounts.ex`, "The family contract (#636)").
+  """
+  @spec rename_muted_target!(Subject.t(), String.t(), String.t(), String.t()) :: :renamed | :noop
+  def rename_muted_target!({_, _} = subject, network_slug, old_target, new_target)
+      when is_binary(network_slug) and is_binary(old_target) and is_binary(new_target) do
+    case rekey_pair(network_slug, old_target, new_target) do
+      nil -> :noop
+      {old_key, new_key} -> rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+    end
+  end
+
+  # `nil` when the two spellings fold to ONE key — a casing change, not a
+  # rename, so there is no key to migrate and no reason to reach the DB.
+  @spec rekey_pair(String.t(), String.t(), String.t()) :: {String.t(), String.t()} | nil
+  defp rekey_pair(network_slug, old_target, new_target) do
     old_key = Identifier.channel_key(network_slug, old_target)
     new_key = Identifier.channel_key(network_slug, new_target)
 
-    if old_key == new_key do
-      {:ok, :noop}
-    else
-      # Same `data` blob, same lost-update hazard as the setters (#1375), so
-      # the same frame — but NOT `update_data/2`: a rename must never CREATE
-      # the row, and it reports which of the two things it did.
-      write_transaction(fn ->
-        rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
-      end)
-    end
+    if old_key == new_key, do: nil, else: {old_key, new_key}
   end
 
   @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) :: :renamed | :noop

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -25,12 +25,27 @@ defmodule Grappa.UserSettings do
 
   ## Access model
 
-  - **Writers** use `get_or_init/1` first (which creates the row on
-    first access), then a typed accessor (`set_highlight_patterns/2`).
+  - **Writers** call a typed setter (`set_highlight_patterns/2`), which
+    routes through the ONE private write path, `update_data/2`.
   - **Readers** use typed accessors directly (`get_highlight_patterns/1`),
     which return safe defaults (`[]`, `nil`, etc.) when no row exists.
     Readers do NOT auto-create the row — side-effect-free reads are
     observable-stable and don't pollute the DB with empty rows.
+
+  ## One write path, because a JSON blob loses concurrent writes (#1375)
+
+  `data` is a single column. Every setter necessarily REPLACES it whole, so
+  a read-modify-write pair that straddles another writer's commit drops that
+  writer's key — two writers touching completely DIFFERENT keys, last one
+  wins, no error anywhere. That is not hypothetical: `put_last_client_prefix64/2`
+  fires from `Grappa.Vhosts.record_client_source/2` on every client connect,
+  in the socket's own process and its own pool connection, while the settings
+  drawer PUTs from another.
+
+  So there is exactly ONE writer here — `update_data/2` — and it holds the
+  read and the write in a single `Repo.immediate_transaction/1`. A new
+  setter MUST go through it; a second read-modify-write pair spelled by
+  hand reintroduces the defect for its own key.
 
   ## String-key invariant
 
@@ -341,15 +356,29 @@ defmodule Grappa.UserSettings do
   @spec get_or_init(Subject.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def get_or_init({_, _} = subject) do
+    # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
+    # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518).
+    do_get_or_init(subject, fn op -> Repo.BusyRetry.run(op) end)
+  end
+
+  # In-transaction twin of `get_or_init/1` (#1375): the row init as the first
+  # statement of `update_data/2`'s transaction. NO retry of its own — the
+  # enclosing `BusyRetry.run/1` retries the WHOLE transaction, and a nested
+  # retry would sleep holding the open transaction's connection, extending the
+  # very contention it waits on. The bang is that contract: a transient busy
+  # RAISES through to the enclosing budget instead of becoming a return value.
+  @spec get_or_init!(Subject.t()) :: {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  defp get_or_init!(subject), do: do_get_or_init(subject, fn op -> op.() end)
+
+  @spec do_get_or_init(Subject.t(), ((-> term()) -> term())) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp do_get_or_init(subject, run) do
     with :ok <- validate_subject_exists(subject) do
       attrs = Subject.put_subject_id(%{data: %{}}, subject)
       cs = Settings.changeset(%Settings{}, attrs)
 
-      # #523 — ride out a transient SQLITE_BUSY on the row init; sustained
-      # saturation degrades to `{:error, :db_unavailable}` → a clean 503 (#518)
-      # at every PUT /me/settings setter (they all init through here first).
       insert_result =
-        Repo.BusyRetry.run(fn ->
+        run.(fn ->
           Repo.insert(cs, on_conflict: :nothing, conflict_target: conflict_target(subject))
         end)
 
@@ -440,11 +469,8 @@ defmodule Grappa.UserSettings do
   @spec set_highlight_patterns(Subject.t(), [String.t()]) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def set_highlight_patterns({_, _} = subject, patterns) when is_list(patterns) do
-    with :ok <- validate_patterns(patterns, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, "highlight_patterns", patterns)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_patterns(patterns, subject) do
+      update_data(subject, &Map.put(&1, "highlight_patterns", patterns))
     end
   end
 
@@ -584,11 +610,9 @@ defmodule Grappa.UserSettings do
   @spec put_notification_prefs(Subject.t(), notification_prefs()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_notification_prefs({_, _} = subject, prefs) when is_map(prefs) do
-    with {:ok, normalized} <- validate_and_normalize_prefs(prefs, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @notification_prefs_key, stringify_prefs(normalized))
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_prefs(prefs, subject) do
+      stringified = stringify_prefs(normalized)
+      update_data(subject, &Map.put(&1, @notification_prefs_key, stringified))
     end
   end
 
@@ -645,13 +669,17 @@ defmodule Grappa.UserSettings do
     if old_key == new_key do
       {:ok, :noop}
     else
-      rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      # Same `data` blob, same lost-update hazard as the setters (#1375), so
+      # the same frame — but NOT `update_data/2`: a rename must never CREATE
+      # the row, and it reports which of the two things it did.
+      write_transaction(fn ->
+        rekey_muted_target(fetch_existing_or_nil(subject), old_key, new_key)
+      end)
     end
   end
 
-  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) ::
-          {:ok, :renamed | :noop} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp rekey_muted_target(nil, _, _), do: {:ok, :noop}
+  @spec rekey_muted_target(Settings.t() | nil, String.t(), String.t()) :: :renamed | :noop
+  defp rekey_muted_target(nil, _, _), do: :noop
 
   defp rekey_muted_target(%Settings{} = settings, old_key, new_key) do
     prefs = Map.get(settings.data, @notification_prefs_key, %{})
@@ -659,19 +687,16 @@ defmodule Grappa.UserSettings do
 
     case is_map(muted) and Map.has_key?(muted, old_key) do
       false ->
-        {:ok, :noop}
+        :noop
 
       true ->
         {entry, without_old} = Map.pop(muted, old_key)
         # put_new, not put: the destination's own entry wins the collision.
         next_muted = Map.put_new(without_old, new_key, entry)
         next_prefs = Map.put(prefs, "muted_targets", next_muted)
-        next_data = Map.put(settings.data, @notification_prefs_key, next_prefs)
 
-        case persist(Settings.changeset(settings, %{data: next_data})) do
-          {:ok, _} -> {:ok, :renamed}
-          {:error, _} = error -> error
-        end
+        _ = write_data!(settings, Map.put(settings.data, @notification_prefs_key, next_prefs))
+        :renamed
     end
   end
 
@@ -719,16 +744,8 @@ defmodule Grappa.UserSettings do
   @spec put_upload_ttl_seconds(Subject.t(), pos_integer() | nil) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_upload_ttl_seconds({_, _} = subject, seconds) do
-    with :ok <- validate_upload_ttl_seconds(seconds, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        case seconds do
-          nil -> Map.delete(settings.data, @upload_ttl_seconds_key)
-          n -> Map.put(settings.data, @upload_ttl_seconds_key, n)
-        end
-
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_upload_ttl_seconds(seconds, subject) do
+      update_data(subject, &put_or_delete(&1, @upload_ttl_seconds_key, seconds))
     end
   end
 
@@ -822,20 +839,12 @@ defmodule Grappa.UserSettings do
   def put_auto_away_debounce_seconds({_, _} = subject, value, subject_label)
       when is_binary(subject_label) do
     with :ok <- validate_auto_away_debounce_seconds(value, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        case value do
-          nil -> Map.delete(settings.data, @auto_away_debounce_seconds_key)
-          :disabled -> Map.put(settings.data, @auto_away_debounce_seconds_key, 0)
-          n -> Map.put(settings.data, @auto_away_debounce_seconds_key, n)
-        end
-
-      cs = Settings.changeset(settings, %{data: merged_data})
-
-      with {:ok, saved} <- persist(cs) do
-        :ok = broadcast_auto_away_debounce(value, subject_label)
-        {:ok, saved}
-      end
+         {:ok, saved} <- update_data(subject, &put_auto_away_debounce(&1, value)) do
+      # AFTER the transaction returned, never inside it: a retried attempt
+      # (`BusyRetry` wraps `update_data/2`'s transaction) would re-announce a
+      # change that had been rolled back.
+      :ok = broadcast_auto_away_debounce(value, subject_label)
+      {:ok, saved}
     end
   end
 
@@ -866,6 +875,15 @@ defmodule Grappa.UserSettings do
         Wire.auto_away_debounce_changed(value)
       )
   end
+
+  # Write-side twin of `decode_auto_away_debounce/1`: `:disabled` is the `0`
+  # sentinel on the JSON side, `nil` clears the key back to the server default.
+  @spec put_auto_away_debounce(map(), auto_away_debounce()) :: map()
+  defp put_auto_away_debounce(data, :disabled),
+    do: Map.put(data, @auto_away_debounce_seconds_key, 0)
+
+  defp put_auto_away_debounce(data, value),
+    do: put_or_delete(data, @auto_away_debounce_seconds_key, value)
 
   @spec decode_auto_away_debounce(term()) :: auto_away_debounce()
   defp decode_auto_away_debounce(0), do: :disabled
@@ -940,11 +958,8 @@ defmodule Grappa.UserSettings do
   @spec put_vhost_selection(Subject.t(), [String.t()]) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_vhost_selection({_, _} = subject, addresses) when is_list(addresses) do
-    with :ok <- validate_vhost_selection(addresses, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @vhost_selection_key, addresses)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_vhost_selection(addresses, subject) do
+      update_data(subject, &Map.put(&1, @vhost_selection_key, addresses))
     end
   end
 
@@ -1001,11 +1016,8 @@ defmodule Grappa.UserSettings do
   @spec put_last_client_prefix64(Subject.t(), String.t()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_last_client_prefix64({_, _} = subject, hex) when is_binary(hex) do
-    with :ok <- validate_base16(hex, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @last_client_prefix64_key, hex)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with :ok <- validate_base16(hex, subject) do
+      update_data(subject, &Map.put(&1, @last_client_prefix64_key, hex))
     end
   end
 
@@ -1080,20 +1092,14 @@ defmodule Grappa.UserSettings do
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_theme_pair({_, _} = subject, light_id, dark_id) do
     with :ok <- validate_theme_pointer(light_id, subject, :active_theme_id),
-         :ok <- validate_theme_pointer(dark_id, subject, :dark_theme_id),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data =
-        settings.data
+         :ok <- validate_theme_pointer(dark_id, subject, :dark_theme_id) do
+      update_data(subject, fn data ->
+        data
         |> put_or_delete(@active_theme_id_key, light_id)
         |> put_or_delete(@dark_theme_id_key, dark_id)
-
-      persist(Settings.changeset(settings, %{data: merged_data}))
+      end)
     end
   end
-
-  # Merge helper: a positive id is stored, a nil clears the key.
-  defp put_or_delete(data, key, nil), do: Map.delete(data, key)
-  defp put_or_delete(data, key, id), do: Map.put(data, key, id)
 
   @spec validate_theme_pointer(term(), Subject.t(), atom()) :: :ok | {:error, Ecto.Changeset.t()}
   defp validate_theme_pointer(nil, _, _), do: :ok
@@ -1192,11 +1198,8 @@ defmodule Grappa.UserSettings do
   @spec set_aliases(Subject.t(), %{optional(String.t()) => term()}) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def set_aliases({_, _} = subject, aliases) when is_map(aliases) do
-    with {:ok, normalized} <- validate_and_normalize_aliases(aliases, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @aliases_key, normalized)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_aliases(aliases, subject) do
+      update_data(subject, &Map.put(&1, @aliases_key, normalized))
     end
   end
 
@@ -1282,11 +1285,8 @@ defmodule Grappa.UserSettings do
   @spec put_display_prefs(Subject.t(), map()) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def put_display_prefs({_, _} = subject, prefs) when is_map(prefs) do
-    with {:ok, normalized} <- validate_and_normalize_display_prefs(prefs, subject),
-         {:ok, settings} <- get_or_init(subject) do
-      merged_data = Map.put(settings.data, @display_prefs_key, normalized)
-      cs = Settings.changeset(settings, %{data: merged_data})
-      persist(cs)
+    with {:ok, normalized} <- validate_and_normalize_display_prefs(prefs, subject) do
+      update_data(subject, &Map.put(&1, @display_prefs_key, normalized))
     end
   end
 
@@ -1294,14 +1294,51 @@ defmodule Grappa.UserSettings do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # #523 — the single write choke point for every setter. Rides out a transient
-  # SQLITE_BUSY on the `user_settings` UPDATE; sustained saturation degrades to
-  # `{:error, :db_unavailable}` → a clean 503 (#518) at the PUT /me/settings
-  # family instead of a 500 raise. `Repo.update/1` returns exactly the
-  # `{:ok, _} | {:error, changeset}` shape `BusyRetry.run/1` expects.
-  @spec persist(Ecto.Changeset.t()) ::
+  # #1375 — the single write path for every `data` key. `fun` receives the
+  # CURRENT `data` map and returns the next one; it must be pure, because a
+  # `BusyRetry` retry replays the whole transaction and therefore replays it.
+  #
+  # Read and write are ONE `BEGIN IMMEDIATE` transaction (see the moduledoc):
+  # SQLite serialises writers at the file level, so a concurrent writer waits
+  # for this commit and then reads the merged blob, instead of overwriting it
+  # from a snapshot taken before it.
+  @spec update_data(Subject.t(), (map() -> map())) ::
           {:ok, Settings.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
-  defp persist(cs), do: Repo.BusyRetry.run(fn -> Repo.update(cs) end)
+  defp update_data(subject, fun) do
+    write_transaction(fn ->
+      case get_or_init!(subject) do
+        {:ok, settings} -> write_data!(settings, fun.(settings.data))
+        {:error, cs} -> Repo.rollback(cs)
+      end
+    end)
+  end
+
+  # The retry goes OUTSIDE the transaction and the transaction INSIDE it — the
+  # `Grappa.Visitors.create_anon/4` nesting. A retry loop opened inside an
+  # already-open transaction would sleep while holding that transaction's
+  # connection, extending the very contention it waits on. #523's degrade
+  # contract is unchanged: sustained saturation still surfaces as
+  # `{:error, :db_unavailable}` → a clean 503 (#518) at PUT /me/settings.
+  @typep write_result :: Settings.t() | :renamed | :noop
+  @spec write_transaction((-> write_result())) ::
+          {:ok, write_result()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+  defp write_transaction(fun), do: Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)
+
+  # The module's only `Repo.update`. In-transaction by construction, so a
+  # changeset error ROLLS BACK rather than returning into a half-applied
+  # transaction; `write_transaction/1` surfaces it as `{:error, changeset}`.
+  @spec write_data!(Settings.t(), map()) :: Settings.t()
+  defp write_data!(settings, data) do
+    case Repo.update(Settings.changeset(settings, %{data: data})) do
+      {:ok, saved} -> saved
+      {:error, cs} -> Repo.rollback(cs)
+    end
+  end
+
+  # Merge helper: a value is stored, a nil clears the key.
+  @spec put_or_delete(map(), String.t(), term()) :: map()
+  defp put_or_delete(data, key, nil), do: Map.delete(data, key)
+  defp put_or_delete(data, key, value), do: Map.put(data, key, value)
 
   # Mirror of `Grappa.QueryWindows.conflict_target/1` — partial
   # indexes carry the predicate so the upsert must repeat it.

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -237,7 +237,12 @@ defmodule Grappa.Visitors do
          {:ok, _} <- seed_incognito_upload_ttl(visitor, incognito) do
       visitor
     else
-      {:error, changeset} -> Repo.rollback(changeset)
+      # #1374 P-S7 — `reason`, not `changeset`: the seed step can also fail
+      # with a plain `{:error, %Ecto.Changeset{}}` from a validation, and
+      # `create_anon/4`'s spec admits `:db_unavailable` from the enclosing
+      # engine. Naming the binding after one of the shapes invited the next
+      # reader to pattern-match `%Ecto.Changeset{}` on the rollback value.
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 
@@ -250,12 +255,19 @@ defmodule Grappa.Visitors do
   # the holder raises it up to the 72h ladder from the drawer and the server
   # leaves them be (vjt 2026-07-26). Non-incognito provisions leave the pref
   # unset and fall through to the standard 24h upload default.
+  # #1374 P-S7 — the `!` seam: this runs as the third statement of
+  # `create_anon/4`'s OPEN transaction, so it must not retry. The retrying
+  # spelling ran two nested `BusyRetry.run` loops here, each sleeping while
+  # holding the transaction's connection (extending the contention it was
+  # waiting on) and each converting the busy into a return value, which
+  # `Repo.rollback/1` then turned into a 503 WITHOUT the enclosing engine
+  # ever spending its own budget. The raise is what hands the retry up.
   @spec seed_incognito_upload_ttl(Visitor.t(), boolean()) ::
-          {:ok, term()} | {:error, Ecto.Changeset.t() | :db_unavailable}
+          {:ok, term()} | {:error, Ecto.Changeset.t()}
   defp seed_incognito_upload_ttl(_, false), do: {:ok, :not_incognito}
 
   defp seed_incognito_upload_ttl(%Visitor{id: id}, true),
-    do: UserSettings.put_upload_ttl_seconds({:visitor, id}, @incognito_upload_ttl_seconds)
+    do: UserSettings.put_upload_ttl_seconds!({:visitor, id}, @incognito_upload_ttl_seconds)
 
   @doc """
   #211 phase 7 — resolve the visitor's `(visitor_id, network_id)`

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -947,7 +947,7 @@ defmodule Grappa.Visitors do
   mid-flight — race tolerated).
   """
   @spec update_last_joined_channels(Ecto.UUID.t(), pos_integer(), [String.t()]) ::
-          :ok | {:error, :not_found | Ecto.Changeset.t()}
+          :ok | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def update_last_joined_channels(visitor_id, network_id, channels)
       when is_binary(visitor_id) and is_integer(network_id) and is_list(channels) do
     Credentials.update_visitor_last_joined_channels(visitor_id, network_id, channels)
@@ -983,7 +983,7 @@ defmodule Grappa.Visitors do
   network).
   """
   @spec remove_autojoin_channel(Visitor.t(), pos_integer(), String.t()) ::
-          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t() | :db_unavailable}
   def remove_autojoin_channel(%Visitor{id: id}, network_id, channel_name)
       when is_integer(network_id) and is_binary(channel_name) do
     Credentials.remove_visitor_last_joined_channel(id, network_id, channel_name)

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -141,7 +141,7 @@ defmodule GrappaWeb.ArchiveController do
   def delete(_, _), do: {:error, :bad_request}
 
   @spec delete_for_target(String.t(), Grappa.Subject.t(), pos_integer()) ::
-          {:ok, non_neg_integer()}
+          {:ok, non_neg_integer()} | {:error, :db_unavailable}
   defp delete_for_target(canonical_target, session_subject, network_id) do
     case Scrollback.target_kind(canonical_target) do
       :channel ->

--- a/test/grappa/nick_migration_test.exs
+++ b/test/grappa/nick_migration_test.exs
@@ -1,0 +1,161 @@
+defmodule Grappa.NickMigrationTest do
+  @moduledoc """
+  #1378 — the nick-rename migration set must not take SQLite's write lock to
+  migrate nothing.
+
+  ## The oracle, and why it is a savepoint and not `BEGIN IMMEDIATE`
+
+  `Grappa.Repo.TransactionModeGateTest` establishes that the transaction MODE
+  is undecidable at runtime: under the SQL Sandbox every test already runs
+  inside a transaction, so `exqlite` collapses every mode to
+  `SAVEPOINT exqlite_savepoint`. That argument does not reach THIS defect.
+  Whether a transaction is opened AT ALL is perfectly decidable — the
+  savepoint statement is emitted or it is not — and it is the same statement
+  that, unsandboxed, is the `BEGIN IMMEDIATE` that took the lock. So the
+  oracle counts transaction-control statements off Ecto's own query
+  telemetry, and reads a savepoint as the sandbox's image of the write lock.
+
+  The e2e half of the proof (the `busy_locked` fault disappearing from
+  `issue458-presence-page-yield` under load) lives where load exists; this
+  file owns the decision, deterministically and with no IRC in sight.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{Accounts, Networks, NickMigration, QueryWindows, Scrollback, UserSettings}
+  alias Grappa.IRC.Identifier
+
+  defp user_fixture do
+    name = "nm-user-#{System.unique_integer([:positive])}"
+    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
+    user
+  end
+
+  defp network_fixture do
+    slug = "nm-net-#{System.unique_integer([:positive])}"
+    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
+    network
+  end
+
+  # Every SQL statement Ecto reports while `fun` runs, lowercased. `async:
+  # false` because the handler is global: a concurrent test's queries would
+  # land in this list and the counts below would stop meaning anything.
+  defp capture_sql(fun) do
+    ref = make_ref()
+    test = self()
+
+    :telemetry.attach(
+      "nm-sql-#{inspect(ref)}",
+      [:grappa, :repo, :query],
+      fn _, _, %{query: query}, _ -> send(test, {ref, String.downcase(query)}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach("nm-sql-#{inspect(ref)}")
+    end
+
+    drain(ref, [])
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, query} -> drain(ref, [query | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp transaction_statements(queries) do
+    Enum.filter(queries, &(&1 =~ "savepoint" or String.starts_with?(&1, "begin")))
+  end
+
+  describe "peer_renamed/5 opens no transaction when there is nothing to migrate" do
+    test "a peer with no query window and no mute costs zero transaction statements" do
+      user = user_fixture()
+      net = network_fixture()
+      subject = {:user, user.id}
+
+      queries =
+        capture_sql(fn ->
+          assert {:ok, %{window: :noop, rows: 0, mute: :noop}} =
+                   NickMigration.peer_renamed(subject, net.id, net.slug, "oldnick", "newnick")
+        end)
+
+      assert transaction_statements(queries) == [],
+             "a rename with nothing to move opened a write transaction: " <>
+               inspect(transaction_statements(queries))
+    end
+
+    test "the probe is the only reason it is cheap — a peer WITH a window still transacts" do
+      # The complement, and the assertion that stops the fix from degrading
+      # into "never transact": the real migration path must keep its
+      # transaction, which is the whole atomicity contract.
+      user = user_fixture()
+      net = network_fixture()
+      subject = {:user, user.id}
+      {:ok, _} = QueryWindows.open(subject, net.id, "oldnick", user.name)
+
+      queries =
+        capture_sql(fn ->
+          assert {:ok, %{window: :renamed}} =
+                   NickMigration.peer_renamed(subject, net.id, net.slug, "oldnick", "newnick")
+        end)
+
+      refute transaction_statements(queries) == [],
+             "the migration path lost its transaction"
+    end
+  end
+
+  describe "peer_renamed/5 still migrates everything it used to" do
+    test "a windowed peer moves window, DM history and cursor together" do
+      user = user_fixture()
+      net = network_fixture()
+      subject = {:user, user.id}
+      {:ok, _} = QueryWindows.open(subject, net.id, "oldnick", user.name)
+
+      {:ok, _} =
+        Scrollback.persist_event(%{
+          network_id: net.id,
+          user_id: user.id,
+          channel: "oldnick",
+          dm_with: "oldnick",
+          server_time: System.system_time(:millisecond),
+          kind: :privmsg,
+          sender: "oldnick",
+          body: "before the rename"
+        })
+
+      assert {:ok, %{window: :renamed, rows: rows}} =
+               NickMigration.peer_renamed(subject, net.id, net.slug, "oldnick", "newnick")
+
+      assert rows >= 1
+      assert QueryWindows.exists?(subject, net.id, "newnick")
+      refute QueryWindows.exists?(subject, net.id, "oldnick")
+    end
+
+    test "a windowless peer's MUTE still follows — the store that outlives the window" do
+      # The reason the no-transaction path is not simply an early return: with
+      # no window the mute is the one store that can still move, and #1340
+      # migrates it UNCONDITIONALLY because a mute outlives the window it
+      # silenced. A fix that skipped the whole call when no window exists
+      # would strand exactly the mute nobody can see to fix.
+      user = user_fixture()
+      net = network_fixture()
+      subject = {:user, user.id}
+      old_key = Identifier.channel_key(net.slug, "oldnick")
+      new_key = Identifier.channel_key(net.slug, "newnick")
+
+      prefs = UserSettings.default_notification_prefs()
+      {:ok, _} = UserSettings.put_notification_prefs(subject, %{prefs | muted_targets: %{old_key => %{}}})
+
+      assert {:ok, %{window: :noop, mute: :renamed}} =
+               NickMigration.peer_renamed(subject, net.id, net.slug, "oldnick", "newnick")
+
+      muted = UserSettings.get_notification_prefs(subject)["muted_targets"]
+      assert Map.has_key?(muted, new_key)
+      refute Map.has_key?(muted, old_key)
+    end
+  end
+end

--- a/test/grappa/nick_migration_test.exs
+++ b/test/grappa/nick_migration_test.exs
@@ -148,12 +148,21 @@ defmodule Grappa.NickMigrationTest do
       new_key = Identifier.channel_key(net.slug, "newnick")
 
       prefs = UserSettings.default_notification_prefs()
-      {:ok, _} = UserSettings.put_notification_prefs(subject, %{prefs | muted_targets: %{old_key => %{}}})
+
+      {:ok, _} =
+        UserSettings.put_notification_prefs(subject, %{
+          prefs
+          | muted_targets: %{old_key => %{"until" => nil}}
+        })
 
       assert {:ok, %{window: :noop, mute: :renamed}} =
                NickMigration.peer_renamed(subject, net.id, net.slug, "oldnick", "newnick")
 
-      muted = UserSettings.get_notification_prefs(subject)["muted_targets"]
+      # `get_notification_prefs/1` closes over ATOM keys — `merge_with_defaults/1`
+      # rebuilds the map rather than returning the stored blob — so reaching for
+      # the string key here silently reads `nil` off a map that does have the
+      # mute. Asked with the string key, this assertion could only ever crash.
+      muted = UserSettings.get_notification_prefs(subject).muted_targets
       assert Map.has_key?(muted, new_key)
       refute Map.has_key?(muted, old_key)
     end

--- a/test/grappa/repo/transaction_mode_gate_test.exs
+++ b/test/grappa/repo/transaction_mode_gate_test.exs
@@ -1,0 +1,89 @@
+defmodule Grappa.Repo.TransactionModeGateTest do
+  @moduledoc """
+  #1374 P-S3 — the static gate for the write-transaction contract.
+
+  `Grappa.Repo.immediate_transaction/1`'s docstring is unambiguous: "Use
+  this for every WRITE transaction." Until #1374 that contract was
+  comment-only, and seven call sites had drifted off it. Two spellings in
+  one repo is the split CLAUDE.md warns about — the next session copies
+  whichever is nearest.
+
+  ## Why the gate is STATIC and not a runtime assertion
+
+  It cannot be a runtime assertion. `exqlite`'s `handle_begin/2`
+  (`connection.ex:297-316`) emits `BEGIN IMMEDIATE` only when
+  `transaction_status == :idle`; nested, EVERY mode collapses to
+  `SAVEPOINT exqlite_savepoint`. Under the SQL Sandbox every test already
+  runs inside a transaction, so `immediate_transaction/1` is always a
+  savepoint there and no ExUnit oracle can tell it from `transaction/1`.
+  The defect is undecidable at runtime and decidable at compile time, so
+  the gate reads the source.
+
+  ## What it does and does not catch
+
+  It matches the remote-call AST `*.Repo.transaction(…)` — the spelling
+  every call site in `lib/` uses, in pipes too (the pipe's right-hand node
+  is the same call node). It does NOT catch a call routed through a
+  renaming alias (`alias Grappa.Repo, as: R; R.transaction(…)`); nothing
+  short of a compiler pass would, and no such spelling exists here. Stated
+  so the gate's reach is known rather than assumed.
+
+  A genuinely read-only transaction is still legitimate (deferred preserves
+  WAL read concurrency) — but it must SAY so at the call site. Add a
+  `Grappa.Repo.deferred_transaction/1` sibling and call that; do not reach
+  for the raw verb, which is the one whose default is the #524 trap.
+  """
+  use ExUnit.Case, async: true
+
+  # The contract's own home: `immediate_transaction/1` delegates to
+  # `transaction/2` there, which is the one place it is meant to happen.
+  @definition "lib/grappa/repo.ex"
+  @lib_glob "lib/**/*.ex"
+
+  test "no module outside Grappa.Repo opens a bare Repo.transaction" do
+    offenders =
+      @lib_glob
+      |> Path.wildcard()
+      |> Enum.reject(&(&1 == @definition))
+      |> Enum.flat_map(&scan/1)
+
+    assert offenders == [],
+           """
+           bare `Repo.transaction/1` outside #{@definition}:
+
+           #{Enum.map_join(offenders, "\n", fn {path, line} -> "  #{path}:#{line}" end)}
+
+           Every WRITE transaction takes `Grappa.Repo.immediate_transaction/1`:
+           a deferred transaction's read->write upgrade raises an IMMEDIATE
+           SQLITE_BUSY that `busy_timeout` does not cover (#524). If this one is
+           genuinely READ-ONLY, add `Grappa.Repo.deferred_transaction/1` and say
+           so at the call site.
+           """
+  end
+
+  @spec scan(Path.t()) :: [{Path.t(), pos_integer()}]
+  defp scan(path) do
+    {_ast, offenders} =
+      path
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> Macro.prewalk([], fn node, acc ->
+        case transaction_call_line(node) do
+          nil -> {node, acc}
+          line -> {node, [{path, line} | acc]}
+        end
+      end)
+
+    Enum.reverse(offenders)
+  end
+
+  # `Repo.transaction(…)` / `Grappa.Repo.transaction(…)`, however many args
+  # (a pipe leaves the call node with one fewer). `immediate_transaction`
+  # is a DIFFERENT function name and never matches here.
+  @spec transaction_call_line(Macro.t()) :: pos_integer() | nil
+  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _args}) do
+    if List.last(segments) == :Repo, do: Keyword.get(meta, :line), else: nil
+  end
+
+  defp transaction_call_line(_), do: nil
+end

--- a/test/grappa/repo/transaction_mode_gate_test.exs
+++ b/test/grappa/repo/transaction_mode_gate_test.exs
@@ -63,7 +63,7 @@ defmodule Grappa.Repo.TransactionModeGateTest do
 
   @spec scan(Path.t()) :: [{Path.t(), pos_integer()}]
   defp scan(path) do
-    {_ast, offenders} =
+    {_, offenders} =
       path
       |> File.read!()
       |> Code.string_to_quoted!()
@@ -81,7 +81,7 @@ defmodule Grappa.Repo.TransactionModeGateTest do
   # (a pipe leaves the call node with one fewer). `immediate_transaction`
   # is a DIFFERENT function name and never matches here.
   @spec transaction_call_line(Macro.t()) :: pos_integer() | nil
-  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _args}) do
+  defp transaction_call_line({{:., _, [{:__aliases__, _, segments}, :transaction]}, meta, _}) do
     if List.last(segments) == :Repo, do: Keyword.get(meta, :line), else: nil
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3219,6 +3219,85 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
+
+    # #1374 P-S2 — the migration chain used to run bare against `Repo`, each
+    # step strictly bound (`{:ok, _} =` / `:ok =`) inside the supervised
+    # session. A transient SQLITE_BUSY therefore RAISED and took the session
+    # (and the user's connection) down, mid-migration: the exact class of the
+    # 2026-07-19 incident, and the trigger — a netsplit rejoin renaming many
+    # peers at once — is precisely the correlated write burst.
+    test "a sustained DB busy during a peer rename drops it whole and the session survives" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      own = "grappa-test"
+      subject = {:user, user.id}
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      net_id = network.id
+      slug = network.slug
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, _} =
+               put_all_muted(subject, %{"#{slug} guest87449" => %{"until" => nil}})
+
+      IRCServer.feed(server, ":Guest87449!~g@host JOIN #sniffo\r\n")
+      IRCServer.feed(server, ":Guest87449!~g@host PRIVMSG #{own} :ciao\r\n")
+
+      # #422 auto-open: waiting for the window broadcast proves the whole
+      # pre-state (window row + DM row) exists BEFORE the fault is armed, and
+      # drains the topic so a later broadcast cannot be mistaken for this one.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :query_windows_list,
+                         windows: %{^net_id => [%{target_nick: "Guest87449"}]}
+                       }
+                     },
+                     1_000
+
+      assert [pre_row] = Scrollback.fetch(subject, net_id, "Guest87449", nil, 10, own, false)
+      {:ok, _} = ReadCursor.set(subject, net_id, "Guest87449", pre_row.id)
+
+      # Saturate every retry loop this session enters from here on.
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
+      on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":Guest87449!~g@host NICK :NickTemporaneo\r\n")
+
+          # DB-free FIFO barrier: PING is answered from the SAME serial
+          # mailbox, so the PONG proves the NICK's effects have fully run.
+          # It cannot itself be starved by the armed fault (no Repo call on
+          # that path), which every DB-backed barrier here could be.
+          IRCServer.feed(server, "PING :rename-barrier\r\n")
+
+          assert {:ok, _} =
+                   IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      # The terminal is the #590 background-DROP posture, not a crash.
+      assert Process.alive?(pid)
+      assert log =~ "peer NICK migration db unavailable — session continues"
+
+      # And the drop is WHOLE: window row, DM history and read cursor all
+      # still stand at the old nick. A per-step retry would have let the
+      # earlier steps land and stranded the later ones.
+      assert [%{target_nick: "Guest87449"}] = QueryWindows.list_for_subject(subject)[net_id]
+      assert [_] = Scrollback.fetch(subject, net_id, "Guest87449", nil, 10, own, false)
+      assert Scrollback.fetch(subject, net_id, "NickTemporaneo", nil, 10, own, false) == []
+      assert %{last_read_message_id: _} = ReadCursor.get(subject, net_id, "Guest87449")
+      assert ReadCursor.get(subject, net_id, "NickTemporaneo") == nil
+
+      assert Grappa.UserSettings.get_notification_prefs(subject).muted_targets == %{
+               "#{slug} guest87449" => %{"until" => nil}
+             }
+
+      Repo.BusyRetry.disarm_faults(pid)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
   end
 
   describe "#948 — the SELF window follows OUR OWN NICK change" do

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3300,6 +3300,49 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#1374 P-S8 — the session-driven credential persisters" do
+    # `update_last_joined_channels/3` fires on every self-JOIN / self-PART /
+    # self-KICK and `update_away/4` on every away transition. Both did
+    # `Repo.get_by` + `Repo.update` with no retry: the call sites handle a
+    # RETURNED `{:error, _}` with a warning, but a transient busy RAISED and
+    # the raise escaped the persister closure into the GenServer. Bootstrap
+    # spawning N sessions x M autojoin channels is that write burst.
+    test "a sustained DB busy on the rejoin snapshot drops it and the session survives" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
+      on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+      log =
+        capture_log(fn ->
+          # A self-JOIN is the cheapest trigger: it mutates the members
+          # keyset, which is the ONLY thing that arms the snapshot write.
+          IRCServer.feed(server, ":grappa-test!~g@host JOIN #busy-room\r\n")
+
+          # DB-free FIFO barrier (see the peer-rename test): the PONG proves
+          # the JOIN was fully handled, and the armed fault cannot starve it.
+          IRCServer.feed(server, "PING :snapshot-barrier\r\n")
+          assert {:ok, _} = IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      assert Process.alive?(pid)
+      assert log =~ "last_joined_channels persist failed"
+      assert log =~ "db_unavailable"
+
+      # Dropped, not written: the credential still carries the pre-JOIN
+      # snapshot. Read through the context, never a raw Repo query.
+      {:ok, cred} = Credentials.get_credential(user, network)
+      refute "#busy-room" in cred.last_joined_channels
+
+      Repo.BusyRetry.disarm_faults(pid)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#948 — the SELF window follows OUR OWN NICK change" do
     test "a self /nick migrates the self window row, its scrollback and its read cursor" do
       {server, port} = start_server()

--- a/test/grappa/user_settings_concurrency_test.exs
+++ b/test/grappa/user_settings_concurrency_test.exs
@@ -1,0 +1,127 @@
+defmodule Grappa.UserSettingsConcurrencyTest do
+  @moduledoc """
+  #1375 — two writers, two DIFFERENT `data` keys, neither write lost.
+
+  `user_settings.data` is one JSON column, so every setter writes it WHOLE.
+  A setter that reads the blob, merges its key and writes it back drops any
+  key another writer committed in between — silently, with `{:ok, _}` on both
+  sides. The pair driven here is the pair the issue names as reachable in
+  production: `put_last_client_prefix64/2` fires from
+  `Grappa.Vhosts.record_client_source/2` on every client connect, in the
+  socket's own process, while a settings-drawer PUT runs in another.
+
+  ## How the interleave is forced
+
+  Ecto's per-query telemetry (`[:grappa, :repo, :query]`, the event
+  `Grappa.DbLatency` already folds) runs its handlers SYNCHRONOUSLY in the
+  process that issued the query. Attaching a handler that blocks on the
+  writer's `user_settings` SELECT therefore suspends it exactly between its
+  read and its write — no production code has a test seam in it, and there is
+  no sleep-and-hope: the second writer is signalled from inside that window.
+
+  ## What the harness substitutes, and what it therefore cannot buy
+
+  In production the two writers hold two of the pool's ten connections and
+  the serialisation comes from SQLite's file-level write lock: the second
+  `BEGIN IMMEDIATE` waits out `busy_timeout` and its read then sees the first
+  writer's commit. The Sandbox has ONE connection (`config/test.exs`,
+  `pool_size: 1`), so here the second writer blocks on the checkout the open
+  transaction holds. Same serialisation, different lock — which is why these
+  tests prove that the read and the write are ONE transaction, and do NOT
+  prove the `:immediate` spelling of it. That distinction is invisible at
+  runtime under the Sandbox (nested, every mode is a `SAVEPOINT`) and both
+  tests stay green with `Repo.transaction/1` — measured, not assumed.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{Accounts, UserSettings}
+  alias Grappa.IRC.Identifier
+  alias Grappa.UserSettings.Settings
+
+  @handler_id {__MODULE__, :pause_between_read_and_write}
+
+  # How long the paused writer waits for the other one. Reached only when the
+  # other writer is BLOCKED (the fixed shape), so it is a per-test cost, not a
+  # timing guess: generous on purpose, because a window too short to let an
+  # UNGUARDED writer commit would turn the defect green.
+  @peer_grace_ms 1_000
+
+  defp user_fixture do
+    name = "us-conc-#{System.unique_integer([:positive])}"
+    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
+    user
+  end
+
+  # Spawns the second writer, then arms the pause. `peer_write` runs only once
+  # the paused writer has read, and the pause ends as soon as it reports back.
+  defp interleave(subject, peer_write) do
+    parent = self()
+
+    peer =
+      spawn(fn ->
+        receive do
+          :go -> send(parent, {:peer_done, peer_write.(subject)})
+        end
+      end)
+
+    Ecto.Adapters.SQL.Sandbox.allow(Grappa.Repo, parent, peer)
+
+    :telemetry.attach(
+      @handler_id,
+      [:grappa, :repo, :query],
+      # `:telemetry` handler args: event, measurements, metadata, config.
+      fn _, _, meta, _ ->
+        if self() == parent and meta[:source] == "user_settings" and
+             String.starts_with?(meta[:query] || "", "SELECT") and
+             Process.get(@handler_id) == nil do
+          Process.put(@handler_id, :fired)
+          send(peer, :go)
+
+          receive do
+            {:peer_done, _} = landed -> send(parent, landed)
+          after
+            @peer_grace_ms -> :ok
+          end
+        end
+      end,
+      nil
+    )
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach(@handler_id) end)
+  end
+
+  defp write_prefix(subject), do: UserSettings.put_last_client_prefix64(subject, "AABB")
+
+  test "a setter does not drop a key another writer commits between its read and its write" do
+    user = user_fixture()
+    subject = {:user, user.id}
+    {:ok, _} = UserSettings.get_or_init(subject)
+
+    interleave(subject, &write_prefix/1)
+
+    assert {:ok, %Settings{}} = UserSettings.set_highlight_patterns(subject, ["ciao"])
+    assert_receive {:peer_done, {:ok, %Settings{}}}, 2_000
+
+    assert UserSettings.get_highlight_patterns(subject) == ["ciao"]
+    assert UserSettings.get_last_client_prefix64(subject) == "AABB"
+  end
+
+  test "a mute rename does not drop a key another writer commits between its read and its write" do
+    user = user_fixture()
+    subject = {:user, user.id}
+
+    muted = %{Identifier.channel_key("azzurra", "old") => %{"until" => nil}}
+    prefs = Map.put(UserSettings.default_notification_prefs(), :muted_targets, muted)
+
+    {:ok, _} = UserSettings.put_notification_prefs(subject, prefs)
+
+    interleave(subject, &write_prefix/1)
+
+    assert {:ok, :renamed} = UserSettings.rename_muted_target(subject, "azzurra", "old", "new")
+    assert_receive {:peer_done, {:ok, %Settings{}}}, 2_000
+
+    renamed = UserSettings.get_notification_prefs(subject).muted_targets
+    assert Map.has_key?(renamed, Identifier.channel_key("azzurra", "new"))
+    assert UserSettings.get_last_client_prefix64(subject) == "AABB"
+  end
+end

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -1686,4 +1686,48 @@ defmodule Grappa.UserSettingsTest do
       refute_receive {:auto_away_debounce_changed, _}, 100
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #1374 P-S7 — the in-transaction (`!`) seam
+  # ---------------------------------------------------------------------------
+
+  describe "in-transaction seam (#1374 P-S7)" do
+    # `Grappa.Visitors.create_anon/4` seeds the incognito upload TTL as the
+    # third statement of an already-open `BusyRetry.run(fn ->
+    # immediate_transaction(…) end)`. The retrying spelling ran TWO more
+    # retry loops in there — `get_or_init/1` and `persist/1` — each sleeping
+    # while holding the transaction's connection and each converting the
+    # busy into a return value that `Repo.rollback/1` then surfaced as a 503
+    # WITHOUT the enclosing engine ever spending its budget.
+    #
+    # What this measures: the `!` spelling has NO retry loop, so the armed
+    # fault (which fires only at the top of a `BusyRetry.run` attempt) has
+    # nothing to grab and the write lands; its retrying twin, on the same
+    # armed faults, degrades. That is the whole difference between the two,
+    # and it is what a mutant swapping `persist!/1` back to `persist/1`
+    # breaks.
+    #
+    # What it does NOT establish: that a REAL SQLITE_BUSY raises through to
+    # the caller's transaction. The pool_size:1 Sandbox cannot produce one
+    # (that is why the injection seam exists), and the seam reaches only
+    # code already inside a retry loop — the very thing the `!` variant
+    # lacks. The raise-through is argued from `Repo.update/1`'s own
+    # behaviour, not measured here.
+    test "the `!` setters carry no retry loop, where their twins degrade" do
+      seam_visitor = visitor_fixture()
+      twin_visitor = visitor_fixture()
+
+      Repo.BusyRetry.inject_transient_faults(10_000)
+
+      assert {:ok, %Settings{}} =
+               UserSettings.put_upload_ttl_seconds!({:visitor, seam_visitor.id}, 3_600)
+
+      assert UserSettings.get_upload_ttl_seconds({:visitor, seam_visitor.id}) == 3_600
+
+      assert {:error, :db_unavailable} =
+               UserSettings.put_upload_ttl_seconds({:visitor, twin_visitor.id}, 3_600)
+
+      assert UserSettings.get_upload_ttl_seconds({:visitor, twin_visitor.id}) == nil
+    end
+  end
 end

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -180,6 +180,32 @@ defmodule GrappaWeb.ArchiveControllerTest do
       assert slug == net.slug
     end
 
+    # #1374 P-S8 — the two archive purges were the last web-reachable
+    # scrollback writes with no retry: a transient SQLITE_BUSY raised out of
+    # `Repo.delete_all` and left the operator with a 500 where #518 promises
+    # a typed 503, on a door #523 B1's own stated scope already covered.
+    test "sustained DB busy on a purge is a typed 503, and the rows survive",
+         %{conn: conn, vjt: vjt} do
+      net = net_with_credential(vjt)
+      :ok = seed_archive_rows(vjt, net)
+
+      Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(vjt.name))
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      degraded = delete(conn, "/networks/#{net.slug}/archive/#{URI.encode_www_form("#a")}")
+
+      assert json_response(degraded, 503) == %{"error" => "db_unavailable"}
+
+      # Refused, not half-done: the rows are still there, and NO purge was
+      # announced — a broadcast here would tell every cic tab to drop a
+      # cache the server still holds.
+      remaining = Scrollback.list_archive({:user, vjt.id}, net.id, MapSet.new())
+      assert Enum.any?(remaining, &(&1.target == "#a"))
+
+      refute_received %Phoenix.Socket.Broadcast{payload: %{kind: :archive_purged}}
+    end
+
     test "query-shaped target → 204 + drops DM rows + broadcasts archive_purged",
          %{conn: conn, vjt: vjt} do
       net = net_with_credential(vjt)

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -28,6 +28,7 @@ defmodule GrappaWeb.AuthControllerTest do
   alias Grappa.Networks.Credential
   alias Grappa.PubSub.Topic
   alias Grappa.RateLimit.FailureWindow
+  alias Grappa.Repo.BusyRetry
   alias Grappa.Session.Server, as: SessionServer
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.PasskeyOrigin
@@ -274,7 +275,7 @@ defmodule GrappaWeb.AuthControllerTest do
       armed_step = Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step
       assert is_integer(armed_step)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       degraded =
         post(conn, "/auth/totp/verify", %{
@@ -700,7 +701,7 @@ defmodule GrappaWeb.AuthControllerTest do
       {_, port} = start_server()
       {_, _} = setup_visitor_network(port)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       conn = post(conn, "/auth/login", %{"identifier" => "vjt"})
 
@@ -1012,7 +1013,7 @@ defmodule GrappaWeb.AuthControllerTest do
     test "returns 503 db_unavailable when the revoke degrades, leaving the bearer live",
          %{conn: conn} do
       {_, session} = user_and_session()
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
       conn =
         conn

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -246,6 +246,51 @@ defmodule GrappaWeb.AuthControllerTest do
       assert session_count() == 1
     end
 
+    # #1374 P-S3 — the 2FA door was the ONE second-factor path with no
+    # `BusyRetry` anywhere: `verify_second_factor/3` called `TOTP.verify/3`
+    # bare, and `TOTP.verify/3` is the #524 shape exactly (a `Repo.get!` READ
+    # then a conditional `update_all` WRITE inside one DEFERRED transaction).
+    # A transient busy there surfaced as an uncaught `Exqlite.Error` — a 500
+    # at the login door, where #518 promises a typed 503.
+    #
+    # The Sandbox cannot raise a real SQLITE_BUSY (pool_size 1, no
+    # self-contention), hence the seam. Armed AFTER the password step so the
+    # faults can only land on the verify request.
+    test "sustained DB busy at the TOTP door is a typed 503, not a 500", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      on_exit(fn -> clear_totp_window(user.id) end)
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      # `arm_totp/1` already spent the PREVIOUS step, so the pre-state is a
+      # non-nil step — read it rather than assume nil, or the assertion below
+      # would pass against a value the enrolment set.
+      armed_step = Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step
+      assert is_integer(armed_step)
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      degraded =
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => pending["challenge_token"],
+          "code" => code
+        })
+
+      assert json_response(degraded, 503) == %{"error" => "db_unavailable"}
+
+      # Degraded, not half-spent: no bearer, and the TOTP step was NOT
+      # consumed — the code is still redeemable once the DB frees up. A
+      # rolled-back transaction is what makes that true.
+      assert session_count() == 0
+      assert Repo.get!(Grappa.Accounts.User, user.id).totp_last_used_step == armed_step
+    end
+
     test "invalid TOTP never mints a bearer", %{conn: conn} do
       {user, password} = user_fixture_with_password()
       _ = arm_totp(user)


### PR DESCRIPTION
## What this is

A union branch. It re-lands `settings(#1375)` verbatim — cherry-picked, so its
message and author date survive intact — and puts the #1374 work on top,
including a probe that closes the defect #1375's own "Accepted cost" section
had declined to close.

Sources: the #1374 branch behind #1378 (closed by hand, same content), and
`83d90cb1`, which #1414 reverted out of main.

## Why #1375 has to come back

`user_settings.data` is one JSON column, so every setter writes it whole. Two
writers touching completely DIFFERENT keys both read the same snapshot, both
write a full replacement, and the second commit drops the first's key — with
`{:ok, _}` on both sides and nothing in the logs. #1375 closed that by holding
the read and the write in one `BEGIN IMMEDIATE`. Reverting it stopped a red; it
also put the lost update back. This branch is how the fix returns.

## Why it could not come back unchanged

Holding the read and the write together means `rename_muted_target/4` opens a
write transaction on every call — and it is called once per peer NICK change
per live session. IRC delivers a NICK to every session sharing a channel, and
almost none of them mute that peer, so almost every one of those transactions
takes SQLite's single write lock to migrate nothing.

Measured, not argued. `NickMigrationTest` counts transaction-control statements
off Ecto's per-query telemetry and reports, for a peer with no query window and
no mute:

```
a rename with nothing to move opened a write transaction: ["begin"]
```

The probe closes it. `muted_prefs/2` is the ONE "is this key muted?" question:
the probe asks it outside the transaction to decide whether to open one, and
`rekey_muted_target/3` asks it again inside to decide what to write. Sharing
the predicate is what makes a probe safe — the same discipline
`QueryWindows.exists?/3` already gives the window — so the cheap path and the
authoritative path cannot drift onto different notions of "nothing to migrate".
The probe's read is never trusted for the write: the transaction re-reads, and
only that read decides.

The mute still migrates unconditionally (#1340). The probe decides whether a
TRANSACTION is needed, never whether the MIGRATION is.

## 🔴 Declared risk: this re-lands the commit measured to cause the red

On `83d90cb1` the `integration` job went red four runs out of four, three of
them on `issue458-presence-page-yield`. Its parent was green four runs in a
row. Reverting it restored green. That is a before/after on the only venue that
reproduces, and it is why main is currently without #1375.

**This branch puts that commit back.** The hypothesis is that the probe removes
the mechanism — the lock taken to migrate nothing — and therefore the red. That
hypothesis is NOT measured. If it is wrong, the `integration` job on this PR
goes red and main stays where it is.

That is the honest state of it: this PR is the experiment, not the conclusion.

## Why CI is the only place this can be settled

Local reproduction was attempted and failed. The two valid arms are evidence
against, not for:

| arm | tree | load | verdict | `saturated` / `dropped` / `busy_locked` |
|---|---|---|---|---|
| A′ quiet | probe reverted | none | 10 passed | 0 / 0 / 0 |
| A′/L | probe reverted | generated, band 4.86–9.12 vs a 3.2–4.7 floor | 10 passed | 0 / 0 / 0 |

The signature — `fault=busy_locked`, a scrollback row dropped under the #336
never-crash contract, a rename landing tens of seconds behind its assertion
window — appeared only while an unrelated ExUnit suite happened to be running
from ANOTHER worktree on the same host. It did not appear on a quiet host, and
it did not appear under a deliberately generated load that was *heavier* by
loadavg.

The likely reason, recorded because it will mislead the next person the same
way: **loadavg measures the CPU run queue, not contention on SQLite's single
writer.** The generated load was more pressure of a different kind — different
`_build`, different mix container, different disk access pattern. So a green on
that workstation is not an acquittal; it says the venue cannot show the defect,
not that the defect is absent. A contended CI runner is a different venue, and
the only one where the question is decidable.

### Arms run, and the three discarded

So the two greens above are not mistaken for the whole attempt.

| arm | why discarded |
|---|---|
| A′ (first) | a neighbour's ExUnit suite ran during it, and its heavy phase falls inside this arm's window but outside the comparison arm's — a time-varying neighbour on sequential arms can manufacture a differential from nothing |
| FIX (first) | same neighbour, but after its heavy phase ended: not the same load as the arm it would be compared against |
| A′/L (first) | the load generator ran from the tree under measurement, so the load differed between arms by construction; regenerated from a fixed separate worktree |

## Test plan

- [ ] `scripts/check.sh` on the union — pending the COMPILE lane. The old
      branch was green, but on a different base; the union is gated whole, not
      in parts
- [x] union tree verified byte-identical to the reviewed branch
      (`git diff` empty against it)
- [x] `NickMigrationTest` transaction-statement oracle fails without the probe
      and passes with it
- [x] `design-notes-gate.sh` green; DESIGN_NOTES two-sided numstat 215/0 against
      the base, boundary shape read on the file
- [ ] `integration` on CI — the decisive one, for the reason above
