### PR TITLE
union: replay #1407 + #1391 onto main so one gate covers both

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -498,10 +498,6 @@ config :logger, :console,
     # per-upload across the reaper + GET surface.
     :upload_id,
     :slug,
-    # UX-6-B2 (2026-05-21): admin PUT /settings unknown-key warn line
-    # carries the offending key so an admin typo (`globalcap_bytes`)
-    # surfaces in the log without dumping the whole body.
-    :setting_key,
     # Numeric severity (CP13 server-window cluster): :ok for 1xx/2xx/3xx,
     # :error for 4xx/5xx — rides the :notice persist for routed numerics
     # so log lines are color-greppable. Mirrors Scrollback.Meta.@known_keys

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44632,3 +44632,76 @@ Not established: whether any second publisher on `Topic.session_log/0`
 is coming. The re-grep the review asked for still shows one
 (`session_log.ex`), so this change buys resilience against a future that
 has not arrived, not a fix for an outage that happened.
+<!-- entry #1391 -->
+
+---
+
+## 2026-08-16 — #1391: the reply accumulators are structs, and the check lives in the pattern
+
+The five in-flight reply accumulators — WHOIS, WHOWAS, LUSERS, LINKS and the
+type-A LIST-MODE — were bare maps carried in `Session.Server` state and read
+in `Session.Wire` through fifty-five `Map.get/2` calls. `Map.get/2` has no
+key-membership check, so a misspelt field read `nil` and the payload shipped
+a null the client could not tell from a genuinely absent one. A map `@type`
+would not have helped: it documents the key set without enforcing it, and
+all fifty-five reads would have stayed exactly as unsafe.
+
+They are structs now, and the reads are field accesses. The gain is measured
+rather than asserted, with one mutant at a time, injected exactly once and
+the restore verified:
+
+  * READER — misspell a field in `wire.ex` and it is a COMPILE error:
+    `unknown key`, `typing violation`, the exact line. Elixir 1.19's
+    set-theoretic inference, not Dialyzer, and `--warnings-as-errors` makes
+    it a red build.
+  * WRITER — misspell a key in a producer and it compiles clean, then dies
+    at runtime on `struct!/2` with a `KeyError`. `struct!/2` is deliberately
+    the only write door, which is also why there is NO separate type for a
+    fold's delta: a second declaration of the key set is a second thing to
+    drift.
+
+The negative belongs here too, because it bounds the claim. On the WHOIS
+accumulator `struct!/2` added no coverage the tests did not already have —
+eight sampled fields were all asserted at accumulator level, so the writer
+mutant would have died anyway. What it buys is that the guard no longer
+DEPENDS on that coverage. The reader guard is the net gain.
+
+### The check does not survive a list, unless you put it in the pattern
+
+The mutants came back split, and the split is the durable finding. A
+misspelt field on an ACCUMULATOR is a compile error; the same misspelling on
+an ENTRY — the nested `Entry` structs under WHOWAS, LINKS and LIST-MODE —
+compiled clean and only died at runtime.
+
+Inference works from VALUES, not from `@type` specs, and it does not carry
+an element type out of a list. `accum.entries` is declared `[Entry.t()]`,
+but `[head | _] -> head` or `fn e ->` leaves the binding `dynamic()` and
+every read through it unchecked. Naming the struct in the PATTERN —
+`[%Entry{} = head | _]`, `fn %Entry{} = e ->` — restores it, and the two
+surviving mutants then die at compile time like the other two.
+
+So the rule for any future accumulator: the struct declaration is not the
+guard. The guard is the struct appearing in a pattern on the path the value
+actually travels. The `@type` documents; the pattern enforces.
+
+That stricter clause immediately caught something the mutants could not: a
+test feeding `banlist_bundle/4` entries that were bare maps. Nothing would
+ever have flagged it, because a map and the struct built from it project to
+the same payload — the assertion passed while the declared element type was
+a fiction.
+
+### Two shapes, one function
+
+The entry struct is the INTERNAL accumulator shape; the payload stays a
+plain map. `banlist_entry/0` and `links_entry/0` are what the TS codegen
+reads and what Jason encodes, so the builders project struct → map, and the
+tests assert bare maps on the payload side and structs on the input side.
+Deliberately two things, at the two ends of one function.
+
+The `Entry` modules are NESTED in their accumulator's file rather than given
+files of their own, and the reason is measured:
+`Deploy.Preflight.collect_state_blocks/1` walks a whole file's AST and
+collects EVERY `defstruct` in it, so an entry beside its parent inherits the
+parent's cold-deploy check with no second `@state_helpers` registration.
+Separate files would have cost three files and six registry lines for
+identical coverage.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44539,3 +44539,96 @@ and cannot be read in jsdom either. What is established is that WE draw
 nothing before this change and something after it. Whether the reporter
 now sees an acknowledgement in time is a device verification, still
 owed — and stated as owed rather than parked.
+<!-- entry #1407 -->
+
+---
+
+## 2026-08-16 — #1407: two admin boundaries that argued against their own code
+
+Bucket E of the 2026-08-15 review carried two MEDIUMs of one shape: a
+boundary whose behaviour contradicts the prose sitting on top of it.
+Both were still live on `origin/main` at `1552312d`.
+
+### `PUT /admin/settings` answered 200 to a typo
+
+The moduledoc promised that anything invalid collapses to 422
+`invalid_setting` naming the offending dotted key. That covered bad
+VALUES. A bad KEY was logged at warning and the action returned 200 with
+the full settings view, indistinguishable from a save that did
+something. An operator who typed `image_per_file_cap` for
+`image_per_file_cap_bytes` watched the save succeed and change nothing.
+
+The fix rejects any key outside the two closed sets, and it does so
+BEFORE the per-key fold rather than inside it. That ordering is the
+half of this that is easy to skip: the red measured a body mixing a good
+key with a typo writing the good one (image cap at before+4096) and then
+dropping the typo, and the sibling admin controllers are all-or-nothing
+precisely because they validate keys before they build attrs.
+
+The envelope departs from those siblings on purpose. Every one of them
+answers a bare `{:error, :bad_request}` for an unknown key; this door
+answers 422 `invalid_setting` with the dotted key in `field`. The
+siblings answer `bad_request` because they have no field vocabulary to
+answer with — this one does, and cic already consumes it:
+`AdminSettingsTab` reads `err.info.field` and highlights the offending
+input inline. Naming the key IS the repair; a bare 400 leaves the
+operator exactly as uninformed as the 200 did, which is the complaint.
+"Same problem, same solution" is satisfied at the level that matters
+(no door silently accepts an unknown key); the wire token is where the
+two doors' vocabularies legitimately differ.
+
+The forward-compat tolerance the old comment claimed does not survive
+contact with the client either: `AdminSettingsTab` sends a fixed literal
+of the seven known upload keys and no addressing subtree at all, so no
+cic build can produce an unknown key — only a hand-rolled request can,
+and that is the operator this change is for.
+
+### `AdminChannel` had no `handle_info/2` catch-all, one screen below the comment explaining why it must
+
+Phoenix dispatches `handle_info/2` whenever a channel exports it, and
+this one's three clauses matched `:after_join`, `:overview_tick`, and a
+single hardcoded event name on `Topic.session_log/0`. Anything else —
+a second publisher, a renamed event, a stray `send/2` — killed the
+operator console with a `FunctionClauseError`, which is the exact
+outcome the `handle_in/3` catch-all sitting below it refuses to allow
+for inbound frames. The review derived that crash from Phoenix's
+dispatch rule without executing it; the red executes it.
+
+The catch-all is not invented here. `SessionRevocationListener` (#1338
+M-S2, already on main although its issue is still open) and
+`IRC.Client` both log `Logger.warning("unexpected mailbox message",
+unexpected: inspect(msg))`, so this is the third member of one family
+rather than a second dialect, and the `unexpected:` metadata key is
+already allowlisted for exactly this use.
+
+It is not a funnel. The message is logged, so what the channel cannot
+read stays visible in the operator's own log. Crashing surfaces it too,
+but strictly worse, and for the same two reasons #1338 wrote down: the
+push this channel performs is per-message and stateless, so a crash
+cannot retry the unread message, only discard the live session-log
+events queued behind it; and a second publisher is a repeating
+condition, so crashing per message walks the restart intensity until the
+console is gone for good.
+
+### What the mutants bought, and what they did not
+
+Six mutants, each killed. Removing the catch-all kills both channel
+tests through the crash; MUTING it — same clause, no log line — kills
+both again, which is what separates "the console survived" from "and the
+operator can see what it survived". Dropping the subtree prefix from the
+`field` string kills the two naming tests and leaves the third alive.
+Removing the addressing check alone kills the addressing test alone.
+
+The ordering thesis needed two attempts. Moving the key check after the
+fold kills the mixed-body test, but through a `FunctionClauseError` in
+`apply_upload_key/2` (the permissive clause is gone), so it proves the
+order matters without isolating what it costs. The sixth mutant restores
+a permissive clause alongside the reordering: the door still answers
+422, and exactly one assertion dies —
+`image_per_file_cap_bytes` reading 10489856 against an expected 10485760.
+That is the partial write, measured.
+
+Not established: whether any second publisher on `Topic.session_log/0`
+is coming. The re-grep the review asked for still shows one
+(`session_log.ex`), so this change buys resilience against a future that
+has not arrived, not a fix for an outage that happened.

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -128,8 +128,12 @@ defmodule Grappa.HotReload.LongLivedModules do
   @state_helpers [
     Grappa.Session.AwayState,
     Grappa.Session.GhostRecovery,
+    Grappa.Session.LinksAccum,
+    Grappa.Session.ListModeAccum,
+    Grappa.Session.LusersAccum,
     Grappa.Session.RecoverIdentity,
     Grappa.Session.WhoisAccum,
+    Grappa.Session.WhowasAccum,
     Grappa.Session.WindowState
   ]
 
@@ -165,8 +169,12 @@ defmodule Grappa.HotReload.LongLivedModules do
   @type state_helper ::
           Grappa.Session.AwayState
           | Grappa.Session.GhostRecovery
+          | Grappa.Session.LinksAccum
+          | Grappa.Session.ListModeAccum
+          | Grappa.Session.LusersAccum
           | Grappa.Session.RecoverIdentity
           | Grappa.Session.WhoisAccum
+          | Grappa.Session.WhowasAccum
           | Grappa.Session.WindowState
 
   @doc """

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -129,6 +129,7 @@ defmodule Grappa.HotReload.LongLivedModules do
     Grappa.Session.AwayState,
     Grappa.Session.GhostRecovery,
     Grappa.Session.RecoverIdentity,
+    Grappa.Session.WhoisAccum,
     Grappa.Session.WindowState
   ]
 
@@ -165,6 +166,7 @@ defmodule Grappa.HotReload.LongLivedModules do
           Grappa.Session.AwayState
           | Grappa.Session.GhostRecovery
           | Grappa.Session.RecoverIdentity
+          | Grappa.Session.WhoisAccum
           | Grappa.Session.WindowState
 
   @doc """

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1686,7 +1686,7 @@ defmodule Grappa.Session.EventRouter do
     case drain_key && Map.fetch(pending, drain_key) do
       {:ok, accum} ->
         next_state = %{state | who_pending: Map.delete(pending, drain_key)}
-        target_display = accum.target_display || target
+        target_display = Map.get(accum, :target_display, target)
 
         # Replies prepended LIFO in who_fold for O(1) fold — reverse to
         # restore server wire order before emitting.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -91,7 +91,18 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Message}
   alias Grappa.{Scrollback, Session}
