### PR TITLE
codegen(#1406): give a union-of-atoms map key its keys back (X-S4)

### DIFF
--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -61,7 +61,34 @@ export const SCROLLBACK_MESSAGE_KIND = [
 ] as const;
 export type ScrollbackMessageKind = (typeof SCROLLBACK_MESSAGE_KIND)[number];
 
-export type ScrollbackMetaT = Record<string, unknown>;
+export const SCROLLBACK_META_TKEY = [
+  "target",
+  "new_nick",
+  "modes",
+  "args",
+  "numeric",
+  "severity",
+  "who",
+  "who_target",
+  "names",
+  "names_target",
+  "raw_verb",
+  "raw_sender",
+  "raw_params",
+  "sender_user",
+  "sender_host",
+  "sender_prefix",
+  "sender_kind",
+  "ctcp_verb",
+  "ctcp_args",
+  "ctcp_target",
+  "notice_target",
+  "statusmsg",
+  "nick_fallback",
+] as const;
+export type ScrollbackMetaTKey = (typeof SCROLLBACK_META_TKEY)[number];
+
+export type ScrollbackMetaT = Partial<Record<ScrollbackMetaTKey, unknown>>;
 
 export type SessionISupportCasemapping = IRCIdentifierCasemapping;
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45042,3 +45042,83 @@ setup-beam call sites read back from the parse tree, which proves the
 files are well-formed and wired, not that the runner resolves the
 versions. `scripts/shellcheck.sh` was not run and did not need to be —
 no shell script changed.
+<!-- entry #1406 X-S4 -->
+
+---
+
+## 2026-08-16 — #1406 X-S4: the codegen dropped a map's key names, and said nothing
+
+`Grappa.Scrollback.Meta.t/0` is the most carefully bounded map on the wire —
+23 atom keys the server enforces at `cast/1` and `dump/1`, with a moduledoc
+arguing the closed set at length. cic mirrored it as
+`Record<string, unknown>` and reached its fields through ad-hoc `typeof`
+guards.
+
+### The defect is the silence, not the fallback
+
+`atom_keyed_field?/1` matches a map field keyed by a SINGLE atom. `Meta.t/0`
+is ONE association keyed by a UNION of atoms, so it failed the all-atom-keyed
+test and took the open-map branch. That branch is correct for
+`%{String.t() => T}` and wrong here, and nothing distinguished the two: the
+codegen's moduledoc flags `Record<string, unknown>` as "defeats codegen
+purpose" and `do_render/1` warns for bare `map()`, but the union-keyed road
+to the same output passed without a word.
+
+So the fix is not only the new shape. Any map whose keys are atom-derived and
+which STILL cannot be expressed now warns, and the warning is the general
+rule: `Record<string, unknown>` is reachable by several roads and every one
+of them has to say so.
+
+### A second thing the fall-through was doing
+
+The open-map branch took the FIRST field's key and value AST and applied them
+to the whole map. For a mixed shape — a named key beside a union-keyed
+association — that rendered `Record<string, string>` off the named field
+alone: not a loss of precision but a claim about every value that the
+typespec never made. The degraded branch now drops the value type together
+with the keys, so the honest `unknown` is what survives.
+
+### `Partial`, and why the runtime does NOT check the keys
+
+The keys come from an `optional(...)` association, so `Partial` is the
+accurate quantifier. The type pins which keys cic may READ; it does not claim
+the server sends no others, and TS object types are not exact, so it cannot
+be read as claiming that.
+
+That distinction is load-bearing rather than pedantic. `Meta.load/1` is
+deliberately LENIENT — a row written before a key left the allowlist still
+round-trips as a string rather than crashing the fetch — so the set of keys
+that can ARRIVE is wider than the set the allowlist defines. A runtime key
+check in `wireSchema.ts` would therefore reject exactly the historical rows
+the server goes out of its way to keep readable, turning a server-side
+leniency into a client-side drop. The runtime twin stays a record of
+`unknown`; only the compile-time type narrows.
+
+### The key set is named, not inlined
+
+Inlined, 23 quoted keys blow past biome's `lineWidth: 100`, and biome
+reformats them into a nested `Partial<\n  Record<\n    | "a"` shape — measured,
+not predicted. This emitter hand-matches biome's output in three places
+already so the `--check` drift gate stays green; adding a fourth wrapper for
+a nested generic would be the most fragile of them. Lifting the keys into the
+same `as const` array plus derived type that #411 D6b gives every atom union
+keeps the typedef one short line and sidesteps the matching entirely — and
+the key set becomes available at RUNTIME, like every other closed set on the
+wire.
+
+### Proven end to end, and what is not done
+
+Removing `:ctcp_verb` from `Meta.t/0` and regenerating turns 13 cic sites
+red. That is the chain — Elixir typespec → codegen → `wireTypes.ts` → call
+site — and before this change removing that key was invisible to every one of
+them.
+
+Known residual, pre-existing and not introduced here: a partial record NESTED
+inside another type renders inline, and a long one would out-run the same
+line-width matching the named form avoids. There is no such typespec today.
+
+The other three MEDIUMs of #1406 (X-S8 `window_state`, X-S9 the theme
+vocabularies, X-S10 the `/me` and `/auth/login` discriminators) are untouched.
+They are one class — a closed set that never reaches codegen, either because
+its module sits outside the glob or because no `*wire.ex` re-exports it — and
+that class is a different change from teaching the renderer a new shape.

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -236,6 +236,24 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     end
   end
 
