### PR TITLE
#1404: two more medium items — ceilings for the stores a stranger fills

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44324,3 +44324,51 @@ segment, and that `new URL(...).pathname` is exactly `/share`. The
 scrub is pinned by sampling `location.hash` INSIDE the mocked request
 rather than after it: "empty afterwards" is precisely what the old
 scrub-on-success produced, so only the ordering distinguishes them.
+## 2026-08-16 — #1404: ceilings for the stores a stranger fills
+
+Two more from the 2026-08-15 review, and they are the same defect twice.
+Stated at the level of the control, as the tracking issue asks.
+
+### The rule both share
+
+A store whose eviction is lifecycle-driven must also bound the entries the
+lifecycle can never reach. Neither store was missing an eviction; both
+evictions were correct for the entries they were written for. What was
+missing is that population and eviction covered DIFFERENT sets, and the
+difference was the part nobody chose — it was the residue between two
+rules, each locally right.
+
+That is the shape to look for in the next store: not "does it evict", but
+"does the set it evicts contain the set it admits".
+
+### The WHOIS-userhost cache
+
+It is populated from three doors and evicted on membership events, so an
+entry that arrives for someone we share no channel with is exactly the kind
+no membership event will ever name. The typedoc claimed a bound — "unique
+nicks across currently-joined channels" — that only ever described one of
+the three doors.
+
+The cache now has an explicit ceiling and ONE door (`cache_put/3`) that all
+three population sites pass through, so a fourth site cannot reintroduce the
+gap by simply not knowing about it. At the ceiling the cache keeps the
+entries membership eviction can still reach, and at most half the cap of
+them. That second bound is not tidiness: a session whose membership alone
+exceeded the cap would otherwise re-prune on every inbound row, and a
+ceiling that scans on every row is a better amplifier than the growth it
+replaced. Refreshing a key already present never prunes — an overwrite
+cannot grow a map, and spending the cache to re-learn a fact it already
+holds would be pure loss.
+
+**Which half survives is map order, deliberately.** An LRU wants an
+access-order structure beside the map, maintained by each of the eviction
+paths; a shadow index that drifts out of step with its map is a worse defect
+than an arbitrary victim in a cache that is best-effort by construction. The
+miss costs one WHOIS, and WHOIS was always the authoritative answer — the
+cache only ever saved the round trip.
+
+**Rejected: gating population on membership.** It would close the gap
+exactly, and it would also delete a feature: ban-mask derivation
+legitimately wants the answer for someone in no channel of ours. The ceiling
+keeps that use and bounds the abuse of it; the gate would have traded one
+for the other.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44324,6 +44324,10 @@ segment, and that `new URL(...).pathname` is exactly `/share`. The
 scrub is pinned by sampling `location.hash` INSIDE the mocked request
 rather than after it: "empty afterwards" is precisely what the old
 scrub-on-success produced, so only the ordering distinguishes them.
+<!-- entry #1404d -->
+
+---
+
 ## 2026-08-16 — #1404: ceilings for the stores a stranger fills
 
 Two more from the 2026-08-15 review, and they are the same defect twice.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44372,3 +44372,33 @@ exactly, and it would also delete a feature: ban-mask derivation
 legitimately wants the answer for someone in no channel of ours. The ceiling
 keeps that use and bounds the abuse of it; the gate would have traded one
 for the other.