-  alias Grappa.Session.{IdentityState, ISupport, ListModes, NumericRouter, Presence, WhoisAccum}
+  alias Grappa.Session.{
+    IdentityState,
+    ISupport,
+    ListModeAccum,
+    ListModes,
+    LinksAccum,
+    LusersAccum,
+    NumericRouter,
+    Presence,
+    WhoisAccum,
+    WhowasAccum
+  }
 
   @typedoc """
   The Session.Server state subset this module reads + mutates. The
@@ -232,16 +243,16 @@ defmodule Grappa.Session.EventRouter do
           # lifts it out of the `*_pending` accumulator it just drained; `nil`
           # means no connection owns this reply and `Session.Server` falls
           # back to the per-user fan-out.
-          | {:whois_bundle, target :: String.t(), accum :: map(), Grappa.Session.reply_to()}
+          | {:whois_bundle, target :: String.t(), WhoisAccum.t(), Grappa.Session.reply_to()}
           | {:peer_away, peer :: String.t(), away_message :: String.t()}
           | {:invite_ack, channel :: String.t(), peer :: String.t()}
           | {:rejoin_invited, channel :: String.t()}
           | {:invited, channel :: String.t(), inviter :: String.t()}
-          | {:lusers_bundle, accum :: map()}
-          | {:whowas_bundle, target :: String.t(), accum :: map(), Grappa.Session.reply_to()}
-          | {:list_mode_bundle, channel :: String.t(), mode :: ListModes.mode(), accum :: map(),
+          | {:lusers_bundle, LusersAccum.t()}
+          | {:whowas_bundle, target :: String.t(), WhowasAccum.t(), Grappa.Session.reply_to()}
+          | {:list_mode_bundle, channel :: String.t(), mode :: ListModes.mode(), ListModeAccum.t(),
              Grappa.Session.reply_to()}
-          | {:links_bundle, accum :: map(), Grappa.Session.reply_to()}
+          | {:links_bundle, LinksAccum.t(), Grappa.Session.reply_to()}
           | {:umode_changed, modes :: [String.t()]}
           | {:supported_umodes_changed, modes :: [String.t()]}
           | {:session_identity_changed, :acquired | :lost}
@@ -1675,7 +1686,7 @@ defmodule Grappa.Session.EventRouter do
     case drain_key && Map.fetch(pending, drain_key) do
       {:ok, accum} ->
         next_state = %{state | who_pending: Map.delete(pending, drain_key)}
-        target_display = Map.get(accum, :target_display, target)
+        target_display = accum.target_display || target
 
         # Replies prepended LIFO in who_fold for O(1) fold — reverse to
         # restore server wire order before emitting.
@@ -1963,7 +1974,8 @@ defmodule Grappa.Session.EventRouter do
        when is_list(params) do
     [n, i, s] = extract_lusers_ints(List.last(params), 3)
 
-    {:cont, Map.put(state, :lusers_pending, %{total_users: n, invisible: i, servers: s}), []}
+    {:cont,
+     Map.put(state, :lusers_pending, %LusersAccum{total_users: n, invisible: i, servers: s}), []}
   end
 
   # 252 RPL_LUSEROP: `<N> :IRC Operators online`.
@@ -2026,7 +2038,9 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_list(params) do
     [n, m] = extract_lusers_ints(List.last(params), 2)
-    accum = Map.merge(Map.get(state, :lusers_pending) || %{}, %{current_global: n, max_global: m})
+    accum =
+      struct!(Map.get(state, :lusers_pending) || %LusersAccum{}, %{current_global: n, max_global: m})
+
     {:cont, Map.put(state, :lusers_pending, nil), [{:lusers_bundle, accum}]}
   end
 
@@ -2062,7 +2076,7 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(target) and is_binary(user) and is_binary(host) do
     realname = whois_trailing(rest)
-    entry = %{user: user, host: host, realname: realname}
+    entry = %WhowasAccum.Entry{user: user, host: host, realname: realname}
     {:cont, whowas_append_entry(state, target, entry), []}
   end
 
@@ -2083,7 +2097,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state,
          [
-           {:whowas_bundle, Map.get(accum, :target_display, target), accum, Map.get(accum, :reply_to)}
+           {:whowas_bundle, accum.target_display || target, accum, accum.reply_to}
          ]}
 
       :error ->
@@ -2107,7 +2121,7 @@ defmodule Grappa.Session.EventRouter do
     case Map.fetch(pending, nick_key) do
       {:ok, accum} ->
         next_state = %{state | whowas_pending: Map.delete(pending, nick_key)}
-        target_display = Map.get(accum, :target_display, target)
+        target_display = accum.target_display || target
 
         # The not-found bundle is built fresh rather than drained, so
         # `reply_to` is lifted off the accumulator explicitly — a 406 is as
@@ -2115,8 +2129,8 @@ defmodule Grappa.Session.EventRouter do
         # reach the same one connection.
         {:cont, next_state,
          [
-           {:whowas_bundle, target_display, %{target_display: target_display, not_found: true},
-            Map.get(accum, :reply_to)}
+           {:whowas_bundle, target_display,
+            %WhowasAccum{target_display: target_display, not_found: true}, accum.reply_to}
          ]}
 
       :error ->
@@ -2154,7 +2168,7 @@ defmodule Grappa.Session.EventRouter do
          state
        )
        when numeric in [367, 348, 346] and is_binary(channel) and is_binary(mask) do
-    entry = %{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
+    entry = %ListModeAccum.Entry{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
     {:cont, list_mode_append_entry(state, channel, numeric_list_mode(numeric), entry), []}
   end
 
@@ -2167,7 +2181,7 @@ defmodule Grappa.Session.EventRouter do
          state
        )
        when is_binary(channel) and is_binary(mask) and byte_size(mode) == 1 do
-    entry = %{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
+    entry = %ListModeAccum.Entry{mask: mask, setter: Enum.at(rest, 0), set_ts: Enum.at(rest, 1)}
     {:cont, list_mode_append_entry(state, channel, mode, entry), []}
   end
 
@@ -2224,7 +2238,12 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(server) and is_binary(linked_to) do
     {hopcount, description} = parse_links_trailing(List.last(rest))
-    entry = %{server: server, linked_to: linked_to, hopcount: hopcount, description: description}
+    entry = %LinksAccum.Entry{
+      server: server,
+      linked_to: linked_to,
+      hopcount: hopcount,
+      description: description
+    }
     {:cont, links_append_entry(state, entry), []}
   end
 
@@ -2239,8 +2258,8 @@ defmodule Grappa.Session.EventRouter do
       nil ->
         {:cont, state, []}
 
-      accum when is_map(accum) ->
-        {:cont, %{state | links_pending: nil}, [{:links_bundle, accum, Map.get(accum, :reply_to)}]}
+      %LinksAccum{} = accum ->
+        {:cont, %{state | links_pending: nil}, [{:links_bundle, accum, accum.reply_to}]}
     end
   end
 
@@ -4056,8 +4075,8 @@ defmodule Grappa.Session.EventRouter do
   # 252 before 251 — defensive).
   @spec lusers_fold(state(), map()) :: state()
   defp lusers_fold(state, fold) when is_map(fold) do
-    accum = Map.get(state, :lusers_pending) || %{}
-    Map.put(state, :lusers_pending, Map.merge(accum, fold))
+    accum = struct!(Map.get(state, :lusers_pending) || %LusersAccum{}, fold)
+    Map.put(state, :lusers_pending, accum)
   end
 
   # P-0c — append a 314 RPL_WHOWASUSER entry to the WHOWAS accumulator's
@@ -4067,9 +4086,9 @@ defmodule Grappa.Session.EventRouter do
   # builder reads `hd(entries)` for the most-recent projection.
   # Skips when no whowas_pending entry exists (operator never issued
   # /whowas; an unsolicited 314 is not actionable).
-  @spec whowas_append_entry(state(), String.t(), map()) :: state()
-  defp whowas_append_entry(state, target, entry)
-       when is_binary(target) and is_map(entry) do
+  @spec whowas_append_entry(state(), String.t(), WhowasAccum.Entry.t()) :: state()
+  defp whowas_append_entry(state, target, %WhowasAccum.Entry{} = entry)
+       when is_binary(target) do
     pending = Map.get(state, :whowas_pending, %{})
     nick_key = normalize_nick(target, casemapping(state))
 
@@ -4078,8 +4097,7 @@ defmodule Grappa.Session.EventRouter do
         state
 
       {:ok, accum} ->
-        entries = [entry | Map.get(accum, :entries, [])]
-        merged = Map.put(accum, :entries, entries)
+        merged = %{accum | entries: [entry | accum.entries]}
         %{state | whowas_pending: Map.put(pending, nick_key, merged)}
     end
   end
@@ -4103,9 +4121,10 @@ defmodule Grappa.Session.EventRouter do
   # (unsolicited row — the operator never issued the query; not actionable).
   # Mirror of `whowas_append_entry/3` but keyed by `{folded channel (#364),
   # mode}`, not nick.
-  @spec list_mode_append_entry(state(), String.t(), ListModes.mode(), map()) :: state()
-  defp list_mode_append_entry(state, channel, mode, entry)
-       when is_binary(channel) and is_binary(mode) and is_map(entry) do
+  @spec list_mode_append_entry(state(), String.t(), ListModes.mode(), ListModeAccum.Entry.t()) ::
+          state()
+  defp list_mode_append_entry(state, channel, mode, %ListModeAccum.Entry{} = entry)
+       when is_binary(channel) and is_binary(mode) do
     pending = Map.get(state, :list_mode_pending, %{})
     key = {normalize_channel(channel, casemapping(state)), mode}
 
@@ -4114,8 +4133,7 @@ defmodule Grappa.Session.EventRouter do
         state
 
       {:ok, accum} ->
-        entries = [entry | Map.get(accum, :entries, [])]
-        merged = Map.put(accum, :entries, entries)
+        merged = %{accum | entries: [entry | accum.entries]}
         Map.put(state, :list_mode_pending, Map.put(pending, key, merged))
     end
   end
@@ -4135,7 +4153,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state,
          [
-           {:list_mode_bundle, Map.get(accum, :channel_display, channel), mode, accum, Map.get(accum, :reply_to)}
+           {:list_mode_bundle, accum.channel_display || channel, mode, accum, accum.reply_to}
          ]}
 
       :error ->
@@ -4151,15 +4169,14 @@ defmodule Grappa.Session.EventRouter do
   # /links; not actionable). Un-keyed (one topology per network, like
   # LUSERS), so unlike whowas/banlist there is no per-target map —
   # `links_pending` is `nil | %{entries: [...]}`.
-  @spec links_append_entry(state(), map()) :: state()
-  defp links_append_entry(state, entry) when is_map(entry) do
+  @spec links_append_entry(state(), LinksAccum.Entry.t()) :: state()
+  defp links_append_entry(state, %LinksAccum.Entry{} = entry) do
     case Map.get(state, :links_pending) do
       nil ->
         state
 
-      accum when is_map(accum) ->
-        entries = [entry | Map.get(accum, :entries, [])]
-        %{state | links_pending: Map.put(accum, :entries, entries)}
+      %LinksAccum{} = accum ->
+        %{state | links_pending: %{accum | entries: [entry | accum.entries]}}
     end
   end
 
@@ -4195,13 +4212,12 @@ defmodule Grappa.Session.EventRouter do
         state
 
       {:ok, accum} ->
-        case Map.get(accum, :entries, []) do
+        case accum.entries do
           [] ->
             state
 
           [head | tail] ->
-            new_entries = [Map.merge(head, fold) | tail]
-            merged = Map.put(accum, :entries, new_entries)
+            merged = %{accum | entries: [struct!(head, fold) | tail]}
             %{state | whowas_pending: Map.put(pending, nick_key, merged)}
         end
     end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -94,9 +94,9 @@ defmodule Grappa.Session.EventRouter do
   alias Grappa.Session.{
     IdentityState,
     ISupport,
+    LinksAccum,
     ListModeAccum,
     ListModes,
-    LinksAccum,
     LusersAccum,
     NumericRouter,
     Presence,

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -91,7 +91,7 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Message}
   alias Grappa.{Scrollback, Session}
-  alias Grappa.Session.{IdentityState, ISupport, ListModes, NumericRouter, Presence}
+  alias Grappa.Session.{IdentityState, ISupport, ListModes, NumericRouter, Presence, WhoisAccum}
 
   @typedoc """
   The Session.Server state subset this module reads + mutates. The
@@ -1341,7 +1341,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state,
          [
-           {:whois_bundle, Map.get(accum, :target_display, target), accum, Map.get(accum, :reply_to)}
+           {:whois_bundle, accum.target_display || target, accum, accum.reply_to}
          ]}
 
       :error ->
@@ -3915,16 +3915,23 @@ defmodule Grappa.Session.EventRouter do
   # special-case appends to the existing `:channels` list rather than
   # overwriting (319 may chunk over multiple lines).
   @spec whois_fold(state(), String.t(), map()) :: state()
+  # The fold delta stays `map()` deliberately — see `whois_merge/2`.
   # #944 — has the pending bundle for `nick_key` started ARRIVING? Derived from
   # the 311 fold rather than tracked separately: 311 RPL_WHOISUSER is the first
   # numeric of every WHOIS reply and the only one that folds `:user`, so its
   # presence in the accumulator IS the "bundle open" fact. A primed-but-unopened
   # entry means we asked and upstream has not answered yet, which is exactly
   # when a 301 must be read as the standalone reply to our own PRIVMSG.
-  @spec whois_bundle_open?(map(), String.t()) :: boolean()
+  # #1391 — `accum.user != nil`, NOT `Map.has_key?`: every key of a struct
+  # always exists, so the pre-struct membership test would answer `true` for a
+  # primed-but-unanswered bundle and break the 301 discrimination above. The
+  # two are equivalent because 311 is the only writer of `:user` and its head
+  # guards `is_binary(user)`, so the field is nil exactly when 311 has not
+  # arrived.
+  @spec whois_bundle_open?(%{String.t() => WhoisAccum.t()}, String.t()) :: boolean()
   defp whois_bundle_open?(pending, nick_key) do
     case Map.fetch(pending, nick_key) do
-      {:ok, accum} -> Map.has_key?(accum, :user)
+      {:ok, accum} -> accum.user != nil
       :error -> false
     end
   end
@@ -3946,17 +3953,31 @@ defmodule Grappa.Session.EventRouter do
   # Most fields overwrite. `:channels_chunk` (319 partial list) appends
   # into `:channels` instead of replacing — accumulating across multi-line
   # responses for users in many channels.
-  @spec whois_merge(map(), map()) :: map()
-  defp whois_merge(accum, fold) do
-    Enum.reduce(fold, accum, fn
-      {:channels_chunk, chans}, acc ->
-        existing = Map.get(acc, :channels, [])
-        Map.put(acc, :channels, existing ++ chans)
+  #
+  # #1391 — `struct!/2` is the WRITE-side guard: a fold key `WhoisAccum` does
+  # not declare raises `KeyError` here instead of writing a field nobody reads,
+  # which is how a producer typo used to reach the client as a silent `null`.
+  # `:channels_chunk` is popped FIRST because it is a verb, not a field — it
+  # means "append to `:channels`" — and `struct!/2` would (correctly) reject it.
+  # No separate delta type: enumerating the legal fold keys would be a second
+  # copy of the struct's own field list, and the two would drift.
+  @spec whois_merge(WhoisAccum.t(), map()) :: WhoisAccum.t()
+  defp whois_merge(%WhoisAccum{} = accum, fold) when is_map(fold) do
+    {chunk, fields} = Map.pop(fold, :channels_chunk)
 
-      {k, v}, acc ->
-        Map.put(acc, k, v)
-    end)
+    accum
+    |> append_whois_channels(chunk)
+    |> struct!(fields)
   end
+
+  @spec append_whois_channels(WhoisAccum.t(), [String.t()] | nil) :: WhoisAccum.t()
+  defp append_whois_channels(accum, nil), do: accum
+
+  # `|| []` — `channels` defaults to nil (the wire ships `null` when 319 never
+  # arrived; an empty list is a different value), so the first chunk appends
+  # onto nothing rather than onto `[]`.
+  defp append_whois_channels(accum, chans) when is_list(chans),
+    do: %{accum | channels: (accum.channels || []) ++ chans}
 
   # #221 — append one unhandled/free-form WHOIS-leg numeric to the
   # `extra_lines` accumulator (arrival order preserved). Used by 320
@@ -3988,8 +4009,8 @@ defmodule Grappa.Session.EventRouter do
         # window by Server, so folding it here would double it into the
         # card as well.
         if NumericRouter.absorbable_whois_leg?(code, nosuchnick_absorbed?(accum)) do
-          existing = Map.get(accum, :extra_lines, [])
-          merged = Map.put(accum, :extra_lines, [%{numeric: code, text: text} | existing])
+          existing = accum.extra_lines || []
+          merged = %{accum | extra_lines: [%{numeric: code, text: text} | existing]}
           %{state | whois_pending: Map.put(pending, nick_key, merged)}
         else
           state
@@ -4021,13 +4042,11 @@ defmodule Grappa.Session.EventRouter do
         do: key
   end
 
-  @spec nosuchnick_absorbed?(map()) :: boolean()
-  defp nosuchnick_absorbed?(accum) when is_map(accum) do
+  @spec nosuchnick_absorbed?(WhoisAccum.t()) :: boolean()
+  defp nosuchnick_absorbed?(%WhoisAccum{} = accum) do
     nosuchnick = NumericRouter.nosuchnick_numeric()
 
-    accum
-    |> Map.get(:extra_lines, [])
-    |> Enum.any?(&(Map.get(&1, :numeric) == nosuchnick))
+    Enum.any?(accum.extra_lines || [], &(Map.get(&1, :numeric) == nosuchnick))
   end
 
   # P-0d — fold one or more LUSERS fields into `state.lusers_pending`.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -91,6 +91,7 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Message}
   alias Grappa.{Scrollback, Session}
