### PR TITLE
#1404: nine of the thirteen medium items, in one branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,11 @@ updates:
       - hex
 
   # ── GitHub Actions
+  #    Every `uses:` in .github/workflows is pinned to a commit SHA with a
+  #    `# vX.Y.Z` comment (#1404). This ecosystem is the update path for those
+  #    pins: it rewrites the SHA and the comment together, weekly, so pinning
+  #    does not decay into running an unpatched action forever.
+  #    `test/infra/actions_sha_pin_test.bats` is the guard on the other side.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           # fetch-depth: 0 is a cost this job pays for ONE gate: the
@@ -33,13 +33,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup BEAM
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache deps + build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             deps
@@ -187,7 +187,7 @@ jobs:
         run: infra/cloud/check-drift.sh
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: always()
         with:
           files: ./cover/excoveralls.json
@@ -212,7 +212,7 @@ jobs:
     name: shottino (build + tests)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -279,18 +279,18 @@ jobs:
     env:
       MIX_ENV: dev
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
       - name: Setup BEAM
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache deps + build + PLTs
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             deps
@@ -351,10 +351,10 @@ jobs:
         working-directory: cicchetto
     steps:
       # No submodules: bats-core and friends are Elixir/shell-side only.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache bun install
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('cicchetto/bun.lock') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,7 +112,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # azzurra-testnet (cicchetto/e2e/infra) is a public submodule —
           # `recursive` initializes it via the default GITHUB_TOKEN
