### PR TITLE
cic(#1413): the long-press shows nothing while it runs

### DIFF
--- a/cicchetto/e2e/tests/issue1413-hold-press-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue1413-hold-press-feedback.spec.ts
@@ -1,0 +1,210 @@
+// #1413 — the long-press used to run its 500ms in total silence: the timer
+// armed on touchstart and nothing was drawn until the menu was already up, so
+// the press read as a dead touch. The sibling gesture never had that problem —
+// the swipe slides the row under the finger, and #1156 refused to arm that
+// slide where nothing could be quoted, on the grounds that the slide IS the
+// promise. The hold makes the same promise, and now shows the same evidence.
+//
+// The oracle here is the PAINT, not the class: `getComputedStyle` on the row
+// during the hold. A class assertion would survive the stylesheet never
+// matching — a typo in the selector, or the rule sitting above the mention and
+// highlight rules whose `background` shorthand resets `background-image`. The
+// tint is a background LAYER, so "painted" reads as a `background-image` that
+// is not `none`.
+//
+// Harness + limits, same as #1067's sibling spec:
+//   * chromium, untagged. Chromium's TouchEvent/Touch constructors are
+//     reliable (webkit's are not — Playwright webkit ≠ real iOS), so the
+//     gesture is synthesized in-page on the ROW and reaches the production
+//     listener by bubbling to `.scrollback`, exactly as a real finger does.
+//   * This buys the MECHANICS: the cue appears while the timer runs and is
+//     gone by every way the timer can die. It does NOT buy the FEEL — whether
+//     the ramp reads as an acknowledgement on a real phone, and whether iOS
+//     Safari paints anything of its own during those 500ms, is vjt's on-device
+//     dogfood and is not settled by this file.
+import type { Page } from "@playwright/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Outside both 20px edge zones (#1041 sidebar / #308 members), so the hold is
+// the only gesture in play.
+const AT = { x: 200, y: 400 };
+
+// Past HOLD_MOVE_TOLERANCE_PX (10) and vertical, so it reads as the scroll it
+// is meant to be rather than as a rightward swipe claim.
+const DRIFT_PX = 40;
+
+// How far into the hold to sample. Early enough that the timer is unambiguously
+// still running whatever the threshold is — the spec never hardcodes 500, it
+// reads the duration the binder hands to CSS (see `holdRow`).
+const SAMPLE_AT_MS = 120;
+
+type Sample = {
+  // `background-image` on the row: `none` when unpainted, a gradient otherwise.
+  paint: string;
+  // The ramp duration the binder wrote, e.g. "500ms". Production's own copy of
+  // the threshold — the spec derives its waits from this rather than keeping a
+  // second 500 that could drift.
+  holdMs: string;
+};
+
+type HoldResult = {
+  during: Sample;
+  after: Sample;
+};
+
+/**
+ * touchstart on the row carrying `body`, sample the paint mid-hold, then take
+ * one of the three exits and sample again.
+ *
+ * - `release`  — touchend before the threshold: a tap.
+ * - `drift`    — touchmove past the tolerance: a scroll.
+ * - `fire`     — hold past the threshold so the menu opens, then release.
+ *
+ * The whole gesture runs inside ONE page.evaluate: the samples have to be taken
+ * while the touch is live, and a round trip per step would let the threshold
+ * elapse between them.
+ */
+async function holdRow(
+  page: Page,
+  body: string,
+  exit: "release" | "drift" | "fire",
+): Promise<HoldResult> {
+  return await page.evaluate(
+    async ({ body: text, at, exit: how, sampleAtMs, driftPx }) => {
+      const rows = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-testid="scrollback-line"]'),
+      );
+      const row = rows.find((r) => r.textContent?.includes(text));
+      if (row === undefined) throw new Error(`no scrollback row containing ${text}`);
+      const mk = (y: number) =>
+        new Touch({ identifier: 1, target: row, clientX: at.x, clientY: y });
+      const fire = (type: "touchstart" | "touchmove" | "touchend", y: number): void => {
+        const t = mk(y);
+        const active = type === "touchend" ? [] : [t];
+        row.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: active,
+            targetTouches: active,
+            changedTouches: [t],
+          }),
+        );
+      };
+      const sample = () => ({
+        paint: window.getComputedStyle(row).backgroundImage,
+        holdMs: row.style.getPropertyValue("--hold-ms"),
+      });
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+      fire("touchstart", at.y);
+      await sleep(sampleAtMs);
+      const during = sample();
+
+      if (how === "release") {
+        fire("touchend", at.y);
+      } else if (how === "drift") {
+        fire("touchmove", at.y + driftPx);
+      } else {
+        // Derive the wait from what the binder itself declared, so this spec
+        // cannot drift from LONG_PRESS_MS the way a hardcoded 500 would. The
+        // margin covers a timer that fires a touch late under load.
+        const declared = Number.parseInt(during.holdMs, 10);
+        if (!Number.isFinite(declared))
+          throw new Error(`no --hold-ms on the row: ${during.holdMs}`);
+        await sleep(declared - sampleAtMs + 250);
+        fire("touchend", at.y);
+      }
+      // A frame for the class removal to reach the computed style.
+      await sleep(80);
+      return { during, after: sample() };
+    },
+    { body, at: AT, exit, sampleAtMs: SAMPLE_AT_MS, driftPx: DRIFT_PX },
+  );
+}
+
+// A body unique per run: the e2e sqlite scrollback persists across KEEP_STACK=1
+// re-runs, and a static string would match two rows on the second run and trip
+// Playwright strict mode.
+function uniqueBody(tag: string): string {
+  return `issue1413 ${tag} ${Date.now()}`;
+}
+
+async function postMessage(page: Page, body: string): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await composeSend(page, body);
+  await expect(page.locator('[data-testid="scrollback-line"]', { hasText: body })).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+const menu = (page: Page) => page.locator(".context-menu");
+
+test("issue1413 — the row is painted while the hold runs, and unpainted once the menu arrives", async ({
+  page,
+}) => {
+  const body = uniqueBody("fire");
+  await postMessage(page, body);
+
+  // The pre-state, asserted rather than assumed: a row already carrying a
+  // background would make "painted during" true for the wrong reason.
+  const before = await page
+    .locator('[data-testid="scrollback-line"]', { hasText: body })
+    .evaluate((el) => window.getComputedStyle(el).backgroundImage);
+  expect(before).toBe("none");
+  await expect(menu(page)).toBeHidden();
+
+  const result = await holdRow(page, body, "fire");
+
+  // THE outcome: something is on screen while the timer runs. Before #1413
+  // this was `none` for the whole 500ms.
+  expect(result.during.paint).not.toBe("none");
+  expect(result.during.holdMs).toMatch(/^\d+ms$/);
+
+  // …and the menu the cue was promising actually arrived.
+  await expect(menu(page)).toBeVisible();
+  // The promise is kept, so the cue is spent: nothing is left latched on the
+  // row once the menu is up.
+  expect(result.after.paint).toBe("none");
+  expect(result.after.holdMs).toBe("");
+});
+
+test("issue1413 — a release before the threshold unpaints the row and opens no menu", async ({
+  page,
+}) => {
+  const body = uniqueBody("tap");
+  await postMessage(page, body);
+
+  const result = await holdRow(page, body, "release");
+
+  expect(result.during.paint).not.toBe("none");
+  expect(result.after.paint).toBe("none");
+  await expect(menu(page)).toBeHidden();
+});
+
+// The same escape the timer already honours: past the tolerance this is a
+// scroll, and a row still lit under a scrolling finger would be promising a
+// menu that is no longer coming.
+test("issue1413 — a finger that drifts past the tolerance unpaints the row and opens no menu", async ({
+  page,
+}) => {
+  const body = uniqueBody("drift");
+  await postMessage(page, body);
+
+  const result = await holdRow(page, body, "drift");
+
+  expect(result.during.paint).not.toBe("none");
+  expect(result.after.paint).toBe("none");
+  // Well past the threshold: the drift killed the timer, not just the paint.
+  await page.waitForTimeout(900);
+  await expect(menu(page)).toBeHidden();
+});