+
   alias Grappa.Session.{
     IdentityState,
     ISupport,
@@ -1974,8 +1975,7 @@ defmodule Grappa.Session.EventRouter do
        when is_list(params) do
     [n, i, s] = extract_lusers_ints(List.last(params), 3)
 
-    {:cont,
-     Map.put(state, :lusers_pending, %LusersAccum{total_users: n, invisible: i, servers: s}), []}
+    {:cont, Map.put(state, :lusers_pending, %LusersAccum{total_users: n, invisible: i, servers: s}), []}
   end
 
   # 252 RPL_LUSEROP: `<N> :IRC Operators online`.
@@ -2038,6 +2038,7 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_list(params) do
     [n, m] = extract_lusers_ints(List.last(params), 2)
+
     accum =
       struct!(Map.get(state, :lusers_pending) || %LusersAccum{}, %{current_global: n, max_global: m})
 
@@ -2129,8 +2130,8 @@ defmodule Grappa.Session.EventRouter do
         # reach the same one connection.
         {:cont, next_state,
          [
-           {:whowas_bundle, target_display,
-            %WhowasAccum{target_display: target_display, not_found: true}, accum.reply_to}
+           {:whowas_bundle, target_display, %WhowasAccum{target_display: target_display, not_found: true},
+            accum.reply_to}
          ]}
 
       :error ->
@@ -2238,12 +2239,14 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(server) and is_binary(linked_to) do
     {hopcount, description} = parse_links_trailing(List.last(rest))
+
     entry = %LinksAccum.Entry{
       server: server,
       linked_to: linked_to,
       hopcount: hopcount,
       description: description
     }
+
     {:cont, links_append_entry(state, entry), []}
   end
 

--- a/lib/grappa/session/links_accum.ex
+++ b/lib/grappa/session/links_accum.ex
@@ -1,0 +1,64 @@
+defmodule Grappa.Session.LinksAccum do
+  @moduledoc """
+  #1391 — the in-flight `/links` accumulator, as a struct.
+
+  `Session.Server`'s `links_pending`: `nil` when idle, a struct once
+  `handle_call({:send_links, ...})` primes it. 364 RPL_LINKS prepends an
+  entry, 365 RPL_ENDOFLINKS drains it into `{:links_bundle, accum,
+  reply_to}`. Unkeyed (one topology per network), so it never passes through
+  `prime_pending/3` and carries no `__primed_at_ms` — `requested_at` is its
+  own staleness stamp, read by the #513b re-prime gate.
+
+  Sibling of `Grappa.Session.WhoisAccum`; the rationale for a struct rather
+  than a `map()` is written once, there.
+
+  `requested_at` stays `integer() | nil` and the #513b gate keeps its
+  `is_integer(ts)` guard: `now - nil` raises and `n < nil` is `true` under
+  Erlang term order, so the guard is load-bearing, not decoration.
+
+  `mask` is `nil` for a full-mesh request and rides to the client so cic can
+  tell "mask matched nothing" from "topology restricted" (#513a). Entries
+  are stored REVERSED for an O(1) prepend; `Wire.links_bundle/2` reverses.
+  """
+
+  alias Grappa.Session
+
+  @type t :: %__MODULE__{
+          entries: [__MODULE__.Entry.t()],
+          mask: String.t() | nil,
+          requested_at: integer() | nil,
+          reply_to: Session.reply_to()
+        }
+
+  defstruct entries: [],
+            mask: nil,
+            requested_at: nil,
+            reply_to: nil
+
+  defmodule Entry do
+    @moduledoc """
+    #1391 — one 364 RPL_LINKS topology row, as a struct.
+
+    `server` is the node, `linked_to` its uplink; the root self-links
+    (`server == linked_to`, `hopcount == 0`). `hopcount` and `description`
+    are nil only when the upstream trailing is malformed — the parse is
+    defensive, so the nullability is real rather than theoretical.
+
+    Projected by `Wire.links_bundle/2` into the `links_entry/0` WIRE shape,
+    which stays a plain map (payload = what the codegen reads and Jason
+    encodes). cic reconstructs the spanning tree from the `linked_to`
+    parent edges: the typed bundle IS the tree, cic never parses IRC.
+
+    Nested in its accumulator on purpose — see `WhowasAccum.Entry`.
+    """
+
+    @type t :: %__MODULE__{
+            server: String.t() | nil,
+            linked_to: String.t() | nil,
+            hopcount: integer() | nil,
+            description: String.t() | nil
+          }
+
+    defstruct server: nil, linked_to: nil, hopcount: nil, description: nil
+  end
+end

--- a/lib/grappa/session/list_mode_accum.ex
+++ b/lib/grappa/session/list_mode_accum.ex
@@ -1,0 +1,65 @@
+defmodule Grappa.Session.ListModeAccum do
+  @moduledoc """
+  #1391 — the in-flight channel LIST-MODE accumulator, as a struct.
+
+  One entry of `Session.Server`'s `list_mode_pending` map, keyed by
+  `{FOLDED channel (#364 channel pattern), mode letter}` so two type-A lists
+  of the same channel can stream concurrently. Primed by
+  `handle_call({:send_list_mode, ...})`, appended to by each row numeric,
+  drained on the end numeric into `{:list_mode_bundle, channel, mode, accum,
+  reply_to}` — which `Grappa.Session.Wire.banlist_bundle/4` projects (the
+  payload keeps its `b`-era name; see that typedoc).
+
+  Sibling of `Grappa.Session.WhoisAccum`; the rationale for a struct rather
+  than a `map()` is written once, there.
+
+  `channel_display` holds the FOLDED channel, not the operator's spelling —
+  channels carry no display column under the #537 channel pattern, the
+  folded key IS the display. Entries are stored REVERSED for an O(1)
+  prepend; `Wire.banlist_bundle/4` reverses.
+  """
+
+  alias Grappa.Session
+  alias Grappa.Session.ListModes
+
+  @type t :: %__MODULE__{
+          channel_display: String.t() | nil,
+          mode: ListModes.mode() | nil,
+          entries: [__MODULE__.Entry.t()],
+          reply_to: Session.reply_to(),
+          __primed_at_ms: integer() | nil
+        }
+
+  defstruct channel_display: nil,
+            mode: nil,
+            entries: [],
+            reply_to: nil,
+            __primed_at_ms: nil
+
+  defmodule Entry do
+    @moduledoc """
+    #1391 — one row of a type-A channel list, as a struct.
+
+    Built by 367 RPL_BANLIST / 348 / 346 / 728, which carry `setter` and
+    `set_ts` OPTIONALLY — older ircds and solanum send the mask alone, so
+    both stay nullable. `set_ts` is the RAW upstream epoch STRING, shipped
+    verbatim: cic formats it to the viewer's locale
+    (`feedback_no_localized_strings_server_side`).
+
+    Projected by `Wire.banlist_bundle/4` into the `banlist_entry/0` WIRE
+    shape, which stays a plain map — the payload is what the TS codegen
+    reads and what Jason encodes. This struct is the internal accumulator
+    shape; they are deliberately two things.
+
+    Nested in its accumulator on purpose — see `WhowasAccum.Entry`.
+    """
+
+    @type t :: %__MODULE__{
+            mask: String.t() | nil,
+            setter: String.t() | nil,
+            set_ts: String.t() | nil
+          }
+
+    defstruct mask: nil, setter: nil, set_ts: nil
+  end
+end

--- a/lib/grappa/session/lusers_accum.ex
+++ b/lib/grappa/session/lusers_accum.ex
@@ -1,0 +1,51 @@
+defmodule Grappa.Session.LusersAccum do
+  @moduledoc """
+  #1391 — the in-flight LUSERS accumulator, as a struct.
+
+  `Session.Server`'s `lusers_pending`: `nil` when idle, a struct while
+  Bahamut's fixed 251 → 252 → 253? → 254 → 255 → 265 → 266 sequence is
+  arriving. There is no terminator numeric — 251 resets the accumulator and
+  266 flushes it into `{:lusers_bundle, accum}`, which
+  `Grappa.Session.Wire.lusers_bundle/2` projects to the client payload.
+
+  Sibling of `Grappa.Session.WhoisAccum`; the rationale for a struct rather
+  than a `map()` (or a map `@type`) is written once, there. In short: the
+  readers used `Map.get/2`, which has no key-membership check, so a map type
+  would have left all twelve of them exactly as unsafe.
+
+  Every field defaults nil because `lusers_bundle_payload/0` declares every
+  one `integer() | nil` — a stripped-down ircd that omits 253
+  RPL_LUSERUNKNOWN ships `null`, and that is the wire contract. Unkeyed (one
+  topology per network), so unlike the whowas / list-mode accumulators this
+  one never passes through `prime_pending/3` and carries no
+  `__primed_at_ms`.
+  """
+
+  @type t :: %__MODULE__{
+          total_users: integer() | nil,
+          invisible: integer() | nil,
+          servers: integer() | nil,
+          operators: integer() | nil,
+          unknown_connections: integer() | nil,
+          channels_formed: integer() | nil,
+          local_clients: integer() | nil,
+          local_servers: integer() | nil,
+          current_local: integer() | nil,
+          max_local: integer() | nil,
+          current_global: integer() | nil,
+          max_global: integer() | nil
+        }
+
+  defstruct total_users: nil,
+            invisible: nil,
+            servers: nil,
+            operators: nil,
+            unknown_connections: nil,
+            channels_formed: nil,
+            local_clients: nil,
+            local_servers: nil,
+            current_local: nil,
+            max_local: nil,
+            current_global: nil,
+            max_global: nil
+end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -107,7 +107,10 @@ defmodule Grappa.Session.Server do
     GhostRecovery,
     IdentityState,
     ISupport,
+    LinksAccum,
+    ListModeAccum,
     ListModes,
+    LusersAccum,
     ModeChunker,
     NSInterceptor,
     NumericRouter,
@@ -117,6 +120,7 @@ defmodule Grappa.Session.Server do
     Presence,
     RecoverIdentity,
     WhoisAccum,
+    WhowasAccum,
     WindowState
   }
 
@@ -857,7 +861,7 @@ defmodule Grappa.Session.Server do
           # `nil` = no bundle in progress (idle); the map starts on the
           # first LUSERS numeric and fills until flush. NOT persisted
           # across crashes — operator types /lusers to refresh.
-          lusers_pending: nil | map(),
+          lusers_pending: LusersAccum.t() | nil,
           # #238/#513 — pending LINKS topology accumulator. Un-keyed (one
           # topology per network, like LUSERS) but PRIMED on `:send_links`
           # (unlike LUSERS): `nil` = idle, `%{entries: [...], mask: mask,
@@ -878,7 +882,7 @@ defmodule Grappa.Session.Server do
           # GATED on staleness: past `@links_stale_ms` the pending is treated
           # as abandoned and a fresh /links clobbers + re-sends. So restricted
           # networks are never bricked. NOT persisted across crashes.
-          links_pending: nil | map(),
+          links_pending: LinksAccum.t() | nil,
           # #127 — per-source server-text-reply accumulators, primed by
           # `:send_info` / `:send_version` / `:send_motd`. `nil` = idle (no
           # explicit request in flight); `%{lines: [...]}` = collecting the
@@ -911,7 +915,7 @@ defmodule Grappa.Session.Server do
           # `not_found: true`. Bounded by in-flight /whowas commands
           # (typically 0-1 at a time) AND the S10 lazy @pending_ttl_ms sweep
           # (withheld 369/406 can't strand the entry). NOT persisted.
-          whowas_pending: %{String.t() => map()},
+          whowas_pending: %{String.t() => WhowasAccum.t()},
           # #376/#1251 — pending channel LIST-MODE accumulators keyed by
           # `{FOLDED channel (#364), mode letter}`, not nick. A type-A mode is
           # a LIST (`b` bans, `e` exempts, `I` invex, `z`/`q` restrict/quiet),
@@ -924,7 +928,7 @@ defmodule Grappa.Session.Server do
           # @pending_ttl_ms sweep (a withheld terminator — e.g. the 482 an
           # ircd answers a non-op `MODE #chan e` with — can't strand the
           # entry). NOT persisted across crashes.
-          list_mode_pending: %{{String.t(), ListModes.mode()} => map()},
+          list_mode_pending: %{{String.t(), ListModes.mode()} => ListModeAccum.t()},
           # Channel directory (#84) refresh tunables — config-derived at
           # boot (`config :grappa, Grappa.ChannelDirectory`), opts-overridable
           # in `do_init/1` so tests can pin them. Read by later tasks: the
@@ -2131,7 +2135,7 @@ defmodule Grappa.Session.Server do
         {:reply, Client.send_links(state.client, mask),
          %{
            state
-           | links_pending: %{entries: [], mask: mask, requested_at: now, reply_to: reply_to}
+           | links_pending: %LinksAccum{mask: mask, requested_at: now, reply_to: reply_to}
          }}
     end
   end
@@ -2246,10 +2250,9 @@ defmodule Grappa.Session.Server do
       chan_key = fold_key(state, channel)
 
       next_pending =
