### PR TITLE
admin(#1407): make two admin boundaries do what their own prose says

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -498,10 +498,6 @@ config :logger, :console,
     # per-upload across the reaper + GET surface.
     :upload_id,
     :slug,
-    # UX-6-B2 (2026-05-21): admin PUT /settings unknown-key warn line
-    # carries the offending key so an admin typo (`globalcap_bytes`)
-    # surfaces in the log without dumping the whole body.
-    :setting_key,
     # Numeric severity (CP13 server-window cluster): :ok for 1xx/2xx/3xx,
     # :error for 4xx/5xx — rides the :notice persist for routed numerics
     # so log lines are color-greppable. Mirrors Scrollback.Meta.@known_keys

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44539,3 +44539,96 @@ and cannot be read in jsdom either. What is established is that WE draw
 nothing before this change and something after it. Whether the reporter
 now sees an acknowledgement in time is a device verification, still
 owed — and stated as owed rather than parked.
+<!-- entry #1407 -->
+
+---
+
+## 2026-08-16 — #1407: two admin boundaries that argued against their own code
+
+Bucket E of the 2026-08-15 review carried two MEDIUMs of one shape: a
+boundary whose behaviour contradicts the prose sitting on top of it.
+Both were still live on `origin/main` at `1552312d`.
+
+### `PUT /admin/settings` answered 200 to a typo
+
+The moduledoc promised that anything invalid collapses to 422
+`invalid_setting` naming the offending dotted key. That covered bad
+VALUES. A bad KEY was logged at warning and the action returned 200 with
+the full settings view, indistinguishable from a save that did
+something. An operator who typed `image_per_file_cap` for
+`image_per_file_cap_bytes` watched the save succeed and change nothing.
+
+The fix rejects any key outside the two closed sets, and it does so
+BEFORE the per-key fold rather than inside it. That ordering is the
+half of this that is easy to skip: the red measured a body mixing a good
+key with a typo writing the good one (image cap at before+4096) and then
+dropping the typo, and the sibling admin controllers are all-or-nothing
+precisely because they validate keys before they build attrs.
+
+The envelope departs from those siblings on purpose. Every one of them
+answers a bare `{:error, :bad_request}` for an unknown key; this door
+answers 422 `invalid_setting` with the dotted key in `field`. The
+siblings answer `bad_request` because they have no field vocabulary to
+answer with — this one does, and cic already consumes it:
+`AdminSettingsTab` reads `err.info.field` and highlights the offending
+input inline. Naming the key IS the repair; a bare 400 leaves the
+operator exactly as uninformed as the 200 did, which is the complaint.
+"Same problem, same solution" is satisfied at the level that matters
+(no door silently accepts an unknown key); the wire token is where the
+two doors' vocabularies legitimately differ.
+
+The forward-compat tolerance the old comment claimed does not survive
+contact with the client either: `AdminSettingsTab` sends a fixed literal
+of the seven known upload keys and no addressing subtree at all, so no
+cic build can produce an unknown key — only a hand-rolled request can,
+and that is the operator this change is for.
+
+### `AdminChannel` had no `handle_info/2` catch-all, one screen below the comment explaining why it must
+
+Phoenix dispatches `handle_info/2` whenever a channel exports it, and
+this one's three clauses matched `:after_join`, `:overview_tick`, and a
+single hardcoded event name on `Topic.session_log/0`. Anything else —
+a second publisher, a renamed event, a stray `send/2` — killed the
+operator console with a `FunctionClauseError`, which is the exact
+outcome the `handle_in/3` catch-all sitting below it refuses to allow
+for inbound frames. The review derived that crash from Phoenix's
+dispatch rule without executing it; the red executes it.
+
+The catch-all is not invented here. `SessionRevocationListener` (#1338
+M-S2, already on main although its issue is still open) and
+`IRC.Client` both log `Logger.warning("unexpected mailbox message",
+unexpected: inspect(msg))`, so this is the third member of one family
+rather than a second dialect, and the `unexpected:` metadata key is
+already allowlisted for exactly this use.
+
+It is not a funnel. The message is logged, so what the channel cannot
+read stays visible in the operator's own log. Crashing surfaces it too,
+but strictly worse, and for the same two reasons #1338 wrote down: the
+push this channel performs is per-message and stateless, so a crash
+cannot retry the unread message, only discard the live session-log
+events queued behind it; and a second publisher is a repeating
+condition, so crashing per message walks the restart intensity until the
+console is gone for good.
+
+### What the mutants bought, and what they did not
+
+Six mutants, each killed. Removing the catch-all kills both channel
+tests through the crash; MUTING it — same clause, no log line — kills
+both again, which is what separates "the console survived" from "and the
+operator can see what it survived". Dropping the subtree prefix from the
+`field` string kills the two naming tests and leaves the third alive.
+Removing the addressing check alone kills the addressing test alone.
+
+The ordering thesis needed two attempts. Moving the key check after the
+fold kills the mixed-body test, but through a `FunctionClauseError` in
+`apply_upload_key/2` (the permissive clause is gone), so it proves the
+order matters without isolating what it costs. The sixth mutant restores
+a permissive clause alongside the reordering: the door still answers
+422, and exactly one assertion dies —
+`image_per_file_cap_bytes` reading 10489856 against an expected 10485760.
+That is the partial write, measured.
+
+Not established: whether any second publisher on `Topic.session_log/0`
+is coming. The re-grep the review asked for still shows one
+(`session_log.ex`), so this change buys resilience against a future that
+has not arrived, not a fix for an outage that happened.

--- a/lib/grappa_web/channels/admin_channel.ex
+++ b/lib/grappa_web/channels/admin_channel.ex
@@ -34,6 +34,14 @@ defmodule GrappaWeb.AdminChannel do
   carries only live updates. Reuses the admin socket rather than a second
   channel (Option B: two persisted admin surfaces, one operator socket).
 
+  ## Nothing unknown is fatal, in either direction (#1407 W-S7)
+
+  Neither an unrecognised inbound frame nor an unrecognised mailbox
+  message takes the operator's console down: both collapse to a
+  catch-all, and the `handle_info/2` one logs at warning so the message
+  it cannot read stays visible. See that clause for why crashing would
+  surface less, not more.
+
   ## No inbound handlers
 
   Admin events are server-originated only. The single `handle_in/3`
@@ -54,6 +62,8 @@ defmodule GrappaWeb.AdminChannel do
 
   alias Grappa.{AdminEvents, AdminOverview}
   alias Grappa.PubSub.Topic
+
+  require Logger
 
   @impl Phoenix.Channel
   def join("grappa:admin:events", _, socket) do
@@ -93,6 +103,32 @@ defmodule GrappaWeb.AdminChannel do
         socket
       ) do
     push(socket, "session_log_event", payload)
