### PR TITLE
infra(#1409): three infra findings from the 2026-08-15 review, plus the cache-id refusal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,18 @@ VAPID_PRIVATE_KEY=
 POOL_SIZE=10
 
 # Phoenix HTTP listener port. Defaults to 4000.
+#
+# 🔴 NOT SUPPORTED ON DOCKER (#1409 D-S6). Compose passes this into the app,
+# but every other Docker-side consumer hardcodes 4000: the container side of
+# the publish, the compose healthcheck, the Dockerfile EXPOSE + HEALTHCHECK,
+# scripts/healthcheck.sh, and the /admin/reload + /admin/cic-bundle-changed
+# POSTs. Set it to anything else and the container is healthy while reported
+# unhealthy, `depends_on: service_healthy` never resolves, and the deploy
+# fails at the reload POST. To move the port on Docker, change
+# GRAPPA_PUBLISH (the HOST side) and leave this alone.
+#
+# It IS honoured on the Docker-free substrates — infra/linux/install.sh and
+# the release image both thread ${PORT} end to end.
 PORT=4000
 
 # UX-6-B1 (2026-05-20): embedded image uploader storage directory.

--- a/compose.oneshot.yaml
+++ b/compose.oneshot.yaml
@@ -2,14 +2,20 @@
 # `in_oneshot()` for ephemeral mix tasks (test, credo, dialyzer, format,
 # deps.get, ecto.migrate) that have to coexist with a running container.
 #
-# Without it a oneshot inherits `container_name: grappa` and the host
-# port-publishes, and both collide with the long-lived copy.
+# ONE key, because one is all that is needed (#1409 D-S7). This file used to
+# also `!reset` `container_name` and `ports` against a stated collision with
+# the long-lived copy. Measured 2026-08-16 with `grappa` up and holding
+# 192.168.53.12:4000: `compose run` names its container
+# `grappa-grappa-run-<hash>` and never `grappa`, creates it with
+# `PortBindings: {}` (with `--service-ports` as the positive control, which
+# DOES bind), and sets `RestartPolicy: no` on its own. Three no-ops guarding
+# a hazard that does not exist — which is why six deploy-path `run --rm`
+# invocations never layered this file and never collided.
+#
+# The healthcheck is the exception: it IS inherited in full, and a oneshot
+# never boots phx.server, so the /healthz probe would fail forever.
 
 services:
   grappa:
-    container_name: !reset null
-    ports: !reset []
-    # A oneshot never boots phx.server, so the /healthz probe would always fail.
     healthcheck:
       disable: true
-    restart: "no"

--- a/compose.yaml
+++ b/compose.yaml
@@ -95,6 +95,13 @@ services:
       # Literal defaults, NOT the empty-default form used above: an empty
       # string reaches String.to_integer/1 and crashes at boot (#369 X1).
       POOL_SIZE: ${POOL_SIZE:-10}
+      # PORT is NOT SUPPORTED on this substrate (#1409 D-S6): this line is
+      # the only Docker-side consumer. The container side of the publish
+      # above, the healthcheck below, the Dockerfile probe, and the deploy
+      # POSTs all hardcode 4000, so an override makes the app listen
+      # somewhere nothing looks. Move the port with GRAPPA_PUBLISH (host
+      # side) instead. Honoured end to end only on the Docker-free
+      # substrates.
       PORT: ${PORT:-4000}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     healthcheck:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45086,6 +45086,45 @@ else's product, break on their upgrade with our tree unchanged, and cost
 a docker run inside a CI already near forty minutes (#1331 cost
 tiebreak).
 
+### D-S7, fourth piece: the cache id this substrate cannot honour
+
+The review's other branch for the same finding was to route the six
+`run --rm` through `in_oneshot`, which would hand them `CACHE_ENV` and
+`CACHE_VOLUMES` — the per-worker caches of #1263, which they currently
+lack under `GRAPPA_CACHE_ID`. Declined, on one measured asymmetry:
+**`docker compose up` exposes no `-v`** (its only `-V` is
+`--renew-anon-volumes`) while `run` does. The oneshots could therefore
+take the per-id binds and the long-running container they migrate FOR
+could not. The operator would get a deploy that migrated the database
+inside `.caches/<id>` and then booted the box from the shared
+`_build`/`deps` — not isolation, a deploy split across two caches, with
+nothing in the output to say which half it was on. Half an isolation is
+a worse outcome than none, so passing the arrays to the oneshots alone
+is not the smaller version of the fix; it is a different, worse fix.
+
+What is left is to say so. One guard, in the hook set both Docker doors
+have shared since #1384, so the answer does not depend on which door the
+operator walked through — `scripts/deploy.sh` and `infra/docker/deploy.sh
+update` alike refuse when `GRAPPA_CACHE_ID` is set, naming the variable
+and the reason. It sits first in `establish_deploy_env`, ahead of the
+`.env` check, because it is about the environment being incompatible
+with the substrate at all rather than about the box being installed; it
+stays inside the hook rather than at source time so the flag parse still
+runs first and `--bogus` remains a usage error. **Unset — every deploy
+that runs today — the path is byte for byte the previous one**, one
+`[ -n ]` and nothing else. `scripts/deploy-cic.sh` is out of scope: it
+touches no Elixir cache.
+
+**Never observed. This was deduced by reading the two compose surfaces,
+not reproduced from an incident** — no operator has reported a deploy
+gone half-isolated, and none is known to have run one.
+
+One consequence worth writing down, because it bit the suites before it
+could bite an operator: bats runs on the HOST and inherits the caller's
+environment whole, so `GRAPPA_CACHE_ID=w2 scripts/bats.sh` would now turn
+every deploy case in the two Docker suites red. Both `setup()`s unset it,
+the way `cache_id_isolation_test.bats` already did.
+
 ### D-S11: the fallback was dead code, and the tool died mute
 
 The review had `db.sh` "silently reporting `dev`" and then failing on the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45042,3 +45042,93 @@ setup-beam call sites read back from the parse tree, which proves the
 files are well-formed and wired, not that the runner resolves the
 versions. `scripts/shellcheck.sh` was not run and did not need to be —
 no shell script changed.
+<!-- entry #1409 -->
+
+---
+
+## 2026-08-16 — #1409: three infra findings, and what measurement did to their premises
+
+Bucket I of the 2026-08-15 review. All three findings survive; none of
+the three survives in the shape the review wrote it, and one of them was
+posed as an either/or that only an experiment could settle.
+
+### D-S7: the collision the overlay guarded against does not happen
+
+`compose.oneshot.yaml` and `_lib.sh` both stated that a oneshot without
+the overlay "inherits `container_name: grappa` and the host
+port-publishes, and both collide with the long-lived copy". Six
+`compose run --rm` invocations on the deploy path never layered it and
+never collided. Both could not be true.
+
+The first experiment was worthless and is recorded because of it. With
+`grappa` up and holding `192.168.53.12:4000`, the raw `run --rm`
+succeeded — but the falsification step, the same run with
+`--service-ports`, ALSO succeeded. A collision oracle cannot separate
+"`run` suppresses the publish" from "this host tolerates a double bind",
+so the pass proved nothing.
+
+Measuring the thing itself instead, via `docker inspect` on the
+ephemeral container, with `--service-ports` as the positive control:
+
+| overlay key | measured without it | verdict |
+|---|---|---|
+| `container_name: !reset null` | `/grappa-grappa-run-3f90d538d15f` | no-op |
+| `ports: !reset []` | `PortBindings: {}` (control: binds `192.168.53.12:4000`) | no-op |
+| `restart: "no"` | `RestartPolicy: no` already | no-op |
+| `healthcheck: disable: true` | full `curl /healthz`, 5 retries, INHERITED | load-bearing |
+
+So the prose was the defect and the file reduces to one key. **Scope of
+that measurement, which bounds the claim: Docker Desktop on macOS, one
+Compose version, one host, on 2026-08-16. It was not verified on the
+Linux the CI runs.** The bats suite deliberately pins OUR file and not
+Compose's semantics — a test asserting `PortBindings` would pin someone
+else's product, break on their upgrade with our tree unchanged, and cost
+a docker run inside a CI already near forty minutes (#1331 cost
+tiebreak).
+
+### D-S11: the fallback was dead code, and the tool died mute
+
+The review had `db.sh` "silently reporting `dev`" and then failing on the
+next `in_container` call. Measured from a real worktree, it exits 1
+having written nothing to either stream, and never reaches the second
+call.
+
+`die` is an `exit 1`. An `exit` inside a command substitution terminates
+the SUBSHELL, so in
+
+    env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+
+the `|| echo dev` could never run — it was dead the day it was written.
+`env` came back empty, `set -e` ended the script on the assignment, and
+the message was already inside `2>/dev/null`. General rule worth
+carrying: **a `|| fallback` on a command substitution whose command can
+`exit` is not a fallback.** It only catches a non-zero RETURN.
+
+The repair the review advised — quote `$MODE_ARG` — would have added a
+second bug: quoting an empty scalar hands sqlite3 `""` as its first
+argument, which it reads as a filename. The unquoted form was getting
+that right by accident, so the mode became an array, which gets it right
+on purpose. A green-before-and-after test pins it, and the mutant that
+applies the review's advice is what makes that test worth its line.
+
+### D-S6: honest documentation beats a knob with no user
+
+`PORT` is honoured by exactly one Docker-side consumer, the compose line
+that passes it into the app; everything else hardcodes 4000. Docker is
+the local dev stack, so threading it would mean the publish, two
+healthchecks, three probes and two POSTs for no user. It is marked
+unsupported in the two places an operator reads, with `GRAPPA_PUBLISH`
+named as the knob that does work. The drift gate that pins "no consumer"
+first points the same grep at `infra/linux/install.sh`, the substrate
+that DOES honour `${PORT}`: if that known-positive stops matching, the
+probe is broken and every absence assertion is vacuous.
+
+### What the review's line numbers cost
+
+Two of the three findings cite `scripts/deploy.sh` lines that do not
+exist: it has been a 69-line consumer since #1384 and the six raw
+`run --rm` now live in `infra/lib/deploy_docker.sh` plus
+`scripts/deploy-cic.sh`. The "one-character-edit hazard" phrase quoted
+from `_lib.sh` is not in the file either. A review pinned to a base
+(`575e203a`) that has since moved is a set of claims to re-locate, not a
+map to follow.

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -74,6 +74,25 @@ COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 # installed that way was covered and a hand-installed one was not. One
 # mechanism now, for both doors.
 establish_deploy_env() {
+	# GRAPPA_CACHE_ID (#1263) is honourable by `compose run` and by nothing
+	# else: `run` is the only compose verb that takes `-v`, and `up` — which
+	# is how the long-running container is created — takes none. Threading
+	# the per-id binds through this substrate's oneshots would therefore
+	# migrate the database inside `.caches/<id>` and then boot the box from
+	# the shared `_build`/`deps`, which is not isolation but a deploy split
+	# across two caches with nothing in the output to say so. Refuse instead:
+	# an operator who set the variable asked for isolation, and silently
+	# giving them half of it is the failure mode, not the fix.
+	#
+	# First in the function, ahead of the .env check: this one is about the
+	# operator's environment being incompatible with the substrate at all,
+	# and it holds whether or not the box is installed. Still inside the
+	# hook (not at source time), for the reason the file header gives — the
+	# flag parse must run first, so `--bogus` stays a usage error.
+	if [ -n "${GRAPPA_CACHE_ID:-}" ]; then
+		die "GRAPPA_CACHE_ID is set ('$GRAPPA_CACHE_ID') and the Docker deploy substrate cannot honour it: only 'compose run' accepts -v, so the oneshots would use the per-id caches while 'compose up' boots the container from the shared ones. Unset GRAPPA_CACHE_ID to deploy."
+	fi
+
 	if [ ! -f .env ]; then
 		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
 	fi

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -246,10 +246,13 @@ in_container() {
 # Run a one-shot mix task without the long-running container (e.g. `mix
 # deps.get` before first boot), layering worktree source overrides.
 #
-# `compose.oneshot.yaml` MUST stay layered LAST — its `ports: !reset []` +
-# `container_name: !reset null` drop host-side bindings inherited from the
-# base file or the personal override. Its path is absolute via $SRC_ROOT so
-# it resolves to the worktree copy, like the WORKTREE_VOLUMES mounts.
+# `compose.oneshot.yaml` carries ONE key, `healthcheck: disable: true`, and
+# it is layered here because `run` DOES inherit the service healthcheck
+# while a oneshot never boots phx.server. It used to also reset
+# `container_name` and `ports` against a collision that measurement showed
+# does not happen — see that file for the numbers. Its path is absolute via
+# $SRC_ROOT so it resolves to the worktree copy, like the WORKTREE_VOLUMES
+# mounts.
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
 in_oneshot() {
     docker compose "${COMPOSE_ARGS[@]}" -f "$SRC_ROOT/compose.oneshot.yaml" \

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -6,24 +6,45 @@
 #   scripts/db.sh "SELECT * FROM messages LIMIT 5;"   # one-shot query
 #
 # Reads MIX_ENV from the running container to pick the right db file (dev when
-# there is none). Prod DBs open read-only.
+# there is none). Prod DBs open read-only. Works from a worktree: the sqlite3
+# invocation goes through in_container_or_oneshot, which falls back to a
+# oneshot rather than dying (#1409).
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"
 
-env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+# `detect_mix_env` is the SoT for this probe (#1409 D-S11). The hand-rolled
+# `in_container printenv MIX_ENV 2>/dev/null || echo dev` it replaces was
+# broken two ways: it dropped the `tr -d '\r'` normalisation, so a `\r`
+# produced a path nothing could open, and `in_container` DIES from a
+# worktree — where, by rule, every code change happens. `die` is an
+# `exit 1`, and an `exit` inside a command substitution kills the subshell,
+# so the `|| echo dev` fallback never ran: the probe came back empty and
+# `set -e` ended the script with no message at all, the `die` having gone
+# into `2>/dev/null`.
+env="$(detect_mix_env)"
+# Empty means no container is up. dev is the documented default and is
+# applied HERE, in the open, instead of riding a fallback that could not fire.
+[ -n "$env" ] || env=dev
+
 # Path shape via the _lib.sh SoT — never hardcode it, or it drifts from
 # compose.yaml / scripts/mix.sh (#364).
 DB="$(db_path_for_env "$env")"
-MODE_ARG=""
+
+# An ARRAY, not a quoted scalar: quoting an empty `$MODE_ARG` would hand
+# sqlite3 "" as its first argument, which it reads as a filename. Empty
+# array expands to nothing, exactly as the unquoted form did by accident.
+mode_args=()
 if [ "$env" = "prod" ]; then
-    MODE_ARG="-readonly"
+    mode_args=(-readonly)
 fi
 
+# `in_container_or_oneshot`, so the tool CLAUDE.md calls first-resort works
+# from the worktree it is meant to be used in.
 if [ $# -eq 0 ]; then
-    in_container sqlite3 $MODE_ARG "$DB"
+    in_container_or_oneshot sqlite3 "${mode_args[@]}" "$DB"
 else
-    in_container sqlite3 $MODE_ARG "$DB" "$*"
+    in_container_or_oneshot sqlite3 "${mode_args[@]}" "$DB" "$*"
 fi

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -440,3 +440,17 @@ seed_mix_env() {
     [ "$status" -eq 0 ]
     grep -q "docker" "$ARGV_LOG"
 }
+
+@test "GRAPPA_CACHE_ID outranks the .env check — it holds on an uninstalled box too (#1409)" {
+    # The guard is about the operator's environment being incompatible with
+    # this substrate, which is true whether or not the box was ever
+    # installed. Without this case the placement is only a comment: moving
+    # the guard below the .env check leaves every other case green.
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+    rm -f "$REPO_ROOT/.env"
+
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+}

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -93,8 +93,10 @@ EOF
     # it again.
     make_env
     # An ambient MIX_ENV from the developer's shell would satisfy the D-S3
-    # cases without the script having established anything.
-    unset MIX_ENV
+    # cases without the script having established anything. An ambient
+    # GRAPPA_CACHE_ID would make every case in this file refuse (#1409): bats
+    # runs on the host and inherits the caller's environment whole.
+    unset MIX_ENV GRAPPA_CACHE_ID
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -403,4 +405,38 @@ seed_mix_env() {
     [ "$status" -ne 0 ]
     [[ "$output" == *".env"* ]]
     refute grep -q "docker" "$ARGV_LOG"           # died before any side effect
+}
+
+# --- GRAPPA_CACHE_ID is not honourable on this substrate (#1409) -------------
+#
+# GRAPPA_CACHE_ID (#1263) binds `.caches/<id>` over `_build`, `deps` and
+# `priv/plts` — on `compose run`, which is the only compose verb that takes
+# `-v`. A deploy is not made of oneshots alone: the long-running container
+# comes up through `compose up`, which has no `-v` at all. Threading the binds
+# through the six oneshots would migrate the database inside the isolated cache
+# and then boot the box from the shared one, so the operator would get HALF an
+# isolation and no way to see it. The substrate says so instead, once, in the
+# hook set both doors source.
+#
+# The two cases below are a PAIR. The second is not a duplicate of the auto-mode
+# case above: it is the control that stops the first from passing because the
+# fixture died of something else, and it is also the ⛔ pin — with the variable
+# absent, this deploy is the one that shipped before the guard existed.
+
+@test "GRAPPA_CACHE_ID set: the deploy is refused by name, before any docker call (#1409)" {
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    refute grep -q "docker" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID unset: the same deploy runs — the refusal is the variable (#1409)" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    grep -q "docker" "$ARGV_LOG"
 }

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -76,6 +76,9 @@ GRAPPA_PUBLISH=127.0.0.1:3100
 EOF
 
     # ---- env the script needs ------------------------------------------
+    # An ambient GRAPPA_CACHE_ID would make every case in this file refuse
+    # (#1409): bats runs on the host and inherits the caller's environment.
+    unset GRAPPA_CACHE_ID
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -185,6 +188,23 @@ run_update() {
     run_update
     [ "$status" -ne 0 ]
     refute grep -q "force-recreate" "$ARGV_LOG"
+}
+
+@test "update: GRAPPA_CACHE_ID is refused on this door too — one guard, both doors (#1409)" {
+    # The refusal lives in the hook set this door SHARES with
+    # scripts/deploy.sh (#1384), so it must fire identically here. Control for
+    # this case: "box up + code change + HOT verdict reloads" below is this
+    # exact body with the variable absent, and it stays green.
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+
+    run_update
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    # Refused at the top of substrate_pull: nothing pulled, nothing recreated.
+    [ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
+    refute grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 @test "update: a box owned by another checkout is refused, and the owner is named" {

--- a/test/infra/port_docker_unsupported_test.bats
+++ b/test/infra/port_docker_unsupported_test.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Bats suite for the `PORT` knob on the Docker substrate (#1409 D-S6).
+#
+# WHY THIS EXISTS
+#
+# `.env.example` presented `PORT` as an ordinary knob with no caveat and
+# `compose.yaml` gave it a literal default specifically so the override would
+# not be a silent no-op (#369 X1). But on the Docker substrate NOTHING
+# consumes it: the container side of the publish, the compose healthcheck,
+# the Dockerfile EXPOSE + HEALTHCHECK, `scripts/healthcheck.sh`, the
+# `/admin/reload` and `/admin/cic-bundle-changed` POSTs all hardcode 4000.
+# `PORT=4001` therefore yields a container that is healthy and reported
+# unhealthy, a `depends_on: service_healthy` that never resolves, and a
+# deploy that fails at the reload POST.
+#
+# Docker is the LOCAL DEV stack (CLAUDE.md: nothing production runs on it),
+# so threading the port through it is work with no user. The knob is marked
+# unsupported there instead, and this suite pins BOTH halves of that: the
+# prose that says so, and the absence of the consumer that would make the
+# prose a lie.
+#
+# The absence half needs a probe that can be trusted, so the same grep is
+# first pointed at `infra/linux/install.sh`, the Docker-free substrate that
+# DOES honour `${PORT}`. If that known-positive stops matching, the probe is
+# broken and every "absent" assertion below is vacuous.
+
+load ../bats_helpers
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "the PORT probe finds the substrate that does honour it (falsification)" {
+    # Positive control for every "no consumer" assertion in this file.
+    grep -qE '\$\{PORT' "$ROOT/infra/linux/install.sh"
+}
+
+@test ".env.example marks PORT unsupported on Docker" {
+    grep -A4 '^PORT=' "$ROOT/.env.example" > "$BATS_TEST_TMPDIR/port_block" || true
+    grep -B6 '^PORT=' "$ROOT/.env.example" >> "$BATS_TEST_TMPDIR/port_block" || true
+    grep -qi 'docker' "$BATS_TEST_TMPDIR/port_block"
+}
+
+@test "the compose PORT line carries the same caveat" {
+    grep -B6 'PORT: \${PORT' "$ROOT/compose.yaml" > "$BATS_TEST_TMPDIR/compose_block"
+    grep -qi 'docker' "$BATS_TEST_TMPDIR/compose_block"
+}
+
+@test "no Docker-side consumer reads PORT" {
+    # compose.yaml:98 passes it INTO the app and is the one legitimate
+    # mention; everything else on this substrate must not pretend to read it.
+    for f in "$ROOT/Dockerfile" "$ROOT/scripts/healthcheck.sh" \
+             "$ROOT/scripts/deploy-cic.sh" "$ROOT/infra/lib/deploy_docker.sh"; do
+        refute grep -qE '\$\{?PORT' "$f"
+    done
+}
+
+@test "the Docker substrate still hardcodes 4000, so the caveat is not stale" {
+    # The inverse pin: the day someone threads PORT for real, these fail and
+    # the caveat must be revisited rather than left lying.
+    grep -q 'localhost:4000/healthz' "$ROOT/scripts/healthcheck.sh"
+    grep -q 'localhost:4000/admin/reload' "$ROOT/infra/lib/deploy_docker.sh"
+}

--- a/test/scripts/db_worktree_test.bats
+++ b/test/scripts/db_worktree_test.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/db.sh — the MIX_ENV probe and the worktree door
+# (#1409 D-S11).
+#
+# WHY THIS EXISTS
+#
+# CLAUDE.md names `scripts/db.sh` a first-resort investigation tool, and it
+# also rules that every code change happens in a worktree. The tool was
+# therefore broken exactly where it is meant to be used, and it broke MUTE:
+# measured from a real worktree, `scripts/db.sh "SELECT 1;"` exited 1 having
+# written nothing at all, to either stream.
+#
+# The mechanism is worth stating, because it is not the one the review
+# guessed. `db.sh` probed the env with
+#
+#     env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+#
+# and `in_container` calls `die`, which is an `exit 1`. An `exit` inside a
+# command substitution terminates the SUBSHELL — so `|| echo dev` never ran
+# and the fallback was dead code. `env` came back empty, `set -e` killed the
+# script on the assignment, and `die`'s message had already gone into
+# `2>/dev/null`. It never reported `dev`, and it never reached the second
+# `in_container` call the review expected to fail.
+#
+# Scope: asserts the SHAPE of the docker invocation — which door is used and
+# which db path is opened. Stubs `docker` on PATH so no container is touched;
+# `git` is real, so `_lib.sh` derives a genuine SRC_ROOT != REPO_ROOT from an
+# actual `git worktree add`.
+
+load ../bats_helpers
+
+setup() {
+    DB_SH="$BATS_TEST_DIRNAME/../../scripts/db.sh"
+    LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Physical base so _lib.sh's `pwd`-derived SRC_ROOT and its
+    # `git rev-parse`-derived REPO_ROOT agree on macOS (/var → /private/var).
+    TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
+
+    MAIN="$TMP/main"
+    git init -q -b main "$MAIN"
+    git -C "$MAIN" config user.email test@grappa.local
+    git -C "$MAIN" config user.name "bats"
+    mkdir -p "$MAIN/scripts" "$MAIN/lib"
+    cp "$DB_SH" "$MAIN/scripts/db.sh"
+    cp "$LIB_SH" "$MAIN/scripts/_lib.sh"
+    : > "$MAIN/compose.yaml"
+    echo base > "$MAIN/lib/base.ex"
+    git -C "$MAIN" add -A
+    git -C "$MAIN" commit -qm base
+
+    WT="$TMP/wt"
+    git -C "$MAIN" worktree add -q -b wt "$WT"
+
+    # `MIX_ENV` the probe will read, and whether a live container exists.
+    # Per-test overridable via the environment the stub re-reads at run time.
+    STUB_ENV_FILE="$FAKE_DIR/mixenv"
+    STUB_CID_FILE="$FAKE_DIR/cid"
+    printf 'dev' > "$STUB_ENV_FILE"
+    printf 'fakecontainerid\n' > "$STUB_CID_FILE"
+
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+args="\$*"
+case "\$args" in
+    *"ps -q grappa"*)   cat "$STUB_CID_FILE"; exit 0 ;;
+    *"printenv MIX_ENV"*)
+        # No container up → compose exec fails, exactly as it would live.
+        if [ ! -s "$STUB_CID_FILE" ]; then exit 1; fi
+        cat "$STUB_ENV_FILE"
+        exit 0
+        ;;
+    *)                  exit 0 ;;
+esac
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+@test "db.sh from a worktree opens the db instead of dying mute" {
+    cd "$WT"
+    run "$WT/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    # A oneshot, because the live container carries main's source, not ours.
+    grep -q "run --rm" "$ARGV_LOG"
+    grep -q "sqlite3" "$ARGV_LOG"
+}
+
+@test "db.sh from a worktree that cannot reach the db says so out loud" {
+    # The residual failure mode must still be legible: whatever goes wrong,
+    # it may not go wrong in silence the way the swallowed `die` did.
+    printf '' > "$STUB_CID_FILE"
+    cd "$WT"
+    run "$WT/scripts/db.sh" "SELECT 1;"
+    # Either it works through the oneshot or it fails — but a non-zero exit
+    # with an empty message is the one outcome this test forbids.
+    if [ "$status" -ne 0 ]; then
+        [ -n "$output" ]
+    fi
+}
+
+@test "no live container falls back to dev, not to an empty db path" {
+    printf '' > "$STUB_CID_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q "grappa_dev.db" "$ARGV_LOG"
+    refute grep -q "grappa_.db" "$ARGV_LOG"
+}
+
+@test "a CR from the container never reaches the db path" {
+    # `detect_mix_env` strips it; the hand-rolled probe db.sh used did not,
+    # so a `\r` produced db_path_for_env "prod\r" and a nonexistent file.
+    printf 'prod\r' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q "grappa_prod.db" "$ARGV_LOG"
+    refute grep -q 'grappa_prod\$' "$ARGV_LOG"
+}
+
+@test "prod passes -readonly as one argument" {
+    printf 'prod' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q " -readonly " "$ARGV_LOG"
+}
+
+@test "dev passes no empty argument to sqlite3" {
+    # Guards the naive repair of the unquoted `$MODE_ARG`: quoting it as a
+    # scalar hands sqlite3 an empty string as its FIRST argument, which it
+    # reads as a filename. The mode has to be an array, not a quoted scalar.
+    printf 'dev' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    refute grep -q "sqlite3 ''" "$ARGV_LOG"
+}

--- a/test/scripts/oneshot_overlay_test.bats
+++ b/test/scripts/oneshot_overlay_test.bats
@@ -37,18 +37,24 @@ setup() {
     ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
     OVERLAY="$ROOT/compose.oneshot.yaml"
     LIB="$ROOT/scripts/_lib.sh"
+
+    # The claim is about the KEYS the overlay SETS, not about whether the
+    # file may explain why they are gone. Grepping the comments too would
+    # make the explanation itself a failure, so strip them first.
+    KEYS="$BATS_TEST_TMPDIR/keys"
+    grep -v '^[[:space:]]*#' "$OVERLAY" > "$KEYS"
 }
 
 @test "the overlay still disables the healthcheck — the one key that is load-bearing" {
-    grep -q 'disable: true' "$OVERLAY"
+    grep -q 'disable: true' "$KEYS"
 }
 
 @test "the overlay no longer claims a container_name collision" {
-    refute grep -q 'container_name' "$OVERLAY"
+    refute grep -q 'container_name' "$KEYS"
 }
 
 @test "the overlay no longer resets ports it never inherited" {
-    refute grep -q 'ports' "$OVERLAY"
+    refute grep -q 'ports' "$KEYS"
 }
 
 @test "_lib.sh no longer claims the overlay drops inherited host bindings" {

--- a/test/scripts/oneshot_overlay_test.bats
+++ b/test/scripts/oneshot_overlay_test.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+#
+# Bats suite for compose.oneshot.yaml — what the overlay actually buys
+# (#1409 D-S7).
+#
+# WHY THIS EXISTS
+#
+# The overlay and `_lib.sh` both claimed a hazard: "without it a oneshot
+# inherits `container_name: grappa` and the host port-publishes, and both
+# collide with the long-lived copy", with a misplaced `-f` called a
+# "one-character-edit hazard". Meanwhile six `compose run --rm` invocations
+# on the deploy path do not layer the overlay at all and run against a live
+# `grappa` by design. Both could not be true.
+#
+# Measured on 2026-08-16, with the long-lived `grappa` up and holding
+# `192.168.53.12:4000`, by inspecting the ephemeral container `compose run`
+# creates:
+#
+#   container_name  →  /grappa-grappa-run-3f90d538d15f, never `grappa`
+#   PortBindings    →  {} (with --service-ports as the positive control:
+#                      {"4000/tcp":[{"HostIp":"192.168.53.12",...}]})
+#   RestartPolicy   →  "no", without the overlay's help
+#   Healthcheck     →  INHERITED in full, curl /healthz, 5 retries
+#
+# So three of the four overlay keys were no-ops and the hazard prose was
+# false. Only `healthcheck: disable: true` earns its keep, and this suite
+# pins that reduction so the prose cannot grow back.
+#
+# Scope caveat, deliberately narrow: that measurement is Docker Desktop on
+# macOS, one Compose version, one host. This suite pins OUR file, not
+# Compose's semantics — a bats that asserted PortBindings would pin someone
+# else's product and break on their upgrade with our tree unchanged.
+
+load ../bats_helpers
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    OVERLAY="$ROOT/compose.oneshot.yaml"
+    LIB="$ROOT/scripts/_lib.sh"
+}
+
+@test "the overlay still disables the healthcheck — the one key that is load-bearing" {
+    grep -q 'disable: true' "$OVERLAY"
+}
+
+@test "the overlay no longer claims a container_name collision" {
+    refute grep -q 'container_name' "$OVERLAY"
+}
+
+@test "the overlay no longer resets ports it never inherited" {
+    refute grep -q 'ports' "$OVERLAY"
+}
+
+@test "_lib.sh no longer claims the overlay drops inherited host bindings" {
+    # The review quoted a "one-character-edit hazard" phrase at :249-252 that
+    # is not in the file — what IS there is the same falsified claim, that
+    # `ports: !reset []` + `container_name: !reset null` "drop host-side
+    # bindings inherited from the base file or the personal override". They
+    # drop nothing: `run` never applied either.
+    refute grep -q 'drop host-side bindings' "$LIB"
+    refute grep -q 'container_name: !reset null' "$LIB"
+}
+
+@test "in_oneshot still layers the overlay last" {
+    # The reduction is about what the file CONTAINS, not about dropping it:
+    # the healthcheck override only applies if it is still layered.
+    grep -q 'compose.oneshot.yaml' "$LIB"
+}


### PR DESCRIPTION
Bucket I of the 2026-08-15 codebase review — issue #1409. All three
findings survive; none survives in the shape the review wrote it.

## What is in here

**D-S7 — `compose.oneshot.yaml`.** The overlay claimed a oneshot without
it "inherits `container_name: grappa` and the host port-publishes, and
both collide with the long-lived copy". Six `compose run --rm` on the
deploy path never layered it and never collided, so both statements
could not be true. Measured with `docker inspect` on the ephemeral
container (`--service-ports` as the positive control): the name is
`/grappa-grappa-run-<hash>`, `PortBindings` is `{}`, `RestartPolicy` is
already `no` — three no-ops. Only `healthcheck: disable: true` is
load-bearing, and it is inherited in full. The file reduces to that one
key and the prose goes. Scope of the measurement, stated in
DESIGN_NOTES: Docker Desktop on macOS, one Compose version, one host,
2026-08-16 — not verified on the Linux CI runs on.

**D-S7, fourth piece — `GRAPPA_CACHE_ID`.** The review's other branch was
to route the six oneshots through `in_oneshot` so they gain
`CACHE_ENV`/`CACHE_VOLUMES`. Declined on a measured asymmetry: `compose
up` exposes no `-v` and `run` does, so the oneshots could take the per-id
binds and the long-running container they migrate FOR could not — a
deploy that migrates inside `.caches/<id>` and then boots from the shared
`_build`/`deps`, with nothing in the output to say which half it is on.
Half an isolation is worse than none. So the substrate says what it
cannot do: ONE guard, in the hook set both Docker doors have shared since
#1384, refusing with the variable named. Unset — every deploy that runs
today — the path is byte for byte the previous one.

**D-S11 — `scripts/db.sh` died mute.** `die` is an `exit 1`, and an
`exit` inside a command substitution kills the subshell, so the
`|| echo dev` fallback was dead the day it was written: the script exited
1 with zero bytes on both streams. The review's advised repair (quote
`$MODE_ARG`) would have added a second bug — an empty quoted scalar
reaches sqlite3 as a filename — so the mode is an array now.

**D-S6 — `PORT` on Docker.** Honoured by exactly one Docker-side
consumer; everything else hardcodes 4000. Marked unsupported in the two
places an operator reads, with `GRAPPA_PUBLISH` named as the knob that
works. The drift gate points its grep at `infra/linux/install.sh` first —
a substrate that DOES honour `${PORT}` — so a broken probe says so
instead of passing vacuously.

## Not observed

The cache-id defect was **deduced by reading the two compose surfaces,
not reproduced**. No half-isolated deploy has been reported or is known
to have been run.

## Testing

- `scripts/bats.sh` (full set): 532 ok / 0 not ok, rc 0 — before the
  rebase and again on `origin/main` after it. Baseline was 528; the four
  new cases account for the difference exactly.
- `scripts/design-notes-gate.sh`: rc 0, one entry heading, separator and
  marker present, re-checked after the rebase.
- Red first for all three findings, and for the guard: with
  `GRAPPA_CACHE_ID` set both doors exited 0 before it existed. The unset
  twin is the control — green before AND after, which is what makes the
  red attributable to the variable rather than to a broken fixture.
- Mutants: the message stripped of the variable name kills exactly the
  two message assertions; a guard narrowed to `scripts/deploy.sh` kills
  exactly the standalone-door case; `[ -n ]` → `[ -z ]` kills 37,
  including the control. A fourth mutant — the guard moved below the
  `.env` check — SURVIVED the first three cases, which proved the
  "holds on an uninstalled box too" claim was prose; the case that pins
  it was added, and that mutant now dies to exactly one assertion.
- `scripts/shellcheck.sh` was not run locally (it is a docker run, and
  the lane is allocated elsewhere). CI runs it.

## Note for reviewers

`bats` runs on the host and inherits the caller's environment, so an
ambient `GRAPPA_CACHE_ID` would have turned every deploy case in the two
Docker suites red once the guard landed. Both `setup()`s unset it, the
way `cache_id_isolation_test.bats` already did.