### PR TITLE
review(#1408): three runbook claims that named gates not covering them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  ELIXIR_VERSION: "1.19.5"
-  OTP_VERSION: "28.5"
-
 jobs:
   test:
     name: test + lint + audit
@@ -33,10 +29,17 @@ jobs:
           fetch-depth: 0
 
       - name: Setup BEAM
+        id: beam
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          # #1408 D-S10 — the pin lives in .tool-versions and nowhere else.
+          # `version-type: strict` is mandatory with version-file, not a
+          # style choice: setup-beam throws before reading the file without
+          # it. The asdf spellings resolve as-is — `1.19.5-otp-28` has its
+          # `-otp-N` suffix stripped for the lookup and reused as the OTP
+          # constraint, and `28.5` matches the builds listing's `OTP-28.5`.
+          version-file: .tool-versions
+          version-type: strict
 
       - name: Cache deps + build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -44,9 +47,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+            ${{ runner.os }}-mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
 
       - name: Install dependencies
         run: |
@@ -284,10 +287,17 @@ jobs:
           submodules: recursive
 
       - name: Setup BEAM
+        id: beam
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          # #1408 D-S10 — the pin lives in .tool-versions and nowhere else.
+          # `version-type: strict` is mandatory with version-file, not a
+          # style choice: setup-beam throws before reading the file without
+          # it. The asdf spellings resolve as-is — `1.19.5-otp-28` has its
+          # `-otp-N` suffix stripped for the lookup and reused as the OTP
+          # constraint, and `28.5` matches the builds listing's `OTP-28.5`.
+          version-file: .tool-versions
+          version-type: strict
 
       - name: Cache deps + build + PLTs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -296,9 +306,9 @@ jobs:
             deps
             _build
             priv/plts
-          key: ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}-v1
+          key: ${{ runner.os }}-plt-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}-v1
           restore-keys: |
-            ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+            ${{ runner.os }}-plt-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
 
       - name: Install deps + compile
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,6 +24,24 @@ name: integration
 # in scope: they define the images the suite boots. The e2e-local
 # Dockerfiles and compose files are already covered by cicchetto/e2e/**.
 #
+# That rule was stated here before it was applied (#1408 D-S8). Two e2e
+# services build `grappa:e2e` with `context: ../..`, so `.dockerignore`
+# governs what is tarred into that context — its own trailing entries
+# (`.worktrees/`, the e2e cert dir) exist because a bad exclude BREAKS the
+# build. And the cic build container mounts only ../../cicchetto, so it
+# cannot read the version: `scripts/integration.sh` runs
+# `infra/packaging/version.sh` over the repo-root `VERSION` and exports
+# `GRAPPA_VERSION`, which an empty value makes vite fail loud on. All
+# three are listed below. `bin/start.sh` is NOT, though it is the image
+# CMD and is docker-COLD in preflight.ex: both services that build from
+# the repo root override `command:`, so this suite never executes it.
+#
+# The two blocks below are byte-identical by necessity — GitHub Actions
+# does not expand YAML anchors — and
+# `test/infra/integration_path_filter_test.bats` is what keeps them so,
+# and what derives the three entries above from the compose file and the
+# script rather than trusting this comment.
+#
 # Stack timing: cold ~6-8 min for the testnet+grappa+nginx images +
 # Playwright base pull; warm with cache it's faster but we don't cache
 # docker layers cross-runs (would need a registry push). Suite itself
@@ -63,7 +81,10 @@ on:
       - "mix.exs"
       - "mix.lock"
       - "Dockerfile"
+      - ".dockerignore"
       - "compose.yaml"
+      - "VERSION"
+      - "infra/packaging/version.sh"
       - ".github/workflows/integration.yml"
   pull_request:
     branches: [main]
@@ -81,7 +102,10 @@ on:
       - "mix.exs"
       - "mix.lock"
       - "Dockerfile"
+      - ".dockerignore"
       - "compose.yaml"
+      - "VERSION"
+      - "infra/packaging/version.sh"
       - ".github/workflows/integration.yml"
 
 # Avoid duplicate runs on PRs from same-repo branches; cancel an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,10 +130,6 @@ concurrency:
 permissions:
   contents: write
 
-env:
-  ELIXIR_VERSION: "1.19.5"
-  OTP_VERSION: "28.5"
-
 jobs:
   deb:
     name: build + prove .deb (amd64)
@@ -172,11 +168,18 @@ jobs:
           fi
           echo "version=$tag" >> "$GITHUB_OUTPUT"
 
