### PR TITLE
cic(#1438): swipe up or down to dismiss the media viewer

### DIFF
--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -1,0 +1,157 @@
+// #1438 — a vertical drag on the media viewer dismisses it, and the modal
+// follows the finger on the way out.
+//
+// WHAT THESE PROVE, and what they deliberately do not:
+//
+//   1. DISMISSAL (chromium): a synthesized vertical drag on the modal makes the
+//      viewer GO AWAY. The outcome asserted is the visible one — the dialog is
+//      gone — not that a callback fired. Reverting the wiring turns this red.
+//   2. DISPLACEMENT (chromium): mid-drag, the browser's own computed matrix
+//      says the modal has moved by exactly the finger's travel and by nothing
+//      else. That second half is the point: the modal is centered by a CSS
+//      `transform: translate(-50%, -50%)` that an inline transform REPLACES, so
+//      a paint that forgot to re-state it would displace the modal by half its
+//      own height and this assertion is what measures the difference.
+//   3. CSS CONTRACT (@webkit, iPhone 15): the modal container is
+//      `touch-action: none` on the real target browser, so iOS hands the whole
+//      vertical drag to our JS instead of reading it as its own overscroll.
+//      Same guard shape as #213's third test, on the container rather than the
+//      image because a <video> has to dismiss like an <img>.
+//
+// NOT PROVEN ANYWHERE, on purpose rather than by omission:
+//
+//   * The FEEL. A synthesized TouchEvent drives no compositor and Playwright's
+//     webkit does not reproduce real iOS scroll physics
+//     (feedback_playwright_webkit_not_ios_scroll), so nothing here says the
+//     follow is smooth or that DISMISS_COMMIT_FRACTION = 0.15 is the right
+//     threshold. That is a device call — vjt's, on a phone, post-ship, exactly
+//     as the sibling #213 gesture was calibrated.
+//   * That a <video>'s NATIVE CONTROLS survive the gesture. The argument is
+//     that a vertical claim never takes a scrubber drag (which is horizontal)
+//     and never takes a tap under the 8px slop — but the controls live in the
+//     UA shadow DOM, `closest()` cannot see them, and no assertion here
+//     reaches them. The video's DISMISSAL is covered in jsdom
+//     (MediaViewerModal.test.tsx); the controls are not covered at all.
+//
+// The binder's decision table — which drags commit, which spring back, what it
+// refuses to claim — is unit-tested against a bare element in
+// src/__tests__/mediaViewerGesture.test.ts. These are the end-to-end doors.
+
+import type { Locator, Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Upload a tiny image and open it in the media viewer, mirroring #213's
+// harness: the anchor's OWN click opens the overlay (no Playwright
+// scroll-into-view). Every spec that opens this viewer carries its own copy of
+// these six lines — a pre-existing duplication across nine files, not one this
+// change introduces, and not one it is in scope to sweep.
+async function openImageViewer(page: Page): Promise<{ viewer: Locator }> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const { slug } = await uploadViaPicker(
+    page,
+    { name: "x1438.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+    { postTimeout: 10_000 },
+  );
+  const { link } = await mediaScrollbackRow(page, "📸", slug);
+  await link.evaluate((el) => (el as HTMLElement).click());
+
+  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  return { viewer };
+}
+
+// One vertical drag on the modal, plus the browser's own reading of where the
+// modal sat before and during it. Body inlined in the page rather than passed
+// as a stringified function: `new Function` in page context is eval, and cic
+// serves a CSP with no `unsafe-eval` — the drag would throw where it matters
+// and nowhere else.
+//
+// `dy` is applied in TWO moves because the binder claims LATE: it decides on a
+// touchmove, never on the touchstart. `lift` is optional so a caller can read
+// the paint with the finger still down, which is the only moment it exists.
+async function dragOnModal(
+  viewer: Locator,
+  dy: number,
+  lift: boolean,
+): Promise<{ before: number; after: number }> {
+  return viewer.evaluate(
+    (el, opts) => {
+      // The vertical component of the computed matrix — what the browser
+      // actually resolved, not the inline string we wrote.
+      const verticalOffset = (): number =>
+        new DOMMatrixReadOnly(getComputedStyle(el).transform).f;
+      const at = (y: number): Touch =>
+        new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
+      const fire = (type: string, touch: Touch): void => {
+        const list = type === "touchend" ? [] : [touch];
+        el.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: list,
+            targetTouches: list,
+            changedTouches: [touch],
+          }),
+        );
+      };
+      const y0 = 200;
+      const before = verticalOffset();
+      fire("touchstart", at(y0));
+      fire("touchmove", at(y0 + Math.sign(opts.dy) * 40));
+      fire("touchmove", at(y0 + opts.dy));
+      const after = verticalOffset();
+      if (opts.lift) fire("touchend", at(y0 + opts.dy));
+      return { before, after };
+    },
+    { dy, lift },
+  );
+}
+
+test("#1438 — a downward drag on the viewer dismisses it (chromium)", async ({ page }) => {
+  test.slow();
+  const { viewer } = await openImageViewer(page);
+
+  // Half a viewport of travel — comfortably past the commit fraction whatever
+  // the exact threshold is, so this spec asserts the dismissal and not the
+  // calibration of a constant it does not own.
+  const half = Math.round((await page.evaluate(() => window.innerHeight)) / 2);
+  await dragOnModal(viewer, half, true);
+
+  await expect(viewer).toBeHidden({ timeout: 5_000 });
+});
+
+test("#1438 — mid-drag the modal moves by the finger's travel, centering intact (chromium)", async ({
+  page,
+}) => {
+  test.slow();
+  const { viewer } = await openImageViewer(page);
+
+  // A correct paint moves the modal by exactly the 90px pulled: the rule's own
+  // `translate(-50%, -50%)` contributes -height/2 to that same component, so a
+  // paint that dropped the centering would read +height/2 + 90 instead. The
+  // two failure modes are far apart, and the browser does the arithmetic.
+  const { before, after } = await dragOnModal(viewer, 90, false);
+
+  expect(after - before).toBeCloseTo(90, 0);
+});
+
+test("@webkit #1438 — the viewer container is touch-action:none (iPhone 15)", async ({ page }) => {
+  test.slow();
+  const { viewer } = await openImageViewer(page);
+
+  // Declared on the CONTAINER, not the media element: the UA intersects
+  // touch-action down the ancestor chain, which is what makes a <video>
+  // dismissible on the same terms as an <img>. Reverting the rule turns this
+  // red — and nothing else in the suite would.
+  const touchAction = await viewer.evaluate((el) => getComputedStyle(el).touchAction);
+  expect(touchAction).toBe("none");
+});