@@ -152,7 +152,7 @@ jobs:
         # ephemeral per-run token; it has `packages: read` scope (see
         # job-level permissions above) and can pull same-owner
         # packages.
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload Playwright traces (on failure)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-traces
           path: cicchetto/e2e/test-results/
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload Playwright HTML report (on failure)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: cicchetto/e2e/playwright-report/
@@ -201,7 +201,7 @@ jobs:
         # `if-no-files-found: ignore` because the job can also fail before
         # the stack exists at all (checkout, compose plugin, GHCR login).
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-logs
           path: cicchetto/e2e/container-logs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
       - name: Checkout (tags for #391 version derivation)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           # Check out the RELEASE TAG explicitly so a workflow_dispatch repair
@@ -173,13 +173,13 @@ jobs:
           echo "version=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Setup BEAM (Elixir 1.19 / OTP 28)
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Setup bun (cicchetto build)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       # pkg-config + the ncursesw/openssl headers are shottino's BUILD
       # deps: build.sh compiles the terminal client into the staging tree
@@ -234,7 +234,7 @@ jobs:
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grappa-deb
           path: dist/*.deb
@@ -263,7 +263,7 @@ jobs:
             base-devel git elixir bun namcap sqlite sudo pacman-contrib
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           # Check out the release tag so a repair dispatch builds the tagged
@@ -364,7 +364,7 @@ jobs:
           cp infra/packaging/aur/PKGBUILD infra/packaging/aur/.SRCINFO arch-out/
 
       - name: Upload Arch artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grappa-arch
           path: arch-out/*
@@ -426,10 +426,10 @@ jobs:
             tar gzip unzip findutils sqlite openssl util-linux
 
       - name: Setup bun (cicchetto build)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Checkout (tags for #391 version derivation)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           # Check out the RELEASE TAG explicitly (a dispatch repair builds the
@@ -510,7 +510,7 @@ jobs:
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
       - name: Upload .rpm artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grappa-rpm
           path: dist/*.rpm
@@ -572,7 +572,7 @@ jobs:
       REPAIR_TAG: ${{ github.event_name == 'workflow_dispatch' && !inputs.docker_validation && inputs.tag || '' }}
     steps:
       - name: Checkout (the TRIGGERING ref; tags for #391 + :latest gate)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # image build COPYs only in-tree paths (cicchetto is a plain subdir);
           # the declared submodules are test-only, one behind a `git@` SSH URL the
@@ -712,7 +712,7 @@ jobs:
           emit_tags "${shottino_name}" shottino_tags
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           # The arm64 leg is emulated on the amd64 runner, and an OLD QEMU
           # crashes the emulated BEAM JIT (BeamAsm) at the first `mix` call with
@@ -726,7 +726,7 @@ jobs:
           image: tonistiigi/binfmt:latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to ghcr.io
         # Both publishing paths (tag push, repair). A docker_validation dry-run
@@ -734,14 +734,14 @@ jobs:
         # dry-run's guarantee, and it stays a property of the credentials, not of
         # a flag someone could flip by mistake.
         if: ${{ github.event_name == 'push' || env.IMAGE_REPAIR == 'true' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build multi-arch release image (push only on a real tag)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.release
@@ -783,7 +783,7 @@ jobs:
         # — the same call DESIGN_NOTES makes for the jail deploy, where a
         # CLIENT compile must never withhold a SERVER artifact. Reversed, one
         # bad C commit would hold back the thing people actually came for.
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.shottino
@@ -826,7 +826,7 @@ jobs:
       REPAIR_TAG: ${{ github.event_name == 'workflow_dispatch' && !inputs.docker_validation && inputs.tag || '' }}
     steps:
       - name: Checkout (the ref whose image is under test — it carries the smoke driver)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Same reasoning as the docker job: the pushed TAG on a release, the
           # DISPATCHED BRANCH on a dry-run, the REPAIRED TAG on a repair.
@@ -843,7 +843,7 @@ jobs:
         # The two publishing paths pull from the registry; the dry-run builds
         # locally and never authenticates.
         if: ${{ github.event_name == 'push' || env.IMAGE_REPAIR == 'true' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -864,12 +864,12 @@ jobs:
         # PUBLISHES, so it takes the pull path above; re-exporting from cache
         # there would probe a local image instead of the pushed one.
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_validation }}
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Re-export the amd64 image from the build cache (dry-run path)
         id: build
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_validation }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.release
@@ -915,7 +915,7 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
       - name: Checkout (for the release-asset audit script)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # publish needs infra/packaging/release_assets.sh (the expected-vs-
           # arrived audit + the partial-release body marker). NO ref override —
@@ -929,7 +929,7 @@ jobs:
           submodules: false
 
       - name: Download built artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: assets
 

--- a/cicchetto/e2e/tests/issue335-identity-card-share.spec.ts
+++ b/cicchetto/e2e/tests/issue335-identity-card-share.spec.ts
@@ -44,7 +44,7 @@ async function seedVisitor(page: import("@playwright/test").Page, visitor: Visit
 }
 
 // Open Settings → tap the share entry → the share MODAL opens
-// (#392), waiting for the mint to resolve into a /share/ URL.
+// (#392), waiting for the mint to resolve into a /share#<token> URL.
 async function openShareModalFromSettings(page: import("@playwright/test").Page) {
   await openSettingsDrawer(page);
   await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
@@ -83,7 +83,7 @@ test.describe("#335 — visitor identity card + share section + native share", (
     }
   });
 
-  test("native share invokes navigator.share with the /share/ URL", async ({ page }) => {
+  test("native share invokes navigator.share with the /share# URL", async ({ page }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`n335-${Date.now()}`);
     try {
@@ -113,7 +113,8 @@ test.describe("#335 — visitor identity card + share section + native share", (
       );
       expect(payload).not.toBeNull();
       expect(payload?.url).toBe(shareUrl);
-      expect(payload?.url).toMatch(/\/share\//);
+      // #1404 — the token rides the fragment, so the path is bare `/share`.
+      expect(payload?.url).toMatch(/\/share#/);
     } finally {
       await reapVisitors(admin.token, visitor.id);
     }

--- a/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
+++ b/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
@@ -51,11 +51,12 @@ test.describe("#392 — home restyle + session-share modal", () => {
       await page.getByTestId("share-session-entry").click();
 
       await expect(page.getByTestId("share-modal")).toBeVisible();
-      // The QR renders as an inline <svg> built from the minted /share/ URL.
+      // The QR renders as an inline <svg> built from the minted
+      // /share#<token> URL (#1404 — the token is in the fragment).
       await expect(page.getByTestId("share-qr").locator("svg")).toBeVisible({ timeout: 10_000 });
       const url = page.getByTestId("share-url");
       await expect(url).not.toHaveValue("", { timeout: 10_000 });
-      expect(await url.inputValue()).toMatch(/\/share\//);
+      expect(await url.inputValue()).toMatch(/\/share#/);
     } finally {
       await reapVisitors(admin.token, visitor.id);
     }

--- a/cicchetto/e2e/tests/issue793-invite-link.spec.ts
+++ b/cicchetto/e2e/tests/issue793-invite-link.spec.ts
@@ -17,7 +17,7 @@
 // `?go=` is a query param on `/`, deliberately: vjt asked for it in those
 // words so an invite could never collide with a client route. The first
 // shipment used `/<network>/<channel>` instead and had to keep a denylist of
-// reserved first segments to stay out of `/share/:token`'s way. Nothing here
+// reserved first segments to stay out of `/share`'s way. Nothing here
 // depends on the path any more, which is the property that made the denylist
 // unnecessary.
 

--- a/cicchetto/e2e/tests/session-sharing.spec.ts
+++ b/cicchetto/e2e/tests/session-sharing.spec.ts
@@ -141,8 +141,7 @@ for (const shareClass of SHARE_CLASSES) {
       // Device B navigates to the share URL. The ROUTE is a plain path
       // (`@solidjs/router` v0.16 is path-mode, and the SPA fallback
       // serves it); only the TOKEN is in the fragment (#1404), which
-      // `goto` carries across because the browser keeps it client-side —
-      // the same reason it never reaches a proxy log.
+      // `goto` carries across because the browser keeps it client-side.
       const sharePath = shareUrl.replace(/^https?:\/\/[^/]+/, "");
       await ctxB.addInitScript(() => {
         localStorage.setItem("cic.installChoice", "browser");

--- a/cicchetto/e2e/tests/session-sharing.spec.ts
+++ b/cicchetto/e2e/tests/session-sharing.spec.ts
@@ -136,12 +136,13 @@ for (const shareClass of SHARE_CLASSES) {
       await expect(urlInput).not.toHaveValue("", { timeout: 10_000 });
 
       const shareUrl = await urlInput.inputValue();
-      expect(shareUrl).toMatch(/\/share\//);
+      expect(shareUrl).toMatch(/\/share#/);
 
-      // Device B navigates to the share URL. Plain path (NOT hash) —
-      // `@solidjs/router` v0.16 uses path-mode by default; the SPA
-      // fallback serves any unknown path so `/share/<token>` reaches
-      // the ShareConsume route.
+      // Device B navigates to the share URL. The ROUTE is a plain path
+      // (`@solidjs/router` v0.16 is path-mode, and the SPA fallback
+      // serves it); only the TOKEN is in the fragment (#1404), which
+      // `goto` carries across because the browser keeps it client-side —
+      // the same reason it never reaches a proxy log.
       const sharePath = shareUrl.replace(/^https?:\/\/[^/]+/, "");
       await ctxB.addInitScript(() => {
         localStorage.setItem("cic.installChoice", "browser");

--- a/cicchetto/src/ShareConsume.tsx
+++ b/cicchetto/src/ShareConsume.tsx
@@ -29,23 +29,20 @@ import { installSharedSession } from "./lib/auth";
 // one-tap-to-second-device flow. Whoever opened the link already chose
 // to; we just complete the loop.
 //
-// #1404 — the token arrives in the FRAGMENT, not a path segment. A
-// fragment is the one part of a URL the browser keeps to itself: it is
-// absent from the request line every reverse proxy logs verbatim, and
-// absent from the `Referer` this document sends on its own same-origin
-// requests. Same move `socket.ts` made when the WS bearer went to a
-// subprotocol.
+// #1404 — the token arrives in the FRAGMENT, not a path segment. The
+// link IS a credential, so it travels in the one part of a URL the
+// browser keeps to itself: a fragment is not transmitted with the
+// request and is not carried in `Referer`. Same move `socket.ts` made
+// when the WS bearer went to a subprotocol.
 
 // Read the token out of the fragment and remove it from the address bar
-// and from history in the same breath, BEFORE the network call. Scrubbing
-// after a successful consume — which is what this did while the token
-// rode the path — leaves the credential in the bar and in history on
-// every link that failed or was never redeemed, which is precisely the
-// link most likely to be re-opened or shared again while it is still
-// live. The trade, taken deliberately: a reload after a failed consume
-// no longer re-attempts with the real code, it reports `missing_token`.
-// A one-shot credential is not worth keeping around to improve the
-// wording of an error the page has already rendered.
+// and from history in the same breath, BEFORE the network call — so the
+// credential is present for the length of a mount rather than for the
+// lifetime of the tab, on every link alike and not only on the ones that
+// redeem successfully. The trade, taken deliberately: a reload after a
+// failed consume no longer re-attempts with the real code, it reports
+// `missing_token`. A one-shot credential is not worth keeping around to
+// improve the wording of an error the page has already rendered.
 const takeTokenFromFragment = (): string => {
   const raw = window.location.hash.replace(/^#/, "");
   if (raw !== "") {

--- a/cicchetto/src/ShareConsume.tsx
+++ b/cicchetto/src/ShareConsume.tsx
@@ -1,11 +1,12 @@
-import { useNavigate, useParams } from "@solidjs/router";
+import { useNavigate } from "@solidjs/router";
 import { type Component, createSignal, onMount, Show } from "solid-js";
 import { consumeShareToken } from "./lib/api";
 import { installSharedSession } from "./lib/auth";
 
-// Session-sharing — landing route for `/share/:token`.
-// Mounted in `main.tsx` under the hash router. Auto-consumes on mount:
-//   1. POST /auth/share/consume with the URL token.
+// Session-sharing — landing route for `/share`, path-mode, mounted in
+// `main.tsx`. Auto-consumes on mount:
+//   1. Read the token from the FRAGMENT and scrub it (see below), then
+//      POST /auth/share/consume with it.
 //   2. On 200, installSharedSession({token, subject}) writes the bearer
 //      + subject into localStorage and the existing RequireAuth
 //      createEffect navigates the user into the Shell.
@@ -19,13 +20,50 @@ import { installSharedSession } from "./lib/auth";
 //   unauthorized          → tampered / unsigned token
 //   bad_request           → malformed
 //
+// One code is decided locally and never leaves the browser:
+//   missing_token         → the URL carries no fragment (or a reload
+//                           after the fragment was scrubbed)
+//
 // Auto-consume on mount because the link IS the auth credential — any
 // additional "click here to log in" intermediary defeats the
 // one-tap-to-second-device flow. Whoever opened the link already chose
 // to; we just complete the loop.
+//
+// #1404 — the token arrives in the FRAGMENT, not a path segment. A
+// fragment is the one part of a URL the browser keeps to itself: it is
+// absent from the request line every reverse proxy logs verbatim, and
+// absent from the `Referer` this document sends on its own same-origin
+// requests. Same move `socket.ts` made when the WS bearer went to a
+// subprotocol.
+
+// Read the token out of the fragment and remove it from the address bar
+// and from history in the same breath, BEFORE the network call. Scrubbing
+// after a successful consume — which is what this did while the token
+// rode the path — leaves the credential in the bar and in history on
+// every link that failed or was never redeemed, which is precisely the
+// link most likely to be re-opened or shared again while it is still
+// live. The trade, taken deliberately: a reload after a failed consume
+// no longer re-attempts with the real code, it reports `missing_token`.
+// A one-shot credential is not worth keeping around to improve the
+// wording of an error the page has already rendered.
+const takeTokenFromFragment = (): string => {
+  const raw = window.location.hash.replace(/^#/, "");
+  if (raw !== "") {
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}`,
+    );
+  }
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // A malformed percent-escape is a corrupted link, not a token.
+    return "";
+  }
+};
 
 const ShareConsume: Component = () => {
-  const params = useParams<{ token: string }>();
   const navigate = useNavigate();
   const [error, setError] = createSignal<string | null>(null);
   const [busy, setBusy] = createSignal(true);
@@ -37,8 +75,17 @@ const ShareConsume: Component = () => {
   const consume = async () => {
     setBusy(true);
     setError(null);
+    const shareToken = takeTokenFromFragment();
+    // An empty fragment never reaches the server: posting "" would spend a
+    // round trip to be told `bad_request`, and the honest local answer is
+    // that this URL carries no credential at all.
+    if (shareToken === "") {
+      setError("missing_token");
+      setBusy(false);
+      return;
+    }
     try {
-      const { token: bearer, subject } = await consumeShareToken(params.token);
+      const { token: bearer, subject } = await consumeShareToken(shareToken);
       installSharedSession(bearer, subject);
       navigate("/", { replace: true });
     } catch (err) {

--- a/cicchetto/src/ShareConsume.tsx
+++ b/cicchetto/src/ShareConsume.tsx
@@ -46,11 +46,7 @@ import { installSharedSession } from "./lib/auth";
 const takeTokenFromFragment = (): string => {
   const raw = window.location.hash.replace(/^#/, "");
   if (raw !== "") {
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}${window.location.search}`,
-    );
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
   }
   try {
     return decodeURIComponent(raw);

--- a/cicchetto/src/ShareSessionModal.tsx
+++ b/cicchetto/src/ShareSessionModal.tsx
@@ -80,12 +80,11 @@ const ShareSessionModal: Component = () => {
       // prevents. The once-mounted modal must guard this manually (the
       // #335 sub-page got it free by unmounting on close).
       if (!shareModalOpen()) return;
-      // The token rides the FRAGMENT, never the path (#1404). A fragment is
-      // the only part of a URL a browser does not transmit: it stays out of
-      // the request line every reverse proxy logs verbatim, and out of the
-      // `Referer` the landing document sends on its own same-origin requests.
-      // Same reasoning that moved the WS bearer to a subprotocol in
-      // `socket.ts` — this link never got that treatment until now.
+      // The token rides the FRAGMENT, never the path (#1404). The link IS a
+      // credential, and a fragment is the one part of a URL the browser
+      // keeps to itself: not transmitted with the request, not carried in
+      // `Referer`. Same reasoning that moved the WS bearer to a subprotocol
+      // in `socket.ts` — this link never got that treatment until now.
       //
       // `/share` stays a plain path route (@solidjs/router v0.16 is
       // path-mode) and the SPA catch-all serves it on every substrate; only

--- a/cicchetto/src/ShareSessionModal.tsx
+++ b/cicchetto/src/ShareSessionModal.tsx
@@ -80,9 +80,17 @@ const ShareSessionModal: Component = () => {
       // prevents. The once-mounted modal must guard this manually (the
       // #335 sub-page got it free by unmounting on close).
       if (!shareModalOpen()) return;
-      // Plain path route — @solidjs/router v0.16 is path-mode; nginx try_files
-      // falls back to the SPA so /share/<token> reaches ShareConsume.
-      setShareUrl(`${window.location.origin}/share/${encodeURIComponent(shareToken)}`);
+      // The token rides the FRAGMENT, never the path (#1404). A fragment is
+      // the only part of a URL a browser does not transmit: it stays out of
+      // the request line every reverse proxy logs verbatim, and out of the
+      // `Referer` the landing document sends on its own same-origin requests.
+      // Same reasoning that moved the WS bearer to a subprotocol in
+      // `socket.ts` — this link never got that treatment until now.
+      //
+      // `/share` stays a plain path route (@solidjs/router v0.16 is
+      // path-mode) and the SPA catch-all serves it on every substrate; only
+      // the credential moved off the path. `ShareConsume` reads the fragment.
+      setShareUrl(`${window.location.origin}/share#${encodeURIComponent(shareToken)}`);
       setExpiresAt(new Date(expires_at));
       setNow(new Date());
       startTick();

--- a/cicchetto/src/__tests__/ShareConsume.test.tsx
+++ b/cicchetto/src/__tests__/ShareConsume.test.tsx
@@ -145,8 +145,8 @@ describe("ShareConsume", () => {
         expect(screen.getByTestId("share-consume-error").textContent).toBe("share_token_consumed");
       });
 
-      // The link that failed is the one most likely to be reopened or
-      // forwarded again while it is still live.
+      // The scrub is unconditional: a consume that fails clears the
+      // fragment exactly like one that succeeds.
       expect(window.location.hash).toBe("");
     });
 

--- a/cicchetto/src/__tests__/ShareConsume.test.tsx
+++ b/cicchetto/src/__tests__/ShareConsume.test.tsx
@@ -1,14 +1,21 @@
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// #1404 — the token arrives in the fragment, so there is no `useParams` to
+// mock any more: the component reads `window.location.hash` and jsdom gives
+// us a real one. Mocking a param accessor here would have re-created the
+// path-shaped world in the test while production had left it.
 const routerHolder = vi.hoisted(() => ({
   navigate: vi.fn(),
-  params: { token: "signed-payload" } as { token: string },
 }));
 vi.mock("@solidjs/router", () => ({
   useNavigate: () => routerHolder.navigate,
-  useParams: () => routerHolder.params,
 }));
+
+// Put a token in the address bar the way a followed link would.
+const landOn = (hash: string) => {
+  window.history.replaceState(null, "", `/share${hash}`);
+};
 
 const apiHolder = vi.hoisted(() => ({
   consumeShareToken: vi.fn(),
@@ -34,7 +41,7 @@ import ShareConsume from "../ShareConsume";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  routerHolder.params = { token: "signed-payload" };
+  landOn("#signed-payload");
 });
 
 describe("ShareConsume", () => {
@@ -96,5 +103,63 @@ describe("ShareConsume", () => {
     screen.getByTestId("share-consume-go-login").click();
 
     expect(routerHolder.navigate).toHaveBeenCalledWith("/login", { replace: true });
+  });
+
+  // #1404 — the fragment keeps the token off the wire; these three keep it
+  // out of the address bar and out of history, which is the other half.
+  describe("the token does not linger in the URL", () => {
+    it("is already gone from the bar by the time the request goes out", async () => {
+      // Pre-state: the bar really does carry the token before we render.
+      // Without this the assertions below would also pass on a component
+      // that never saw a fragment at all.
+      expect(window.location.hash).toBe("#signed-payload");
+
+      // Sampled INSIDE the call rather than after it: "empty afterwards" is
+      // what scrubbing on success also produced, and that left every failed
+      // or unredeemed link sitting in the bar. The property is ordering.
+      let hashDuringRequest: string | null = null;
+      apiHolder.consumeShareToken.mockImplementation(async (token: string) => {
+        hashDuringRequest = window.location.hash;
+        return {
+          token: `bearer-for-${token}`,
+          subject: { kind: "visitor", id: "v1", registered: false },
+        };
+      });
+
+      render(() => <ShareConsume />);
+
+      await waitFor(() => {
+        expect(apiHolder.consumeShareToken).toHaveBeenCalledWith("signed-payload");
+      });
+
+      expect(hashDuringRequest).toBe("");
+      expect(window.location.pathname).toBe("/share");
+    });
+
+    it("is gone after a REFUSED consume too, not only a successful one", async () => {
+      apiHolder.consumeShareToken.mockRejectedValue(new Error("share_token_consumed"));
+
+      render(() => <ShareConsume />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("share-consume-error").textContent).toBe("share_token_consumed");
+      });
+
+      // The link that failed is the one most likely to be reopened or
+      // forwarded again while it is still live.
+      expect(window.location.hash).toBe("");
+    });
+
+    it("answers missing_token locally when there is no fragment, spending no request", async () => {
+      landOn("");
+
+      render(() => <ShareConsume />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("share-consume-error").textContent).toBe("missing_token");
+      });
+
+      expect(apiHolder.consumeShareToken).not.toHaveBeenCalled();
+    });
   });
 });

--- a/cicchetto/src/__tests__/ShareSessionModal.test.tsx
+++ b/cicchetto/src/__tests__/ShareSessionModal.test.tsx
@@ -52,9 +52,15 @@ describe("ShareSessionModal (#392)", () => {
     expect(qr.querySelector("svg")).not.toBeNull();
     expect(qr.className).toContain("qr-frame");
 
-    // The link the user sends to themselves.
+    // The link the user sends to themselves. #1404 — the token is in the
+    // FRAGMENT. Asserted as three separate properties rather than one
+    // `toContain`, because "the URL happens to have the token somewhere in
+    // it" is exactly what the path form also satisfied: the token must sit
+    // after the `#`, and the path must carry no token segment at all.
     const url = (await screen.findByTestId("share-url")) as HTMLInputElement;
-    expect(url.value).toContain("/share/SHARETOK");
+    expect(url.value).toContain("/share#SHARETOK");
+    expect(url.value).not.toContain("/share/");
+    expect(new URL(url.value).pathname).toBe("/share");
 
     // #462 — the dialog's own title is the third rendering of the shared
     // name, so it comes from the constant like the other two.
@@ -122,7 +128,7 @@ describe("ShareSessionModal (#392)", () => {
     mintShareToken.mockResolvedValue({ token: "FRESH", expires_at: futureIso() });
     openShareModal();
     const url = (await screen.findByTestId("share-url")) as HTMLInputElement;
-    expect(url.value).toContain("/share/FRESH");
+    expect(url.value).toContain("/share#FRESH");
     expect(url.value).not.toContain("LATE");
   });
 });

--- a/cicchetto/src/lib/auth.ts
+++ b/cicchetto/src/lib/auth.ts
@@ -180,7 +180,7 @@ export async function loginWithRecoveryCode(identifier: string, code: string): P
 // request: the consume endpoint already verified the one-shot signed
 // token + minted a fresh accounts_sessions row for the SAME subject
 // (#1306 — a user or a visitor; the token itself carries which).
-// Callers (the `/share/:token` SPA route) need a write path that lands
+// Callers (the `/share` SPA route) need a write path that lands
 // on the same localStorage keys without re-running the credential
 // dance. Without an explicit helper, the consume route would either
 // reach for the module-private SUBJECT_KEY or duplicate the JSON write

--- a/cicchetto/src/lib/inviteLink.ts
+++ b/cicchetto/src/lib/inviteLink.ts
@@ -19,7 +19,7 @@ import { createToastQueue } from "./toasts";
 // path-prefix collision with the SPA routes)"*. The first shipment read
 // `/<network>/<channel>` from `location.pathname` instead, which put every
 // invite in the same namespace as every present and future client route —
-// `/login`, `/share/:token`, and whatever comes next — and needed a
+// `/login`, `/share`, and whatever comes next — and needed a
 // reserved-segment denylist to keep them apart. A query param has no such
 // namespace to share, so the denylist is gone with it.
 //

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -388,9 +388,8 @@ render(
             signed token and navigates into Shell once localStorage
             is populated.
             No `:token` segment (#1404): the token rides the FRAGMENT,
-            which the browser keeps to itself, so it never reaches the
-            request line a proxy logs. `ShareConsume` reads it from
-            `location.hash`. */}
+            which the browser keeps to itself and does not transmit.
+            `ShareConsume` reads it from `location.hash`. */}
         <Route path="/share" component={ShareConsume} />
         {/* #717 — the boundary wraps Shell ONLY, inside RequireAuth. A boot
             fetch that rejects puts its resource in `errored` state and every

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -386,8 +386,12 @@ render(
             the link works even when the destination device has no
             existing bearer. The route auto-consumes the one-shot
             signed token and navigates into Shell once localStorage
-            is populated. */}
-        <Route path="/share/:token" component={ShareConsume} />
+            is populated.
+            No `:token` segment (#1404): the token rides the FRAGMENT,
+            which the browser keeps to itself, so it never reaches the
+            request line a proxy logs. `ShareConsume` reads it from
+            `location.hash`. */}
+        <Route path="/share" component={ShareConsume} />
         {/* #717 — the boundary wraps Shell ONLY, inside RequireAuth. A boot
             fetch that rejects puts its resource in `errored` state and every
             read re-throws (CrtSplash's `!user()` predicate among them); with

--- a/config/config.exs
+++ b/config/config.exs
@@ -158,6 +158,23 @@ config :grappa, :send_throttle,
   oper_capacity: 50,
   oper_refill_per_sec: 5.0
 
+# #1404 — the ceiling on answers a session emits on a STRANGER's command
+# (the CTCP VERSION / PING auto-replies). Distinct from `:send_throttle`
+# above in WHO sets the pace: that one meters the operator's own sends and
+# lives in a node-global `RateLimit.TokenBucket`; this one meters a rate
+# chosen by whoever sends the query, so the arithmetic is pure and the
+# bucket lives in the session's own state — a remote-paced path must not
+# be able to enqueue serialized calls into a node-global process.
+#
+# Same pair of numbers as the ORDINARY send drip on purpose: an answer
+# grappa emits on a stranger's command may not consume more of the
+# upstream's flood allowance than the operator's own client is allowed to.
+# One query costs an outbound frame AND a scrollback row, and one token
+# buys both — see `Grappa.Session.AutoReplyBudget`.
+config :grappa, :auto_reply_budget,
+  capacity: 5,
+  refill_per_sec: 0.5
+
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is
 # the shared OUTER gate that a flooder cannot dodge by switching surface;

--- a/config/config.exs
+++ b/config/config.exs
@@ -158,22 +158,21 @@ config :grappa, :send_throttle,
   oper_capacity: 50,
   oper_refill_per_sec: 5.0
 
-# #1404 — the ceiling on answers a session emits on a STRANGER's command
-# (the CTCP VERSION / PING auto-replies). Distinct from `:send_throttle`
-# above in WHO sets the pace: that one meters the operator's own sends and
-# lives in a node-global `RateLimit.TokenBucket`; this one meters a rate
-# chosen by whoever sends the query, so the arithmetic is pure and the
-# bucket lives in the session's own state — a remote-paced path must not
-# be able to enqueue serialized calls into a node-global process.
+# #1404 — the ORDINARY pair above has a SECOND consumer:
+# `Grappa.Session.AutoReplyBudget`, the ceiling on answers a session emits
+# on a STRANGER's command (the CTCP VERSION / PING auto-replies). It reads
+# these keys rather than owning a knob of its own, because an answer
+# emitted on a stranger's command may not consume more of the upstream's
+# allowance than the operator's own client is allowed to — so re-measuring
+# a network moves one pair of numbers, not two that drift.
 #
-# Same pair of numbers as the ORDINARY send drip on purpose: an answer
-# grappa emits on a stranger's command may not consume more of the
-# upstream's flood allowance than the operator's own client is allowed to.
-# One query costs an outbound frame AND a scrollback row, and one token
-# buys both — see `Grappa.Session.AutoReplyBudget`.
-config :grappa, :auto_reply_budget,
-  capacity: 5,
-  refill_per_sec: 0.5
+# The two differ in WHO sets the pace, and that is why the mechanisms
+# differ: `:send_throttle` meters a human through a node-global
+# `RateLimit.TokenBucket`, while the auto-reply budget is pure arithmetic
+# in the session's own state, since a remote-paced path must not be able to
+# enqueue serialized calls into a node-global process. The oper pair is
+# deliberately NOT read there: it describes a connection the ircd meters
+# loosely, which says nothing about courtesy answers.
 
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is

--- a/config/config.exs
+++ b/config/config.exs
@@ -174,6 +174,28 @@ config :grappa, :send_throttle,
 # deliberately NOT read there: it describes a connection the ircd meters
 # loosely, which says nothing about courtesy answers.
 
+# #1404 — the archive listing door. `GET /networks/:slug/archive` is the
+# one authenticated READ that answers from the whole `(subject, network)`
+# partition instead of a page, so it is metered per `(subject, network)`
+# like the send door rather than riding the coarse `:request_budget`
+# (which meters writes on purpose). Same shared `TokenBucket`, distinct
+# bucket atom. Read via `Application.compile_env/3` in
+# `GrappaWeb.ArchiveController`; the 429's `retry-after` is derived from
+# `refill_per_sec` there, so this pair is the only knob.
+#
+# The numbers come from the client's shape, not from taste: cic refetches
+# the list once per PART (`archive_changed`) in every open tab, plus once
+# per modal open.
+#
+#   * capacity — burst allowance. 20 covers a hand-driven run of parts
+#     fanned out across several tabs without ever refusing one.
+#   * refill_per_sec — sustained ceiling once the burst is spent. One
+#     listing per 5s is far above any human cadence and far below what a
+#     scripted caller would want.
+config :grappa, :archive_read,
+  capacity: 20,
+  refill_per_sec: 0.2
+
 # GH #630 — coarse per-subject INBOUND request budget spanning EVERY WS
 # `handle_in` verb AND every REST write (POST/PUT/PATCH/DELETE). This is
 # the shared OUTER gate that a flooder cannot dodge by switching surface;

--- a/config/test.exs
+++ b/config/test.exs
@@ -238,6 +238,17 @@ config :grappa, :send_throttle,
   oper_capacity: 6,
   oper_refill_per_sec: 0.25
 
+# #1404 — the archive-listing bucket, small enough that a test can empty
+# it in a handful of calls. Safe to shrink globally: the bucket keys on
+# `(subject, network)` and every archive spec builds its own subject, so
+# no other test can spend these tokens. The refill is slower than the
+# ordinary send pair (0.2 = one token per 5s) so a token cannot trickle
+# back mid-test and turn an expected 429 into a wall-clock race — the
+# same reason #480 slowed the oper pair down rather than up.
+config :grappa, :archive_read,
+  capacity: 3,
+  refill_per_sec: 0.2
+
 # GH #630 — the request budget is effectively OFF by default in test:
 # it now meters EVERY WS handle_in verb AND every REST write, so a low
 # global capacity would 429/sever unrelated controller + channel tests

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44259,3 +44259,69 @@ predate the #372 fold and the live folded family carries `id, kind` at the
 tail instead, which is the deferral DESIGN_NOTES 17317-17332 already
 records. Cheaper is not bounded, and that migration is cold-class, so it
 stays a separate decision with a measurement attached.
+<!-- entry #1404c -->
+
+---
+
+## 2026-08-16 — #1404: the share token moves to the fragment
+
+A share link is a credential, and it was riding the URL path. It now
+rides the fragment. The route did not move: `/share` is still a plain
+path served by the SPA catch-all, and `ShareConsume` still auto-consumes
+on mount — only the token left the path.
+
+### Why the fragment and not a redaction
+
+The fragment is the one part of a URL a browser does not transmit. It is
+absent from the request line a reverse proxy logs verbatim, and absent
+from the `Referer` the landing document sends on its own same-origin
+requests under the `same-origin` referrer policy.
+
+Both redactions that sit nearby were checked and neither reaches a path
+segment: `filter_parameters` keys on a parameter NAME, and the proxy
+config is not ours to edit on every substrate — the m42 jail is fronted
+by a vhost outside this repository, and a self-hoster's proxy is theirs.
+That is what makes this a URL-shape change rather than a logging one: a
+remedy that only works where we own the proxy is not a remedy.
+
+The precedent was already in-house. The WS bearer moved to a subprotocol
+for the same reason, recorded in `socket.ts`; the share link never had
+the treatment applied.
+
+### Scrub before the request, not after a success
+
+`ShareConsume` reads `location.hash` and clears it with `replaceState`
+before it calls the server. The previous order scrubbed the address bar
+only after a SUCCESSFUL consume, which left the credential in the bar and
+in history for every link that failed or was never redeemed — the ones
+most likely to be reopened or forwarded again while still live.
+
+Accepted trade, stated so it is a decision and not a surprise: reloading
+after a failed consume reports `missing_token` rather than re-attempting
+with the real code. A one-shot credential is not worth keeping in
+history to improve the wording of an error the page has already
+rendered. An absent fragment is answered locally and spends no request.
+
+### The finding was three sites of prose, not one
+
+The review named the `ShareTokenController` moduledoc. Sweeping for the
+old shape found two more: `ShareConsume`'s own header comment, which
+described BOTH a token path and a hash router that does not exist, and
+the operator-side mint in `Admin.VisitorsController`, which repeated the
+fragment claim for links an operator hands out.
+
+This is the part worth keeping. The false moduledoc did not merely fail
+to help — an auditor read it, concluded the token never reached a log,
+and cleared the item. Prose asserting a security property the code does
+not provide buys a pass that the code would not have got on its own,
+which is why the controller's paragraph now carries an explicit note
+that it is load-bearing and must move with the client.
+
+### Why the test asserts three properties, not one
+
+A single `toContain(token)` is satisfied by the path form too. The client
+test pins that the token follows `#`, that the URL contains no `/share/`
+segment, and that `new URL(...).pathname` is exactly `/share`. The
+scrub is pinned by sampling `location.hash` INSIDE the mocked request
+rather than after it: "empty afterwards" is precisely what the old
+scrub-on-success produced, so only the ordering distinguishes them.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44117,10 +44117,22 @@ per-sender ledger was rejected twice over: it grows a keyspace with the
 number of strangers who ask, and it does not bound the aggregate, which is
 the quantity the upstream meters.
 
-The numbers are the ORDINARY send drip of #340 rather than a pair of their
-own. An answer grappa emits on a stranger's command may not consume more
-of the upstream's allowance than the operator's own client may, and an
-operator who re-measures their network moves one pair, not two that drift.
+The numbers are READ FROM `:send_throttle` — the ORDINARY pair — rather
+than duplicated into a knob of their own. An answer grappa emits on a
+stranger's command may not consume more of the upstream's allowance than
+the operator's own client may, and sharing the config key makes that a
+property of the code instead of a promise in a comment: re-measuring a
+network moves one pair, not two that drift. The oper pair is deliberately
+not read there; it describes a connection the ircd meters loosely, which
+says nothing about courtesy answers.
+
+The module exposes no accessor for either number, and the tests read the
+same config keys. A function returning a compile-time constant cannot
+carry a spec that is both general and true under `:underspecs` — the
+success typing is the literal — and the alternative, pinning the spec to
+today's literal the way `Grappa.Protocol` does, is only correct there
+because that constant is not configurable. Here it would break the build
+of an operator who retunes the pair.
 
 ### `format_status/1` on `Session.Server`
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44069,3 +44069,76 @@ below-floor clients only (`user_socket_test.exs`,
 `issue447-protocol-handshake.spec.ts`), and that spec hand-composes
 `/socket/websocket` itself, so it witnesses the server contract and never the
 client's composition.
+<!-- entry #1404a -->
+
+---
+
+## 2026-08-16 — #1404: three guards on the session process
+
+Hardening from the 2026-08-15 review. Stated at the level of the control,
+per the terms the tracking issue sets: what is guarded now, and why the
+guard has the shape it has.
+
+### A valueless message-tag carries `""`
+
+IRCv3 message-tags §3.2 gives `@foo` and `@foo=` the same absent value, so
+`Grappa.IRC.Parser` now gives them the same representation, and
+`Message.tags` narrows from `String.t() | true` to `String.t()`.
+
+The narrowing is the point, not the spelling. `NumericRouter.label_lookup/2`
+splits on `nil` versus binary; with a third inhabitant in the type that
+split was partial, and the partiality was DECLARED, so nothing could
+object to it. With the type narrowed, the two clauses cover the domain and
+the compiler can prove it — a catch-all clause would have covered the same
+ground while leaving the next consumer to rediscover the same trap.
+
+The parser test now asserts that the two spellings AGREE rather than
+pinning each to its own literal, which is the property that actually has
+to hold. Routing is pinned from a real parse: a value shape only the
+parser produces is exactly the shape a hand-built fixture never exercises.
+
+### The CTCP auto-reply has a ceiling, and it covers both costs
+
+`Grappa.Session.AutoReplyBudget` — pure token-bucket arithmetic, held in
+the session's own state. `EventRouter` emits `{:auto_reply, line, persist}`
+as ONE effect, and `Session.Server` spends one token for the pair, then
+expands it back into the ordinary `{:reply, _}` and `{:persist, _, _}`
+arms. A stranger chooses how often this path runs, and each run costs both
+an upstream frame and a row in the shared sqlite file; metering them
+separately would let the scrollback claim an answer that never went out.
+
+**Why not `RateLimit.TokenBucket`.** That bucket is right for what it
+does: it meters the SUBJECT's own sends, a human sets the pace, and a
+node-global GenServer suits a `(subject, network)` key. This path is paced
+by whoever sends the query. Routing it through a node-global process would
+let any peer on any bound network enqueue serialized work for the whole
+node — a bound that relocates a flood rather than stopping one. A
+per-sender ledger was rejected twice over: it grows a keyspace with the
+number of strangers who ask, and it does not bound the aggregate, which is
+the quantity the upstream meters.
+
+The numbers are the ORDINARY send drip of #340 rather than a pair of their
+own. An answer grappa emits on a stranger's command may not consume more
+of the upstream's allowance than the operator's own client may, and an
+operator who re-measures their network moves one pair, not two that drift.
+
+### `format_status/1` on `Session.Server`
+
+Upstream credentials are plaintext in that state for as long as the
+handshake needs them — decrypted from Cloak at boot, threaded to the wire.
+`redact: true` guards the columns, `@derive Inspect` guards `AuthFSM`,
+`filter_parameters` guards HTTP params, and none of the three is consulted
+when OTP renders a GenServer's state through `inspect/2`. `format_status/1`
+owns that door. The house `@derive {Inspect, except: …}` pattern is not
+available: this state is a bare map, not a struct.
+
+Redaction is uniform — present becomes `:redacted`, absent stays `nil`.
+The operator keeps the diagnostic that matters, and what has to stay
+current is one list of keys rather than a set of per-key value shapes.
+
+**The test asserts on the VALUE, not on the key**, walking the whole
+formatted term. This state map is a declared target for regrouping; a
+key-name assertion would keep passing after the keys moved under a nested
+struct while the guard had stopped covering them. Written this way, the
+regrouping breaks the test loudly. Two mutants pin it: a pass-through
+callback, and one key dropped from the list, which fails naming that key.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44272,17 +44272,16 @@ on mount — only the token left the path.
 
 ### Why the fragment and not a redaction
 
-The fragment is the one part of a URL a browser does not transmit. It is
-absent from the request line a reverse proxy logs verbatim, and absent
-from the `Referer` the landing document sends on its own same-origin
-requests under the `same-origin` referrer policy.
+The fragment is the one part of a URL a browser keeps to itself: it is
+not transmitted with the request, and it is not carried in `Referer`.
+That is the property a credential needs from the URL that carries it.
 
-Both redactions that sit nearby were checked and neither reaches a path
-segment: `filter_parameters` keys on a parameter NAME, and the proxy
-config is not ours to edit on every substrate — the m42 jail is fronted
-by a vhost outside this repository, and a self-hoster's proxy is theirs.
-That is what makes this a URL-shape change rather than a logging one: a
-remedy that only works where we own the proxy is not a remedy.
+The redactions that sit nearby were checked and neither one applies to
+this shape: they key on parameter NAMES, and on several substrates the
+serving configuration is not ours to edit at all — a self-hoster's is
+theirs. That is what makes this a URL-shape change rather than a
+redaction one: a remedy that holds only where we own the whole path is
+not a remedy for a self-hoster.
 
 The precedent was already in-house. The WS bearer moved to a subprotocol
 for the same reason, recorded in `socket.ts`; the share link never had
@@ -44291,10 +44290,10 @@ the treatment applied.
 ### Scrub before the request, not after a success
 
 `ShareConsume` reads `location.hash` and clears it with `replaceState`
-before it calls the server. The previous order scrubbed the address bar
-only after a SUCCESSFUL consume, which left the credential in the bar and
-in history for every link that failed or was never redeemed — the ones
-most likely to be reopened or forwarded again while still live.
+before it calls the server, so the credential is present for the length
+of a mount rather than for the lifetime of the tab. The ordering is the
+substance: scrubbing on success would be conditional on the outcome, and
+the scrub has to hold for every link alike.
 
 Accepted trade, stated so it is a decision and not a surprise: reloading
 after a failed consume reports `missing_token` rather than re-attempting
@@ -44311,8 +44310,8 @@ the operator-side mint in `Admin.VisitorsController`, which repeated the
 fragment claim for links an operator hands out.
 
 This is the part worth keeping. The false moduledoc did not merely fail
-to help — an auditor read it, concluded the token never reached a log,
-and cleared the item. Prose asserting a security property the code does
+to help — an auditor read it, concluded the property already held, and
+cleared the item. Prose asserting a security property the code does
 not provide buys a pass that the code would not have got on its own,
 which is why the controller's paragraph now carries an explicit note
 that it is load-bearing and must move with the client.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44205,6 +44205,18 @@ of five. The stored PNG additionally consumes the global storage cap every
 other write to that store consumes, checked beside `Uploads.create/3`
 because the byte count only exists after the re-encode.
 
+**Where the cap VALUE is read from is a boundary decision, and the answer
+already existed.** `Uploads.check_global_cap/2` takes the ceiling as an
+ARGUMENT so `Grappa.Uploads` needs no `ServerSettings` dep — which means
+the read belongs to whichever context calls it. `Grappa.Themes` therefore
+gains that dep rather than growing a cap parameter on a public door. It is
+the same split `Grappa.Networks` makes for `Vhosts.effective_source/3`:
+the leaf that ENFORCES takes the number, the context that CALLS it reads
+the setting, and the leaf stays reusable by a caller with a different
+source for the same ceiling. Threading the value down from the controller
+would have put an Uploads-owned number in a Themes signature and given one
+setting two unlike read sites.
+
 **Deliberately not done: an `expires_at` on these rows.** A background is
 referenced by a live theme payload, so an expiry would delete the image
 out from under a theme still in use. Unswept AND unbounded was the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44154,3 +44154,96 @@ key-name assertion would keep passing after the keys moved under a nested
 struct while the guard had stopped covering them. Written this way, the
 regrouping breaks the test loudly. Two mutants pin it: a pass-through
 callback, and one key dropped from the list, which fails naming that key.
+<!-- entry #1404b -->
+
+---
+
+## 2026-08-16 — #1404: three metering doors
+
+Hardening from the 2026-08-15 review, second batch. Same terms as the
+first: what is metered now, and why each door meters the way it does.
+
+### The operator console spends the same budget as every other scope
+
+`:request_budget` now sits on the `/admin` scope, after `:authn`, which is
+what assigns the subject and session id the budget keys on. `:admin_authn`
+answers WHO may call and was standing alone; it is not a rate, and a scope
+that answers only the first question is unmetered no matter how narrow the
+answer.
+
+The plug's own moduledoc had claimed the opposite — "on every
+authenticated resource scope" — which is the part worth recording. A
+reader auditing coverage found a sentence asserting the audit's result.
+The prose now enumerates what is deliberately outside (the two
+`Mix.env() in [:dev, :test]` scopes, which exist so a spec can provision
+its own subject) and says where a read of unusual COST belongs instead: a
+bound at its own door, not a coarse token here.
+
+Writes only, still. A metered GET would make the console's own dashboard
+poll a flood, and the test pins that direction too.
+
+**Driven, not read.** `Phoenix.Router.__routes__/0` does not expose a
+route's `pipe_through`, so no structural assertion about the scope exists,
+and grepping the router would pin the DECLARATION rather than witness the
+plug running. The test drives a real admin write until the budget refuses
+it, with `sever_after` set above the refusals it provokes — crossing it
+would revoke the bearer and turn the 429 under test into a 401, a
+different control answering.
+
+### A theme background spends the quota its own prose cited
+
+`ImageFetcher.Req` justified having no in-flight byte ceiling by citing
+"~5 theme ops/user/day". `create` and `copy` consumed that quota;
+`store_background/2`, the door that reaches the fetcher, did not. The
+repair is to make the sentence true rather than to invent a second number,
+so the gate is the SAME `:theme_create` bucket.
+
+It is consumed BEFORE the fetch. What is being rationed is a remote GET
+plus a re-encode, so charging only for successes would leave failures
+running free — a subject who spends a slot on a broken URL has spent one
+of five. The stored PNG additionally consumes the global storage cap every
+other write to that store consumes, checked beside `Uploads.create/3`
+because the byte count only exists after the re-encode.
+
+**Deliberately not done: an `expires_at` on these rows.** A background is
+referenced by a live theme payload, so an expiry would delete the image
+out from under a theme still in use. Unswept AND unbounded was the
+combination that did not hold; unswept and bounded is a design choice, and
+the comment now says which of the two it is.
+
+### The archive listing has a bucket of its own
+
+`GET /networks/:slug/archive` is the one authenticated read that answers
+from a whole `(subject, network)` partition instead of a page: there is no
+`limit` to negotiate, so its cost tracks the partition rather than the
+request. It takes one token from a per-`(subject, network)` bucket before
+it builds anything; an empty bucket answers 429 with a `retry-after` and
+runs no query.
+
+The limiter is the shared `RateLimit.TokenBucket` under a distinct bucket
+atom — a listing can never spend a send token, and the two ceilings stay
+independently tunable. `retry-after` is derived from this bucket's own
+refill, the one-pair shape the auto-reply budget arrived at in the first
+batch: an operator who retunes moves one pair, not two that drift.
+
+**The numbers come from the client's shape, not from taste.** cic refetches
+this list once per PART (`archive_changed`) in every open tab, so the burst
+allowance has to clear a hand-driven run of parts fanned out across
+several tabs; only the sustained refill is a real ceiling. A bucket tight
+enough to be interesting would have refused ordinary use, and cic keeps
+the previous entries on a failed load rather than retrying, so the refusal
+would have been silent.
+
+**What this does not do**, recorded so the next reader does not have to
+re-derive it: it bounds how OFTEN the aggregate runs, not what one run
+costs. Two candidates for the second half were considered and left open. A
+scan ceiling (a row cap, or a `server_time` floor) is the only remedy that
+is a bound by construction, but it changes a user-visible list — a target
+whose most recent row falls outside the window stops appearing, and
+`row_count` becomes window-relative — so it is a product decision, not a
+hardening one. An index that carries `server_time` alongside the folded
+archive key would make one run cheaper; the two `messages_archive_*_idx`
+predate the #372 fold and the live folded family carries `id, kind` at the
+tail instead, which is the deferral DESIGN_NOTES 17317-17332 already
+records. Cheaper is not bounded, and that migration is cold-class, so it
+stays a separate decision with a measurement attached.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1844,6 +1844,31 @@ source per untrusted client `/64`, inside the configured derivation
 `/80` (`addressing.static_mapping_prefix`), and binds it for the
 session lifetime.
 
+> ⚠️ **The derivation is keyed to YOUR deployment, and the key is
+> `SECRET_KEY_BASE` (#1404).** The derived address is what the IRC
+> network publishes as the user's host, so it must not be a value a
+> stranger can recompute from a guessed client address. It is now
+> `HMAC-SHA256` under a subkey derived from `SECRET_KEY_BASE` at boot;
+> two deployments derive different addresses for the same subscriber.
+> No new secret to manage — but two consequences you need before you
+> hit them:
+>
+> * **Upgrading to the release carrying #1404 renumbers a mode-2
+>   deployment ONCE.** Every subject moves to one new stable address at
+>   its next connect. Nothing is lost: derived addresses are computed on
+>   demand and never stored, so this is the same event as renumbering
+>   the prefix, which this mode already supports —
+>   `Grappa.Net.SourceAliasManager` reconciles the alias set at boot.
+>   Expect a burst of alias churn on the first start, and expect users
+>   to see a new host. If your ircd, your channel bans or your oper
+>   tooling reference the old hosts, they need updating in the same
+>   window.
+> * **Rotating `SECRET_KEY_BASE` renumbers a mode-2 deployment again**,
+>   for the same reason. On the default `pool_with_reservations` mode
+>   neither of these applies: nothing is derived.
+>
+> Deployments on the default mode can ignore this note entirely.
+
 > **Addresses in this section, and why they are not interchangeable.**
 > Anything shown as a **template you would adapt** uses the RFC 3849
 > documentation prefix `2001:db8::/32` — never routable, so a

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1846,10 +1846,10 @@ session lifetime.
 
 > ⚠️ **The derivation is keyed to YOUR deployment, and the key is
 > `SECRET_KEY_BASE` (#1404).** The derived address is what the IRC
-> network publishes as the user's host, so it must not be a value a
-> stranger can recompute from a guessed client address. It is now
-> `HMAC-SHA256` under a subkey derived from `SECRET_KEY_BASE` at boot;
-> two deployments derive different addresses for the same subscriber.
+> network publishes as the user's host, so it must be private to your
+> deployment. It is now `HMAC-SHA256` under a subkey derived from
+> `SECRET_KEY_BASE` at boot; two deployments derive different addresses
+> for the same subscriber.
 > No new secret to manage — but two consequences you need before you
 > hit them:
 >

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -109,11 +109,11 @@ defmodule Grappa.Application do
 
     # #1404 — derive the source-mapping MAC key from the deployment's
     # `secret_key_base` into `:persistent_term`, so mode-2's outbound
-    # address is a keyed function of the client prefix rather than a
-    # constant-tagged hash anyone can recompute. Same boot-time
-    # `Application.get_env` boundary as the seams above; reads the endpoint
-    # config because that is where `config/runtime.exs` already puts the
-    # secret, rather than introducing a second place it lives.
+    # address is a keyed function of the client prefix, private to this
+    # deployment. Same boot-time `Application.get_env` boundary as the
+    # seams above; reads the endpoint config because that is where
+    # `config/runtime.exs` already puts the secret, rather than
+    # introducing a second place it lives.
     #
     # Ordering: before `SourceAliasManager` (which reconciles the alias set
     # against derived addresses) and before any session can egress, both of

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -27,6 +27,10 @@ defmodule Grappa.Application do
       Grappa.Uploads,
       Grappa.Uploads.Reaper,
       Grappa.Vault,
+      # #1404 — start/2 calls Vhosts.boot/1 to seed the deployment's
+      # source-mapping key, the same boot-time DI-seam shape as the
+      # SourceAlias.Config and Themes seams above.
+      Grappa.Vhosts,
       Grappa.Accounts.Reaper,
       Grappa.Visitors.Reaper,
       # #364 J/cross-module-S2: start/2 calls WindowCounts.PushSource.boot/0

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -107,6 +107,24 @@ defmodule Grappa.Application do
     # manager computes it once the Repo is up (it needs the DB prefix).
     :ok = Grappa.Net.SourceAlias.Config.boot()
 
+    # #1404 — derive the source-mapping MAC key from the deployment's
+    # `secret_key_base` into `:persistent_term`, so mode-2's outbound
+    # address is a keyed function of the client prefix rather than a
+    # constant-tagged hash anyone can recompute. Same boot-time
+    # `Application.get_env` boundary as the seams above; reads the endpoint
+    # config because that is where `config/runtime.exs` already puts the
+    # secret, rather than introducing a second place it lives.
+    #
+    # Ordering: before `SourceAliasManager` (which reconciles the alias set
+    # against derived addresses) and before any session can egress, both of
+    # which start with the supervision tree below. `SourceMapping.derive/2`
+    # raises without this, deliberately — there is no safe default for a key.
+    :ok =
+      :grappa
+      |> Application.get_env(GrappaWeb.Endpoint, [])
+      |> Keyword.fetch!(:secret_key_base)
+      |> Grappa.Vhosts.boot()
+
     # Outbound v6 source-address pool. Initialize an EMPTY pool at boot;
     # `Grappa.Bootstrap` installs the DB-curated `in_pool` vhosts via
     # `apply_pool/1` before spawning any session (#228 — DB-driven, no

--- a/lib/grappa/irc/message.ex
+++ b/lib/grappa/irc/message.ex
@@ -72,7 +72,7 @@ defmodule Grappa.IRC.Message do
           | {:numeric, 1..999}
           | {:unknown, String.t()}
 
-  @type tags :: %{optional(String.t()) => String.t() | true}
+  @type tags :: %{optional(String.t()) => String.t()}
 
   @type t :: %__MODULE__{
           tags: tags(),
@@ -139,21 +139,24 @@ defmodule Grappa.IRC.Message do
 
   @doc """
   Returns the value of an IRCv3 message-tag, or `nil` when the tag is
-  absent. Tag-only entries (`@account` with no `=`) yield `true`.
+  absent. A tag-only entry (`@account`, no `=`) yields `""`, the same as
+  `@account=` — IRCv3 message-tags §3.2 gives both an absent value, so a
+  consumer never has to branch on which spelling arrived.
 
   Centralised accessor so consumers do not poke at the `tags` map
   directly — keeps the storage shape (today: a `%{String.t() => ...}`
   map; tomorrow: maybe a struct with normalized vendor-prefix keys) an
   implementation detail of this module.
   """
-  @spec tag(t(), String.t()) :: String.t() | true | nil
+  @spec tag(t(), String.t()) :: String.t() | nil
   def tag(%__MODULE__{tags: tags}, key) when is_binary(key), do: Map.get(tags, key)
 
   @doc """
   Returns the value of an IRCv3 message-tag, or `default` when absent.
-  Tag-only entries (`@account` with no `=`) yield `true`.
+  A tag-only entry (`@account`, no `=`) yields `""`, not the default —
+  the tag IS present, it just carries no value.
   """
-  @spec tag(t(), String.t(), default) :: String.t() | true | default when default: term()
+  @spec tag(t(), String.t(), default) :: String.t() | default when default: term()
   def tag(%__MODULE__{tags: tags}, key, default) when is_binary(key),
     do: Map.get(tags, key, default)
 end

--- a/lib/grappa/irc/parser.ex
+++ b/lib/grappa/irc/parser.ex
@@ -194,10 +194,15 @@ defmodule Grappa.IRC.Parser do
     |> Map.new(&parse_tag/1)
   end
 
+  # A tag with no `=` and a tag with an empty value are the SAME thing per
+  # IRCv3 message-tags §3.2 — both carry an absent value — so both yield
+  # `""`. The alternative (a boolean for the first form) would make the tag
+  # map heterogeneous, which costs every consumer a value-shape branch it
+  # has no domain reason to write; the type below is the enforcement.
   defp parse_tag(entry) do
     case String.split(entry, "=", parts: 2) do
       [key, value] -> {key, unescape_tag_value(value)}
-      [key] -> {key, true}
+      [key] -> {key, ""}
     end
   end
 

--- a/lib/grappa/session/auto_reply_budget.ex
+++ b/lib/grappa/session/auto_reply_budget.ex
@@ -38,14 +38,16 @@ defmodule Grappa.Session.AutoReplyBudget do
   behaviour testable without sleeping.
   """
 
-  # Deliberately the ORDINARY send drip of #340 (`config :grappa,
-  # :send_throttle`), not a number of its own: an answer grappa emits on a
-  # stranger's command may not consume more of the upstream's allowance
-  # than the operator's own client is allowed to consume. Tying the two
-  # together also means an operator who re-measures their network's
-  # allowance moves one pair of numbers, not two that drift.
-  @capacity Application.compile_env(:grappa, [:auto_reply_budget, :capacity], 5)
-  @refill_per_sec Application.compile_env(:grappa, [:auto_reply_budget, :refill_per_sec], 0.5)
+  # READ FROM `:send_throttle`, not from a knob of this module's own. An
+  # answer grappa emits on a stranger's command may not consume more of the
+  # upstream's allowance than the operator's own client is allowed to
+  # consume — and an operator who re-measures their network's allowance
+  # should move one pair of numbers, not two that drift. Sharing the source
+  # makes that a property of the code rather than a promise in a comment.
+  # The ORDINARY pair specifically: the oper pair belongs to a connection
+  # the ircd meters loosely, which says nothing about courtesy answers.
+  @capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:send_throttle, :refill_per_sec], 0.5)
 
   @typedoc """
   Remaining tokens plus the monotonic stamp they were computed at.
@@ -79,17 +81,4 @@ defmodule Grappa.Session.AutoReplyBudget do
       {:error, :rate_limited, %{tokens: refilled, last_ms: now_ms}}
     end
   end
-
-  @doc """
-  The configured burst allowance — exposed so a test states the ceiling by
-  reading it rather than by re-typing the number.
-  """
-  @spec capacity() :: pos_integer()
-  def capacity, do: @capacity
-
-  @doc """
-  The configured sustained refill rate, in tokens per second.
-  """
-  @spec refill_per_sec() :: number()
-  def refill_per_sec, do: @refill_per_sec
 end

--- a/lib/grappa/session/auto_reply_budget.ex
+++ b/lib/grappa/session/auto_reply_budget.ex
@@ -1,0 +1,95 @@
+defmodule Grappa.Session.AutoReplyBudget do
+  @moduledoc """
+  The ceiling on UNSOLICITED outbound answers one session emits on remote
+  command — today the CTCP VERSION / PING auto-replies.
+
+  Two quantities are bounded by the same token, because one query produces
+  both: a line to the upstream socket, and a visibility row in the shared
+  sqlite file. Metering only the line would leave the writes uncapped;
+  metering them separately would let the scrollback claim an answer that
+  never went out.
+
+  ## Why this is not the #340 bucket
+
+  `Grappa.RateLimit.TokenBucket` meters the SUBJECT's own sends. A human
+  paces those, the key is `(subject, network)`, and a node-global
+  GenServer is the right home for it.
+
+  This budget meters answers a STRANGER paces. Sending a remote-paced path
+  through a node-global process hands every peer on every bound network
+  the ability to enqueue a serialized call for the whole node — a bound
+  that relocates the flood rather than stopping it. So the arithmetic is
+  pure and the bucket lives in the state of the session that owns it: no
+  shared process, no shared table, and — the reason a per-sender ledger
+  was rejected too — no keyspace that grows with the number of strangers
+  who ask. A per-sender bound would also miss the aggregate, which is the
+  quantity the upstream actually meters.
+
+  ## Shape
+
+  Lazy refill, no timer: `tokens + elapsed_s * refill`, capped at
+  `capacity`, computed on access. This mirrors `TokenBucket`'s model
+  deliberately — same arithmetic, different home. A fresh budget starts
+  FULL, so a session that has answered nothing answers the first query
+  immediately.
+
+  `now_ms` is supplied by the caller (`System.monotonic_time(:millisecond)`
+  in production) rather than read here, which is what makes refill
+  behaviour testable without sleeping.
+  """
+
+  # Deliberately the ORDINARY send drip of #340 (`config :grappa,
+  # :send_throttle`), not a number of its own: an answer grappa emits on a
+  # stranger's command may not consume more of the upstream's allowance
+  # than the operator's own client is allowed to consume. Tying the two
+  # together also means an operator who re-measures their network's
+  # allowance moves one pair of numbers, not two that drift.
+  @capacity Application.compile_env(:grappa, [:auto_reply_budget, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:auto_reply_budget, :refill_per_sec], 0.5)
+
+  @typedoc """
+  Remaining tokens plus the monotonic stamp they were computed at.
+  """
+  @type t :: %{tokens: float(), last_ms: integer()}
+
+  @doc """
+  A full budget stamped at `now_ms`.
+  """
+  @spec new(integer()) :: t()
+  def new(now_ms) when is_integer(now_ms) do
+    %{tokens: @capacity * 1.0, last_ms: now_ms}
+  end
+
+  @doc """
+  Refill for the elapsed time, then try to consume one token.
+
+  `{:ok, budget}` when a token was available and consumed;
+  `{:error, :rate_limited, budget}` when it was not. Both arms return the
+  refilled budget — a denied take still advances the clock, so the next
+  call refills from here instead of re-crediting the same interval.
+  """
+  @spec take(t(), integer()) :: {:ok, t()} | {:error, :rate_limited, t()}
+  def take(%{tokens: tokens, last_ms: last_ms}, now_ms) when is_integer(now_ms) do
+    elapsed_s = (now_ms - last_ms) / 1000
+    refilled = min(@capacity * 1.0, tokens + elapsed_s * @refill_per_sec)
+
+    if refilled >= 1.0 do
+      {:ok, %{tokens: refilled - 1.0, last_ms: now_ms}}
+    else
+      {:error, :rate_limited, %{tokens: refilled, last_ms: now_ms}}
+    end
+  end
+
+  @doc """
+  The configured burst allowance — exposed so a test states the ceiling by
+  reading it rather than by re-typing the number.
+  """
+  @spec capacity() :: pos_integer()
+  def capacity, do: @capacity
+
+  @doc """
+  The configured sustained refill rate, in tokens per second.
+  """
+  @spec refill_per_sec() :: number()
+  def refill_per_sec, do: @refill_per_sec
+end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -10,6 +10,7 @@ defmodule Grappa.Session.EventRouter do
       @type effect ::
               {:persist, kind, persist_attrs}    -- write a Scrollback row
               | {:reply, iodata()}                -- send a line upstream
+              | {:auto_reply, iodata(), persist}   -- both, or neither, under a ceiling
               | {:topic_changed, channel, topic_entry()}
               | {:channel_modes_changed, channel, channel_mode_entry()}
               | {:members_seeded, channel, members} -- 366 RPL_ENDOFNAMES landed; carries snapshot
@@ -197,6 +198,8 @@ defmodule Grappa.Session.EventRouter do
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
           | {:reply, iodata()}
+          | {:auto_reply, iodata(),
+             {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
           | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}
           | {:topic_changed, String.t(), topic_entry()}
@@ -442,15 +445,21 @@ defmodule Grappa.Session.EventRouter do
   # responses MUST go via NOTICE (not PRIVMSG) to the SENDER's nick to
   # prevent reply loops between two responsive bots.
   #
-  # Two effects:
-  #   1. {:reply, line}    — outbound NOTICE response. Client.send_line
-  #      guarantees CRLF at the transport boundary (see ensure_crlf/1
-  #      in irc/client.ex), so callers don't need to remember.
+  # ONE effect carrying two, `{:auto_reply, line, persist}`:
+  #   1. the outbound NOTICE response. Client.send_line guarantees CRLF at
+  #      the transport boundary (see ensure_crlf/1 in irc/client.ex), so
+  #      callers don't need to remember.
   #   2. {:persist, :notice, attrs} — visible scrollback row in the DM
   #      window for the sender, so cic shows "alice queried grappa for
   #      VERSION" instead of silently consuming the CTCP. CTCP framing
   #      stripped from body for readability; the notice kind matches the
   #      outbound reply (also a NOTICE), pairing query + answer visually.
+  #
+  # They travel as one effect rather than two because the ceiling in
+  # `Session.Server` (`AutoReplyBudget`) must decide for the pair: a row
+  # saying the query was answered, next to a line that was never sent, is
+  # worse than neither. The rate at which this arm can fire is chosen by
+  # whoever sends the query, not by the operator — hence a ceiling at all.
   defp do_route(%Message{command: :privmsg, params: [target, body]} = msg, state)
        when is_binary(target) and is_binary(body) and
               binary_part(body, 0, 1) == <<0x01>> do
@@ -494,7 +503,7 @@ defmodule Grappa.Session.EventRouter do
         {state2, persist_eff} =
           build_persist(state, :notice, dm_channel, sender, notice_body, sender_meta(msg))
 
-        {:cont, state2, [{:reply, reply}, persist_eff]}
+        {:cont, state2, [{:auto_reply, reply, persist_eff}]}
 
       {"PING", _} ->
         # Answered in its own function, not inline: this clause was at
@@ -2899,7 +2908,7 @@ defmodule Grappa.Session.EventRouter do
         sender_meta(msg)
       )
 
-    {:cont, state2, [{:reply, reply}, persist_eff]}
+    {:cont, state2, [{:auto_reply, reply, persist_eff}]}
   end
 
   # #591 — the typed CTCP meta for a persisted row whose body is a CTCP frame,

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -198,8 +198,7 @@ defmodule Grappa.Session.EventRouter do
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
           | {:reply, iodata()}
-          | {:auto_reply, iodata(),
-             {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
+          | {:auto_reply, iodata(), {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
           | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}
           | {:topic_changed, String.t(), topic_entry()}

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1669,7 +1669,7 @@ defmodule Grappa.Session.Server do
   defp redact_key(key, state) do
     case Map.get(state, key) do
       nil -> state
-      _held -> Map.put(state, key, :redacted)
+      _ -> Map.put(state, key, :redacted)
     end
   end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1631,6 +1631,46 @@ defmodule Grappa.Session.Server do
   # dead code post-boundary-fix and removed per
   # `feedback_no_silent_drops_closed` (a safety net that catches an
   # impossible exception silently absorbs the next class of bug).
+  # The state map carries upstream credentials in PLAINTEXT for as long as
+  # the handshake needs them — that is the design (they are decrypted from
+  # Cloak at boot and threaded to the wire), and every existing protection
+  # stops one layer short of a crash report: the schema columns are
+  # `redact: true`, `AuthFSM` derives `Inspect`, `filter_parameters` covers
+  # HTTP params. None of them is consulted when OTP formats a dying
+  # GenServer, which prints `State:` through `inspect/2`.
+  #
+  # `@derive {Inspect, except: …}` is the house pattern and is NOT
+  # available here: this state is a bare map, not a struct. `format_status/1`
+  # is the callback that owns the same question for a GenServer.
+  #
+  # Redaction is uniform — present ⇒ `:redacted`, absent stays `nil` — so
+  # the operator keeps the one diagnostic that matters (was a secret held
+  # at crash time) and the list below stays a list of KEYS, with no
+  # per-key value shapes to keep in step.
+  @redacted_state_keys [
+    :pending_auth,
+    :pending_password,
+    :pending_registration_secret,
+    :perform_list,
+    :oper_pass
+  ]
+
+  @impl GenServer
+  def format_status(status) do
+    Map.update(status, :state, nil, fn
+      state when is_map(state) ->
+        Enum.reduce(@redacted_state_keys, state, fn key, acc ->
+          case Map.get(acc, key) do
+            nil -> acc
+            _ -> Map.put(acc, key, :redacted)
+          end
+        end)
+
+      other ->
+        other
+    end)
+  end
+
   @impl GenServer
   def terminate(reason, state)
       when reason == :shutdown or (is_tuple(reason) and elem(reason, 0) == :shutdown) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1656,19 +1656,21 @@ defmodule Grappa.Session.Server do
   ]
 
   @impl GenServer
-  def format_status(status) do
-    Map.update(status, :state, nil, fn
-      state when is_map(state) ->
-        Enum.reduce(@redacted_state_keys, state, fn key, acc ->
-          case Map.get(acc, key) do
-            nil -> acc
-            _ -> Map.put(acc, key, :redacted)
-          end
-        end)
+  def format_status(status), do: Map.update(status, :state, nil, &redact_secrets/1)
 
-      other ->
-        other
-    end)
+  @spec redact_secrets(term()) :: term()
+  defp redact_secrets(state) when is_map(state) do
+    Enum.reduce(@redacted_state_keys, state, &redact_key/2)
+  end
+
+  defp redact_secrets(other), do: other
+
+  @spec redact_key(atom(), map()) :: map()
+  defp redact_key(key, state) do
+    case Map.get(state, key) do
+      nil -> state
+      _held -> Map.put(state, key, :redacted)
+    end
   end
 
   @impl GenServer

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -98,6 +98,7 @@ defmodule Grappa.Session.Server do
   alias Grappa.Scrollback.Wire
 
   alias Grappa.Session.{
+    AutoReplyBudget,
     AwayState,
     Backoff,
     Broadcaster,
@@ -594,6 +595,11 @@ defmodule Grappa.Session.Server do
           # on …" line.
           channels_created: %{String.t() => DateTime.t()},
           userhost_cache: EventRouter.userhost_cache(),
+          # The ceiling on answers this session emits on a stranger's
+          # command (CTCP VERSION/PING). Read with a `Map.get` default so a
+          # process hot-reloaded across the field's introduction answers
+          # instead of KeyError-crashing (the #216 contract).
+          auto_reply_budget: AutoReplyBudget.t(),
           # CP15 B1 + cluster #6 extraction: per-channel window state
           # bundle (states + failure_reasons + failure_numerics +
           # kicked_meta in one struct). Sibling to `members` —
@@ -1204,6 +1210,7 @@ defmodule Grappa.Session.Server do
       channel_modes: %{},
       channels_created: %{},
       userhost_cache: %{},
+      auto_reply_budget: AutoReplyBudget.new(System.monotonic_time(:millisecond)),
       window_state: WindowState.new(),
       in_flight_joins: %{},
       awaiting_invite: MapSet.new(),
@@ -6009,6 +6016,39 @@ defmodule Grappa.Session.Server do
     end
 
     apply_effects(rest, state)
+  end
+
+  # An answer emitted on a STRANGER's command (CTCP VERSION / PING), under
+  # a ceiling. Whoever sends the query chooses the rate, and each one costs
+  # an outbound frame plus a row in the shared sqlite file — two quantities
+  # nothing else on this path bounds, since `RateLimit.TokenBucket` and
+  # `RequestBudget` both meter the SUBJECT's own sends at the web edge.
+  #
+  # Allowed ⇒ expand back into the two ordinary effects, so the line still
+  # leaves through the one `{:reply, _}` door and the row through the one
+  # `{:persist, _, _}` door. Denied ⇒ drop BOTH: the pair travels together
+  # precisely so the scrollback can never claim an answer that never went
+  # out. Not logged per drop — a log line per dropped query would restore
+  # the write amplification the ceiling exists to remove.
+  # `Map.get`/`Map.put`, not `state.field`/`%{state | field}`: a process
+  # hot-reloaded across this field's introduction has no such key, and the
+  # #216 contract is that it answers rather than KeyError-crashes. A fresh
+  # (full) budget is the honest default — it has emitted nothing this
+  # incarnation can account for.
+  defp apply_effects([{:auto_reply, line, persist_eff} | rest], state) do
+    now_ms = System.monotonic_time(:millisecond)
+    budget = Map.get_lazy(state, :auto_reply_budget, fn -> AutoReplyBudget.new(now_ms) end)
+
+    case AutoReplyBudget.take(budget, now_ms) do
+      {:ok, spent} ->
+        apply_effects(
+          [{:reply, line}, persist_eff | rest],
+          Map.put(state, :auto_reply_budget, spent)
+        )
+
+      {:error, :rate_limited, spent} ->
+        apply_effects(rest, Map.put(state, :auto_reply_budget, spent))
+    end
   end
 
   defp apply_effects([{:reply, line} | rest], state) do

--- a/lib/grappa/themes.ex
+++ b/lib/grappa/themes.ex
@@ -345,11 +345,21 @@ defmodule Grappa.Themes do
   return the uploads slug for storing in a theme payload's `background.image_id`.
   The context is the door — controllers call this, never the sub-module. Takes
   the bare-id subject tuple (`Grappa.Uploads` scope shape).
+
+  Consumes the SAME `#{@quota_bucket}` daily quota `create/3` and `copy/3` do,
+  and consumes it BEFORE the fetch rather than after. That order is the whole
+  point: the resource being rationed is the fetch itself — a remote GET plus an
+  ffmpeg re-encode, whose cost `ImageFetcher` bounds only after buffering — so
+  charging only for successes would leave failures running free, which is the
+  cheaper flood to mount. A subject who burns a slot on a broken URL has spent
+  one of five, which is the intended shape of a burst bound.
   """
   @spec store_background(Subject.t(), BackgroundImage.source()) ::
-          {:ok, String.t()} | {:error, BackgroundImage.error()}
+          {:ok, String.t()} | {:error, BackgroundImage.error() | :rate_limited}
   def store_background(subject, source) do
-    BackgroundImage.process_and_store(subject, source)
+    with :ok <- consume_quota(subject) do
+      BackgroundImage.process_and_store(subject, source)
+    end
   end
 
   @doc """
@@ -481,11 +491,15 @@ defmodule Grappa.Themes do
   defp authorize(_, %Theme{}), do: {:error, :forbidden}
 
   # Daily creation quota — applies to BOTH subjects (~5/day burst bound).
-  defp check_quota({:user, %User{id: id}}),
-    do: DailyQuota.check_and_record(@quota_bucket, {:user, id}, @daily_quota)
+  # The struct-shaped clauses exist because `create`/`copy` hold the loaded
+  # subject; they narrow to the bare-id `Grappa.Subject.t()` the quota is
+  # actually keyed by, which is the shape `store_background/2` already has.
+  defp check_quota({:user, %User{id: id}}), do: consume_quota({:user, id})
+  defp check_quota({:visitor, %Visitor{id: id}}), do: consume_quota({:visitor, id})
 
-  defp check_quota({:visitor, %Visitor{id: id}}),
-    do: DailyQuota.check_and_record(@quota_bucket, {:visitor, id}, @daily_quota)
+  @spec consume_quota(Subject.t()) :: :ok | {:error, :rate_limited}
+  defp consume_quota(subject),
+    do: DailyQuota.check_and_record(@quota_bucket, subject, @daily_quota)
 
   # Total owned-theme cap — VISITORS only (users are unchanged: no lifetime
   # cap). Pure count, no side effect — runs before the quota so a capped

--- a/lib/grappa/themes.ex
+++ b/lib/grappa/themes.ex
@@ -50,6 +50,12 @@ defmodule Grappa.Themes do
       Grappa.Networks,
       Grappa.RateLimit,
       Grappa.Repo,
+      # The global storage cap is a `ServerSettings` value, and
+      # `Uploads.check_global_cap/2` takes it as an ARGUMENT so `Uploads`
+      # stays off a `ServerSettings` dep. That puts the read on the calling
+      # context — the same split `Networks.SessionPlan` already makes when it
+      # reads the addressing settings for `Vhosts.effective_source/3`.
+      Grappa.ServerSettings,
       Grappa.Subject,
       Grappa.Sys.HardenedCmd,
       Grappa.Uploads,

--- a/lib/grappa/themes/background_image.ex
+++ b/lib/grappa/themes/background_image.ex
@@ -205,10 +205,10 @@ defmodule Grappa.Themes.BackgroundImage do
     # `expires_at` omitted → NULL → the Uploads Reaper never sweeps theme
     # backgrounds, and that stays deliberate: a background is referenced by a
     # live theme payload, so an expiry would delete the image out from under
-    # a theme the subject is still using. What was missing is the OTHER half —
-    # the global storage cap `UploadsController` consumes on every other write
-    # to the same store. Unswept and unbounded is the combination that does
-    # not hold; unswept and bounded is a design choice.
+    # a theme the subject is still using. The OTHER half is the global storage
+    # cap `UploadsController` consumes on every other write to the same store,
+    # and this path consumes it too: unswept and bounded is a design choice,
+    # unswept and unbounded is not.
     #
     # Checked here rather than in the context door because the byte count only
     # exists after the re-encode: what lands on disk is this PNG, not whatever

--- a/lib/grappa/themes/background_image.ex
+++ b/lib/grappa/themes/background_image.ex
@@ -27,6 +27,7 @@ defmodule Grappa.Themes.BackgroundImage do
 
   Returns `{:ok, slug}` or a tagged `{:error, reason}`; never raises.
   """
+  alias Grappa.ServerSettings
   alias Grappa.Sys.HardenedCmd
   alias Grappa.Themes.ImageFetcher
   alias Grappa.Uploads
@@ -43,7 +44,13 @@ defmodule Grappa.Themes.BackgroundImage do
   @fetcher_key {__MODULE__, :image_fetcher}
 
   @type source :: {:upload, Plug.Upload.t()} | {:url, String.t()}
-  @type error :: :not_raster | :too_large | :ssrf_blocked | :fetch_failed | :image_reencode_failed
+  @type error ::
+          :not_raster
+          | :too_large
+          | :ssrf_blocked
+          | :fetch_failed
+          | :image_reencode_failed
+          | :insufficient_storage
 
   @doc """
   Reads the injected `image_fetcher` from `config :grappa, :themes` once and
@@ -197,9 +204,28 @@ defmodule Grappa.Themes.BackgroundImage do
 
   defp store(subject, png) do
     # `expires_at` omitted → NULL → the Uploads Reaper never sweeps theme
-    # backgrounds. mime forced to image/png (we just produced it).
+    # backgrounds, and that stays deliberate: a background is referenced by a
+    # live theme payload, so an expiry would delete the image out from under
+    # a theme the subject is still using. What was missing is the OTHER half —
+    # the global storage cap `UploadsController` consumes on every other write
+    # to the same store. Unswept and unbounded is the combination that does
+    # not hold; unswept and bounded is a design choice.
+    #
+    # Checked here rather than in the context door because the byte count only
+    # exists after the re-encode: what lands on disk is this PNG, not whatever
+    # was fetched.
     attrs = %{subject: subject, mime: "image/png"}
 
+    with :ok <-
+           Uploads.check_global_cap(
+             byte_size(png),
+             ServerSettings.get_upload_global_cap_bytes()
+           ) do
+      insert(attrs, png)
+    end
+  end
+
+  defp insert(attrs, png) do
     case Uploads.create(png, attrs, storage_root: Uploads.storage_root()) do
       {:ok, %Uploads.Upload{slug: slug}} ->
         {:ok, slug}

--- a/lib/grappa/themes/background_image.ex
+++ b/lib/grappa/themes/background_image.ex
@@ -27,10 +27,9 @@ defmodule Grappa.Themes.BackgroundImage do
 
   Returns `{:ok, slug}` or a tagged `{:error, reason}`; never raises.
   """
-  alias Grappa.ServerSettings
+  alias Grappa.{ServerSettings, Uploads}
   alias Grappa.Sys.HardenedCmd
   alias Grappa.Themes.ImageFetcher
-  alias Grappa.Uploads
 
   require Logger
 

--- a/lib/grappa/themes/image_fetcher/req.ex
+++ b/lib/grappa/themes/image_fetcher/req.ex
@@ -24,8 +24,17 @@ defmodule Grappa.Themes.ImageFetcher.Req do
   is bounded by `@receive_timeout_ms`. A hostile server omitting `content-length`
   and streaming indefinitely is capped by that timeout rather than a hard
   in-flight byte ceiling — acceptable because this path is authenticated and
-  rate-limited (~5 theme ops/user/day), and the bytes are immediately re-encoded
-  through a wall-clock-bounded ffmpeg pass downstream.
+  rate-limited, and the bytes are immediately re-encoded through a
+  wall-clock-bounded ffmpeg pass downstream.
+
+  **Which rate limit, named rather than assumed.** The `~5 ops/user/day`
+  figure this paragraph leans on is `Grappa.Themes`' `:theme_create` daily
+  quota, and it reaches here only because `Themes.store_background/2`
+  consumes that quota BEFORE calling the fetcher (#1404). It used to be
+  spent by `create`/`copy` alone, so the sentence described a bound that was
+  not on this path at all. If a future caller reaches this module without
+  passing through that door, this justification stops holding and the
+  in-flight ceiling becomes the thing to build.
   """
   @behaviour Grappa.Themes.ImageFetcher
 

--- a/lib/grappa/themes/image_fetcher/req.ex
+++ b/lib/grappa/themes/image_fetcher/req.ex
@@ -29,12 +29,12 @@ defmodule Grappa.Themes.ImageFetcher.Req do
 
   **Which rate limit, named rather than assumed.** The `~5 ops/user/day`
   figure this paragraph leans on is `Grappa.Themes`' `:theme_create` daily
-  quota, and it reaches here only because `Themes.store_background/2`
-  consumes that quota BEFORE calling the fetcher (#1404). It used to be
-  spent by `create`/`copy` alone, so the sentence described a bound that was
-  not on this path at all. If a future caller reaches this module without
-  passing through that door, this justification stops holding and the
-  in-flight ceiling becomes the thing to build.
+  quota, and it reaches here because `Themes.store_background/2` consumes
+  that quota BEFORE calling the fetcher (#1404) — the same quota `create/3`
+  and `copy/3` consume. The paragraph above is only true while that holds:
+  a caller reaching this module without passing through that door has no
+  such bound, and for one the in-flight byte ceiling becomes the thing to
+  build.
   """
   @behaviour Grappa.Themes.ImageFetcher
 

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -90,6 +90,19 @@ defmodule Grappa.Vhosts do
 
   require Logger
 
+  @doc """
+  #1404 — seed the deployment's source-mapping MAC key from
+  `secret_key_base`. Called once from `Grappa.Application.start/2`.
+
+  Lives on the context rather than being reached through to
+  `SourceMapping` directly: that module is internal to this boundary and
+  is not exported, and the boot seam is public API like every other verb
+  here. See `SourceMapping`'s moduledoc for why the derivation is keyed
+  and why the key has no default.
+  """
+  @spec boot(String.t()) :: :ok
+  defdelegate boot(secret_key_base), to: SourceMapping
+
   # ---------------------------------------------------------------------------
   # Inventory CRUD
   # ---------------------------------------------------------------------------

--- a/lib/grappa/vhosts/source_mapping.ex
+++ b/lib/grappa/vhosts/source_mapping.ex
@@ -28,23 +28,22 @@ defmodule Grappa.Vhosts.SourceMapping do
   ## The derivation is KEYED (#1404, correcting #543)
 
   `derive/2` fills the host bits of the prefix from
-  `hmac_sha256(deployment_key, client_key)`.
+  `hmac_sha256(deployment_key, client_key)`, so the client → address
+  mapping is a property of the DEPLOYMENT rather than of the code.
 
-  #543 shipped this as a bare `sha256(@domain_tag <> client_key)` on the
-  premise, stated in this moduledoc, that reversibility was irrelevant
-  because the mapping runs client-prefix → our-own-block rather than
-  holding a secret. **That premise does not survive contact with what the
-  output IS**: the derived address is the host the ircd publishes for the
-  session, the input space is a single client prefix, and the domain tag
-  was a public constant in this file. Anyone who can see the published
-  host can confirm a guessed input. Hiding the subscriber behind the
-  bouncer is the property the bouncer exists to provide, so this is the
-  one derivation in the codebase where reversibility is the whole point.
+  #543 shipped this unkeyed, on the premise — stated in this moduledoc —
+  that reversibility was irrelevant because the mapping runs
+  client-prefix → our-own-block rather than holding a secret. That
+  premise was wrong about what the output IS: the derived address is the
+  host the ircd publishes for the session, and hiding the subscriber
+  behind the bouncer is the property the bouncer exists to provide. So
+  this is the one derivation in the codebase where non-reversibility is
+  the point, and it is keyed accordingly.
 
   The MAC keeps every property #543 actually relied on. HMAC-SHA256 is
   the same near-uniform spread over the host bits, so the collision math
-  below is unchanged; determinism is unchanged (same client, same
-  address); only guessability moves.
+  below is unchanged, and determinism is unchanged (same client, same
+  deployment, same address).
 
   ## The key, and why there is no default
 
@@ -57,10 +56,9 @@ defmodule Grappa.Vhosts.SourceMapping do
 
   `mac_key/0` deliberately has **no default**. Every other
   `:persistent_term` seam in the codebase defaults to a value that
-  preserves graceful degradation; a key cannot, because the only
-  available default is a constant every reader of this file knows, which
-  is exactly the defect being fixed. An unbooted node raises rather than
-  silently deriving a guessable address.
+  preserves graceful degradation; a key cannot, because the only default
+  available is a constant compiled into the release, which is not a key.
+  An unbooted node raises rather than deriving without a deployment key.
 
   ## Operator consequence — this renumbers a mode-2 deployment ONCE
 
@@ -122,8 +120,7 @@ defmodule Grappa.Vhosts.SourceMapping do
   end
 
   # No default, deliberately — see the moduledoc. An unbooted node must
-  # raise here rather than fall back to a constant that is public by
-  # construction.
+  # raise here rather than fall back to a compiled-in constant.
   @spec mac_key() :: binary()
   defp mac_key, do: :persistent_term.get(@mac_key)
 
@@ -148,8 +145,8 @@ defmodule Grappa.Vhosts.SourceMapping do
 
   Returns `{:error, :invalid_prefix}` when `prefix_cidr` is not a strict
   IPv6 CIDR (`parse_cidr6/1` rejects it). Raises if `boot/1` has not run
-  — a missing key is a boot defect, never a reason to degrade to a
-  guessable address.
+  — a missing key is a boot defect, never a reason to derive without a
+  deployment key.
   """
   @spec derive(binary(), String.t()) :: {:ok, String.t()} | {:error, :invalid_prefix}
   def derive(key, prefix_cidr) when is_binary(key) do

--- a/lib/grappa/vhosts/source_mapping.ex
+++ b/lib/grappa/vhosts/source_mapping.ex
@@ -25,19 +25,58 @@ defmodule Grappa.Vhosts.SourceMapping do
   derived address is INTENDED ("come se si collegassero direttamente"):
   they share an upstream vantage point, so they share an egress.
 
-  ## The hash is NOT keyed (#543)
+  ## The derivation is KEYED (#1404, correcting #543)
 
   `derive/2` fills the host bits of the prefix from
-  `sha256(@domain_tag <> client_key)`. There is deliberately NO secret
-  key: reversibility is irrelevant here (the mapping is client-prefix →
-  our-own-block, not a privacy secret), so the only property that
-  matters is collision-freedom, and an unkeyed SHA-256 already gives a
-  near-uniform spread over the host space. A keyed MAC would add key
-  management for zero benefit.
+  `hmac_sha256(deployment_key, client_key)`.
 
-  `@domain_tag` provides domain separation so this derivation never
-  aliases some other SHA-256 use over the same client bytes — it is a
-  namespace label, NOT a secret.
+  #543 shipped this as a bare `sha256(@domain_tag <> client_key)` on the
+  premise, stated in this moduledoc, that reversibility was irrelevant
+  because the mapping runs client-prefix → our-own-block rather than
+  holding a secret. **That premise does not survive contact with what the
+  output IS**: the derived address is the host the ircd publishes for the
+  session, the input space is a single client prefix, and the domain tag
+  was a public constant in this file. Anyone who can see the published
+  host can confirm a guessed input. Hiding the subscriber behind the
+  bouncer is the property the bouncer exists to provide, so this is the
+  one derivation in the codebase where reversibility is the whole point.
+
+  The MAC keeps every property #543 actually relied on. HMAC-SHA256 is
+  the same near-uniform spread over the host bits, so the collision math
+  below is unchanged; determinism is unchanged (same client, same
+  address); only guessability moves.
+
+  ## The key, and why there is no default
+
+  The key is derived ONCE at boot from the deployment's
+  `secret_key_base`, domain-separated by `@domain_tag`, and stashed in
+  `:persistent_term` (`boot/1`) — the CLAUDE.md non-process DI seam, as
+  `Grappa.HttpHosts` and `Grappa.Net.SourceAlias.Config` do. No new
+  operator secret: `secret_key_base` is already mandatory, already
+  secret, and already the root of every other derived key here.
+
+  `mac_key/0` deliberately has **no default**. Every other
+  `:persistent_term` seam in the codebase defaults to a value that
+  preserves graceful degradation; a key cannot, because the only
+  available default is a constant every reader of this file knows, which
+  is exactly the defect being fixed. An unbooted node raises rather than
+  silently deriving a guessable address.
+
+  ## Operator consequence — this renumbers a mode-2 deployment ONCE
+
+  Derived addresses are computed on demand and never stored (only the
+  client KEY is persisted), so changing the derivation is operationally
+  the same event as the operator renumbering the prefix, which this
+  design already supports: every subject moves to one new stable address
+  at its next connect, and `Grappa.Net.SourceAliasManager` reconciles the
+  alias set at boot. Deployments on the DEFAULT `pool_with_reservations`
+  mode derive nothing and are unaffected. Rotating `secret_key_base`
+  renumbers a mode-2 deployment for the same reason — see
+  `docs/OPERATIONS.md`.
+
+  `@domain_tag` still provides domain separation, now as the key
+  derivation's label rather than as a message prefix. It remains a
+  namespace label and is still NOT the secret.
 
   ## Collision math
 
@@ -59,8 +98,34 @@ defmodule Grappa.Vhosts.SourceMapping do
 
   alias Grappa.Net.IpLiteral
 
-  # Domain separation for the SHA-256 input — a namespace label, NOT a secret.
+  # Domain separation for the key derivation — a namespace label, NOT a
+  # secret. Bumping the version suffix renumbers a mode-2 deployment, so
+  # it is a deliberate operator-visible act, not a refactor.
   @domain_tag "grappa/source-mapping/v1"
+
+  @mac_key {__MODULE__, :mac_key}
+
+  @doc """
+  Derive the deployment's source-mapping MAC key from `secret_key_base`
+  and stash it in `:persistent_term`. Called once from
+  `Grappa.Application.start/2`.
+
+  PBKDF2 via `Plug.Crypto.KeyGenerator` rather than using
+  `secret_key_base` directly, so this purpose gets its own subkey and
+  never shares key material with `Phoenix.Token` or any other consumer
+  of the same root. Run once at boot, never per derivation.
+  """
+  @spec boot(String.t()) :: :ok
+  def boot(secret_key_base) when is_binary(secret_key_base) do
+    :persistent_term.put(@mac_key, Plug.Crypto.KeyGenerator.generate(secret_key_base, @domain_tag))
+    :ok
+  end
+
+  # No default, deliberately — see the moduledoc. An unbooted node must
+  # raise here rather than fall back to a constant that is public by
+  # construction.
+  @spec mac_key() :: binary()
+  defp mac_key, do: :persistent_term.get(@mac_key)
 
   @doc """
   Reduces a client IP tuple to its routable-prefix key: the v6 `/64`
@@ -75,12 +140,16 @@ defmodule Grappa.Vhosts.SourceMapping do
   Derives the deterministic source address for `key` inside `prefix_cidr`.
 
   Keeps the prefix's network bits verbatim and fills the host bits from
-  `sha256(@domain_tag <> key)`, returning a canonical v6 literal strictly
-  inside `prefix_cidr`. Deterministic and idempotent for a given
-  `(key, prefix_cidr)`.
+  `hmac_sha256(mac_key(), key)`, returning a canonical v6 literal
+  strictly inside `prefix_cidr`. Deterministic and idempotent for a given
+  `(key, prefix_cidr)` on a given deployment; two deployments with
+  different `secret_key_base` derive different addresses from the same
+  client, which is the #1404 property.
 
   Returns `{:error, :invalid_prefix}` when `prefix_cidr` is not a strict
-  IPv6 CIDR (`parse_cidr6/1` rejects it).
+  IPv6 CIDR (`parse_cidr6/1` rejects it). Raises if `boot/1` has not run
+  — a missing key is a boot defect, never a reason to degrade to a
+  guessable address.
   """
   @spec derive(binary(), String.t()) :: {:ok, String.t()} | {:error, :invalid_prefix}
   def derive(key, prefix_cidr) when is_binary(key) do
@@ -88,9 +157,9 @@ defmodule Grappa.Vhosts.SourceMapping do
       {:ok, {net_tuple, len}} ->
         host_bits = 128 - len
         <<net::size(len), _::bitstring>> = ip6_bits(net_tuple)
-        # SHA-256 is 256 bits ≥ host_bits (≤128) for any len, so this
+        # HMAC-SHA256 is 256 bits ≥ host_bits (≤128) for any len, so this
         # match holds for EVERY prefix length — no /8-alignment needed.
-        <<host::size(host_bits), _::bitstring>> = :crypto.hash(:sha256, @domain_tag <> key)
+        <<host::size(host_bits), _::bitstring>> = :crypto.mac(:hmac, :sha256, mac_key(), key)
         # net ‖ host is exactly 128 bits regardless of where `len` falls,
         # so re-slice it straight into the 8×16 tuple (no integer round-trip).
         <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> =

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -100,8 +100,8 @@ defmodule GrappaWeb.Admin.VisitorsController do
   themselves (#982). Returns `200` + `{token, expires_at}`; wrapping it
   into `https://<host>/share#<token>` stays the client's job, as on
   the visitor-side mint. The token belongs in the FRAGMENT and not in
-  the path (#1404) — see `ShareTokenController`'s moduledoc for why;
-  an operator-minted link is logged by the same proxies as any other.
+  the path (#1404) — see `ShareTokenController`'s moduledoc for why. An
+  operator-minted link is the same credential and takes the same shape.
 
   Refuses an incognito visitor with 403 (#363) and an unknown id with
   404, the same 404 the `DELETE` verb returns.

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -98,8 +98,10 @@ defmodule GrappaWeb.Admin.VisitorsController do
   @doc """
   Mint a share link for a visitor who can no longer authenticate as
   themselves (#982). Returns `200` + `{token, expires_at}`; wrapping it
-  into `https://<host>/#/share/<token>` stays the client's job, as on
-  the visitor-side mint.
+  into `https://<host>/share#<token>` stays the client's job, as on
+  the visitor-side mint. The token belongs in the FRAGMENT and not in
+  the path (#1404) — see `ShareTokenController`'s moduledoc for why;
+  an operator-minted link is logged by the same proxies as any other.
 
   Refuses an incognito visitor with 403 (#363) and an unknown id with
   404, the same 404 the `DELETE` verb returns.

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -52,9 +52,9 @@ defmodule GrappaWeb.ArchiveController do
   import GrappaWeb.Validation, only: [validate_target_name: 1]
 
   alias Grappa.Accounts.User
-  alias Grappa.RateLimit.TokenBucket
   alias Grappa.{PubSub, QueryWindows, Scrollback, Session}
   alias Grappa.PubSub.Topic
+  alias Grappa.RateLimit.TokenBucket
   alias Grappa.Scrollback.Wire
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.Subject

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -34,6 +34,13 @@ defmodule GrappaWeb.ArchiveController do
   `subject_where/2` partitions on `visitor_id` for `{:visitor, _}`
   subjects (per-subject iso mirror of the user path).
 
+  The listing is METERED — one token per call from a per-`(subject,
+  network)` bucket of its own (#1404), because it is an aggregate over
+  the partition rather than a paged read and the coarse request budget
+  meters writes by design. An empty bucket answers 429 `rate_limited`
+  with a `retry-after` and runs no query. The DELETE is a write and is
+  already covered by the coarse budget, so it takes no archive token.
+
   Iso boundary: `Plugs.ResolveNetwork` collapses unknown-slug /
   not-your-network to 404 BEFORE this action runs. `:no_session` is
   not surfaced to the wire — an absent session simply means an empty
@@ -45,11 +52,45 @@ defmodule GrappaWeb.ArchiveController do
   import GrappaWeb.Validation, only: [validate_target_name: 1]
 
   alias Grappa.Accounts.User
+  alias Grappa.RateLimit.TokenBucket
   alias Grappa.{PubSub, QueryWindows, Scrollback, Session}
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.Subject
+
+  # #1404 — the archive listing is the one authenticated READ that is a
+  # per-network aggregate rather than a paged fetch: it answers from the
+  # whole `(subject, network)` partition, so its cost tracks the partition
+  # and not a `limit` param. The coarse `:request_budget` plug deliberately
+  # lets reads through (paging and snapshots are legitimate high-volume
+  # traffic), and its moduledoc says where a read of unusual cost belongs
+  # instead — a bound of its own, at the door that knows the cost. This is
+  # that bound: one token per listing from a per-`(subject, network)`
+  # bucket, the same shared limiter the send door uses (#340), a distinct
+  # bucket atom so a listing can never spend a send token.
+  #
+  # The numbers are set by the CLIENT's own shape, not by taste: cic
+  # refetches this list on every `archive_changed` (one per PART) in every
+  # open tab, so a hand-driven burst of parts across a few tabs must pass
+  # untouched. Capacity covers that burst; the refill is the sustained
+  # ceiling. Boot-time config per CLAUDE.md (`Application.get_env` at
+  # runtime is banned).
+  @archive_read_bucket :archive_read
+  @archive_read_capacity Application.compile_env(:grappa, [:archive_read, :capacity], 20)
+  @archive_read_refill_per_sec Application.compile_env(
+                                 :grappa,
+                                 [:archive_read, :refill_per_sec],
+                                 0.2
+                               )
+
+  # Seconds until one token refills — the client-facing hint on the 429,
+  # derived from THIS bucket's refill so cic paces against the bucket that
+  # actually refused it. One knob pair, not two that drift. `ceil` so the
+  # client never under-waits and re-trips instantly; `max(1, _)` guards a
+  # sub-second config from flooring to 0. HTTP Retry-After is integer
+  # seconds (RFC 7231 §7.1.3).
+  @archive_read_retry_after_seconds max(1, ceil(1.0 / @archive_read_refill_per_sec))
 
   @doc """
   `GET /networks/:network_id/archive` — returns the archived target
@@ -57,17 +98,40 @@ defmodule GrappaWeb.ArchiveController do
 
   Wire shape per entry: `%{target, kind, last_activity, row_count}`
   where `kind` is the wire string `"channel" | "query"`.
+
+  Metered: one token per call from the per-`(subject, network)`
+  `#{@archive_read_bucket}` bucket. An empty bucket answers 429
+  `rate_limited` with a `retry-after` hint and runs no query.
   """
-  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, {:rate_limited, pos_integer()}}
   def index(conn, _) do
     subject = conn.assigns.current_subject
     network = conn.assigns.network
     session_subject = Subject.to_session(subject)
 
-    active_keyset = build_active_keyset(subject, session_subject, network.id)
+    with :ok <- take_archive_token(session_subject, network.id) do
+      active_keyset = build_active_keyset(subject, session_subject, network.id)
 
-    entries = Scrollback.list_archive(session_subject, network.id, active_keyset)
-    render(conn, :index, archive: entries)
+      entries = Scrollback.list_archive(session_subject, network.id, active_keyset)
+      render(conn, :index, archive: entries)
+    end
+  end
+
+  # The token is taken BEFORE the keyset is built, so a refused listing
+  # costs no query at all — a bound that still pays for the work it
+  # refuses is not a bound.
+  @spec take_archive_token(Session.subject(), integer()) ::
+          :ok | {:error, {:rate_limited, pos_integer()}}
+  defp take_archive_token(session_subject, network_id) do
+    case TokenBucket.take(
+           @archive_read_bucket,
+           {session_subject, network_id},
+           @archive_read_capacity,
+           @archive_read_refill_per_sec
+         ) do
+      :ok -> :ok
+      {:error, :rate_limited} -> {:error, {:rate_limited, @archive_read_retry_after_seconds}}
+    end
   end
 
   @doc """

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -14,16 +14,15 @@ defmodule GrappaWeb.ShareTokenController do
 
   ## Why the token rides the fragment (#1404)
 
-  The fragment is the only part of a URL a browser does not transmit. It
-  stays out of the request line — which a reverse proxy logs verbatim,
-  `infra/snippets/log-format.conf` logging `$request` — and out of the
-  `Referer` the landing document would otherwise send on its own
-  same-origin requests under the `same-origin` referrer policy. Neither
-  redaction that exists nearby reaches a path segment:
-  `filter_parameters` keys on a parameter NAME, and the proxy config is
-  not ours to edit on every substrate (the m42 jail is fronted by a
-  vhost outside this repository). Moving the credential is the only
-  remedy that holds wherever grappa is deployed.
+  A share link IS a credential, so it belongs in the one part of a URL
+  the browser keeps to itself: the fragment is not transmitted with the
+  request, and it is not carried in `Referer`.
+
+  Carrying it there rather than redacting it downstream, because the
+  redactions available to us key on parameter NAMES, and on several
+  substrates the serving configuration is not ours to edit at all. A
+  remedy that holds only where we own the whole path is not a remedy for
+  a self-hoster.
 
   Same move the WS bearer already made when it went to a subprotocol
   rather than `?token=`; the share link had simply never had the

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -4,13 +4,36 @@ defmodule GrappaWeb.ShareTokenController do
 
     * `POST /me/share-token` — mints a Phoenix-signed, short-TTL token
       bound to the caller's own tagged subject. cic wraps the token in
-      a shareable URL (`https://<host>/#/share/<token>`) so the caller
+      a shareable URL (`https://<host>/share#<token>`) so the caller
       can forward it to another device of their own.
     * `POST /auth/share/consume` — unauthenticated. Body `{token}`.
       Verifies signature + TTL, checks the one-shot ETS ledger
       (`Grappa.ShareTokens`), confirms the subject row still exists,
       and mints a fresh `accounts_sessions` row for the SAME subject.
       Returns `{token, subject}` mirroring the login wire.
+
+  ## Why the token rides the fragment (#1404)
+
+  The fragment is the only part of a URL a browser does not transmit. It
+  stays out of the request line — which a reverse proxy logs verbatim,
+  `infra/snippets/log-format.conf` logging `$request` — and out of the
+  `Referer` the landing document would otherwise send on its own
+  same-origin requests under the `same-origin` referrer policy. Neither
+  redaction that exists nearby reaches a path segment:
+  `filter_parameters` keys on a parameter NAME, and the proxy config is
+  not ours to edit on every substrate (the m42 jail is fronted by a
+  vhost outside this repository). Moving the credential is the only
+  remedy that holds wherever grappa is deployed.
+
+  Same move the WS bearer already made when it went to a subprotocol
+  rather than `?token=`; the share link had simply never had the
+  treatment applied.
+
+  **This paragraph is load-bearing — keep it in step with the client.**
+  It described a fragment before the client used one, and a reader
+  auditing this surface believed the moduledoc over the code. Prose that
+  claims a property the implementation does not provide does not merely
+  fail to help; it actively buys a pass.
 
   ## Who may mint (#1306)
 

--- a/lib/grappa_web/plugs/request_budget.ex
+++ b/lib/grappa_web/plugs/request_budget.ex
@@ -2,10 +2,18 @@ defmodule GrappaWeb.Plugs.RequestBudget do
   @moduledoc """
   GH #630 — the REST door of the coarse per-subject inbound request
   budget. Mounted downstream of `:authn` (needs `current_subject` +
-  `current_session_id`) on every authenticated resource scope; it meters
-  only WRITE methods (`POST`/`PUT`/`PATCH`/`DELETE`) — GET reads (scrollback
-  pagination, snapshots) are legitimate high-volume traffic and are not the
-  flood vector, so they pass through untouched.
+  `current_session_id`) on every authenticated resource scope the release
+  ships, the operator console included — `:admin_authn` answers who may
+  call, never how often, so it is not a substitute for this. The two
+  `Mix.env() in [:dev, :test]` scopes in the router are deliberately
+  outside: they exist to let a spec provision its own subject, and metering
+  them would make the suite's own setup a flood.
+
+  It meters only WRITE methods (`POST`/`PUT`/`PATCH`/`DELETE`) — GET reads
+  (scrollback pagination, snapshots) are legitimate high-volume traffic and
+  are not the flood vector, so they pass through untouched. A read whose
+  COST does not fit that description needs its own bound at the context,
+  not a coarse token here.
 
   It calls `GrappaWeb.RequestBudget.guard/3` — the SAME decision + sever
   code path the WS `handle_in` guard uses (one feature, one code path, both

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -125,8 +125,13 @@ defmodule GrappaWeb.Router do
   # :admin_authn`, so it's reachable over the public surface AND gated
   # on `current_subject = {:user, %User{is_admin: true}}`. Controllers
   # live under `GrappaWeb.Admin.*` namespace.
+  # `:request_budget` belongs here for the same reason it is on every other
+  # authenticated scope, and the `is_admin` gate above is not a substitute:
+  # it answers WHO may call, never HOW OFTEN. It sits after `:authn`, which
+  # is what assigns the `current_subject` + `current_session_id` the budget
+  # keys on.
   scope "/admin", GrappaWeb.Admin do
-    pipe_through [:api, :authn, :admin_authn]
+    pipe_through [:api, :authn, :admin_authn, :request_budget]
 
     get "/me", MeController, :index
     # #1075 — scalar projection for the operator top bar (#1073): session

--- a/test/grappa/irc/message_test.exs
+++ b/test/grappa/irc/message_test.exs
@@ -62,9 +62,13 @@ defmodule Grappa.IRC.MessageTest do
       assert Message.tag(msg, "account") == nil
     end
 
-    test "tag/2 returns true for tag-only entries (no = in the wire form)" do
-      msg = %Message{command: :privmsg, tags: %{"draft/typing" => true}}
-      assert Message.tag(msg, "draft/typing") == true
+    # `""` and not `nil`: the tag IS present. A consumer distinguishing
+    # "absent" from "present but valueless" must be able to, and the only
+    # thing that carries that distinction is the nil/binary split.
+    test "tag/2 returns \"\" for tag-only entries (no = in the wire form)" do
+      msg = %Message{command: :privmsg, tags: %{"draft/typing" => ""}}
+      assert Message.tag(msg, "draft/typing") == ""
+      refute Message.tag(msg, "draft/typing") == nil
     end
 
     test "tag/3 returns the default when the tag is absent" do

--- a/test/grappa/irc/parser_test.exs
+++ b/test/grappa/irc/parser_test.exs
@@ -193,11 +193,12 @@ defmodule Grappa.IRC.ParserTest do
                Parser.parse("@time=2026-04-25T12:00:00.000Z;account=vjt :vjt!~vjt@host PRIVMSG #x :hi")
     end
 
-    test "tag without value (key-only): value is `true`" do
-      assert {:ok, %Message{tags: %{"foo" => true}}} = Parser.parse("@foo PING :x")
-    end
-
-    test "tag with empty value (key=): value is empty string" do
+    # IRCv3 message-tags §3.2 gives `@foo` and `@foo=` the same absent
+    # value, so the parser gives them the same representation. Asserted as
+    # one pair rather than two independent cases: the property is that the
+    # two spellings AGREE, and two separate literals would let one drift.
+    test "tag without value (key-only) parses identically to an empty value" do
+      assert {:ok, %Message{tags: %{"foo" => ""}}} = Parser.parse("@foo PING :x")
       assert {:ok, %Message{tags: %{"foo" => ""}}} = Parser.parse("@foo= PING :x")
     end
 

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -1,0 +1,80 @@
+defmodule Grappa.Session.AutoReplyBudgetTest do
+  @moduledoc """
+  Unit tests for `Grappa.Session.AutoReplyBudget`.
+
+  Every case supplies its own monotonic stamp, so refill is exercised by
+  arithmetic rather than by sleeping — the reason `take/2` takes `now_ms`
+  at all.
+
+  The ceiling is read from the module (`capacity/0`, `refill_per_sec/0`)
+  rather than re-typed here: a test that hardcodes 5 keeps passing after an
+  operator lowers the configured burst to 1, which is the one change these
+  tests exist to notice.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.AutoReplyBudget
+
+  @t0 1_000_000
+
+  defp drain(budget, 0, _now), do: budget
+
+  defp drain(budget, n, now) when n > 0 do
+    {:ok, next} = AutoReplyBudget.take(budget, now)
+    drain(next, n - 1, now)
+  end
+
+  describe "take/2" do
+    test "a fresh budget answers the first query immediately" do
+      assert {:ok, _} = AutoReplyBudget.take(AutoReplyBudget.new(@t0), @t0)
+    end
+
+    test "the burst is exactly `capacity` takes, and the next one is refused" do
+      capacity = AutoReplyBudget.capacity()
+
+      drained = drain(AutoReplyBudget.new(@t0), capacity, @t0)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(drained, @t0)
+    end
+
+    test "a refused take consumes nothing — it stays refused at the same instant" do
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+
+      {:error, :rate_limited, after_first} = AutoReplyBudget.take(drained, @t0)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(after_first, @t0)
+    end
+
+    test "one token's worth of elapsed time buys exactly one more answer" do
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+
+      {:ok, spent} = AutoReplyBudget.take(drained, @t0 + one_token_ms)
+
+      # The second take at the SAME instant is what proves the refill
+      # credited one token and not the whole bucket.
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(spent, @t0 + one_token_ms)
+    end
+
+    test "refill is capped at capacity — an idle century does not buy a bigger burst" do
+      century_ms = 100 * 365 * 24 * 60 * 60 * 1000
+
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      recovered = drain(drained, AutoReplyBudget.capacity(), @t0 + century_ms)
+
+      assert {:error, :rate_limited, _} = AutoReplyBudget.take(recovered, @t0 + century_ms)
+    end
+
+    test "a refused take still advances the clock, so the interval is not credited twice" do
+      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+
+      # Refused mid-interval: the partial refill is banked and stamped.
+      {:error, :rate_limited, mid} = AutoReplyBudget.take(drained, @t0 + div(one_token_ms, 2))
+
+      # Had the denial NOT re-stamped, the full interval would be credited
+      # again here and this second half-interval would buy a whole token.
+      assert {:ok, _} = AutoReplyBudget.take(mid, @t0 + one_token_ms)
+    end
+  end
+end

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -17,7 +17,7 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
 
   @t0 1_000_000
 
-  defp drain(budget, 0, _now), do: budget
+  defp drain(budget, 0, _), do: budget
 
   defp drain(budget, n, now) when n > 0 do
     {:ok, next} = AutoReplyBudget.take(budget, now)

--- a/test/grappa/session/auto_reply_budget_test.exs
+++ b/test/grappa/session/auto_reply_budget_test.exs
@@ -6,16 +6,20 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
   arithmetic rather than by sleeping — the reason `take/2` takes `now_ms`
   at all.
 
-  The ceiling is read from the module (`capacity/0`, `refill_per_sec/0`)
-  rather than re-typed here: a test that hardcodes 5 keeps passing after an
-  operator lowers the configured burst to 1, which is the one change these
-  tests exist to notice.
+  The ceiling is read from the SAME config keys the module reads, never
+  re-typed: a test that hardcodes 5 keeps passing after an operator lowers
+  the configured burst to 1, which is the one change these tests exist to
+  notice. The module exposes no accessor for them on purpose — a function
+  returning a compile-time constant cannot carry a spec that is both
+  general and true under `:underspecs`.
   """
   use ExUnit.Case, async: true
 
   alias Grappa.Session.AutoReplyBudget
 
   @t0 1_000_000
+  @capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+  @refill_per_sec Application.compile_env(:grappa, [:send_throttle, :refill_per_sec], 0.5)
 
   defp drain(budget, 0, _), do: budget
 
@@ -30,15 +34,13 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     end
 
     test "the burst is exactly `capacity` takes, and the next one is refused" do
-      capacity = AutoReplyBudget.capacity()
-
-      drained = drain(AutoReplyBudget.new(@t0), capacity, @t0)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       assert {:error, :rate_limited, _} = AutoReplyBudget.take(drained, @t0)
     end
 
     test "a refused take consumes nothing — it stays refused at the same instant" do
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       {:error, :rate_limited, after_first} = AutoReplyBudget.take(drained, @t0)
 
@@ -46,8 +48,8 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     end
 
     test "one token's worth of elapsed time buys exactly one more answer" do
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
-      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
+      one_token_ms = ceil(1000 / @refill_per_sec)
 
       {:ok, spent} = AutoReplyBudget.take(drained, @t0 + one_token_ms)
 
@@ -59,15 +61,15 @@ defmodule Grappa.Session.AutoReplyBudgetTest do
     test "refill is capped at capacity — an idle century does not buy a bigger burst" do
       century_ms = 100 * 365 * 24 * 60 * 60 * 1000
 
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
-      recovered = drain(drained, AutoReplyBudget.capacity(), @t0 + century_ms)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
+      recovered = drain(drained, @capacity, @t0 + century_ms)
 
       assert {:error, :rate_limited, _} = AutoReplyBudget.take(recovered, @t0 + century_ms)
     end
 
     test "a refused take still advances the clock, so the interval is not credited twice" do
-      one_token_ms = ceil(1000 / AutoReplyBudget.refill_per_sec())
-      drained = drain(AutoReplyBudget.new(@t0), AutoReplyBudget.capacity(), @t0)
+      one_token_ms = ceil(1000 / @refill_per_sec)
+      drained = drain(AutoReplyBudget.new(@t0), @capacity, @t0)
 
       # Refused mid-interval: the partial refill is banked and stamped.
       {:error, :rate_limited, mid} = AutoReplyBudget.take(drained, @t0 + div(one_token_ms, 2))

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -503,7 +503,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       # RFC 2812 + CTCP spec: response goes via NOTICE (NOT PRIVMSG) to
@@ -593,7 +593,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "PING 1753776000123", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, _, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01PING 1753776000123\x01"
@@ -615,7 +615,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "PING", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, _}]} =
+      assert {:cont, _, [{:auto_reply, line, {:persist, :notice, _}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01PING\x01"
@@ -633,7 +633,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION", 0x01>>
       m = msg(:privmsg, ["#italia", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:auto_reply, line, {:persist, :notice, attrs}}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) =~ "NOTICE alice :"
@@ -649,7 +649,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "VERSION ", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, ^state, [{:reply, _}, {:persist, :notice, _}]} =
+      assert {:cont, ^state, [{:auto_reply, _, {:persist, :notice, _}}]} =
                EventRouter.route(m, state)
     end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -13,6 +13,7 @@ defmodule Grappa.Session.NumericRouterTest do
   use ExUnitProperties
 
   alias Grappa.IRC.{JoinFailure, Message}
+  alias Grappa.IRC.Parser
   alias Grappa.Session.NumericRouter
 
   # ---------------------------------------------------------------------------
@@ -1081,6 +1082,20 @@ defmodule Grappa.Session.NumericRouterTest do
 
       state =
         state(labels_pending: %{"abc" => %{kind: :channel, target: "#other"}})
+
+      assert {:channel, "#sniffo"} = NumericRouter.route(m, state)
+    end
+
+    # Routed from a REAL parse, not a hand-built `%Message{}`: the value a
+    # bare `@label` (no `=`) carries is the parser's answer, and this test
+    # exists to pin that the whole chain is total for it. Every numeric
+    # enters `route/2` through the label lookup, so a value shape the lookup
+    # cannot match makes the FIRST numeric of a connection unroutable —
+    # which is the property under test, not the tag's spelling.
+    test "a valueless `@label` on the wire still routes by params" do
+      {:ok, m} = Parser.parse("@label :irc.example.org 404 vjt #sniffo :Cannot send")
+
+      state = state(labels_pending: %{"abc" => %{kind: :channel, target: "#other"}})
 
       assert {:channel, "#sniffo"} = NumericRouter.route(m, state)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1153,7 +1153,7 @@ defmodule Grappa.Session.ServerTest do
 
     defp secret_needles do
       Enum.map(@secrets, fn
-        {_, {needle, _deadline}} -> needle
+        {_, {needle, _}} -> needle
         {_, needle} -> needle
       end)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -33,7 +33,17 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.IRC.Message
   alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
-  alias Grappa.Session.{AwayState, Backoff, GhostRecovery, ISupport, RecoverIdentity, Server, WindowState}
+  alias Grappa.Session.{
+    AutoReplyBudget,
+    AwayState,
+    Backoff,
+    GhostRecovery,
+    ISupport,
+    RecoverIdentity,
+    Server,
+    WindowState
+  }
+
   alias Grappa.SessionStateHelpers
   alias Grappa.WindowCounts.PushSource
 
@@ -91,6 +101,23 @@ defmodule Grappa.Session.ServerTest do
   defp await_handshake(server) do
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
     :ok
+  end
+
+  # Poll until the fake ircd has seen `target` CTCP PING answers, or the
+  # deadline passes — a condition, not a sleep. Returns whatever the last
+  # sample was so the caller asserts on a number rather than on a timeout.
+  defp await_ctcp_ping_answers(server, target) do
+    await_ctcp_ping_answers(server, target, System.monotonic_time(:millisecond) + 2_000)
+  end
+
+  defp await_ctcp_ping_answers(server, target, deadline) do
+    seen = Enum.count(IRCServer.sent_lines(server), &String.contains?(&1, "\x01PING"))
+
+    cond do
+      seen >= target -> seen
+      System.monotonic_time(:millisecond) >= deadline -> seen
+      true -> await_ctcp_ping_answers(server, target, deadline)
+    end
   end
 
   # #543 INC-6 — a full synthetic connect plan (no `refresh_plan`, so the
@@ -2720,6 +2747,83 @@ defmodule Grappa.Session.ServerTest do
 
       assert Enum.any?(entries, &(&1.target_nick == "bob"))
       assert QueryWindows.open?({:user, user.id}, net_id, "bob")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1404 — the auto-answer is paced by whoever asks, and each answer
+    # costs an outbound frame AND a row in the shared sqlite file. Both are
+    # bounded by ONE budget, so the two counts must move together: a row
+    # claiming the query was answered, beside a line that never went out,
+    # would be a worse outcome than dropping the pair.
+    #
+    # The oracle is the RATIO, not an absolute — `capacity` is a config
+    # knob, so it is read from the module rather than retyped, and the
+    # assertion is that answers are strictly fewer than queries. Refill is
+    # one token per two seconds, so a burst fed in one go cannot earn a
+    # second helping while the feed is in flight; `sent + 1` absorbs at
+    # most one token of slack should the box be slow enough to cross it.
+    test "#1404 a burst of peer CTCP queries is answered under a ceiling, line and row together" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      # The per-channel topic, not the user topic: these rows land at
+      # `channel = own_nick` (the DM-shaped key an inbound query takes), and
+      # a `:message` broadcast rides the channel topic.
+      :ok =
+        Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      capacity = AutoReplyBudget.capacity()
+      queries = capacity * 4
+
+      for n <- 1..queries do
+        IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01PING #{n}\x01\r\n")
+      end
+
+      # Barrier, and the reason it is a plain PRIVMSG rather than a
+      # `:sys.get_state/1`: the queries are still in flight through the
+      # IRCServer → socket → Client hop when the feed loop returns, so a
+      # round-trip to the session proves only that ITS mailbox is empty.
+      # The session routes inbound in arrival order and persists after each
+      # one, so the broadcast for a marker fed LAST is a durable witness
+      # that every query ahead of it was already routed — answered or
+      # dropped. `assert_receive` matches anywhere in the mailbox, so the
+      # visibility rows queued ahead of the marker do not hide it.
+      marker = "burst drained"
+      IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :#{marker}\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :message, message: %{body: ^marker}}
+                     },
+                     5_000
+
+      # Counted straight off the table rather than through `fetch/7`: the
+      # quantity under test is "how many rows did the flood write", and a
+      # read path with its own windowing and own-nick semantics would put a
+      # second thing between the assertion and the answer.
+      rows =
+        Grappa.Scrollback.Message
+        |> Ecto.Query.where(
+          [m],
+          m.network_id == ^network.id and m.body == "CTCP PING query → answered"
+        )
+        |> Repo.aggregate(:count)
+
+      assert rows > 0, "the ceiling must bound the courtesy answer, not remove it"
+      assert rows < queries, "every query was answered — nothing bounded the burst"
+      assert rows <= capacity + 1
+
+      # The rows are final at this point; the outbound frames may still be
+      # crossing the loopback socket, so converge on the count rather than
+      # sampling it once. Equality is the property under test — one budget
+      # buys both, so a wire count that never reaches the row count is the
+      # failure this waits to expose.
+      assert await_ctcp_ping_answers(server, rows) == rows,
+             "the visibility row and the outbound line must not diverge"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -33,6 +33,7 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.IRC.Message
   alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
+
   alias Grappa.Session.{
     AutoReplyBudget,
     AwayState,

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -35,7 +35,6 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.Networks.{Credentials, SessionPlan}
 
   alias Grappa.Session.{
-    AutoReplyBudget,
     AwayState,
     Backoff,
     GhostRecovery,
@@ -2829,6 +2828,9 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # Read from the same config key the budget module reads, never retyped.
+    @auto_reply_capacity Application.compile_env(:grappa, [:send_throttle, :capacity], 5)
+
     # #1404 — the auto-answer is paced by whoever asks, and each answer
     # costs an outbound frame AND a row in the shared sqlite file. Both are
     # bounded by ONE budget, so the two counts must move together: a row
@@ -2854,8 +2856,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       :ok = await_handshake(server)
 
-      capacity = AutoReplyBudget.capacity()
-      queries = capacity * 4
+      queries = @auto_reply_capacity * 4
 
       for n <- 1..queries do
         IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01PING #{n}\x01\r\n")
@@ -2893,7 +2894,7 @@ defmodule Grappa.Session.ServerTest do
 
       assert rows > 0, "the ceiling must bound the courtesy answer, not remove it"
       assert rows < queries, "every query was answered — nothing bounded the burst"
-      assert rows <= capacity + 1
+      assert rows <= @auto_reply_capacity + 1
 
       # The rows are final at this point; the outbound frames may still be
       # crossing the loopback socket, so converge on the count rather than

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -1128,6 +1128,83 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "format_status/1 — upstream credentials never reach a status dump" do
+    # The upstream credentials are plaintext in this state by design: they
+    # are decrypted from Cloak at boot and threaded to the wire. Everything
+    # that protects them elsewhere — `redact: true` on the columns,
+    # `@derive Inspect` on AuthFSM, `filter_parameters` on HTTP params —
+    # stops before OTP formats a dying process, which prints the state
+    # through `inspect/2`. `format_status/1` is the callback that owns
+    # that door, and `:sys.get_status/1` routes through the very same one.
+    #
+    # The oracle is deliberately the VALUE, not the key: it inspects the
+    # whole formatted term and asks whether the secret is anywhere in it.
+    # That is what keeps the test honest across a state-map regrouping —
+    # move these keys under a nested struct and a key-name assertion would
+    # still pass while the guard had quietly stopped covering them.
+    @secrets %{
+      pending_password: "ns-plaintext-must-not-print",
+      oper_pass: "oper-plaintext-must-not-print",
+      pending_registration_secret: "register-plaintext-must-not-print",
+      perform_list: "PRIVMSG NickServ :IDENTIFY perform-plaintext-must-not-print",
+      pending_auth: {"rendezvous-plaintext-must-not-print", 123_456}
+    }
+
+    defp secret_needles do
+      Enum.map(@secrets, fn
+        {_, {needle, _deadline}} -> needle
+        {_, needle} -> needle
+      end)
+    end
+
+    defp deep_inspect(term) do
+      inspect(term, limit: :infinity, printable_limit: :infinity, structs: false)
+    end
+
+    test "every credential-bearing state key is redacted in the status dump" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      :sys.replace_state(pid, &Map.merge(&1, @secrets))
+
+      # Pre-state: without this the refute below would pass on a session
+      # that never held a secret in the first place.
+      raw = deep_inspect(:sys.get_state(pid))
+
+      for needle <- secret_needles() do
+        assert raw =~ needle, "planting failed — #{needle} is not in the live state"
+      end
+
+      dumped = deep_inspect(:sys.get_status(pid))
+
+      for needle <- secret_needles() do
+        refute dumped =~ needle, "#{needle} reached a status dump"
+      end
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "absent stays absent — redaction does not invent a secret that was never held" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      status = Server.format_status(%{state: :sys.get_state(pid)})
+
+      # A session that holds no oper password must not read as one that
+      # holds a redacted one: `nil` is a diagnostic, and flattening it into
+      # `:redacted` would tell the operator the opposite of the truth.
+      assert status.state.oper_pass == nil
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "terminate/2 — clean QUIT on supervisor shutdown" do
     # When the BEAM stops (SIGTERM, Application.stop, scripts/deploy.sh
     # recreating the container), the SessionSupervisor takes each

--- a/test/grappa/themes_test.exs
+++ b/test/grappa/themes_test.exs
@@ -6,6 +6,9 @@ defmodule Grappa.ThemesTest do
 
   alias Grappa.{Networks, Repo, Themes, Themes.Theme, Themes.TokenModel, Themes.Wire, Uploads, Visitors.Visitor}
 
+  # Read from the same key `Grappa.Themes` reads, never retyped.
+  @daily_quota Application.compile_env(:grappa, [:themes, :daily_quota], 5)
+
   defp valid_payload do
     %{
       "colors" => Map.new(TokenModel.color_keys(), fn k -> {k, "#123456"} end),
@@ -572,6 +575,52 @@ defmodule Grappa.ThemesTest do
       upload = %Plug.Upload{path: path, content_type: "text/plain", filename: "x.txt"}
 
       assert {:error, :not_raster} = Themes.store_background({:user, user.id}, {:upload, upload})
+    end
+
+    # #1404 — the fetcher's own moduledoc justifies having no in-flight byte
+    # ceiling by citing "~5 theme ops/user/day". That quota was spent by
+    # `create`/`copy` only, so the sentence described a bound that was not on
+    # this path. The assertion is that the door is now metered by the SAME
+    # bucket, which is what makes the justification true.
+    test "consumes the theme daily quota, so a burst is refused" do
+      user = user_fixture()
+      path = Path.join(System.tmp_dir!(), "themetest-" <> Uploads.mint_slug())
+      File.write!(path, bytes(:gps_png))
+      on_exit(fn -> File.rm(path) end)
+      upload = %Plug.Upload{path: path, content_type: "image/png", filename: "bg.png"}
+
+      results =
+        for _ <- 1..(@daily_quota + 1) do
+          Themes.store_background({:user, user.id}, {:upload, upload})
+        end
+
+      # Pre-state: the door opens at all. Without it, an all-refused result
+      # would read as "metered" when it actually means "broken".
+      assert match?({:ok, _}, hd(results))
+      assert {:error, :rate_limited} = List.last(results)
+    end
+
+    # A REFUSED fetch still burns a slot, and that is the intended order: the
+    # resource being rationed is the fetch, so charging only for successes
+    # would leave failures free to run — the cheaper flood of the two.
+    test "a failed source still spends its slot" do
+      user = user_fixture()
+      path = Path.join(System.tmp_dir!(), "themetest-" <> Uploads.mint_slug())
+      File.write!(path, "hi")
+      on_exit(fn -> File.rm(path) end)
+      bad = %Plug.Upload{path: path, content_type: "text/plain", filename: "x.txt"}
+
+      for _ <- 1..@daily_quota do
+        assert {:error, :not_raster} = Themes.store_background({:user, user.id}, {:upload, bad})
+      end
+
+      good_path = Path.join(System.tmp_dir!(), "themetest-" <> Uploads.mint_slug())
+      File.write!(good_path, bytes(:gps_png))
+      on_exit(fn -> File.rm(good_path) end)
+      good = %Plug.Upload{path: good_path, content_type: "image/png", filename: "bg.png"}
+
+      assert {:error, :rate_limited} =
+               Themes.store_background({:user, user.id}, {:upload, good})
     end
   end
 

--- a/test/grappa/vhosts/source_mapping_key_test.exs
+++ b/test/grappa/vhosts/source_mapping_key_test.exs
@@ -49,9 +49,8 @@ defmodule Grappa.Vhosts.SourceMappingKeyTest do
       ours = derive!(@secret, @client_v6)
       theirs = derive!(@other_secret, @client_v6)
 
-      # This is the whole property. Under the unkeyed derivation these two
-      # are equal — the address was a function of the client alone, so
-      # anyone holding the published host could recompute it from a guess.
+      # This is the whole property: the address is a function of the
+      # client AND the deployment, so it is ours and not the code's.
       refute ours == theirs,
              "the same client derived #{ours} under both deployment keys — the derivation is not keyed"
 
@@ -89,13 +88,13 @@ defmodule Grappa.Vhosts.SourceMappingKeyTest do
   end
 
   describe "an unbooted node refuses to derive" do
-    test "derive raises rather than falling back to a guessable address" do
+    test "derive raises rather than deriving without a deployment key" do
       :persistent_term.erase({SourceMapping, :mac_key})
 
       # The one seam in the codebase with no default. Every other
       # `:persistent_term` reader degrades gracefully; here the only
-      # available fallback is a constant this repository publishes, which
-      # is the defect being fixed — so absence has to be loud.
+      # fallback available is a compiled-in constant, which is not a key —
+      # so absence has to be loud.
       assert_raise ArgumentError, fn ->
         SourceMapping.derive(SourceMapping.client_key(@client_v6), @prefix)
       end

--- a/test/grappa/vhosts/source_mapping_key_test.exs
+++ b/test/grappa/vhosts/source_mapping_key_test.exs
@@ -1,0 +1,104 @@
+defmodule Grappa.Vhosts.SourceMappingKeyTest do
+  @moduledoc """
+  #1404 — the mode-2 outbound address is a KEYED function of the client
+  prefix, and the derivation is pinned so it cannot move in silence.
+
+  Separate module from `SourceMappingTest` because these cases swap the
+  deployment key, which lives in `:persistent_term` and is therefore
+  node-global: `async: false`, and every case restores the key
+  `Grappa.Application.start/2` installed.
+
+  Why a separate FILE and not more cases over there: every test in
+  `SourceMappingTest` asserts a RELATIVE property — determinism, two
+  inputs differing, the network bits staying put — and all of them hold
+  just as well under an unkeyed hash, or under any future derivation
+  someone swaps in. That was measured before this change and it is the
+  gap this file closes.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Grappa.Vhosts.SourceMapping
+
+  @prefix "2a03:4000:20:2d3:cb::/80"
+
+  # A client `/64` and a client `/32`, as `client_key/1` reduces them.
+  @client_v6 {0x2001, 0xDB8, 1, 2, 0xAAAA, 0xBBBB, 0xCCCC, 0xDDDD}
+  @client_v4 {203, 0, 113, 7}
+
+  # Fixed deployment secrets, so a case reads the same on every host.
+  @secret "w1-1404-source-mapping-pin-secret"
+  @other_secret "a-different-deployment-entirely"
+
+  setup do
+    booted = Application.get_env(:grappa, GrappaWeb.Endpoint, [])[:secret_key_base]
+    # Restore what the application installed, not a value of our own: a
+    # test that leaves a foreign key behind renumbers every later case.
+    on_exit(fn -> :ok = SourceMapping.boot(booted) end)
+    :ok
+  end
+
+  defp derive!(secret, client) do
+    :ok = SourceMapping.boot(secret)
+    {:ok, addr} = SourceMapping.derive(SourceMapping.client_key(client), @prefix)
+    addr
+  end
+
+  describe "the derivation is keyed to the deployment" do
+    test "two deployments derive DIFFERENT addresses for the same client" do
+      ours = derive!(@secret, @client_v6)
+      theirs = derive!(@other_secret, @client_v6)
+
+      # This is the whole property. Under the unkeyed derivation these two
+      # are equal — the address was a function of the client alone, so
+      # anyone holding the published host could recompute it from a guess.
+      refute ours == theirs,
+             "the same client derived #{ours} under both deployment keys — the derivation is not keyed"
+
+      # Keying must not have cost the properties mode 2 relies on.
+      assert SourceMapping.in_prefix?(ours, @prefix)
+      assert SourceMapping.in_prefix?(theirs, @prefix)
+    end
+
+    test "a deployment derives the SAME address for the same client, every time" do
+      # Determinism across a re-boot of the key, not merely across two
+      # calls: the key is derived from the secret at boot, so a
+      # non-deterministic derivation step would surface here and nowhere
+      # else.
+      assert derive!(@secret, @client_v6) == derive!(@secret, @client_v6)
+      assert derive!(@secret, @client_v4) == derive!(@secret, @client_v4)
+    end
+  end
+
+  describe "the derived value is pinned" do
+    # Changing the derivation renumbers every subject on a live mode-2
+    # deployment at their next connect. That is a supported event — it is
+    # what a prefix renumber does — but it must be a DECISION. Before
+    # this pin existed, swapping the hash passed green and the operator
+    # found out from the alias churn.
+    #
+    # Regenerating these after a deliberate change: boot the same secret
+    # and read what `derive/2` returns. Do not hand-edit a digit.
+    test "a v6 /64 derives its pinned address" do
+      assert derive!(@secret, @client_v6) == "2a03:4000:20:2d3:cb:fa3:3b49:9720"
+    end
+
+    test "a v4 /32 derives its pinned address" do
+      assert derive!(@secret, @client_v4) == "2a03:4000:20:2d3:cb:83b:b8d6:126f"
+    end
+  end
+
+  describe "an unbooted node refuses to derive" do
+    test "derive raises rather than falling back to a guessable address" do
+      :persistent_term.erase({SourceMapping, :mac_key})
+
+      # The one seam in the codebase with no default. Every other
+      # `:persistent_term` reader degrades gracefully; here the only
+      # available fallback is a constant this repository publishes, which
+      # is the defect being fixed — so absence has to be loud.
+      assert_raise ArgumentError, fn ->
+        SourceMapping.derive(SourceMapping.client_key(@client_v6), @prefix)
+      end
+    end
+  end
+end

--- a/test/grappa_web/admin_request_budget_test.exs
+++ b/test/grappa_web/admin_request_budget_test.exs
@@ -1,0 +1,83 @@
+defmodule GrappaWeb.AdminRequestBudgetTest do
+  @moduledoc """
+  #1404 — the operator console consumes the same per-subject request
+  budget every other authenticated scope does.
+
+  **Driven, not read.** `Phoenix.Router.__routes__/0` does not expose a
+  route's `pipe_through` list, so a structural assertion about the scope is
+  not available; and a test that greps `router.ex` for the pipeline name
+  would pin the SOURCE, which is not a witness that the plug ran. So this
+  drives a real admin write until the budget refuses it.
+
+  `async: false` — `put_test_config/1` writes `:persistent_term`, which is
+  node-global.
+  """
+  use GrappaWeb.ConnCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.RateLimit.RequestBudget, as: Budget
+
+  # Small enough to exhaust in a handful of calls, and `sever_after` set
+  # above the number of refusals this test provokes: crossing it would
+  # revoke the bearer and turn the 429 under test into a 401, which is a
+  # different control answering.
+  @capacity 3
+  @sever_after 50
+
+  setup do
+    original = Budget.config()
+
+    Budget.put_test_config(%Budget{
+      capacity: @capacity,
+      refill_per_sec: 0.001,
+      sever_after: @sever_after,
+      sever_window_ms: 60_000
+    })
+
+    on_exit(fn -> Budget.put_test_config(original) end)
+    :ok
+  end
+
+  defp admin_bearer(conn) do
+    {user, session} = user_and_session()
+    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
+    put_bearer(conn, session.id)
+  end
+
+  describe "the admin scope is metered" do
+    test "an admin write is refused once the subject's budget is spent", %{conn: conn} do
+      conn = admin_bearer(conn)
+
+      # Pre-state: the door is open before the budget is spent. Without
+      # this the 429 below could just as well mean the route is broken.
+      assert conn |> post("/admin/db_latency/reset") |> Map.fetch!(:status) == 204
+
+      statuses =
+        for _ <- 1..(@capacity + 2) do
+          conn |> post("/admin/db_latency/reset") |> Map.fetch!(:status)
+        end
+
+      assert 429 in statuses,
+             "the operator console spent no budget: got #{inspect(statuses)}"
+
+      assert Enum.all?(statuses, &(&1 in [204, 429])),
+             "expected only 204/429, got #{inspect(statuses)} — another control answered"
+    end
+
+    test "an admin READ is not metered, matching every other scope" do
+      # The budget meters writes only, and the console must not be the one
+      # scope where that stops being true — a metered GET would make the
+      # operator's own dashboard poll a flood.
+      conn = admin_bearer(Phoenix.ConnTest.build_conn())
+
+      statuses =
+        for _ <- 1..(@capacity + 3) do
+          conn |> get("/admin/db_latency") |> Map.fetch!(:status)
+        end
+
+      assert Enum.all?(statuses, &(&1 == 200)), "got #{inspect(statuses)}"
+    end
+  end
+end

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -29,6 +29,15 @@ defmodule GrappaWeb.ArchiveControllerTest do
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback
 
+  # #1404 — read the SAME config keys `GrappaWeb.ArchiveController` reads,
+  # rather than an accessor on the controller: an accessor returning a
+  # compile-time constant cannot carry an honest `@spec` under Dialyzer's
+  # `:underspecs`, and a literal here would pin the test to a number the
+  # operator is meant to retune.
+  @archive_capacity Application.compile_env(:grappa, [:archive_read, :capacity])
+  @archive_refill_per_sec Application.compile_env(:grappa, [:archive_read, :refill_per_sec])
+  @archive_retry_after max(1, ceil(1.0 / @archive_refill_per_sec))
+
   setup %{conn: conn} do
     vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
     session = session_fixture(vjt)
@@ -149,6 +158,63 @@ defmodule GrappaWeb.ArchiveControllerTest do
         |> get("/networks/#{net.slug}/archive")
 
       assert json_response(conn, 404) == %{"error" => "not_found"}
+    end
+  end
+
+  describe "GET /networks/:network_id/archive is metered" do
+    test "the listing is refused once the subject's archive bucket is spent",
+         %{conn: conn, vjt: vjt} do
+      net = net_with_credential(vjt)
+
+      # Pre-state: the door is open before the bucket is spent. Without
+      # this the 429 below could just as well mean the route is broken.
+      assert conn |> get("/networks/#{net.slug}/archive") |> Map.fetch!(:status) == 200
+
+      answers = for _ <- 1..@archive_capacity, do: get(conn, "/networks/#{net.slug}/archive")
+      refused = Enum.find(answers, &(&1.status != 200))
+
+      assert refused,
+             "the archive listing spent no token: #{@archive_capacity + 1} calls all passed"
+
+      assert refused.status == 429
+      assert json_response(refused, 429) == %{"error" => "rate_limited"}
+
+      # The hint must come from THIS bucket's refill, not from the coarse
+      # budget's much faster one — pacing a client against the wrong
+      # bucket re-429s it on the very next call.
+      assert Plug.Conn.get_resp_header(refused, "retry-after") == [
+               Integer.to_string(@archive_retry_after)
+             ]
+    end
+
+    test "the bucket keys on (subject, network) — a spent network does not refuse another",
+         %{conn: conn, vjt: vjt} do
+      spent = net_with_credential(vjt)
+      other = net_with_credential(vjt)
+
+      for _ <- 1..(@archive_capacity + 1), do: get(conn, "/networks/#{spent.slug}/archive")
+
+      assert conn |> get("/networks/#{spent.slug}/archive") |> Map.fetch!(:status) == 429,
+             "the first network's bucket was expected to be empty by now"
+
+      assert conn |> get("/networks/#{other.slug}/archive") |> Map.fetch!(:status) == 200,
+             "a second network shared the first one's bucket"
+    end
+
+    test "the DELETE takes no archive token — it is a write, already metered upstream",
+         %{conn: conn, vjt: vjt} do
+      net = net_with_credential(vjt)
+      :ok = seed_archive_rows(vjt, net)
+
+      for _ <- 1..(@archive_capacity + 1), do: get(conn, "/networks/#{net.slug}/archive")
+
+      assert conn |> get("/networks/#{net.slug}/archive") |> Map.fetch!(:status) == 429,
+             "the listing bucket was expected to be empty by now"
+
+      target = URI.encode_www_form("#a")
+
+      assert conn |> delete("/networks/#{net.slug}/archive/#{target}") |> Map.fetch!(:status) ==
+               204
     end
   end
 

--- a/test/infra/actions_sha_pin_test.bats
+++ b/test/infra/actions_sha_pin_test.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+#
+# Bats suite for #1404 — supply-chain: every third-party GitHub Action a
+# workflow runs MUST be referenced by commit SHA, not by a tag.
+#
+# A tag is a pointer its owner can move. The jobs in `release.yml` hold
+# `contents: write` and `packages: write` — they publish the container image
+# and attach the Release assets — so what those jobs execute has to be a fixed
+# object, chosen here, not resolved at run time from a name someone else
+# controls. `ci.yml` and `integration.yml` are pinned on the same terms rather
+# than "the risky ones only": a half-pinned tree gives the next author two
+# patterns to copy from, and the wrong one still looks like the house style.
+#
+# The `# vX.Y.Z` comment is not decoration. It is the human-readable half of
+# the pin (a bare SHA says nothing about what you are running) AND the handle
+# Dependabot rewrites: the `github-actions` ecosystem is already configured in
+# `.github/dependabot.yml`, and it bumps a SHA-pinned `uses:` while keeping the
+# comment in step. That is the documented update path — pinning without one
+# just trades a moving target for a frozen, unpatched one.
+#
+# This is the drift GUARD, not the pin itself. It reads the worktree's tracked
+# workflows, so it judges the change under test, not `main`. Local composite
+# actions (`uses: ./...`) are excluded: they live in this repository and move
+# only when this repository moves.
+#
+# Refresh a pin by hand when Dependabot is not the one doing it:
+#   gh api repos/<owner>/<repo>/commits/<tag> --jq .sha
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+# Every third-party `uses:` in the tracked workflows. `git grep -n` →
+# `path:line:content`. Local `./` actions are not third-party; a commented-out
+# `# uses:` line is prose.
+action_refs() {
+    git -C "$REPO_ROOT" grep -nE '^[[:space:]]*(- )?uses:' -- '.github/workflows/*.yml' 2>/dev/null \
+        | while IFS= read -r line; do
+            content="${line#*:*:}"                        # strip `path:line:`
+            trimmed="$(printf '%s' "$content" | sed 's/^[[:space:]]*//')"
+            case "$trimmed" in
+                \#*) continue ;;                          # comment line — prose
+                *uses:\ ./*) continue ;;                  # local composite action
+            esac
+            printf '%s\n' "$line"
+        done
+}
+
+@test "every third-party action is pinned to a commit SHA (#1404)" {
+    refs="$(action_refs)"
+
+    # Guard against a vacuous pass: with the grep or the filter wrong, the
+    # assertion below would trivially hold over an empty set. The three
+    # workflows carry well over thirty `uses:` between them.
+    count="$(printf '%s\n' "$refs" | grep -c . || true)"
+    [ "$count" -ge 30 ] || {
+        echo "expected >=30 third-party action references, found $count — grep/filter is wrong:" >&2
+        printf '%s\n' "$refs" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$refs" | grep -vE '@[0-9a-f]{40}( |$)' || true)"
+    [ -z "$violations" ] || {
+        echo "TAG-pinned action reference(s) — pin to a commit SHA (#1404):" >&2
+        printf '%s\n' "$violations" >&2
+        echo "    gh api repos/<owner>/<repo>/commits/<tag> --jq .sha" >&2
+        return 1
+    }
+}
+
+@test "every pinned action carries its human-readable version comment (#1404)" {
+    # Without it the reference is unreadable to a human AND unbumpable by
+    # Dependabot, which keys its rewrite on the comment it wrote last time.
+    #
+    # Scoped to the refs that ARE sha-pinned, so a tag left behind fails the
+    # test above and this one only. One defect, one red line.
+    missing="$(action_refs | grep -E '@[0-9a-f]{40}' | grep -vE '@[0-9a-f]{40} # v[0-9]' || true)"
+    [ -z "$missing" ] || {
+        echo "pinned action(s) with no '# vX.Y.Z' version comment (#1404):" >&2
+        printf '%s\n' "$missing" >&2
+        return 1
+    }
+}
+
+# `owner/repo@sha # version`, one per line, for every reference above.
+pinned_tokens() {
+    action_refs | grep -oE '[A-Za-z0-9._/-]+@[0-9a-f]{40} # v[0-9][^ ]*'
+}
+
+@test "all references to one action carry the SAME sha and version (#1404)" {
+    # `actions/checkout` is transcribed eleven times across the three
+    # workflows. Bumping some of them is the failure this catches: the jobs
+    # that were missed keep running the old object silently, and the tree
+    # reads as pinned either way.
+    tokens="$(pinned_tokens)"
+    actions="$(printf '%s\n' "$tokens" | sed 's/@.*//' | sort -u)"
+
+    multi_ref_actions=0
+    conflicts=""
+
+    for action in $actions; do
+        refs="$(printf '%s\n' "$tokens" | grep -cF -- "$action@")"
+        pins="$(printf '%s\n' "$tokens" | grep -F -- "$action@" | sed "s|^$action@||" | sort -u)"
+
+        [ "$refs" -ge 2 ] && multi_ref_actions=$((multi_ref_actions + 1))
+
+        if [ "$(printf '%s\n' "$pins" | grep -c .)" -gt 1 ]; then
+            # Name the FILES, not just the action: the references are
+            # textually identical, so "these two pins disagree" would leave
+            # the reader to grep eleven call sites for the one that moved.
+            conflicts="${conflicts}${action}: $(printf '%s' "$pins" | tr '\n' ' ')
+$(action_refs | grep -F -- "$action@" | sed 's/^/    /')
+"
+        fi
+    done
+
+    # Same anti-vacuous reasoning as the count check: with every action down
+    # to a single reference this test asserts nothing.
+    [ "$multi_ref_actions" -ge 1 ] || {
+        echo "no action is referenced twice — the equality assertion is vacuous:" >&2
+        printf '%s\n' "$tokens" >&2
+        return 1
+    }
+
+    [ -z "$conflicts" ] || {
+        echo "DIVERGENT pins for the same action — bump every call site together (#1404):" >&2
+        printf '%s' "$conflicts" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
Nine of the thirteen medium items from the 2026-08-15 review, in one
branch. Stated at the level of the control, per the terms #1404 sets:
what is guarded now, and why each guard has the shape it has.

**Why one branch and not five.** The work was cut into five slices while
it was written, and three of them touch the same files —
`docs/DESIGN_NOTES.md`, `lib/grappa/session/server.ex`,
`lib/grappa_web/controllers/archive_controller.ex`. Five separate greens
attest five slices; they do not attest their combination, and after the
first merge the other four are stale against a main they were never
measured on. One branch, one gate, one merge is the shape that actually
gets measured.

The slices are preserved as commits, in the order they were written:
session guards, metering doors, share link, source derivation, action
pins.

---

## 1 — Three guards on the session process

Two of these sit on doors the 2026-08-15 architecture review already has
buckets for, and the issue's sequencing note asks that hardening not
travel inside the structural change: the outbound-reply arm the `E
outbound-door` bucket proposes to replace with a single
`send_outbound/2`, and the state map the `A session-decomposition` bucket
proposes to regroup. The redaction test is written against VALUES, not
key names, precisely so that a regrouping breaks it loudly rather than
quietly stepping around it.

- **A valueless IRCv3 message-tag carries `""`**, the value the spec
  gives it, and the tag type narrows to `String.t()`. The consumer that
  splits on `nil` versus binary is now total by construction rather than
  by a catch-all clause.
- **The CTCP VERSION/PING auto-reply has a ceiling**, and one token buys
  both of its costs — the upstream frame and the scrollback row —
  because a row claiming an answer that never went out is worse than
  neither. The arithmetic is pure and lives in the session's own state,
  since a remote-paced path must not enqueue serialized calls into a
  node-global process. It reads the `:send_throttle` numbers rather than
  owning a second pair that drifts.
- **`format_status/1` keeps upstream credentials out of a status dump.**
  The house `@derive Inspect` pattern is unavailable here (a bare map,
  not a struct), so this is the callback that owns the same question for
  a GenServer.

## 2 — Three authenticated doors that were unmetered

**The operator console spends the same budget as every other scope.**
`:request_budget` now sits on the `/admin` scope, after `:authn`, which
is what assigns the subject and session id the budget keys on.
`:admin_authn` answers WHO may call; that is not a rate. The plug's own
moduledoc had claimed the opposite — "on every authenticated resource
scope" — so a reader auditing coverage met a sentence asserting the
audit's result. The prose now enumerates what is deliberately outside and
says where a read of unusual COST belongs instead. Writes only, still: a
metered GET would make the console's own dashboard poll a flood, and a
second case pins that direction.

**A theme background spends the quota its own prose cited.**
`ImageFetcher.Req` justified having no in-flight byte ceiling by citing
"~5 theme ops/user/day". `create` and `copy` consumed that quota;
`store_background/2`, the door that reaches the fetcher, now consumes the
SAME `:theme_create` bucket rather than inventing a second number. It is
consumed BEFORE the fetch: what is rationed is a remote GET plus a
re-encode, so charging only for successes would leave failures running
free. The stored PNG additionally consumes the global storage cap every
other write to that store consumes, checked beside `Uploads.create/3`
because the byte count only exists after the re-encode.

Deliberately not done: an `expires_at` on these rows. A background is
referenced by a live theme payload, so an expiry would delete the image
out from under a theme still in use. Unswept and bounded is a design
choice, and the comment now says which of the two it is.

**The archive listing has a bucket of its own.**
`GET /networks/:slug/archive` is the one authenticated read that answers
from a whole `(subject, network)` partition instead of a page: there is
no `limit` to negotiate, so its cost tracks the partition rather than the
request. It takes one token from a per-`(subject, network)` bucket before
it builds anything; an empty bucket answers 429 with a `retry-after` and
runs no query. Shared `RateLimit.TokenBucket`, distinct bucket atom, so a
listing can never spend a send token. The numbers come from the client's
shape, not from taste: cic refetches this list once per PART in every
open tab, so the burst allowance has to clear a hand-driven run of parts
fanned out across several tabs, and only the sustained refill is a real
ceiling.

**What it does not do**, recorded in DESIGN_NOTES so the next reader need
not re-derive it: it bounds how often the aggregate runs, not what one
run costs. A scan ceiling is the only remedy that bounds by construction,
but it changes a user-visible list, so it is a product decision rather
than a hardening one; an index carrying `server_time` alongside the
folded archive key would make one run cheaper, and cheaper is not
bounded. Both are left open with the measurement each needs.

## 3 — The share link travels in the fragment

A session-share link is a credential. It now travels in the URL
**fragment** — `https://<host>/share#<token>` — the one part of a URL a
browser keeps to itself. The route did not move: `/share` is still a
plain path route under the path-mode router, still served by the SPA
catch-all on every substrate. Only the credential moved.

Carried there rather than redacted downstream, because the redactions
available to us key on parameter NAMES, and on several substrates the
serving configuration is not ours to edit at all. A remedy that holds
only where we own the whole path is not a remedy for a self-hoster. In-
house precedent: the WebSocket bearer travels in a subprotocol for the
same reason.

`ShareConsume` reads the fragment and clears it from the address bar and
from history with `replaceState` **before** the network call. The
ordering is the substance: scrubbing on success would make it conditional
on the outcome, and it has to hold for every link alike. An empty
fragment is answered locally and never posted; a malformed
percent-escape is treated as a corrupted link, not a token. **Trade taken
deliberately:** a reload after a failed consume reports `missing_token`
instead of retrying with the real code.

The review named one stale prose site; grepping the old shape found two
more, and all three now describe what the code sends — including a cic
header that described a hash **router** this app does not use, wrong in
the opposite direction from the code beside it.

**Scope, declared rather than hidden:** this slice is 13 files, above
CLAUDE.md's ~10 ceiling. One behaviour change plus every consumer that
named the old shape, including four e2e specs that match on the old URL
form and would otherwise go red on a shape they only describe. Leaving
them out would be the half-migration the house rule forbids.

## 4 — The mode-2 source derivation is keyed to the deployment

Touches `static_mapping` mode only; the default `pool_with_reservations`
derives nothing and is unaffected. The outbound source address for a
client is now derived by a keyed MAC — `hmac_sha256(deployment_key,
client_key)` — so the client→address mapping is a property of the
deployment rather than a property of the code.

Every guarantee the mapping actually rests on is unchanged: HMAC-SHA256
gives the same near-uniform spread over the host bits, so the collision
math in the moduledoc holds unmodified, and the derivation is still
deterministic, so a client keeps one stable address.

**No new operator secret.** The key is derived once at boot from
`secret_key_base` via `Plug.Crypto.KeyGenerator`, domain-separated, and
held in `:persistent_term` — the CLAUDE.md non-process DI seam. `boot/1`
is exposed on the `Grappa.Vhosts` context rather than the internal
module, which is inside that boundary and not exported. **The accessor
has no default, deliberately:** every other `:persistent_term` seam here
defaults to a value that keeps graceful degradation through the
hot-deploy window, and a key cannot — the only default available is a
constant compiled into the release. An unbooted node raises.

**Operator consequence: this renumbers a mode-2 deployment once.**
Derived addresses are computed on demand and never stored — only the
client key is persisted — so this is operationally the same event as
renumbering the prefix, which the mode already supports. Rotating
`secret_key_base` renumbers it again. Recorded in `docs/OPERATIONS.md`,
with the caveat that channel bans and oper tooling naming the old hosts
need updating in the same window.

## 5 — Every GitHub Action pinned to a commit SHA

36 `uses:` references across `ci.yml`, `integration.yml` and
`release.yml`; 11 distinct actions, each with a `# vX.Y.Z` comment
carrying the readable version. A tag is a pointer its owner can move, and
the `release.yml` jobs hold `contents: write` and `packages: write`.

All three workflows, not only the publish-capable one: a half-pinned tree
gives the next author two patterns to copy from, and the unpinned one
still reads as the house style. Same argument
`test/infra/base_image_digest_pin_test.bats` already settled for base
images.

The version comment is load-bearing — it is the readable half of the
reference and the handle Dependabot rewrites. `dependabot.yml` now
records that this is the update path for the pins, so pinning trades a
moving target for a maintained one rather than a frozen one.

Guarded by `test/infra/actions_sha_pin_test.bats`: every third-party
`uses:` is SHA-shaped; every pinned one carries its version comment;
all references to one action agree on both SHA and version, and the
failure names the FILES, because eleven textually identical
`actions/checkout` lines make "these two disagree" unactionable on its
own. Local `./` composite actions are excluded — they move only when this
repository moves. Each assertion carries the anti-vacuous count check the
base-image sibling established.

---

## Gates

Every rc below was read from the rc FILE, never from a completion
notification (that reports the wrapper's exit, not the command's).

| gate | tree | base | rc | what the log says |
|---|---|---|---|---|
| `check.sh`, session slice alone | `f408b6e3` | `e974baed` | **0** | 8 doctests, 60 properties, 6358 tests, 0 failures; Dialyzer passed; Sobelow 0; 496/496 bats |
| `check.sh`, action-pin slice alone | `1ef73583` | `e974baed` | **0** | 6349 tests, 0 failures; 499/499 bats, including the three new pin assertions |
| `check.sh`, union | `935c9e1f` | `e974baed` | **0** | 6382 tests, 0 failures; Dialyzer passed; Sobelow 0; 499/499 bats |
| cic `check` / `test`, union | `935c9e1f` | `e974baed` | **0** / **0** | 59 warnings + 6 infos (the tree's baseline); 286 test files |
| `check.sh`, union rebased | `50c00362` | `b8b09a1f` | **0** | 6384 tests, 0 failures; Dialyzer passed; Sobelow 0; 499/499 bats |
| cic `check` / `test`, union rebased | `50c00362` | `b8b09a1f` | **0** / **0** | 59 warnings + 6 infos; 287 test files |
| `design-notes-gate.sh` | `50c00362` | `b8b09a1f` | **0** | 3 new entry headings, separator and marker present |

The two slices that had never been compiled were gated ALONE first, so
that a red on the union would have been attributable to one of five
rather than to the set. Both were green before the union was built.

**Base moved twice while this was being measured** (`4ed33d2c` →
`e974baed` → `b8b09a1f`). The branch was re-picked onto the current main
and re-gated rather than shipped on a dead base. The re-pick is provably
content-neutral: `diff(union@e974baed, union@b8b09a1f)` is byte-for-byte
`diff(e974baed, b8b09a1f)` — six files, none of them this branch's.

**`docs/DESIGN_NOTES.md` was resolved once, deterministically, not
merged.** The file is `merge=union`, so a wrong result lands with rc=0
and no conflict marker. It bit twice during construction and both times
only the two-sided numstat caught it: once adding 9 lines of a main entry
into this branch's contribution, once the reverse. The end state is
`origin/main`'s content plus three entry blocks appended verbatim — 255
additions, **0 deletions**, the exact sum of 85 + 105 + 65 measured per
slice before the replay; three markers, one occurrence each; and the
boundary shape read on the file rather than inferred, at all three:
prose / marker / blank / `---` / blank / heading, with no blank before
the marker.

**Mutants that were RUN, not predicted:**

- Six on the session slice. Two of them corrected the work: one exposed a
  barrier that was not a barrier, and one showed a divergence assertion
  was never being reached.
- One on the mode-2 address pin. The two pinned literals were computed
  out of band before any Elixir ran, and a pin that passes first try is
  exactly the case where a test can be vacuous — so a digit was changed
  in the v4 literal: `5 tests, 1 failure`, exactly one assertion, and
  production answered the predicted value.
- Three on the action pins, run against THIS tree: a tag where a SHA
  belongs, a pin stripped of its version comment, and one `checkout`
  reference pointed at a different SHA. Each killed **exactly one** named
  assertion, and the one it was aimed at.

## What is NOT established

- **Integration CI has not been run** — not on any slice, not on the
  union. That gate is outstanding.
- **The four rewritten e2e share specs have not been run.** They rest on
  Playwright's `page.goto()` carrying a fragment through, which I did not
  verify; it is the first thing to look at if `session-sharing.spec.ts`
  goes red.
- **No mutants were run on the metering slice.** Its tests are green in
  the union, but a green test is not evidence that its assertion bites.
- **The archive bound is a frequency bound, not a cost bound.** One
  listing still costs what it cost.
- **Nothing here measures SEC-28**, which the review itself files with
  "no latency or saturation measurement was taken".
- **No measurement of guess cost, nor of the ircd's own cloaking
  behaviour**, for the mode-2 derivation — the review's two "not
  established" notes stand unchanged.
- **Not verified that the alias manager handles the one-time mass
  renumber without orphans.** That claim is derived from prefix renumber
  being a supported event, not from a measurement, and it is the most
  exposed sentence in the operator note.
- **The green above is against `b8b09a1f`.** If main moves again before
  this merges, the DESIGN_NOTES rite has to be re-run — a bad union merge
  of that file is silent.

## Not closed by this branch

Four of the thirteen medium items remain: SEC-3, SEC-28, SEC-29 and
SEC-32.

**SEC-32 is one I decline to close as written**, and it needs a decision
rather than a commit. The declared remedy — narrowing the media source
list — is not available without deleting a shipped feature: the media
viewer accepts any `https:` media URL by design (#1240) and the upload
host is operator-selectable, so a host allowlist breaks cross-host media
for every deployment that uses one. Theme backgrounds are not the reason
the channel is open: they are re-hosted same-origin. What I would land
instead is the truthful version of the justification — it currently
claims a coverage it does not have — pinned by a test, so that a later
widening is a decision rather than an oversight. Worth noting that the
neighbouring directives are enumerated narrowly and the review found no
reachable XSS in cic, so this is a defence-in-depth degradation with a
false premise attached rather than a break on its own; the review says
as much.
