### PR TITLE
cic: validate the 24 one-to-one REST doors instead of casting (#1400)

### DIFF
--- a/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
+++ b/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
@@ -50,6 +50,29 @@ const VHOST_VIEW = {
   selection: [],
 };
 
+// The `PATCH /networks/:slug` 200 body — a mirror of
+// `Grappa.Networks.Wire.credential_to_json/1`, which the client validates
+// against `S_NetworksWireCredentialJson` before returning. `connection_state`
+// is overwritten per request with the state that was asked for, so the stub
+// answers like the server (the response IS the updated credential). If the
+// wire grows a required field this fixture goes stale and this spec reddens —
+// truthfully, and with the narrower naming the shape.
+const CREDENTIAL_JSON = {
+  network: ANCHOR,
+  nick: "e2e-p282",
+  ident: null,
+  realname: null,
+  sasl_user: null,
+  auth_method: "none",
+  auth_command_template: null,
+  autojoin_channels: [],
+  connection_state: "parked",
+  connection_state_reason: null,
+  connection_state_changed_at: null,
+  inserted_at: "2026-08-16T00:00:00Z",
+  updated_at: "2026-08-16T00:00:00Z",
+};
+
 async function waitForNetworkState(
   token: string,
   slug: string,
@@ -102,11 +125,24 @@ async function bootToVhostPage(
 
   // Record + short-circuit the connection_state PATCH (the reconnect verb's
   // wire trace). Non-PATCH requests to this exact path fall through.
+  //
+  // The fulfilled body is a FULL `credential_json` echoing the requested
+  // state, not `{}`. Since #1400 `patchNetwork` runs the response through
+  // `narrowCredentialResponse`, which THROWS `WireShapeError` on a shape the
+  // bundle cannot read — and `bounce()` awaits the park before issuing the
+  // reconnect, so one unreadable response silently costs the second PATCH.
+  // `{}` is a body the server never sends: `Wire.credential_to_json/1` always
+  // renders all thirteen fields.
   await page.route(`**/networks/${ANCHOR}`, (route) => {
     if (route.request().method() === "PATCH") {
       const body = route.request().postDataJSON() as { connection_state?: string } | null;
-      if (typeof body?.connection_state === "string") patches.push(body.connection_state);
-      return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      const state = body?.connection_state;
+      if (typeof state === "string") patches.push(state);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...CREDENTIAL_JSON, connection_state: state ?? "parked" }),
+      });
     }
     return route.continue();
   });

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../lib/api";
+import { WireShapeError } from "../lib/wireNarrow";
 
 // `api.ts` boundary: REST shape + 401 dead-token detect. The 401
 // handler registry is the only mutable module-level state — explicit