--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -87,8 +87,7 @@ async function dragOnModal(
     (el, opts) => {
       // The vertical component of the computed matrix — what the browser
       // actually resolved, not the inline string we wrote.
-      const verticalOffset = (): number =>
-        new DOMMatrixReadOnly(getComputedStyle(el).transform).f;
+      const verticalOffset = (): number => new DOMMatrixReadOnly(getComputedStyle(el).transform).f;
       const at = (y: number): Touch =>
         new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
       const fire = (type: string, touch: Touch): void => {

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -290,8 +290,7 @@ const MediaViewerBody: Component<{ state: MediaViewerState; onScale: (scale: num
 // and an inline transform REPLACES that declaration wholesale. The drag offset
 // therefore has to re-state the centering, or the modal jumps by half its own
 // size the instant a finger claims it.
-const draggedTransform = (dy: number): string =>
-  `translate(-50%, -50%) translateY(${dy}px)`;
+const draggedTransform = (dy: number): string => `translate(-50%, -50%) translateY(${dy}px)`;
 
 // The backdrop thins out with the pull and is fully clear at one viewport of
 // travel. Deliberately NOT keyed to DISMISS_COMMIT_FRACTION: a ramp that hit

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
 import { closeMediaViewer, type MediaViewerState, mediaViewerState } from "./lib/mediaViewer";
+import { bindDismissGesture } from "./lib/mediaViewerGesture";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import {
   applyPan,
@@ -71,10 +72,28 @@ const touchPoint = (t: Touch): Point => ({ x: t.clientX, y: t.clientY });
 // preventDefault would silently no-op (DESIGN_NOTES 2026-06-24 / 2026-07-12).
 // The pure geometry lives in lib/pinchZoom.ts; this owns only the DOM wiring +
 // gesture state.
-const ZoomableImage: Component<{ href: string; onLoad: () => void; onError: () => void }> = (
-  props,
-) => {
+//
+// #1438 — the zoom level is PUBLISHED upward (`onScale`) instead of the
+// transform being lifted into the modal. The dismiss gesture needs one bit
+// ("is this image zoomed?") to stand down, and the transform is deliberately
+// element-scoped: hoisting it would put the image's pan geometry in a
+// component that also owns a <video>. Published synchronously with every
+// mutation rather than through an effect, because the reader is a touchstart
+// handler and a frame of lag there is a dismiss that fires on a pan.
+const ZoomableImage: Component<{
+  href: string;
+  onLoad: () => void;
+  onError: () => void;
+  onScale: (scale: number) => void;
+}> = (props) => {
   const [transform, setTransform] = createSignal<Transform>(IDENTITY);
+
+  // The ONE writer: signal + publication cannot drift apart if there is no
+  // other way to move the transform.
+  const apply = (next: Transform): void => {
+    setTransform(next);
+    props.onScale(next.scale);
+  };
 
   // Non-reactive gesture state, mutated across the touchstart→move→end span.
   let gestureStart: Transform = IDENTITY; // transform when the current gesture began
@@ -105,7 +124,7 @@ const ZoomableImage: Component<{ href: string; onLoad: () => void; onError: () =
     // Double-tap toggles fit⇄2x. Second tap within the window → toggle and
     // arm nothing (don't treat the toggle tap as a pan start).
     if (e.timeStamp - lastTapAt < DOUBLE_TAP_MS) {
-      setTransform(toggleZoom(transform()));
+      apply(toggleZoom(transform()));
       lastTapAt = 0;
       startPan = null;
       return;
@@ -123,9 +142,7 @@ const ZoomableImage: Component<{ href: string; onLoad: () => void; onError: () =
       const a = e.touches[0];
       const b = e.touches[1];
       if (a && b) {
-        setTransform(
-          applyPinch(gestureStart, startDistance, distance(touchPoint(a), touchPoint(b)), vp),
-        );
+        apply(applyPinch(gestureStart, startDistance, distance(touchPoint(a), touchPoint(b)), vp));
       }
       return;
     }
@@ -134,7 +151,7 @@ const ZoomableImage: Component<{ href: string; onLoad: () => void; onError: () =
       const t0 = e.touches[0];
       if (t0) {
         const delta = { x: t0.clientX - startPan.x, y: t0.clientY - startPan.y };
-        setTransform(applyPan(gestureStart, delta, vp));
+        apply(applyPan(gestureStart, delta, vp));
       }
     }
   };
@@ -194,7 +211,9 @@ const ZoomableImage: Component<{ href: string; onLoad: () => void; onError: () =
 // 404 can't spin forever. The failed media element is unmounted —
 // a broken <img> would render its alt text (the raw URL) under the
 // failure line.
-const MediaViewerBody: Component<{ state: MediaViewerState }> = (props) => {
+const MediaViewerBody: Component<{ state: MediaViewerState; onScale: (scale: number) => void }> = (
+  props,
+) => {
   const [status, setStatus] = createSignal<MediaLoadStatus>("loading");
   // Transitions only leave "loading" (review fix): a transient
   // mid-playback error must not unmount a ready element, and a suspend
@@ -222,7 +241,12 @@ const MediaViewerBody: Component<{ state: MediaViewerState }> = (props) => {
         fallback={
           <Switch>
             <Match when={props.state.kind === "image"}>
-              <ZoomableImage href={props.state.href} onLoad={ready} onError={failed} />
+              <ZoomableImage
+                href={props.state.href}
+                onLoad={ready}
+                onError={failed}
+                onScale={props.onScale}
+              />
             </Match>
             <Match when={props.state.kind === "video"}>
               {/* playsinline: without it iOS hands the element to the
@@ -262,6 +286,112 @@ const MediaViewerBody: Component<{ state: MediaViewerState }> = (props) => {
   );
 };
 
+// #1438 — the modal is centered by a CSS `transform: translate(-50%, -50%)`,
+// and an inline transform REPLACES that declaration wholesale. The drag offset
+// therefore has to re-state the centering, or the modal jumps by half its own
+// size the instant a finger claims it.
+const draggedTransform = (dy: number): string =>
+  `translate(-50%, -50%) translateY(${dy}px)`;
+
+// The backdrop thins out with the pull and is fully clear at one viewport of
+// travel. Deliberately NOT keyed to DISMISS_COMMIT_FRACTION: a ramp that hit
+// zero at the commit point would black-flash back to full on every drag that
+// crosses the line and springs back anyway, and a second threshold is a second
+// thing to keep in step.
+const backdropOpacity = (dy: number, viewportHeight: number): number =>
+  viewportHeight <= 0 ? 1 : Math.max(0, 1 - Math.abs(dy) / viewportHeight);
+
+// Everything that must be FRESH per open lives here, not in the parent: the
+// keyed <Show> remounts this subtree for every viewer state, which is what
+// gives each open a zero zoom level and an untouched drag offset — the same
+// reason MediaViewerBody is its own component.
+const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
+  // Plain mutable, not a signal: nothing RENDERS from the zoom level. It is
+  // read once per touchstart by a DOM callback, and a signal here would only
+  // advertise a reactivity that does not exist.
+  let scale = MIN_SCALE;
+  let backdrop: HTMLButtonElement | undefined;
+
+  const paint = (el: HTMLElement, dy: number): void => {
+    el.style.transform = draggedTransform(dy);
+    if (backdrop !== undefined) {
+      backdrop.style.opacity = String(backdropOpacity(dy, window.innerHeight));
+    }
+  };
+
+  const unpaint = (el: HTMLElement): void => {
+    el.style.removeProperty("transform");
+    backdrop?.style.removeProperty("opacity");
+  };
+
+  const bindDismiss = (el: HTMLDivElement): void => {
+    const dispose = bindDismissGesture(el, {
+      viewportHeight: () => window.innerHeight,
+      // A zoomed image owns the one-finger drag as a PAN (#213), so the viewer
+      // stands down until the image is back at fit. Video and audio never
+      // publish a scale, which is exactly right: they are always dismissible.
+      canDismiss: () => scale <= MIN_SCALE,
+      onProgress: (dy) => {
+        paint(el, dy);
+      },
+      // Through the shared close verb, never a bare state poke: #1121 and #535
+      // both closed on that path doing more than clearing the signal.
+      onCommit: closeMediaViewer,
+      onRelease: () => {
+        unpaint(el);
+      },
+    });
+    onCleanup(dispose);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={backdrop}
+        class="media-viewer-backdrop"
+        aria-label="Close media viewer backdrop"
+        onClick={closeMediaViewer}
+      />
+      <div
+        ref={bindDismiss}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Media viewer"
+        class="media-viewer-modal"
+      >
+        <div class="media-viewer-header">
+          <a
+            href={props.state.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="media-viewer-open-external"
+            onClick={(e) => {
+              maybeEscapePwaClick(e, props.state.href);
+            }}
+          >
+            open in browser
+          </a>
+          <button
+            type="button"
+            class="media-viewer-close"
+            aria-label="Close media viewer"
+            onClick={closeMediaViewer}
+          >
+            ✕
+          </button>
+        </div>
+        <MediaViewerBody
+          state={props.state}
+          onScale={(next) => {
+            scale = next;
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
 const MediaViewerModal: Component = () => {
   // UX-6 bucket A — refcounted overlay scroll-lock (shared
   // createOverlayLock wiring, extracted from the ArchiveModal/
@@ -272,40 +402,7 @@ const MediaViewerModal: Component = () => {
 
   return (
     <Show when={mediaViewerState()} keyed>
-      {(state) => (
-        <>
-          <button
-            type="button"
-            class="media-viewer-backdrop"
-            aria-label="Close media viewer backdrop"
-            onClick={closeMediaViewer}
-          />
-          <div role="dialog" aria-modal="true" aria-label="Media viewer" class="media-viewer-modal">
-            <div class="media-viewer-header">
-              <a
-                href={state.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="media-viewer-open-external"
-                onClick={(e) => {
-                  maybeEscapePwaClick(e, state.href);
-                }}
-              >
-                open in browser
-              </a>
-              <button
-                type="button"
-                class="media-viewer-close"
-                aria-label="Close media viewer"
-                onClick={closeMediaViewer}
-              >
-                ✕
-              </button>
-            </div>
-            <MediaViewerBody state={state} />
-          </div>
-        </>
-      )}
+      {(state) => <MediaViewerDialog state={state} />}
     </Show>
   );
 };

--- a/cicchetto/src/__tests__/MediaViewerModal.test.tsx
+++ b/cicchetto/src/__tests__/MediaViewerModal.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../lib/overlayScrollLock";
 import MediaViewerModal from "../MediaViewerModal";
 import { resetPlatformStubs, stubIosStandalone } from "./helpers/platformStubs";
+import { fireTouchAt } from "./helpers/touchEvents";
 
 // `maybeEscapePwaClick` is mocked at the module boundary: its escaping
 // branch calls window.location.assign, which jsdom makes unforgeable
@@ -257,5 +258,116 @@ describe("MediaViewerModal — loading state", () => {
     video?.dispatchEvent(new Event("suspend"));
     expect(screen.getByText(/failed to load/i)).not.toBeNull();
     expect(container.querySelector("video")).toBeNull();
+  });
+});
+
+// #1438 — swipe up or down to dismiss. The binder's decision table (which
+// drags commit, which spring back, what it refuses to claim) is pinned in
+// mediaViewerGesture.test.ts against a bare element; what is asserted HERE is
+// the wiring only this component can get wrong: the listener sits on the modal
+// BODY so a video is as dismissible as an image, the paint re-states the CSS
+// centering the inline transform overwrites, the backdrop thins with the pull,
+// and a zoomed image keeps its pan.
+//
+// What these do NOT prove: the follow itself. A synthetic touch in jsdom moves
+// no compositor, so this pins the transform STRING the component writes, not
+// that anything tracked a finger. That half is on-device (see the module).
+describe("MediaViewerModal — swipe to dismiss (#1438)", () => {
+  const SLOW_MS = 2_000; // well under the flick threshold, so distance decides
+  const X = 160;
+  const Y0 = 300;
+
+  const dialogIn = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (el === null) throw new Error("no media viewer dialog rendered");
+    return el;
+  };
+
+  const backdropIn = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(".media-viewer-backdrop");
+    if (el === null) throw new Error("no media viewer backdrop rendered");
+    return el;
+  };
+
+  // Touch DOWN and drag to `dy`, finger still on the glass — the mid-drag paint
+  // is only observable before the release puts everything back.
+  const dragTo = (target: HTMLElement, dy: number): void => {
+    fireTouchAt(target, "touchstart", 0, { clientX: X, clientY: Y0 });
+    fireTouchAt(target, "touchmove", SLOW_MS / 2, { clientX: X, clientY: Y0 + dy });
+  };
+
+  const dragAndLift = (target: HTMLElement, dy: number): void => {
+    dragTo(target, dy);
+    fireTouchAt(target, "touchend", SLOW_MS, { clientX: X, clientY: Y0 + dy });
+  };
+
+  it("a long downward drag on the image closes the viewer through the shared close verb", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    dragAndLift(dialogIn(container), 400);
+    expect(mediaViewerState()).toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("a long upward drag on a VIDEO closes it too — the listener is on the modal, not the image", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(VIDEO_URL, "video");
+    dragAndLift(dialogIn(container), -400);
+    expect(mediaViewerState()).toBeNull();
+  });
+
+  it("translates the modal by the drag distance while the finger is down", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    const dialog = dialogIn(container);
+    dragTo(dialog, 50);
+    expect(dialog.style.transform).toContain("translateY(50px)");
+  });
+
+  it("keeps the CSS centering in the dragged transform (an inline transform replaces the rule)", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    const dialog = dialogIn(container);
+    dragTo(dialog, 50);
+    expect(dialog.style.transform).toContain("translate(-50%, -50%)");
+  });
+
+  it("thins the backdrop as the pull grows", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    const dialog = dialogIn(container);
+    const backdrop = backdropIn(container);
+    dragTo(dialog, 50);
+    const near = Number(backdrop.style.opacity);
+    fireTouchAt(dialog, "touchmove", SLOW_MS, { clientX: X, clientY: Y0 + 300 });
+    const far = Number(backdrop.style.opacity);
+    expect(near).toBeLessThan(1);
+    expect(far).toBeLessThan(near);
+    expect(far).toBeGreaterThanOrEqual(0);
+  });
+
+  it("a short slow drag springs the modal and the backdrop back to rest", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    const dialog = dialogIn(container);
+    const backdrop = backdropIn(container);
+    dragAndLift(dialog, 50);
+    expect(mediaViewerState()).not.toBeNull();
+    expect(dialog.style.transform).toBe("");
+    expect(backdrop.style.opacity).toBe("");
+  });
+
+  it("a zoomed image keeps its pan — the dismiss stands down until it is back at fit", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    const img = container.querySelector<HTMLElement>("img");
+    if (img === null) throw new Error("no image rendered");
+    // Double-tap zoom (#213), the same two touchstarts the viewer reads: it is
+    // the published scale, not a test seam, that stands the dismiss down.
+    fireTouchAt(img, "touchstart", 1_000, { clientX: X, clientY: Y0 });
+    fireTouchAt(img, "touchend", 1_020, { clientX: X, clientY: Y0 });
+    fireTouchAt(img, "touchstart", 1_100, { clientX: X, clientY: Y0 });
+    dragAndLift(dialogIn(container), 400);
+    expect(mediaViewerState()).not.toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/helpers/touchEvents.ts
+++ b/cicchetto/src/__tests__/helpers/touchEvents.ts
@@ -21,6 +21,30 @@ export function fireTouch(el: HTMLElement, type: string, ...points: TouchPoint[]
   return ev;
 }
 
+// Same, with a chosen `timeStamp` — for gestures whose decision reads the clock
+// (#1438's velocity gate). It has to be its own function rather than a caller
+// stamping the returned event: `fireTouch` DISPATCHES before it returns, so a
+// `defineProperty` afterwards lands too late and every listener still sees
+// jsdom's 0. A gesture graded on velocity would then read every drag as
+// instantaneous, and its "slow drag does nothing" arm would pass against an
+// implementation with no velocity gate at all.
+export function fireTouchAt(
+  el: HTMLElement,
+  type: string,
+  timeStamp: number,
+  ...points: TouchPoint[]
+): Event {
+  const ev = new Event(type, { bubbles: true, cancelable: true });
+  const list = points as unknown as TouchList;
+  Object.defineProperty(ev, "touches", {
+    value: type === "touchend" ? ([] as unknown as TouchList) : list,
+  });
+  Object.defineProperty(ev, "changedTouches", { value: list });
+  Object.defineProperty(ev, "timeStamp", { value: timeStamp });
+  el.dispatchEvent(ev);
+  return ev;
+}
+
 // One full edge swipe: start → two moves → end. The intermediate moves are what
 // let the directive claim mid-drag (it claims late, never on touchstart).
 export function swipeHorizontally(el: HTMLElement, fromX: number, toX: number, y: number): void {

--- a/cicchetto/src/__tests__/mediaViewerGesture.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerGesture.test.ts
@@ -5,7 +5,7 @@ import {
   DISMISS_COMMIT_FRACTION,
   DRAGGING_CLASS,
 } from "../lib/mediaViewerGesture";
-import { fireTouch } from "./helpers/touchEvents";
+import { fireTouch, fireTouchAt } from "./helpers/touchEvents";
 
 // #1438 — a vertical drag on the media viewer dismisses it, and the modal
 // follows the finger on the way. Composed from `lib/swipe.ts` (the #123
@@ -69,19 +69,15 @@ function dragVertically(
   dy: number,
   elapsedMs: number,
 ): { moves: Event[]; end: Event } {
-  const at = (e: Event, ms: number): Event => {
-    Object.defineProperty(e, "timeStamp", { value: ms });
-    return e;
-  };
-  at(fireTouch(target, "touchstart", { clientX: X, clientY: START_Y }), 0);
+  fireTouchAt(target, "touchstart", 0, { clientX: X, clientY: START_Y });
   const moves = [
-    at(fireTouch(target, "touchmove", { clientX: X, clientY: START_Y + dy / 3 }), elapsedMs / 3),
-    at(
-      fireTouch(target, "touchmove", { clientX: X, clientY: START_Y + (dy * 2) / 3 }),
-      (elapsedMs * 2) / 3,
-    ),
+    fireTouchAt(target, "touchmove", elapsedMs / 3, { clientX: X, clientY: START_Y + dy / 3 }),
+    fireTouchAt(target, "touchmove", (elapsedMs * 2) / 3, {
+      clientX: X,
+      clientY: START_Y + (dy * 2) / 3,
+    }),
   ];
-  const end = at(fireTouch(target, "touchend", { clientX: X, clientY: START_Y + dy }), elapsedMs);
+  const end = fireTouchAt(target, "touchend", elapsedMs, { clientX: X, clientY: START_Y + dy });
   return { moves, end };
 }
 

--- a/cicchetto/src/__tests__/mediaViewerGesture.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerGesture.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import {
+  bindDismissGesture,
+  DISMISS_COMMIT_FRACTION,
+  DRAGGING_CLASS,
+} from "../lib/mediaViewerGesture";
+import { fireTouch } from "./helpers/touchEvents";
+
+// #1438 — a vertical drag on the media viewer dismisses it, and the modal
+// follows the finger on the way. Composed from `lib/swipe.ts` (the #123
+// geometry toolkit) and `lib/touchGesture.ts`'s angle gate rather than a second
+// gesture engine, exactly as `bindMessageGestures` does — see the module.
+//
+// jsdom proves the DECISION path and the hard constraints: which drags commit,
+// which spring back, that a horizontal drag is never claimed, that a zoomed
+// image keeps its pan. It does NOT prove the feel, and it cannot prove the
+// follow — a synthetic event drives no compositor. That half is vjt's
+// on-device dogfood; see the spec header and the issue.
+
+const VH = 800; // viewport height fed to the binder (jsdom has no layout)
+const COMMIT_PX = VH * DISMISS_COMMIT_FRACTION;
+const X = 200;
+const START_Y = 400;
+
+let modal: HTMLDivElement;
+let media: HTMLImageElement;
+let onProgress: Mock<(dy: number) => void>;
+let onCommit: Mock<() => void>;
+let onRelease: Mock<() => void>;
+let canDismiss: Mock<() => boolean>;
+let dispose: () => void;
+
+function bind(): void {
+  dispose = bindDismissGesture(modal, {
+    viewportHeight: () => VH,
+    canDismiss,
+    onProgress,
+    onCommit,
+    onRelease,
+  });
+}
+
+beforeEach(() => {
+  modal = document.createElement("div");
+  modal.className = "media-viewer-modal";
+  media = document.createElement("img");
+  media.className = "media-viewer-media";
+  modal.appendChild(media);
+  document.body.appendChild(modal);
+  onProgress = vi.fn<(dy: number) => void>();
+  onCommit = vi.fn<() => void>();
+  onRelease = vi.fn<() => void>();
+  canDismiss = vi.fn<() => boolean>(() => true);
+  bind();
+});
+
+afterEach(() => {
+  dispose();
+  document.body.innerHTML = "";
+});
+
+// A vertical drag of `dy` px (negative = up), in three steps so the binder can
+// claim mid-drag — it claims late, never on touchstart. `elapsed` spaces the
+// synthetic timeStamps so the velocity gate is exercised deliberately rather
+// than by accident: jsdom stamps every synthetic event 0.
+function dragVertically(
+  target: HTMLElement,
+  dy: number,
+  elapsedMs: number,
+): { moves: Event[]; end: Event } {
+  const at = (e: Event, ms: number): Event => {
+    Object.defineProperty(e, "timeStamp", { value: ms });
+    return e;
+  };
+  at(fireTouch(target, "touchstart", { clientX: X, clientY: START_Y }), 0);
+  const moves = [
+    at(fireTouch(target, "touchmove", { clientX: X, clientY: START_Y + dy / 3 }), elapsedMs / 3),
+    at(
+      fireTouch(target, "touchmove", { clientX: X, clientY: START_Y + (dy * 2) / 3 }),
+      (elapsedMs * 2) / 3,
+    ),
+  ];
+  const end = at(fireTouch(target, "touchend", { clientX: X, clientY: START_Y + dy }), elapsedMs);
+  return { moves, end };
+}
+
+describe("bindDismissGesture — commit vs spring back", () => {
+  it("dismisses on a slow downward drag past the commit distance", () => {
+    dragVertically(media, COMMIT_PX + 20, 2_000);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on an upward drag too — both directions close", () => {
+    dragVertically(media, -(COMMIT_PX + 20), 2_000);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses a short but FAST flick, below the commit distance", () => {
+    dragVertically(media, 60, 100);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("springs back on a short slow drag — neither distance nor velocity", () => {
+    dragVertically(media, 60, 2_000);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bindDismissGesture — following the finger", () => {
+  it("reports the running delta mid-drag so the caller can move the modal", () => {
+    dragVertically(media, 90, 2_000);
+    expect(onProgress.mock.calls.map(([dy]) => dy)).toEqual([30, 60]);
+  });
+
+  it("marks the element as dragging so CSS can drop its snap-back transition", () => {
+    fireTouch(media, "touchstart", { clientX: X, clientY: START_Y });
+    expect(modal.classList.contains(DRAGGING_CLASS)).toBe(false); // not until claimed
+    fireTouch(media, "touchmove", { clientX: X, clientY: START_Y + 40 });
+    expect(modal.classList.contains(DRAGGING_CLASS)).toBe(true);
+    fireTouch(media, "touchend", { clientX: X, clientY: START_Y + 40 });
+    expect(modal.classList.contains(DRAGGING_CLASS)).toBe(false);
+  });
+
+  it("claims the gesture only once vertical intent is proven", () => {
+    const { moves } = dragVertically(media, 90, 2_000);
+    expect(moves.every((m) => m.defaultPrevented)).toBe(true);
+  });
+});
+
+describe("bindDismissGesture — what it must NOT take", () => {
+  it("leaves a horizontal-dominant drag entirely alone", () => {
+    fireTouch(media, "touchstart", { clientX: X, clientY: START_Y });
+    const move = fireTouch(media, "touchmove", { clientX: X + 90, clientY: START_Y + 10 });
+    const end = fireTouch(media, "touchend", { clientX: X + 120, clientY: START_Y + 12 });
+    expect(move.defaultPrevented).toBe(false);
+    expect(end.defaultPrevented).toBe(false);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("stands down entirely when the caller says it cannot dismiss (zoomed image)", () => {
+    canDismiss.mockReturnValue(false);
+    const { moves } = dragVertically(media, COMMIT_PX + 20, 2_000);
+    expect(moves.some((m) => m.defaultPrevented)).toBe(false);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("ignores a two-finger gesture — a pinch is the image's, not ours", () => {
+    fireTouch(
+      media,
+      "touchstart",
+      { clientX: X, clientY: START_Y },
+      { clientX: X + 50, clientY: START_Y + 50 },
+    );
+    fireTouch(
+      media,
+      "touchmove",
+      { clientX: X, clientY: START_Y + 200 },
+      { clientX: X + 50, clientY: START_Y + 250 },
+    );
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("drops the gesture on touchcancel without dismissing", () => {
+    fireTouch(media, "touchstart", { clientX: X, clientY: START_Y });
+    fireTouch(media, "touchmove", { clientX: X, clientY: START_Y + COMMIT_PX + 20 });
+    fireTouch(media, "touchcancel", { clientX: X, clientY: START_Y + COMMIT_PX + 20 });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+    expect(modal.classList.contains(DRAGGING_CLASS)).toBe(false);
+  });
+});
+
+describe("bindDismissGesture — lifecycle", () => {
+  it("stops listening once disposed (Solid never re-invokes a ref at unmount)", () => {
+    dispose();
+    dragVertically(media, COMMIT_PX + 20, 2_000);
+    expect(onCommit).not.toHaveBeenCalled();
+    dispose = (): void => {}; // afterEach must not double-dispose
+  });
+});

--- a/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { DRAGGING_CLASS } from "../lib/mediaViewerGesture";
+import { ruleBody } from "./helpers/themeCss";
+
+// #1438 — the stylesheet half of swipe-to-dismiss, asserted at SOURCE level
+// (the ipadSafeArea/railExpandedHome precedent): jsdom applies no stylesheet,
+// so a computed-style oracle here would read the property back as empty
+// whether or not the rule exists.
+//
+// Both declarations are invisible in every unit and e2e run and only bite on a
+// real phone, which is exactly why they need a guard that fails in CI: a drag
+// with no `touch-action: none` still dismisses in Playwright while iOS drags
+// its own chrome in behind the modal, and a live snap-back transition still
+// leaves the modal in the right place while making it lag 180ms behind the
+// finger. Neither symptom is reachable from a headless browser.
+
+describe("media viewer — swipe-to-dismiss stylesheet contract (#1438)", () => {
+  it("claims the whole touch stream on the modal container", () => {
+    // On the CONTAINER, not per media element: the UA intersects touch-action
+    // down the ancestor chain, so this one declaration is what covers the
+    // <video> as well as the <img>.
+    expect(ruleBody(".media-viewer-modal")).toMatch(/touch-action:\s*none/);
+  });
+
+  it("declares the spring-back transition an uncommitted drag returns on", () => {
+    expect(ruleBody(".media-viewer-modal")).toMatch(/transition:\s*transform/);
+  });
+
+  it("drops that transition under the class the binder writes, so the modal tracks the finger", () => {
+    // Looked up through the exported constant on purpose: renaming the class
+    // in the module without renaming the rule is the failure this catches, and
+    // ruleBody throws on a missing selector rather than passing vacuously.
+    expect(ruleBody(`.${DRAGGING_CLASS}`)).toMatch(/transition:\s*none/);
+  });
+});

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -1,21 +1,148 @@
-// #1438 — STUB. The behaviour lands in the next commit; this exists so the
-// spec's red is per-assertion and readable by name rather than one
-// module-not-found that exercises nothing.
-import type { Point } from "./swipe";
+// #1438 — swipe up or down to dismiss the media viewer, modal following the
+// finger. Requested by vjt; the whole CONTAINER moves, not the picture inside a
+// stationary chrome (vjt's ruling), and videos behave the same as images.
+//
+// This is not a new gesture engine. It COMPOSES `./swipe` (the #123 pure
+// geometry toolkit — travel floor, direction, velocity) and `./touchGesture`'s
+// angle gate, exactly as `bindEdgeGesture` and `bindMessageGestures` do. Three
+// engines on one app would be three answers to "what counts as a swipe".
+//
+// Element-level listeners with a non-passive touchmove: Solid delegates touch
+// to a single PASSIVE document listener, where preventDefault silently no-ops
+// (#308 landmine 1). Returns a disposer the caller wraps in `onCleanup` —
+// Solid does NOT re-invoke a function ref with undefined at unmount the way
+// React does (#308 landmine 3), so cleanup is explicit.
+//
+// The gesture reports PROGRESS, which `bindEdgeGesture` deliberately does not:
+// #1041 ruled a follow-the-finger panel out of scope there, and it is exactly
+// the progress channel that ruling avoided. Here the follow IS the feature, so
+// the caller gets `onProgress` and owns the paint — this module writes no
+// transform of its own, because the modal and the backdrop move together and a
+// binder that knew about both would be a binder that knew about the viewer.
+import { isFastSwipe, type Point, swipeDirection } from "./swipe";
+import { verticalClaim } from "./touchGesture";
 
+// How far down (or up) the drag must reach to dismiss on distance alone,
+// as a fraction of the viewport height. A fraction rather than a pixel
+// constant because the same gesture has to feel the same on a phone and on a
+// tablet, and because jsdom has no layout — the height is injected, like
+// `viewportWidth` in the sibling binders.
+//
+// 0.15 is a defensible default, NOT a measurement — the same standing this
+// module's velocity threshold carries in `swipe.ts` ("velocity feel is a device
+// call"). vjt calibrates it on-device; nothing here was verified on a phone.
 export const DISMISS_COMMIT_FRACTION = 0.15;
+
+// Worn by the bound element for exactly as long as the finger is driving it, so
+// the stylesheet can drop its snap-back transition and let the modal track the
+// finger instead of easing behind it. Same device as `SWIPING_CLASS` in
+// `messageGestures`.
 export const DRAGGING_CLASS = "media-viewer-modal--dragging";
 
 export type DismissGestureParams = {
+  // Injected (not read off the element) because jsdom has no layout.
   viewportHeight: () => number;
+  // Asked at touchstart, the way `bindMessageGestures` asks `canReply` per row:
+  // this module is DOM-only and must stay that way. A zoomed image owns the
+  // one-finger drag as a PAN, so the viewer answers false while its scale is
+  // off the fit baseline — but a scale, or a media kind, in here would be a
+  // second classifier racing the one that already exists.
   canDismiss: () => boolean;
+  // Running vertical delta in px (negative = up), on every claimed move. The
+  // caller translates the modal and ramps the backdrop with it.
   onProgress: (dy: number) => void;
+  // Past the distance or the velocity: close, through the caller's normal
+  // close path (#1121 / #535 — a dismiss that bypassed it would strand the
+  // reader exactly the way those two issues closed).
   onCommit: () => void;
+  // Claimed but not committed, or cancelled: put it back.
   onRelease: () => void;
 };
 
-export type { Point };
+function soleTouch(e: TouchEvent): Touch | undefined {
+  const list = e.touches.length > 0 ? e.touches : e.changedTouches;
+  return list.length === 1 ? list[0] : undefined;
+}
 
-export function bindDismissGesture(_el: HTMLElement, _params: DismissGestureParams): () => void {
-  return () => {};
+export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams): () => void {
+  let start: Point | null = null; // non-null ⇒ armed
+  let startedAt = 0; // touchstart timeStamp, for the velocity gate
+  let claimed = false; // vertical intent proven → we own the gesture
+
+  const disarm = (): void => {
+    start = null;
+    claimed = false;
+    el.classList.remove(DRAGGING_CLASS);
+  };
+
+  const onStart = (e: TouchEvent): void => {
+    disarm();
+    if (e.touches.length !== 1) return; // a pinch is the image's, not ours
+    const t = soleTouch(e);
+    if (t === undefined) return;
+    if (!params.canDismiss()) return;
+    start = { x: t.clientX, y: t.clientY };
+    startedAt = e.timeStamp;
+  };
+
+  const onMove = (e: TouchEvent): void => {
+    if (start === null || e.touches.length !== 1) return;
+    const t = soleTouch(e);
+    if (t === undefined) return;
+    const current = { x: t.clientX, y: t.clientY };
+    if (!claimed) {
+      // Claim LATE and VERTICAL-dominant only. A horizontal drag is released
+      // whole — it is how a `<video>` scrubber survives, and how a future
+      // left/right binding on this surface stays possible.
+      if (!verticalClaim(start, current)) return;
+      claimed = true;
+      el.classList.add(DRAGGING_CLASS);
+    }
+    // Own the gesture: suppress native pan. Reached ONLY after a vertical claim.
+    if (e.cancelable) e.preventDefault();
+    params.onProgress(current.y - start.y);
+  };
+
+  const onEnd = (e: TouchEvent): void => {
+    const s = start;
+    const wasClaimed = claimed;
+    const elapsed = e.timeStamp - startedAt;
+    disarm();
+    if (!wasClaimed || s === null) return;
+    const t = e.changedTouches[0];
+    if (t === undefined) {
+      params.onRelease();
+      return;
+    }
+    const end = { x: t.clientX, y: t.clientY };
+    // Two independent ways to mean it, the pair every photo viewer uses: a
+    // deliberate long pull, or a short flick. `swipeDirection` floors the
+    // travel at SWIPE_MIN_PX first, so neither route fires on a stray nudge.
+    const direction = swipeDirection(s, end);
+    const farEnough = Math.abs(end.y - s.y) >= params.viewportHeight() * DISMISS_COMMIT_FRACTION;
+    const flicked = isFastSwipe(s, end, elapsed);
+    if ((direction === "up" || direction === "down") && (farEnough || flicked)) {
+      params.onCommit();
+      return;
+    }
+    params.onRelease();
+  };
+
+  const onCancel = (): void => {
+    const wasClaimed = claimed;
+    disarm();
+    if (wasClaimed) params.onRelease();
+  };
+
+  el.addEventListener("touchstart", onStart, { passive: true });
+  el.addEventListener("touchmove", onMove, { passive: false });
+  el.addEventListener("touchend", onEnd, { passive: true });
+  el.addEventListener("touchcancel", onCancel, { passive: true });
+  return () => {
+    disarm();
+    el.removeEventListener("touchstart", onStart);
+    el.removeEventListener("touchmove", onMove);
+    el.removeEventListener("touchend", onEnd);
+    el.removeEventListener("touchcancel", onCancel);
+  };
 }

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -1,0 +1,21 @@
+// #1438 — STUB. The behaviour lands in the next commit; this exists so the
+// spec's red is per-assertion and readable by name rather than one
+// module-not-found that exercises nothing.
+import type { Point } from "./swipe";
+
+export const DISMISS_COMMIT_FRACTION = 0.15;
+export const DRAGGING_CLASS = "media-viewer-modal--dragging";
+
+export type DismissGestureParams = {
+  viewportHeight: () => number;
+  canDismiss: () => boolean;
+  onProgress: (dy: number) => void;
+  onCommit: () => void;
+  onRelease: () => void;
+};
+
+export type { Point };
+
+export function bindDismissGesture(_el: HTMLElement, _params: DismissGestureParams): () => void {
+  return () => {};
+}

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -59,6 +59,10 @@ export type DismissGestureParams = {
   onRelease: () => void;
 };
 
+// The ONE place "single finger only" is spelled: undefined for a pinch, which
+// is the image's gesture and not ours. Every arm reads it, so there is no
+// second copy of the predicate to drift — and mutating it is what a spec
+// asserting the pinch is ignored actually has to kill.
 function soleTouch(e: TouchEvent): Touch | undefined {
   const list = e.touches.length > 0 ? e.touches : e.changedTouches;
   return list.length === 1 ? list[0] : undefined;
@@ -77,7 +81,6 @@ export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams
 
   const onStart = (e: TouchEvent): void => {
     disarm();
-    if (e.touches.length !== 1) return; // a pinch is the image's, not ours
     const t = soleTouch(e);
     if (t === undefined) return;
     if (!params.canDismiss()) return;
@@ -86,7 +89,7 @@ export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams
   };
 
   const onMove = (e: TouchEvent): void => {
-    if (start === null || e.touches.length !== 1) return;
+    if (start === null) return;
     const t = soleTouch(e);
     if (t === undefined) return;
     const current = { x: t.clientX, y: t.clientY };

--- a/cicchetto/src/lib/touchGesture.ts
+++ b/cicchetto/src/lib/touchGesture.ts
@@ -60,6 +60,29 @@ export const horizontalClaim = (
   return ax >= ay * k;
 };
 
+// The mirror of `horizontalClaim`, for gestures whose axis is the other one
+// (#1438's swipe-to-dismiss). Same shape, same slop, same angle gate, axes
+// swapped: claim ONLY once the drag clears the slop AND is vertical-dominant
+// past `k`. A horizontal-dominant or ambiguous drag returns false, so the
+// caller never preventDefaults it and whatever owns the horizontal axis keeps
+// it — which is how the dismiss gesture leaves a `<video>` scrubber alone, and
+// how a future left/right binding on the same surface stays available.
+//
+// It lives here rather than in the media viewer for the reason this module
+// exists: the angle gate is one decision, and a second copy is the drift that
+// makes two gestures on one surface disagree about what counts as vertical.
+export const verticalClaim = (
+  start: Point,
+  current: Point,
+  k: number = ANGLE_GATE_K,
+  slopPx: number = DRAG_SLOP_PX,
+): boolean => {
+  const ax = Math.abs(current.x - start.x);
+  const ay = Math.abs(current.y - start.y);
+  if (ay <= slopPx) return false; // under the slop — still undecided
+  return ay >= ax * k;
+};
+
 // Parameters for the two edge → open-drawer gestures. `viewportWidth` is
 // injected (not read off the element) so the geometry is testable in jsdom,
 // which has no layout; the call site passes `() => window.innerWidth`.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -12144,6 +12144,32 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   display: flex;
   flex-direction: column;
   z-index: 1101;
+  /* #1438 — a vertical drag dismisses the viewer, so the whole touch stream
+     belongs to our JS, exactly as .media-viewer-media--zoomable already claims
+     it for the pinch. Declared on the CONTAINER because the UA intersects
+     touch-action down the ancestor chain: one declaration covers the <video>
+     too, and there is no per-media copy to forget. Without it iOS reads the
+     drag as its own overscroll and hauls the browser chrome in behind the
+     modal. `none` rather than .scrollback's fail-open `pan-y` — nothing here
+     scrolls (.media-viewer-body is overflow:hidden), and pan-y is the very
+     axis we take.
+     The transition is the SPRING BACK for a drag that did not commit; the
+     inline transform the component writes per frame overrides this rule's
+     centering, which is why the component re-states it. */
+  touch-action: none;
+  transition: transform 0.18s ease-out;
+}
+
+/* Worn for exactly as long as the finger drives the modal (DRAGGING_CLASS in
+   lib/mediaViewerGesture.ts). Killing the transition is what makes the modal
+   TRACK the finger instead of easing 180ms behind it — the same device as
+   .scrollback-line-swiping. The backdrop's opacity is written inline per frame
+   and cleared on release, and deliberately carries no transition of its own:
+   it is a previous SIBLING, unreachable from this class without a :has()
+   selector the codebase uses nowhere, and an overlay re-darkening in one frame
+   is not a motion the eye follows. */
+.media-viewer-modal--dragging {
+  transition: none;
 }
 
 .media-viewer-header {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44705,3 +44705,111 @@ collects EVERY `defstruct` in it, so an entry beside its parent inherits the
 parent's cold-deploy check with no second `@state_helpers` registration.
 Separate files would have cost three files and six registry lines for
 identical coverage.
+<!-- entry #1438 -->
+
+---
+
+## 2026-08-16 — #1438: swipe up or down to dismiss the media viewer
+
+vjt asked for the media viewer to close on a vertical swipe, the modal
+following the finger, videos behaving like images.
+
+### The issue's premise was wrong, and it changed the design
+
+#1438 lists under "Not established" that *"the only swipe implementation
+in the tree is local to `ComposeBox.tsx:423`"*. Measured on `1552312d`
+and re-validated identical on `9808cb51`, that is false: `lib/swipe.ts`
+is a DOM-free geometry toolkit (travel floor, direction, velocity) that
+`lib/touchGesture.ts` already composes for the edge drawers and
+`lib/messageGestures.ts` for the reply swipe — the latter already doing
+follow-the-finger with a `translateX` and a snap-back class.
+
+Taken at its word the issue would have bought a fourth gesture engine,
+which is four answers to "what counts as a swipe". `lib/mediaViewerGesture.ts`
+composes the existing two instead, and the only NEW geometry is
+`verticalClaim` in `touchGesture.ts` — the exact mirror of
+`horizontalClaim`, same slop, same angle gate, axes swapped.
+
+### The binder reports progress; the caller owns the paint
+
+`bindEdgeGesture` deliberately does not report progress: #1041 ruled a
+follow-the-finger panel out of scope there, and progress is precisely
+the channel that ruling avoided. Here the follow IS the feature, so
+`bindDismissGesture` hands the caller a running delta and writes no
+transform of its own. The reason is not symmetry — the modal and the
+backdrop move together, and a binder that knew about both would be a
+binder that knew about the viewer.
+
+The claim is LATE and VERTICAL-dominant, so a horizontal drag is
+released whole. That is what leaves a `<video>` scrubber usable, and it
+keeps a future left/right binding on this surface possible.
+
+Commit is distance OR velocity: `DISMISS_COMMIT_FRACTION` of the
+viewport, or `isFastSwipe`. The fraction is INJECTED rather than a pixel
+constant — jsdom has no layout, and the same gesture has to feel the
+same on a phone and a tablet.
+
+### The zoom gate is published, not lifted
+
+A zoomed image owns the one-finger drag as a PAN, so the viewer must
+stand down while the image is off its fit baseline. The scale lives in
+`ZoomableImage`'s private `transform()` signal and #213 keeps it
+element-scoped on purpose, so it is PUBLISHED upward as one bit rather
+than hoisted: lifting the transform would move an image's pan geometry
+into a component that also renders `<audio>`. Published synchronously
+with every mutation, through a single writer, rather than through an
+effect — the reader is a touchstart handler, and a frame of lag there is
+a dismiss that fires on a pan.
+
+Video and audio never publish a scale, which is exactly right: they are
+always dismissible, which is the issue's third constraint.
+
+### The listener sits on the container, and so does touch-action
+
+The dismisser binds to the modal BODY, not the media element, or it
+would not cover videos. `touch-action` follows it for a different
+reason: the UA intersects the property down the ancestor chain, so ONE
+declaration on `.media-viewer-modal` covers every media kind and leaves
+no per-element copy to forget when a fourth one lands.
+
+Measured before writing it: `.media-viewer-modal`, `.media-viewer-body`
+and `.media-viewer-media` declared no `touch-action` at all — only
+`.media-viewer-media--zoomable` did, for the #213 pinch. `none` rather
+than `.scrollback`'s fail-open `pan-y`: nothing inside the viewer
+scrolls, and `pan-y` is the very axis the gesture takes.
+
+The modal is centered by `transform: translate(-50%, -50%)`, and an
+inline transform replaces that declaration WHOLESALE. The per-frame
+paint therefore re-states the centering; a bare `translateY` would jump
+the modal by half its own height on the first claimed move. Both the
+jsdom spec and the e2e measure that specific difference.
+
+The backdrop's opacity is written inline per frame and cleared on
+release, with no transition of its own. It is a previous SIBLING of the
+modal, unreachable from the dragging class without a `:has()` selector
+this codebase uses nowhere, and an overlay re-darkening in one frame is
+not a motion the eye follows.
+
+### What is proven, and what is owed
+
+Twelve unit tests pin the binder's decision table against a bare
+element; seven more pin the wiring, and six mutants establish that each
+of those bites — five of the six killing exactly one assertion. Three
+source-level assertions pin the stylesheet, and the FIRST version of
+that rule described `touch-action` in prose without declaring it, which
+is what the new spec caught. Three e2e tests assert the visible outcome:
+the dialog goes away, and mid-drag the browser's own computed matrix
+says the modal moved by the finger's travel and by nothing else.
+
+None of that is the feel. A synthetic touch drives no compositor and
+Playwright's webkit is not iOS Safari, so the follow is asserted as a
+transform the browser resolved, never as motion anyone saw.
+`DISMISS_COMMIT_FRACTION = 0.15` is a defensible default, not a measured
+optimum — the same standing `swipe.ts` already claims for its velocity
+threshold. Device verification is owed, and stated as owed.
+
+One thing is not covered at all: that a `<video>`'s native controls
+survive the gesture. The argument is that a vertical claim never takes a
+scrubber drag (horizontal) nor a tap under the slop — but the controls
+live in the UA shadow DOM, `closest()` cannot see them, and no
+assertion in this change reaches them.


### PR DESCRIPTION
Refs #1438.

A vertical drag on the media viewer dismisses it, with the modal following
the finger. Videos behave like images, per the issue's third constraint.

## The issue's premise was false, and it changed the design

#1438 lists under "Not established" that *"the only swipe implementation in
the tree is local to `ComposeBox.tsx:423`"*. Measured on `1552312d` and
re-validated identical on `9808cb51`, that is wrong: `lib/swipe.ts` is a
DOM-free geometry toolkit that `lib/touchGesture.ts` already composes for the
edge drawers and `lib/messageGestures.ts` for the reply swipe — the latter
already doing follow-the-finger with a `translateX` and a snap-back class.

Taken at its word the issue would have bought a fourth gesture engine, i.e.
four answers to "what counts as a swipe". `lib/mediaViewerGesture.ts` composes
the existing two instead; the only NEW geometry is `verticalClaim`, the exact
mirror of `horizontalClaim` (same slop, same angle gate, axes swapped).

## Design

* **The binder reports progress; the caller owns the paint.** The modal and
  the backdrop move together, and a binder that knew about both would be a
  binder that knew about the viewer. `bindEdgeGesture` deliberately does not
  report progress (#1041 ruled a follow-the-finger panel out of scope there);
  here the follow IS the feature.
* **The claim is late and vertical-dominant**, so a horizontal drag is released
  whole. That is what leaves a `<video>` scrubber usable.
* **Commit is distance OR velocity** — `DISMISS_COMMIT_FRACTION` of the
  viewport, or `isFastSwipe`. The fraction is injected rather than a pixel
  constant: jsdom has no layout, and the gesture must feel the same on a phone
  and a tablet.
* **The zoom gate is a published bit, not a lifted transform.** #213 keeps the
  pan geometry element-scoped on purpose; hoisting it would move an image's pan
  state into a component that also renders `<audio>`. Published synchronously
  through a single writer, because the reader is a touchstart handler and a
  frame of lag there is a dismiss that fires on a pan.
* **The listener and `touch-action` both sit on the container.** The dismisser
  binds to the modal body or it would not cover videos, and the UA intersects
  `touch-action` down the ancestor chain, so one declaration covers every media
  kind. Measured before writing it: `.media-viewer-modal`,
  `.media-viewer-body` and `.media-viewer-media` declared no `touch-action` at
  all — only `.media-viewer-media--zoomable` did, for the #213 pinch.
* **The paint re-states `translate(-50%, -50%)`.** The modal is centered by
  that CSS transform and an inline transform replaces the declaration
  wholesale, so a bare `translateY` would jump the modal by half its own
  height. Two assertions measure exactly that difference.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` (biome + tsc src + tsc e2e) | RC=0 |
| full vitest suite | RC=0 — 289 files, 5569 tests |
| `integration.sh --grep "#1438"` | RC=0 — 3/3 (chromium ×2, webkit iPhone 15) |
| `design-notes-gate.sh origin/main` | RC=0 |

**Mutation campaigns, because green-on-the-first-run proves nothing.**
Six mutants against the wiring specs: five kill exactly one assertion each,
and "gesture never bound" kills five. Three mutants against the e2e — commit
does not close, centering dropped, `touch-action` removed — each killed its
own test and left the other two standing. Every new assertion is killed by at
least one mutant; none is vacuous.

The CSS guard earned its keep immediately: the first version of that rule
described `touch-action` in a comment and never declared it, and the new spec
is what caught it.

## What this does NOT prove

* **The feel.** A synthesized TouchEvent drives no compositor and Playwright's
  webkit is not iOS Safari. The follow is asserted as a transform the browser
  resolved, never as motion anyone saw.
* **The calibration.** `DISMISS_COMMIT_FRACTION = 0.15` is a defensible
  default, not a measured optimum — the same standing `swipe.ts` already claims
  for its velocity threshold. Nothing here has been on a phone; device
  verification is owed.
* **That a `<video>`'s native controls survive the gesture.** The argument is
  that a vertical claim never takes a scrubber drag (horizontal) nor a tap
  under the slop, but the controls live in the UA shadow DOM, `closest()`
  cannot see them, and no assertion in this branch reaches them. Uncovered.

## Debt observed, not swept

Nine e2e specs open the media viewer, each with its own copy of the same six
lines of glue; this one is the tenth. Lifting the helper into a fixture would
have touched ten files and blown the declared budget, so it is named here and
in the spec's own comment rather than done quietly. Worth its own cleanup
issue.