### PR TITLE
wire(#1393): give the six identical admin index envelopes a Wire home

### DIFF
--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -46,6 +46,11 @@ export const S_AccountsAdminWireT = {
   },
 } as const;
 
+// Grappa.Accounts.AdminWire.index_payload/0
+export const S_AccountsAdminWireIndexPayload = {
+  o: { users: { a: S_AccountsAdminWireT } },
+} as const;
+
 // Grappa.Accounts.Wire.client_token_json/0
 export const S_AccountsWireClientTokenJson = {
   o: {
@@ -558,6 +563,11 @@ export const S_LiveIntrospectionAdminWireT = {
   },
 } as const;
 
+// Grappa.LiveIntrospection.AdminWire.index_payload/0
+export const S_LiveIntrospectionAdminWireIndexPayload = {
+  o: { sessions: { a: S_LiveIntrospectionAdminWireT } },
+} as const;
+
 // Grappa.Networks.Network.services_flavor/0
 export const S_NetworksNetworkServicesFlavor = {
   e: [...NETWORKS_NETWORK_SERVICES_FLAVOR],
@@ -600,16 +610,6 @@ export const S_NetworksCredentialsAdminWireLiveStateJson = {
   },
 } as const;
 
-// Grappa.Networks.Credentials.AdminWire.session_action/0
-export const S_NetworksCredentialsAdminWireSessionAction = {
-  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION],
-} as const;
-
-// Grappa.Networks.Credentials.AdminWire.spawn_error/0
-export const S_NetworksCredentialsAdminWireSpawnError = {
-  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR],
-} as const;
-
 // Grappa.Networks.Credentials.AdminWire.t/0
 export const S_NetworksCredentialsAdminWireT = {
   o: {
@@ -636,6 +636,21 @@ export const S_NetworksCredentialsAdminWireT = {
   },
 } as const;
 
+// Grappa.Networks.Credentials.AdminWire.index_payload/0
+export const S_NetworksCredentialsAdminWireIndexPayload = {
+  o: { credentials: { a: S_NetworksCredentialsAdminWireT } },
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.session_action/0
+export const S_NetworksCredentialsAdminWireSessionAction = {
+  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION],
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.spawn_error/0
+export const S_NetworksCredentialsAdminWireSpawnError = {
+  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SPAWN_ERROR],
+} as const;
+
 // Grappa.Networks.FeaturedChannels.AdminWire.t/0
 export const S_NetworksFeaturedChannelsAdminWireT = {
   o: {
@@ -648,6 +663,11 @@ export const S_NetworksFeaturedChannelsAdminWireT = {
     inserted_at: "s",
     updated_at: "s",
   },
+} as const;
+
+// Grappa.Networks.FeaturedChannels.AdminWire.index_payload/0
+export const S_NetworksFeaturedChannelsAdminWireIndexPayload = {
+  o: { featured_channels: { a: S_NetworksFeaturedChannelsAdminWireT } },
 } as const;
 
 // Grappa.Networks.FeaturedChannels.Wire.link/0
@@ -674,6 +694,11 @@ export const S_NetworksServersAdminWireT = {
     inserted_at: "s",
     updated_at: "s",
   },
+} as const;
+
+// Grappa.Networks.Servers.AdminWire.index_payload/0
+export const S_NetworksServersAdminWireIndexPayload = {
+  o: { servers: { a: S_NetworksServersAdminWireT } },
 } as const;
 
 // Grappa.Networks.Wire.available_network_row/0
@@ -1438,6 +1463,11 @@ export const S_VisitorsAdminWireT = {
     last_seen_at: { u: ["s", "z"] },
     networks: { a: S_VisitorsAdminWireNetworkJson },
   },
+} as const;
+
+// Grappa.Visitors.AdminWire.index_payload/0
+export const S_VisitorsAdminWireIndexPayload = {
+  o: { visitors: { a: S_VisitorsAdminWireT } },
 } as const;
 
 // Grappa.Visitors.Wire.credential_json/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -90,6 +90,10 @@ export type AccountsAdminWireT = {
   live_session_count: number;
 };
 