--- a/cicchetto/src/__tests__/messageGestures.test.ts
+++ b/cicchetto/src/__tests__/messageGestures.test.ts
@@ -4,6 +4,8 @@ import { LONG_PRESS_MS } from "../lib/keepKeyboard";
 import {
   bindMessageGestures,
   HOLD_MOVE_TOLERANCE_PX,
+  HOLD_MS_VAR,
+  HOLDING_CLASS,
   SWIPE_MAX_SLIDE_PX,
   SWIPING_CLASS,
 } from "../lib/messageGestures";
@@ -332,5 +334,105 @@ describe("bindMessageGestures — a row the call site refuses (#1156)", () => {
     swipeRight(body, 90);
     expect(onReply).toHaveBeenCalledTimes(1);
     expect(onReply.mock.calls[0]?.[0]).toBe(row);
+  });
+});
+
+// #1413 — the hold used to run its 500ms in total silence: the timer armed on
+// touchstart and NOTHING was drawn until the menu was already up, so the press
+// read as a dead touch. The sibling gesture has never had that problem — the
+// swipe slides the row under the finger, and #1156 refused to arm that slide
+// where nothing could be quoted precisely because the slide IS the promise. The
+// hold makes the same promise, so it has to show the same kind of evidence.
+//
+// The class is driven off the SAME state the timer is driven off: one machine,
+// so what is painted and what will fire cannot disagree. Every way the timer
+// can die — release, drift past the tolerance, cancel, dispose — unpaints it,
+// because they all pass through `cancelHold`.
+//
+// jsdom proves the MECHANICS only. Whether the ramp reads as an acknowledgement
+// on a real phone, and whether iOS paints anything of its own during those
+// 500ms, is a device call.
+describe("bindMessageGestures — the hold announces itself (#1413)", () => {
+  it("paints the row from touchstart, while the timer is still running", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(true);
+    vi.advanceTimersByTime(LONG_PRESS_MS - 50);
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(true);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  // Hands the ramp its duration from the constant rather than letting the
+  // stylesheet keep a second copy of 500 — the two would drift the day the
+  // threshold moves, and the cue would then finish early or late.
+  it("hands the CSS the hold duration, so the ramp cannot drift from the timer", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    expect(row.style.getPropertyValue(HOLD_MS_VAR)).toBe(`${LONG_PRESS_MS}ms`);
+  });
+
+  it("unpaints it when the menu opens: the promise has been kept", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    vi.advanceTimersByTime(LONG_PRESS_MS);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+    expect(row.style.getPropertyValue(HOLD_MS_VAR)).toBe("");
+  });
+
+  it("unpaints it on the release of a short tap", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    vi.advanceTimersByTime(LONG_PRESS_MS - 50);
+    fireTouch(body, "touchend", { clientX: CENTER_X, clientY: 300 });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+  });
+
+  // The same escape the timer already honours: past the tolerance this is a
+  // scroll or a swipe, and a row still lit under a scrolling finger would be
+  // promising a menu that is no longer coming.
+  it("unpaints it once the finger drifts past the tolerance", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    fireTouch(body, "touchmove", {
+      clientX: CENTER_X,
+      clientY: 300 + HOLD_MOVE_TOLERANCE_PX + 5,
+    });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+    vi.advanceTimersByTime(LONG_PRESS_MS + 100);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("keeps it through a jitter under the tolerance (a real finger is never still)", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    fireTouch(body, "touchmove", { clientX: CENTER_X + 2, clientY: 303 });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(true);
+  });
+
+  it("unpaints it on touchcancel", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    fireTouch(body, "touchcancel", { clientX: CENTER_X, clientY: 300 });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+  });
+
+  it("unpaints it when the binder is disposed mid-touch", () => {
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    dispose();
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+  });
+
+  // Never paints where the hold never armed: the cue means "a menu is coming",
+  // and on an inline control (#350 link, #354 nick) it is not.
+  it("never paints a row whose hold never armed", () => {
+    fireTouch(link, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    expect(row.classList.contains(HOLDING_CLASS)).toBe(false);
+    vi.advanceTimersByTime(LONG_PRESS_MS + 100);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  // #1156 gates the SWIPE, not the hold: the menu opens on a join row too, so
+  // the cue that announces it has to appear there as well. Reading the paint
+  // off the swipe's arming state would have left presence rows silent.
+  it("paints a row the call site refuses a reply for (the hold arms there too)", () => {
+    fireTouch(refusedBody, "touchstart", { clientX: CENTER_X, clientY: 300 });
+    expect(refusedRow.classList.contains(HOLDING_CLASS)).toBe(true);
+    vi.advanceTimersByTime(LONG_PRESS_MS);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(refusedRow.classList.contains(HOLDING_CLASS)).toBe(false);
   });
 });

--- a/cicchetto/src/lib/messageGestures.ts
+++ b/cicchetto/src/lib/messageGestures.ts
@@ -44,6 +44,17 @@ export const HOLD_MOVE_TOLERANCE_PX = 10;
 // so the slide tracks the finger instead of easing behind it.
 export const SWIPING_CLASS = "scrollback-line-swiping";
 
+// #1413 — carried by the row for exactly as long as the hold timer is running.
+// The stylesheet ramps a tint under it so the press is acknowledged the instant
+// it lands and the wait reads as a wait: before this, the 500ms ran with
+// nothing drawn and the hold felt like a dead touch.
+export const HOLDING_CLASS = "scrollback-line-holding";
+
+// The ramp's duration, handed to CSS at arm time rather than written into the
+// stylesheet: LONG_PRESS_MS is the one threshold, and a second copy of 500 in
+// a rule would finish early or late the day the threshold moves.
+export const HOLD_MS_VAR = "--hold-ms";
+
 // Exported since #1115: the desktop `contextmenu` door resolves the row the
 // same way this binder does, and two copies of the selector would let the two
 // doors open over different elements.
@@ -76,10 +87,24 @@ export function bindMessageGestures(el: HTMLElement, params: MessageGestureParam
   let claimed = false; // rightward intent proven → we own the gesture
   let holdTimer: ReturnType<typeof setTimeout> | undefined;
   let held = false; // the menu opened during THIS touch
+  // #1413 — the row currently wearing the cue. Tracked separately from `row`,
+  // which is the SWIPE's arming state: #1156 leaves a presence row unarmed for
+  // the swipe while the hold still arms on it, so reading the paint off `row`
+  // would leave exactly those rows silent.
+  let pressed: HTMLElement | null = null;
 
+  // The ONE teardown for the hold, in both senses: the timer that would open
+  // the menu and the cue that promises it. Every exit runs through here —
+  // release, drift past the tolerance, cancel, dispose, and the fire itself —
+  // so what is painted and what will fire cannot disagree.
   const cancelHold = (): void => {
     if (holdTimer !== undefined) clearTimeout(holdTimer);
     holdTimer = undefined;
+    if (pressed !== null) {
+      pressed.classList.remove(HOLDING_CLASS);
+      pressed.style.removeProperty(HOLD_MS_VAR);
+      pressed = null;
+    }
   };
 
   const release = (): void => {
@@ -129,8 +154,15 @@ export function bindMessageGestures(el: HTMLElement, params: MessageGestureParam
     if (params.canReply(line)) row = line;
     const at = start;
     const held_ = line;
+    // #1413 — armed and announced in the same breath. The cue is the hold's
+    // half of what the swipe gets for free from the slide.
+    pressed = line;
+    line.style.setProperty(HOLD_MS_VAR, `${LONG_PRESS_MS}ms`);
+    line.classList.add(HOLDING_CLASS);
     holdTimer = setTimeout(() => {
-      holdTimer = undefined;
+      // Unpaint through the shared teardown: the menu is up, the promise the
+      // cue was making has been kept, and there is nothing left to wait for.
+      cancelHold();
       held = true;
       // Disarm the swipe: this touch has become a press, and its release must
       // not also quote the message.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2914,6 +2914,58 @@ html.resize-dragging * {
   opacity: 0.75;
 }
 
+/* #1413 — what the hold shows while it runs. The 500ms used to pass with
+   nothing drawn at all, so the press read as a dead touch: the sibling swipe
+   slides the row under the finger and #1156 refused to arm that slide where
+   nothing could be quoted, on the grounds that the slide IS the promise. The
+   hold makes the same promise and owed the same evidence.
+
+   It RAMPS rather than snapping on, because the complaint is an unknown DELAY:
+   a cue that appears instantly says "touched", one that fills says "wait, and
+   for this long". Starting from transparent also means a flick that cancels
+   within a few tens of ms has painted next to nothing. The duration is
+   `--hold-ms`, set by the binder from LONG_PRESS_MS — the stylesheet keeps no
+   second copy of 500 to drift from the timer.
+
+   Placed AFTER the mention and highlight rules on purpose: those set the
+   `background` SHORTHAND, which resets `background-image`, so a tint declared
+   above them would be wiped off exactly the rows that already carry a colour.
+   Declared as a background LAYER rather than a `background-color` for the same
+   reason — it composes over whatever they put underneath instead of replacing
+   it.
+
+   Paint only: no `position`, no `filter`, no `user-select`, nothing that moves
+   a box or joins the selection machinery iOS starts over copyable text during
+   a long press (`lib/keepKeyboard.ts` exists because that path is delicate).
+   Whether iOS paints something of its own underneath is a device question this
+   rule does not answer. */
+.scrollback-line.scrollback-line-holding {
+  animation-name: scrollback-hold;
+  animation-duration: var(--hold-ms);
+  animation-timing-function: linear;
+  /* Holds the tint on the last frame so a timer running a frame behind the
+     animation cannot flash the row back to bare before the menu arrives. */
+  animation-fill-mode: forwards;
+}
+
+@keyframes scrollback-hold {
+  from {
+    background-image: linear-gradient(transparent, transparent);
+  }
+  to {
+    background-image: linear-gradient(var(--border), var(--border));
+  }
+}
+
+/* The acknowledgement stays, the motion goes: reduced-motion asks for no
+   animation, not for the dead touch back. */
+@media (prefers-reduced-motion: reduce) {
+  .scrollback-line.scrollback-line-holding {
+    animation-name: none;
+    background-image: linear-gradient(var(--border), var(--border));
+  }
+}
+
 /* #237: on-JOIN inline topic line. Presentational row (not .scrollback-line)
    derived from the topic store; prints the FULL topic in the buffer flow so
    the mobile-truncated TopicBar is no longer the only surface. The row wraps

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44406,3 +44406,99 @@ accept. Refusals are logged per occurrence: the volume is bounded by
 whatever rate upstream lets a sender INVITE at, and it rotates, whereas the
 alternative is an operator who never learns that invitations are being
 turned away.
+<!-- entry #1413 -->
+
+---
+
+## 2026-08-16 — #1413: the hold had nothing to show for itself
+
+An iOS user reported that the long-press message menu feels like a dead
+touch. Their proposal was to fire the menu on a timer from touchstart
+instead of on release — which is already exactly what happens, and has
+since #1067. The report was still right; it just named the wrong cause.
+The 500ms was not too long. It was invisible.
+
+### Why the number was not the knob
+
+`LONG_PRESS_MS` is imported by `lib/keepKeyboard.ts` to tell a tap from a
+hold for the keyboard gate, deliberately rather than redeclared, so that
+one press cannot be a hold for one handler and a tap for the other.
+Shortening it to make the menu feel quicker would silently shorten that
+gate too. It is a shared threshold, not a tuning dial, and it is
+untouched here.
+
+`navigator.vibrate` was on the table as the cheap answer and was
+rejected: iOS Safari does not implement it, so the one person who
+reported this would have got nothing. A haptic can only ever be an extra
+on platforms that have one — never the fix.
+
+### The argument the sibling gesture had already made
+
+The swipe on the same row is self-describing: the row slides under the
+finger, so the gesture proves it is armed while it is still reversible.
+#1156 refused to arm that slide on rows with nothing to quote precisely
+because the slide IS the promise, and a promise that cannot be kept must
+not be made. The hold makes the same promise as the swipe — something is
+about to happen — and made it with nothing on screen at all.
+
+So the fix signals the hold rather than shortening it, which is what the
+issue proposed and what the twin-gesture argument independently
+demands.
+
+### One machine, not two
+
+The cue is added and removed by the same code that arms and disarms the
+timer, and every teardown runs through `cancelHold`: release, drift past
+`HOLD_MOVE_TOLERANCE_PX`, touchcancel, dispose, and the fire itself. A
+second observer of the touch stream would have been free to disagree
+with the one that actually opens the menu — a row still lit under a
+scrolling finger promises a menu that is no longer coming.
+
+It is tracked apart from the swipe's arming state on purpose. #1156
+leaves a presence row unarmed for the swipe while the hold still arms on
+it (Copy and Select… are useful on a join), so keying the paint to the
+swipe's state would have left exactly those rows silent. That mistake is
+pinned by a mutant in the unit suite rather than by a comment.
+
+### It ramps, and the stylesheet keeps no second copy of 500
+
+The complaint is of an unknown DELAY, not of an unacknowledged touch. A
+cue that snaps on says "touched"; one that fills says "wait, and for
+this long" — the same information the swipe conveys by tracking the
+finger. Ramping from transparent also means a flick that cancels within
+a few tens of milliseconds has painted next to nothing.
+
+The duration reaches CSS as a `--hold-ms` custom property written by the
+binder from `LONG_PRESS_MS`. A hardcoded `500ms` in the rule would have
+been a second copy of the threshold, finishing early or late the day the
+first one moves.
+
+### Where the rule sits is load-bearing
+
+The tint is a `background-image` LAYER, declared AFTER the mention and
+highlight rules. Those set the `background` SHORTHAND, which resets
+`background-image`, so a tint declared above them would have been wiped
+off exactly the rows that already carry a colour — and a
+`background-color` would have replaced those colours instead of
+composing over them.
+
+Nothing else is touched: no `position`, no `filter`, no `user-select`,
+nothing that moves a box or joins the selection machinery iOS starts
+over copyable text during a long press. `keepKeyboard.ts` exists because
+that path is delicate, and this change stays out of it.
+
+### What is bought, and what is still owed
+
+The unit suite proves the state machine in jsdom; seven mutants
+establish that every one of its assertions bites, three of them killing
+exactly one test. The e2e proves the PAINT — `getComputedStyle`, sampled
+while the touch is live, so a stylesheet that never matches cannot pass
+— across all three exits.
+
+Neither buys the feel. Playwright's webkit is not iOS Safari, and
+whether iOS paints anything of its own during those 500ms (a
+touch-callout, a selection affordance) cannot be read from the source
+and cannot be read in jsdom either. What is established is that WE draw
+nothing before this change and something after it. Whether the reporter
+now sees an acknowledgement in time is a device verification, still
+owed — and stated as owed rather than parked.


### PR DESCRIPTION
## Summary

The long-press message menu armed its 500ms timer on `touchstart` and drew
**nothing** until the menu was already up, so on iOS the press read as a dead
touch. This adds the missing signal.

The number was never the knob. Firing the menu from a timer on `touchstart` is
already what happens, and has since #1067 — which is what the reporter asked
for. The absence of a signal during it is the defect.

Verified still live on `origin/main` at `4ed33d2c` (the issue measured
`83d90cb1`, which had since been replaced by the #1375 revert), and no open PR
touched the gesture files.

### What it does

A cue on the row, driven off the **same state machine as the timer**:

- painted where the timer arms, on `touchstart`;
- unpainted through `cancelHold`, which is already the one exit for **every**
  way the timer can die — release, drift past `HOLD_MOVE_TOLERANCE_PX`,
  `touchcancel`, dispose, and now the fire itself.

A second observer of the touch stream would have been free to disagree with the
one that actually opens the menu; a row still lit under a scrolling finger
promises a menu that is no longer coming.

It is tracked apart from the swipe's arming state on purpose: #1156 leaves a
presence row unarmed for the swipe while the hold still arms on it (Copy and
Select… are useful on a join), so keying the paint to the swipe's state would
have left exactly those rows silent. A mutant pins that.

The cue **ramps** rather than snapping on, because the report is of an unknown
*delay*: a cue that appears instantly says "touched", one that fills says "wait,
and for this long" — the same information the sibling swipe conveys for free by
sliding under the finger, which is the ground #1156 stood on when it refused to
arm a slide that could not be honoured. The duration reaches CSS as a
`--hold-ms` custom property written from `LONG_PRESS_MS`, so the stylesheet
keeps no second copy of 500 to drift from.

### What it deliberately does not do

- **`LONG_PRESS_MS` is untouched.** `lib/keepKeyboard.ts` imports the same
  constant to tell a tap from a hold for the keyboard gate, deliberately rather
  than redeclaring it, so that one press cannot be a hold for one handler and a
  tap for the other. Shortening it to make the menu feel quicker would silently
  shorten that gate too.
- **No `navigator.vibrate`.** iOS Safari does not implement it, so it would have
  done nothing for the person who reported this. A haptic can only ever be an
  extra on platforms that have one — never the fix.

### Why the CSS sits where it sits

The tint is a `background-image` **layer**, declared *after* the mention and
highlight rules. Those set the `background` **shorthand**, which resets
`background-image`, so a tint declared above them would have been wiped off
exactly the rows that already carry a colour — and a `background-color` would
have replaced those colours instead of composing over them. The placement is
load-bearing and commented as such.

## The selection path, explicitly

**This change does not touch it.** No `preventDefault`, no `user-select`, no
`touch-action`, no `position`, no `filter` — nothing that moves a box or joins
the selection machinery iOS begins over copyable text during a long press.
`keepKeyboard.ts` exists because that path is delicate, and the diff stays out
of it: what is added is a paint-only background layer plus a class toggle in the
existing binder.

That is an argument from the properties changed, not a measurement. See below.

## What this does NOT establish

1. **Whether iOS Safari already paints something of its own during those
   500ms** — a touch-callout, a selection affordance. That cannot be read from
   the source, and jsdom cannot tell it either. So the claim made here is
   narrow and deliberate: **we** drew nothing before this change and draw
   something after it. Not that the user saw nothing.
2. **Whether the paint disturbs the selection iOS starts over copyable text.**
   The reasoning above says it should not, because no property involved in
   selection or layout is touched. It has not been observed on a device.
3. **The feel.** Whether the ramp reads as an acknowledgement in time, on a real
   phone, in a real hand.

## Device verification is owed, and Playwright does not cover it

The e2e buys the **mechanics**: the paint is present while the hold runs and
gone by every exit. It does **not** buy the feel — Playwright's webkit is not
iOS Safari and does not reproduce real iOS touch physics.

Stated plainly so it is not read as verified: **this ships without device
verification, and the device verification remains due** — it is declared, not
parked.

## Test plan

- [x] `bun run test` — 5516 cic unit tests green (286 files), including 10 new
      jsdom tests over the hold's state machine.
- [x] **Mutation-tested.** Seven mutants; every one of the 10 new tests dies for
      at least one, and three die for exactly one: no `--hold-ms` var, the paint
      keyed to the swipe state (which silences #1156 presence rows), and a row
      painted whose hold never armed. That last mutant had to be written after
      its test survived all the others — a test that never dies is decorative.
- [x] `bun run check` — biome + tsc over `src` and `e2e`, clean; no diagnostic
      on the new rule or the new spec.
- [x] `scripts/design-notes-gate.sh` — checks the entry this branch adds
      (re-run after the rebase, with the entry committed, so it is a real pass
      and not a "nothing to check").
- [ ] **e2e, on CI** — `cicchetto/e2e/tests/issue1413-hold-press-feedback.spec.ts`.
      Three exits (menu fires, early release, drift past the tolerance). The
      oracle is `getComputedStyle(row).backgroundImage`, sampled while the touch
      is live, **not** the class: a class assertion would have gone green with
      the stylesheet never matching at all. The spec never writes the threshold
      down — it reads the `--hold-ms` the binder hands to CSS and derives its own
      wait from it.
- [ ] **On-device**, per the section above.