-      - name: Setup BEAM (Elixir 1.19 / OTP 28)
+      - name: Setup BEAM (from .tool-versions)
+        id: beam
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          # #1408 D-S10 — the pin lives in .tool-versions and nowhere else.
+          # `version-type: strict` is mandatory with version-file, not a
+          # style choice: setup-beam throws before reading the file without
+          # it. The asdf spellings resolve as-is — `1.19.5-otp-28` has its
+          # `-otp-N` suffix stripped for the lookup and reused as the OTP
+          # constraint, and `28.5` matches the builds listing's `OTP-28.5`.
+          version-file: .tool-versions
+          version-type: strict
 
       - name: Setup bun (cicchetto build)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44914,3 +44914,131 @@ module, which is a codegen change and not this one. The four MEDIUMs of the
 same issue (X-S4 open-map keys, X-S8 `window_state`, X-S9 theme vocabularies,
 X-S10 the `/me` and `/auth/login` discriminators) are all server-side and
 untouched here.
+<!-- entry #1408 -->
+
+---
+
+## 2026-08-16 — #1408: three runbook claims that named gates not covering them
+
+Bucket G of the 2026-08-15 review, three MEDIUMs sharing one defect
+class: a document claims a gate, and the gate does not cover what the
+claim says. The interesting part of the work was not writing the gates.
+It was deciding, per finding, whether to move the gate up to the prose
+or the prose down to the gate — and one of the three sub-claims did not
+survive being measured at all.
+
+### D-S8 — the integration filter did not cover what the suite boots
+
+`integration.yml`'s header states its own rule: the root `Dockerfile`
+and `compose.yaml` are in scope because "they define the images the
+suite boots". Three files the rule covers were never listed, so a change
+confined to them ran no end-to-end anything, and a workflow that does
+not trigger is indistinguishable from one that passes.
+
+Measured against `cicchetto/e2e/compose.yaml` rather than taken from the
+review's hand-list. Two services build `grappa:e2e` with
+`context: ../..`, which puts `.dockerignore` in scope — not because
+anything is `COPY`ed (the toolchain image has no `COPY`; the runtime
+bind-mounts the repo) but because a bad exclude breaks the CONTEXT
+TRANSFER, which is precisely why that file's trailing entries
+(`.worktrees/`, the e2e cert dir) were added. The cic build container
+mounts only `../../cicchetto` and so cannot read the version;
+`scripts/integration.sh` runs `infra/packaging/version.sh` over the
+repo-root `VERSION` and exports `GRAPPA_VERSION`, which an empty value
+makes vite fail loud on. Both carriers are now listed.
+
+**`bin/start.sh` was refused, against the review's list.** The review
+justified it as "the image `CMD`, `Dockerfile:53`; already docker-COLD
+in `preflight.ex:442`". Both halves are true and neither is relevant
+here: both services that build from the repo root override `command:`,
+and the string appears nowhere under `cicchetto/e2e` nor in the two
+orchestration scripts. The suite never executes it. The lesson
+generalises past this one entry — `Preflight.docker_image?/1` reads like
+the list this filter wants, and it is NOT: preflight answers "does the
+deployed container need a COLD restart", the filter answers "can this
+break the e2e suite". Deriving one from the other would have imported
+`bin/start.sh` and `bin/grappa` on an argument that does not hold.
+
+The gate derives each expectation from the artefact that creates the
+dependency, so moving the dependency moves the expectation. It also
+pins the two `paths:` blocks as byte-identical: GitHub Actions does not
+expand YAML anchors, so the 15-line duplication the review wanted
+factored out cannot be factored out, and a gate is the only thing that
+can keep the copies equal.
+
+### D-S9 — the digest-pin runbook over-claimed its own gate's scope
+
+The runbook said `base_image_digest_pin_test.bats` "fails the build if
+any real image reference in a tracked build file loses its `@sha256:`".
+The suite greps two families. Counted on this tree, ten-odd references
+sit outside them.
+
+Neither branch of the review's fix menu is right on its own. Pinning
+`elixir:1.19-otp-28-alpine` by digest needs a registry round-trip to
+mint and freezes a base that is deliberately allowed to move; widening
+the grep any further would demand a digest for `alpine:3.24`, which is
+an argued FLOOR whose entire purpose is to keep floating so security
+patches flow (`assert-abi-lockstep.sh` is what proves the ABI contract
+instead). So the gate's scope stays and the LIE goes: the runbook now
+quotes the gate's pattern byte-for-byte, and a fourth assertion fails
+unless it does. Widen `PINNED_FAMILIES` and the sentence must move in
+the same commit. Every uncovered family is enumerated with its reason in
+the test header — where a reader about to widen the pattern is actually
+standing, rather than in a doc they may never open.
+
+An over-claimed gate is worse than a narrow one. A narrow gate at least
+tells the truth about what it will catch.
+
+### D-S10 — "CI reads the same file" was aspirational
+
+`OPERATIONS.md` argues that a distro's Erlang packaging cannot be
+trusted, that `install_toolchain.sh` therefore runs a bare
+`asdf install` against `.tool-versions`, and that this leaves "no second
+hand-maintained pin to drift" — naming CI as `erlef/setup-beam`,
+"reading the same file". CI was not reading it. Both workflows carried
+their own `ELIXIR_VERSION` / `OTP_VERSION` literals that merely happened
+to agree.
+
+All three setup-beam steps now pass `version-file: .tool-versions`.
+**The review's proposed fix stops one line short:** `version-type:
+strict` is mandatory with `version-file` — setup-beam throws
+`you have to set version-type=strict if you're using version-file`
+before it reads anything. The review recorded the format question as
+untried; it was settled here by reading the action's source at the
+pinned sha rather than by a CI round-trip. `1.19.5-otp-28` has its
+`-otp-N` suffix stripped for the Elixir lookup and reused as the OTP
+constraint (`getElixirVersion`), and `28.5` matches the ubuntu builds
+listing's `OTP-28.5` key after `maybeRemoveOTPPrefix`. What that does
+NOT establish is the listing's contents at run time; the first CI run on
+this branch is the remaining evidence.
+
+The deleted `env:` blocks also fed four cache keys. Those now read the
+versions back off the setup-beam step's outputs, which is a strictly
+better key: it names what was installed rather than what someone typed.
+
+The Dockerfile stays a fourth carrier by necessity — an image tag is not
+an asdf version string — so the gate asserts AGREEMENT, and only as far
+as a tag reaches. `elixir:1.19-otp-28-alpine` pins the minor line and
+the OTP major and floats the Elixir PATCH, which `.tool-versions` names
+exactly. **That is a second thing the runbook got wrong**, in the
+opposite direction from D-S9: it claimed "Elixir and OTP stay pinned by
+the tag", which reads as an exact pin. The gate now fails on a minor or
+OTP-major divergence and deliberately lets a patch bump pass, and the
+runbook says so.
+
+### What is proven, and what is not
+
+Eleven bats assertions across three suites, each red before it was
+green. Nine mutants, each killing exactly one assertion after two were
+rewritten: the first `M4` widened the family pattern to `debian:trixie`
+and took down the pin assertion as collateral, and the first `M6`
+reintroduced a real version literal and so tripped the
+re-transcription check as well. An impure mutant proves less than it
+appears to, because it cannot say WHICH assertion did the work.
+
+Not established: nothing here was run in CI, and the workflow changes
+are the kind that only CI can falsify. The YAML was parsed and the three
+setup-beam call sites read back from the parse tree, which proves the
+files are well-formed and wired, not that the runner resolves the
+versions. `scripts/shellcheck.sh` was not run and did not need to be —
+no shell script changed.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2534,8 +2534,24 @@ on an intentional bump:
 docker buildx imagetools inspect oven/bun:1 --format '{{.Manifest.Digest}}'
 ```
 
-`test/infra/base_image_digest_pin_test.bats` fails the build if any real
-image reference in a tracked build file loses its `@sha256:`.
+`test/infra/base_image_digest_pin_test.bats` fails the build if a real
+image reference in a tracked build file loses its `@sha256:` — for the
+families it covers, and only those. The pattern is `oven/bun:|nginx:alpine`,
+and the suite asserts that this sentence quotes it verbatim (#1408 D-S9),
+so widening the gate forces the claim to move with it.
+
+**Everything else in the tree is unpinned on purpose, and the reasons are
+listed in that file's header, next to the pattern.** The short version:
+locally built images have no bytes to pin; `ghcr.io/vjt/*` tags come from
+a shell variable; `alpine:3.24` is a deliberate FLOOR proved by
+`assert-abi-lockstep.sh` (below); the e2e-only third parties are test
+fixtures no operator ever pulls; and the Elixir toolchain base is pinned
+by TAG rather than digest — a weaker pin than it looks, gated separately
+by `test/infra/toolchain_pin_test.bats` (§ "The toolchain pin is the
+repo's pin, never the distro's"). This paragraph used to claim the suite
+covered "any real image reference", which was the review finding: an
+over-claimed gate is worse than a narrow one, because a narrow gate at
+least tells the truth about what it will catch.
 
 ## The two images: Dockerfile (toolchain) vs Dockerfile.release
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2578,9 +2578,16 @@ DESIGN_NOTES 2026-07-31, "#503 unit C".
 earlier multi-stage debian build used
 `hexpm/elixir:VSN-erlang-VSN-debian-VSN` for tighter tuple pinning, but
 `hexpm/elixir` does NOT publish alpine variants for Elixir 1.19 / OTP 28,
-so the official image is the upstream-supported alpine path. Elixir and
-OTP stay pinned by the tag; the alpine version floats with whatever the
-Docker library publishes for it.
+so the official image is the upstream-supported alpine path. The tag pins
+the Elixir MINOR line and the OTP major; the alpine version floats with
+whatever the Docker library publishes for it, **and so does the Elixir
+patch** — `1.19` is not `1.19.5`, which is what `.tool-versions` names.
+This paragraph used to say "Elixir and OTP stay pinned by the tag",
+which reads like an exact pin and is not one (#1408 D-S9/D-S10). The
+divergence is bounded, not eliminated:
+`test/infra/toolchain_pin_test.bats` fails if the tag leaves the
+`.tool-versions` minor line or changes OTP major, and lets a patch bump
+pass — see § "The toolchain pin is the repo's pin, never the distro's".
 
 **Do not add a deps layer to the toolchain image.** It is toolchain-ONLY
 by design (#364 docker S1, described above): every runtime shape mounts
@@ -3624,6 +3631,16 @@ governs every substrate that builds Grappa from source:
   already in asdf's native format, so the pin CI runs is the pin
   installed here, with no second hand-maintained pin to drift. asdf over
   raw kerl for exactly that reason — kerl would need its own pin.
+  **"reading the same file" was aspirational until #1408 D-S10.** Both
+  workflows carried their own `ELIXIR_VERSION` / `OTP_VERSION` literals,
+  so CI ran a hand-maintained pin that merely happened to agree; the
+  three `erlef/setup-beam` steps now pass `version-file: .tool-versions`
+  and the cache keys read the versions back off the step's outputs
+  instead of off the deleted `env:` block. `version-type: strict` rides
+  along because setup-beam refuses `version-file` without it. What keeps
+  the sentence true is `test/infra/toolchain_pin_test.bats`, which fails
+  on any setup-beam step that does not read the file and on any workflow
+  that re-transcribes a version the file already pins.
 - **Wrong shape.** A distro that SPLITS OTP into per-application
   packages leaves you with a valid-looking Erlang that is missing
   modules the release loads at runtime. Arch is the live case

--- a/test/infra/base_image_digest_pin_test.bats
+++ b/test/infra/base_image_digest_pin_test.bats
@@ -23,10 +23,40 @@
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 
+# The families this gate covers, as ONE string — the regex below and the
+# runbook's description of it both read from here (#1408 D-S9).
+#
+# It is deliberately NOT every image reference in the tree, and the last
+# test in this file is what stops the runbook from claiming otherwise.
+# What is left out, and why:
+#
+#   - `elixir:1.19-otp-28-alpine` (Dockerfile, Dockerfile.release) — the
+#     TAG carries the pin. It floats the alpine minor by design and the
+#     Elixir PATCH as a side effect, which is the toolchain-carrier
+#     problem, gated by test/infra/toolchain_pin_test.bats, not by a
+#     digest.
+#   - `alpine:3.24` (Dockerfile.release, Dockerfile.shottino) — an
+#     argued FLOOR, not a mirror of the build base; a digest would
+#     freeze it and stop security patches flowing. Proved instead by
+#     infra/docker/assert-abi-lockstep.sh.
+#   - locally built images (`grappa:latest`, `grappa:e2e`,
+#     `grappa-shottino:latest`, `grappa-e2e-push-catcher:dev`) — never
+#     pulled, so there are no bytes to pin.
+#   - own-org tags resolved from a variable (`ghcr.io/vjt/bahamut`,
+#     `ghcr.io/vjt/services`, `ghcr.io/vjt/grappa`) — a literal digest
+#     cannot express `${BAHAMUT_TAG:-main}`.
+#   - e2e-only third parties (`debian:trixie`, `node:22-alpine`,
+#     `alpine:3.20`, `axllent/mailpit`, the playwright runner base) —
+#     test-fixture images that never reach an operator.
+#
+# Adding a family here REQUIRES amending the runbook line the last test
+# reads; that is the whole point of the pin.
+PINNED_FAMILIES='oven/bun:|nginx:alpine'
+
 # Every reference to a pinned family in tracked build files, minus comments
 # and the docs/test prose trees. git grep -n → `path:line:content`.
 matched_refs() {
-    git -C "$REPO_ROOT" grep -nE 'oven/bun:|nginx:alpine' -- \
+    git -C "$REPO_ROOT" grep -nE "$PINNED_FAMILIES" -- \
         '*.sh' '*.yaml' '*.yml' '*Dockerfile*' ':!docs/**' ':!test/**' 2>/dev/null \
         | while IFS= read -r line; do
             content="${line#*:*:}"                        # strip `path:line:`
@@ -125,6 +155,29 @@ $(matched_refs | grep -F -- "$family@sha256:" | sed 's/^/    /')
     [ -z "$bad" ] || {
         echo "malformed digest(s) — expected sha256:<64 lowercase hex>:" >&2
         printf '%s\n' "$bad" >&2
+        return 1
+    }
+}
+
+@test "the runbook quotes this gate's family pattern verbatim (#1408)" {
+    # D-S9: the runbook used to describe this suite as failing "if any real
+    # image reference in a tracked build file loses its @sha256:". It covers
+    # two families. Ten-odd references sit outside them — the Elixir
+    # toolchain base among them — each for a reason recorded above, and none
+    # of them guarded by this file.
+    #
+    # An over-claimed gate is worse than a narrow one: the narrow gate at
+    # least tells the truth about what it will catch. So the runbook now
+    # carries the pattern ITSELF, byte-for-byte, and this is the pin that
+    # keeps the two equal. Widen PINNED_FAMILIES and the sentence describing
+    # it must move in the same commit.
+    local runbook="$REPO_ROOT/docs/OPERATIONS.md"
+
+    grep -qF -- "$PINNED_FAMILIES" "$runbook" || {
+        printf 'docs/OPERATIONS.md does not quote this gate'"'"'s pattern.\n' >&2
+        printf 'expected the literal string: %s\n' "$PINNED_FAMILIES" >&2
+        printf 'nearby runbook text:\n' >&2
+        grep -n 'base_image_digest_pin_test' "$runbook" >&2 || true
         return 1
     }
 }

--- a/test/infra/integration_path_filter_test.bats
+++ b/test/infra/integration_path_filter_test.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1408 D-S8 — the `integration` workflow's path filter
+# must cover the files that decide what the suite boots.
+#
+# The filter states its own rule in prose (integration.yml, header): the
+# root Dockerfile and compose.yaml are in scope because "they define the
+# images the suite boots". Prose cannot fail a build. Three files that the
+# rule covers were never listed, and a workflow that does not run is
+# indistinguishable from one that passes.
+#
+# Every check DERIVES its expectation from the artefact that creates the
+# dependency — `cicchetto/e2e/compose.yaml` for the build inputs, the
+# orchestration script for the version carrier — so that moving the
+# dependency moves the expectation with it. A hand-transcribed list here
+# would be a second copy of the filter, drifting the same way the filter
+# drifts from itself.
+#
+# NOT derived from `Grappa.Deploy.Preflight.docker_image?/1`, though it
+# reads like the same list: preflight answers "does the deployed container
+# need a COLD restart", this filter answers "can this change break the e2e
+# suite". They diverge — `bin/start.sh` is the image CMD and so is
+# preflight's business, but both services this suite builds from the repo
+# root override `command:`, so the CMD never runs here.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    WORKFLOW="$REPO_ROOT/.github/workflows/integration.yml"
+    E2E_COMPOSE="$REPO_ROOT/cicchetto/e2e/compose.yaml"
+}
+
+# The `paths:` entries under `on.<trigger>`, one per line, quotes stripped.
+# A two-space key resets the trigger, so `jobs:`/`concurrency:` cannot leak
+# a later `paths:` into a block that has already closed.
+paths_for() {
+    awk -v want="$1" '
+        /^  [a-z_]+:$/ { trigger = substr($1, 1, length($1) - 1); inpaths = 0 }
+        trigger == want && /^    paths:$/ { inpaths = 1; next }
+        inpaths && /^      - / {
+            entry = $0
+            sub(/^      - /, "", entry)
+            gsub(/"/, "", entry)
+            print entry
+            next
+        }
+        inpaths { inpaths = 0 }
+    ' "$WORKFLOW"
+}
+
+# Fail unless `$2` is an exact entry of the filter list in `$1`.
+assert_listed() {
+    local paths="$1" wanted="$2" why="$3"
+    printf '%s\n' "$paths" | grep -qxF "$wanted" && return 0
+
+    printf 'MISSING from integration.yml paths: %s\n  reason: %s\n' "$wanted" "$why" >&2
+    printf 'current filter:\n%s\n' "$paths" >&2
+    return 1
+}
+
+@test "the push and pull_request path filters are identical (#1408)" {
+    # GitHub Actions does not expand YAML anchors, so the 15-line block is
+    # transcribed twice by necessity. This is the only thing that keeps the
+    # two copies equal: an entry added to one and forgotten in the other
+    # silently halves the filter's coverage, and the half that still runs
+    # makes the gap look like it is not there.
+    local push pr
+    push="$(paths_for push)"
+    pr="$(paths_for pull_request)"
+
+    # Vacuity guard: a parser that matched nothing would compare "" to ""
+    # and pass. Both blocks are well over ten entries today.
+    local count
+    count="$(printf '%s\n' "$push" | grep -c . || true)"
+    [ "$count" -ge 10 ] || {
+        printf 'parsed only %s push path entries — the awk extractor is broken:\n%s\n' \
+            "$count" "$push" >&2
+        return 1
+    }
+
+    [ "$push" = "$pr" ] || {
+        printf 'push and pull_request path filters DIVERGE:\n' >&2
+        diff <(printf '%s\n' "$push") <(printf '%s\n' "$pr") >&2 || true
+        return 1
+    }
+}
+
+@test "the repo-root build context's image inputs are in the filter (#1408)" {
+    # Two e2e services build `grappa:e2e` with `context: ../..` — the repo
+    # root, and therefore the root Dockerfile plus the `.dockerignore` that
+    # decides what gets tarred into that context. The toolchain image has no
+    # `COPY`, so `.dockerignore` never lands anything IN the image; it is in
+    # scope because a bad exclude breaks the context transfer itself, which
+    # is exactly what its own trailing entries (`.worktrees/`, the e2e
+    # cert dir) were added to prevent.
+    local root_builds
+    root_builds="$(grep -cE '^ +context: \.\./\.\.$' "$E2E_COMPOSE" || true)"
+    [ "$root_builds" -ge 1 ] || {
+        printf 'no e2e service builds from the repo root — this assertion is vacuous\n' >&2
+        return 1
+    }
+
+    local paths
+    paths="$(paths_for push)"
+    assert_listed "$paths" "Dockerfile" \
+        "the image $root_builds e2e service(s) build from context ../.."
+    assert_listed "$paths" ".dockerignore" \
+        "it decides what enters that same build context"
+}
+
+@test "the GRAPPA_VERSION carriers the e2e stack reads are in the filter (#1408)" {
+    # The cic build container mounts only ../../cicchetto, so it cannot read
+    # the version itself; the orchestration script derives it and exports it
+    # (e2e compose: `GRAPPA_VERSION: ${GRAPPA_VERSION:-}`, and an empty value
+    # makes vite fail loud). Both ends of that channel are derived here: the
+    # consumer from the compose file, the producer from the script.
+    grep -qE '^ +GRAPPA_VERSION: ' "$E2E_COMPOSE" || {
+        printf 'the e2e compose no longer consumes GRAPPA_VERSION — assertion vacuous\n' >&2
+        return 1
+    }
+
+    local producer
+    producer="$(grep -oE '\$SRC_ROOT/[A-Za-z0-9._/-]+/version\.sh' \
+                    "$REPO_ROOT/scripts/integration.sh" \
+                | sed -E 's|^\$SRC_ROOT/||' | sort -u)"
+    [ "$(printf '%s\n' "$producer" | grep -c .)" -eq 1 ] || {
+        printf 'expected exactly one version producer in scripts/integration.sh, got:\n%s\n' \
+            "$producer" >&2
+        return 1
+    }
+
+    local paths
+    paths="$(paths_for push)"
+    assert_listed "$paths" "$producer" \
+        "scripts/integration.sh runs it to export GRAPPA_VERSION"
+
+    # ...and whatever THAT script reads, which is the version's single source
+    # of truth. Derived, not transcribed: if the producer ever grows a second
+    # input, the second input is required here too.
+    local sources
+    sources="$(grep -oE '\$\{REPO_ROOT\}/[A-Za-z0-9._/-]+' "$REPO_ROOT/$producer" \
+               | sed -E 's|^\$\{REPO_ROOT\}/||' | sort -u)"
+    [ -n "$sources" ] || {
+        printf '%s reads no ${REPO_ROOT}-rooted file — the derivation is broken\n' \
+            "$producer" >&2
+        return 1
+    }
+
+    local source_file
+    while IFS= read -r source_file; do
+        [ -n "$source_file" ] || continue
+        assert_listed "$paths" "$source_file" \
+            "$producer reads it to produce GRAPPA_VERSION"
+    done <<<"$sources"
+}

--- a/test/infra/toolchain_pin_test.bats
+++ b/test/infra/toolchain_pin_test.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1408 D-S10 — `.tool-versions` is the toolchain pin,
+# and every other carrier must derive from it or agree with it.
+#
+# `docs/OPERATIONS.md` § "The toolchain pin is the repo's pin, never the
+# distro's" argues that a drifted OTP "silently diverges from what CI
+# (`erlef/setup-beam`, reading the same file) and the FreeBSD jail
+# actually run", and concludes there is "no second hand-maintained pin to
+# drift". At the time that was written CI did not read the file: both
+# workflows carried their own `ELIXIR_VERSION` / `OTP_VERSION` literals,
+# and the Dockerfiles carry a third spelling. Four carriers, three of
+# them hand-maintained, and the sentence saying otherwise is the one a
+# future editor trusts.
+#
+# The workflows now pass `version-file: .tool-versions`, which makes the
+# sentence true; these checks are what keep it true. `version-type:
+# strict` is REQUIRED, not decorative — setup-beam throws
+# "you have to set version-type=strict if you're using version-file"
+# before it reads anything (src/setup-beam.js, main()).
+#
+# The Dockerfile stays a separate carrier: it needs a published image
+# tag, and `elixir:1.19.5-otp-28-alpine` is a different pin from an asdf
+# version string. What is checked is AGREEMENT, and only as far as the
+# tag goes — `elixir:1.19-otp-28-alpine` pins the minor line and the OTP
+# major, so the Elixir PATCH floats there while `.tool-versions` names
+# 1.19.5 exactly. That gap is real and deliberate; a MINOR or OTP-major
+# divergence is not, and is what fails here.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    TOOL_VERSIONS="$REPO_ROOT/.tool-versions"
+
+    # asdf format: `<app> <version>`, one per line.
+    ELIXIR_PIN="$(awk '$1 == "elixir" { print $2 }' "$TOOL_VERSIONS")"
+    ERLANG_PIN="$(awk '$1 == "erlang" { print $2 }' "$TOOL_VERSIONS")"
+}
+
+workflow_files() {
+    local f
+    WORKFLOWS=()
+    while IFS= read -r f; do WORKFLOWS+=("$f"); done \
+        < <(find "$REPO_ROOT/.github/workflows" -name '*.yml' -type f | sort)
+}
+
+@test ".tool-versions names both toolchain pins (#1408)" {
+    # Every other check derives from these two strings; an empty one would
+    # make all of them hold vacuously.
+    [[ "$ELIXIR_PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+-otp-[0-9]+$ ]] || {
+        printf 'unexpected elixir pin in .tool-versions: %s\n' "$ELIXIR_PIN" >&2
+        return 1
+    }
+    [[ "$ERLANG_PIN" =~ ^[0-9]+\.[0-9]+ ]] || {
+        printf 'unexpected erlang pin in .tool-versions: %s\n' "$ERLANG_PIN" >&2
+        return 1
+    }
+}
+
+@test "every setup-beam step installs from .tool-versions (#1408)" {
+    workflow_files
+
+    local sites=0 f n block
+    for f in "${WORKFLOWS[@]}"; do
+        while IFS= read -r n; do
+            sites=$((sites + 1))
+            # The step's `with:` block: setup-beam takes at most a handful
+            # of inputs, and every site here is followed by its own block.
+            block="$(sed -n "$((n + 1)),$((n + 8))p" "$f")"
+
+            printf '%s' "$block" | grep -q 'version-file: .tool-versions' || {
+                printf '%s:%s — setup-beam does not read .tool-versions:\n%s\n' \
+                    "$f" "$n" "$block" >&2
+                return 1
+            }
+
+            # Without this setup-beam refuses to start; a version-file with
+            # no strict flag is a red run, not a loose one.
+            printf '%s' "$block" | grep -q 'version-type: strict' || {
+                printf '%s:%s — version-file without `version-type: strict`:\n%s\n' \
+                    "$f" "$n" "$block" >&2
+                return 1
+            }
+        done < <(grep -n 'uses: erlef/setup-beam' "$f" | cut -d: -f1)
+    done
+
+    [ "$sites" -ge 3 ] || {
+        printf 'found only %s setup-beam step(s) — the scan is broken\n' "$sites" >&2
+        return 1
+    }
+}
+
+@test "no workflow re-transcribes a .tool-versions pin (#1408)" {
+    # Derived from the pins themselves, so this catches a re-transcription
+    # anywhere in a workflow — an `env:` block, an inline input, a matrix
+    # entry — not just the two spellings that existed when it was written.
+    # Comments are stripped first: prose may legitimately name a version.
+    workflow_files
+
+    # Three spellings, because a workflow transcribes the version WITHOUT
+    # the `-otp-N` suffix that asdf needs — which is exactly the literal
+    # this gate exists to remove.
+    local offenders="" f hits pin
+    for f in "${WORKFLOWS[@]}"; do
+        for pin in "$ELIXIR_PIN" "${ELIXIR_PIN%-otp-*}" "$ERLANG_PIN"; do
+            hits="$(sed 's/#.*$//' "$f" | grep -nF -- "$pin" || true)"
+            [ -n "$hits" ] && offenders="${offenders}${f}: ${pin}
+$(printf '%s\n' "$hits" | sed 's/^/    /')
+"
+        done
+    done
+
+    [ -z "$offenders" ] || {
+        printf 'a workflow hardcodes a version that .tool-versions already pins:\n%s' \
+            "$offenders" >&2
+        printf 'Use `version-file: .tool-versions` (and setup-beam outputs for cache keys).\n' >&2
+        return 1
+    }
+}
+
+@test "the elixir base image tag agrees with .tool-versions (#1408)" {
+    # `elixir:<v>-otp-<n>-alpine` — the tag pins the minor line and the OTP
+    # major. Assert exactly that much: the tag's version must be a
+    # dot-boundary PREFIX of the .tool-versions elixir version, and the OTP
+    # major must match. A patch bump in .tool-versions is allowed to leave
+    # the tag alone; a minor or OTP-major bump is not.
+    local want_version="${ELIXIR_PIN%-otp-*}"
+    local want_otp="${ELIXIR_PIN##*-otp-}"
+
+    # git grep prefixes a line number even with -h when `grep.lineNumber` is
+    # set, which it is in this repo — so the git grep anchors the match to
+    # the start of the LINE, and the extracting grep must not re-anchor
+    # against the prefixed OUTPUT. Same trap the sibling digest-pin suite
+    # documents for `git grep -o`.
+    local tags
+    tags="$(git -C "$REPO_ROOT" grep -hE '^FROM elixir:' -- '*Dockerfile*' \
+            | grep -oE 'FROM elixir:[A-Za-z0-9._-]+' \
+            | sed 's/^FROM elixir://' | sort -u)"
+
+    local count
+    count="$(printf '%s\n' "$tags" | grep -c . || true)"
+    [ "$count" -ge 1 ] || {
+        printf 'no `FROM elixir:` line found — the scan is broken\n' >&2
+        return 1
+    }
+
+    local tag tag_version tag_otp
+    while IFS= read -r tag; do
+        [ -n "$tag" ] || continue
+        tag_version="${tag%%-otp-*}"
+        tag_otp="${tag#*-otp-}"
+        tag_otp="${tag_otp%%-*}"
+
+        [ "$tag_otp" = "$want_otp" ] || {
+            printf 'elixir:%s pins OTP %s, .tool-versions says %s\n' \
+                "$tag" "$tag_otp" "$want_otp" >&2
+            return 1
+        }
+
+        case "$want_version." in
+            "$tag_version".*) ;;
+            *)
+                printf 'elixir:%s is not on the .tool-versions line (%s)\n' \
+                    "$tag" "$ELIXIR_PIN" >&2
+                return 1
+                ;;
+        esac
+    done <<<"$tags"
+}


### PR DESCRIPTION
Bucket G of the 2026-08-15 review — D-S8, D-S9, D-S10. All three share
one defect class: a document claims a gate, and the gate does not cover
what the claim says. Ref #1408.

The fix is not uniform across the three, and deciding which way each one
went was the work:

- **D-S8** — move the gate up to the prose. `integration.yml` states
  that files defining the images the suite boots are in scope, then
  omits three of them. `.dockerignore`, `VERSION` and
  `infra/packaging/version.sh` are added to both `paths:` blocks.
- **D-S9** — move the prose down to the gate. The digest-pin runbook
  claimed the bats suite covers "any real image reference"; it covers
  two families, and ten-odd references sit outside them, each for a
  recorded reason. The runbook now quotes the gate's pattern verbatim
  and a new assertion fails unless it does.
- **D-S10** — both. `OPERATIONS.md` names CI as "`erlef/setup-beam`,
  reading the same file"; CI carried its own version literals. All three
  setup-beam steps now pass `version-file: .tool-versions`.

## What was refused, and why

**`bin/start.sh` is not added to the path filter**, against the issue's
list. It is the image `CMD` and it is docker-COLD in `preflight.ex`,
both true — but both e2e services that build from the repo root override
`command:`, and the string appears nowhere under `cicchetto/e2e` or in
the two orchestration scripts. The suite never executes it. Related:
`Preflight.docker_image?/1` reads like the list this filter wants and is
not — preflight asks "does the deployed container need a COLD restart",
the filter asks "can this break the e2e suite".

**The Elixir base is not digest-pinned and the grep is not widened.**
Pinning needs a registry round-trip to mint, and widening any further
would demand a digest for `alpine:3.24` — an argued FLOOR whose purpose
is to keep floating so security patches flow.

## Corrections to the issue text

- The issue says the unpinned Elixir base "is argued nowhere". It is
  argued, in the same document, under "The two images" — but the
  argument itself over-claims: "Elixir and OTP stay pinned by the tag"
  reads as exact, and `1.19` is not `1.19.5`. Both sentences are fixed.
- The proposed D-S10 fix stops one line short. `version-type: strict`
  is mandatory with `version-file`; setup-beam throws before reading the
  file without it.
- Every `file:line` in the issue for `OPERATIONS.md` was stale
  (2354/3401 → 2530/3602). Everything was re-localised.

## Test plan

- [x] `scripts/bats.sh` full — **520 ok / 0 not ok**, RC read from file.
      `@test` count is 512 on `origin/main` and 520 on this branch, so
      the delta is exactly the 8 assertions added here.
- [x] Every new assertion red before green, each red read for its
      reason. 9 mutants, each killing exactly one assertion — two were
      rewritten after killing two apiece (an impure mutant cannot say
      which assertion did the work).
- [x] `scripts/design-notes-gate.sh` RC=0, re-run after the rebase onto
      `df6b7191`; marker unique, boundary shape re-read on the file.
- [x] Workflow YAML parsed and the three setup-beam call sites read back
      off the parse tree.
- [x] setup-beam's `.tool-versions` handling verified by reading the
      action's source at the pinned sha, not by a CI round-trip.
- [ ] **Not established:** no CI run. The workflow changes are the kind
      only CI can falsify — the builds listing's contents at run time is
      the remaining unknown. `scripts/shellcheck.sh` not run and not
      needed: no shell script changed.