+export type AccountsAdminWireIndexPayload = {
+  users: AccountsAdminWireT[];
+};
+
 // === Grappa.Accounts.Wire ===
 
 export type AccountsWireUserJson = {
@@ -549,6 +553,10 @@ export type LiveIntrospectionAdminWireT = {
   live_state: LiveIntrospectionAdminWireLiveStateJson;
 };
 
+export type LiveIntrospectionAdminWireIndexPayload = {
+  sessions: LiveIntrospectionAdminWireT[];
+};
+
 // === Grappa.Networks.AdminWire ===
 
 export type NetworksAdminWireT = {
@@ -599,6 +607,10 @@ export type NetworksCredentialsAdminWireT = {
   live_state: NetworksCredentialsAdminWireLiveStateJson | null;
 };
 
+export type NetworksCredentialsAdminWireIndexPayload = {
+  credentials: NetworksCredentialsAdminWireT[];
+};
+
 export const NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION = [
   "left_alone",
   "stopped",
@@ -633,6 +645,10 @@ export type NetworksFeaturedChannelsAdminWireT = {
   updated_at: string;
 };
 
+export type NetworksFeaturedChannelsAdminWireIndexPayload = {
+  featured_channels: NetworksFeaturedChannelsAdminWireT[];
+};
+
 // === Grappa.Networks.FeaturedChannels.Wire ===
 
 export type NetworksFeaturedChannelsWireLink = {
@@ -657,6 +673,10 @@ export type NetworksServersAdminWireT = {
   source_address: string | null;
   inserted_at: string;
   updated_at: string;
+};
+
+export type NetworksServersAdminWireIndexPayload = {
+  servers: NetworksServersAdminWireT[];
 };
 
 // === Grappa.Networks.Wire ===
@@ -1453,6 +1473,10 @@ export type VisitorsAdminWireT = {
   inserted_at: string;
   last_seen_at: string | null;
   networks: VisitorsAdminWireNetworkJson[];
+};
+
+export type VisitorsAdminWireIndexPayload = {
+  visitors: VisitorsAdminWireT[];
 };
 
 // === Grappa.Visitors.Wire ===

--- a/lib/grappa/accounts/admin_wire.ex
+++ b/lib/grappa/accounts/admin_wire.ex
@@ -42,6 +42,8 @@ defmodule Grappa.Accounts.AdminWire do
           live_session_count: non_neg_integer()
         }
 
+  @type index_payload :: %{users: [t()]}
+
   @doc """
   Render a User row + injected live session count to the admin JSON
   shape. The count is supplied by the controller from a single
@@ -60,4 +62,8 @@ defmodule Grappa.Accounts.AdminWire do
       live_session_count: live_session_count
     }
   end
+
+  @doc "Wraps the rendered rows as the `GET /admin/users` envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{users: rows}
 end

--- a/lib/grappa/live_introspection/admin_wire.ex
+++ b/lib/grappa/live_introspection/admin_wire.ex
@@ -61,6 +61,8 @@ defmodule Grappa.LiveIntrospection.AdminWire do
           live_state: live_state_json()
         }
 
+  @type index_payload :: %{sessions: [t()]}
+
   @doc """
   Render one `SessionEntry` + its resolved `subject_label` +
   optional `last_seen_at` to the admin JSON shape.
@@ -137,6 +139,10 @@ defmodule Grappa.LiveIntrospection.AdminWire do
       }
     }
   end
+
+  @doc "Wraps the rendered rows as the `GET /admin/sessions` envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{sessions: rows}
 
   defp encode_last_seen(nil), do: nil
   defp encode_last_seen(%DateTime{} = dt), do: DateTime.to_iso8601(dt)

--- a/lib/grappa/networks/credentials/admin_wire.ex
+++ b/lib/grappa/networks/credentials/admin_wire.ex
@@ -96,6 +96,8 @@ defmodule Grappa.Networks.Credentials.AdminWire do
           live_state: live_state_json() | nil
         }
 