-        prime_pending(state.list_mode_pending, {chan_key, mode}, %{
+        prime_pending(state.list_mode_pending, {chan_key, mode}, %ListModeAccum{
           channel_display: chan_key,
           mode: mode,
-          entries: [],
           reply_to: reply_to
         })
 
@@ -2317,9 +2320,8 @@ defmodule Grappa.Session.Server do
     nick_key = fold_key(state, target)
 
     next_pending =
-      prime_pending(state.whowas_pending, nick_key, %{
+      prime_pending(state.whowas_pending, nick_key, %WhowasAccum{
         target_display: target,
-        entries: [],
         reply_to: reply_to
       })
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -116,6 +116,7 @@ defmodule Grappa.Session.Server do
     Persistor,
     Presence,
     RecoverIdentity,
+    WhoisAccum,
     WindowState
   }
 
@@ -836,7 +837,7 @@ defmodule Grappa.Session.Server do
           # AND a lazy @pending_ttl_ms sweep (S10) — a withheld 318 can't
           # strand the entry. Each value carries an internal `:__primed_at_ms`
           # stamp (invisible to the wire builder's explicit field extraction).
-          whois_pending: %{String.t() => map()},
+          whois_pending: %{String.t() => WhoisAccum.t()},
           # CP22 cluster B — per-target WHO accumulator. Keyed by
           # lowercased target channel. Entry shape:
           # `%{target_display: String.t(), replies: [map()]}` where each
@@ -2293,7 +2294,7 @@ defmodule Grappa.Session.Server do
     nick_key = fold_key(state, target)
 
     next_pending =
-      prime_pending(state.whois_pending, nick_key, %{
+      prime_pending(state.whois_pending, nick_key, %WhoisAccum{
         target_display: target,
         source: origin,
         reply_to: reply_to
@@ -4981,6 +4982,12 @@ defmodule Grappa.Session.Server do
   # `*_bundle` builders read the accumulator via explicit `Map.get` field
   # extraction — and dies with the entry on drain (Map.delete of the whole key),
   # so no drain site needs to know about it.
+  # #1391 — `Map.put` and not `%{value | __primed_at_ms: now}`: this helper is
+  # generic over FIVE keyed accumulators and only `whois_pending` carries a
+  # struct so far. The update syntax would raise on the four that are still
+  # plain maps without the key. Convert this to the update syntax — which
+  # fails loudly on an accumulator that forgot to declare the field — once all
+  # five are structs; until then it is the one map-generic seam left.
   @spec prime_pending(%{optional(term()) => map()}, term(), map()) ::
           %{optional(term()) => map()}
   defp prime_pending(pending, key, value) when is_map(pending) and is_map(value) do

--- a/lib/grappa/session/whois_accum.ex
+++ b/lib/grappa/session/whois_accum.ex
@@ -1,0 +1,116 @@
+defmodule Grappa.Session.WhoisAccum do
+  @moduledoc """
+  #1391 — the in-flight `/whois` accumulator, as a struct.
+
+  One entry of `Session.Server`'s `whois_pending` map: primed by
+  `handle_call({:send_whois, ...})` the instant the command is on the wire,
+  folded by `EventRouter` as each WHOIS-leg numeric arrives, and drained on
+  318 RPL_ENDOFWHOIS into `{:whois_bundle, target, accum, reply_to}`, which
+  `Grappa.Session.Wire.whois_bundle/3` projects to the client payload.
+
+  ## Why a struct and not a `map()` (or a `@type` over a map)
+
+  The accumulator used to be a bare `map()` from producer to wire, joined to
+  its 28 readers by nothing but the atom spelling. The 2026-08-15 architecture
+  review (bucket B, #1391) proposed declaring a map type for it. A map type
+  does not close the defect: the readers use `Map.get(accum, :key)`, which has
+  no key-membership check at all — a misspelled key returns the default and
+  renders as `null` no matter how precisely the map is typed.
+
+  A struct closes both ends, by two different mechanisms:
+
+    * **read** — `accum.away_messge` is not a silent `nil`; the field set is
+      fixed at compile time.
+    * **write** — folds go through `struct!/2`, which raises `KeyError` on a
+      key this struct does not declare. A producer typo takes the session
+      down loudly instead of dropping one field from the card.
+
+  It is also what the house already does for state that lives inside
+  `Session.Server`'s state map: `AwayState`, `GhostRecovery`,
+  `RecoverIdentity` and `WindowState` are all structs, and all four are
+  listed in `Grappa.HotReload.LongLivedModules`'s `@state_helpers` so a
+  `defstruct` change refuses a hot deploy. This struct joins them.
+
+  ## Defaults are the wire contract
+
+  Every default here is the value `Session.Wire.whois_bundle/3` used to
+  supply at read time via `Map.get(accum, :key, default)`. Booleans default
+  `false`, strings `nil`, and the two lists default **`nil`, not `[]`** —
+  `channels` and `extra_lines` ship as JSON `null` when the numeric never
+  arrived, and an empty list is a different wire value. Moving the defaults
+  here removes the duplication rather than relocating it: they are now
+  declared once, next to the data.
+
+  `target_display`, `reply_to` and `__primed_at_ms` are routing/lifecycle
+  metadata, not wire fields — the drain and the S10 stale sweep read them.
+  """
+
+  alias Grappa.Session
+  alias Grappa.Session.Wire
+
+  @type t :: %__MODULE__{
+          target_display: String.t() | nil,
+          source: :user | :rail,
+          reply_to: Session.reply_to(),
+          __primed_at_ms: integer() | nil,
+          user: String.t() | nil,
+          host: String.t() | nil,
+          realname: String.t() | nil,
+          server: String.t() | nil,
+          server_info: String.t() | nil,
+          is_operator: boolean(),
+          oper_text: String.t() | nil,
+          idle_seconds: integer() | nil,
+          signon: integer() | nil,
+          channels: [String.t()] | nil,
+          using_ssl: boolean(),
+          is_registered: boolean(),
+          is_admin: boolean(),
+          is_services_admin: boolean(),
+          is_helper: boolean(),
+          is_chanop: boolean(),
+          is_agent: boolean(),
+          is_java: boolean(),
+          umodes: String.t() | nil,
+          away_message: String.t() | nil,
+          actually_host: String.t() | nil,
+          actually_ip: String.t() | nil,
+          account: String.t() | nil,
+          secure: boolean(),
+          secure_cipher: String.t() | nil,
+          certfp: String.t() | nil,
+          extra_lines: [Wire.whois_extra_line()] | nil
+        }
+
+  defstruct target_display: nil,
+            source: :user,
+            reply_to: nil,
+            __primed_at_ms: nil,
+            user: nil,
+            host: nil,
+            realname: nil,
+            server: nil,
+            server_info: nil,
+            is_operator: false,
+            oper_text: nil,
+            idle_seconds: nil,
+            signon: nil,
+            channels: nil,
+            using_ssl: false,
+            is_registered: false,
+            is_admin: false,
+            is_services_admin: false,
+            is_helper: false,
+            is_chanop: false,
+            is_agent: false,
+            is_java: false,
+            umodes: nil,
+            away_message: nil,
+            actually_host: nil,
+            actually_ip: nil,
+            account: nil,
+            secure: false,
+            secure_cipher: nil,
+            certfp: nil,
+            extra_lines: nil
+end

--- a/lib/grappa/session/whowas_accum.ex
+++ b/lib/grappa/session/whowas_accum.ex
@@ -1,0 +1,66 @@
+defmodule Grappa.Session.WhowasAccum do
+  @moduledoc """
+  #1391 — the in-flight `/whowas` accumulator, as a struct.
+
+  One entry of `Session.Server`'s `whowas_pending` map: primed by
+  `handle_call({:send_whowas, ...})`, appended to by each 314
+  RPL_WHOWASUSER, merged into by the WHOWAS-flavoured 312, and drained on
+  369 RPL_ENDOFWHOWAS — or on 406 ERR_WASNOSUCHNICK, which builds a fresh
+  `not_found: true` struct rather than draining the primed one.
+
+  Sibling of `Grappa.Session.WhoisAccum`; the rationale for a struct rather
+  than a `map()` is written once, there.
+
+  `entries` defaults to `[]`, NOT nil: the prime sets it empty and
+  `Wire.whowas_bundle/3` reads it as a list to take the head from. That is
+  the opposite of `WhoisAccum`'s `channels` / `extra_lines`, which default
+  nil because they ship as JSON `null` — here the list never reaches the
+  wire, only its most recent element does.
+
+  Entries are stored REVERSED (head = most recent 314) so the 312 fold into
+  the LAST entry is an O(1) head-prepend.
+  """
+
+  alias Grappa.Session
+
+  @type t :: %__MODULE__{
+          target_display: String.t() | nil,
+          entries: [__MODULE__.Entry.t()],
+          not_found: boolean(),
+          reply_to: Session.reply_to(),
+          __primed_at_ms: integer() | nil
+        }
+
+  defstruct target_display: nil,
+            entries: [],
+            not_found: false,
+            reply_to: nil,
+            __primed_at_ms: nil
+
+  defmodule Entry do
+    @moduledoc """
+    #1391 — one historical WHOWAS record, as a struct.
+
+    Built by 314 RPL_WHOWASUSER (`user`, `host`, `realname`) and completed
+    by the WHOWAS-flavoured 312, which merges `server` + `logoff_time` into
+    the most recent entry. `Wire.whowas_bundle/3` projects the head of the
+    list; every field is nullable because a stripped-down upstream may omit
+    the trailing or never send the 312 at all.
+
+    Nested in its accumulator on purpose: an entry has no meaning outside
+    one, and `Deploy.Preflight` collects every `defstruct` in a file, so
+    living here inherits the parent's cold-deploy check with no second
+    registry entry (measured in `Preflight.collect_state_blocks/1`).
+    """
+
+    @type t :: %__MODULE__{
+            user: String.t() | nil,
+            host: String.t() | nil,
+            realname: String.t() | nil,
+            server: String.t() | nil,
+            logoff_time: String.t() | nil
+          }
+
+    defstruct user: nil, host: nil, realname: nil, server: nil, logoff_time: nil
+  end
+end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -59,7 +59,16 @@ defmodule Grappa.Session.Wire do
 
   alias Grappa.IRC.LineSplit
   alias Grappa.Scrollback.Message
-  alias Grappa.Session.{EventRouter, ISupport, ListModes, WhoisAccum}
+  alias Grappa.Session.{
+    EventRouter,
+    ISupport,
+    LinksAccum,
+    ListModeAccum,
+    ListModes,
+    LusersAccum,
+    WhoisAccum,
+    WhowasAccum
+  }
 
   @typedoc """
   The closed set of event kinds emitted by Session. Useful when
@@ -1551,24 +1560,23 @@ defmodule Grappa.Session.Wire do
   persisted — operator types /lusers to refresh; cic shows the most
   recent snapshot only.
   """
-  @spec lusers_bundle(String.t(), map()) :: lusers_bundle_payload()
-  def lusers_bundle(network_slug, accum)
-      when is_binary(network_slug) and is_map(accum) do
+  @spec lusers_bundle(String.t(), LusersAccum.t()) :: lusers_bundle_payload()
+  def lusers_bundle(network_slug, %LusersAccum{} = accum) when is_binary(network_slug) do
     %{
       kind: :lusers_bundle,
       network: network_slug,
-      total_users: Map.get(accum, :total_users),
-      invisible: Map.get(accum, :invisible),
-      servers: Map.get(accum, :servers),
-      operators: Map.get(accum, :operators),
-      unknown_connections: Map.get(accum, :unknown_connections),
-      channels_formed: Map.get(accum, :channels_formed),
-      local_clients: Map.get(accum, :local_clients),
-      local_servers: Map.get(accum, :local_servers),
-      current_local: Map.get(accum, :current_local),
-      max_local: Map.get(accum, :max_local),
-      current_global: Map.get(accum, :current_global),
-      max_global: Map.get(accum, :max_global)
+      total_users: accum.total_users,
+      invisible: accum.invisible,
+      servers: accum.servers,
+      operators: accum.operators,
+      unknown_connections: accum.unknown_connections,
+      channels_formed: accum.channels_formed,
+      local_clients: accum.local_clients,
+      local_servers: accum.local_servers,
+      current_local: accum.current_local,
+      max_local: accum.max_local,
+      current_global: accum.current_global,
+      max_global: accum.max_global
     }
   end
 
@@ -1584,17 +1592,21 @@ defmodule Grappa.Session.Wire do
   user/host/realname/server/logoff_time fields. NOT persisted —
   operator types /whowas to refresh.
   """
-  @spec whowas_bundle(String.t(), String.t(), map()) :: whowas_bundle_payload()
-  def whowas_bundle(network_slug, target, accum)
-      when is_binary(network_slug) and is_binary(target) and is_map(accum) do
-    not_found = Map.get(accum, :not_found, false)
+  @spec whowas_bundle(String.t(), String.t(), WhowasAccum.t()) :: whowas_bundle_payload()
+  def whowas_bundle(network_slug, target, %WhowasAccum{} = accum)
+      when is_binary(network_slug) and is_binary(target) do
+    not_found = accum.not_found
 
+    # #1391 — the empty case is an empty ENTRY, not an empty map: every
+    # projection below is now a struct field access, and `%{}` has no fields.
+    # A `not_found` bundle and a bundle whose 369 arrived with no 314 both
+    # ship the same all-nil historical fields, exactly as before.
     last_entry =
       if not_found do
-        %{}
+        %WhowasAccum.Entry{}
       else
-        case Map.get(accum, :entries, []) do
-          [] -> %{}
+        case accum.entries do
+          [] -> %WhowasAccum.Entry{}
           # Entries are stored REVERSED by EventRouter (head = most
           # recent 314 RPL_WHOWASUSER). MVP renders only the most-
           # recent entry; multi-history is out of scope.
@@ -1606,11 +1618,11 @@ defmodule Grappa.Session.Wire do
       kind: :whowas_bundle,
       network: network_slug,
       target: target,
-      user: Map.get(last_entry, :user),
-      host: Map.get(last_entry, :host),
-      realname: Map.get(last_entry, :realname),
-      server: Map.get(last_entry, :server),
-      logoff_time: Map.get(last_entry, :logoff_time),
+      user: last_entry.user,
+      host: last_entry.host,
+      realname: last_entry.realname,
+      server: last_entry.server,
+      logoff_time: last_entry.logoff_time,
       not_found: not_found
     }
   end
@@ -1631,19 +1643,15 @@ defmodule Grappa.Session.Wire do
   `mode` is the type-A letter the bundle answers for; see
   `banlist_bundle_payload/0` for why the kind keeps its `b`-era name.
   """
-  @spec banlist_bundle(String.t(), String.t(), String.t(), map()) :: banlist_bundle_payload()
-  def banlist_bundle(network_slug, channel, mode, accum)
-      when is_binary(network_slug) and is_binary(channel) and is_binary(mode) and is_map(accum) do
+  @spec banlist_bundle(String.t(), String.t(), String.t(), ListModeAccum.t()) ::
+          banlist_bundle_payload()
+  def banlist_bundle(network_slug, channel, mode, %ListModeAccum{} = accum)
+      when is_binary(network_slug) and is_binary(channel) and is_binary(mode) do
     entries =
-      accum
-      |> Map.get(:entries, [])
+      accum.entries
       |> Enum.reverse()
       |> Enum.map(fn e ->
-        %{
-          mask: Map.get(e, :mask),
-          setter: Map.get(e, :setter),
-          set_ts: Map.get(e, :set_ts)
-        }
+        %{mask: e.mask, setter: e.setter, set_ts: e.set_ts}
       end)
 
     %{
@@ -1672,26 +1680,24 @@ defmodule Grappa.Session.Wire do
   it is the restricted-topology signal. NOT persisted — operator types
   /links to refresh.
   """
-  @spec links_bundle(String.t(), map()) :: links_bundle_payload()
-  def links_bundle(network_slug, accum)
-      when is_binary(network_slug) and is_map(accum) do
+  @spec links_bundle(String.t(), LinksAccum.t()) :: links_bundle_payload()
+  def links_bundle(network_slug, %LinksAccum{} = accum) when is_binary(network_slug) do
     entries =
-      accum
-      |> Map.get(:entries, [])
+      accum.entries
       |> Enum.reverse()
       |> Enum.map(fn e ->
         %{
-          server: Map.get(e, :server),
-          linked_to: Map.get(e, :linked_to),
-          hopcount: Map.get(e, :hopcount),
-          description: Map.get(e, :description)
+          server: e.server,
+          linked_to: e.linked_to,
+          hopcount: e.hopcount,
+          description: e.description
         }
       end)
 
     %{
       kind: :links_bundle,
       network: network_slug,
-      mask: Map.get(accum, :mask),
+      mask: accum.mask,
       entries: entries
     }
   end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Session.Wire do
 
   alias Grappa.IRC.LineSplit
   alias Grappa.Scrollback.Message
+
   alias Grappa.Session.{
     EventRouter,
     ISupport,

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -59,7 +59,7 @@ defmodule Grappa.Session.Wire do
 
   alias Grappa.IRC.LineSplit
   alias Grappa.Scrollback.Message
-  alias Grappa.Session.{EventRouter, ISupport, ListModes}
+  alias Grappa.Session.{EventRouter, ISupport, ListModes, WhoisAccum}
 
   @typedoc """
   The closed set of event kinds emitted by Session. Useful when
@@ -1461,52 +1461,53 @@ defmodule Grappa.Session.Wire do
   network and replaces on each new bundle (one card visible at a time
   per network).
   """
-  @spec whois_bundle(String.t(), String.t(), map()) :: whois_bundle_payload()
-  def whois_bundle(network_slug, target, accum)
-      when is_binary(network_slug) and is_binary(target) and is_map(accum) do
+  # #1391 — field access, not `Map.get/2,3`. The defaults that used to sit on
+  # the third argument of each `Map.get` now live once on `WhoisAccum`'s
+  # `defstruct`, next to the data: `source` still defaults to `:user`, the
+  # flags to `false`, `channels` / `extra_lines` to nil (a `null` on the wire,
+  # which is NOT the same value as `[]`). Duplication removed, not moved.
+  @spec whois_bundle(String.t(), String.t(), WhoisAccum.t()) :: whois_bundle_payload()
+  def whois_bundle(network_slug, target, %WhoisAccum{} = accum)
+      when is_binary(network_slug) and is_binary(target) do
     %{
       kind: :whois_bundle,
       network: network_slug,
       target: target,
-      # #606 — request origin, defaulting to :user for a bundle primed by
-      # pre-#606 code (hot-deploy in-flight accumulator) or any path that
-      # somehow skipped it. Jason encodes the atom to "user"/"rail".
-      source: Map.get(accum, :source, :user),
-      user: Map.get(accum, :user),
-      host: Map.get(accum, :host),
-      realname: Map.get(accum, :realname),
-      server: Map.get(accum, :server),
-      server_info: Map.get(accum, :server_info),
-      is_operator: Map.get(accum, :is_operator, false),
+      # #606 — request origin. Jason encodes the atom to "user"/"rail".
+      source: accum.source,
+      user: accum.user,
+      host: accum.host,
+      realname: accum.realname,
+      server: accum.server,
+      server_info: accum.server_info,
+      is_operator: accum.is_operator,
       # #367 — trailing role text from 313 (nil for a bare 313 or no oper).
-      oper_text: Map.get(accum, :oper_text),
-      idle_seconds: Map.get(accum, :idle_seconds),
-      signon: Map.get(accum, :signon),
-      channels: Map.get(accum, :channels),
-      # P-0a — 11 new WHOIS-leg flags / strings folded by EventRouter.
-      # Booleans default to false; strings default to nil. cic localizes.
-      using_ssl: Map.get(accum, :using_ssl, false),
-      is_registered: Map.get(accum, :is_registered, false),
-      is_admin: Map.get(accum, :is_admin, false),
-      is_services_admin: Map.get(accum, :is_services_admin, false),
-      is_helper: Map.get(accum, :is_helper, false),
-      is_chanop: Map.get(accum, :is_chanop, false),
-      is_agent: Map.get(accum, :is_agent, false),
-      is_java: Map.get(accum, :is_java, false),
-      umodes: Map.get(accum, :umodes),
-      away_message: Map.get(accum, :away_message),
-      actually_host: Map.get(accum, :actually_host),
-      actually_ip: Map.get(accum, :actually_ip),
-      # #221 — solanum WHOIS-leg fields. Booleans default false, strings /
-      # lists nil, so a bahamut bundle (none of these numerics fired)
-      # marshals unchanged.
-      account: Map.get(accum, :account),
-      secure: Map.get(accum, :secure, false),
-      secure_cipher: Map.get(accum, :secure_cipher),
-      certfp: Map.get(accum, :certfp),
+      oper_text: accum.oper_text,
+      idle_seconds: accum.idle_seconds,
+      signon: accum.signon,
+      channels: accum.channels,
+      # P-0a — 11 WHOIS-leg flags / strings folded by EventRouter.
+      using_ssl: accum.using_ssl,
+      is_registered: accum.is_registered,
+      is_admin: accum.is_admin,
+      is_services_admin: accum.is_services_admin,
+      is_helper: accum.is_helper,
+      is_chanop: accum.is_chanop,
+      is_agent: accum.is_agent,
+      is_java: accum.is_java,
+      umodes: accum.umodes,
+      away_message: accum.away_message,
+      actually_host: accum.actually_host,
+      actually_ip: accum.actually_ip,
+      # #221 — solanum WHOIS-leg fields. A bahamut bundle (none of these
+      # numerics fired) marshals unchanged off the struct defaults.
+      account: accum.account,
+      secure: accum.secure,
+      secure_cipher: accum.secure_cipher,
+      certfp: accum.certfp,
       # #221 — extra_lines are prepended LIFO by whois_extra_line_fold for
       # O(1) fold; reverse here so cic sees them in arrival (wire) order.
-      extra_lines: reverse_extra_lines(Map.get(accum, :extra_lines))
+      extra_lines: reverse_extra_lines(accum.extra_lines)
     }
   end
 

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -1611,7 +1611,13 @@ defmodule Grappa.Session.Wire do
           # Entries are stored REVERSED by EventRouter (head = most
           # recent 314 RPL_WHOWASUSER). MVP renders only the most-
           # recent entry; multi-history is out of scope.
-          [head | _] -> head
+          #
+          # #1391 — the match is `%Entry{} = head`, not a bare `head`, and it
+          # is load-bearing: inference does not carry an element type out of a
+          # list, so a bare binding leaves the reads below `dynamic()` and a
+          # misspelt field survives compilation (measured — it then dies at
+          # runtime on KeyError, one gate later than the accumulator layer).
+          [%WhowasAccum.Entry{} = head | _] -> head
         end
       end
 
@@ -1651,7 +1657,9 @@ defmodule Grappa.Session.Wire do
     entries =
       accum.entries
       |> Enum.reverse()
-      |> Enum.map(fn e ->
+      # The `%Entry{}` in the head is the compile-time guard — see
+      # `whowas_bundle/3` for why a bare `e` would not be one.
+      |> Enum.map(fn %ListModeAccum.Entry{} = e ->
         %{mask: e.mask, setter: e.setter, set_ts: e.set_ts}
       end)
 
@@ -1686,7 +1694,9 @@ defmodule Grappa.Session.Wire do
     entries =
       accum.entries
       |> Enum.reverse()
-      |> Enum.map(fn e ->
+      # Same guard as `banlist_bundle/4` — the struct in the head is what
+      # keeps these four reads checked at compile time.
+      |> Enum.map(fn %LinksAccum.Entry{} = e ->
         %{
           server: e.server,
           linked_to: e.linked_to,

--- a/lib/grappa_web/channels/admin_channel.ex
+++ b/lib/grappa_web/channels/admin_channel.ex
@@ -34,6 +34,14 @@ defmodule GrappaWeb.AdminChannel do
   carries only live updates. Reuses the admin socket rather than a second
   channel (Option B: two persisted admin surfaces, one operator socket).
 
+  ## Nothing unknown is fatal, in either direction (#1407 W-S7)
+
+  Neither an unrecognised inbound frame nor an unrecognised mailbox
+  message takes the operator's console down: both collapse to a
+  catch-all, and the `handle_info/2` one logs at warning so the message
+  it cannot read stays visible. See that clause for why crashing would
+  surface less, not more.
+
   ## No inbound handlers
 
   Admin events are server-originated only. The single `handle_in/3`
@@ -54,6 +62,8 @@ defmodule GrappaWeb.AdminChannel do
 
   alias Grappa.{AdminEvents, AdminOverview}
   alias Grappa.PubSub.Topic
+
+  require Logger
 
   @impl Phoenix.Channel
   def join("grappa:admin:events", _, socket) do
@@ -93,6 +103,32 @@ defmodule GrappaWeb.AdminChannel do
         socket
       ) do
     push(socket, "session_log_event", payload)
+    {:noreply, socket}
+  end
+
+  # W-S7 (#1407) — the info-side twin of the inbound catch-all below, and
+  # the third instance of the #1338 `unknown-is-never-fatal` family: same
+  # logged shape as `GrappaWeb.SessionRevocationListener` and
+  # `Grappa.IRC.Client`, chosen over inventing a second one.
+  #
+  # The three clauses above are exhaustive only by luck — one hardcoded
+  # event name (`PubSub.broadcast_event/2`) from the one publisher on
+  # `Topic.session_log/0`. A second publisher, a renamed event, or any
+  # stray `send/2` would otherwise kill the console with a
+  # `FunctionClauseError`, which is the exact outcome the `handle_in/3`
+  # catch-all below refuses to allow — this module argued one posture and
+  # implemented the other.
+  #
+  # Not a funnel: the message is logged at warning under the allowlisted
+  # `unexpected:` key, so what this channel cannot read is visible in the
+  # operator's own log rather than swallowed. Crashing would surface it
+  # too, but strictly worse: the push this channel performs is
+  # per-MESSAGE and stateless, so a crash cannot retry the unread message
+  # — it only discards the mailbox behind it, taking live session-log
+  # events down with it, and a repeating publisher then walks the restart
+  # intensity until the operator's console is gone for good.
+  def handle_info(msg, socket) do
+    Logger.warning("unexpected mailbox message", unexpected: inspect(msg))
     {:noreply, socket}
   end
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -158,12 +158,19 @@ defmodule GrappaWeb.Admin.SettingsController do
         :ok
 
       subtree when is_map(subtree) ->
-        with :ok <- reject_unknown_keys(subtree, allowed, key) do
-          Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
-        end
+        apply_known_keys(subtree, allowed, key, fun)
 
       _ ->
         {:error, :bad_request}
+    end
+  end
+
+  # Gate then fold, in that order — see `reject_unknown_keys/3` for why the
+  # gate cannot move after the fold. Its own function so neither the guard
+  # nor the fold lambda nests inside the shape `case` above.
+  defp apply_known_keys(subtree, allowed, key, fun) do
+    with :ok <- reject_unknown_keys(subtree, allowed, key) do
+      Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
     end
   end
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -55,7 +55,10 @@ defmodule GrappaWeb.Admin.SettingsController do
   every key within each is optional — the controller upserts only the keys
   present in the body. Any invalid value (out-of-set host/mode string,
   non-positive integer cap, non-16-bit-group prefix length) collapses to
-  422 `invalid_setting` with the offending dotted key in `field`.
+  422 `invalid_setting` with the offending dotted key in `field`, and so
+  does any key outside the two closed sets above (#1407 W-S3) — a typo is
+  named, never absorbed, and it refuses the WHOLE body rather than
+  applying the keys it did recognise.
 
   On success: 200 with the new full settings view AND fan-out of a
   `server_settings_changed` push on every live `Topic.user(name)`
@@ -77,7 +80,15 @@ defmodule GrappaWeb.Admin.SettingsController do
   alias Grappa.PubSub.Topic
   alias Grappa.ServerSettings.Wire, as: SettingsWire
 
-  require Logger
+  # The two closed key sets. Every entry here MUST have a matching
+  # `apply_upload_key/2` clause (resp. a `resolve_addressing_*` one) —
+  # adding a key to one and not the other is caught by that key's own
+  # per-key test, loudly, never silently.
+  @upload_keys ~w(active_host image_per_file_cap_bytes video_per_file_cap_bytes
+                  document_per_file_cap_bytes audio_per_file_cap_bytes
+                  global_cap_bytes video_max_duration_seconds)
+
+  @addressing_keys ~w(mode static_mapping_prefix)
 
   @doc false
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -131,7 +142,7 @@ defmodule GrappaWeb.Admin.SettingsController do
   # ---- Internal ----------------------------------------------------
 
   defp apply_updates(params) when is_map(params) do
-    with :ok <- apply_subtree(params, "upload", &apply_upload_key/2) do
+    with :ok <- apply_subtree(params, "upload", @upload_keys, &apply_upload_key/2) do
       apply_addressing(Map.get(params, "addressing"))
     end
   end
@@ -141,16 +152,43 @@ defmodule GrappaWeb.Admin.SettingsController do
   # Fold a present subtree through its per-key applier. Absent subtree → :ok
   # (each is independently optional — an empty body updates nothing); a
   # non-map subtree → bad_request (no silent swallow of a malformed shape).
-  defp apply_subtree(params, key, fun) do
+  defp apply_subtree(params, key, allowed, fun) do
     case Map.get(params, key) do
       nil ->
         :ok
 
       subtree when is_map(subtree) ->
-        Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
+        with :ok <- reject_unknown_keys(subtree, allowed, key) do
+          Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
+        end
 
       _ ->
         {:error, :bad_request}
+    end
+  end
+
+  # W-S3 (#1407) — an unrecognised key is a typo, not a forward-compat
+  # shape: `AdminSettingsTab` sends a fixed literal set, so nothing but a
+  # hand-rolled request can produce one. It used to be logged and dropped
+  # while the action still answered 200 with the full view, so an operator
+  # who typed `image_per_file_cap` watched a save succeed and change
+  # nothing — the "no silent-swallow at boundaries" failure exactly.
+  #
+  # The check runs BEFORE the fold, so a body mixing a good key with a typo
+  # writes nothing: the all-or-nothing posture every sibling admin
+  # controller already takes by validating keys before building attrs.
+  #
+  # The 422 `invalid_setting` envelope is chosen over the siblings' bare
+  # `bad_request` because this door already has a `field` vocabulary and
+  # cic already reads it (`AdminSettingsTab`'s `err.info.field` highlights
+  # the offending input inline). Naming the key IS the fix; a bare 400
+  # would leave the operator exactly as uninformed as the 200 did.
+  # Sorted, so a body carrying several unknown keys names the same one on
+  # every request.
+  defp reject_unknown_keys(subtree, allowed, subtree_name) do
+    case subtree |> Map.keys() |> Enum.reject(&(&1 in allowed)) |> Enum.sort() do
+      [] -> :ok
+      [key | _] -> {:error, {:invalid_setting, subtree_name <> "." <> key}}
     end
   end
 
@@ -197,16 +235,8 @@ defmodule GrappaWeb.Admin.SettingsController do
   defp apply_upload_key("video_max_duration_seconds", _),
     do: {:error, {:invalid_setting, "upload.video_max_duration_seconds"}}
 
-  # Unknown key — ignore but log at warning level. Tolerant of
-  # forward-compat shapes cic might send when an admin opens an
-  # older deploy, while still discoverable when an admin typos
-  # `globalcap_bytes` and wonders why nothing changed
-  # (per `feedback_no_silent_drops_closed` — silent acceptance
-  # absorbs the next class of bug).
-  defp apply_upload_key(k, _) do
-    Logger.warning("admin PUT /settings: unknown upload key", setting_key: k)
-    :ok
-  end
+  # No unknown-key clause: `reject_unknown_keys/3` has already refused
+  # every key outside `@upload_keys` before this fold begins.
 
   # ---- addressing.* — probe-gated unit apply (#543 / #609) ----------
   #
@@ -219,9 +249,8 @@ defmodule GrappaWeb.Admin.SettingsController do
   defp apply_addressing(nil), do: :ok
 
   defp apply_addressing(subtree) when is_map(subtree) do
-    warn_unknown_addressing_keys(subtree)
-
-    with {:ok, mode} <- resolve_addressing_mode(subtree),
+    with :ok <- reject_unknown_keys(subtree, @addressing_keys, "addressing"),
+         {:ok, mode} <- resolve_addressing_mode(subtree),
          {:ok, prefix} <- resolve_addressing_prefix(subtree),
          :ok <- arm_if_static(mode, prefix),
          :ok <- persist_addressing_prefix(subtree),
@@ -298,16 +327,6 @@ defmodule GrappaWeb.Admin.SettingsController do
     do: ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
 
   defp persist_addressing_mode(_), do: :ok
-
-  # Unknown addressing key — ignore but log (tolerant of forward-compat shapes,
-  # discoverable on a typo). Same posture as `apply_upload_key/2`'s catch-all.
-  defp warn_unknown_addressing_keys(subtree) do
-    for {k, _} <- subtree, k not in ["mode", "static_mapping_prefix"] do
-      Logger.warning("admin PUT /settings: unknown addressing key", setting_key: k)
-    end
-
-    :ok
-  end
 
   # Translate per-key return to Enum.reduce_while continuation. `:ok`
   # → continue; `{:error, _}` → halt with the error preserved.

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -12,7 +12,7 @@ defmodule Grappa.Session.EventRouterTest do
   use ExUnit.Case, async: true
 
   alias Grappa.IRC.{JoinFailure, Message, Parser}
-  alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, Wire}
+  alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, WhoisAccum, Wire}
 
   @user_id "00000000-0000-0000-0000-000000000001"
   @subject {:user, @user_id}
@@ -4073,7 +4073,7 @@ defmodule Grappa.Session.EventRouterTest do
     defp whois_pending_state(target_display) do
       base_state(%{
         whois_pending: %{
-          String.downcase(target_display) => %{target_display: target_display}
+          String.downcase(target_display) => %WhoisAccum{target_display: target_display}
         }
       })
     end
@@ -4090,9 +4090,9 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.whois_pending["alice"][:user] == "alice_u"
-      assert new_state.whois_pending["alice"][:host] == "alice.host"
-      assert new_state.whois_pending["alice"][:realname] == "Alice Realname"
+      assert new_state.whois_pending["alice"].user == "alice_u"
+      assert new_state.whois_pending["alice"].host == "alice.host"
+      assert new_state.whois_pending["alice"].realname == "Alice Realname"
       # userhost_cache also still updates (existing S2.4 behaviour).
       assert new_state.userhost_cache["alice"] == %{user: "alice_u", host: "alice.host"}
     end
@@ -4124,8 +4124,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:server] == "irc.azzurra.org"
-      assert new_state.whois_pending["alice"][:server_info] == "Azzurra Hub"
+      assert new_state.whois_pending["alice"].server == "irc.azzurra.org"
+      assert new_state.whois_pending["alice"].server_info == "Azzurra Hub"
     end
 
     test "313 RPL_WHOISOPERATOR folds is_operator: true + oper_text from trailing" do
@@ -4139,11 +4139,11 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_operator] == true
+      assert new_state.whois_pending["alice"].is_operator == true
       # #367 — the ircd role text distinguishes IRC Operator from Server /
       # Services Administrator; it is upstream pass-through data, captured
       # verbatim (NOT a grappa-localized string — see the bundle note).
-      assert new_state.whois_pending["alice"][:oper_text] == "is a Services Administrator"
+      assert new_state.whois_pending["alice"].oper_text == "is a Services Administrator"
     end
 
     test "313 RPL_WHOISOPERATOR with no trailing text folds is_operator: true, oper_text nil" do
@@ -4155,8 +4155,8 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg({:numeric, 313}, ["vjt", "alice"], {:server, "irc.test.org"})
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_operator] == true
-      assert new_state.whois_pending["alice"][:oper_text] == nil
+      assert new_state.whois_pending["alice"].is_operator == true
+      assert new_state.whois_pending["alice"].oper_text == nil
     end
 
     test "317 RPL_WHOISIDLE folds idle_seconds + signon (3-arg shape)" do
@@ -4170,8 +4170,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:idle_seconds] == 42
-      assert new_state.whois_pending["alice"][:signon] == 1_700_000_000
+      assert new_state.whois_pending["alice"].idle_seconds == 42
+      assert new_state.whois_pending["alice"].signon == 1_700_000_000
     end
 
     test "317 with only idle_seconds (no signon) folds idle_seconds; signon absent" do
@@ -4180,8 +4180,8 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg({:numeric, 317}, ["vjt", "alice", "42", "seconds idle"], {:server, "irc.test.org"})
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:idle_seconds] == 42
-      refute Map.has_key?(new_state.whois_pending["alice"], :signon)
+      assert new_state.whois_pending["alice"].idle_seconds == 42
+      assert new_state.whois_pending["alice"].signon == nil
     end
 
     test "319 RPL_WHOISCHANNELS folds the channels list (split on whitespace, prefixes preserved)" do
@@ -4195,7 +4195,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:channels] == ["@#italia", "+#grappa", "#lobby"]
+      assert new_state.whois_pending["alice"].channels == ["@#italia", "+#grappa", "#lobby"]
     end
 
     test "319 chunks across multiple lines append (not overwrite)" do
@@ -4206,14 +4206,14 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, s1, []} = EventRouter.route(m1, state)
       {:cont, s2, []} = EventRouter.route(m2, s1)
-      assert s2.whois_pending["alice"][:channels] == ["@#a", "+#b", "#c", "#d"]
+      assert s2.whois_pending["alice"].channels == ["@#a", "+#b", "#c", "#d"]
     end
 
     test "318 RPL_ENDOFWHOIS emits :whois_bundle effect with accum + drops entry" do
       state =
         base_state(%{
           whois_pending: %{
-            "alice" => %{
+            "alice" => %WhoisAccum{
               target_display: "Alice",
               user: "alice_u",
               host: "alice.host",
@@ -4226,8 +4226,8 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, [{:whois_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "Alice"
-      assert accum[:user] == "alice_u"
-      assert accum[:realname] == "Alice Liddell"
+      assert accum.user == "alice_u"
+      assert accum.realname == "Alice Liddell"
       assert new_state.whois_pending == %{}
     end
 
@@ -4242,13 +4242,13 @@ defmodule Grappa.Session.EventRouterTest do
 
     test "318 lookup is case-insensitive on target nick (RFC 2812 §2.2)" do
       state =
-        base_state(%{whois_pending: %{"alice" => %{target_display: "alice", user: "u"}}})
+        base_state(%{whois_pending: %{"alice" => %WhoisAccum{target_display: "alice", user: "u"}}})
 
       # Server may echo a different case for the target than what the user typed.
       m = msg({:numeric, 318}, ["vjt", "ALICE", "End of /WHOIS list"], {:server, "irc.test.org"})
 
       {:cont, new_state, [{:whois_bundle, _, accum, _}]} = EventRouter.route(m, state)
-      assert accum[:user] == "u"
+      assert accum.user == "u"
       assert new_state.whois_pending == %{}
     end
   end
@@ -4274,7 +4274,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:using_ssl] == true
+      assert new_state.whois_pending["alice"].using_ssl == true
     end
 
     test "275 with no whois_pending entry is silently ignored (no fold, no notice)" do
@@ -4313,7 +4313,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:away_message] == "Gone fishing"
+      assert new_state.whois_pending["alice"].away_message == "Gone fishing"
     end
 
     # #944 — a pending WHOIS is NOT enough to claim a 301. Bahamut answers a
@@ -4339,7 +4339,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, [{:peer_away, "alice", "Gone fishing"}]} = EventRouter.route(m, state)
-      refute Map.has_key?(new_state.whois_pending["alice"], :away_message)
+      assert new_state.whois_pending["alice"].away_message == nil
     end
 
     test "301 with no whois_pending entry emits :peer_away typed effect (P-0b standalone)" do
@@ -4377,7 +4377,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_registered] == true
+      assert new_state.whois_pending["alice"].is_registered == true
     end
 
     test "308 RPL_WHOISADMIN folds is_admin: true" do
@@ -4391,7 +4391,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_admin] == true
+      assert new_state.whois_pending["alice"].is_admin == true
     end
 
     test "309 RPL_WHOISSADMIN folds is_services_admin: true" do
@@ -4405,7 +4405,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_services_admin] == true
+      assert new_state.whois_pending["alice"].is_services_admin == true
     end
 
     test "310 RPL_WHOISHELPER folds is_helper: true" do
@@ -4419,7 +4419,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_helper] == true
+      assert new_state.whois_pending["alice"].is_helper == true
     end
 
     test "316 RPL_WHOISCHANOP folds is_chanop: true" do
@@ -4428,7 +4428,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg({:numeric, 316}, ["vjt", "alice", "is a chanop"], {:server, "irc.test.org"})
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_chanop] == true
+      assert new_state.whois_pending["alice"].is_chanop == true
     end
 
     test "325 RPL_WHOISAGENT folds is_agent: true (Azzurra services)" do
@@ -4442,7 +4442,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_agent] == true
+      assert new_state.whois_pending["alice"].is_agent == true
     end
 
     test "326 RPL_WHOISMODES extracts mode string from localized prefix" do
@@ -4456,7 +4456,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:umodes] == "+iZ"
+      assert new_state.whois_pending["alice"].umodes == "+iZ"
     end
 
     test "326 with unexpected template (not the Bahamut prefix) folds nothing" do
@@ -4470,7 +4470,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      refute Map.has_key?(new_state.whois_pending["alice"], :umodes)
+      assert new_state.whois_pending["alice"].umodes == nil
     end
 
     test "339 RPL_WHOISJAVA folds is_java: true" do
@@ -4479,7 +4479,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg({:numeric, 339}, ["vjt", "alice", "is a Java User"], {:server, "irc.test.org"})
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:is_java] == true
+      assert new_state.whois_pending["alice"].is_java == true
     end
 
     test "378 RPL_WHOISACTUALLY extracts host + ip from localized template" do
@@ -4493,8 +4493,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:actually_host] == "real.host.example"
-      assert new_state.whois_pending["alice"][:actually_ip] == "192.0.2.42"
+      assert new_state.whois_pending["alice"].actually_host == "real.host.example"
+      assert new_state.whois_pending["alice"].actually_ip == "192.0.2.42"
     end
 
     test "378 with malformed template folds nothing" do
@@ -4508,8 +4508,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      refute Map.has_key?(new_state.whois_pending["alice"], :actually_host)
-      refute Map.has_key?(new_state.whois_pending["alice"], :actually_ip)
+      assert new_state.whois_pending["alice"].actually_host == nil
+      assert new_state.whois_pending["alice"].actually_ip == nil
     end
 
     test "318 RPL_ENDOFWHOIS bundle carries all P-0a flags through to wire payload" do
@@ -4570,7 +4570,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "wire payload defaults all P-0a booleans to false when accum is empty" do
-      payload = Wire.whois_bundle("test-net", "ghost", %{})
+      payload = Wire.whois_bundle("test-net", "ghost", %WhoisAccum{})
 
       assert payload.using_ssl == false
       assert payload.is_registered == false
@@ -4794,7 +4794,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:account] == "AliceAccount"
+      assert new_state.whois_pending["alice"].account == "AliceAccount"
     end
 
     test "330 with no whois_pending entry is silently ignored (no fold, no notice)" do
@@ -4831,8 +4831,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:secure] == true
-      assert new_state.whois_pending["alice"][:secure_cipher] == "TLSv1.3, TLS_AES_256_GCM_SHA384"
+      assert new_state.whois_pending["alice"].secure == true
+      assert new_state.whois_pending["alice"].secure_cipher == "TLSv1.3, TLS_AES_256_GCM_SHA384"
     end
 
     test "671 RPL_WHOISSECURE with no bracketed cipher still folds secure: true (nil cipher)" do
@@ -4849,8 +4849,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:secure] == true
-      refute Map.has_key?(new_state.whois_pending["alice"], :secure_cipher)
+      assert new_state.whois_pending["alice"].secure == true
+      assert new_state.whois_pending["alice"].secure_cipher == nil
     end
 
     test "276 RPL_WHOISCERTFP folds certfp from the trailing tail token" do
@@ -4864,7 +4864,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:certfp] == "deadbeefcafef00d"
+      assert new_state.whois_pending["alice"].certfp == "deadbeefcafef00d"
     end
 
     test "338 RPL_WHOISACTUALLY (solanum) folds the IP from the middle param" do
@@ -4883,11 +4883,11 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:actually_ip] == "203.0.113.7"
+      assert new_state.whois_pending["alice"].actually_ip == "203.0.113.7"
       # The localized "actually using host" trailing must NOT leak into any
       # field (feedback_no_localized_strings_server_side).
-      refute new_state.whois_pending["alice"][:actually_host] == "actually using host"
-      refute new_state.whois_pending["alice"][:actually_ip] == "actually using host"
+      refute new_state.whois_pending["alice"].actually_host == "actually using host"
+      refute new_state.whois_pending["alice"].actually_ip == "actually using host"
     end
 
     test "338 with no whois_pending entry is silently ignored (no fold)" do
@@ -4916,7 +4916,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.whois_pending["alice"][:extra_lines] == [
+      assert new_state.whois_pending["alice"].extra_lines == [
                %{numeric: 320, text: "is a Libera.Chat volunteer staff member"}
              ]
     end
@@ -4984,7 +4984,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.whois_pending["alice"][:extra_lines] == [
+      assert new_state.whois_pending["alice"].extra_lines == [
                %{numeric: 617, text: "is doing something new and typed nowhere yet"}
              ]
     end
@@ -5009,7 +5009,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.whois_pending["alice"][:extra_lines] == [
+      assert new_state.whois_pending["alice"].extra_lines == [
                %{numeric: 340, text: "is currently shunned"}
              ]
     end
@@ -5199,11 +5199,11 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, [{:lusers_bundle, accum}]} = EventRouter.route(m, state)
       assert new_state.lusers_pending == nil
-      assert accum[:current_global] == 1234
-      assert accum[:max_global] == 5000
+      assert accum.current_global == 1234
+      assert accum.max_global == 5000
       # prior folded fields survive into the bundle
-      assert accum[:total_users] == 1234
-      assert accum[:operators] == 7
+      assert accum.total_users == 1234
+      assert accum.operators == 7
     end
 
     test "266 with no prior pending (sequence-out-of-order) still emits a bundle with the global counts" do
@@ -5345,7 +5345,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "312 with whois_pending entry takes precedence over whowas_pending (WHOIS-bias)" do
       state =
         base_state(%{
-          whois_pending: %{"alice" => %{target_display: "alice"}},
+          whois_pending: %{"alice" => %WhoisAccum{target_display: "alice"}},
           whowas_pending: %{
             "alice" => %{target_display: "alice", entries: [%{user: "u", host: "h"}]}
           }
@@ -5359,8 +5359,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whois_pending["alice"][:server] == "irc.test.org"
-      assert new_state.whois_pending["alice"][:server_info] == "irc.test.org server info"
+      assert new_state.whois_pending["alice"].server == "irc.test.org"
+      assert new_state.whois_pending["alice"].server_info == "irc.test.org server info"
       # whowas entry untouched
       [last] = new_state.whowas_pending["alice"][:entries]
       refute Map.has_key?(last, :server)
@@ -5400,7 +5400,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, [{:whowas_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "Alice"
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
       assert new_state.whowas_pending == %{}
     end
 
@@ -5422,7 +5422,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg({:numeric, 369}, ["vjt", "ALICE", "End of WHOWAS"], {:server, "irc.test.org"})
 
       {:cont, new_state, [{:whowas_bundle, _, accum, _}]} = EventRouter.route(m, state)
-      assert hd(accum[:entries])[:user] == "u"
+      assert hd(accum.entries)[:user] == "u"
       assert new_state.whowas_pending == %{}
     end
 
@@ -5438,7 +5438,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, [{:whowas_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "ghost"
-      assert accum[:not_found] == true
+      assert accum.not_found == true
       assert new_state.whowas_pending == %{}
     end
 
@@ -5544,7 +5544,7 @@ defmodule Grappa.Session.EventRouterTest do
       # The EFFECT accum stores entries reversed (head = most recent 367,
       # O(1) prepend); `Wire.banlist_bundle/3` reverses to restore the wire
       # order (asserted in wire_test). Here we lock the storage contract.
-      assert Enum.map(accum[:entries], & &1[:mask]) == ["b!*@2", "a!*@1"]
+      assert Enum.map(accum.entries, & &1[:mask]) == ["b!*@2", "a!*@1"]
     end
 
     test "368 RPL_ENDOFBANLIST emits :list_mode_bundle effect + drops entry" do
@@ -5573,7 +5573,7 @@ defmodule Grappa.Session.EventRouterTest do
       # already folded it, so the live `channel_display` is the canonical
       # spelling (#364) — see the server.ex :send_list_mode comment.
       assert channel == "#Test"
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
       assert new_state.list_mode_pending == %{}
     end
 
@@ -5604,7 +5604,7 @@ defmodule Grappa.Session.EventRouterTest do
         msg({:numeric, 368}, ["vjt", "#CHAN", "End"], {:server, "irc.test.org"})
 
       {:cont, s2, [{:list_mode_bundle, _, "b", accum, _}]} = EventRouter.route(m368, s1)
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
       assert s2.list_mode_pending == %{}
     end
   end
@@ -5627,7 +5627,7 @@ defmodule Grappa.Session.EventRouterTest do
       m349 = msg({:numeric, 349}, ["vjt", "#test", "End of Channel Exception List"], {:server, "irc.t"})
       {:cont, s2, [{:list_mode_bundle, "#test", "e", accum, _}]} = EventRouter.route(m349, s1)
 
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
       assert s2.list_mode_pending == %{}
     end
 
@@ -5640,7 +5640,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m347 = msg({:numeric, 347}, ["vjt", "#test", "End of Channel Invite List"], {:server, "irc.t"})
       {:cont, _, [{:list_mode_bundle, "#test", "I", accum, _}]} = EventRouter.route(m347, s1)
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
     end
 
     # bahamut src/s_err.c:812 — `":%s 728 %s %s z %s %s %lu"`.
@@ -5656,7 +5656,7 @@ defmodule Grappa.Session.EventRouterTest do
       m729 = msg({:numeric, 729}, ["vjt", "#test", "z", "End of Channel Restrict List"], {:server, "irc.t"})
       {:cont, s2, [{:list_mode_bundle, "#test", "z", accum, _}]} = EventRouter.route(m729, s1)
 
-      assert length(accum[:entries]) == 1
+      assert length(accum.entries) == 1
       assert s2.list_mode_pending == %{}
     end
 
@@ -6521,7 +6521,7 @@ defmodule Grappa.Session.EventRouterTest do
       assert new_state.links_pending == nil
       # Accumulator carries the entries as-stored (reversed); the wire
       # builder restores wire order.
-      assert length(accum[:entries]) == 2
+      assert length(accum.entries) == 2
     end
 
     test "365 with an EMPTY entries list (restricted/hidden topology) flushes an empty bundle" do
@@ -6536,7 +6536,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, [{:links_bundle, accum, _}]} = EventRouter.route(m, state)
       assert new_state.links_pending == nil
-      assert accum[:entries] == []
+      assert accum.entries == []
     end
 
     test "365 with NO links_pending is silently ignored (unsolicited terminator)" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -12,6 +12,7 @@ defmodule Grappa.Session.EventRouterTest do
   use ExUnit.Case, async: true
 
   alias Grappa.IRC.{JoinFailure, Message, Parser}
+
   alias Grappa.Session.{
     EventRouter,
     GhostRecovery,
@@ -5108,7 +5109,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending == %{total_users: 1234, invisible: 56, servers: 3}
+      assert new_state.lusers_pending == %LusersAccum{total_users: 1234, invisible: 56, servers: 3}
     end
 
     test "252 RPL_LUSEROP folds operators count from positional param" do
@@ -5122,9 +5123,9 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending[:operators] == 7
+      assert new_state.lusers_pending.operators == 7
       # prior fields preserved
-      assert new_state.lusers_pending[:total_users] == 1234
+      assert new_state.lusers_pending.total_users == 1234
     end
 
     test "253 RPL_LUSERUNKNOWN folds unknown_connections (when present)" do
@@ -5138,7 +5139,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending[:unknown_connections] == 2
+      assert new_state.lusers_pending.unknown_connections == 2
     end
 
     test "254 RPL_LUSERCHANNELS folds channels_formed" do
@@ -5152,7 +5153,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending[:channels_formed] == 89
+      assert new_state.lusers_pending.channels_formed == 89
     end
 
     test "255 RPL_LUSERME folds local_clients + local_servers from trailing" do
@@ -5166,8 +5167,8 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending[:local_clients] == 100
-      assert new_state.lusers_pending[:local_servers] == 1
+      assert new_state.lusers_pending.local_clients == 100
+      assert new_state.lusers_pending.local_servers == 1
     end
 
     test "265 RPL_LOCALUSERS folds current_local + max_local from trailing" do
@@ -5181,12 +5182,12 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending[:current_local] == 100
-      assert new_state.lusers_pending[:max_local] == 200
+      assert new_state.lusers_pending.current_local == 100
+      assert new_state.lusers_pending.max_local == 200
     end
 
     test "266 RPL_GLOBALUSERS flushes :lusers_bundle effect with full accum + clears pending" do
-      accum_so_far = %{
+      accum_so_far = %LusersAccum{
         total_users: 1234,
         invisible: 56,
         servers: 3,
@@ -5271,8 +5272,8 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.whowas_pending["alice"][:entries] == [
-               %{user: "alice_u", host: "alice.host", realname: "Alice Liddell"}
+      assert new_state.whowas_pending["alice"].entries == [
+               %WhowasAccum.Entry{user: "alice_u", host: "alice.host", realname: "Alice Liddell"}
              ]
     end
 
@@ -5310,12 +5311,12 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s1, []} = EventRouter.route(m1, state)
       {:cont, s2, []} = EventRouter.route(m2, s1)
 
-      entries = s2.whowas_pending["alice"][:entries]
+      entries = s2.whowas_pending["alice"].entries
       assert length(entries) == 2
       # Head = most recent (m2). Wire builder reads `hd(entries)` for the
       # most-recent projection per MVP scope.
-      assert Enum.at(entries, 0) == %{user: "u2", host: "h2", realname: "Alice@h2"}
-      assert Enum.at(entries, 1) == %{user: "u1", host: "h1", realname: "Alice@h1"}
+      assert Enum.at(entries, 0) == %WhowasAccum.Entry{user: "u2", host: "h2", realname: "Alice@h2"}
+      assert Enum.at(entries, 1) == %WhowasAccum.Entry{user: "u1", host: "h1", realname: "Alice@h1"}
     end
 
     test "312 with whowas_pending and NO whois_pending folds server + logoff_time into MOST-RECENT entry (head)" do
@@ -5323,12 +5324,12 @@ defmodule Grappa.Session.EventRouterTest do
         base_state(%{
           whois_pending: %{},
           whowas_pending: %{
-            "alice" => %{
+            "alice" => %WhowasAccum{
               target_display: "alice",
               # Most recent entry (m2) at head; older (m1) at tail.
               entries: [
-                %{user: "u2", host: "h2", realname: "Alice@h2"},
-                %{user: "u1", host: "h1", realname: "Alice@h1"}
+                %WhowasAccum.Entry{user: "u2", host: "h2", realname: "Alice@h2"},
+                %WhowasAccum.Entry{user: "u1", host: "h1", realname: "Alice@h1"}
               ]
             }
           }
@@ -5342,14 +5343,14 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      [head, older] = new_state.whowas_pending["alice"][:entries]
-      assert head[:server] == "irc.test.org"
-      assert head[:logoff_time] == "Mon May 13 12:34:56 2026"
+      [head, older] = new_state.whowas_pending["alice"].entries
+      assert head.server == "irc.test.org"
+      assert head.logoff_time == "Mon May 13 12:34:56 2026"
       # head's original fields preserved
-      assert head[:user] == "u2"
+      assert head.user == "u2"
       # older entry untouched
-      assert older[:user] == "u1"
-      refute Map.has_key?(older, :server)
+      assert older.user == "u1"
+      assert older.server == nil
     end
 
     test "312 with whois_pending entry takes precedence over whowas_pending (WHOIS-bias)" do
@@ -5372,9 +5373,9 @@ defmodule Grappa.Session.EventRouterTest do
       assert new_state.whois_pending["alice"].server == "irc.test.org"
       assert new_state.whois_pending["alice"].server_info == "irc.test.org server info"
       # whowas entry untouched
-      [last] = new_state.whowas_pending["alice"][:entries]
-      refute Map.has_key?(last, :server)
-      refute Map.has_key?(last, :logoff_time)
+      [last] = new_state.whowas_pending["alice"].entries
+      assert last.server == nil
+      assert last.logoff_time == nil
     end
 
     test "312 with whowas_pending but EMPTY entries list is a no-op (defensive)" do
@@ -5392,14 +5393,14 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.whowas_pending["alice"][:entries] == []
+      assert new_state.whowas_pending["alice"].entries == []
     end
 
     test "369 RPL_ENDOFWHOWAS emits :whowas_bundle effect with accum + drops entry" do
       state =
         base_state(%{
           whowas_pending: %{
-            "alice" => %{
+            "alice" => %WhowasAccum{
               target_display: "Alice",
               entries: [%WhowasAccum.Entry{user: "u", host: "h", realname: "Alice"}]
             }
@@ -5490,7 +5491,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     defp entries_for(state, channel, mode) do
-      state.list_mode_pending[{Grappa.IRC.Identifier.canonical_target(channel), mode}][:entries]
+      state.list_mode_pending[{Grappa.IRC.Identifier.canonical_target(channel), mode}].entries
     end
 
     test "367 RPL_BANLIST appends a ban entry to entries list" do
@@ -5506,7 +5507,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, new_state, []} = EventRouter.route(m, state)
 
       assert entries_for(new_state, "#test", "b") == [
-               %{mask: "*!*@banned.host", setter: "op!u@h", set_ts: "1784572878"}
+               %ListModeAccum.Entry{mask: "*!*@banned.host", setter: "op!u@h", set_ts: "1784572878"}
              ]
     end
 
@@ -5532,7 +5533,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, new_state, []} = EventRouter.route(m, state)
 
       assert entries_for(new_state, "#test", "b") == [
-               %{mask: "*!*@old.host", setter: nil, set_ts: nil}
+               %ListModeAccum.Entry{mask: "*!*@old.host", setter: nil, set_ts: nil}
              ]
     end
 
@@ -5632,7 +5633,7 @@ defmodule Grappa.Session.EventRouterTest do
         msg({:numeric, 348}, ["vjt", "#test", "*!*@safe.host", "op", "111"], {:server, "irc.t"})
 
       {:cont, s1, []} = EventRouter.route(m348, state)
-      assert entries_for(s1, "#test", "e") == [%{mask: "*!*@safe.host", setter: "op", set_ts: "111"}]
+      assert entries_for(s1, "#test", "e") == [%ListModeAccum.Entry{mask: "*!*@safe.host", setter: "op", set_ts: "111"}]
 
       m349 = msg({:numeric, 349}, ["vjt", "#test", "End of Channel Exception List"], {:server, "irc.t"})
       {:cont, s2, [{:list_mode_bundle, "#test", "e", accum, _}]} = EventRouter.route(m349, s1)
@@ -5661,7 +5662,7 @@ defmodule Grappa.Session.EventRouterTest do
         msg({:numeric, 728}, ["vjt", "#test", "z", "*!*@rogue", "op", "333"], {:server, "irc.t"})
 
       {:cont, s1, []} = EventRouter.route(m728, state)
-      assert entries_for(s1, "#test", "z") == [%{mask: "*!*@rogue", setter: "op", set_ts: "333"}]
+      assert entries_for(s1, "#test", "z") == [%ListModeAccum.Entry{mask: "*!*@rogue", setter: "op", set_ts: "333"}]
 
       m729 = msg({:numeric, 729}, ["vjt", "#test", "z", "End of Channel Restrict List"], {:server, "irc.t"})
       {:cont, s2, [{:list_mode_bundle, "#test", "z", accum, _}]} = EventRouter.route(m729, s1)
@@ -6424,8 +6425,8 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
 
-      assert new_state.links_pending[:entries] == [
-               %{
+      assert new_state.links_pending.entries == [
+               %LinksAccum.Entry{
                  server: "leaf.azzurra.org",
                  linked_to: "hub.azzurra.org",
                  hopcount: 1,
@@ -6459,7 +6460,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      [entry] = new_state.links_pending[:entries]
+      [entry] = new_state.links_pending.entries
       assert entry.server == "hub.azzurra.org"
       assert entry.linked_to == "hub.azzurra.org"
       assert entry.hopcount == 0
@@ -6486,7 +6487,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s1, []} = EventRouter.route(m1, state)
       {:cont, s2, []} = EventRouter.route(m2, s1)
 
-      entries = s2.links_pending[:entries]
+      entries = s2.links_pending.entries
       assert length(entries) == 2
       # Head = most recent (m2); wire builder reverses to restore wire order.
       assert Enum.at(entries, 0).server == "leaf.azzurra.org"
@@ -6504,7 +6505,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      [entry] = new_state.links_pending[:entries]
+      [entry] = new_state.links_pending.entries
       assert entry.hopcount == 0
       assert entry.description == ""
     end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -12,7 +12,17 @@ defmodule Grappa.Session.EventRouterTest do
   use ExUnit.Case, async: true
 
   alias Grappa.IRC.{JoinFailure, Message, Parser}
-  alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, WhoisAccum, Wire}
+  alias Grappa.Session.{
+    EventRouter,
+    GhostRecovery,
+    ISupport,
+    LinksAccum,
+    ListModeAccum,
+    LusersAccum,
+    WhoisAccum,
+    WhowasAccum,
+    Wire
+  }
 
   @user_id "00000000-0000-0000-0000-000000000001"
   @subject {:user, @user_id}
@@ -5102,7 +5112,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "252 RPL_LUSEROP folds operators count from positional param" do
-      state = base_state(%{lusers_pending: %{total_users: 1234, invisible: 56, servers: 3}})
+      state = base_state(%{lusers_pending: %LusersAccum{total_users: 1234, invisible: 56, servers: 3}})
 
       m =
         msg(
@@ -5118,7 +5128,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "253 RPL_LUSERUNKNOWN folds unknown_connections (when present)" do
-      state = base_state(%{lusers_pending: %{total_users: 1234}})
+      state = base_state(%{lusers_pending: %LusersAccum{total_users: 1234}})
 
       m =
         msg(
@@ -5132,7 +5142,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "254 RPL_LUSERCHANNELS folds channels_formed" do
-      state = base_state(%{lusers_pending: %{total_users: 1234}})
+      state = base_state(%{lusers_pending: %LusersAccum{total_users: 1234}})
 
       m =
         msg(
@@ -5146,7 +5156,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "255 RPL_LUSERME folds local_clients + local_servers from trailing" do
-      state = base_state(%{lusers_pending: %{}})
+      state = base_state(%{lusers_pending: %LusersAccum{}})
 
       m =
         msg(
@@ -5161,7 +5171,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "265 RPL_LOCALUSERS folds current_local + max_local from trailing" do
-      state = base_state(%{lusers_pending: %{}})
+      state = base_state(%{lusers_pending: %LusersAccum{}})
 
       m =
         msg(
@@ -5217,11 +5227,11 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, _, [{:lusers_bundle, accum}]} = EventRouter.route(m, state)
-      assert accum == %{current_global: 42, max_global: 100}
+      assert accum == %LusersAccum{current_global: 42, max_global: 100}
     end
 
     test "251 resets the accumulator (start of new sequence drops prior partial)" do
-      state = base_state(%{lusers_pending: %{stale: :data, leftover: 42}})
+      state = base_state(%{lusers_pending: %LusersAccum{operators: 7, max_global: 42}})
 
       m =
         msg(
@@ -5231,7 +5241,7 @@ defmodule Grappa.Session.EventRouterTest do
         )
 
       {:cont, new_state, []} = EventRouter.route(m, state)
-      assert new_state.lusers_pending == %{total_users: 5, invisible: 0, servers: 1}
+      assert new_state.lusers_pending == %LusersAccum{total_users: 5, invisible: 0, servers: 1}
     end
   end
 
@@ -5244,7 +5254,7 @@ defmodule Grappa.Session.EventRouterTest do
     defp whowas_pending_state(target_display) do
       base_state(%{
         whowas_pending: %{
-          String.downcase(target_display) => %{target_display: target_display, entries: []}
+          String.downcase(target_display) => %WhowasAccum{target_display: target_display, entries: []}
         }
       })
     end
@@ -5347,7 +5357,7 @@ defmodule Grappa.Session.EventRouterTest do
         base_state(%{
           whois_pending: %{"alice" => %WhoisAccum{target_display: "alice"}},
           whowas_pending: %{
-            "alice" => %{target_display: "alice", entries: [%{user: "u", host: "h"}]}
+            "alice" => %WhowasAccum{target_display: "alice", entries: [%WhowasAccum.Entry{user: "u", host: "h"}]}
           }
         })
 
@@ -5371,7 +5381,7 @@ defmodule Grappa.Session.EventRouterTest do
       state =
         base_state(%{
           whois_pending: %{},
-          whowas_pending: %{"alice" => %{target_display: "alice", entries: []}}
+          whowas_pending: %{"alice" => %WhowasAccum{target_display: "alice", entries: []}}
         })
 
       m =
@@ -5391,7 +5401,7 @@ defmodule Grappa.Session.EventRouterTest do
           whowas_pending: %{
             "alice" => %{
               target_display: "Alice",
-              entries: [%{user: "u", host: "h", realname: "Alice"}]
+              entries: [%WhowasAccum.Entry{user: "u", host: "h", realname: "Alice"}]
             }
           }
         })
@@ -5416,13 +5426,13 @@ defmodule Grappa.Session.EventRouterTest do
     test "369 lookup is case-insensitive on target nick (RFC 2812 §2.2)" do
       state =
         base_state(%{
-          whowas_pending: %{"alice" => %{target_display: "alice", entries: [%{user: "u"}]}}
+          whowas_pending: %{"alice" => %WhowasAccum{target_display: "alice", entries: [%WhowasAccum.Entry{user: "u"}]}}
         })
 
       m = msg({:numeric, 369}, ["vjt", "ALICE", "End of WHOWAS"], {:server, "irc.test.org"})
 
       {:cont, new_state, [{:whowas_bundle, _, accum, _}]} = EventRouter.route(m, state)
-      assert hd(accum.entries)[:user] == "u"
+      assert hd(accum.entries).user == "u"
       assert new_state.whowas_pending == %{}
     end
 
@@ -5470,7 +5480,7 @@ defmodule Grappa.Session.EventRouterTest do
     defp list_mode_pending_state(channel_display, mode) do
       base_state(%{
         list_mode_pending: %{
-          {Grappa.IRC.Identifier.canonical_target(channel_display), mode} => %{
+          {Grappa.IRC.Identifier.canonical_target(channel_display), mode} => %ListModeAccum{
             channel_display: channel_display,
             mode: mode,
             entries: []
@@ -5544,17 +5554,17 @@ defmodule Grappa.Session.EventRouterTest do
       # The EFFECT accum stores entries reversed (head = most recent 367,
       # O(1) prepend); `Wire.banlist_bundle/3` reverses to restore the wire
       # order (asserted in wire_test). Here we lock the storage contract.
-      assert Enum.map(accum.entries, & &1[:mask]) == ["b!*@2", "a!*@1"]
+      assert Enum.map(accum.entries, & &1.mask) == ["b!*@2", "a!*@1"]
     end
 
     test "368 RPL_ENDOFBANLIST emits :list_mode_bundle effect + drops entry" do
       state =
         base_state(%{
           list_mode_pending: %{
-            {"#test", "b"} => %{
+            {"#test", "b"} => %ListModeAccum{
               channel_display: "#Test",
               mode: "b",
-              entries: [%{mask: "*!*@h", setter: "op", set_ts: "1784572878"}]
+              entries: [%ListModeAccum.Entry{mask: "*!*@h", setter: "op", set_ts: "1784572878"}]
             }
           }
         })
@@ -5690,8 +5700,8 @@ defmodule Grappa.Session.EventRouterTest do
       state =
         base_state(%{
           list_mode_pending: %{
-            {"#test", "b"} => %{channel_display: "#test", mode: "b", entries: []},
-            {"#test", "e"} => %{channel_display: "#test", mode: "e", entries: []}
+            {"#test", "b"} => %ListModeAccum{channel_display: "#test", mode: "b", entries: []},
+            {"#test", "e"} => %ListModeAccum{channel_display: "#test", mode: "e", entries: []}
           }
         })
 
@@ -5701,8 +5711,8 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s1, []} = EventRouter.route(m367, state)
       {:cont, s2, []} = EventRouter.route(m348, s1)
 
-      assert Enum.map(entries_for(s2, "#test", "b"), & &1[:mask]) == ["*!*@banned"]
-      assert Enum.map(entries_for(s2, "#test", "e"), & &1[:mask]) == ["*!*@exempt"]
+      assert Enum.map(entries_for(s2, "#test", "b"), & &1.mask) == ["*!*@banned"]
+      assert Enum.map(entries_for(s2, "#test", "e"), & &1.mask) == ["*!*@exempt"]
 
       # And the ban terminator drains ONLY the ban list.
       m368 = msg({:numeric, 368}, ["vjt", "#test", "End of Channel Ban List"], {:server, "irc.t"})
@@ -6399,7 +6409,7 @@ defmodule Grappa.Session.EventRouterTest do
     # prime gate makes an unsolicited 364/365 a no-op (an ircd never
     # emits LINKS unrequested — LINKS is not in the connect burst).
     defp links_pending_state do
-      base_state(%{links_pending: %{entries: []}})
+      base_state(%{links_pending: %LinksAccum{entries: []}})
     end
 
     test "364 RPL_LINKS appends a {server, linked_to, hopcount, description} entry" do
@@ -6502,7 +6512,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "365 RPL_ENDOFLINKS flushes {:links_bundle, accum, reply_to} and clears links_pending" do
       state =
         base_state(%{
-          links_pending: %{
+          links_pending: %LinksAccum{
             entries: [
               %{server: "leaf.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 1, description: "Leaf"},
               %{server: "hub.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 0, description: "Hub"}
@@ -6525,7 +6535,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "365 with an EMPTY entries list (restricted/hidden topology) flushes an empty bundle" do
-      state = base_state(%{links_pending: %{entries: []}})
+      state = base_state(%{links_pending: %LinksAccum{entries: []}})
 
       m =
         msg(

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -41,6 +41,7 @@ defmodule Grappa.Session.ServerTest do
     ISupport,
     RecoverIdentity,
     Server,
+    WhoisAccum,
     WindowState
   }
 
@@ -11030,7 +11031,7 @@ defmodule Grappa.Session.ServerTest do
 
       _ =
         :sys.replace_state(pid, fn state ->
-          %{state | whois_pending: %{"ghost" => %{target_display: "ghost", __primed_at_ms: stale_at}}}
+          %{state | whois_pending: %{"ghost" => %WhoisAccum{target_display: "ghost", __primed_at_ms: stale_at}}}
         end)
 
       assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user, nil)
@@ -11053,7 +11054,7 @@ defmodule Grappa.Session.ServerTest do
 
       _ =
         :sys.replace_state(pid, fn state ->
-          %{state | whois_pending: %{"recent" => %{target_display: "recent", __primed_at_ms: recent_at}}}
+          %{state | whois_pending: %{"recent" => %WhoisAccum{target_display: "recent", __primed_at_ms: recent_at}}}
         end)
 
       assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user, nil)

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -22,7 +22,15 @@ defmodule Grappa.Session.WireTest do
 
   alias Grappa.RelayFrameHelpers
   alias Grappa.Scrollback.Message
-  alias Grappa.Session.{ISupport, WhoisAccum, Wire}
+  alias Grappa.Session.{
+    ISupport,
+    LinksAccum,
+    ListModeAccum,
+    LusersAccum,
+    WhoisAccum,
+    WhowasAccum,
+    Wire
+  }
 
   describe "channels_changed/0" do
     test "returns the discriminator-only payload" do
@@ -909,7 +917,7 @@ defmodule Grappa.Session.WireTest do
 
   describe "lusers_bundle/2" do
     test "projects accum integers into the wire shape, all 12 numeric fields present" do
-      accum = %{
+      accum = %LusersAccum{
         total_users: 1234,
         invisible: 56,
         servers: 3,
@@ -945,7 +953,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "missing accum keys project to nil (graceful degradation for partial bundles)" do
-      payload = Wire.lusers_bundle("net", %{total_users: 42})
+      payload = Wire.lusers_bundle("net", %LusersAccum{total_users: 42})
 
       assert payload.kind == :lusers_bundle
       assert payload.total_users == 42
@@ -959,17 +967,17 @@ defmodule Grappa.Session.WireTest do
     test "projects MOST-RECENT entry (head of reversed list) into typed historical fields" do
       # EventRouter stores entries reversed (head = most recent 314).
       # Wire builder reads `hd(entries)` for the projection.
-      accum = %{
+      accum = %WhowasAccum{
         target_display: "Alice",
         entries: [
-          %{
+          %WhowasAccum.Entry{
             user: "alice_u",
             host: "alice.host",
             realname: "Alice Liddell",
             server: "irc.test.org",
             logoff_time: "Mon May 13 12:34:56 2026"
           },
-          %{user: "old_u", host: "old.host", realname: "Old Alice"}
+          %WhowasAccum.Entry{user: "old_u", host: "old.host", realname: "Old Alice"}
         ]
       }
 
@@ -989,7 +997,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "not_found: true projects nil for all historical fields (406 ERR_WASNOSUCHNICK case)" do
-      payload = Wire.whowas_bundle("net", "ghost", %{not_found: true})
+      payload = Wire.whowas_bundle("net", "ghost", %WhowasAccum{not_found: true})
 
       assert payload == %{
                kind: :whowas_bundle,
@@ -1005,7 +1013,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "empty entries with not_found absent defaults to not_found: false + nil fields" do
-      payload = Wire.whowas_bundle("net", "alice", %{entries: []})
+      payload = Wire.whowas_bundle("net", "alice", %WhowasAccum{})
 
       assert payload.kind == :whowas_bundle
       assert payload.target == "alice"
@@ -1022,7 +1030,7 @@ defmodule Grappa.Session.WireTest do
   describe "banlist_bundle/4" do
     test "ships all entries in wire order with mask/setter/set_ts" do
       # EventRouter prepends (head = most recent 367); wire builder reverses.
-      accum = %{
+      accum = %ListModeAccum{
         channel_display: "#Test",
         entries: [
           %{mask: "b!*@2", setter: "op2", set_ts: "222"},
@@ -1045,7 +1053,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "empty entries → empty list (channel with no bans)" do
-      payload = Wire.banlist_bundle("net", "#empty", "b", %{channel_display: "#empty", entries: []})
+      payload = Wire.banlist_bundle("net", "#empty", "b", %ListModeAccum{channel_display: "#empty"})
 
       assert payload == %{
                kind: :banlist_bundle,
@@ -1060,7 +1068,7 @@ defmodule Grappa.Session.WireTest do
     # `mode` is what tells the client WHICH list it got. A bundle that
     # dropped it would render solanum's quiet list as a ban list.
     test "carries the queried mode letter verbatim (not always b)" do
-      accum = %{channel_display: "#c", entries: [%{mask: "*!*@muted", setter: "op", set_ts: "1"}]}
+      accum = %ListModeAccum{channel_display: "#c", entries: [%ListModeAccum.Entry{mask: "*!*@muted", setter: "op", set_ts: "1"}]}
 
       assert Wire.banlist_bundle("libera", "#c", "q", accum).mode == "q"
       assert Wire.banlist_bundle("azzurra", "#c", "z", accum).mode == "z"
@@ -1068,7 +1076,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "entry with nil setter/set_ts (older ircd) round-trips nils" do
-      accum = %{channel_display: "#c", entries: [%{mask: "*!*@h", setter: nil, set_ts: nil}]}
+      accum = %ListModeAccum{channel_display: "#c", entries: [%ListModeAccum.Entry{mask: "*!*@h", setter: nil, set_ts: nil}]}
       payload = Wire.banlist_bundle("net", "#c", "b", accum)
 
       assert payload.entries == [%{mask: "*!*@h", setter: nil, set_ts: nil}]
@@ -1079,10 +1087,10 @@ defmodule Grappa.Session.WireTest do
     test "ships all topology entries in wire order (reverses EventRouter's prepend)" do
       # EventRouter prepends (head = most recent 364); wire builder reverses
       # so the wire order matches the ircd emit order (root first).
-      accum = %{
+      accum = %LinksAccum{
         entries: [
-          %{server: "leaf.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 1, description: "Leaf"},
-          %{server: "hub.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 0, description: "Hub"}
+          %LinksAccum.Entry{server: "leaf.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 1, description: "Leaf"},
+          %LinksAccum.Entry{server: "hub.azzurra.org", linked_to: "hub.azzurra.org", hopcount: 0, description: "Hub"}
         ]
       }
 
@@ -1100,7 +1108,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "empty entries + no mask → empty list, mask nil (restricted/hidden topology)" do
-      payload = Wire.links_bundle("net", %{entries: []})
+      payload = Wire.links_bundle("net", %LinksAccum{})
 
       assert payload == %{kind: :links_bundle, network: "net", mask: nil, entries: []}
     end
@@ -1109,13 +1117,18 @@ defmodule Grappa.Session.WireTest do
       # An empty bundle WITH a mask means the mask matched nothing (e.g.
       # `/links all` answered with a bare 365) — cic renders "no server
       # matches <mask>", not "hides topology".
-      payload = Wire.links_bundle("net", %{entries: [], mask: "all"})
+      payload = Wire.links_bundle("net", %LinksAccum{mask: "all"})
 
       assert payload == %{kind: :links_bundle, network: "net", mask: "all", entries: []}
     end
 
     test "entry with nil linked_to/hopcount/description (malformed line) round-trips nils" do
-      accum = %{entries: [%{server: "s.host", linked_to: nil, hopcount: nil, description: nil}]}
+      accum =
+        %LinksAccum{
+          entries: [
+            %LinksAccum.Entry{server: "s.host", linked_to: nil, hopcount: nil, description: nil}
+          ]
+        }
       payload = Wire.links_bundle("net", accum)
 
       assert payload.entries == [%{server: "s.host", linked_to: nil, hopcount: nil, description: nil}]
@@ -1139,11 +1152,11 @@ defmodule Grappa.Session.WireTest do
         Wire.whois_bundle("net", "alice", %WhoisAccum{}),
         Wire.peer_away("net", "alice", "Gone fishing"),
         Wire.invite_ack("net", "#italia", "alice"),
-        Wire.lusers_bundle("net", %{}),
-        Wire.whowas_bundle("net", "alice", %{}),
-        Wire.whowas_bundle("net", "ghost", %{not_found: true}),
-        Wire.banlist_bundle("net", "#c", "b", %{channel_display: "#c", entries: []}),
-        Wire.links_bundle("net", %{entries: []}),
+        Wire.lusers_bundle("net", %LusersAccum{}),
+        Wire.whowas_bundle("net", "alice", %WhowasAccum{}),
+        Wire.whowas_bundle("net", "ghost", %WhowasAccum{not_found: true}),
+        Wire.banlist_bundle("net", "#c", "b", %ListModeAccum{channel_display: "#c"}),
+        Wire.links_bundle("net", %LinksAccum{}),
         Wire.connection_progress("net", :connecting),
         Wire.connection_progress("net", :connected)
       ]

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -22,6 +22,7 @@ defmodule Grappa.Session.WireTest do
 
   alias Grappa.RelayFrameHelpers
   alias Grappa.Scrollback.Message
+
   alias Grappa.Session.{
     ISupport,
     LinksAccum,
@@ -1083,6 +1084,7 @@ defmodule Grappa.Session.WireTest do
         channel_display: "#c",
         entries: [%ListModeAccum.Entry{mask: "*!*@h", setter: nil, set_ts: nil}]
       }
+
       payload = Wire.banlist_bundle("net", "#c", "b", accum)
 
       assert payload.entries == [%{mask: "*!*@h", setter: nil, set_ts: nil}]
@@ -1135,6 +1137,7 @@ defmodule Grappa.Session.WireTest do
             %LinksAccum.Entry{server: "s.host", linked_to: nil, hopcount: nil, description: nil}
           ]
         }
+
       payload = Wire.links_bundle("net", accum)
 
       assert payload.entries == [%{server: "s.host", linked_to: nil, hopcount: nil, description: nil}]

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -22,7 +22,7 @@ defmodule Grappa.Session.WireTest do
 
   alias Grappa.RelayFrameHelpers
   alias Grappa.Scrollback.Message
-  alias Grappa.Session.{ISupport, Wire}
+  alias Grappa.Session.{ISupport, WhoisAccum, Wire}
 
   describe "channels_changed/0" do
     test "returns the discriminator-only payload" do
@@ -744,7 +744,7 @@ defmodule Grappa.Session.WireTest do
 
   describe "whois_bundle/3" do
     test "projects the accum map into the wire shape with kind: injected" do
-      accum = %{
+      accum = %WhoisAccum{
         user: "alice_u",
         host: "alice.host",
         realname: "Alice Liddell",
@@ -803,7 +803,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "tolerates an empty accum (no numerics fired before 318) — every field nil; is_operator false" do
-      payload = Wire.whois_bundle("azzurra", "ghost", %{})
+      payload = Wire.whois_bundle("azzurra", "ghost", %WhoisAccum{})
 
       assert payload == %{
                kind: :whois_bundle,
@@ -845,7 +845,7 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "#221 — projects solanum fields (account/secure/certfp/actually_ip/extra_lines)" do
-      accum = %{
+      accum = %WhoisAccum{
         account: "AliceAccount",
         secure: true,
         secure_cipher: "TLSv1.3, TLS_AES_256_GCM_SHA384",
@@ -870,7 +870,7 @@ defmodule Grappa.Session.WireTest do
     # verbatim. :rail is the query-rail auto-fetch; anything else defaults to
     # :user (proven by the two exact-map tests above, which prime no :source).
     test "projects the accum :source (rail auto-fetch) into the wire shape" do
-      payload = Wire.whois_bundle("azzurra", "alice", %{source: :rail})
+      payload = Wire.whois_bundle("azzurra", "alice", %WhoisAccum{source: :rail})
       assert payload.source == :rail
     end
   end
@@ -1136,7 +1136,7 @@ defmodule Grappa.Session.WireTest do
         Wire.kicked("net", "#c", "by", "r"),
         Wire.away_confirmed("net", :present),
         Wire.mentions_bundle("net", "from", "to", nil, []),
-        Wire.whois_bundle("net", "alice", %{}),
+        Wire.whois_bundle("net", "alice", %WhoisAccum{}),
         Wire.peer_away("net", "alice", "Gone fishing"),
         Wire.invite_ack("net", "#italia", "alice"),
         Wire.lusers_bundle("net", %{}),

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -1034,8 +1034,8 @@ defmodule Grappa.Session.WireTest do
       accum = %ListModeAccum{
         channel_display: "#Test",
         entries: [
-          %{mask: "b!*@2", setter: "op2", set_ts: "222"},
-          %{mask: "a!*@1", setter: "op1", set_ts: "111"}
+          %ListModeAccum.Entry{mask: "b!*@2", setter: "op2", set_ts: "222"},
+          %ListModeAccum.Entry{mask: "a!*@1", setter: "op1", set_ts: "111"}
         ]
       }
 

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -1068,7 +1068,10 @@ defmodule Grappa.Session.WireTest do
     # `mode` is what tells the client WHICH list it got. A bundle that
     # dropped it would render solanum's quiet list as a ban list.
     test "carries the queried mode letter verbatim (not always b)" do
-      accum = %ListModeAccum{channel_display: "#c", entries: [%ListModeAccum.Entry{mask: "*!*@muted", setter: "op", set_ts: "1"}]}
+      accum = %ListModeAccum{
+        channel_display: "#c",
+        entries: [%ListModeAccum.Entry{mask: "*!*@muted", setter: "op", set_ts: "1"}]
+      }
 
       assert Wire.banlist_bundle("libera", "#c", "q", accum).mode == "q"
       assert Wire.banlist_bundle("azzurra", "#c", "z", accum).mode == "z"
@@ -1076,7 +1079,10 @@ defmodule Grappa.Session.WireTest do
     end
 
     test "entry with nil setter/set_ts (older ircd) round-trips nils" do
-      accum = %ListModeAccum{channel_display: "#c", entries: [%ListModeAccum.Entry{mask: "*!*@h", setter: nil, set_ts: nil}]}
+      accum = %ListModeAccum{
+        channel_display: "#c",
+        entries: [%ListModeAccum.Entry{mask: "*!*@h", setter: nil, set_ts: nil}]
+      }
       payload = Wire.banlist_bundle("net", "#c", "b", accum)
 
       assert payload.entries == [%{mask: "*!*@h", setter: nil, set_ts: nil}]

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -18,12 +18,14 @@ defmodule GrappaWeb.AdminChannelTest do
   """
   use GrappaWeb.ChannelCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
   alias Grappa.{AdminEvents, AdminOverview, Repo, SessionLog}
   alias Grappa.AdminEvents.Wire
   alias Grappa.PubSub.Topic
   alias GrappaWeb.UserSocket
+  alias Phoenix.Socket.Broadcast
 
   setup do
     # AdminEvents is the global singleton — reset buffer per-test so
@@ -243,6 +245,53 @@ defmodule GrappaWeb.AdminChannelTest do
 
       ref = push(socket, "anything", %{})
       assert_reply ref, :ok
+    end
+  end
+
+  # W-S7 (#1407) — the info side of the same posture the inbound catch-all
+  # above already takes. The barrier in both tests is mailbox ORDER: the
+  # `push` is enqueued after the stray message, so a reply can only come
+  # back if the stray one was handled without killing the channel pid.
+  describe "unhandled info catch-all" do
+    test "a stray send is logged and leaves the operator console alive" do
+      admin = user_fixture(is_admin: true)
+      raw = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, socket} = subscribe_and_join(raw, "grappa:admin:events", %{})
+      assert_push "snapshot", _
+
+      log =
+        capture_log(fn ->
+          send(socket.channel_pid, :no_clause_matches_this)
+
+          ref = push(socket, "ping", %{})
+          assert_reply ref, :ok
+        end)
+
+      assert log =~ "unhandled message"
+    end
+
+    test "a broadcast the channel has no clause for is logged and not fatal" do
+      admin = user_fixture(is_admin: true)
+      raw = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, socket} = subscribe_and_join(raw, "grappa:admin:events", %{})
+      assert_push "snapshot", _
+
+      log =
+        capture_log(fn ->
+          send(socket.channel_pid, %Broadcast{
+            topic: Topic.session_log(),
+            event: "an_event_name_added_later",
+            payload: %{}
+          })
+
+          ref = push(socket, "ping", %{})
+          assert_reply ref, :ok
+        end)
+
+      assert log =~ "unhandled broadcast"
+      assert log =~ "an_event_name_added_later"
     end
   end
 

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -268,7 +268,8 @@ defmodule GrappaWeb.AdminChannelTest do
           assert_reply ref, :ok
         end)
 
-      assert log =~ "unhandled message"
+      assert log =~ "unexpected mailbox message"
+      assert log =~ "no_clause_matches_this"
     end
 
     test "a broadcast the channel has no clause for is logged and not fatal" do
@@ -290,7 +291,7 @@ defmodule GrappaWeb.AdminChannelTest do
           assert_reply ref, :ok
         end)
 
-      assert log =~ "unhandled broadcast"
+      assert log =~ "unexpected mailbox message"
       assert log =~ "an_event_name_added_later"
     end
   end

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -149,13 +149,39 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert %{"settings" => _} = json_response(conn, 200)
     end
 
-    test "ignores unknown keys", %{conn: conn, session: session} do
+    # W-S3 (#1407) — an unknown key is a typo, not a no-op. It names the
+    # offending dotted key in the SAME 422 shape a bad VALUE gets, because
+    # that is the shape `AdminSettingsTab` already highlights inline.
+    test "422 invalid_setting names an unknown upload key", %{conn: conn, session: session} do
       conn =
         conn
         |> put_bearer(session.id)
-        |> put("/admin/settings", %{"upload" => %{"unknown_key" => "foo"}})
+        |> put("/admin/settings", %{"upload" => %{"image_per_file_cap" => 1_048_576}})
 
-      assert %{"settings" => _} = json_response(conn, 200)
+      assert %{
+               "error" => "invalid_setting",
+               "field" => "upload.image_per_file_cap"
+             } = json_response(conn, 422)
+    end
+
+    # The key check runs BEFORE the per-key applier, so a body that mixes a
+    # good key with a typo writes NOTHING — the sibling admin controllers'
+    # all-or-nothing posture, not a half-applied save.
+    test "an unknown upload key rejects the whole body, valid siblings included", %{
+      conn: conn,
+      session: session
+    } do
+      before = ServerSettings.public_view().upload.image_per_file_cap_bytes
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "upload" => %{"image_per_file_cap_bytes" => before + 4096, "globalcap_bytes" => 1}
+        })
+
+      assert %{"error" => "invalid_setting"} = json_response(conn, 422)
+      assert ServerSettings.public_view().upload.image_per_file_cap_bytes == before
     end
   end
 
@@ -401,6 +427,25 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
                "error" => "invalid_setting",
                "field" => "addressing.static_mapping_prefix"
              }
+    end
+
+    # W-S3 (#1407) — the addressing subtree used to log the typo and apply the
+    # rest; the probe never even ran for a body that named nothing it knows.
+    test "422 invalid_setting names an unknown addressing key — nothing is persisted",
+         %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{"static_prefix" => "2a03:4000:20:2d3:cb::/80"}
+        })
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "addressing.static_prefix"
+             }
+
+      assert ServerSettings.static_mapping_prefix() == nil
     end
 
     test "applies upload AND addressing subtrees in one request", %{conn: conn, session: session} do