+
+### The invited-window store
+
+The same shape, one state along. `:invited` is the only member of the window
+state set a third party puts there: an INVITE needs no shared channel
+upstream, and the window leaves only when the subject joins or declines.
+Population by a stranger, eviction by the operator — so the set that empties
+it is not the set that fills it, and there was no top.
+
+There is one now, checked on the arm that opens the window rather than at
+the router, because what it bounds — two permanent map entries and the
+cold-subscribe payload rebuilt from them — lives on that side. The persist
+row is deliberately left alone: it already lands for the states that skip
+the flip, an invitation is a real thing that happened, and a row whose
+window is not open is precisely what the archive is for. This is a ceiling
+on the window model, not a claim to have bounded inbound writes in general —
+any stranger can already write rows by sending a message.
+
+The count is `invited_by`'s size rather than a scan of the state map,
+leaning on the existing key-iff-`:invited` invariant, so the check is
+constant-time and the two cannot disagree.
+
+**Drop-new, not evict-oldest.** Under a flood the windows already held are
+the likelier genuine ones, and evicting by age would mean an arrival-order
+structure the struct does not carry, paid for by every mutator, in exchange
+for letting a flood displace the invitation the operator was about to
+accept. Refusals are logged per occurrence: the volume is bounded by
+whatever rate upstream lets a sender INVITE at, and it rotates, whereas the
+alternative is an operator who never learns that invitations are being
+turned away.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -189,9 +189,22 @@ defmodule Grappa.Session.EventRouter do
   @typedoc """
   Network-wide WHOIS-userhost cache. Keyed by **lowercased** nick (RFC 2812
   §2.2 nick comparisons are case-insensitive). Updated on JOIN/311/352
-  (population) and evicted on QUIT/PART/KICK/NICK (lifecycle events). Cache
-  is bounded by unique nicks across currently-joined channels — typically
-  <500 entries for normal usage. No LRU or cap in this version.
+  (population) and evicted on QUIT/PART/KICK/NICK (lifecycle events).
+
+  Population and eviction do NOT cover the same set of nicks, and that gap
+  is why the cache carries an explicit ceiling (`userhost_cache_cap/0`).
+  Population is unconditional at all three sites — a 311 or 352 for someone
+  we share no channel with lands here like any other. Eviction is entirely
+  membership-driven, and IRC never delivers a QUIT for a user we do not
+  share a channel with, so those entries have NO lifecycle trigger: absent a
+  ceiling they live for the process lifetime of an always-on session, and a
+  masked WHO answers with as many of them as the network has users.
+
+  At the ceiling the cache keeps at most half the cap, and only entries
+  whose nick still shares a channel with us — the ones eviction can still
+  reach. Dropping the rest is free: this is a best-effort ban-mask helper
+  and a miss falls back to WHOIS, which is authoritative (see
+  `Grappa.Session`'s `:send_ban` derivation).
   """
   @type userhost_cache :: %{(nick :: String.t()) => userhost_entry()}
 
@@ -557,8 +570,11 @@ defmodule Grappa.Session.EventRouter do
     userhost_cache =
       case msg.prefix do
         {:nick, nick, user, host} when is_binary(user) and is_binary(host) ->
+          # Against the members map the JOIN just produced, not the one
+          # before it: the joining nick is resident from this moment, and a
+          # prune reading the stale map would treat them as a stranger.
           nick_key = normalize_nick(nick, casemapping(state))
-          Map.put(Map.get(state, :userhost_cache, %{}), nick_key, %{user: user, host: host})
+          cache_put(%{state | members: members}, nick_key, %{user: user, host: host})
 
         _ ->
           Map.get(state, :userhost_cache, %{})
@@ -1202,7 +1218,7 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(target) and is_binary(user) and is_binary(host) do
     nick_key = normalize_nick(target, casemapping(state))
-    cache = Map.put(Map.get(state, :userhost_cache, %{}), nick_key, %{user: user, host: host})
+    cache = cache_put(state, nick_key, %{user: user, host: host})
     realname = whois_trailing(rest)
 
     state =
@@ -1694,7 +1710,7 @@ defmodule Grappa.Session.EventRouter do
        when is_binary(target) and is_binary(user) and is_binary(host) and
               is_binary(channel) and is_binary(server) and is_binary(flags) do
     nick_key = normalize_nick(target, casemapping(state))
-    cache = Map.put(Map.get(state, :userhost_cache, %{}), nick_key, %{user: user, host: host})
+    cache = cache_put(state, nick_key, %{user: user, host: host})
 
     state_with_cache = %{state | userhost_cache: cache}
 
@@ -2724,6 +2740,72 @@ defmodule Grappa.Session.EventRouter do
   defp apply_kick_effect(:absent, state, _, _) do
     cache = Map.get(state, :userhost_cache, %{})
     {state.members, Map.get(state, :topics, %{}), Map.get(state, :channel_modes, %{}), cache}