+  @type index_payload :: %{credentials: [t()]}
+
   @typedoc """
   What the admin verb did to the session for
   `{:user, user_id} × network_id`. ONE wire key, `session_action`, so ONE
@@ -280,6 +282,10 @@ defmodule Grappa.Networks.Credentials.AdminWire do
   def with_bind_outcome(%{} = json, {:not_spawned, reason}) do
     Map.merge(json, %{session_action: :not_spawned, session_error: error_tag(reason)})
   end
+
+  @doc "Wraps the rendered rows as the `GET /admin/credentials` envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{credentials: rows}
 
   @spec error_tag(spawn_error() | {spawn_error(), term()}) :: spawn_error()
   defp error_tag({tag, _}) when is_atom(tag), do: tag

--- a/lib/grappa/networks/featured_channels/admin_wire.ex
+++ b/lib/grappa/networks/featured_channels/admin_wire.ex
@@ -2,9 +2,12 @@ defmodule Grappa.Networks.FeaturedChannels.AdminWire do
   @moduledoc """
   Admin JSON shape for a `Grappa.Networks.FeaturedChannel` row, scoped
   under `/admin/networks/:network_id/featured_channels`. Mirrors
-  `Grappa.Networks.Servers.AdminWire`. Not a `wire.ex` file → not
-  emitted by `mix grappa.gen_wire_types`; the cic mirror is the
-  hand-rolled `AdminFeaturedChannel` in `api.ts`.
+  `Grappa.Networks.Servers.AdminWire`.
+
+  Codegen-visible: #428 widened the walk to `**/*wire.ex`, so this
+  module is emitted like any `wire.ex` one and cic's
+  `AdminFeaturedChannel` is a plain alias to the generated
+  `NetworksFeaturedChannelsAdminWireT`, not a hand-roll.
   """
   alias Grappa.Networks.FeaturedChannel
 
@@ -18,6 +21,8 @@ defmodule Grappa.Networks.FeaturedChannels.AdminWire do
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
+
+  @type index_payload :: %{featured_channels: [t()]}
 
   @doc "Renders a featured-channel row to the admin JSON shape."
   @spec featured_channel_to_admin_json(FeaturedChannel.t()) :: t()
@@ -33,4 +38,8 @@ defmodule Grappa.Networks.FeaturedChannels.AdminWire do
       updated_at: fc.updated_at
     }
   end
+
+  @doc "Wraps the rendered rows as the network's `featured_channels` index envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{featured_channels: rows}
 end

--- a/lib/grappa/networks/servers/admin_wire.ex
+++ b/lib/grappa/networks/servers/admin_wire.ex
@@ -27,6 +27,8 @@ defmodule Grappa.Networks.Servers.AdminWire do
           updated_at: DateTime.t()
         }
 
+  @type index_payload :: %{servers: [t()]}
+
   @doc """
   Renders a Server row to the admin JSON shape. The `:network`
   preloaded association is intentionally NOT projected — it would leak
@@ -51,4 +53,8 @@ defmodule Grappa.Networks.Servers.AdminWire do
       updated_at: server.updated_at
     }
   end
+
+  @doc "Wraps the rendered rows as the network's `servers` index envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{servers: rows}
 end

--- a/lib/grappa/visitors/admin_wire.ex
+++ b/lib/grappa/visitors/admin_wire.ex
@@ -72,6 +72,8 @@ defmodule Grappa.Visitors.AdminWire do
           networks: [network_json()]
         }
 