@@ -1176,5 +1177,66 @@ describe("#1283 — the enrolment door is password-gated, so cic must knock with
     stubFetch(401, { error: "invalid_credentials" });
     await expect(api.startTotpEnrollment("bearer", "wrong")).rejects.toBeInstanceOf(api.ApiError);
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ── #1400 / #1430 — the REST boundary at the api doors ─────────────
+
+describe("sendMessage reads the STATUS, not just res.ok (#1430)", () => {
+  const row = {
+    id: 4321,
+    network: "azzurra",
+    channel: "#italia",
+    server_time: 1_700_000_000,
+    kind: "privmsg",
+    sender: "vjt",
+    body: "ciao",
+    meta: {},
+  };
+
+  it("returns the narrowed row on 201", async () => {
+    stubFetch(201, row);
+    await expect(api.sendMessage("t", "azzurra", "#italia", "ciao")).resolves.toEqual(row);
+  });
+
+  it("returns null on the 202 ack instead of an id-less object", async () => {
+    // The server's `:no_persist` arm — a *Serv target, /notice to a service, a
+    // no-persist CTCP. 202 is `res.ok`, so before #1430 `{ok: true}` was cast
+    // to a ScrollbackMessage and the caller read `row.id` as undefined.
+    stubFetch(202, { ok: true });
+    await expect(
+      api.sendMessage("t", "nickserv-net", "NickServ", "IDENTIFY x"),
+    ).resolves.toBeNull();
+  });
+
+  it("fails loud on a 201 whose row does not match the schema", async () => {
+    stubFetch(201, { ...row, id: "4321" });
+    await expect(api.sendMessage("t", "azzurra", "#italia", "ciao")).rejects.toBeInstanceOf(
+      WireShapeError,
+    );
+  });
+});
+
+describe("converted REST doors fail loud on a shape mismatch (#1400)", () => {
+  it("rejects an admin vhost response that is missing a required field", async () => {
+    // The deploy-window case: cic ahead of its server. Before #1400 this
+    // returned a type-checked value with a hole in it.
+    stubFetch(201, { id: 1, address: "1.2.3.4", in_pool: true });
+    await expect(api.adminCreateVhost("t", { address: "1.2.3.4" })).rejects.toBeInstanceOf(
+      WireShapeError,
+    );
+  });
+
+  it("passes a complete admin vhost response through", async () => {
+    const vhost = {
+      id: 1,
+      address: "1.2.3.4",
+      in_pool: true,
+      generally_available: false,
+      inserted_at: "2026-08-16T10:00:00Z",
+      updated_at: "2026-08-16T10:00:00Z",
+    };
+    stubFetch(201, vhost);
+    await expect(api.adminCreateVhost("t", { address: "1.2.3.4" })).resolves.toEqual(vhost);
   });
 });

--- a/cicchetto/src/__tests__/wireNarrow.test.ts
+++ b/cicchetto/src/__tests__/wireNarrow.test.ts
@@ -3,7 +3,10 @@ import {
   narrowAdminEvent,
   narrowAdminSnapshot,
   narrowChannelEvent,
+  narrowMessageResponse,
+  narrowThemeResponse,
   narrowWindowStateEvent,
+  WireShapeError,
 } from "../lib/wireNarrow";
 import { ADMISSION_FLOW } from "../lib/wireTypes";
 
@@ -1175,5 +1178,84 @@ describe("narrowAdminSnapshot (REV-G H24)", () => {
     const good = { kind: "reaper_swept", count: 3, at: "2026-05-22T12:00:00Z" };
     const bad = { kind: "reaper_swept", count: "3", at: "2026-05-22T12:00:00Z" };
     expect(narrowAdminSnapshot({ events: [good, bad] })).toBeNull();
+  });
+});
+
+// ── #1400 — the REST boundary narrowers ────────────────────────────
+//
+// The WS narrowers above answer `null` and the caller drops the push, because
+// another tick is coming. A REST response has no next tick, so vjt's ruling on
+// #1400 makes the REST family FAIL LOUD instead. These cases pin the three
+// facts that ruling turns on — it throws on a missing required field, it
+// tolerates an extra one, and what it returns is a RECONSTRUCTION rather than
+// the body it was handed.
+
+describe("REST narrowers (#1400)", () => {
+  const theme = {
+    id: 7,
+    name: "solarized-night",
+    author: "vjt",
+    built_in: false,
+    published: true,
+    apply_count: 12,
+    in_use: 3,
+    mine: true,
+    payload: { colors: { bg: "#002b36" } },
+    inserted_at: "2026-08-16T10:00:00Z",
+  };
+
+  it("returns the payload when the shape matches", () => {
+    expect(narrowThemeResponse(theme)).toEqual(theme);
+  });
+
+  it("THROWS on a missing required field rather than answering null", () => {
+    // The deploy-window case the ruling is about: a bundle newer than its
+    // server. The old cast turned this into `undefined` in a renderer.
+    const { in_use: _dropped, ...older } = theme;
+    expect(() => narrowThemeResponse(older)).toThrow(WireShapeError);
+  });
+
+  it("throws on a wrong-typed required field", () => {
+    expect(() => narrowThemeResponse({ ...theme, apply_count: "12" })).toThrow(WireShapeError);
+  });
+
+  it("names the shape, not the endpoint, on the thrown error", () => {
+    // One label per schema; the stack carries the call site. Twenty-four
+    // hand-written endpoint strings would be twenty-four things to drift.
+    expect(() => narrowThemeResponse({})).toThrow(/theme/);
+  });
+
+  it("tolerates an EXTRA field — the contract is additive (#447)", () => {
+    expect(() => narrowThemeResponse({ ...theme, a_field_from_the_future: 1 })).not.toThrow();
+  });
+
+  it("RECONSTRUCTS the object from declared fields, dropping the undeclared", () => {
+    // The behaviour change a cast did not have: what comes back is built from
+    // the schema, not the parsed body. Measured to be shape-preserving across
+    // the twelve shapes today — asserted here so it stops being invisible.
+    const out = narrowThemeResponse({ ...theme, a_field_from_the_future: 1 });
+    expect(out).toEqual(theme);
+    expect("a_field_from_the_future" in out).toBe(false);
+  });
+
+  it("narrows a message row on the 201 arm", () => {
+    const row = {
+      id: 4321,
+      network: "azzurra",
+      channel: "#italia",
+      server_time: 1_700_000_000,
+      kind: "privmsg",
+      sender: "vjt",
+      body: "ciao",
+      meta: {},
+    };
+    expect(narrowMessageResponse(row)).toEqual(row);
+  });
+
+  it("throws on the 202 ack body — it is not a message and has no schema", () => {
+    // #1430. The caller reads the STATUS and never brings `{ok: true}` here;
+    // this asserts that if it ever did, the boundary would say so loudly
+    // rather than hand back a row-shaped object with no id.
+    expect(() => narrowMessageResponse({ ok: true })).toThrow(WireShapeError);
   });
 });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -15,6 +15,22 @@ import { bootFetch } from "./bootFetch";
 import type { ModesEntry, TopicEntry } from "./channelTopic";
 import { getOrCreateClientId } from "./clientId";
 import type { MemberEntry } from "./memberTypes";