+  # X-S4 (#1406) — a top-level partial record lifts its KEY SET into the same
+  # `as const` array + derived type every atom union already gets (#411 D6b),
+  # then references it. Two reasons, and only the second is cosmetic. The key
+  # set becomes available at RUNTIME, like every other closed set on the wire.
+  # And the reference keeps the typedef one short line: inlined, 23 quoted keys
+  # blow past `lineWidth: 100` and biome reformats them into a nested
+  # `Partial<\n  Record<\n    | "a"` shape this emitter would then have to
+  # reproduce by hand to stay drift-free. Naming the keys sidesteps the whole
+  # hand-matching problem instead of adding a fourth wrapper to match.
+  defp format_plain_typedef(alias_name, {:partial_record, _, [keys, value_ast]}) do
+    key_ts_name = alias_name <> "Key"
+    arms = Enum.map(keys, &~s("#{&1}"))
+
+    emit_enum(key_ts_name, arms) <>
+      "\n\nexport type #{alias_name} = " <>
+      "Partial<Record<#{key_ts_name}, #{do_render(value_ast)}>>;"
+  end
+
   defp format_plain_typedef(alias_name, stripped) do
     body = do_render(stripped)
     sep = if String.starts_with?(body, "\n"), do: "", else: " "
@@ -567,14 +585,66 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   defp strip_map([]), do: {:map, [], []}
 
   defp strip_map(fields) do
-    if Enum.all?(fields, &atom_keyed_field?/1) do
-      {:%{}, [], Enum.map(fields, &strip_atom_keyed_field/1)}
+    cond do
+      Enum.all?(fields, &atom_keyed_field?/1) ->
+        {:%{}, [], Enum.map(fields, &strip_atom_keyed_field/1)}
+
+      match?([_], fields) and partial_record_field?(hd(fields)) ->
+        [{:type, _, :map_field_assoc, [{:type, _, :union, members}, value_ast]}] = fields
+        {:partial_record, [], [Enum.map(members, &literal_key/1), strip_typespec_metadata(value_ast)]}
+
+      true ->
+        degrade_to_open_map(fields)
+    end
+  end
+
+  # X-S4 (#1406) — one association whose key is a UNION of atom literals: the
+  # allowlisted-bag shape (`Grappa.Scrollback.Meta.t/0`). `atom_keyed_field?/1`
+  # only recognises a SINGLE atom key, so this fell to the open-map branch and
+  # rendered `Record<string, unknown>` with the key names gone.
+  defp partial_record_field?({:type, _, :map_field_assoc, [{:type, _, :union, members}, _]}),
+    do: Enum.all?(members, &match?({:atom, _, _}, &1))
+
+  defp partial_record_field?(_), do: false
+
+  # The residual: a map shape with atom-derived keys that no TS type expresses
+  # (a named key MIXED with a union-keyed association, say). It still degrades
+  # to an open map — but it must not degrade SILENTLY, which was the actual
+  # X-S4 defect: `Record<string, unknown>` was reachable by two roads and only
+  # the bare-`map()` one said so.
+  #
+  # The VALUE type is dropped along with the keys. The old branch kept the
+  # FIRST field's value type and applied it to every key, so a mixed map of
+  # `required(:named) => String.t()` plus `optional(:a | :b) => term()`
+  # rendered `Record<string, string>` — not a loss of precision but a claim
+  # about values the typespec never made.
+  defp degrade_to_open_map(fields) do
+    if Enum.any?(fields, &atom_keyed_in_part?/1) do
+      IO.warn(
+        "atom-keyed map in Wire typespec that codegen cannot express — falling " <>
+          "back to Record<string, unknown>, dropping the key names"
+      )
+
+      [{_, _, _, [key_ast, _]} | _] = fields
+      {:open_map, [], [strip_typespec_metadata(key_ast), {:term, [], []}]}
     else