+  @type index_payload :: %{visitors: [t()]}
+
   @doc """
   Render a visitor row + its per-network credentials-with-live-state to
   the admin JSON shape. `per_network` is the `[{credential, live}]` list
@@ -149,4 +151,8 @@ defmodule Grappa.Visitors.AdminWire do
       introspection_degraded: entry.introspection_degraded
     }
   end
+
+  @doc "Wraps the rendered rows as the `GET /admin/visitors` envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{visitors: rows}
 end

--- a/lib/grappa_web/controllers/admin/credentials_controller.ex
+++ b/lib/grappa_web/controllers/admin/credentials_controller.ex
@@ -88,7 +88,7 @@ defmodule GrappaWeb.Admin.CredentialsController do
         )
       end
 
-    json(conn, %{credentials: rows})
+    json(conn, AdminWire.index_payload(rows))
   end
 
   # Single-row twin of the batch above, for the create / update replies.

--- a/lib/grappa_web/controllers/admin/featured_channels_controller.ex
+++ b/lib/grappa_web/controllers/admin/featured_channels_controller.ex
@@ -38,7 +38,7 @@ defmodule GrappaWeb.Admin.FeaturedChannelsController do
         |> FeaturedChannels.list_channels()
         |> Enum.map(&AdminWire.featured_channel_to_admin_json/1)
 
-      json(conn, %{featured_channels: rows})
+      json(conn, AdminWire.index_payload(rows))
     end
   end
 

--- a/lib/grappa_web/controllers/admin/servers_controller.ex
+++ b/lib/grappa_web/controllers/admin/servers_controller.ex
@@ -51,7 +51,7 @@ defmodule GrappaWeb.Admin.ServersController do
         |> Servers.list_servers()
         |> Enum.map(&ServerWire.server_to_admin_json/1)
 
-      json(conn, %{servers: rows})
+      json(conn, ServerWire.index_payload(rows))
     end
   end
 

--- a/lib/grappa_web/controllers/admin/sessions_controller.ex
+++ b/lib/grappa_web/controllers/admin/sessions_controller.ex
@@ -124,7 +124,7 @@ defmodule GrappaWeb.Admin.SessionsController do
         )
       end)
 
-    json(conn, %{sessions: rows})
+    json(conn, AdminWire.index_payload(rows))
   end
 
   # Split the registry-scan into `(user_ids, visitor_ids)` so each

--- a/lib/grappa_web/controllers/admin/users_controller.ex
+++ b/lib/grappa_web/controllers/admin/users_controller.ex
@@ -59,7 +59,7 @@ defmodule GrappaWeb.Admin.UsersController do
         AdminWire.user_to_admin_json(user, Map.get(counts, user.id, 0))
       end
 
-    json(conn, %{users: rows})
+    json(conn, AdminWire.index_payload(rows))
   end
 
   @doc """

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -80,7 +80,7 @@ defmodule GrappaWeb.Admin.VisitorsController do
         AdminWire.visitor_to_admin_json(v, per_network, touch.last_seen_at, touch.ip)
       end
 
