### PR TITLE
e2e(#1429): give a green integration run a measurement instead of silence

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -207,3 +207,16 @@ jobs:
           path: cicchetto/e2e/container-logs/
           retention-days: 14
           if-no-files-found: ignore
+
+      - name: Upload log gap census
+        # #1429 — the measurement taken from the same streams, on EVERY
+        # run. The artifact above stays failure-only because it is ~20 MB
+        # compressed; this one is a few KB, and it is what stops the ~91%
+        # of runs that pass from being unaskable about a stack stall.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: log-gap-census
+          path: cicchetto/e2e/container-logs/gap-scan.tsv
+          retention-days: 14
+          if-no-files-found: ignore

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -912,15 +912,69 @@ extraction on the rare interesting green and nothing at all on a clean
 one — the alternative, teeing 253 MB to disk on every green and
 unlinking it afterwards, pays on the common case to save on the rare.
 
+**🔴 READING THE CENSUS: a gap does not tell you which way the
+causation runs.** A silence in a container's log is not evidence that
+the container was stuck. A Playwright spec hung on a locator stops
+driving the stack, and a server with no traffic logs nothing — so the
+silence can be the EFFECT of the failure rather than its cause. This is
+not hypothetical: the first real red this instrument met showed a
+16.7 s silence on `grappa-test` spanning exactly the failing spec's
+lifetime (provisioned 14:40:14, silence 14:40:15.008 → 14:40:31.720,
+failed 14:40:32) — and that spec then passed 3/3 in isolation, with
+every damage counter at zero. Read it as an environment stall and you
+would have exonerated a spec on no evidence.
+
+So:
+
+| what the census shows | what it licenses |
+|---|---|
+| gap **+ a damage signature** (`db30` / `idle30` / `dropped` / `saturated`) | a stall — the environment is implicated, the spec is not |
+| **bare gap**, every damage counter zero | **nothing.** Traffic drought and a stalled process look identical from here |
+
+The counters therefore live on the same line as the gap, deliberately:
+the gap alone is not a verdict, and putting them in a separate report
+invites reading it as one.
+
 **ATTRIBUTION and RETENTION are different jobs, and only the first is
 single-criterion.** Blaming a red uses ONE rule — a silence at or over
-`GAP_THRESHOLD` — and that rule stands alone. Deciding what evidence to
+`GAP_THRESHOLD` **carrying a damage signature** — and that rule stands
+alone. Deciding what evidence to
 still have tomorrow answers a different question, and there a silence
 is only a PROXY for the mechanism while a dropped row IS the damage. So
-retention fires on **a gap ≥ `GAP_THRESHOLD` OR a non-zero `dropped`**.
-Retaining only on the gap would make *damage WITHOUT a stall*
-permanently unobservable — the class nobody can currently prove exists,
-precisely because its evidence was always discarded.
+retention fires on **a gap ≥ `GAP_THRESHOLD` on an ELIGIBLE SERVICE, OR
+a non-zero `dropped`**. Retaining only on the gap would make *damage
+WITHOUT a stall* permanently unobservable — the class nobody can
+currently prove exists, precisely because its evidence was always
+discarded.
+
+**Eligible means "a container whose silence means something", and the
+set is derived, not listed.** A container that exited CLEANLY is a
+one-shot that finished — the cic build, the cert init — and its silence
+is the interval between invocations. Measured: `cicchetto-build-test`
+exceeded the threshold on both runs it was observed on (111.3 s and
+12.9 s), so retaining on it would retain on essentially every run and
+restore the landfill. A container that exited NON-ZERO crashed, and its
+silence does mean something.
+
+⚠️ **The discriminant is the PAIR `(State, ExitCode)`, never the exit
+code alone.** Sampled on a live stack rather than assumed:
+
+```
+hub|running|0          <- a RUNNING container also reports 0
+cert-init|exited|0     <- a completed one-shot
+grappa-test|running|0
+```
+
+Key on the code by itself and every running service becomes ineligible:
+retention stops firing entirely while the census keeps printing a
+verdict it is no longer computing. `retention_eligible_services` is
+therefore `!(State == exited && ExitCode == 0)`, and
+`integration_log_capture_test.bats` carries a case for exactly that
+mutant.
+
+The census still measures every container — a build one-shot's gap is
+reported and simply retains nothing, which is why the field is named
+`by_service_gap` and not `by_gap`.
 
 **The census records WHICH trigger fired**, as its last line:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -897,13 +897,35 @@ below the 30 s `busy_timeout`), and counts of the damage signatures
 (`db=3xxxx`, `idle=3xxxx`, a dropped scrollback row, a saturated pool).
 That lands in `container-logs/gap-scan.tsv`, a few KB, and on stdout as
 well — on a green CI run the job log is the copy that survives without
-an artifact. `tee` is the mechanism: on a red the stream reaches both
-the disk and the scanner, on a green only the scanner. The workflow
-uploads the census with `if: always()` and leaves the three existing
-`if: failure()` artifact steps alone.
+an artifact. `tee` is the mechanism: the stream reaches the scanner
+either way, and the disk only when the bytes are being kept. The
+workflow uploads the census with `if: always()` and leaves the three
+existing `if: failure()` artifact steps alone.
 