### PR DESCRIPTION
Union of two open PRs, both from w1, replayed onto `9808cb51`:

* **#1439** (`w1-1407-admin-boundaries`, head `7339df1b`) — bucket E of
  the 2026-08-15 review: `PUT /admin/settings` names an unknown key in
  a 422 instead of answering 200 to a typo, and `AdminChannel` gets the
  `handle_info/2` catch-all its own moduledoc argues for.
* **#1437** (`w1-1391-accumulator-types`, head `b63ab6b2`, merge-base
  `1552312d`) — the five reply accumulators become structs, with the
  type check moved into the PATTERN rather than left in the `@type`.

## Why they travel together

Both add an entry to `docs/DESIGN_NOTES.md`. Merging either one first
makes the other CONFLICTING, and a conflicting branch runs ZERO CI — so
the second would reach main having been gated only against a base it no
longer sits on. #1437 was additionally NOT fast-forwardable (born at
`1552312d`) and owed a rebase plus an `integration` run of its own. One
gate, one merge.

## How it was assembled

#1439 was already fast-forwardable on `9808cb51`, so the union branch
STARTS at its head `7339df1b` rather than cherry-picking it: the
commits survive with their own shas and nothing is replayed twice.
#1391 is replayed on top with `git cherry-pick 1552312d..b63ab6b2`.