-      [first | _] = fields
-      {_, _, _, [key_ast, value_ast]} = first
+      [{_, _, _, [key_ast, value_ast]} | _] = fields
       {:open_map, [], [strip_typespec_metadata(key_ast), strip_typespec_metadata(value_ast)]}
     end
   end
+
+  defp atom_keyed_in_part?({:type, _, kind, [key_ast, _]})
+       when kind in [:map_field_assoc, :map_field_exact],
+       do: mentions_atom_literal?(key_ast)
+
+  defp atom_keyed_in_part?(_), do: false
+
+  defp mentions_atom_literal?({:atom, _, _}), do: true
+
+  defp mentions_atom_literal?({:type, _, :union, members}),
+    do: Enum.any?(members, &mentions_atom_literal?/1)
+
+  defp mentions_atom_literal?(_), do: false
 
   # `optional(:k) => T` carries `:map_field_assoc`; `required(:k) => T`
   # (and the `k: T` shorthand) carries `:map_field_exact`. Preserve the
@@ -677,6 +747,17 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   end
 
   defp do_render([t]), do: "#{do_render(t)}[]"
+
+  # X-S4 (#1406) — `Partial<`, not a bare `Record<>`: the keys come from an
+  # `optional(...)` association, so every one of them may be absent. The type
+  # pins which keys cic may READ; it does not claim the server sends no others,
+  # and TS object types are not exact, so it cannot be read as claiming that.
+  # That matters because `Scrollback.Meta.load/1` is deliberately lenient and a
+  # historical row can still carry a key the allowlist has since dropped.
+  defp do_render({:partial_record, _, [keys, value_ast]}) do
+    rendered_keys = Enum.map_join(keys, " | ", &~s("#{&1}"))
+    "Partial<Record<#{rendered_keys}, #{do_render(value_ast)}>>"
+  end
 
   defp do_render({:open_map, _, [_, value_ast]}) do
     # JSON object maps always have string keys on the wire (Jason
@@ -1043,6 +1124,16 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   defp schema_ir([inner], mod), do: {:obj, [{"a", schema_ir(inner, mod)}]}
 
   defp schema_ir({:open_map, _, [_, value]}, mod), do: {:obj, [{"r", schema_ir(value, mod)}]}
+
+  # X-S4 (#1406) — the RUNTIME twin of a partial record stays a plain record of
+  # the value type, key names deliberately NOT enforced. The compile-time type
+  # says which keys cic may read; a runtime key check would say which keys the
+  # server may send, and that is a different and wrong claim —
+  # `Scrollback.Meta.load/1` is lenient by design so that a historical row with
+  # a since-removed key still reads instead of crashing the fetch. Validating
+  # keys here would drop exactly those rows at the client instead.
+  defp schema_ir({:partial_record, _, [_keys, value]}, mod),
+    do: {:obj, [{"r", schema_ir(value, mod)}]}
 
   defp schema_ir({:%{}, _, fields}, mod) do
     props =

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -1132,7 +1132,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # `Scrollback.Meta.load/1` is lenient by design so that a historical row with
   # a since-removed key still reads instead of crashing the fetch. Validating
   # keys here would drop exactly those rows at the client instead.
-  defp schema_ir({:partial_record, _, [_keys, value]}, mod),
+  defp schema_ir({:partial_record, _, [_, value]}, mod),
     do: {:obj, [{"r", schema_ir(value, mod)}]}
 
   defp schema_ir({:%{}, _, fields}, mod) do

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -158,6 +158,42 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
       refute output =~ ~s(  sometimes: string;)
     end
 