+// #1400 — the REST boundary narrowers. `wireNarrow.ts` is the only module that
+// names a generated `S_*` schema; every door here calls a narrower, so the
+// schema constants stay in one place and the failure mode stays in one place.
+import {
+  narrowAdminFeaturedChannelResponse,
+  narrowAdminServerResponse,
+  narrowAdminUserResponse,
+  narrowAdminVhostGrantResponse,
+  narrowAdminVhostResponse,
+  narrowCredentialResponse,
+  narrowDirectoryPageResponse,
+  narrowFeaturedChannelsResponse,
+  narrowMessageResponse,
+  narrowSessionLogListResponse,
+  narrowSessionLogSessionsResponse,
+} from "./wireNarrow";
 // S15/S3 — derive the upload-settings wire shape from the codegen
 // mirror of `Grappa.ServerSettings.Wire.upload_view/0`; the
 // `active_host` closed set (`"embedded" | "litterbox"`) is pinned by
@@ -53,8 +69,6 @@ import type {
   ScrollbackWireT,
   ServerSettingsWireUploadView,
   SessionISupportCasemapping,
-  SessionLogWireListResult,
-  SessionLogWireSessionsResult,
   SessionLogWireT,
   SessionWireBanlistBundlePayload,
   SessionWireBanlistEntry,
@@ -1915,7 +1929,7 @@ export async function adminListSessionLog(
   const url = limit === undefined ? "/admin/session_log" : `/admin/session_log?limit=${limit}`;
   const res = await fetch(url, { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as SessionLogWireListResult;
+  const body = narrowSessionLogListResponse(await res.json());
   return body.session_log;
 }
 
@@ -1936,7 +1950,7 @@ export async function adminListSessionLogSessions(
       : `/admin/session_log/sessions?limit=${limit}`;
   const res = await fetch(url, { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as SessionLogWireSessionsResult;
+  const body = narrowSessionLogSessionsResponse(await res.json());
   return body.session_log_sessions;
 }
 
@@ -2079,7 +2093,7 @@ export async function adminCreateVhost(token: string, body: AdminVhostCreate): P
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminVhost;
+  return narrowAdminVhostResponse(await res.json());
 }
 
 export async function adminPatchVhost(
@@ -2093,7 +2107,7 @@ export async function adminPatchVhost(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminVhost;
+  return narrowAdminVhostResponse(await res.json());
 }
 
 export async function adminDeleteVhost(token: string, id: number): Promise<void> {
@@ -2115,7 +2129,7 @@ export async function adminGrantVhost(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminVhostGrant;
+  return narrowAdminVhostGrantResponse(await res.json());
 }
 
 export async function adminRevokeVhostGrant(token: string, grantId: number): Promise<void> {
@@ -2299,7 +2313,7 @@ export async function listDirectory(
     { headers: buildHeaders(token) },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as DirectoryPage;
+  return narrowDirectoryPageResponse(await res.json());
 }
 
 // Mirror of `GrappaWeb.DirectoryController.refresh/2`. POSTs to kick off
@@ -2422,13 +2436,31 @@ export async function countMessagesAfter(
 // instead of in a comment nobody reads.
 export type MessageRelay = { kind: "ctcp" | "notice"; target: string };
 
+// #1400 / #1430 — this door is a union discriminated by STATUS, not by a field
+// in the body, and until now the client did not read the discriminant.
+// `MessagesController.render_send_result/2` answers either
+//
+//   201 + the persisted row (`Grappa.Scrollback.Wire.to_json/1`)
+//   202 + `{ok: true}`      — an ack for a send the server deliberately did not
+//                             persist: a `*Serv` target, `/notice` to a
+//                             service, a no-persist CTCP
+//
+// and 202 is `res.ok`, so the old `as ScrollbackMessage` cast covered both and
+// handed the caller an object with no `id`. `postTopic` below already reads its
+// own 202 correctly ("we don't read the 202 body"); this door did not.
+//
+// `null` is the 202, and it means "accepted, no row" — not "failed". The 201
+// arm narrows strictly like every other REST door. The 202 body is NOT narrowed
+// and NOT cast: it carries no domain data, and writing a schema for two keys
+// the server never typespec'd would be the second SSOT the codegen exists to
+// prevent.
 export async function sendMessage(
   token: string,
   networkSlug: string,
   channelName: string,
   body: string,
   relay?: MessageRelay,
-): Promise<ScrollbackMessage> {
+): Promise<ScrollbackMessage | null> {
   const payload =
     relay === undefined
       ? { body }
@@ -2444,7 +2476,8 @@ export async function sendMessage(
     },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ScrollbackMessage;
+  if (res.status === 202) return null;
+  return narrowMessageResponse(await res.json());
 }
 
 // Mirror of `GrappaWeb.ChannelsController.topic/2`. Sets the topic on
@@ -2669,7 +2702,7 @@ export async function patchNetwork(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as CredentialJson;
+  return narrowCredentialResponse(await res.json());
 }
 
 // #211 phase 4c/6 — visitor multi-network ACCRETION: attach + spawn an
@@ -2703,7 +2736,7 @@ export async function updateNetworkIdentity(
     body: JSON.stringify(fields),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as CredentialJson;
+  return narrowCredentialResponse(await res.json());
 }
 
 // #189 — per-network on-connect perform list. `perform_list` is the raw
@@ -2743,7 +2776,7 @@ export async function putNetworkPassword(
     body: JSON.stringify({ password }),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as CredentialJson;
+  return narrowCredentialResponse(await res.json());
 }
 
 export async function getPerform(token: string, networkSlug: string): Promise<PerformView> {
@@ -2802,7 +2835,7 @@ export async function adminCreateUser(token: string, body: AdminUserCreate): Pro
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminUser;
+  return narrowAdminUserResponse(await res.json());
 }
 
 export async function adminUpdateUserAdmin(
@@ -2816,7 +2849,7 @@ export async function adminUpdateUserAdmin(
     body: JSON.stringify({ is_admin }),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminUser;
+  return narrowAdminUserResponse(await res.json());
 }
 
 export async function adminUpdateUserPassword(
@@ -2830,7 +2863,7 @@ export async function adminUpdateUserPassword(
     body: JSON.stringify({ password }),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminUser;
+  return narrowAdminUserResponse(await res.json());
 }
 
 export async function adminDeleteUser(token: string, id: string): Promise<void> {
@@ -2912,7 +2945,7 @@ export async function adminAddServer(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminServer;
+  return narrowAdminServerResponse(await res.json());
 }
 
 export async function adminUpdateServer(
@@ -2932,7 +2965,7 @@ export async function adminUpdateServer(
     },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminServer;
+  return narrowAdminServerResponse(await res.json());
 }
 
 export async function adminDeleteServer(
@@ -2985,7 +3018,7 @@ export async function getFeaturedChannels(
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  return ((await res.json()) as FeaturedChannelsResponse).channels;
+  return narrowFeaturedChannelsResponse(await res.json()).channels;
 }
 
 export async function adminListFeaturedChannels(
@@ -3010,7 +3043,7 @@ export async function adminAddFeaturedChannel(
     { method: "POST", headers: buildHeaders(token), body: JSON.stringify(body) },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminFeaturedChannel;
+  return narrowAdminFeaturedChannelResponse(await res.json());
 }
 
 export async function adminUpdateFeaturedChannel(
@@ -3026,7 +3059,7 @@ export async function adminUpdateFeaturedChannel(
     { method: "PUT", headers: buildHeaders(token), body: JSON.stringify(body) },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as AdminFeaturedChannel;
+  return narrowAdminFeaturedChannelResponse(await res.json());
 }
 
 export async function adminDeleteFeaturedChannel(

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1604,14 +1604,24 @@ export async function disableTotp(token: string, password: string): Promise<void
   if (!res.ok) throw await readError(res, false);
 }
 
-async function passkeyRequest<T>(path: string, body: unknown, token?: string): Promise<T> {
+// #1400 — every path routed through here is a POST that renders JSON. The
+// only `:no_content` in `PasskeyController` is `delete/2`, and cic calls that
+// route with a bare `fetch`, never this helper. The 204 arm this used to
+// carry was therefore unreachable, and it asserted `undefined` as `T` — a
+// value no caller can survive. A future 204 here now throws on the empty
+// body, which is the loud failure; the silent `undefined` was not.
+async function passkeyRequest<T extends object>(
+  path: string,
+  body: unknown,
+  token?: string,
+): Promise<T> {
   const res = await fetch(path, {
     method: "POST",
     headers: buildHeaders(token),
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res, false);
-  return (res.status === 204 ? undefined : await res.json()) as T;
+  return (await res.json()) as T;
 }
 
 export const getPasskeyLoginOptions = (identifier: string): Promise<PasskeyOptions> =>

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1174,7 +1174,15 @@ const exports = identityScopedStore((onIdentityChange) => {
     const local = scrollbackByChannel()[key];
     const hasRenderedRow = local !== undefined && local.length > 0;
     const current = getReadCursor(slug, name);
-    if (hasRenderedRow && (current === null || row.id > current)) {
+    // #1430 — `null` is the server's 202 "accepted, no row": a `*Serv` target,
+    // `/notice` to a service, a no-persist CTCP. Nothing was persisted, so
+    // there is no id to advance the cursor TO and no row to advance it PAST.
+    // The gate is skipped whole rather than run against an absent id — which
+    // is what the old cast produced, since `{ok: true} as ScrollbackMessage`
+    // reaches here with `id` undefined and a null cursor lets the disjunct
+    // through. The send-relatch below still fires: the operator did send in
+    // this window, and that is unchanged by whether a row came back.
+    if (row !== null && hasRenderedRow && (current === null || row.id > current)) {
       void setReadCursor(t, slug, name, row.id);
     }
     // Send-relatch (post-resolve half): fire AFTER the optimistic cursor

--- a/cicchetto/src/lib/themesApi.ts
+++ b/cicchetto/src/lib/themesApi.ts
@@ -16,6 +16,7 @@
 
 import { buildHeaders, readError } from "./api";
 import { getOrCreateClientId } from "./clientId";
+import { narrowThemeResponse } from "./wireNarrow";
 import type { ThemesWireT } from "./wireTypes";
 
 // The closed font-family allow-list — mirror of
@@ -135,7 +136,7 @@ export async function listBuiltinBackgrounds(token: string): Promise<BuiltinBack
 export async function getTheme(token: string, id: number): Promise<ThemesWireT> {
   const res = await fetch(`/themes/${id}`, { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 export async function createTheme(token: string, body: CreateThemeBody): Promise<ThemesWireT> {
@@ -145,7 +146,7 @@ export async function createTheme(token: string, body: CreateThemeBody): Promise
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 export async function updateTheme(
@@ -159,7 +160,7 @@ export async function updateTheme(
     body: JSON.stringify(body),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 export async function deleteTheme(token: string, id: number): Promise<void> {
@@ -176,7 +177,7 @@ export async function publishTheme(token: string, id: number): Promise<ThemesWir
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 export async function unpublishTheme(token: string, id: number): Promise<ThemesWireT> {
@@ -185,7 +186,7 @@ export async function unpublishTheme(token: string, id: number): Promise<ThemesW
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 export async function copyTheme(token: string, id: number): Promise<ThemesWireT> {
@@ -194,7 +195,7 @@ export async function copyTheme(token: string, id: number): Promise<ThemesWireT>
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ThemesWireT;
+  return narrowThemeResponse(await res.json());
 }
 
 // #358 — the resolved day/night theme pair. `light` is the day (light-mode)

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -11,11 +11,39 @@ import type { MemberEntry } from "./memberTypes";
 // #429 — the generated RUNTIME schemas. `S_*` consts are the same typespecs
 // `wireTypes.ts` mirrors at compile time, emitted as data so the boundary can
 // enforce them after tsc has erased the types.
-import { S_AdminEventsWireEvent, S_AdminOverviewWireT, S_SessionLogWireT } from "./wireSchema";
+import {
+  S_AccountsAdminWireT,
+  S_AdminEventsWireEvent,
+  S_AdminOverviewWireT,
+  S_ChannelDirectoryWireIndexPayload,
+  S_NetworksFeaturedChannelsAdminWireT,
+  S_NetworksFeaturedChannelsWireIndexPayload,
+  S_NetworksServersAdminWireT,
+  S_NetworksWireCredentialJson,
+  S_ScrollbackWireT,
+  S_SessionLogWireListResult,
+  S_SessionLogWireSessionsResult,
+  S_SessionLogWireT,
+  S_ThemesWireT,
+  S_VhostsAdminWireGrantJson,
+  S_VhostsAdminWireVhostJson,
+} from "./wireSchema";
 import type {
+  AccountsAdminWireT,
   AdminOverviewWireT,
+  ChannelDirectoryWireIndexPayload,
+  NetworksFeaturedChannelsAdminWireT,
+  NetworksFeaturedChannelsWireIndexPayload,
+  NetworksServersAdminWireT,
+  NetworksWireCredentialJson,
+  ScrollbackWireT,
   SessionISupportCasemapping,
+  SessionLogWireListResult,
+  SessionLogWireSessionsResult,
   SessionLogWireT,
+  ThemesWireT,
+  VhostsAdminWireGrantJson,
+  VhostsAdminWireVhostJson,
   WindowCountsSeverity,
 } from "./wireTypes";
 // #410 — the runtime allowlists derive from the codegen-emitted `as const`
@@ -27,6 +55,7 @@ import {
   SCROLLBACK_MESSAGE_KIND,
   WINDOW_COUNTS_SEVERITY,
 } from "./wireTypes";
+import type { Infer, WireNode } from "./wireValidate";
 import { validate } from "./wireValidate";
 
 // #267 — narrow the window_counts severity to the closed union, defaulting
@@ -653,4 +682,154 @@ export function narrowSessionLogEntry(raw: unknown): SessionLogWireT | null {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
   const r = raw as Record<string, unknown>;
   return validate(S_SessionLogWireT, r.old_nick === undefined ? { ...r, old_nick: null } : r);
+}
+
+// ── #1400 — the REST boundary ──────────────────────────────────────
+//
+// The narrowers above serve the WS edge, where `T | null` is the right shape
+// because the caller drops the push and waits: `adminOverview.ts` states it —
+// "A malformed push KEEPS the last good reading … the next honest tick is only
+// an interval away". A REST response has no next tick. Handing the caller
+// `null` would leave it with nothing and no way to say why, so the two edges
+// need different failure MODES over the same schemas.
+//
+// The mode, per vjt's ruling on #1400: FAIL LOUD. A required field that the
+// payload does not carry — the case a deploy window produces, cic newer than
+// its server — makes the boundary reject the response and the surface fail
+// VISIBLY. It does not fall through to `undefined` in a renderer. Extra fields
+// stay harmless: the contract is additive (#447) and `validate` already ignores
+// undeclared keys rather than rejecting them.
+//
+// ## The mode lives HERE, once
+//
+// `narrowRest` is the only place that decides what a REST shape mismatch does.
+// The twelve narrowers below choose a schema and a label; none of them decides
+// how to fail. Thirteen copies of a throw would be thirteen chances to soften
+// one of them into a silent default.
+//
+// ## Where a tolerance goes, when one is needed
+//
+// Not into `narrowRest`, and not into a per-shape `if`. The house pattern is a
+// WRAPPER around the validate call, named as policy — `old_nick` in
+// `narrowSessionLogEntry` above is the worked example, and #1393 measured that
+// exactly three of ~30 arms needed one. A field known to be new gets a wrapper
+// that defaults it; everything else stays strict.
+//
+// ## What the conversion changes about the value
+//
+// A cast handed the caller the parsed body VERBATIM. `validate` hands back an
+// object RECONSTRUCTED from the declared fields only (`walkObject`,
+// `wireValidate.ts:223`). Any key the server sends that its own typespec does
+// not declare is dropped here rather than travelling on unnoticed. Measured
+// before this landed: across the twelve shapes, the twenty render paths behind
+// them attach no such key — every one renders a `*.Wire` result and nothing
+// else — so the reconstruction is shape-preserving today. It is not guaranteed
+// to stay that way by anything but that measurement.
+
+/**
+ * A REST response whose shape the running bundle cannot read.
+ *
+ * Deliberately NOT an `ApiError`. That class carries a `code` from the server's
+ * generated error-token set, and `friendlyApiError` maps it; minting a token
+ * the server never emits would repeat the very defect #1400 records against
+ * the hand-rolled `"Unauthorized"`. This is a client-side boundary rejection,
+ * so it is its own class and `errorMessage` renders its `message` through the
+ * plain-`Error` arm.
+ */
+export class WireShapeError extends Error {
+  readonly shape: string;
+
+  constructor(shape: string) {
+    super(`the server sent a ${shape} this version of the app cannot read`);
+    this.name = "WireShapeError";
+    this.shape = shape;
+  }
+}
+
+/**
+ * The REST failure mode, in one place. Validates `raw` against a generated
+ * schema and THROWS on mismatch — see the section note above for why REST
+ * cannot answer with `null` the way the WS narrowers do.
+ *
+ * `shape` names the wire shape, not the endpoint: the stack already carries
+ * the call site, and one label per schema cannot drift out of step with the
+ * twenty-four call sites the way twenty-four hand-written endpoint strings
+ * could.
+ */
+function narrowRest<const N extends WireNode>(node: N, raw: unknown, shape: string): Infer<N> {
+  const out = validate(node, raw);
+  if (out === null) throw new WireShapeError(shape);
+  return out;
+}
+
+/** `GET /themes/:id`, `POST /themes`, `PATCH /themes/:id`, publish/unpublish/copy. */
+export function narrowThemeResponse(raw: unknown): ThemesWireT {
+  return narrowRest(S_ThemesWireT, raw, "theme");
+}
+
+/** `PATCH /networks/:slug`, `PATCH /networks/:slug/identity`, `PUT /networks/:slug/password`. */
+export function narrowCredentialResponse(raw: unknown): NetworksWireCredentialJson {
+  return narrowRest(S_NetworksWireCredentialJson, raw, "network credential");
+}
+
+/** `POST /admin/users`, `PATCH /admin/users/:id`, `PUT /admin/users/:id/password`. */
+export function narrowAdminUserResponse(raw: unknown): AccountsAdminWireT {
+  return narrowRest(S_AccountsAdminWireT, raw, "user");
+}
+
+/** `POST /admin/vhosts`, `PATCH /admin/vhosts/:id`. */
+export function narrowAdminVhostResponse(raw: unknown): VhostsAdminWireVhostJson {
+  return narrowRest(S_VhostsAdminWireVhostJson, raw, "vhost");
+}
+
+/** `POST /admin/vhosts/:id/grants`. */
+export function narrowAdminVhostGrantResponse(raw: unknown): VhostsAdminWireGrantJson {
+  return narrowRest(S_VhostsAdminWireGrantJson, raw, "vhost grant");
+}
+
+/** `POST` + `PUT /admin/networks/:id/servers[/:id]`. */
+export function narrowAdminServerResponse(raw: unknown): NetworksServersAdminWireT {
+  return narrowRest(S_NetworksServersAdminWireT, raw, "server");
+}
+
+/** `POST` + `PUT /admin/networks/:id/featured_channels[/:id]`. */
+export function narrowAdminFeaturedChannelResponse(
+  raw: unknown,
+): NetworksFeaturedChannelsAdminWireT {
+  return narrowRest(S_NetworksFeaturedChannelsAdminWireT, raw, "featured channel");
+}
+
+/**
+ * The **201** arm of `POST /networks/:slug/channels/:channel/messages` only.
+ *
+ * That endpoint is a union discriminated by STATUS, not by a field: 202 carries
+ * `%{ok: true}` — an ack for a send the server deliberately did not persist (a
+ * `*Serv` target, `/notice` to a service, a no-persist CTCP). The caller reads
+ * the status and never brings the 202 body here; there is no schema for it and
+ * inventing one for two keys would be a second SSOT. See #1430.
+ */
+export function narrowMessageResponse(raw: unknown): ScrollbackWireT {
+  return narrowRest(S_ScrollbackWireT, raw, "message");
+}
+
+/** `GET /admin/session_log`. */
+export function narrowSessionLogListResponse(raw: unknown): SessionLogWireListResult {
+  return narrowRest(S_SessionLogWireListResult, raw, "session log");
+}
+
+/** `GET /admin/session_log/sessions`. */
+export function narrowSessionLogSessionsResponse(raw: unknown): SessionLogWireSessionsResult {
+  return narrowRest(S_SessionLogWireSessionsResult, raw, "session list");
+}
+
+/** `GET /networks/:slug/featured`. */
+export function narrowFeaturedChannelsResponse(
+  raw: unknown,
+): NetworksFeaturedChannelsWireIndexPayload {
+  return narrowRest(S_NetworksFeaturedChannelsWireIndexPayload, raw, "featured channel list");
+}
+
+/** `GET /networks/:slug/directory`. */
+export function narrowDirectoryPageResponse(raw: unknown): ChannelDirectoryWireIndexPayload {
+  return narrowRest(S_ChannelDirectoryWireIndexPayload, raw, "channel directory page");
 }


### PR DESCRIPTION
Bucket **K rest-boundary** of the 2026-08-15 architecture review, first slice.

The WS edge narrows every payload from `unknown`; the REST edge asserted
`(await res.json()) as X` at **83** sites. Same wire, two drift-detection
guarantees. Under a cast a response one vintage behind — normal, since cic
deploys independently of its server — lands as a type-checked value with a
missing field and surfaces as `undefined` in a renderer rather than as a
rejection at the boundary.

## The cut: 24 / 3 / 56 = 83

- **24 converted here** — the sites whose target is one-to-one with a
  generated schema. **12 shapes**, 24 call sites, 20 controller actions behind
  them.
- **3 left out** — the bare arrays (`as ScrollbackMessage[]` ×2,
  `as ChannelEntry[]` ×1). The ELEMENT has a schema; the top-level array does
  not. Composing that array node by hand in the client would be **a second
  SSOT of the schema** — the very defect this issue removes, moved one file
  over. The right place for it is server-side.
- **56 left out** — no generated envelope exists for them at all, because REST
  envelopes are inline literals in controllers rather than `*.Wire` modules.
  **Gated on #1393**: what unblocks them is giving those envelopes a Wire
  module so the codegen can emit their schemas. Named, not forgotten.

## The failure mode: FAIL LOUD, in one place

Per vjt's ruling (the single authoritative version lives in the body of
#1400): a **missing required field** makes the boundary reject the payload and
the surface fail **visibly**. It does not fall through to `undefined` and
degrade silently. **Extra fields stay harmless** — the contract is additive
(#447), and `validate` already ignores undeclared keys rather than rejecting.

That mode lives in exactly one function, `narrowRest`. The twelve narrowers
pick a schema and a label and decide nothing else; thirteen copies of a throw
would be thirteen chances to soften one of them into a silent default. When a
tolerance is genuinely needed it goes where the house already puts it — a
named wrapper around the validate call, as `old_nick` does in
`narrowSessionLogEntry`. #1393 measured that exactly three of ~30 arms ever
needed one.

`wireNarrow.ts` remains the only module that names a generated `S_*` constant.

## `POST /messages` is a union discriminated by the STATUS

This door does not have one shape, and the client was not reading the
discriminant. `MessagesController.render_send_result/2` answers:

- **201** + the persisted row (`Grappa.Scrollback.Wire.to_json/1`)
- **202** + `{ok: true}` — an ack for a send the server deliberately did not
  persist: a `*Serv` target, `/notice` to a service, a no-persist CTCP

**`res.ok` is not the discriminant — the status is.** 202 is `res.ok`, so the
old cast covered both arms and handed the caller an object with no `id`.

It now reads the status: 201 narrows strictly, 202 returns `null` — "accepted,
no row", which is not a failure. The 202 body is neither narrowed nor cast;
writing a schema for two keys the server never typespec'd would be the second
SSOT again. The `scrollback.ts` consumer skips the read-cursor advance on
`null` rather than running its gate against an absent id.

Filed separately as **#1430**. This **mitigates it at this one door and does
not close it**: it does not audit the other REST doors for the same
status-discriminated shape, and it does not establish whether the `undefined`
cursor write ever reached the server. #1430 stays open, deliberately with no
`Closes` keyword.

## What the conversion changes about the value

A cast handed the caller the parsed body **verbatim**. `validate` hands back an
object **RECONSTRUCTED** from the declared fields only (`walkObject`,
`wireValidate.ts:223` — "Undeclared keys are dropped, never rejected"). A key
the server sends that its own typespec does not declare is now dropped here
rather than travelling on unnoticed.

Whether any such key exists was measured before a line was written, because
silent data loss would be worse than the defect being fixed. **Zero hits**, and
established by READING, not by grep:

- **The 20 controller actions behind the 12 shapes, across 11 server files,
  read one by one.** Every one renders a `*.Wire` / `*.AdminWire` result and
  none attaches sibling keys to it — the "half-Wire" pattern #1393 records as
  A7 does not occur on any of them.
- **The 12 Wire builders too**, because a `Map.put` grep sees neither a
  pass-through nor a conditional omission. Ten are single unconditional map
  literals whose keys are exactly the `@type`'s. The two pass-throughs are the
  real candidates and both come back negative: `ChannelDirectory.Wire` receives
  entries its context builds with three explicit keys and adds the declared
  `featured`; `FeaturedChannels.Wire` wraps a `select` that projects exactly
  the two declared keys.

A corollary worth keeping: no builder omits a declared key conditionally, so
strict validation cannot reject ordinary traffic for a shape that varies.

## Where the evidence stops

🔴 The reading above covers the **success** arms. That the other 19 render
paths have a single shape on **every error arm** is a **deduction about the
routing** — error arms exit through `FallbackController`, hence `!res.ok`,
hence cic throws before reaching a narrower — **not a reading of
`FallbackController`**. Anyone extending this work should see where the
measurement ends and the inference begins.

Equally: the reconstruction is shape-preserving **as measured today**. That is
a measurement, not a guarantee.

## The nine local aliases are kept

`ScrollbackMessage = ScrollbackWireT` and its eight siblings are **pure aliases
to the generated types** — they carry no drift channel, they *are* the codegen
output. Replacing them with direct imports would touch dozens of files and
close nothing. (An earlier plan for this work said to delete them; it was
written before the aliases were distinguished from the hand-written mirrors.)

## Tests

13 new cases. They were written **after** the implementation, so a green run
proves little on its own — each was falsified by injecting a mutant on the
commit and reverting it:

- **`narrowRest` returns the value instead of throwing** (the fail-loud policy
  removed, everything else identical) → **6 assertions red**, exactly the six
  that name the throw. The cases covering reconstruction, additive tolerance,
  valid pass-through and 202→`null` stayed green, which is correct: they do not
  speak about the throw.
- **`if (res.status === 202) return null;` deleted** → **1 assertion red**, the
  one that names it.

The second mutant surfaced a guarantee rather than just a test result: with the
status branch gone, the 202 body reaches `narrowMessageResponse` and **throws**.
**#1430 is therefore no longer reintroducible silently** — the worst case is
loud.

## Gates

cic-only, from the worktree root:

| gate | result |
|---|---|
| `scripts/bun.sh run check` | RC=0 — 59 warnings, **identical to the pre-change baseline** |
| `scripts/bun.sh x tsc --noEmit` | RC=0 (run separately: a biome failure short-circuits tsc) |
| `scripts/bun.sh run test` | RC=0 — 287 files, 5533 tests (baseline 5520) |

No server-side gate was run: this branch touches six `cicchetto/` files and
nothing else, but that scoping is a reading of the diff, not a verdict from the
integration suite.