## What was verified, and how

Both source contributions were pinned to files BEFORE the replay
(`git diff --numstat <merge-base>..<head>`) and the union's contribution
compared against their sum, per file. Exact match on all 18 files —
additions unchanged in both directions (an addition count going UP is
the tell of the inverse failure, a driver resurrecting suppressed
lines) and zero delta on deletions. `docs/DESIGN_NOTES.md`: +166/-0,
which is 93 + 73.

The two markers `<!-- entry #1391 -->` and `<!-- entry #1407 -->` are
distinct from each other and unique in the file — a shared suffix would
rebuild the identical prefix the marker exists to destroy. The boundary
shape was then read on the FILE for BOTH entries, not inferred from the
numstat: text / marker / blank / `---` / blank / `## heading`, no blank
ahead of either marker. `scripts/design-notes-gate.sh` reports
`2 new entry heading(s), separator and marker present`, RC=0, on the
committed tree.

## Not established

No gate was re-run on the union itself — `scripts/check.sh` was green
on each source branch separately, at its own base, and neither of those
runs measured this tree. The CI on this PR is the first measurement of
the two together, and it is the one that counts. The union also touches
two disjoint file sets (`grappa_web/**/admin*` versus
`grappa/session/**`), so nothing here establishes that the interaction
is empty beyond that disjointness.