+    # X-S4 (#1406) — `atom_keyed_field?/1` matches a map field whose key is a
+    # SINGLE atom, so a key that is a UNION of atoms failed the all-atom-keyed
+    # test and dropped to the open-map branch: `Record<string, unknown>`, key
+    # names gone. Worse than the bare-`map()` fallback it lands on, because
+    # bare `map()` at least warns. The keys are a closed set the server
+    # enforces, so they belong in the type.
+    test "renders a union-of-atoms map key as a Partial Record of those keys" do
+      output = GenWireTypes.render_module_for_test(Grappa.WireFixture)
+
+      assert output =~
+               ~s(export const WIRE_FIXTURE_UNION_KEYED_PAYLOAD_KEY = ["alpha", "beta"] as const;)
+
+      assert output =~
+               "export type WireFixtureUnionKeyedPayloadKey = " <>
+                 "(typeof WIRE_FIXTURE_UNION_KEYED_PAYLOAD_KEY)[number];"
+
+      assert output =~
+               ~s(export type WireFixtureUnionKeyedPayload = Partial<Record<WireFixtureUnionKeyedPayloadKey, unknown>>;)
+
+      refute output =~ ~s(export type WireFixtureUnionKeyedPayload = Record<string, unknown>;)
+    end
+
+    # The residual: a union-keyed association mixed with a named key has no
+    # TS shape the codegen can emit, so it still degrades to an open map —
+    # but the degradation must be LOUD. Silence is the actual defect X-S4
+    # reported; `Record<string, unknown>` reached by two different roads, one
+    # of which said nothing.
+    test "warns when a map degrades to Record<string, unknown> with atom keys in it" do
+      warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          GenWireTypes.render_module_for_test(Grappa.WireFixture)
+        end)
+
+      assert warning =~ "atom-keyed map in Wire typespec"
+    end
+
     # Pins the real production deliverable: Cic.Wire's `version` is
     # `optional(:version) => String.t()`, so the generated
     # CicWireBundleHashPayload must carry `version?: string`.

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -188,10 +188,16 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
     test "warns when a map degrades to Record<string, unknown> with atom keys in it" do
       warning =
         ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          GenWireTypes.render_module_for_test(Grappa.WireFixture)
+          send(self(), {:rendered, GenWireTypes.render_module_for_test(Grappa.WireFixtureDegraded)})
         end)
 
+      assert_received {:rendered, rendered}
       assert warning =~ "atom-keyed map in Wire typespec"
+
+      # The degraded render drops the VALUE type with the keys: taking the
+      # named field's `String.t()` and applying it to every key would claim
+      # something the typespec never said.
+      assert rendered =~ ~s(export type WireFixtureDegradedMixedKeyPayload = Record<string, unknown>;)
     end
 
     # Pins the real production deliverable: Cic.Wire's `version` is

--- a/test/support/wire_fixture.ex
+++ b/test/support/wire_fixture.ex
@@ -23,4 +23,23 @@ defmodule Grappa.WireFixture do
           required(:always) => String.t(),
           optional(:sometimes) => String.t()
         }
+
+  # X-S4 (#1406) — a map whose ONE association is keyed by a UNION of atom
+  # literals. This is the allowlisted-metadata-bag shape that
+  # `Grappa.Scrollback.Meta.t/0` uses, and the one map form the codegen
+  # could not express: `atom_keyed_field?/1` matches a SINGLE atom key, so
+  # a union key fell to the open-map branch and rendered
+  # `Record<string, unknown>` — the key names dropped, and unlike bare
+  # `map()` without even a warning to say they had been.
+  @type union_keyed_payload :: %{
+          optional(:alpha | :beta) => term()
+        }
+
+  # The residual shape the codegen still cannot express: a union-keyed
+  # association MIXED with a named key. It stays an open map on purpose,
+  # but it must not stay SILENT about it.
+  @type mixed_key_payload :: %{
+          required(:named) => String.t(),
+          optional(:alpha | :beta) => term()
+        }
 end

--- a/test/support/wire_fixture.ex
+++ b/test/support/wire_fixture.ex
@@ -34,12 +34,4 @@ defmodule Grappa.WireFixture do
   @type union_keyed_payload :: %{
           optional(:alpha | :beta) => term()
         }
-
-  # The residual shape the codegen still cannot express: a union-keyed
-  # association MIXED with a named key. It stays an open map on purpose,
-  # but it must not stay SILENT about it.
-  @type mixed_key_payload :: %{
-          required(:named) => String.t(),
-          optional(:alpha | :beta) => term()
-        }
 end

