### PR TITLE
cic(#1406): walk the generated Session arms instead of pinning them by hand

### DIFF
--- a/cicchetto/src/lib/wireTypesAssert.ts
+++ b/cicchetto/src/lib/wireTypesAssert.ts
@@ -109,6 +109,7 @@ import type {
   SessionWireWindowPendingPayload,
   UserSettingsWireAutoAwayDebounceChangedPayload,
   WindowCountsWireEvent,
+  WireSessionEvent,
 } from "./wireTypes";
 
 // Bi-directional subtype assert helper. `Equal<A, B>` is `true` when
@@ -300,5 +301,143 @@ export type _Assert_ConnectionProgress = Assert<
   Equal<
     Extract<WireUserEvent, { kind: "connection_progress" }>,
     SessionWireConnectionProgressPayload
+  >
+>;
+
+// === #1406 — the Session arm population is WALKED, not listed ===
+// Every pin above names its arm by hand, so a new server arm lands with no
+// pin unless a human remembers to write one. That is not a lapse, it is the
+// shape of the mechanism: the maintenance note at the top of this file asks
+// for a line per type, and 16 of the 37 `WireSessionEvent` arms never got
+// one. Codegen already emits the exhaustive union, so the population can be
+// quantified over instead of transcribed — and then a new server arm is
+// covered the moment codegen emits it, and the pins for the arms it covers
+// stop being a list anybody has to maintain.
+//
+// Two failures are checked separately, because they fail differently:
+//
+//   * `_Assert_NoUndeclaredArm` — a generated arm cic declares on NEITHER
+//     topic. No hand pin can catch this class at all: there is nothing yet
+//     to write the pin about.
+//   * `_Assert_No{User,Channel}ArmDrift` — a generated arm whose cic copy
+//     has a different shape. Walked per union rather than over their union,
+//     so the four dual-topic arms (`joined`, `join_failed`, `kicked`,
+//     `isupport_changed`) are pinned to the generated payload on BOTH
+//     topics, which pins the two copies to each other as a side effect.
+
+// `Flatten` first: many cic arms are declared as an INTERSECTION with the
+// standalone type their stores reuse (`({ kind: "whois_bundle" } &
+// WhoisBundle)`), and an intersection is never `Equal` to the flat object
+// it is equivalent to — `Equal` compares type identity and `A & B` keeps
+// both operands. The homomorphic mapped type collapses it into one object,
+// preserving optional and readonly modifiers. Without it the walk reports
+// every intersection-declared arm as drift and the exemptions below would
+// have to swallow the mechanism whole.
+type Flatten<T> = { [K in keyof T]: T[K] };
+
+// The empty-set check is spelled as a MAPPED TYPE rather than
+// `Equal<T, never>` so the tsc error NAMES the offending arms — it prints
+// `Type '{ recover_progress: "…"; }' does not satisfy the constraint
+// 'true'` — instead of the anonymous `Type 'false' is not assignable to
+// type 'true'` the pins above produce. A tuple `[Message, T]` does NOT
+// work: tsc prints the unexpanded alias reference inside it.
+type NoArms<Message extends string, T> = [T] extends [never]
+  ? true
+  : { [K in T & string]: Message };
+
+// Arms whose cic copy diverges from the generated payload ON PURPOSE, each
+// mapped to the ONE field it widens. This is not an exemption list with a
+// hole in it: `_Assert_NoWidening{User,Channel}Overrun` below re-checks
+// every OTHER field of these arms exactly, and checks that the widened
+// field is a genuine SUPERSET of what the server can send. Adding a kind
+// here without naming its field does not type-check.
+//
+// All three entries are the same posture, and it is the additive-only wire
+// rule (#447) reaching the type layer: a value that only SELECTS COPY must
+// not be allowed to drop its event when the server adds to its vocabulary.
+//
+//   * `isupport_changed.frame_budget_base` (#1108) — absent means a server
+//     predating the field, the realistic case being a cic-only bundle
+//     deploy. `narrowIsupportChanged` degrades to `null` rather than
+//     rejecting the envelope, which would take the whole capability table
+//     (and with it the /mode toggles) down.
+//   * `recover_progress.reason` / `recover_result.reason` (#581) — kept a
+//     nullable string, deliberately NOT hardened to the token union, so an
+//     additive server reason can never drop a terminal recovery result;
+//     `RecoverModal.reasonCopy` maps the known tokens and falls back.
+//     #1338 X-S14 widened `web_session_severed.code` citing exactly this
+//     posture, so hardening these two would reverse a standing ruling.
+//
+// The generated type describes the server we ship; a widened field
+// describes the set of servers cic must survive. That is why these are not
+// drift — and why the widening still has to be bounded.
+type DeliberatelyWidened = {
+  isupport_changed: "frame_budget_base";
+  recover_progress: "reason";
+  recover_result: "reason";
+};
+
+type WidenedArm = keyof DeliberatelyWidened & WireSessionEvent["kind"];
+type WalkedArm = Exclude<WireSessionEvent["kind"], WidenedArm>;
+
+type GeneratedArm<K extends WireSessionEvent["kind"]> = Extract<WireSessionEvent, { kind: K }>;
+
+// Index by a key tsc can prove is present. A bare `T[DeliberatelyWidened[K]]`
+// is rejected inside the generic walk; `Extract<F, keyof T>` is assignable to
+// `keyof T`, and the `extends keyof` guard at the call site keeps the absent
+// case from resolving to `never` and passing vacuously.
+type At<T, F> = T[Extract<F, keyof T>];
+
+type DriftedIn<U extends { kind: string }> = {
+  [K in WalkedArm]: K extends U["kind"]
+    ? Equal<Flatten<Extract<U, { kind: K }>>, Flatten<GeneratedArm<K>>> extends true
+      ? never
+      : K
+    : never;
+}[WalkedArm];
+
+// A widened arm overruns its exemption when anything OTHER than the named
+// field differs, or when the named field stops covering every value the
+// generated type admits (`[Gen] extends [Cic]` — cic must accept at least
+// what the server can send; a server-side retype of the field lands here).
+type WideningOverrunIn<U extends { kind: string }> = {
+  [K in WidenedArm]: K extends U["kind"]
+    ? Equal<
+        Flatten<Omit<Extract<U, { kind: K }>, DeliberatelyWidened[K]>>,
+        Flatten<Omit<GeneratedArm<K>, DeliberatelyWidened[K]>>
+      > extends true
+      ? DeliberatelyWidened[K] extends keyof GeneratedArm<K>
+        ? [At<GeneratedArm<K>, DeliberatelyWidened[K]>] extends [
+            At<Extract<U, { kind: K }>, DeliberatelyWidened[K]>,
+          ]
+          ? never
+          : K
+        : K
+      : K
+    : never;
+}[WidenedArm];
+
+export type _Assert_NoUndeclaredArm = Assert<
+  NoArms<
+    "generated Session arms cic declares on neither topic",
+    Exclude<WireSessionEvent["kind"], WireUserEvent["kind"] | WireChannelEvent["kind"]>
+  >
+>;
+export type _Assert_NoUserArmDrift = Assert<
+  NoArms<"user-topic arms whose cic copy differs from codegen", DriftedIn<WireUserEvent>>
+>;
+export type _Assert_NoChannelArmDrift = Assert<
+  NoArms<"channel-topic arms whose cic copy differs from codegen", DriftedIn<WireChannelEvent>>
+>;
+export type _Assert_NoWideningOverrunUser = Assert<
+  NoArms<
+    "user-topic arms widening more than their declared field",
+    WideningOverrunIn<WireUserEvent>
+  >
+>;
+export type _Assert_NoWideningOverrunChannel = Assert<
+  NoArms<
+    "channel-topic arms widening more than their declared field",
+    WideningOverrunIn<WireChannelEvent>
   >
 >;

--- a/cicchetto/src/lib/wireTypesAssert.ts
+++ b/cicchetto/src/lib/wireTypesAssert.ts
@@ -36,7 +36,10 @@
 //   * Add an assert for every api.ts type that has a wireTypes.ts
 //     counterpart. When server-side adds a new Wire module + type,
 //     the codegen emits it; if a cic consumer needs the new shape,
-//     add the assert + the api.ts mirror.
+//     add the assert + the api.ts mirror. EXCEPT for arms of
+//     `WireSessionEvent`: #1406 walks that population instead, so a new
+//     Session arm needs no line here and gets none of the silence that
+//     a forgotten line used to buy.
 //
 //   * If an assert fails (`Type 'true' is not assignable to type
 //     'never'` at the `: true = true` lines), the api.ts mirror has
@@ -51,16 +54,11 @@ import type {
   HomeData,
   HomeNetworkRow,
   LinksEntry,
-  LinksReply,
   MentionsBundleMessage,
-  NamesReply,
   NotifyEntry,
   QueryWindowEntry,
   ScrollbackMessage,
-  WhoisBundle,
-  WhoReply,
   WhoUser,
-  WhowasBundle,
   WireChannelEvent,
   WireUserEvent,
 } from "./api";
@@ -84,29 +82,12 @@ import type {
   ScrollbackWireEvent,
   ScrollbackWireT,
   ServerSettingsWireChangedPayload,
-  SessionWireAwayConfirmedPayload,
   SessionWireChannelModesWire,
-  SessionWireConnectionProgressPayload,
-  SessionWireJoinedPayload,
-  SessionWireJoinFailedPayload,
-  SessionWireKickedPayload,
-  SessionWireLinksBundlePayload,
   SessionWireLinksEntry,
-  SessionWireLusersBundlePayload,
   SessionWireMember,
   SessionWireMentionsBundleMessage,
-  SessionWireNamesReplyPayload,
-  SessionWirePresenceChangedPayload,
-  SessionWirePresenceErrorPayload,
-  SessionWirePresenceSnapshotPayload,
   SessionWireTopicEntryWire,
-  SessionWireWhoisBundlePayload,
-  SessionWireWhoReplyPayload,
   SessionWireWhoUser,
-  SessionWireWhowasBundlePayload,
-  SessionWireWindowInviteDeclinedPayload,
-  SessionWireWindowInvitedPayload,
-  SessionWireWindowPendingPayload,
   UserSettingsWireAutoAwayDebounceChangedPayload,
   WindowCountsWireEvent,
   WireSessionEvent,
@@ -165,50 +146,19 @@ export type _Assert_HomeData = Assert<Equal<HomeData, NetworksWireHomeData>>;
 export type _Assert_CredentialJson = Assert<Equal<CredentialJson, NetworksWireCredentialJson>>;
 
 // === cross-surface S7 (2026-07-19 review) — the biggest boundary payloads ===
-// The assert list above stated the rule "per-arm PAYLOADS that have a flat
-// counterpart are pinned below", but the LARGEST payloads on the wire had
-// no pin: WhoisBundle (28 fields — it has already grown three times, P-0a +
-// #221 + #367 oper_text),
-// WhowasBundle, LusersBundle, the NamesReply/WhoReply envelopes, and the
-// #247 presence arms. A server-side field add/rename in any of these
-// regenerates wireTypes.ts cleanly and would leave the api.ts hand mirror +
-// its runtime narrower (userTopic.ts) silently stale — dropping every such
-// bundle at runtime with only console noise. These pins make that drift a
-// `tsc` error instead.
+// S7 pinned the largest payloads on the wire — WhoisBundle (28 fields, grown
+// three times: P-0a, #221, #367 oper_text), WhowasBundle, LusersBundle, the
+// NamesReply/WhoReply envelopes, the #238 LINKS bundle and the #247 presence
+// arms — because a server-side field add or rename regenerates wireTypes.ts
+// cleanly and would leave the api.ts mirror plus its runtime narrower
+// silently stale, dropping every such bundle with only console noise.
 //
-// Standalone hand-rolled types (the shape cic actually reuses in its stores)
-// are pinned against `Omit<SessionWireXPayload, "kind">`; the union-inline
-// arms (no standalone type) are pinned via `Extract<WireUserEvent, {kind}>`
-// against the full generated payload (kind included).
-export type _Assert_WhoisBundle = Assert<
-  Equal<WhoisBundle, Omit<SessionWireWhoisBundlePayload, "kind">>
->;
-export type _Assert_WhowasBundle = Assert<
-  Equal<WhowasBundle, Omit<SessionWireWhowasBundlePayload, "kind">>
->;
-export type _Assert_NamesReply = Assert<
-  Equal<NamesReply, Omit<SessionWireNamesReplyPayload, "kind">>
->;
-export type _Assert_WhoReply = Assert<Equal<WhoReply, Omit<SessionWireWhoReplyPayload, "kind">>>;
-export type _Assert_LusersBundle = Assert<
-  Equal<Extract<WireUserEvent, { kind: "lusers_bundle" }>, SessionWireLusersBundlePayload>
->;
-// #238 — LINKS topology bundle. `LinksEntry` pinned like `WhoUser`; the
-// `LinksReply` envelope pinned like `WhoReply` (Omit kind — the union arm
-// adds `kind: "links_bundle"`).
+// #1406 removed those pins: all of them named `WireSessionEvent` arms, and
+// the walk at the bottom of this file re-derives exactly the same relation
+// for the whole 37-arm population. What survives here is the ELEMENT type
+// nested inside an arm, which the walk covers only through its container
+// and which cic also reuses standalone in its stores.
 export type _Assert_LinksEntry = Assert<Equal<LinksEntry, SessionWireLinksEntry>>;
-export type _Assert_LinksReply = Assert<
-  Equal<LinksReply, Omit<SessionWireLinksBundlePayload, "kind">>
->;
-export type _Assert_PresenceChanged = Assert<
-  Equal<Extract<WireUserEvent, { kind: "presence_changed" }>, SessionWirePresenceChangedPayload>
->;
-export type _Assert_PresenceError = Assert<
-  Equal<Extract<WireUserEvent, { kind: "presence_error" }>, SessionWirePresenceErrorPayload>
->;
-export type _Assert_PresenceSnapshot = Assert<
-  Equal<Extract<WireUserEvent, { kind: "presence_snapshot" }>, SessionWirePresenceSnapshotPayload>
->;
 
 // === cross-surface S1 (2026-07-19 review) — envelope discriminator pins ===
 // The envelope `kind` (and Session `state`) discriminators of ~10 Wire
@@ -221,8 +171,9 @@ export type _Assert_PresenceSnapshot = Assert<
 // emits `kind: "literal"`); these pins tie cic's hand-rolled union arms
 // to the generated literal payloads so a future rename is a `tsc` error.
 // Each `Extract<Union, {kind}>` also revalidates the arm's full field
-// shape (kind + body) against the generated type — the same guarantee as
-// the S7 pins above.
+// shape (kind + body) against the generated type. These arms come from
+// other Wire modules, so no generated union covers them and the #1406 walk
+// cannot reach them — they stay hand-pinned.
 export type _Assert_ScrollbackMessageEvent = Assert<
   Equal<Extract<WireChannelEvent, { kind: "message" }>, ScrollbackWireEvent>
 >;
@@ -269,39 +220,6 @@ export type _Assert_ConnectionStateChanged = Assert<
 // `kind` discriminator only — that is the rename gap S1 closes.
 export type _Assert_BundleHashKind = Assert<
   Equal<Extract<WireUserEvent, { kind: "bundle_hash" }>["kind"], CicWireBundleHashPayload["kind"]>
->;
-
-// Session window-state arms — the `state` discriminator was `String.t()`
-// too; now a literal atom union. Pin each arm (kind + state + body).
-export type _Assert_Joined = Assert<
-  Equal<Extract<WireChannelEvent, { kind: "joined" }>, SessionWireJoinedPayload>
->;
-export type _Assert_JoinFailed = Assert<
-  Equal<Extract<WireChannelEvent, { kind: "join_failed" }>, SessionWireJoinFailedPayload>
->;
-export type _Assert_Kicked = Assert<
-  Equal<Extract<WireChannelEvent, { kind: "kicked" }>, SessionWireKickedPayload>
->;
-export type _Assert_WindowPending = Assert<
-  Equal<Extract<WireUserEvent, { kind: "window_pending" }>, SessionWireWindowPendingPayload>
->;
-export type _Assert_WindowInvited = Assert<
-  Equal<Extract<WireUserEvent, { kind: "window_invited" }>, SessionWireWindowInvitedPayload>
->;
-export type _Assert_WindowInviteDeclined = Assert<
-  Equal<
-    Extract<WireUserEvent, { kind: "window_invite_declined" }>,
-    SessionWireWindowInviteDeclinedPayload
-  >
->;
-export type _Assert_AwayConfirmed = Assert<
-  Equal<Extract<WireUserEvent, { kind: "away_confirmed" }>, SessionWireAwayConfirmedPayload>
->;
-export type _Assert_ConnectionProgress = Assert<
-  Equal<
-    Extract<WireUserEvent, { kind: "connection_progress" }>,
-    SessionWireConnectionProgressPayload
-  >
 >;
 
 // === #1406 — the Session arm population is WALKED, not listed ===

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44813,3 +44813,104 @@ survive the gesture. The argument is that a vertical claim never takes a
 scrubber drag (horizontal) nor a tap under the slop — but the controls
 live in the UA shadow DOM, `closest()` cannot see them, and no
 assertion in this change reaches them.
+<!-- entry #1406 -->
+
+---
+
+## 2026-08-16 — #1406: the Session arm pins are walked, and the "live drift" is a deliberate widening
+
+X-S1 of the 2026-08-15 review reported that 16 of the 37 `WireSessionEvent`
+arms carry no drift pin and that one, `isupport_changed.frame_budget_base`,
+has already drifted. The count is right. The drift is not, and the fix the
+issue prescribes — drop the `| null`, the "stale" comment and the `?? null`
+in `narrowIsupportChanged` — would have deleted a documented degradation
+contract.
+
+### Measured: there is no undocumented drift, there is a widening CLASS
+
+A derived walk over all 37 generated arms, comparing each against cic's copy
+on each topic union, names exactly three divergences. Every one of them is a
+deliberate client widening with a comment already explaining itself:
+
+* `isupport_changed.frame_budget_base` (#1108) — `number | null` against a
+  generated `number`. Absent means a server predating the field, and the
+  realistic case is a cic-only bundle deploy. `narrowIsupportChanged`
+  degrades to `null` rather than rejecting the envelope, which would take
+  the whole ISUPPORT capability table, and with it the `/mode` toggles,
+  down with it. It sits beside four sibling fallbacks in the same narrower
+  (`list_modes_queryable ?? ["b"]`, `chantypes ?? [...]`, the casemapping
+  degrade, `maxlist ?? {}`) — hardening one of five would have been
+  incoherent as well as wrong.
+* `recover_progress.reason` and `recover_result.reason` (#581) — a nullable
+  string against the four-token `SessionWireRecoverReason`, kept wide on
+  purpose so an additive server token can never drop a TERMINAL recovery
+  result; `RecoverModal.reasonCopy` maps what it knows and falls back.
+  #1338 X-S14 widened `web_session_severed.code` citing this exact posture,
+  so hardening these two reverses a standing ruling.
+
+The generated type describes the server we ship; a widened field describes
+the set of servers cic must survive. Those are different quantifiers, which
+is why the `| null` comment reads false only if you assume it is talking
+about this server. The general rule the three share is the additive-only
+wire (#447) reaching the type layer: **a value that only selects COPY must
+never be allowed to drop its event when the server adds to its vocabulary**,
+and the type that receives it has to be wide enough to say so.
+
+Note also which two arms actually diverge undeclared: `recover_*`, which the
+issue lists as merely unpinned. `isupport_changed`, the one it names, is the
+best-documented of the three.
+
+### The gate: walk the population, declare the widened FIELD
+
+The real defect X-S1 found is not any arm, it is that the pin population was
+transcribed. `wireTypesAssert.ts` asks for a line per type, so an arm is
+guarded only when somebody remembers — and sixteen times nobody did. The
+walk maps every generated arm kind to `never` when cic's copy matches and to
+the kind itself when it does not; a generated arm cic declares on NEITHER
+topic fails separately, a class no hand pin can express because there is
+nothing yet to write the pin about. It runs per topic union, so the four
+dual-topic arms are pinned on both sides and thereby to each other.
+
+The three widenings are declared with the FIELD they widen, not merely
+exempted. The walk still compares every other field of those arms exactly,
+and still requires the widened field to accept everything the generated type
+admits, so the exemption cannot quietly grow into a hole — and a kind added
+without naming its field does not type-check. That is the difference between
+an exemption list and a bounded one.
+
+Two TypeScript mechanics the shape depends on, both found the hard way:
+
+* `Equal<A & B, Flat>` is always false. An intersection keeps its operands
+  and `Equal` compares type identity, so the arms declared as
+  `({ kind: "whois_bundle" } & WhoisBundle)` all read as drift until a
+  homomorphic `Flatten<T> = { [K in keyof T]: T[K] }` collapses them. Without
+  it the exemption list swallows the mechanism.
+* The empty-set check must be a MAPPED TYPE, not `Equal<T, never>` and not a
+  tuple. `Assert<Equal<T, never>>` prints an anonymous `false`; a tuple
+  prints the alias reference unexpanded (`DriftedIn<WireUserEvent>`, measured
+  twice). `{ [K in T & string]: Message }` prints
+  `{ recover_progress: "…"; }` — the offending kinds, by name.
+
+### Seventeen pins removed, five of which could never have failed
+
+Every pin naming a `WireSessionEvent` arm is gone: the walk re-derives the
+same relation for the whole population. Leaving them would have been worse
+than redundant, since a hand pin beside a walked arm invites the eighteenth
+and restores the belief that the population is a list.
+
+Five of the removed pins were vacuous by construction: `WhoisBundle`,
+`WhowasBundle`, `NamesReply`, `WhoReply` and `LinksReply` are all declared
+`Omit<SessionWire…Payload, "kind">`, so `Equal<WhoisBundle, Omit<…, "kind">>`
+was an identity. Measured, not inferred — a mutant adding a field to the
+generated whois payload produced errors in six consumers and NOTHING in the
+assert file, because the alias had already moved with it.
+
+### What this does not reach
+
+The walk covers the 37 `Session.Wire` arms. Thirteen more cic kinds come
+from other Wire modules that emit no union — those keep their hand pins, and
+giving them the same treatment means teaching codegen to emit a union per
+module, which is a codegen change and not this one. The four MEDIUMs of the
+same issue (X-S4 open-map keys, X-S8 `window_state`, X-S9 theme vocabularies,
+X-S10 the `/me` and `/auth/login` discriminators) are all server-side and
+untouched here.


### PR DESCRIPTION
Takes X-S1 of #1406 (bucket J remainder). The four MEDIUMs are untouched —
they are server-side typespec plus codegen work and do not belong in a
cic-only slice.

## The reported drift is a deliberate widening, and the prescribed fix would reverse two rulings

X-S1 reports 16 of the 37 `WireSessionEvent` arms unpinned and one already
drifted, and prescribes dropping the `| null`, the "stale" comment and the
`?? null` in `narrowIsupportChanged`. The count is right. The drift is not.

A derived walk over all 37 arms names exactly three divergences, and every
one is a deliberate client widening that already documents itself:

| arm | cic | generated | documented at |
|---|---|---|---|
| `isupport_changed.frame_budget_base` | `number \| null` | `number` | #1108 |
| `recover_progress.reason` | `string \| null` | `SessionWireRecoverReason \| null` | #581 |
| `recover_result.reason` | `string \| null` | `SessionWireRecoverReason \| null` | #581 |

- Dropping the `?? null` deletes a degradation contract. An absent field
  means a server predating #1108 — a cic-only bundle deploy is the realistic
  case — and rejecting the envelope instead takes the whole ISUPPORT
  capability table, and with it the `/mode` toggles, down. It sits among four
  sibling fallbacks in the same narrower.
- Hardening the two `recover_*.reason` reverses a standing ruling: #1338
  X-S14 widened `web_session_severed.code` citing this exact posture.
- The generated type describes the server we ship; a widened field describes
  the set of servers cic must survive. The rule the three share is the
  additive-only wire (#447) reaching the type layer — a value that only
  selects copy must not drop its event when the server adds to its
  vocabulary.

Worth noting which arms diverge least documented: `recover_*`, which the
issue lists as merely unpinned.

## What lands instead

The real defect is that the pin population was transcribed by hand — the
file's own maintenance note asks for a line per type, and sixteen times
nobody wrote it. So the walk quantifies over the population codegen already
emits:

- every generated arm kind compared against cic's copy, per topic union, so
  the four dual-topic arms are pinned on both sides and thereby to each other;
- a generated arm cic declares on NEITHER topic fails separately — a class no
  hand pin can express;
- the three widenings are declared with the FIELD they widen. Every other
  field of those arms is still compared exactly, and the widened field must
  still accept everything the generated type admits, so a kind added without
  naming its field does not type-check;
- 17 hand pins removed: all of them named `WireSessionEvent` arms. Five were
  vacuous by construction — their cic type is an `Omit<Generated, "kind">`
  alias, so the pin was an identity.

Two TypeScript mechanics the shape depends on, both found by measurement and
recorded in DESIGN_NOTES: an intersection is never `Equal` to its flat
equivalent (so the `({ kind } & Type)` arms need a homomorphic flatten), and
only a mapped type makes tsc PRINT the offending kinds — `Equal<T, never>`
prints an anonymous `false` and a tuple prints the alias unexpanded.

## Test plan

- [x] `bun run check` RC=0 on a clean pre-state, and RC=0 on the final tree
- [x] full vitest RC=0, 287/287 files
- [x] `scripts/design-notes-gate.sh origin/main` RC=0
- [x] mutation campaign, 8 mutants, one assertion killed per mutant and the
      offending arm named in each: a field added to an unpinned user arm, to
      a channel arm, and to an exempted arm; a brand-new generated arm cic
      never declares; the widened field retyped; and two cic-side mutants
      covering an intersection-declared arm and an arm whose hand pin this PR
      deletes
- [ ] not verified: `tsc` cost before and after the walk was not measured