-This is evidence collection, not a gate: neither branch of the trap
-touches the exit code, and a green run stays green.
+**A green run that MEASURED a stall keeps its bytes.** Discarding them
+on every green would throw the evidence away in exactly the interesting
+case: a census reading *"30 s hole on a passing run"* is the first
+non-blind green there has ever been, and a census cannot be
+forensicked. So `census_tripped` re-reads the census it just wrote and,
+if any silence was named, captures again with the bytes. Costs a second
+extraction on the rare interesting green and nothing at all on a clean
+one. The trigger is the scanner's OWN verdict at `GAP_THRESHOLD` — the
+same threshold that attributes the reds, deliberately not a second
+criterion to keep in step. Known consequence: a damage signature
+WITHOUT a silence (a dropped row, a saturated pool, neither preceded by
+a gap ≥10 s) is reported in the census but does not retain the bytes.
+
+That makes the scanner load-bearing in a way a report never is: it no
+longer describes the run, it decides what evidence survives it. A
+silent change to what counts as a gap would move the retention policy
+without touching the script that implements it — which is why
+`scripts/log-gap-scan.awk` is pinned clause by clause in
+`test/scripts/log_gap_scan_test.bats` (threshold boundary from both
+sides, arithmetic, midnight rollover, one case per damage signature,
+and the refusal to default a missing threshold).
+
+This is evidence collection, not a gate: no branch of the trap touches
+the exit code, and a green run stays green.
 
 **The service list for that capture is DERIVED, never hand-written
 (the #441 lesson).** A hand list stops covering the service added after

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -873,12 +873,37 @@ destroys the containers — by the time a CI workflow step could run
 failure would have to be diagnosed from the browser side alone. The
 Playwright trace shows the browser half of a failure whose cause is
 usually upstream (grappa, bahamut, services). One file per container.
-Capture is failure-only: a green run's logs answer no question, and
-capturing them every time is how an artifact store becomes a landfill.
 The run prints the captured sizes, so what this costs per failed run is
 a measurement rather than an estimate — that is the number to revisit
 if it ever grows into something worth capping. `KEEP_STACK=1` opts out
 of the tear-down entirely for iterative debugging.
+
+**The BYTES are failure-only; the MEASUREMENT is not (#1429).** Keeping
+every run's logs is how an artifact store becomes a landfill — ~275 MB
+uncompressed per run, ~20 MB in the artifact, and a fortnight's green
+runs are on the order of 9 GB. But discarding them wholesale made the
+other half of the sentence false: a green run's logs answered the one
+question nobody could otherwise ask, because the open question about
+the 30.1 s stall regime (#1420, #1421) is whether it also hits the runs
+that PASS, and those were exactly the runs kept blind. The census that
+came out of that investigation covered 7 of 59 runs *that produced
+logs* — never 7 of 626, because the other 567 were never asked.
+
+So the trap now streams each service's log through
+`scripts/log-gap-scan.awk` on every exit and keeps only what it
+measured: the largest silence between consecutive lines, every silence
+at or over `GAP_THRESHOLD` (10 s — above the 5 s healthcheck cadence,
+below the 30 s `busy_timeout`), and counts of the damage signatures
+(`db=3xxxx`, `idle=3xxxx`, a dropped scrollback row, a saturated pool).
+That lands in `container-logs/gap-scan.tsv`, a few KB, and on stdout as
+well — on a green CI run the job log is the copy that survives without
+an artifact. `tee` is the mechanism: on a red the stream reaches both
+the disk and the scanner, on a green only the scanner. The workflow
+uploads the census with `if: always()` and leaves the three existing
+`if: failure()` artifact steps alone.
+
+This is evidence collection, not a gate: neither branch of the trap
+touches the exit code, and a green run stays green.
 
 **The service list for that capture is DERIVED, never hand-written
 (the #441 lesson).** A hand list stops covering the service added after

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -902,18 +902,41 @@ either way, and the disk only when the bytes are being kept. The
 workflow uploads the census with `if: always()` and leaves the three
 existing `if: failure()` artifact steps alone.
 
-**A green run that MEASURED a stall keeps its bytes.** Discarding them
-on every green would throw the evidence away in exactly the interesting
-case: a census reading *"30 s hole on a passing run"* is the first
-non-blind green there has ever been, and a census cannot be
-forensicked. So `census_tripped` re-reads the census it just wrote and,
-if any silence was named, captures again with the bytes. Costs a second
+**A green run that measured something keeps its bytes.** Discarding
+them on every green would throw the evidence away in exactly the
+interesting case: a census reading *"30 s hole on a passing run"* is
+the first non-blind green there has ever been, and a census cannot be
+forensicked. So the trap re-reads the census it just wrote and, if
+either trigger fired, captures again with the bytes. Costs a second
 extraction on the rare interesting green and nothing at all on a clean
-one. The trigger is the scanner's OWN verdict at `GAP_THRESHOLD` — the
-same threshold that attributes the reds, deliberately not a second
-criterion to keep in step. Known consequence: a damage signature
-WITHOUT a silence (a dropped row, a saturated pool, neither preceded by
-a gap ≥10 s) is reported in the census but does not retain the bytes.
+one — the alternative, teeing 253 MB to disk on every green and
+unlinking it afterwards, pays on the common case to save on the rare.
+
+**ATTRIBUTION and RETENTION are different jobs, and only the first is
+single-criterion.** Blaming a red uses ONE rule — a silence at or over
+`GAP_THRESHOLD` — and that rule stands alone. Deciding what evidence to
+still have tomorrow answers a different question, and there a silence
+is only a PROXY for the mechanism while a dropped row IS the damage. So
+retention fires on **a gap ≥ `GAP_THRESHOLD` OR a non-zero `dropped`**.
+Retaining only on the gap would make *damage WITHOUT a stall*
+permanently unobservable — the class nobody can currently prove exists,
+precisely because its evidence was always discarded.
+
+**The census records WHICH trigger fired**, as its last line:
+
+```
+RUN	RETENTION	kept=yes	by_gap=0	by_dropped=1
+```
+
+Retained is not the same as countable. With the field, *damage without
+a stall* is one grep over the uploaded artifacts
+(`kept=yes by_gap=0 by_dropped=1`); without it, the class is kept and
+still unmeasurable. The line is written AFTER the last capture, because
+the capture truncates the census and a verdict written earlier would be
+wiped by it. It is recorded on reds too: retention is unconditional
+there, but *what was observed* is not, and a red carrying damage
+without a stall has to stay countable alongside the greens. If the
+volume ever grows, the cut is decided on that count, not on caution.
 
 That makes the scanner load-bearing in a way a report never is: it no
 longer describes the run, it decides what evidence survives it. A

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -18,6 +18,8 @@
 #     propagated.
 #   - Trap on EXIT runs `testnet.sh down`; on a NON-ZERO exit it first
 #     dumps every container's log to cicchetto/e2e/container-logs/.
+#   - On EVERY exit, green included, it writes a gap census beside them
+#     (#1429): the same streams, scanned in flight, a few KB.
 #   - KEEP_STACK=1 opts out of the tear-down for iterative debugging.
 #
 # Canonical "which test runner do I use?" + e2e cascade-vs-flake-vs-real-bug
@@ -38,40 +40,72 @@ GRAPPA_VERSION="$("$SRC_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
 
 LOG_DIR="$E2E_DIR/container-logs"
+CENSUS_FILE="$LOG_DIR/gap-scan.tsv"
+SCAN_AWK="$(cd "$(dirname "$0")" && pwd)/log-gap-scan.awk"
 
-# One log file per container, written BEFORE the tear-down destroys them.
-# Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)" (#702).
+# Inter-line silence worth naming, in seconds. Above the stack's 5 s
+# healthcheck cadence, below the 30 s busy_timeout whose expiry #1420 is
+# counting — so an idle stack scores zero gaps and a stalled one scores.
+GAP_THRESHOLD=10
+
+# One log file per container, written BEFORE the tear-down destroys them,
+# plus the gap census taken from the same streams on EVERY exit.
+# Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)"
+# (#702, #1429).
+#
+# $1 is "raw" to also materialise the streams to disk, anything else to
+# keep the census alone. Required: the caller holds the exit code.
 capture_container_logs() {
-    local services svc
+    local mode="$1"
+    local services svc sink
+
     mkdir -p "$LOG_DIR"
     cd "$E2E_DIR" || return 0
 
     # DERIVED from what compose actually has containers for, never a hand
     # list. `compose run --rm` one-shots are already gone and self-exclude.
-    docker compose ps --all >"$LOG_DIR/compose-ps.txt" 2>&1 || true
+    if [ "$mode" = raw ]; then
+        docker compose ps --all >"$LOG_DIR/compose-ps.txt" 2>&1 || true
+    fi
     services="$(docker compose ps --all --services 2>/dev/null || true)"
 
+    : >"$CENSUS_FILE"
     while IFS= read -r svc; do
         [ -n "$svc" ] || continue
+        if [ "$mode" = raw ]; then sink="$LOG_DIR/$svc.log"; else sink=/dev/null; fi
         # --timestamps so a server-side event can be lined up against the
-        # trace's clock across services; --no-log-prefix because the
-        # service name is already the filename.
-        docker compose logs --no-color --timestamps --no-log-prefix "$svc" \
-            >"$LOG_DIR/$svc.log" 2>&1 || true
+        # trace's clock across services — and so the census can measure the
+        # silence BETWEEN lines; --no-log-prefix because the service name
+        # is already the filename. `tee` is what lets the ~275 MB reach the
+        # scanner without reaching the disk on a green run.
+        docker compose logs --no-color --timestamps --no-log-prefix "$svc" 2>&1 \
+            | tee "$sink" \
+            | awk -v SVC="$svc" -v THRESH="$GAP_THRESHOLD" -f "$SCAN_AWK" \
+                >>"$CENSUS_FILE" || true
     done <<<"$services"
 
-    # Print the sizes — what a failed run costs in artifacts is measured,
-    # not estimated.
-    echo "=== #702: container logs captured to $LOG_DIR ==="
-    ls -l "$LOG_DIR" || true
+    # To stdout as well: on a green run CI keeps the job log and no
+    # artifact, so this is the copy that survives by default.
+    echo "=== #1429: log gap census (threshold ${GAP_THRESHOLD}s) ==="
+    cat "$CENSUS_FILE" || true
+
+    if [ "$mode" = raw ]; then
+        # Print the sizes — what a failed run costs in artifacts is
+        # measured, not estimated.
+        echo "=== #702: container logs captured to $LOG_DIR ==="
+        ls -l "$LOG_DIR" || true
+    fi
 }
 
 cleanup() {
     local rc=$?
 
-    # Failure-only — a green run's logs answer no question.
+    # The census on both exits; the bytes only on a red. Evidence
+    # collection, never an assertion — neither branch touches $rc.
     if [ "$rc" -ne 0 ]; then
-        capture_container_logs
+        capture_container_logs raw
+    else
+        capture_container_logs census-only
     fi
 
     if [ "${KEEP_STACK:-}" != "1" ]; then

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -97,15 +97,31 @@ capture_container_logs() {
     fi
 }
 
+# Did the census name at least one silence at or over GAP_THRESHOLD? This
+# is the retention trigger, so it reads the scanner's OWN verdict rather
+# than re-deciding what a stall is — one criterion, not two.
+census_tripped() {
+    grep -q -- $'\tGAP\t' "$CENSUS_FILE" 2>/dev/null
+}
+
 cleanup() {
     local rc=$?
 
-    # The census on both exits; the bytes only on a red. Evidence
-    # collection, never an assertion — neither branch touches $rc.
+    # The census on both exits; the bytes on a red, and on a green only
+    # when the census itself tripped. Evidence collection, never an
+    # assertion — no branch here touches $rc.
     if [ "$rc" -ne 0 ]; then
         capture_container_logs raw
     else
         capture_container_logs census-only
+        if census_tripped; then
+            # The one green worth its bytes: a measured stall on a passing
+            # run is the first non-blind green there has been, and a
+            # census cannot be forensicked. Costs a second extraction,
+            # which is the right place to spend it.
+            echo "=== #1429: census tripped on a GREEN run — keeping the bytes ==="
+            capture_container_logs raw
+        fi
     fi
 
     if [ "${KEEP_STACK:-}" != "1" ]; then

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -107,8 +107,41 @@ capture_container_logs() {
 # the bytes of a run that lost data without stalling would make "damage
 # WITHOUT a stall" permanently unobservable — the class nobody can
 # currently prove exists.
-census_has_gap() {
-    grep -q -- $'\tGAP\t' "$CENSUS_FILE" 2>/dev/null
+#
+# And a silence is only a trigger where silence MEANS something — see
+# retention_eligible_services below.
+
+# Services whose silence means something, DERIVED from compose rather
+# than hand-listed (the #441 lesson again).
+#
+# A container that EXITED CLEANLY is a one-shot that finished — the cic
+# build, the cert init. Its silence is the interval between invocations,
+# not a stall: measured at 111.3 s and 12.9 s on two consecutive runs, so
+# retaining on it would retain on essentially every run and restore the
+# landfill this change exists to avoid. A container that exited NON-ZERO
+# crashed, and its silence does mean something.
+#
+# The discriminant is the PAIR, never the code alone. Sampled on a live
+# stack: `hub|running|0` — a RUNNING container reports ExitCode 0 exactly
+# like a completed one-shot. Keying on the code would make every service
+# ineligible and retention would stop firing while still printing a
+# verdict.
+retention_eligible_services() {
+    cd "$E2E_DIR" || return 0
+    docker compose ps --all --format '{{.Service}}\t{{.State}}\t{{.ExitCode}}' 2>/dev/null \
+        | awk -F'\t' '!($2 == "exited" && $3 == "0") { print $1 }'
+}
+
+# A silence on one of those services. Not "a silence anywhere".
+census_has_service_gap() {
+    local svc
+    while IFS= read -r svc; do
+        [ -n "$svc" ] || continue
+        if grep -q -- "^$svc"$'\tGAP\t' "$CENSUS_FILE" 2>/dev/null; then
+            return 0
+        fi
+    done < <(retention_eligible_services)
+    return 1
 }
 
 census_has_dropped() {
@@ -119,13 +152,13 @@ census_has_dropped() {
 # "damage without a stall" COUNTABLE across artifacts rather than merely
 # retained: one grep over the uploads answers whether the class exists.
 record_retention() {
-    printf 'RUN\tRETENTION\tkept=%s\tby_gap=%s\tby_dropped=%s\n' \
+    printf 'RUN\tRETENTION\tkept=%s\tby_service_gap=%s\tby_dropped=%s\n' \
         "$1" "$2" "$3" >>"$CENSUS_FILE"
 }
 
 cleanup() {
     local rc=$?
-    local by_gap=0 by_dropped=0 kept=no
+    local by_service_gap=0 by_dropped=0 kept=no
 
     # The census on both exits; the bytes on a red, and on a green when
     # either trigger fired. Evidence collection, never an assertion — no
@@ -137,10 +170,10 @@ cleanup() {
         capture_container_logs census-only
     fi
 
-    if census_has_gap; then by_gap=1; fi
+    if census_has_service_gap; then by_service_gap=1; fi
     if census_has_dropped; then by_dropped=1; fi
 
-    if [ "$kept" = no ] && { [ "$by_gap" = 1 ] || [ "$by_dropped" = 1 ]; }; then
+    if [ "$kept" = no ] && { [ "$by_service_gap" = 1 ] || [ "$by_dropped" = 1 ]; }; then
         # The one green worth its bytes. Costs a second extraction, which
         # is the right place to spend it.
         echo "=== #1429: census tripped on a GREEN run — keeping the bytes ==="
@@ -150,7 +183,7 @@ cleanup() {
 
     # AFTER the last capture: capture_container_logs truncates the census,
     # so a verdict written before it would be wiped by it.
-    record_retention "$kept" "$by_gap" "$by_dropped"
+    record_retention "$kept" "$by_service_gap" "$by_dropped"
 
     if [ "${KEEP_STACK:-}" != "1" ]; then
         "$TESTNET" down 2>&1 || true

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -97,32 +97,60 @@ capture_container_logs() {
     fi
 }
 
-# Did the census name at least one silence at or over GAP_THRESHOLD? This
-# is the retention trigger, so it reads the scanner's OWN verdict rather
-# than re-deciding what a stall is — one criterion, not two.
-census_tripped() {
+# The two retention triggers, read off the census the trap just wrote.
+#
+# ATTRIBUTION and RETENTION are different jobs, and only the first is
+# single-criterion. Blaming a red uses ONE rule — a silence at or over
+# GAP_THRESHOLD — and that rule is untouched here. Deciding what evidence
+# to still have tomorrow is the other job, and there a silence is only a
+# PROXY for the mechanism while a dropped row IS the damage. Discarding
+# the bytes of a run that lost data without stalling would make "damage
+# WITHOUT a stall" permanently unobservable — the class nobody can
+# currently prove exists.
+census_has_gap() {
     grep -q -- $'\tGAP\t' "$CENSUS_FILE" 2>/dev/null
+}
+
+census_has_dropped() {
+    grep -qE -- $'\tdropped=[1-9]' "$CENSUS_FILE" 2>/dev/null
+}
+
+# Which trigger fired, as the census's last line. Costs nothing and makes
+# "damage without a stall" COUNTABLE across artifacts rather than merely
+# retained: one grep over the uploads answers whether the class exists.
+record_retention() {
+    printf 'RUN\tRETENTION\tkept=%s\tby_gap=%s\tby_dropped=%s\n' \
+        "$1" "$2" "$3" >>"$CENSUS_FILE"
 }
 
 cleanup() {
     local rc=$?
+    local by_gap=0 by_dropped=0 kept=no
 
-    # The census on both exits; the bytes on a red, and on a green only
-    # when the census itself tripped. Evidence collection, never an
-    # assertion — no branch here touches $rc.
+    # The census on both exits; the bytes on a red, and on a green when
+    # either trigger fired. Evidence collection, never an assertion — no
+    # branch here touches $rc.
     if [ "$rc" -ne 0 ]; then
         capture_container_logs raw
+        kept=yes
     else
         capture_container_logs census-only
-        if census_tripped; then
-            # The one green worth its bytes: a measured stall on a passing
-            # run is the first non-blind green there has been, and a
-            # census cannot be forensicked. Costs a second extraction,
-            # which is the right place to spend it.
-            echo "=== #1429: census tripped on a GREEN run — keeping the bytes ==="
-            capture_container_logs raw
-        fi
     fi
+
+    if census_has_gap; then by_gap=1; fi
+    if census_has_dropped; then by_dropped=1; fi
+
+    if [ "$kept" = no ] && { [ "$by_gap" = 1 ] || [ "$by_dropped" = 1 ]; }; then
+        # The one green worth its bytes. Costs a second extraction, which
+        # is the right place to spend it.
+        echo "=== #1429: census tripped on a GREEN run — keeping the bytes ==="
+        capture_container_logs raw
+        kept=yes
+    fi
+
+    # AFTER the last capture: capture_container_logs truncates the census,
+    # so a verdict written before it would be wiped by it.
+    record_retention "$kept" "$by_gap" "$by_dropped"
 
     if [ "${KEEP_STACK:-}" != "1" ]; then
         "$TESTNET" down 2>&1 || true

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -11,6 +11,26 @@
 # the MEASUREMENT taken from those same bytes costs a few KB, so the
 # stream is scanned in flight and only a red materialises it to disk.
 #
+# 🔴 HOW TO READ A GAP — the direction of causation is NOT given.
+#
+# A silence in a log is not evidence that the process was stuck. A
+# Playwright spec hung on a locator stops driving the stack, and a server
+# with no traffic logs nothing: the silence is then the EFFECT of the
+# failure, not its cause. Measured instance — a 16.7 s silence on
+# grappa-test spanning exactly the lifetime of a failing spec (provision
+# 14:40:14, silence 14:40:15.008 -> 14:40:31.720, failure 14:40:32), with
+# every damage counter at zero, and that spec passing 3/3 in isolation.
+#
+#   gap + a DAMAGE SIGNATURE (db30 / idle30 / dropped / saturated)
+#       => a stall. The environment is implicated, the spec is not.
+#   BARE gap (every damage counter zero)
+#       => attributes NOTHING. Traffic drought and a stalled process
+#          look identical from here.
+#
+# This is why the counters share the line with the gap rather than living
+# in a separate report: the gap alone is not a verdict, and separating
+# them invites reading it as one.
+#
 # What it reports, per service:
 #   - the largest silence between consecutive timestamped lines, and when
 #     it started. A quiet stack still logs its 5 s healthcheck cadence, so

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -1,0 +1,76 @@
+#!/usr/bin/awk -f
+#
+# #1429 — one streaming pass over a `docker compose logs --timestamps`
+# stream, emitting a few hundred bytes instead of a few hundred megabytes.
+#
+# WHY THIS EXISTS. scripts/integration.sh used to keep the containers'
+# logs only when the suite went red, so roughly 91% of runs left no
+# server-side evidence at all — and the open question about the 30.1 s
+# stall regime (#1420, #1421) is precisely whether it also hits the runs
+# that pass. Keeping ~275 MB per green run was never affordable; keeping
+# the MEASUREMENT taken from those same bytes costs a few KB, so the
+# stream is scanned in flight and only a red materialises it to disk.
+#
+# What it reports, per service:
+#   - the largest silence between consecutive timestamped lines, and when
+#     it started. A quiet stack still logs its 5 s healthcheck cadence, so
+#     a maxgap materially above that is the signal.
+#   - every silence at or over THRESH seconds, individually.
+#   - counts of the damage signatures that accompany the regime: a
+#     statement or a checked-out connection held for 30-something seconds
+#     (db=3xxxx / idle=3xxxx), a dropped scrollback row, a saturated pool.
+#
+# Usage: awk -v SVC=<service> -v THRESH=<seconds> -f log-gap-scan.awk
+#
+# THRESH is REQUIRED. A defaulted threshold would let a caller that forgot
+# it report a plausible-looking census measured against something other
+# than what the caller meant.
+
+BEGIN {
+    if (THRESH + 0 <= 0) {
+        print "log-gap-scan.awk: -v THRESH=<seconds> is required" >"/dev/stderr"
+        missing_thresh = 1
+        exit 2
+    }
+    prev = -1
+    maxgap = 0
+    maxat = ""
+    ngap = 0
+    db30 = 0
+    idle30 = 0
+    dropped = 0
+    saturated = 0
+    lines = 0
+}
+
+{
+    lines++
+
+    # `docker logs --timestamps` prefixes RFC3339: 2026-08-16T12:09:04.535…Z.
+    # Positions rather than a regex — this runs over a million lines.
+    if (substr($0, 5, 1) == "-" && substr($0, 11, 1) == "T") {
+        t = substr($0, 12, 2) * 3600 + substr($0, 15, 2) * 60 + substr($0, 18, 9)
+        if (prev >= 0) {
+            d = t - prev
+            if (d < 0) d += 86400          # midnight rollover
+            if (d > maxgap) { maxgap = d; maxat = prevstamp }
+            if (d >= THRESH) {
+                ngap++
+                printf "%s\tGAP\t%.1f\t%s -> %s\n", SVC, d, prevstamp, substr($0, 12, 12)
+            }
+        }
+        prev = t
+        prevstamp = substr($0, 12, 12)
+    }
+
+    if ($0 ~ /db=3[0-9][0-9][0-9][0-9]\./) db30++
+    if ($0 ~ /idle=3[0-9][0-9][0-9][0-9]\./) idle30++
+    if ($0 ~ /scrollback row dropped/) dropped++
+    if ($0 ~ /saturated for the full/) saturated++
+}
+
+END {
+    if (missing_thresh) exit 2
+    printf "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\n", \
+        SVC, lines, maxgap, maxat, THRESH, ngap, db30, idle30, dropped, saturated
+}

--- a/test/scripts/integration_log_capture_test.bats
+++ b/test/scripts/integration_log_capture_test.bats
@@ -81,9 +81,17 @@ EOF
 { printf 'docker'; for a in "\$@"; do printf ' %s' "\$a"; done; printf '\n'; } >> "$LOG"
 case "\$2" in
     ps)
-        if [[ " \$* " == *" --services "* ]]; then
+        if [[ " \$* " == *" --format "* ]]; then
+            # Service / State / ExitCode, the shape measured on a live
+            # stack. Note hub: a RUNNING container also reports 0, which
+            # is why the discriminant is the PAIR and not the code alone.
+            printf 'grappa-test\t%s\t%s\n' "\${FAKE_GRAPPA_STATE:-running}" "\${FAKE_GRAPPA_EXIT:-0}"
+            printf 'hub\trunning\t0\n'
+            printf 'newcomer-svc\trunning\t0\n'
+            printf 'builder-oneshot\texited\t0\n'
+        elif [[ " \$* " == *" --services "* ]]; then
             # 'newcomer-svc' is the derivation probe: no hand list has it.
-            printf '%s\n' grappa-test hub newcomer-svc
+            printf '%s\n' grappa-test hub newcomer-svc builder-oneshot
         else
             printf 'NAME STATUS\n'
         fi
@@ -111,6 +119,13 @@ case "\$2" in
                     printf '2026-08-16T12:09:09.535000000Z healthcheck ok\n'
                     ;;
             esac
+        elif [ "\$svc" = builder-oneshot ]; then
+            # A build container's silence is the interval BETWEEN two
+            # invocations, not a stall. Measured at 111.3 s and 12.9 s on
+            # two real runs — it trips on essentially every run, which is
+            # why it must never retain anything by itself.
+            printf '2026-08-16T14:33:51.370000000Z files generated\n'
+            printf '2026-08-16T14:35:42.634000000Z bun install v1.3.14\n'
         else
             printf 'fake container output for %s\n' "\$svc"
         fi
@@ -175,7 +190,7 @@ first_line() {
     # The verdict is recorded on a red too. Retention is unconditional
     # here, but WHAT was observed still is not — a red that carried damage
     # without a stall has to stay countable alongside the greens.
-    grep -q 'RETENTION.*kept=yes.*by_gap=1.*by_dropped=1' "$CENSUS"
+    grep -q 'RETENTION.*kept=yes.*by_service_gap=1.*by_dropped=1' "$CENSUS"
 }
 
 @test "a CLEAN green run writes the census and keeps no raw logs" {
@@ -197,12 +212,19 @@ first_line() {
     grep -q 'grappa-test.*maxgap=5.0' "$CENSUS"
     grep -q 'grappa-test.*gaps_ge_10=0' "$CENSUS"
     grep -q 'grappa-test.*dropped=0' "$CENSUS"
-    refute grep -q 'GAP' "$CENSUS"
     # A quiet service reads as quiet rather than as missing.
     grep -q 'hub.*maxgap=0.0' "$CENSUS"
 
-    # The 275 MB is the thing that could not be kept on every green: with
-    # nothing measured, there is nothing to forensick, so the bytes go.
+    # MEASURING and RETAINING are two jobs. The build one-shot's 111 s
+    # silence IS censused — dropping it from the measurement would hide a
+    # build that got slower — and it retains NOTHING, because a container
+    # that is quiet while not building is not stalled. Both halves, or
+    # this pins only one of them.
+    grep -q '^builder-oneshot	GAP	111.3' "$CENSUS"
+    grep -q 'RETENTION.*by_service_gap=0' "$CENSUS"
+
+    # The 253 MB is the thing that could not be kept on every green: with
+    # nothing measured on a SERVICE, there is nothing to forensick.
     [ ! -e "$LOGS_DIR/grappa-test.log" ]
     [ ! -e "$LOGS_DIR/hub.log" ]
     [ ! -e "$LOGS_DIR/compose-ps.txt" ]
@@ -214,7 +236,7 @@ first_line() {
     # The verdict is recorded even when nothing was retained, so "no
     # damage" and "not looked at" stay distinguishable in the artifact.
     grep -q 'RETENTION.*kept=no' "$CENSUS"
-    grep -q 'RETENTION.*by_gap=0.*by_dropped=0' "$CENSUS"
+    grep -q 'RETENTION.*by_service_gap=0.*by_dropped=0' "$CENSUS"
 
     # ...and the stack still came down.
     grep -q 'testnet down' "$LOG"
@@ -236,7 +258,7 @@ first_line() {
     [ -s "$LOGS_DIR/compose-ps.txt" ]
     grep -q 'db=30064.1ms query returned' "$LOGS_DIR/grappa-test.log"
 
-    grep -q 'RETENTION.*kept=yes.*by_gap=1' "$CENSUS"
+    grep -q 'RETENTION.*kept=yes.*by_service_gap=1' "$CENSUS"
 }
 
 @test "a green run with DAMAGE but no stall keeps the bytes, and says so" {
@@ -250,7 +272,7 @@ first_line() {
     grep -q 'grappa-test.*maxgap=5.0' "$CENSUS"
     grep -q 'grappa-test.*gaps_ge_10=0' "$CENSUS"
     grep -q 'grappa-test.*dropped=1' "$CENSUS"
-    refute grep -q 'GAP' "$CENSUS"
+    refute grep -q '^grappa-test	GAP' "$CENSUS"
 
     # Retention is a different job from attribution. A gap is a proxy for
     # a mechanism; a dropped row IS the damage. Discarding the bytes here
@@ -261,5 +283,32 @@ first_line() {
 
     # And the census says WHICH trigger fired, so that class becomes
     # countable rather than merely retained: one grep over the artifacts.
-    grep -q 'RETENTION.*kept=yes.*by_gap=0.*by_dropped=1' "$CENSUS"
+    grep -q 'RETENTION.*kept=yes.*by_service_gap=0.*by_dropped=1' "$CENSUS"
+}
+
+@test "a CRASHED service is still a service: its silence retains" {
+    cd "$MAIN"
+    # Exited, but NON-ZERO. This is the hole in "skip whatever exited":
+    # a one-shot that finished and a service that died are both `exited`,
+    # and only the code tells them apart.
+    FAKE_RUNNER_RC=0 FAKE_STREAM=stall FAKE_GRAPPA_STATE=exited FAKE_GRAPPA_EXIT=1 \
+        run "$MAIN/scripts/integration.sh"
+
+    [ "$status" -eq 0 ]
+    grep -q 'RETENTION.*kept=yes.*by_service_gap=1' "$CENSUS"
+    [ -s "$LOGS_DIR/grappa-test.log" ]
+}
+
+@test "a RUNNING service reporting exit code 0 is not mistaken for a one-shot" {
+    cd "$MAIN"
+    # Measured on a live stack: `hub|running|0`. A running container
+    # reports ExitCode 0 exactly like a completed one-shot, so keying on
+    # the code alone would make EVERY service ineligible and retention
+    # would silently never fire again — the feature would report a
+    # verdict it had stopped computing.
+    FAKE_RUNNER_RC=0 FAKE_STREAM=stall run "$MAIN/scripts/integration.sh"
+
+    [ "$status" -eq 0 ]
+    grep -q '^grappa-test	GAP	30.1' "$CENSUS"
+    grep -q 'RETENTION.*kept=yes.*by_service_gap=1' "$CENSUS"
 }

--- a/test/scripts/integration_log_capture_test.bats
+++ b/test/scripts/integration_log_capture_test.bats
@@ -10,6 +10,14 @@
 # asserted "the logs exist" would pass against a capture placed after the
 # tear-down, i.e. against the bug.
 #
+# #1429 — and it must leave a GAP CENSUS behind on EVERY run, green
+# included. This file used to carry a test asserting the opposite ("a
+# green run captures nothing"), which pinned ~91% of runs as unable to
+# answer whether a server-side stall had happened at all. The bytes were
+# the thing that could not be kept (~275 MB per run); the census is a few
+# KB, so it is streamed out of the same `docker compose logs` and the raw
+# bytes are materialised only on a red.
+#
 # Stubs, not a real stack: a `docker` on PATH records every invocation
 # and answers the three queries the capture makes, and testnet.sh is
 # replaced by a recorder. Both append to ONE log, so the order between
@@ -19,12 +27,17 @@
 # contain — the capture derives it from `docker compose ps`, and a
 # derived set is the difference between covering the service added next
 # year and covering the one somebody remembered.
+#
+# The stub's grappa-test stream carries a real 30.064 s hole and two
+# damage signatures, so the census assertions have an oracle: a census
+# that merely EXISTS, or that reports a constant, cannot satisfy them.
 
 load ../bats_helpers
 
 setup() {
     INTEGRATION_SH="$BATS_TEST_DIRNAME/../../scripts/integration.sh"
     LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
+    SCAN_AWK="$BATS_TEST_DIRNAME/../../scripts/log-gap-scan.awk"
     VERSION_SH="$BATS_TEST_DIRNAME/../../infra/packaging/version.sh"
 
     TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
@@ -35,6 +48,9 @@ setup() {
     mkdir -p "$MAIN/scripts" "$MAIN/infra/packaging" "$MAIN/lib" "$MAIN/cicchetto/e2e"
     cp "$INTEGRATION_SH" "$MAIN/scripts/integration.sh"
     cp "$LIB_SH" "$MAIN/scripts/_lib.sh"
+    # The census scanner travels with the script that invokes it: a copy
+    # that omitted it would exercise a capture whose scanner is missing.
+    cp "$SCAN_AWK" "$MAIN/scripts/log-gap-scan.awk"
     # integration.sh derives GRAPPA_VERSION from the repo-root VERSION file
     # (#652) before anything else; under set -e it must succeed.
     cp "$VERSION_SH" "$MAIN/infra/packaging/version.sh"
@@ -72,7 +88,17 @@ case "\$2" in
             printf 'NAME STATUS\n'
         fi
         ;;
-    logs) printf 'fake container output for %s\n' "\${*: -1}" ;;
+    logs)
+        svc="\${*: -1}"
+        if [ "\$svc" = grappa-test ]; then
+            # \`docker logs --timestamps\` shape, with a 30.064 s hole
+            # between the two lines and a damage signature on each.
+            printf '2026-08-16T12:09:04.535000000Z scrollback row dropped\n'
+            printf '2026-08-16T12:09:34.599000000Z db=30064.1ms query returned\n'
+        else
+            printf 'fake container output for %s\n' "\$svc"
+        fi
+        ;;
     run)  exit "\${FAKE_RUNNER_RC:-0}" ;;
 esac
 exit 0
@@ -81,6 +107,7 @@ EOF
     export PATH="$STUB:$PATH"
 
     LOGS_DIR="$MAIN/cicchetto/e2e/container-logs"
+    CENSUS="$LOGS_DIR/gap-scan.tsv"
 }
 
 # First occurrence of a pattern in the shared invocation log, as a line
@@ -115,18 +142,53 @@ first_line() {
     [ -s "$LOGS_DIR/newcomer-svc.log" ]
     [ -s "$LOGS_DIR/compose-ps.txt" ]
 
-    grep -q 'fake container output for grappa-test' "$LOGS_DIR/grappa-test.log"
+    grep -q 'db=30064.1ms query returned' "$LOGS_DIR/grappa-test.log"
 }
 
-@test "a green run captures nothing" {
+@test "a failed run writes the census alongside the raw logs" {
+    cd "$MAIN"
+    FAKE_RUNNER_RC=1 run "$MAIN/scripts/integration.sh"
+    [ "$status" -eq 1 ]
+
+    # The red path keeps both. The census costs nothing beside the bytes,
+    # and one instrument that behaves the same on both exits is easier to
+    # keep honest than a green-only second one.
+    [ -s "$CENSUS" ]
+    grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
+}
+
+@test "a green run writes the gap census and keeps no raw logs" {
     cd "$MAIN"
     FAKE_RUNNER_RC=0 run "$MAIN/scripts/integration.sh"
+
+    # Evidence collection, not a new assertion: a green run stays green.
     [ "$status" -eq 0 ]
 
-    # Failure-only: collecting on every run is how an artifact store
-    # becomes a landfill, and a green run's logs answer no question.
-    refute grep -q 'docker compose logs' "$LOG"
-    [ ! -d "$LOGS_DIR" ]
+    # The census is written, and its service set is DERIVED — including
+    # the one no hand list contains.
+    [ -s "$CENSUS" ]
+    grep -q '^grappa-test' "$CENSUS"
+    grep -q '^hub' "$CENSUS"
+    grep -q '^newcomer-svc' "$CENSUS"
+
+    # ...and it MEASURED. These values come from the stub's stream, so a
+    # census that reported a constant, or scanned nothing, cannot pass.
+    grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
+    grep -q 'grappa-test.*dropped=1' "$CENSUS"
+    grep -q 'grappa-test.*db30=1' "$CENSUS"
+    # A quiet service reads as quiet rather than as missing.
+    grep -q 'hub.*maxgap=0.0' "$CENSUS"
+
+    # The 275 MB is the thing that could not be kept: the raw per-service
+    # logs must NOT survive a green run.
+    [ ! -e "$LOGS_DIR/grappa-test.log" ]
+    [ ! -e "$LOGS_DIR/hub.log" ]
+    [ ! -e "$LOGS_DIR/compose-ps.txt" ]
+
+    # The census also reaches stdout, which CI retains as the job log for
+    # a green run without any artifact at all.
+    grep -q 'maxgap=30.1' <<<"$output"
+
     # ...and the stack still came down.
     grep -q 'testnet down' "$LOG"
 }

--- a/test/scripts/integration_log_capture_test.bats
+++ b/test/scripts/integration_log_capture_test.bats
@@ -91,10 +91,16 @@ case "\$2" in
     logs)
         svc="\${*: -1}"
         if [ "\$svc" = grappa-test ]; then
-            # \`docker logs --timestamps\` shape, with a 30.064 s hole
-            # between the two lines and a damage signature on each.
-            printf '2026-08-16T12:09:04.535000000Z scrollback row dropped\n'
-            printf '2026-08-16T12:09:34.599000000Z db=30064.1ms query returned\n'
+            if [ "\${FAKE_STALL:-1}" = 1 ]; then
+                # \`docker logs --timestamps\` shape, with a 30.064 s hole
+                # between the two lines and a damage signature on each.
+                printf '2026-08-16T12:09:04.535000000Z scrollback row dropped\n'
+                printf '2026-08-16T12:09:34.599000000Z db=30064.1ms query returned\n'
+            else
+                # A healthy stack: the 5 s healthcheck cadence, no damage.
+                printf '2026-08-16T12:09:04.535000000Z healthcheck ok\n'
+                printf '2026-08-16T12:09:09.535000000Z healthcheck ok\n'
+            fi
         else
             printf 'fake container output for %s\n' "\$svc"
         fi
@@ -157,9 +163,9 @@ first_line() {
     grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
 }
 
-@test "a green run writes the gap census and keeps no raw logs" {
+@test "a CLEAN green run writes the census and keeps no raw logs" {
     cd "$MAIN"
-    FAKE_RUNNER_RC=0 run "$MAIN/scripts/integration.sh"
+    FAKE_RUNNER_RC=0 FAKE_STALL=0 run "$MAIN/scripts/integration.sh"
 
     # Evidence collection, not a new assertion: a green run stays green.
     [ "$status" -eq 0 ]
@@ -171,24 +177,43 @@ first_line() {
     grep -q '^hub' "$CENSUS"
     grep -q '^newcomer-svc' "$CENSUS"
 
-    # ...and it MEASURED. These values come from the stub's stream, so a
+    # ...and it MEASURED. The healthcheck cadence is named as such, so a
     # census that reported a constant, or scanned nothing, cannot pass.
-    grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
-    grep -q 'grappa-test.*dropped=1' "$CENSUS"
-    grep -q 'grappa-test.*db30=1' "$CENSUS"
+    grep -q 'grappa-test.*maxgap=5.0' "$CENSUS"
+    grep -q 'grappa-test.*gaps_ge_10=0' "$CENSUS"
+    grep -q 'grappa-test.*dropped=0' "$CENSUS"
+    refute grep -q 'GAP' "$CENSUS"
     # A quiet service reads as quiet rather than as missing.
     grep -q 'hub.*maxgap=0.0' "$CENSUS"
 
-    # The 275 MB is the thing that could not be kept: the raw per-service
-    # logs must NOT survive a green run.
+    # The 275 MB is the thing that could not be kept on every green: with
+    # nothing measured, there is nothing to forensick, so the bytes go.
     [ ! -e "$LOGS_DIR/grappa-test.log" ]
     [ ! -e "$LOGS_DIR/hub.log" ]
     [ ! -e "$LOGS_DIR/compose-ps.txt" ]
 
     # The census also reaches stdout, which CI retains as the job log for
     # a green run without any artifact at all.
-    grep -q 'maxgap=30.1' <<<"$output"
+    grep -q 'maxgap=5.0' <<<"$output"
 
     # ...and the stack still came down.
     grep -q 'testnet down' "$LOG"
+}
+
+@test "a green run that MEASURED a stall keeps the bytes too" {
+    cd "$MAIN"
+    FAKE_RUNNER_RC=0 FAKE_STALL=1 run "$MAIN/scripts/integration.sh"
+
+    # Still not a gate: measuring a stall does not fail the run.
+    [ "$status" -eq 0 ]
+    grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
+
+    # A green run that measured a stall is the first non-blind green there
+    # has ever been, and the census alone cannot be forensicked — so this
+    # is the one green whose bytes are worth keeping. The trigger is the
+    # census's OWN verdict at the same threshold, not a second criterion.
+    [ -s "$LOGS_DIR/grappa-test.log" ]
+    [ -s "$LOGS_DIR/hub.log" ]
+    [ -s "$LOGS_DIR/compose-ps.txt" ]
+    grep -q 'db=30064.1ms query returned' "$LOGS_DIR/grappa-test.log"
 }

--- a/test/scripts/integration_log_capture_test.bats
+++ b/test/scripts/integration_log_capture_test.bats
@@ -91,16 +91,26 @@ case "\$2" in
     logs)
         svc="\${*: -1}"
         if [ "\$svc" = grappa-test ]; then
-            if [ "\${FAKE_STALL:-1}" = 1 ]; then
-                # \`docker logs --timestamps\` shape, with a 30.064 s hole
-                # between the two lines and a damage signature on each.
-                printf '2026-08-16T12:09:04.535000000Z scrollback row dropped\n'
-                printf '2026-08-16T12:09:34.599000000Z db=30064.1ms query returned\n'
-            else
-                # A healthy stack: the 5 s healthcheck cadence, no damage.
-                printf '2026-08-16T12:09:04.535000000Z healthcheck ok\n'
-                printf '2026-08-16T12:09:09.535000000Z healthcheck ok\n'
-            fi
+            case "\${FAKE_STREAM:-stall}" in
+                stall)
+                    # \`docker logs --timestamps\` shape, with a 30.064 s
+                    # hole between the two lines and damage on each.
+                    printf '2026-08-16T12:09:04.535000000Z scrollback row dropped\n'
+                    printf '2026-08-16T12:09:34.599000000Z db=30064.1ms query returned\n'
+                    ;;
+                damage)
+                    # DAMAGE WITHOUT A STALL: a dropped row at the 5 s
+                    # healthcheck cadence. The class that used to be
+                    # unobservable, because nothing here trips a gap.
+                    printf '2026-08-16T12:09:04.535000000Z healthcheck ok\n'
+                    printf '2026-08-16T12:09:09.535000000Z scrollback row dropped\n'
+                    ;;
+                clean)
+                    # A healthy stack: the cadence, and nothing else.
+                    printf '2026-08-16T12:09:04.535000000Z healthcheck ok\n'
+                    printf '2026-08-16T12:09:09.535000000Z healthcheck ok\n'
+                    ;;
+            esac
         else
             printf 'fake container output for %s\n' "\$svc"
         fi
@@ -161,11 +171,16 @@ first_line() {
     # keep honest than a green-only second one.
     [ -s "$CENSUS" ]
     grep -q 'grappa-test.*maxgap=30.1' "$CENSUS"
+
+    # The verdict is recorded on a red too. Retention is unconditional
+    # here, but WHAT was observed still is not — a red that carried damage
+    # without a stall has to stay countable alongside the greens.
+    grep -q 'RETENTION.*kept=yes.*by_gap=1.*by_dropped=1' "$CENSUS"
 }
 
 @test "a CLEAN green run writes the census and keeps no raw logs" {
     cd "$MAIN"
-    FAKE_RUNNER_RC=0 FAKE_STALL=0 run "$MAIN/scripts/integration.sh"
+    FAKE_RUNNER_RC=0 FAKE_STREAM=clean run "$MAIN/scripts/integration.sh"
 
     # Evidence collection, not a new assertion: a green run stays green.
     [ "$status" -eq 0 ]
@@ -196,13 +211,18 @@ first_line() {
     # a green run without any artifact at all.
     grep -q 'maxgap=5.0' <<<"$output"
 
+    # The verdict is recorded even when nothing was retained, so "no
+    # damage" and "not looked at" stay distinguishable in the artifact.
+    grep -q 'RETENTION.*kept=no' "$CENSUS"
+    grep -q 'RETENTION.*by_gap=0.*by_dropped=0' "$CENSUS"
+
     # ...and the stack still came down.
     grep -q 'testnet down' "$LOG"
 }
 
 @test "a green run that MEASURED a stall keeps the bytes too" {
     cd "$MAIN"
-    FAKE_RUNNER_RC=0 FAKE_STALL=1 run "$MAIN/scripts/integration.sh"
+    FAKE_RUNNER_RC=0 FAKE_STREAM=stall run "$MAIN/scripts/integration.sh"
 
     # Still not a gate: measuring a stall does not fail the run.
     [ "$status" -eq 0 ]
@@ -210,10 +230,36 @@ first_line() {
 
     # A green run that measured a stall is the first non-blind green there
     # has ever been, and the census alone cannot be forensicked — so this
-    # is the one green whose bytes are worth keeping. The trigger is the
-    # census's OWN verdict at the same threshold, not a second criterion.
+    # is the one green whose bytes are worth keeping.
     [ -s "$LOGS_DIR/grappa-test.log" ]
     [ -s "$LOGS_DIR/hub.log" ]
     [ -s "$LOGS_DIR/compose-ps.txt" ]
     grep -q 'db=30064.1ms query returned' "$LOGS_DIR/grappa-test.log"
+
+    grep -q 'RETENTION.*kept=yes.*by_gap=1' "$CENSUS"
+}
+
+@test "a green run with DAMAGE but no stall keeps the bytes, and says so" {
+    cd "$MAIN"
+    FAKE_RUNNER_RC=0 FAKE_STREAM=damage run "$MAIN/scripts/integration.sh"
+
+    [ "$status" -eq 0 ]
+
+    # Nothing here trips a silence: the cadence is 5 s, under the
+    # threshold. The damage is the only signal.
+    grep -q 'grappa-test.*maxgap=5.0' "$CENSUS"
+    grep -q 'grappa-test.*gaps_ge_10=0' "$CENSUS"
+    grep -q 'grappa-test.*dropped=1' "$CENSUS"
+    refute grep -q 'GAP' "$CENSUS"
+
+    # Retention is a different job from attribution. A gap is a proxy for
+    # a mechanism; a dropped row IS the damage. Discarding the bytes here
+    # would make "damage WITHOUT a stall" permanently unobservable —
+    # which is the class nobody can currently prove exists.
+    [ -s "$LOGS_DIR/grappa-test.log" ]
+    grep -q 'scrollback row dropped' "$LOGS_DIR/grappa-test.log"
+
+    # And the census says WHICH trigger fired, so that class becomes
+    # countable rather than merely retained: one grep over the artifacts.
+    grep -q 'RETENTION.*kept=yes.*by_gap=0.*by_dropped=1' "$CENSUS"
 }

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+#
+# #1429 — the gap scanner's own definition, pinned.
+#
+# WHY THIS FILE EXISTS. The census used to be a report: if it drifted, a
+# number in an investigation drifted with it and somebody would notice
+# the next time they read it. It is not a report any more —
+# `scripts/integration.sh` asks it whether a GREEN run tripped, and keeps
+# or discards ~275 MB of forensic evidence on the answer. A silent change
+# to what counts as a gap therefore changes the RETENTION policy without
+# changing a line of the script that implements it.
+#
+# So every clause of the definition is pinned here: the threshold
+# boundary, the arithmetic, the rollover, and one assertion per damage
+# signature. The scanner is fed on stdin, which is how integration.sh
+# uses it — no fixture files, no stack, no lane.
+
+load ../bats_helpers
+
+setup() {
+    SCANNER="$BATS_TEST_DIRNAME/../../scripts/log-gap-scan.awk"
+    [ -f "$SCANNER" ]
+}
+
+# The scanner as integration.sh invokes it: a service label and a
+# threshold in seconds, stream on stdin.
+scan() {
+    awk -v SVC=svc -v THRESH="$1" -f "$SCANNER"
+}
+
+# A `docker logs --timestamps` line: RFC3339 stamp, then the payload.
+stamp() {
+    printf '2026-08-16T%s000000Z %s\n' "$1" "$2"
+}
+
+@test "a silence AT the threshold is named; one just below it is not" {
+    # The boundary is the whole contract: it is what decides whether a
+    # green run's bytes are kept. Both halves, or the pin proves nothing.
+    local out
+    out="$( { stamp '12:00:00.' quiet; stamp '12:00:10.' quiet; } | scan 10 )"
+    grep -q 'svc	GAP	10.0' <<<"$out"
+    grep -q 'gaps_ge_10=1' <<<"$out"
+
+    out="$( { stamp '12:00:00.' quiet; stamp '12:00:09.9' quiet; } | scan 10 )"
+    refute grep -q 'GAP' <<<"$out"
+    grep -q 'gaps_ge_10=0' <<<"$out"
+    # ...and it is still MEASURED, just not named: a sub-threshold silence
+    # that vanished from maxgap would hide the run drifting toward the line.
+    grep -q 'maxgap=9.9' <<<"$out"
+}
+
+@test "maxgap reports the LARGEST silence and the stamp it started at" {
+    local out
+    out="$( {
+        stamp '12:00:00.' a
+        stamp '12:00:02.' b     # 2 s
+        stamp '12:00:32.' c     # 30 s — the winner, starting at 12:00:02
+        stamp '12:00:33.' d     # 1 s
+    } | scan 10 )"
+
+    grep -q 'maxgap=30.0' <<<"$out"
+    grep -q 'maxgap_at=12:00:02.000' <<<"$out"
+    # Only the one over the threshold is named individually.
+    grep -q 'gaps_ge_10=1' <<<"$out"
+}
+
+@test "a silence across midnight is a silence, not a negative number" {
+    # Without the rollover this reads as -86390 s, which is not merely
+    # wrong: it is BELOW the threshold, so a stall spanning midnight would
+    # discard the bytes that prove it.
+    local out
+    out="$( { stamp '23:59:59.' before; stamp '00:00:09.' after; } | scan 10 )"
+    grep -q 'svc	GAP	10.0' <<<"$out"
+    grep -q 'maxgap=10.0' <<<"$out"
+}
+
+@test "each damage signature is counted by itself and not by another" {
+    local out
+    out="$( {
+        stamp '12:00:00.' 'db=30064.1ms query returned'
+        stamp '12:00:01.' 'conn idle=30062.4ms checked out'
+        stamp '12:00:02.' 'scrollback row dropped for #bofh'
+        stamp '12:00:03.' 'pool saturated for the full 30s'
+    } | scan 10 )"
+
+    grep -q 'db30=1' <<<"$out"
+    grep -q 'idle30=1' <<<"$out"
+    grep -q 'dropped=1' <<<"$out"
+    grep -q 'saturated=1' <<<"$out"
+}
+
+@test "a sub-30s duration does not score as a 30-something hold" {
+    # db=3xxxx matches 30000-39999 ms. 2999.9 and 4000.1 are the
+    # neighbours that would fall in if the pattern lost a digit.
+    local out
+    out="$( {
+        stamp '12:00:00.' 'db=2999.9ms fast'
+        stamp '12:00:01.' 'db=4000.1ms slowish'
+    } | scan 10 )"
+
+    grep -q 'db30=0' <<<"$out"
+}
+
+@test "untimestamped lines are counted, but never form a gap" {
+    # docker interleaves the odd unprefixed line (a container's own
+    # multi-line output). Treating one as a stamp would invent silences.
+    local out
+    out="$( {
+        stamp '12:00:00.' first
+        printf 'a bare continuation line\n'
+        stamp '12:00:02.' second
+    } | scan 10 )"
+
+    grep -q 'lines=3' <<<"$out"
+    grep -q 'maxgap=2.0' <<<"$out"
+    grep -q 'gaps_ge_10=0' <<<"$out"
+}
+
+@test "an empty stream reads as quiet rather than as an error" {
+    # A container that logged nothing must still produce its row, or the
+    # census silently loses a service instead of reporting a silent one.
+    local out
+    out="$( printf '' | scan 10 )"
+    grep -q 'svc	SUMMARY	lines=0' <<<"$out"
+    grep -q 'maxgap=0.0' <<<"$out"
+}
+
+@test "a missing threshold is refused, not defaulted" {
+    # A census measured against a threshold the caller forgot still looks
+    # plausible, and would be read as one measured against the intended
+    # one. Refusing is the only honest answer.
+    run awk -v SVC=svc -f "$SCANNER" </dev/null
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"THRESH"* ]]
+    refute grep -q 'SUMMARY' <<<"$output"
+}


### PR DESCRIPTION
Refs #1429.

A green `integration` run wrote no container logs at all, so ~449 of 626 runs
since 2026-08-06 left no server-side evidence — **blind by construction**, not by
bad luck. The blindness was also *pinned*: `integration_log_capture_test.bats`
carried a test named "a green run captures nothing".

That mattered because the open question about the 30.1 s stall regime
(#1420, #1421) is whether it also hits the runs that **pass** — and those were
exactly the runs whose evidence was discarded.

## What changes

The EXIT trap now streams every service's log through a tracked scanner on
**every** run and keeps the measurement. The raw bytes are materialised on a
red, and on a green only when the measurement says something.

* `scripts/log-gap-scan.awk` — one streaming pass per service: largest silence
  and when it started, every silence at or over the threshold, and counts of the
  damage signatures (`db=3xxxx`, `idle=3xxxx`, dropped scrollback row, saturated
  pool). A few hundred bytes instead of a few hundred megabytes.
* `scripts/integration.sh` — `tee` gives one code path for both exits: the
  stream always reaches the scanner, the disk only when the bytes are kept.
* `.github/workflows/integration.yml` — one added `if: always()` step uploading
  `gap-scan.tsv` alone. The three existing `if: failure()` steps are untouched.

**This is evidence collection, not a gate.** No branch of the trap touches the
exit code, and a test asserts a green run stays green.

## Retention: attribution and retention are different jobs

Retention fires on **a gap on an eligible service, OR a non-zero `dropped`**,
and the census records which:

```
RUN	RETENTION	kept=yes	by_service_gap=0	by_dropped=1
```

Attribution stays single-criterion. Retention answers a different question —
what evidence do I want to still have tomorrow — and there a gap is only a
*proxy* for a mechanism while a dropped row *is* the damage. Retaining on the
gap alone would make **damage without a stall** permanently unobservable, which
is the class nobody can currently prove exists. The field is what turns
*retained* into *countable*: one grep over the uploaded artifacts answers
whether that class happens, and how often.

**Eligible is derived from `docker compose ps`, and the discriminant is the
pair `(State, ExitCode)`.** A container that exited cleanly is a one-shot that
finished; its silence is the interval between invocations. Measured:
`cicchetto-build-test` exceeded the threshold on **both** runs observed
(111.3 s and 12.9 s), so retaining on any gap would retain on essentially every
run — the ~9 GB landfill this change exists to avoid, restored. A container that
exited non-zero crashed, and its silence does mean something.

The pair is load-bearing, and it was sampled on a live stack rather than
assumed:

```
hub|running|0          <- a RUNNING container also reports 0
cert-init|exited|0     <- a completed one-shot
```

Keying on the exit code alone would have made every service ineligible:
retention would have stopped firing while the census kept printing a verdict it
was no longer computing. There is a test for exactly that mutant.

## Reading a gap: the direction of causation is not given

Documented in the scanner's own header and in `docs/OPERATIONS.md`, because it
is the part a future reader is most likely to get wrong.

| census shows | licenses |
|---|---|
| gap **+ a damage signature** | a stall — the environment is implicated |
| **bare gap**, damage counters zero | **nothing** — traffic drought and a stalled process look identical |

A spec hung on a locator stops driving the stack, and a server with no traffic
logs nothing, so the silence can be the **effect** of a failure rather than its
cause. Not hypothetical: the first real red this instrument met showed a 16.7 s
silence on `grappa-test` spanning exactly the failing spec's lifetime
(provisioned 14:40:14, silence 14:40:15.008 → 14:40:31.720, failed 14:40:32) —
and that spec then passed 3/3 in isolation with every damage counter at zero.
Read as an environment stall, it would have exonerated a spec on no evidence.

## Cost, measured

| | |
|---|---|
| whole capture window, 13 services | **11.23 s** |
| of which the awk pass over `grappa-test` (248 MB / 1,092,461 lines) | **8.99 / 8.94 s** |
| ⇒ extraction + disk write add | **~2.3 s** on top of the scan |
| total captured on a red | **253 MB** |
| `gap-scan.tsv` | **1,511 bytes** |
| share of a 30.3 min suite | **~0.6%** |

The three stages run in a pipe, so the cost is the `max`, not the sum: the
pipeline is **awk-bound**. Extraction is not the expense — scanning is, and it
is already paid on every red today. If the 11 s ever becomes a problem, the
lever is the scanner, not the `tee`.

## Verification

* **bats 512/512, RC=0** on the final tree; TDD throughout, each red read by
  name and committed before its green. One exception is stated in its own commit
  message (`a0b793ed`): that red was reconstructed *after* the implementation
  was written, and the commit says so rather than implying the original order.
* **Mutation, one mutant at a time**, each killed by a distinct assertion:

  | mutant | killed by |
  |---|---|
  | green always keeps the bytes | raw-absence assertion |
  | green never keeps the bytes | the measured-stall case |
  | census withheld from stdout | the job-log copy assertion |
  | service label hardcoded | the derived-set assertion |
  | threshold `>=` to `>` | scanner boundary case |
  | midnight rollover removed | scanner rollover case |
  | `dropped` not counted | scanner damage case |
  | eligibility on `ExitCode` alone | the running-service case |
  | eligibility on `State` alone | the crashed-service case, and only that one |
  | no eligibility filter | the clean-green cases |

* The scanner is pinned clause by clause (`log_gap_scan_test.bats`): threshold
  boundary from both sides, arithmetic, midnight rollover — without which a
  stall spanning midnight reads as minus 86390 s and discards the very bytes
  that prove it — one case per damage signature, the `db=3xxxx` neighbours at
  2999.9 and 4000.1 that must not score, an empty stream reading as quiet rather
  than missing, and the refusal to default a missing threshold. Every expected
  value was read off the scanner before being asserted.

## Not established

* **That green runs stall.** This unblocks the question; it does not answer it.
  No claim about frequency, or about the phenomenon crossing the green/red line.
* **That the census is sufficient.** It captures the signatures the census of
  #1420 needed. A future investigation wanting different evidence would still
  find a clean green unable to answer it — this raises the floor.
* **The extraction cost on the green path specifically.** The run measured went
  red, so the number above is the red path, which bounds green from above.
* **A known local wart, reported rather than fixed here:** `container-logs/` is
  a single fixed directory that every run overwrites. Before this change only
  reds wrote there; now greens that trip do too, so consecutive local runs
  clobber each other's evidence more readily. It cost me the raw log of the red
  described above. Harmless on CI (fresh runner, one artifact per run), real
  locally, and left for a separate change rather than widened into this one.