+  end
+
+  # The ceiling on `userhost_cache`. Chosen well above any membership a
+  # session accumulates by joining rooms, and far below a network's user
+  # list, which is what a masked WHO would otherwise pour in here.
+  @userhost_cache_cap 2_000
+
+  @doc """
+  The `userhost_cache` ceiling. Public so a test can drive the real bound
+  instead of restating the number and drifting from it.
+  """
+  @spec userhost_cache_cap() :: pos_integer()
+  def userhost_cache_cap, do: @userhost_cache_cap
+
+  # The ONLY door into `userhost_cache`. Every population site goes through
+  # here so the ceiling cannot be reintroduced-around by a fourth site.
+  #
+  # An overwrite of a key already present cannot grow the map, so it never
+  # prunes — refreshing an entry must not cost the operator their cache.
+  @spec cache_put(state(), String.t(), userhost_entry()) :: userhost_cache()
+  defp cache_put(state, nick_key, entry) do
+    cache = Map.get(state, :userhost_cache, %{})
+
+    cache =
+      if map_size(cache) >= @userhost_cache_cap and not is_map_key(cache, nick_key) do
+        prune_userhost_cache(cache, state)
+      else
+        cache
+      end
+
+    Map.put(cache, nick_key, entry)
+  end
+
+  # Keeps the entries lifecycle eviction can still reach (the nick shares a
+  # channel with us), and at most half the cap of them, so every prune frees
+  # at least half the cap. Without that second bound a session whose
+  # membership alone exceeds the cap would prune on EVERY inbound row, which
+  # turns the ceiling into the flood amplifier it exists to prevent.
+  #
+  # Which half survives is map order — arbitrary, and deliberately so: an LRU
+  # would need an access-order structure alongside the map, maintained by
+  # every one of the QUIT/PART/KICK/NICK eviction paths, and a drifted
+  # shadow index is a worse defect than an arbitrary victim in a
+  # best-effort cache whose miss costs one WHOIS.
+  @spec prune_userhost_cache(userhost_cache(), state()) :: userhost_cache()
+  defp prune_userhost_cache(cache, state) do
+    resident = resident_member_keys(state)
+
+    cache
+    |> Enum.filter(fn {nick_key, _entry} -> MapSet.member?(resident, nick_key) end)
+    |> Enum.take(div(@userhost_cache_cap, 2))
+    |> Map.new()
+  end
+
+  # The members map is keyed by RAW nick (the key/display split); the cache
+  # is keyed by the fold. Fold here rather than comparing raw, or a peer
+  # whose case differs between JOIN and WHO reads as a non-member and gets
+  # evicted while still in the room.
+  @spec resident_member_keys(state()) :: MapSet.t(String.t())
+  defp resident_member_keys(state) do
+    casemapping = casemapping(state)
+
+    for {_channel, channel_members} <- Map.get(state, :members, %{}),
+        {nick, _modes} <- channel_members,
+        into: MapSet.new(),
+        do: normalize_nick(nick, casemapping)
   end
 
   @spec evict_cache_if_no_overlap(

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2766,14 +2766,14 @@ defmodule Grappa.Session.EventRouter do
   defp cache_put(state, nick_key, entry) do
     cache = Map.get(state, :userhost_cache, %{})
 
-    cache =
+    capped =
       if map_size(cache) >= @userhost_cache_cap and not is_map_key(cache, nick_key) do
         prune_userhost_cache(cache, state)
       else
         cache
       end
 
-    Map.put(cache, nick_key, entry)
+    Map.put(capped, nick_key, entry)
   end
 
   # Keeps the entries lifecycle eviction can still reach (the nick shares a
@@ -2792,7 +2792,7 @@ defmodule Grappa.Session.EventRouter do
     resident = resident_member_keys(state)
 
     cache
-    |> Enum.filter(fn {nick_key, _entry} -> MapSet.member?(resident, nick_key) end)
+    |> Enum.filter(fn {nick_key, _} -> MapSet.member?(resident, nick_key) end)
     |> Enum.take(div(@userhost_cache_cap, 2))
     |> Map.new()
   end
@@ -2805,8 +2805,8 @@ defmodule Grappa.Session.EventRouter do
   defp resident_member_keys(state) do
     casemapping = casemapping(state)
 
-    for {_channel, channel_members} <- Map.get(state, :members, %{}),
-        {nick, _modes} <- channel_members,
+    for {_, channel_members} <- Map.get(state, :members, %{}),
+        {nick, _} <- channel_members,
         into: MapSet.new(),
         do: normalize_nick(nick, casemapping)
   end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2751,7 +2751,10 @@ defmodule Grappa.Session.EventRouter do
   The `userhost_cache` ceiling. Public so a test can drive the real bound
   instead of restating the number and drifting from it.
   """
-  @spec userhost_cache_cap() :: pos_integer()
+  # `unquote(@userhost_cache_cap)` pins the spec to the compile-time
+  # singleton, which is what the success typing is; `pos_integer()` is a
+  # `:underspecs` supertype of it and fails the gate.
+  @spec userhost_cache_cap() :: unquote(@userhost_cache_cap)
   def userhost_cache_cap, do: @userhost_cache_cap
 
   # The ONLY door into `userhost_cache`. Every population site goes through

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5850,34 +5850,10 @@ defmodule Grappa.Session.Server do
   # both the broadcast and the stored state so that banner can name who
   # invited you on a cold subscribe as well as live.
   #
-  # Guard against downgrading a window the operator is already engaging
-  # with: `:joined` (already in the room) and `:pending` (a JOIN in
-  # flight) must NOT be flipped to a greyed `:invited` tab. A `:failed` /
-  # `:kicked` / absent window DOES flip — an INVITE there is newly
-  # actionable (the invite bypasses +i/+k upstream, so the prior failure
-  # is moot). The persist row still lands in the skipped cases — an
-  # invite-while-joined / invite-while-joining is a legitimate in-channel
-  # event. A repeat INVITE while already `:invited` re-affirms the state
-  # (idempotent value + broadcast); harmless.
+  # Which windows an INVITE may move, and whether one may be opened at all,
+  # is `apply_invited/3` below.
   defp apply_effects([{:invited, channel, inviter} | rest], state) do
-    state =
-      case WindowState.state_of(state.window_state, channel) do
-        joined_or_pending when joined_or_pending in [:joined, :pending] ->
-          state
-
-        _ ->
-          broadcast_window_state(
-            state,
-            SessionWire.window_invited(state.network_slug, channel, inviter)
-          )
-
-          %{
-            state
-            | window_state: WindowState.set_invited(state.window_state, channel, inviter)
-          }
-      end
-
-    apply_effects(rest, state)
+    apply_effects(rest, apply_invited(state, channel, inviter))
   end
 
   # CP15 B3 + cluster #6: own-target KICK → window transitions to
@@ -6360,6 +6336,58 @@ defmodule Grappa.Session.Server do
     end
 
     apply_effects(rest, state)
+  end
+
+  # An inbound INVITE we did not ask for, applied to the window model.
+  #
+  # `:joined` (already in the room) and `:pending` (a JOIN in flight) must
+  # NOT be flipped to a greyed `:invited` tab. A `:failed` / `:kicked` /
+  # absent window DOES flip — an INVITE there is newly actionable (the invite
+  # bypasses +i/+k upstream, so the prior failure is moot). A repeat INVITE
+  # while already `:invited` re-affirms the state (idempotent value +
+  # broadcast); harmless. The persist row still lands in the skipped cases —
+  # an invite-while-joined / invite-while-joining is a legitimate in-channel
+  # event.
+  @spec apply_invited(t(), String.t(), String.t()) :: t()
+  defp apply_invited(state, channel, inviter) do
+    case WindowState.state_of(state.window_state, channel) do
+      joined_or_pending when joined_or_pending in [:joined, :pending] ->
+        state
+
+      _ ->
+        admit_invited(state, channel, inviter)
+    end
+  end
+
+  # The ceiling (`WindowState.invite_admissible?/2`) sits HERE, on the arm
+  # that opens the window, and not in the router: what it bounds is the pair
+  # of permanent map entries plus the cold-subscribe payload rebuilt from
+  # them, all of which live on this side. The persist row is deliberately
+  # untouched — it lands for the skipped states already, an invite is a real
+  # thing that happened, and the archive is where a row whose window is not
+  # open is meant to be readable.
+  #
+  # A refusal is logged per occurrence, like a dropped scrollback row: log
+  # volume is bounded by whatever rate the upstream lets a sender INVITE at,
+  # rotates, and is the only trace the operator gets that invitations are
+  # being turned away.
+  @spec admit_invited(t(), String.t(), String.t()) :: t()
+  defp admit_invited(state, channel, inviter) do
+    if WindowState.invite_admissible?(state.window_state, channel) do
+      broadcast_window_state(
+        state,
+        SessionWire.window_invited(state.network_slug, channel, inviter)
+      )
+
+      %{state | window_state: WindowState.set_invited(state.window_state, channel, inviter)}
+    else
+      Logger.warning("inbound INVITE opened no window: session at its invited-window ceiling",
+        network: state.network_slug,
+        channel: channel
+      )
+
+      state
+    end
   end
 
   # The session-side half of an own-nick migration: what an operator reads

--- a/lib/grappa/session/window_state.ex
+++ b/lib/grappa/session/window_state.ex
@@ -360,7 +360,10 @@ defmodule Grappa.Session.WindowState do
   The ceiling on concurrently `:invited` windows. Public so a caller — and a
   test — reads the number instead of restating it.
   """
-  @spec invited_cap() :: pos_integer()
+  # `unquote(@invited_cap)` pins the spec to the compile-time singleton,
+  # which is what the success typing is; `pos_integer()` is a `:underspecs`
+  # supertype of it and fails the gate.
+  @spec invited_cap() :: unquote(@invited_cap)
   def invited_cap, do: @invited_cap
 
   @doc """

--- a/lib/grappa/session/window_state.ex
+++ b/lib/grappa/session/window_state.ex
@@ -91,6 +91,14 @@ defmodule Grappa.Session.WindowState do
             kicked_meta: %{},
             invited_by: %{}
 
+  # The ceiling on concurrently `:invited` windows. Every other state in the
+  # set is reached by something the operator did — a JOIN they issued, a
+  # channel they were in. `:invited` is the only one a stranger can create,
+  # and it is the only one with no expiry, so it is the only one that needs
+  # a number. Set where a human's real backlog of unanswered invitations
+  # cannot reach it, and far below what a flood produces in a second.
+  @invited_cap 64
+
   @doc """
   Returns an empty `WindowState`. Used by `Session.Server.init/1`.
   """
@@ -346,6 +354,38 @@ defmodule Grappa.Session.WindowState do
   @spec invited_by(t(), String.t()) :: String.t() | nil
   def invited_by(%__MODULE__{} = ws, channel) when is_binary(channel) do
     Map.get(ws.invited_by, channel)
+  end
+
+  @doc """
+  The ceiling on concurrently `:invited` windows. Public so a caller — and a
+  test — reads the number instead of restating it.
+  """
+  @spec invited_cap() :: pos_integer()
+  def invited_cap, do: @invited_cap
+
+  @doc """
+  Whether an inbound INVITE may open an `:invited` window for `channel`.
+
+  Every other member of the state set is entered by something the SUBJECT
+  did; `:invited` is entered by something a third party did, needs no shared
+  channel upstream, and leaves only when the subject joins or declines. A
+  store a stranger fills and only the operator empties has to have a top.
+
+  Re-affirming a channel already `:invited` is always admissible — it writes
+  a key that exists and so cannot grow the store. That is also why the count
+  is `invited_by`'s size and not a scan of `states`: by the invariant on
+  `invited_by/2` the key exists if and only if the state is `:invited`, so
+  the size IS the number of invited windows, in constant time.
+
+  Refusal is deliberately drop-NEW rather than evict-oldest. Under a flood
+  the entries already held are the likelier genuine ones, and evicting by
+  age would need an arrival-order structure this struct does not carry —
+  paid for by every mutator, to make a flood able to displace the invitation
+  the operator was about to accept.
+  """
+  @spec invite_admissible?(t(), String.t()) :: boolean()
+  def invite_admissible?(%__MODULE__{invited_by: invited_by}, channel) when is_binary(channel) do
+    Map.has_key?(invited_by, channel) or map_size(invited_by) < @invited_cap
   end
 
   @doc """

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -3810,8 +3810,7 @@ defmodule Grappa.Session.EventRouterTest do
       state =
         base_state(%{
           members: %{"#italia" => %{"alice" => []}},
-          userhost_cache:
-            Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
+          userhost_cache: Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
         })
 
       {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
@@ -3831,8 +3830,7 @@ defmodule Grappa.Session.EventRouterTest do
           # Raw-cased in the members map (the key/display split), folded in
           # the cache: comparing the two unfolded would evict a live member.
           members: %{"#italia" => %{"Alice" => []}},
-          userhost_cache:
-            Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
+          userhost_cache: Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
         })
 
       {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
@@ -3860,8 +3858,7 @@ defmodule Grappa.Session.EventRouterTest do
       state =
         base_state(%{
           members: %{"#italia" => residents},
-          userhost_cache:
-            Map.new(1..cap, fn i -> {"member#{i}", %{user: "u#{i}", host: "h#{i}"}} end)
+          userhost_cache: Map.new(1..cap, fn i -> {"member#{i}", %{user: "u#{i}", host: "h#{i}"}} end)
         })
 
       {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -43,6 +43,24 @@ defmodule Grappa.Session.EventRouterTest do
     %Message{command: command, params: params, prefix: prefix, tags: %{}}
   end
 
+  # SEC-3 — a cache full of nicks we share no channel with: exactly the
+  # population a masked WHO produces, and the one no lifecycle event evicts.
+  defp stranger_cache(count) do
+    Map.new(1..count, fn i -> {"stranger#{i}", %{user: "u#{i}", host: "h#{i}"}} end)
+  end
+
+  defp whoreply(nick, user, host) do
+    msg(
+      {:numeric, 352},
+      ["vjt", "#italia", user, host, "irc.test.org", nick, "H", "0 Realname"],
+      {:server, "irc.test.org"}
+    )
+  end
+
+  defp whoisuser(nick, user, host) do
+    msg({:numeric, 311}, ["vjt", nick, user, host, "*", "Realname"], {:server, "irc.test.org"})
+  end
+
   # #388 — the solanum/OFTC shape. Those ircds ACK `account-notify`, and
   # since vjt's ruling of 2026-08-11 that ACK is what makes the services
   # ACCOUNT count as proof of identity rather than mere display. Every
@@ -3751,6 +3769,104 @@ defmodule Grappa.Session.EventRouterTest do
       # Stored under downcased key
       assert new_state.userhost_cache["alice"] == %{user: "alice_u", host: "alice.host"}
       refute Map.has_key?(new_state.userhost_cache, "Alice")
+    end
+  end
+
+  describe "route/2 — SEC-3 userhost_cache ceiling" do
+    test "352 for a stranger cannot grow the cache past the cap" do
+      cap = EventRouter.userhost_cache_cap()
+      state = base_state(%{userhost_cache: stranger_cache(cap)})
+
+      {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
+
+      assert map_size(new_state.userhost_cache) <= cap
+      assert new_state.userhost_cache["newcomer"] == %{user: "n_u", host: "n.host"}
+    end
+
+    test "311 for a stranger cannot grow the cache past the cap" do
+      cap = EventRouter.userhost_cache_cap()
+      state = base_state(%{userhost_cache: stranger_cache(cap)})
+
+      {:cont, new_state, _} = EventRouter.route(whoisuser("newcomer", "n_u", "n.host"), state)
+
+      assert map_size(new_state.userhost_cache) <= cap
+      assert new_state.userhost_cache["newcomer"] == %{user: "n_u", host: "n.host"}
+    end
+
+    test "a JOIN prefix cannot grow the cache past the cap" do
+      cap = EventRouter.userhost_cache_cap()
+      state = base_state(%{userhost_cache: stranger_cache(cap)})
+      m = msg(:join, ["#italia"], {:nick, "newcomer", "n_u", "n.host"})
+
+      {:cont, new_state, _} = EventRouter.route(m, state)
+
+      assert map_size(new_state.userhost_cache) <= cap
+      assert new_state.userhost_cache["newcomer"] == %{user: "n_u", host: "n.host"}
+    end
+
+    test "the prune keeps a nick still sharing a channel and drops the strangers" do
+      cap = EventRouter.userhost_cache_cap()
+
+      state =
+        base_state(%{
+          members: %{"#italia" => %{"alice" => []}},
+          userhost_cache:
+            Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
+        })
+
+      {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
+
+      # Alice is still in the room, so her QUIT will still evict her — she is
+      # not the leak, and the ceiling must not spend her to make room.
+      assert new_state.userhost_cache["alice"] == %{user: "alice_u", host: "alice.host"}
+      assert new_state.userhost_cache["newcomer"] == %{user: "n_u", host: "n.host"}
+      refute Map.has_key?(new_state.userhost_cache, "stranger1")
+    end
+
+    test "the prune folds the members map before deciding who is resident" do
+      cap = EventRouter.userhost_cache_cap()
+
+      state =
+        base_state(%{
+          # Raw-cased in the members map (the key/display split), folded in
+          # the cache: comparing the two unfolded would evict a live member.
+          members: %{"#italia" => %{"Alice" => []}},
+          userhost_cache:
+            Map.put(stranger_cache(cap - 1), "alice", %{user: "alice_u", host: "alice.host"})
+        })
+
+      {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
+
+      assert new_state.userhost_cache["alice"] == %{user: "alice_u", host: "alice.host"}
+    end
+
+    test "refreshing an entry at the ceiling does not spend the cache" do
+      cap = EventRouter.userhost_cache_cap()
+      state = base_state(%{userhost_cache: stranger_cache(cap)})
+
+      {:cont, new_state, _} = EventRouter.route(whoreply("stranger1", "fresh_u", "fresh.host"), state)
+
+      assert map_size(new_state.userhost_cache) == cap
+      assert new_state.userhost_cache["stranger1"] == %{user: "fresh_u", host: "fresh.host"}
+    end
+
+    test "every prune frees at least half the cap, so the next rows do not re-prune" do
+      cap = EventRouter.userhost_cache_cap()
+      # Membership alone above the ceiling: every entry is resident, so a
+      # residency filter on its own would leave the cache full and prune
+      # again on the very next row.
+      residents = Map.new(1..cap, fn i -> {"member#{i}", []} end)
+
+      state =
+        base_state(%{
+          members: %{"#italia" => residents},
+          userhost_cache:
+            Map.new(1..cap, fn i -> {"member#{i}", %{user: "u#{i}", host: "h#{i}"}} end)
+        })
+
+      {:cont, new_state, _} = EventRouter.route(whoreply("newcomer", "n_u", "n.host"), state)
+
+      assert map_size(new_state.userhost_cache) <= div(cap, 2) + 1
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5936,6 +5936,51 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "an INVITE past the ceiling opens no window, broadcasts nothing, and says so (#1404)" do
+      # An INVITE needs no shared channel upstream, and an `:invited` window
+      # leaves only when the operator joins or declines. So this is the one
+      # window state a stranger creates and only the subject clears, which is
+      # why it is the one with a top.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      cap = WindowState.invited_cap()
+
+      Enum.each(1..cap, fn i ->
+        IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#flood#{i}\r\n")
+      end)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#overtheceiling\r\n")
+          IRCServer.feed(server, "PING :flush\r\n")
+          {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 5_000)
+        end)
+
+      refute_receive %Phoenix.Socket.Broadcast{
+                       payload: %{kind: :window_invited, channel: "#overtheceiling"}
+                     },
+                     200
+
+      state = SessionStateHelpers.fetch(pid)
+      window_state = SessionStateHelpers.window_state(state)
+
+      assert WindowState.state_of(window_state, "#overtheceiling") == nil
+      # The refusal is drop-NEW: what the operator already has on screen is
+      # not spent to make room for whoever is flooding.
+      assert WindowState.state_of(window_state, "#flood1") == :invited
+      # Silently dropping it would leave an operator wondering why invitations
+      # stopped arriving.
+      assert log =~ "invited-window ceiling"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "001 autojoin loop broadcasts window_pending per channel + sets :pending state" do
       # CP17 — symmetric to the :send_join cast: the 001 RPL_WELCOME
       # autojoin path also flows through record_in_flight_join/2, so

--- a/test/grappa/session/window_state_test.exs
+++ b/test/grappa/session/window_state_test.exs
@@ -33,6 +33,14 @@ defmodule Grappa.Session.WindowStateTest do
 
   alias Grappa.Session.WindowState
 
+  # A window model holding exactly as many `:invited` windows as the ceiling
+  # allows — driven from the production number so the two cannot drift.
+  defp invited_to_cap do
+    Enum.reduce(1..WindowState.invited_cap(), WindowState.new(), fn i, ws ->
+      WindowState.set_invited(ws, "#chan#{i}", "stranger#{i}")
+    end)
+  end
+
   describe "new/0" do
     test "returns an empty struct (no channels tracked)" do
       ws = WindowState.new()
@@ -51,6 +59,42 @@ defmodule Grappa.Session.WindowStateTest do
       assert WindowState.state_of(ws, "#grappa") == :pending
       assert WindowState.failure_meta(ws, "#grappa") == nil
       assert WindowState.kicked_meta(ws, "#grappa") == nil
+    end
+  end
+
+  describe "invite_admissible?/2 — the ceiling on :invited" do
+    test "an empty window model admits an invite" do
+      assert WindowState.invite_admissible?(WindowState.new(), "#grappa")
+    end
+
+    test "a fresh channel is refused once the ceiling is reached" do
+      refute WindowState.invite_admissible?(invited_to_cap(), "#one-too-many")
+    end
+
+    test "the last slot below the ceiling is still admitted" do
+      ws = invited_to_cap()
+      # Declining one frees exactly one slot: the ceiling is a live count,
+      # not a high-water mark the session never comes back down from.
+      {:ok, freed} = WindowState.decline_invite(ws, "#chan1")
+
+      assert WindowState.invite_admissible?(freed, "#one-more")
+    end
+
+    test "re-affirming a channel already invited is admissible at the ceiling" do
+      # It writes a key that exists, so it cannot grow the store — and
+      # refusing it would drop the inviter of a window still on screen.
+      assert WindowState.invite_admissible?(invited_to_cap(), "#chan1")
+    end
+
+    test "the ceiling counts invited windows, not windows in general" do
+      # Joined / failed / kicked windows are entered by the subject's own
+      # actions and are not what the ceiling exists to bound.
+      ws =
+        Enum.reduce(1..(WindowState.invited_cap() * 2), WindowState.new(), fn i, acc ->
+          WindowState.set_joined(acc, "#joined#{i}")
+        end)
+
+      assert WindowState.invite_admissible?(ws, "#grappa")
     end
   end
 


### PR DESCRIPTION
Two of the four items left from #1404, both of them the same defect one state
apart: a store whose eviction set does not contain its admission set.

Branched fresh from `main`, not stacked on the union branch.

## What lands

**The WHOIS-userhost cache gets a ceiling.** It admits unconditionally from
three doors and evicts on membership events, so entries for nicks outside our
channels had no lifecycle trigger at all — while the typedoc asserted a bound
that only ever described one of the three doors. All three sites now pass
through a single door that enforces the ceiling, so a fourth site cannot
reintroduce the gap by not knowing about it. At the ceiling the cache keeps
the entries membership eviction can still reach, and at most half the cap of
them: without that second bound a session whose membership alone exceeds the
cap would re-prune on every inbound row, and a ceiling that scans per row is a
better amplifier than the growth it replaces. An overwrite of a key already
present never prunes.

Which half survives is map order, not recency. An LRU wants an access-order
structure beside the map maintained by each eviction path, and a shadow index
that drifts is a worse defect than an arbitrary victim in a cache that is
best-effort by construction — a miss costs one WHOIS, which was always the
authoritative answer. Gating population on membership was rejected: it would
close the gap exactly and delete a use with it, since ban-mask derivation
legitimately wants the answer for someone in no channel of ours.

**The invited-window store gets a ceiling.** `:invited` is the only window
state a third party puts there, and the window leaves only when the subject
joins or declines, so the set that fills it and the set that empties it are
different people. The check sits on the arm that opens the window rather than
in the router, because what it bounds — two permanent map entries and the
cold-subscribe payload rebuilt from them — lives on that side. The count is
the size of the inviter map rather than a scan of the state map, which the
existing key-iff-invited invariant makes exact and constant-time; no parallel
structure is added. Refusal is drop-NEW rather than evict-oldest: under a
flood the windows already held are the likelier genuine ones, and evicting by
age would need an arrival-order structure the struct does not carry. Each
refusal is logged, because an operator who never learns invitations are being
turned away is the worse outcome.

## What this deliberately does NOT do

**The invited ceiling does not bound persisted rows, and does not pretend
to.** The scrollback row still lands. It already lands for the window states
that skip the flip, an invitation is a real thing that happened, and a row
whose window is not open is what the archive exists to surface. More to the
point it is not a new class: any stranger can already cause rows by sending
messages, so bounding this one path while that door stands open would be
theatre.

**Both numbers are CHOSEN, not measured.** The cap on cached userhosts and the
cap on concurrent invited windows are engineering choices, argued in the
commit messages and in the decision log, with no benchmark behind either. They
are stated as choices in the code comments too, so a later reader does not
inherit them as findings.

## One item is HELD, on purpose

The fourth item — the synchronous cross-process call on the persist path plus
the task fan-out behind it — is **not patched here**, and not because it was
forgotten. Its structural claims check out on reading: the call is a real
round trip to a node-global process, made from the session process for every
inbound row, and the fan-out spawns unsupervised tasks that can call back into
the same session. Its *severity* claim does not: the handler on the other end
is a constant-time lookup, no latency or saturation was ever measured, and the
conclusion that a flooded session serialises the node is a reading of the call
graph. Writing the obvious remedy now would change the very numbers that have
to be measured first, so it waits for measurement.

Worth recording while it is in view: the tree already runs a task supervisor
for detached work, and the codebase already states the rule of routing through
it — the three spawn sites on this path do not. That is a divergence from an
established pattern rather than a claim about load, and it is also where a
concurrency ceiling would attach for free.

## Tests

Seven unit tests on the cache ceiling (each door, the resident-survives rule,
the fold before the residency compare, the no-prune-on-overwrite rule, and the
frees-at-least-half property), five unit tests on the invite admission rule,
and one end-to-end session test driving the ceiling through the fake ircd and
asserting that no window opens, nothing is broadcast, and the refusal is
visible in the log. Both ceilings are read from production accessors in the
tests rather than restated, so the numbers cannot drift apart.

The decision log entry carries the general rule both items share, so the next
store gets asked the right question: not "does it evict", but "does the set it
evicts contain the set it admits".