--- a/test/support/wire_fixture_degraded.ex
+++ b/test/support/wire_fixture_degraded.ex
@@ -1,0 +1,19 @@
+defmodule Grappa.WireFixtureDegraded do
+  @moduledoc """
+  Fixture for the ONE gen_wire_types case that must WARN. Not used in
+  production.
+
+  Kept apart from `Grappa.WireFixture` on purpose: rendering a module
+  containing this type emits an `IO.warn`, and every other codegen test
+  renders `WireFixture` — so leaving it there printed the warning ten times
+  across the suite and buried the one assertion that is about it.
+  """
+
+  # X-S4 (#1406) — the residual shape the codegen cannot express: a
+  # union-keyed association MIXED with a named key. It degrades to an open
+  # map on purpose. It must not degrade SILENTLY.
+  @type mixed_key_payload :: %{
+          required(:named) => String.t(),
+          optional(:alpha | :beta) => term()
+        }
+end


### PR DESCRIPTION
Takes X-S4 of #1406. The other three MEDIUMs are untouched and explained
below.

## The defect is the silence, not the fallback

`Grappa.Scrollback.Meta.t/0` is the most carefully bounded map on the wire —
23 atom keys the server enforces at `cast/1` and `dump/1`. cic mirrored it as
`Record<string, unknown>`.

`atom_keyed_field?/1` matches a map field keyed by a SINGLE atom. `Meta.t/0`
is one association keyed by a UNION of atoms, so it failed the all-atom-keyed
test and took the open-map branch. That branch is right for
`%{String.t() => T}` and wrong here, and nothing distinguished the two: the
moduledoc calls `Record<string, unknown>` "defeats codegen purpose" and
`do_render/1` warns for bare `map()`, but the union-keyed road to the same
output said nothing.

So the general rule ships with the instance: any map with atom-derived keys
that still cannot be expressed now warns.

## A second thing the fall-through was doing

The open-map branch took the FIRST field's key and value AST and applied them
to the whole map. Measured on a fixture, a named key beside a union-keyed
association rendered `Record<string, string>` — off the named field alone.
Not a loss of precision but a claim about every value that the typespec never
made. The degraded branch now drops the value type with the keys.

## Two decisions worth reviewing

**The runtime schema deliberately does NOT check the key names.** The type
says which keys cic may READ. A runtime check would say which keys the server
may SEND, which is a different claim: `Meta.load/1` is lenient by design so a
row written before a key left the allowlist still reads instead of crashing
the fetch, and a client-side key check would drop exactly those rows.

**The key set is a named type, not inlined.** Inlined, 23 quoted keys blow
past biome's `lineWidth: 100` and biome reformats them into a nested
`Partial<\n  Record<\n    | "a"` shape — measured by letting it format the
file. This emitter hand-matches biome in three places already to keep the
`--check` drift gate green; a fourth wrapper for a nested generic would be the
most fragile of them. Lifting the keys into the same `as const` array plus
derived type that #411 D6b gives every atom union keeps the typedef one short
line, and the key set becomes available at runtime like every other closed set
on the wire.

## Test plan

- [x] TDD: fixture and tests first, red measured before the fix
- [x] `scripts/test.sh` RC=0 — 6411 tests, 60 properties, 8 doctests
- [x] `scripts/check.sh` RC=0 — format, credo, dialyzer, sobelow, bats, codegen drift
- [x] `bun run check` RC=0 and full vitest RC=0 (289 files, 5569 tests), re-run
      AFTER rebasing onto the main that carries #1443's arm walk, because that
      walk compares an arm this change reaches through `ScrollbackWireT`
- [x] mutation, end to end: reading `meta.ctcp_verbz` in cic errors at exactly
      one site; removing `:ctcp_verb` from `Meta.t/0` in Elixir and
      regenerating turns 13 cic sites red — before this change that removal was
      invisible to all of them
- [x] measured, not assumed: the new warning leaked ten lines across the suite
      until the degrading fixture got its own module; zero after, same 43 green
- [ ] not verified: a partial record NESTED in another type still renders
      inline and a long one would out-run the same line-width matching the
      named form avoids. No such typespec exists today; the limitation is
      pre-existing and general to this emitter.

## Why only one of the four MEDIUMs

X-S8, X-S9 and X-S10 are one class — a closed set that never reaches codegen,
because its module sits outside the glob or because no `*wire.ex` re-exports
it. Same repair verb three times, and together they touch 11+ files. X-S4 is
the only one that repairs the machine rather than moving a type to where the
machine can see it, so it stands alone cleanly.

All four were re-measured alive on `origin/main` after the #1440 merge before
any of this was written.