-    json(conn, %{visitors: rows})
+    json(conn, AdminWire.index_payload(rows))
   end
 
   @doc """

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -311,6 +311,60 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
     end
   end
 
+  # #1393 — the admin index ROWS were already codegen-visible: every admin
+  # controller builds them with an `AdminWire.*_to_admin_json/…`. Only the
+  # collection ENVELOPE was an inline map literal in the controller, so the
+  # shape a client actually receives had no generated schema and cic cast to
+  # a hand-written mirror instead. `Grappa.Networks.FeaturedChannels.Wire`
+  # was the one REST envelope that already had a Wire home — and therefore
+  # the one that was already generated. These pin the same treatment for the
+  # six admin index doors.
+  describe "admin index envelopes (#1393)" do
+    test "each admin index envelope renders as its row type in an array, under the wire key" do
+      for {mod, envelope, key, row} <- admin_index_envelopes() do
+        output = GenWireTypes.render_module_for_test(mod)
+
+        assert output =~ ~s(export type #{envelope} = {),
+               "#{inspect(mod)} emits no `#{envelope}` — the index envelope has no @type"
+
+        assert output =~ ~s(  #{key}: #{row}[];),
+               "`#{envelope}` does not wrap `#{row}[]` under the `#{key}` key"
+      end
+    end
+
+    test "every admin index envelope survives a full generate/0 run" do
+      full = GenWireTypes.generate()
+
+      for {mod, envelope, _key, _row} <- admin_index_envelopes() do
+        assert full =~ ~s(export type #{envelope} = {),
+               "#{inspect(mod)}'s index envelope is missing from the full walk"
+      end
+    end
+  end
+
+  # The six `GET /admin/*` index doors whose row already had a Wire module:
+  # `{wire module, emitted envelope alias, JSON key, emitted row alias}`.
+  # `Grappa.Networks.AdminWire` is deliberately absent — its controller
+  # composes `circuit_state` + `live_counts` onto the row, and that
+  # composition cannot move into the wire without forming the
+  # `Networks → Admission` boundary cycle its moduledoc documents.
+  defp admin_index_envelopes do
+    [
+      {Grappa.Accounts.AdminWire, "AccountsAdminWireIndexPayload", "users", "AccountsAdminWireT"},
+      {Grappa.LiveIntrospection.AdminWire, "LiveIntrospectionAdminWireIndexPayload", "sessions",
+       "LiveIntrospectionAdminWireT"},
+      {Grappa.Networks.Credentials.AdminWire, "NetworksCredentialsAdminWireIndexPayload",
+       "credentials", "NetworksCredentialsAdminWireT"},
+      {Grappa.Networks.FeaturedChannels.AdminWire,
+       "NetworksFeaturedChannelsAdminWireIndexPayload", "featured_channels",
+       "NetworksFeaturedChannelsAdminWireT"},
+      {Grappa.Networks.Servers.AdminWire, "NetworksServersAdminWireIndexPayload", "servers",
+       "NetworksServersAdminWireT"},
+      {Grappa.Visitors.AdminWire, "VisitorsAdminWireIndexPayload", "visitors",
+       "VisitorsAdminWireT"}
+    ]
+  end
+
   describe "--check exit code helper" do
     test "compare_committed/2 returns :ok when committed file matches generated" do
       tmp = Path.join(System.tmp_dir!(), "wireTypes.ts.gentest")

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -353,15 +353,13 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
       {Grappa.Accounts.AdminWire, "AccountsAdminWireIndexPayload", "users", "AccountsAdminWireT"},
       {Grappa.LiveIntrospection.AdminWire, "LiveIntrospectionAdminWireIndexPayload", "sessions",
        "LiveIntrospectionAdminWireT"},
-      {Grappa.Networks.Credentials.AdminWire, "NetworksCredentialsAdminWireIndexPayload",
-       "credentials", "NetworksCredentialsAdminWireT"},
-      {Grappa.Networks.FeaturedChannels.AdminWire,
-       "NetworksFeaturedChannelsAdminWireIndexPayload", "featured_channels",
+      {Grappa.Networks.Credentials.AdminWire, "NetworksCredentialsAdminWireIndexPayload", "credentials",
+       "NetworksCredentialsAdminWireT"},
+      {Grappa.Networks.FeaturedChannels.AdminWire, "NetworksFeaturedChannelsAdminWireIndexPayload", "featured_channels",
        "NetworksFeaturedChannelsAdminWireT"},
       {Grappa.Networks.Servers.AdminWire, "NetworksServersAdminWireIndexPayload", "servers",
        "NetworksServersAdminWireT"},
-      {Grappa.Visitors.AdminWire, "VisitorsAdminWireIndexPayload", "visitors",
-       "VisitorsAdminWireT"}
+      {Grappa.Visitors.AdminWire, "VisitorsAdminWireIndexPayload", "visitors", "VisitorsAdminWireT"}
     ]
   end
 

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -335,7 +335,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
     test "every admin index envelope survives a full generate/0 run" do
       full = GenWireTypes.generate()
 
-      for {mod, envelope, _key, _row} <- admin_index_envelopes() do
+      for {mod, envelope, _, _} <- admin_index_envelopes() do
         assert full =~ ~s(export type #{envelope} = {),
                "#{inspect(mod)}'s index envelope is missing from the full walk"
       end


### PR DESCRIPTION
Slice 1 of #1393 (bucket D, wire-codegen). It stands on its own and does
not depend on any later slice.

## What was actually missing

The admin index **rows** have been codegen-visible since #428 widened the
glob to `lib/grappa/**/*wire.ex` — which also catches `admin_wire.ex`, and
every admin controller already builds its rows with an
`AdminWire.*_to_admin_json/…`. The part that never had a home is the
collection **envelope**: `json(conn, %{users: rows})` is an inline map
literal in the controller, so the shape a client actually receives has no
`@type`, no generated alias and no runtime schema, and cic casts it to a
hand-written mirror instead of validating it.

`Grappa.Networks.FeaturedChannels.Wire.index_payload/1` is the one REST
envelope that already lived in a Wire module, and therefore the one that
was already generated. It is the template these six follow: an
`@type index_payload` next to the existing row type, a builder next to the
existing row builder, and one line of controller.

## The six

`Accounts`, `LiveIntrospection`, `Networks.Credentials`,
`Networks.FeaturedChannels`, `Networks.Servers`, `Visitors` — all
`AdminWire`, all `%{key: [t()]}`, all identical in shape. That identity is
the whole value of the slice, which is why the seventh is not here.

`Grappa.Networks.AdminWire` is deliberately excluded. Its controller
composes `circuit_state` and `live_counts` onto the row, so the envelope's
element is wider than `t()`, and its moduledoc already records why that
composition cannot move into the wire: a `Networks → Admission` reference
would close a boundary cycle against the existing `Admission → Networks`
edge. That is a design question, not a mechanical swap, and it travels
separately.

## Order of the commits

1. `test(#1393)` — the red, pinning all six against the codegen.
2. `wire(#1393)` — the six Wire modules and the six controller lines.
3. `codegen(#1393)` — `mix grappa.gen_wire_types`, no hand editing.
4. `style(#1393)` ×2 — formatter and Credo strict on the new test.

The red was written before a build was available and its commit message
says so. It has since been read: at `9d3a9711` the tests compile and fail
on the assertion (`Grappa.Accounts.AdminWire emits no
AccountsAdminWireIndexPayload`), 2 of 2 — the red that was claimed, not a
compilation error wearing its clothes.

## A note on the regenerated diff

`wireSchema.ts` reads +40/-10 rather than +30/-0. The emitter also moved
`S_NetworksCredentialsAdminWireSessionAction` and
`S_NetworksCredentialsAdminWireSpawnError` to sit after
`S_NetworksCredentialsAdminWireT` and the new index payload. Both blocks
are byte-identical to their previous text, the exported-symbol set loses
nothing and gains exactly six (162 → 168), and running the same task on
the base commit with a clean tree leaves the tree clean — so `main` is
drift-free and the reordering belongs to this change.

## What comes later, and why the gate is last

#1393 blocks 56 of the 83 REST casts in #1400. The remaining envelopes
ship as further slices (`themes`/`notify`/`circuit`/`vhosts`, the auth
ceremony, `uploads`, `settings`, the `%{ok: true}` acks, the one-liners,
and the error shapes). **The structural gate lands last**, once everything
it would flag is already converted — so no exclusion list ever exists in
the tree.

## Verification

`scripts/check.sh` green end to end: compile with Boundary, `mix format
--check-formatted`, Credo strict, Sobelow, `mix deps.audit`, 6399 tests /
60 properties / 8 doctests with 0 failures, doctor, Dialyzer `Total
errors: 0`, the `grappa.gen_wire_types --check` drift gate reporting both
`wireTypes.ts` and `wireSchema.ts` in sync, and the bats suite (499 tests,
no failures).