+    {:noreply, socket}
+  end
+
+  # W-S7 (#1407) — the info-side twin of the inbound catch-all below, and
+  # the third instance of the #1338 `unknown-is-never-fatal` family: same
+  # logged shape as `GrappaWeb.SessionRevocationListener` and
+  # `Grappa.IRC.Client`, chosen over inventing a second one.
+  #
+  # The three clauses above are exhaustive only by luck — one hardcoded
+  # event name (`PubSub.broadcast_event/2`) from the one publisher on
+  # `Topic.session_log/0`. A second publisher, a renamed event, or any
+  # stray `send/2` would otherwise kill the console with a
+  # `FunctionClauseError`, which is the exact outcome the `handle_in/3`
+  # catch-all below refuses to allow — this module argued one posture and
+  # implemented the other.
+  #
+  # Not a funnel: the message is logged at warning under the allowlisted
+  # `unexpected:` key, so what this channel cannot read is visible in the
+  # operator's own log rather than swallowed. Crashing would surface it
+  # too, but strictly worse: the push this channel performs is
+  # per-MESSAGE and stateless, so a crash cannot retry the unread message
+  # — it only discards the mailbox behind it, taking live session-log
+  # events down with it, and a repeating publisher then walks the restart
+  # intensity until the operator's console is gone for good.
+  def handle_info(msg, socket) do
+    Logger.warning("unexpected mailbox message", unexpected: inspect(msg))
     {:noreply, socket}
   end
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -158,12 +158,19 @@ defmodule GrappaWeb.Admin.SettingsController do
         :ok
 
       subtree when is_map(subtree) ->
-        with :ok <- reject_unknown_keys(subtree, allowed, key) do
-          Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
-        end
+        apply_known_keys(subtree, allowed, key, fun)
 
       _ ->
         {:error, :bad_request}
+    end
+  end
+
+  # Gate then fold, in that order — see `reject_unknown_keys/3` for why the
+  # gate cannot move after the fold. Its own function so neither the guard
+  # nor the fold lambda nests inside the shape `case` above.
+  defp apply_known_keys(subtree, allowed, key, fun) do
+    with :ok <- reject_unknown_keys(subtree, allowed, key) do
+      Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
     end
   end
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -55,7 +55,10 @@ defmodule GrappaWeb.Admin.SettingsController do
   every key within each is optional — the controller upserts only the keys
   present in the body. Any invalid value (out-of-set host/mode string,
   non-positive integer cap, non-16-bit-group prefix length) collapses to
-  422 `invalid_setting` with the offending dotted key in `field`.
+  422 `invalid_setting` with the offending dotted key in `field`, and so
+  does any key outside the two closed sets above (#1407 W-S3) — a typo is
+  named, never absorbed, and it refuses the WHOLE body rather than
+  applying the keys it did recognise.
 
   On success: 200 with the new full settings view AND fan-out of a
   `server_settings_changed` push on every live `Topic.user(name)`
@@ -77,7 +80,15 @@ defmodule GrappaWeb.Admin.SettingsController do
   alias Grappa.PubSub.Topic
   alias Grappa.ServerSettings.Wire, as: SettingsWire
 
-  require Logger
+  # The two closed key sets. Every entry here MUST have a matching
+  # `apply_upload_key/2` clause (resp. a `resolve_addressing_*` one) —
+  # adding a key to one and not the other is caught by that key's own
+  # per-key test, loudly, never silently.
+  @upload_keys ~w(active_host image_per_file_cap_bytes video_per_file_cap_bytes
+                  document_per_file_cap_bytes audio_per_file_cap_bytes
+                  global_cap_bytes video_max_duration_seconds)
+
+  @addressing_keys ~w(mode static_mapping_prefix)
 
   @doc false
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -131,7 +142,7 @@ defmodule GrappaWeb.Admin.SettingsController do
   # ---- Internal ----------------------------------------------------
 
   defp apply_updates(params) when is_map(params) do
-    with :ok <- apply_subtree(params, "upload", &apply_upload_key/2) do
+    with :ok <- apply_subtree(params, "upload", @upload_keys, &apply_upload_key/2) do
       apply_addressing(Map.get(params, "addressing"))
     end
   end
@@ -141,16 +152,43 @@ defmodule GrappaWeb.Admin.SettingsController do
   # Fold a present subtree through its per-key applier. Absent subtree → :ok
   # (each is independently optional — an empty body updates nothing); a
   # non-map subtree → bad_request (no silent swallow of a malformed shape).
-  defp apply_subtree(params, key, fun) do
+  defp apply_subtree(params, key, allowed, fun) do
     case Map.get(params, key) do
       nil ->
         :ok
 
       subtree when is_map(subtree) ->
-        Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
+        with :ok <- reject_unknown_keys(subtree, allowed, key) do
+          Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
+        end
 
       _ ->
         {:error, :bad_request}
+    end
+  end
+
+  # W-S3 (#1407) — an unrecognised key is a typo, not a forward-compat
+  # shape: `AdminSettingsTab` sends a fixed literal set, so nothing but a
+  # hand-rolled request can produce one. It used to be logged and dropped
+  # while the action still answered 200 with the full view, so an operator
+  # who typed `image_per_file_cap` watched a save succeed and change
+  # nothing — the "no silent-swallow at boundaries" failure exactly.
+  #
+  # The check runs BEFORE the fold, so a body mixing a good key with a typo
+  # writes nothing: the all-or-nothing posture every sibling admin
+  # controller already takes by validating keys before building attrs.
+  #
+  # The 422 `invalid_setting` envelope is chosen over the siblings' bare
+  # `bad_request` because this door already has a `field` vocabulary and
+  # cic already reads it (`AdminSettingsTab`'s `err.info.field` highlights
+  # the offending input inline). Naming the key IS the fix; a bare 400
+  # would leave the operator exactly as uninformed as the 200 did.
+  # Sorted, so a body carrying several unknown keys names the same one on
+  # every request.
+  defp reject_unknown_keys(subtree, allowed, subtree_name) do
+    case subtree |> Map.keys() |> Enum.reject(&(&1 in allowed)) |> Enum.sort() do
+      [] -> :ok
+      [key | _] -> {:error, {:invalid_setting, subtree_name <> "." <> key}}
     end
   end
 
@@ -197,16 +235,8 @@ defmodule GrappaWeb.Admin.SettingsController do
   defp apply_upload_key("video_max_duration_seconds", _),
     do: {:error, {:invalid_setting, "upload.video_max_duration_seconds"}}
 
-  # Unknown key — ignore but log at warning level. Tolerant of
-  # forward-compat shapes cic might send when an admin opens an
-  # older deploy, while still discoverable when an admin typos
-  # `globalcap_bytes` and wonders why nothing changed
-  # (per `feedback_no_silent_drops_closed` — silent acceptance
-  # absorbs the next class of bug).
-  defp apply_upload_key(k, _) do
-    Logger.warning("admin PUT /settings: unknown upload key", setting_key: k)
-    :ok
-  end
+  # No unknown-key clause: `reject_unknown_keys/3` has already refused
+  # every key outside `@upload_keys` before this fold begins.
 
   # ---- addressing.* — probe-gated unit apply (#543 / #609) ----------
   #
@@ -219,9 +249,8 @@ defmodule GrappaWeb.Admin.SettingsController do
   defp apply_addressing(nil), do: :ok
 
   defp apply_addressing(subtree) when is_map(subtree) do
-    warn_unknown_addressing_keys(subtree)
-
-    with {:ok, mode} <- resolve_addressing_mode(subtree),
+    with :ok <- reject_unknown_keys(subtree, @addressing_keys, "addressing"),
+         {:ok, mode} <- resolve_addressing_mode(subtree),
          {:ok, prefix} <- resolve_addressing_prefix(subtree),
          :ok <- arm_if_static(mode, prefix),
          :ok <- persist_addressing_prefix(subtree),
@@ -298,16 +327,6 @@ defmodule GrappaWeb.Admin.SettingsController do
     do: ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
 
   defp persist_addressing_mode(_), do: :ok
-
-  # Unknown addressing key — ignore but log (tolerant of forward-compat shapes,
-  # discoverable on a typo). Same posture as `apply_upload_key/2`'s catch-all.
-  defp warn_unknown_addressing_keys(subtree) do
-    for {k, _} <- subtree, k not in ["mode", "static_mapping_prefix"] do
-      Logger.warning("admin PUT /settings: unknown addressing key", setting_key: k)
-    end
-
-    :ok
-  end
 
   # Translate per-key return to Enum.reduce_while continuation. `:ok`
   # → continue; `{:error, _}` → halt with the error preserved.

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -18,12 +18,14 @@ defmodule GrappaWeb.AdminChannelTest do
   """
   use GrappaWeb.ChannelCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
   alias Grappa.{AdminEvents, AdminOverview, Repo, SessionLog}
   alias Grappa.AdminEvents.Wire
   alias Grappa.PubSub.Topic
   alias GrappaWeb.UserSocket
+  alias Phoenix.Socket.Broadcast
 
   setup do
     # AdminEvents is the global singleton — reset buffer per-test so
@@ -243,6 +245,53 @@ defmodule GrappaWeb.AdminChannelTest do
 
       ref = push(socket, "anything", %{})
       assert_reply ref, :ok
+    end
+  end
+
+  # W-S7 (#1407) — the info side of the same posture the inbound catch-all
+  # above already takes. The barrier in both tests is mailbox ORDER: the
+  # `push` is enqueued after the stray message, so a reply can only come
+  # back if the stray one was handled without killing the channel pid.
+  describe "unhandled info catch-all" do
+    test "a stray send is logged and leaves the operator console alive" do
+      admin = user_fixture(is_admin: true)
+      raw = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, socket} = subscribe_and_join(raw, "grappa:admin:events", %{})
+      assert_push "snapshot", _
+
+      log =
+        capture_log(fn ->
+          send(socket.channel_pid, :no_clause_matches_this)
+
+          ref = push(socket, "ping", %{})
+          assert_reply ref, :ok
+        end)
+
+      assert log =~ "unhandled message"
+    end
+
+    test "a broadcast the channel has no clause for is logged and not fatal" do
+      admin = user_fixture(is_admin: true)
+      raw = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, socket} = subscribe_and_join(raw, "grappa:admin:events", %{})
+      assert_push "snapshot", _
+
+      log =
+        capture_log(fn ->
+          send(socket.channel_pid, %Broadcast{
+            topic: Topic.session_log(),
+            event: "an_event_name_added_later",
+            payload: %{}
+          })
+
+          ref = push(socket, "ping", %{})
+          assert_reply ref, :ok
+        end)
+
+      assert log =~ "unhandled broadcast"
+      assert log =~ "an_event_name_added_later"
     end
   end
 

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -268,7 +268,8 @@ defmodule GrappaWeb.AdminChannelTest do
           assert_reply ref, :ok
         end)
 
-      assert log =~ "unhandled message"
+      assert log =~ "unexpected mailbox message"
+      assert log =~ "no_clause_matches_this"
     end
 
     test "a broadcast the channel has no clause for is logged and not fatal" do
@@ -290,7 +291,7 @@ defmodule GrappaWeb.AdminChannelTest do
           assert_reply ref, :ok
         end)
 
-      assert log =~ "unhandled broadcast"
+      assert log =~ "unexpected mailbox message"
       assert log =~ "an_event_name_added_later"
     end
   end

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -149,13 +149,39 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert %{"settings" => _} = json_response(conn, 200)
     end
 
-    test "ignores unknown keys", %{conn: conn, session: session} do
+    # W-S3 (#1407) — an unknown key is a typo, not a no-op. It names the
+    # offending dotted key in the SAME 422 shape a bad VALUE gets, because
+    # that is the shape `AdminSettingsTab` already highlights inline.
+    test "422 invalid_setting names an unknown upload key", %{conn: conn, session: session} do
       conn =
         conn
         |> put_bearer(session.id)
-        |> put("/admin/settings", %{"upload" => %{"unknown_key" => "foo"}})
+        |> put("/admin/settings", %{"upload" => %{"image_per_file_cap" => 1_048_576}})
 
-      assert %{"settings" => _} = json_response(conn, 200)
+      assert %{
+               "error" => "invalid_setting",
+               "field" => "upload.image_per_file_cap"
+             } = json_response(conn, 422)
+    end
+
+    # The key check runs BEFORE the per-key applier, so a body that mixes a
+    # good key with a typo writes NOTHING — the sibling admin controllers'
+    # all-or-nothing posture, not a half-applied save.
+    test "an unknown upload key rejects the whole body, valid siblings included", %{
+      conn: conn,
+      session: session
+    } do
+      before = ServerSettings.public_view().upload.image_per_file_cap_bytes
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "upload" => %{"image_per_file_cap_bytes" => before + 4096, "globalcap_bytes" => 1}
+        })
+
+      assert %{"error" => "invalid_setting"} = json_response(conn, 422)
+      assert ServerSettings.public_view().upload.image_per_file_cap_bytes == before
     end
   end
 
@@ -401,6 +427,25 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
                "error" => "invalid_setting",
                "field" => "addressing.static_mapping_prefix"
              }
+    end
+
+    # W-S3 (#1407) — the addressing subtree used to log the typo and apply the
+    # rest; the probe never even ran for a body that named nothing it knows.
+    test "422 invalid_setting names an unknown addressing key — nothing is persisted",
+         %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{"static_prefix" => "2a03:4000:20:2d3:cb::/80"}
+        })
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "addressing.static_prefix"
+             }
+
+      assert ServerSettings.static_mapping_prefix() == nil
     end
 
     test "applies upload AND addressing subtrees in one request", %{conn: conn, session: session} do


### PR DESCRIPTION
Bucket E of the 2026-08-15 codebase review — the two gating MEDIUMs
(W-S3, W-S7). Both were the same shape: a boundary behaving the
opposite of the prose sitting on top of it. Both were still live on
`origin/main` when this branch started.

## W-S3 — `PUT /admin/settings` answered 200 to a typo

An unrecognised key under `upload` or `addressing` was logged at
warning and the action returned 200 with the full settings view,
indistinguishable from a save that did something. The key check now
runs BEFORE the per-key fold, so a body mixing a good key with a typo
writes nothing.

The envelope departs from the sibling admin controllers' bare
`bad_request` on purpose: this door already has a `field` vocabulary
and cic already consumes it — `AdminSettingsTab` reads `err.info.field`
and highlights the offending input inline. Naming the key IS the
repair; a bare 400 leaves the operator as uninformed as the 200 did.
The forward-compat tolerance the old comment claimed does not hold
either: the tab sends a fixed literal of the seven known upload keys
and no addressing subtree, so only a hand-rolled request can carry an
unknown key.

## W-S7 — `AdminChannel.handle_info/2` had no catch-all

One screen below the comment explaining why `handle_in/3` must have
one. Its three clauses were exhaustive only by luck: one hardcoded
event name from the one publisher on `Topic.session_log/0` (re-grepped
— still one). The catch-all is not invented here: it is the same
`Logger.warning("unexpected mailbox message", unexpected: inspect(msg))`
that `SessionRevocationListener` (#1338 M-S2, already on main) and
`IRC.Client` use.

Not a funnel — the message is logged, so what the channel cannot read
stays visible in the operator's log. Crashing surfaces it too, but
strictly worse: the push here is per-message and stateless, so a crash
cannot retry the unread message, only discard the live session-log
events behind it, and a repeating publisher walks the restart intensity
until the console is gone for good.

## Evidence

Red first, read by name: `RC=2`, 5 failures / 52 tests. The two channel
tests died with `FunctionClauseError` in `admin_channel.ex:77` — the
review derived that crash without executing it, this executes it. The
mixed-body test exhibited a partial write the finding had not named:
the image cap moved to before+4096 while the typo'd sibling was
dropped. An existing test asserting the defect (`ignores unknown keys`)
was deleted rather than adapted.

Six mutants, all killed. Removing the catch-all kills both channel
tests through the crash; MUTING it kills both again, which is what
separates "the console survived" from "and the operator can see what it
survived". Dropping the dotted prefix kills the two naming tests and
leaves the third alive. Removing the addressing check alone kills the
addressing test alone.

One mutant did not buy what it was written for, and is reported as
such: moving the key check after the fold kills the mixed-body test
through a `FunctionClauseError`, proving the order matters without
isolating what it costs. A sixth mutant restores a permissive clause
alongside the reordering — the door still answers 422 and exactly one
assertion dies, `image_per_file_cap_bytes` reading 10489856 against an
expected 10485760. That is the partial write, measured. Re-anchored and
re-run after the Credo extraction, so the thesis is bought on the shape
that ships.

`scripts/check.sh` green: Credo `6009 mods/funs, found no issues`,
`8 doctests, 60 properties, 6407 tests, 0 failures`, Dialyzer
`Total errors: 0`, bats `499 ok / 0 not ok`, `deps.audit` clean.
Measured on the pre-rebase base and stated as such; the rebase onto
`9808cb51` is a two-sided numstat match with zero deletions, and the
union touches none of these six files.

## Not established

Whether a second publisher on `Topic.session_log/0` is coming. There is
none. This buys resilience against a future that has not arrived, not a
fix for an outage that happened.