### PR TITLE
STATUSMSG: peel the whole run, and let a wire recipient carry a sigil

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45042,3 +45042,101 @@ setup-beam call sites read back from the parse tree, which proves the
 files are well-formed and wired, not that the runner resolves the
 versions. `scripts/shellcheck.sh` was not run and did not need to be —
 no shell script changed.
+<!-- entry #1303 -->
+
+---
+
+## 2026-08-16 — #1303 + #1301: STATUSMSG is a run, the 005 is the only sigil list, and a recipient is not a window key
+
+Three operator reports on a self-hosted 1.1.0 landed in the same place: the
+STATUSMSG prefix. `@#chan` was refused on send, `@%#chan` misrouted on
+receive, and `@+#chan` misrouted silently. They are one defect class — every
+place that has to decide "is this a membership sigil?" had its own answer,
+and only one of them read the network's 005.
+
+### The peel is the longest run whose remainder is still a channel
+
+`@%#chan` peeled the `@`, found `%#chan` was not a channel, declined the peel
+whole and landed in `$server`. `@+#chan` peeled the `@` and accepted `+#chan`
+as the underlying channel — `+` is an RFC channel prefix in its own right —
+so the row was persisted and broadcast against a channel nobody is in. The
+second is the one that matters more, precisely because nobody reported it:
+it reads as "the message vanished", not "the message went to the wrong tab".
+
+The fix peels every leading sigil the network advertises, and rolls the peel
+back **whole** when what remains is not a channel. Plain greedy was tried on
+paper and rejected, because the `+` collision turns it into a regression:
+on bahamut's `@+` it strips both bytes of `@+chan` — an ops-level notice to
+the modeless channel `+chan` — finds `chan` is no channel, rolls back, and
+sends the row to `$server`. That target routes correctly today under the
+single-sigil peel, so plain greedy would have traded two fixed shapes for two
+broken ones. Backtracking one sigil at a time until the remainder is a
+channel resolves `@+chan`, `++chan`, `@+#chan` and `@%#chan` with no special
+case for any of them, and leaves the modeless-`+chan` guard where it was.
+
+### `meta.statusmsg` is the whole run, because delivery is a union
+
+`@+#chan` records `"@+"`, not `"@"`. A STATUSMSG target reaches the union of
+the named levels, so that line was seen by ops **and** by voiced members.
+Recording only the outermost sigil would let a consumer badge as ops-only a
+line half the channel read — wrong in the direction that matters, and
+uncorrectable downstream because the `+` would simply be gone. The field was
+already typed `String.t()`, so this needs no schema change; what it changes
+is that consumers must stop assuming length 1.
+
+No sorting step, and none is needed: PREFIX is advertised highest-first and
+clients emit sigils in that order, so a well-formed target arrives already
+ordered. A perverse spelling is recorded as it arrived rather than rewritten.
+Rank could not have been recovered anyway — `parse_prefix/1` ends in
+`Map.new/1` and the map crosses the wire as a JSON object, alphabetical by
+mode letter, so the advertised order is destroyed at parse time and never
+reaches a client. The STATUSMSG list is the one place order survives.
+
+### A wire recipient may carry a sigil; a window key may not
+
+`/notice @#chan` 400ed because the POST boundary tested the raw target
+against the channel regex and the nick regex. `@` and `%` were rejected;
+`+#chan` and `&#chan` passed **by accident**, because `+` and `&` are channel
+prefixes — so the voice-level notice worked while the ops-level one, the form
+operators use most, did not.
+
+The fix is a separate validator rather than a widening of
+`validate_post_target_name/1`, and the deciding measurement is where the row
+is keyed. `handle_notice_send/4` keys the echo to the SOURCE window and
+carries the recipient in `meta.notice_target`, so a sigil on a notice
+recipient never becomes a window key. The plain arm is the opposite: there
+the URL channel is both the wire target and the persist key, so admitting
+`@#chan` would manufacture a phantom `@#chan` window — the outbound twin of
+the very defect fixed above. Two arms, two meanings of "target", two doors.
+
+The target reaches the wire **verbatim**. Peeling to validate is not
+permission to rewrite: what `@%#chan` means is the ircd's ruling, so a
+canonicalised target would answer a question nobody asked, and a refusal on
+our own authority would hide the ircd's error behind ours. If the network
+rejects it, the operator sees the truth.
+
+### One sigil list, from the 005, in one place
+
+`Identifier.peel_statusmsg/2` is now the single answer to "what is a STATUSMSG
+sigil on this network", shared by ingress and egress; the SET still arrives
+from the per-network 005 and is never hardcoded. `EventRouter`'s
+`channel_target?/1` delegates to `Identifier.channel_sigil?/1` rather than
+keeping a second copy of `#&!+`: the peel's contract is that what it returns
+is something the dispatch recognises as a channel, and two independent lists
+would drift into a target that peels in one place and lands in `$server` in
+the other.
+
+`Session.statusmsg/2` is the sibling of `casemapping/2` (#537) and exists for
+the same reason — the stateless POST boundary has no `state.isupport`, and
+only the live session has seen the 005. It degrades to the bahamut default
+rather than the empty set: an empty set would refuse every sigil on a parked
+network, which is precisely the failure this issue reported.
+
+### What this does not reach
+
+The member-prefix sigils are a different, adjacent list, and roughly ten
+sites in `lib/` and `cicchetto/src/` still spell `@`/`%`/`+` by hand for
+ranking, glyphs and tier labels. None of them is STATUSMSG and none is
+touched here; they belong to the #1402 class of hand-narrowed closed sets.
+The badge that renders `meta.statusmsg` still names only two levels and still
+assumes one character — that is #1302, deliberately a separate change.

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -224,6 +224,98 @@ defmodule Grappa.IRC.Identifier do
   def valid_channel?(s) when is_binary(s), do: Regex.match?(@channel_regex, s)
   def valid_channel?(_), do: false
 
+  # RFC 2812 §1.3 channel sigils, as a first-BYTE test. Deliberately the
+  # same four characters `@channel_regex` opens with, and deliberately
+  # weaker than the regex: "does a channel start here" is a different
+  # question from "is this a well-formed channel name", and the STATUSMSG
+  # peel needs the former to decide where a target's name begins.
+  @channel_sigils ["#", "&", "!", "+"]
+
+  @doc """
+  True iff `s` STARTS with an RFC 2812 channel sigil (`#`, `&`, `!`, `+`).
+
+  First byte only — it does not validate the rest of the name. This is the
+  "a channel starts here" test, the single source of truth shared by
+  `EventRouter`'s channel-NOTICE dispatch guard and `peel_statusmsg/2`.
+  The two MUST agree byte-for-byte: the peel's whole contract is that what
+  it hands back is something the dispatch will recognise as a channel, and
+  two independent sigil lists would drift into a target that peels here and
+  routes to `$server` there.
+  """
+  @spec channel_sigil?(term()) :: boolean()
+  def channel_sigil?(<<c::binary-size(1), _::binary>>), do: c in @channel_sigils
+  def channel_sigil?(_), do: false
+
+  @doc """
+  Peels a STATUSMSG prefix off an IRC message target.
+
+  Returns `{underlying channel, peeled run}` when `target` is a channel
+  addressed at one or more membership levels, else `{target unchanged,
+  nil}`. `statusmsg` is the network's advertised sigil set
+  (`ISupport.statusmsg/1`) — never a hardcoded list, because the set is
+  per-network (bahamut `@+`, others `@%+`, UnrealIRCd-shaped networks add
+  owner/admin).
+
+  ## What gets peeled (#218, #1303)
+
+  The LONGEST leading run of advertised sigils whose remainder still starts
+  a channel. A character outside the advertised set is not a sigil — it is
+  part of the name, and the walk stops there.
+
+  Greedy alone is not enough, and the reason is the `+` collision: `+` is
+  both the voice sigil and an RFC channel sigil. On bahamut's `@+`, a plain
+  greedy peel of `@+chan` (an ops-level notice to the modeless channel
+  `+chan`) takes both bytes, finds `chan` is no channel, and has to roll the
+  whole peel back to `$server` — regressing a target the single-sigil peel
+  already routed correctly. Backtracking one sigil at a time until the
+  remainder is a channel resolves `@+chan` to `+chan` at level `@`, and
+  `@+#chan` to `#chan` at level `@+`, without a special case for either.
+
+  Rolling the peel back WHOLE when no split works is what keeps the
+  collision guard honest: `+chan` peels to `chan`, which is no channel, so
+  nothing is peeled and no voice level is invented on a channel anyone can
+  read.
+
+  ## What the run means (#1303 ruling)
+
+  Every peeled sigil, in the order it arrived on the wire — `"@+"`, not
+  `"@"`. A STATUSMSG target reaches the UNION of the named levels, so
+  `@+#chan` was seen by ops AND by voiced members; recording only the
+  outermost would let a consumer claim ops-only for a line half the channel
+  read, with the `+` gone and no reader able to correct it. Consumers MUST
+  NOT assume the run is one character.
+
+  No sorting step: PREFIX is advertised highest-first and clients emit
+  sigils in that order, so a well-formed target arrives already ordered.
+  A perverse spelling is recorded as it arrived rather than rewritten —
+  what was delivered is a fact, and a canonical spelling would be our
+  invention.
+  """
+  @spec peel_statusmsg(binary(), [String.t()]) :: {binary(), String.t() | nil}
+  def peel_statusmsg(target, statusmsg) when is_binary(target) and is_list(statusmsg) do
+    case longest_peel(target, statusmsg, "") do
+      {run, channel} -> {channel, run}
+      nil -> {target, nil}
+    end
+  end
+
+  # Longest-first walk: recurse past this sigil before considering a split
+  # here, so the deepest viable split wins and shorter ones are the fallback.
+  @spec longest_peel(binary(), [String.t()], String.t()) :: {String.t(), binary()} | nil
+  defp longest_peel(rest, statusmsg, run) do
+    case deeper_peel(rest, statusmsg, run) do
+      nil -> if run != "" and channel_sigil?(rest), do: {run, rest}, else: nil
+      deeper -> deeper
+    end
+  end
+
+  @spec deeper_peel(binary(), [String.t()], String.t()) :: {String.t(), binary()} | nil
+  defp deeper_peel(<<sigil::binary-size(1), rest::binary>>, statusmsg, run) do
+    if sigil in statusmsg, do: longest_peel(rest, statusmsg, run <> sigil), else: nil
+  end
+
+  defp deeper_peel(_, _, _), do: nil
+
   @doc """
   Strips a SINGLE leading `~` from a user-supplied IRC ident (GH #152).
 

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -140,12 +140,12 @@ defmodule Grappa.Scrollback.Meta do
                                                                   Its ABSENCE on a :notice row is what
                                                                   marks the row INBOUND.)
       :notice  | :privmsg           →  + %{statusmsg: String.t()}
-                                                                 (#1247: the STATUSMSG membership sigil
+                                                                 (#1247: the STATUSMSG membership level
                                                                   the message was DELIVERED at —
                                                                   `@#chan` reaches channel ops only,
                                                                   `+#chan` voiced members. #218 peels the
-                                                                  sigil to route the row to the channel
-                                                                  window; this is the peeled sigil kept
+                                                                  sigils to route the row to the channel
+                                                                  window; this is what was peeled, kept
                                                                   rather than dropped, so a consumer can
                                                                   tell an ops-only broadcast from one the
                                                                   whole channel saw. Verbatim from the
@@ -155,7 +155,14 @@ defmodule Grappa.Scrollback.Meta do
                                                                   `@%+`) — NOT a closed set this end can
                                                                   enumerate. ABSENT on an ordinary
                                                                   channel message; there is no nil form,
-                                                                  presence IS the test.)
+                                                                  presence IS the test.
+                                                                  #1303: the WHOLE peeled run, not one
+                                                                  character — `@+#chan` records `"@+"`.
+                                                                  A STATUSMSG target reaches the UNION of
+                                                                  the named levels, so recording only the
+                                                                  outermost would badge as ops-only a line
+                                                                  voiced members also read. Consumers MUST
+                                                                  NOT assume length 1.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -84,7 +84,7 @@ defmodule Grappa.Session do
     exports: [Backoff, NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
-  alias Grappa.Session.{FloodAllowance, Server}
+  alias Grappa.Session.{FloodAllowance, ISupport, Server}
 
   require Logger
 
@@ -1308,6 +1308,33 @@ defmodule Grappa.Session do
     case call_session(subject, network_id, :casemapping) do
       mapping when mapping in [:ascii, :rfc1459, :rfc1459_strict] -> mapping
       _ -> :ascii
+    end
+  end
+
+  @doc """
+  Returns the network's IRC `STATUSMSG` sigil set as observed by the LIVE
+  session at `(subject, network_id)` — e.g. `["@", "+"]`, `["@", "%", "+"]`.
+
+  #1301 — sibling of `casemapping/2`, and there for the same reason: the
+  stateless POST boundary has to decide whether `@#chan` is a channel
+  addressed at a membership level or a malformed name, and only the live
+  session has seen the 005 that says which sigils this network has. This is
+  the ingress source `GrappaWeb.Validation.validate_wire_recipient_name/2`
+  feeds into `Identifier.peel_statusmsg/2`.
+
+  Returns the bahamut default (`ISupport.default_statusmsg/0`) whenever there
+  is no live session or the call cannot complete. That is the SAME value a
+  live session reports before its 005 arrives, so a parked network answers
+  what every prod network has always advertised rather than refusing every
+  sigil — and a refusal is the failure mode that matters here, since it is
+  what #1301 reported.
+  """
+  @spec statusmsg(subject(), integer()) :: [String.t()]
+  def statusmsg(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    case call_session(subject, network_id, :statusmsg) do
+      sigils when is_list(sigils) -> sigils
+      _ -> ISupport.default_statusmsg()
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -388,7 +388,7 @@ defmodule Grappa.Session.EventRouter do
   # #218 — a STATUSMSG target (`@#chan` ops-only, `+#chan` voice) is a
   # channel message prefixed with a membership sigil; it belongs in the
   # underlying channel window, NOT the network/`$server` tab or a query
-  # window. Strip a leading statusmsg sigil from a `:notice`/`:privmsg`
+  # window. Strip the statusmsg sigils from a `:notice`/`:privmsg`
   # param-0 target BEFORE canonicalisation + the channel-prefix dispatch,
   # so `build_persist` / `normalize_channel/2` receive a clean `#chan` (no
   # need to widen that head's sigil set, which mirrors
@@ -409,30 +409,20 @@ defmodule Grappa.Session.EventRouter do
   # peeling it to route the row and then discarding it destroys the level at
   # ingress, so no consumer downstream can badge what never reached the store.
   # `nil` when nothing was peeled — the vast majority of traffic.
+  #
+  # #1303 — the peel itself moved to `Identifier.peel_statusmsg/2`, which the
+  # POST boundary needs too (`/notice @#chan` was refused as malformed because
+  # nothing outside this module knew what a sigil was). One definition of
+  # "what is a STATUSMSG sigil on this network" for ingress and egress; the
+  # sigil SET still arrives from the per-network 005, never hardcoded.
   @spec strip_statusmsg_target(Message.t(), [String.t()]) :: {Message.t(), String.t() | nil}
   defp strip_statusmsg_target(%Message{command: cmd, params: [target | rest]} = msg, statusmsg)
        when cmd in [:notice, :privmsg] and is_binary(target) do
-    {stripped, level} = strip_statusmsg_prefix(target, statusmsg)
+    {stripped, level} = Identifier.peel_statusmsg(target, statusmsg)
     {%{msg | params: [stripped | rest]}, level}
   end
 
   defp strip_statusmsg_target(msg, _), do: {msg, nil}
-
-  # Peels ONE leading statusmsg sigil iff (a) it is in the network's
-  # advertised set AND (b) a channel sigil (`#&!+`) immediately follows —
-  # so a real `+chan` (voice-typed channel, `+` NOT followed by a channel
-  # sigil) is never mis-stripped (the `+` collision: `+` is both a channel
-  # sigil and the voice membership sigil). Returns `{underlying channel,
-  # peeled sigil}`, else `{target unchanged, nil}` — the `nil` is what keeps
-  # the collision guard from inventing a voice level on a modeless `+chan`.
-  # Reuses `channel_target?/1` so the "what follows is a channel" test agrees
-  # byte-for-byte with the channel-NOTICE dispatch guard.
-  @spec strip_statusmsg_prefix(binary(), [String.t()]) :: {binary(), String.t() | nil}
-  defp strip_statusmsg_prefix(<<sigil::binary-size(1), rest::binary>> = target, statusmsg) do
-    if sigil in statusmsg and channel_target?(rest), do: {rest, sigil}, else: {target, nil}
-  end
-
-  defp strip_statusmsg_prefix(target, _), do: {target, nil}
 
   # #1247 — record the delivery level on the rows this message produced.
   #
@@ -3092,9 +3082,13 @@ defmodule Grappa.Session.EventRouter do
   # prefix check (not `Identifier.valid_channel?/1`) because the NOTICE
   # site needs it inside a `when` guard where Regex.match? is illegal;
   # routing must not diverge between the two arms for a pathological name.
+  #
+  # #1303 — delegates rather than holding its own copy of the four sigils.
+  # `Identifier.peel_statusmsg/2` hands back a target this arm has to
+  # recognise as a channel; two independent lists would drift into a target
+  # that peels there and lands in `$server` here.
   @spec channel_target?(binary()) :: boolean()
-  defp channel_target?(<<c::binary-size(1), _::binary>>), do: c in ["#", "&", "!", "+"]
-  defp channel_target?(_), do: false
+  defp channel_target?(target), do: Identifier.channel_sigil?(target)
 
   @spec channels_with_member(members(), String.t()) :: [String.t()]
   defp channels_with_member(members, nick) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2552,6 +2552,15 @@ defmodule Grappa.Session.Server do
     {:reply, session_casemapping(state), state}
   end
 
+  # #1301 — the network's advertised STATUSMSG sigil set, for the stateless
+  # POST boundary to tell `@#chan` (a channel at ops level) from a malformed
+  # target. Same `Map.get` hot-reload safety as `:casemapping`. Public via
+  # `Grappa.Session.statusmsg/2`, which degrades to the bahamut default when
+  # there is no live pid.
+  def handle_call(:statusmsg, _, state) do
+    {:reply, ISupport.statusmsg(Map.get(state, :isupport, ISupport.default())), state}
+  end
+
   # #247 — the authoritative /notify presence map for this session.
   # Public via `Grappa.Session.presence_snapshot/2`; consumed by the
   # channel after-join snapshot and the REST notify listing (DB list +

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -57,7 +57,12 @@ defmodule GrappaWeb.MessagesController do
   """
   use GrappaWeb, :controller
 
-  import GrappaWeb.Validation, only: [validate_target_name: 1, validate_post_target_name: 1]
+  import GrappaWeb.Validation,
+    only: [
+      validate_target_name: 1,
+      validate_post_target_name: 1,
+      validate_wire_recipient_name: 2
+    ]
 
   alias Grappa.IRC.Identifier
   alias Grappa.PresenceFilter.Resolver
@@ -263,14 +268,15 @@ defmodule GrappaWeb.MessagesController do
     # #640 — a CTCP QUERY (/ctcp, /ping). `channel` (the URL) is the SOURCE
     # window the echo renders in — `validate_target_name` (NOT the post variant)
     # so `$server` is allowed (a /ping typed in the server window is legit).
-    # `ctcp_target` is the wire recipient — `validate_post_target_name` (a real
-    # channel/nick, never the read-only `$server`). The session persists the
-    # echo to `source`, relays the frame to `ctcp_target`, and NEVER opens a
-    # query window for it (the phantom-window bug). One send-token as for a
-    # plain PRIVMSG. `send_ctcp` always persists a row (no `:no_persist` arm).
+    # `ctcp_target` is the wire recipient — `validate_wire_recipient_name` (a
+    # real channel/nick, a channel at a membership level, never the read-only
+    # `$server`). The session persists the echo to `source`, relays the frame
+    # to `ctcp_target`, and NEVER opens a query window for it (the
+    # phantom-window bug). One send-token as for a plain PRIVMSG. `send_ctcp`
+    # always persists a row (no `:no_persist` arm).
     with :ok <- BodyLimit.check(body),
          :ok <- validate_target_name(channel),
-         :ok <- validate_post_target_name(ctcp_target),
+         :ok <- validate_wire_recipient_name(ctcp_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_ctcp(subject, network.id, channel, ctcp_target, body) do
       render_send_result(conn, result)
@@ -285,13 +291,15 @@ defmodule GrappaWeb.MessagesController do
     # #1225 — `/notice <target> <text>`. Same door shape as the #640 CTCP arm
     # above: `channel` (the URL) is the SOURCE window the echo renders in, so it
     # takes `validate_target_name` (a `/notice` typed in `$server` is legit);
-    # `notice_target` is the wire recipient, so it takes the POST variant (a
-    # real nick or channel, never the read-only `$server`). One send-token, as
-    # for a plain PRIVMSG. A *serv recipient answers `{:ok, :no_persist}` (W12),
-    # which `render_send_result/2` already renders as 202.
+    # `notice_target` is the wire recipient, so it takes the recipient variant
+    # (a real nick or channel, or a channel at a membership level per #1301,
+    # never the read-only `$server`). One send-token, as for a plain PRIVMSG.
+    # A *serv recipient answers `{:ok, :no_persist}` (W12), which
+    # `render_send_result/2` already renders as 202.
     with :ok <- BodyLimit.check(body),
          :ok <- validate_target_name(channel),
-         :ok <- validate_post_target_name(notice_target),
+         :ok <-
+           validate_wire_recipient_name(notice_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_notice(subject, network.id, channel, notice_target, body) do
       render_send_result(conn, result)

--- a/lib/grappa_web/validation.ex
+++ b/lib/grappa_web/validation.ex
@@ -134,7 +134,7 @@ defmodule GrappaWeb.Validation do
   @spec validate_wire_recipient_name(String.t(), [String.t()]) :: :ok | {:error, :bad_request}
   def validate_wire_recipient_name(name, statusmsg)
       when is_binary(name) and is_list(statusmsg) do
-    {peeled, _run} = Identifier.peel_statusmsg(name, statusmsg)
+    {peeled, _} = Identifier.peel_statusmsg(name, statusmsg)
     validate_post_target_name(peeled)
   end
 

--- a/lib/grappa_web/validation.ex
+++ b/lib/grappa_web/validation.ex
@@ -92,12 +92,51 @@ defmodule GrappaWeb.Validation do
   bytes upstream, pollute the synthetic Server-window scrollback via the
   single-source echo path, and probe operator privileges. The synthetic
   is for *reading* server-window scrollback, never for *writing*.
-  Used by `MessagesController.create/2`.
+
+  Used by `MessagesController.create/2`'s plain arm, where the target is
+  ALSO the persist key. The notice/CTCP arms take
+  `validate_wire_recipient_name/2` instead — see there for why a wire
+  recipient may carry a STATUSMSG sigil and a window key may not.
   """
   @spec validate_post_target_name(String.t()) :: :ok | {:error, :bad_request}
   def validate_post_target_name("$server"), do: {:error, :bad_request}
 
   def validate_post_target_name(name), do: validate_target_name(name)
+
+  @doc """
+  Like `validate_post_target_name/1` but for a WIRE RECIPIENT: additionally
+  accepts a channel addressed at a membership level (`@#chan`, `@%#chan`),
+  peeling the network's advertised STATUSMSG sigils before testing the name
+  behind them. `statusmsg` comes from `Grappa.Session.statusmsg/2`.
+
+  #1301 — `/notice @#chan` was refused as malformed. A STATUSMSG sigil is
+  neither a channel prefix nor a nick character, so the raw target matched
+  neither validator and the POST 400ed. `@` and `%` were refused outright;
+  `+#chan` and `&#chan` passed, but by accident — `+` and `&` are RFC
+  channel prefixes, so the voice-level notice worked while the ops-level
+  one, the common case, did not.
+
+  ## Why this is a separate validator, not a widening
+
+  `validate_post_target_name/1` also guards the plain `channel_id` arm,
+  where the target IS the persist key. Admitting `@#chan` there would key
+  scrollback to a window nobody is in — the outbound twin of the phantom
+  `+#chan` window #1303 fixes on the inbound side. On the notice/CTCP arms
+  the recipient is not a key: the echo row is keyed to the SOURCE window and
+  the recipient rides `meta.notice_target`, so a sigil costs nothing there.
+  The two arms differ in what the target IS, so they take different doors.
+
+  The peeled remainder is what gets validated; the target reaches the wire
+  **verbatim**. Peeling to validate is not permission to rewrite — what
+  `@%#chan` means is the ircd's ruling, and a target we canonicalised (or
+  refused on our own authority) would answer a question nobody asked.
+  """
+  @spec validate_wire_recipient_name(String.t(), [String.t()]) :: :ok | {:error, :bad_request}
+  def validate_wire_recipient_name(name, statusmsg)
+      when is_binary(name) and is_list(statusmsg) do
+    {peeled, _run} = Identifier.peel_statusmsg(name, statusmsg)
+    validate_post_target_name(peeled)
+  end
 
   @doc """
   Atomizes a whitelisted subset of string-keyed `params` into an

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -212,12 +212,6 @@ defmodule Grappa.IRC.IdentifierTest do
       assert Identifier.peel_statusmsg("@+#chan", @bahamut) == {"#chan", "@+"}
     end
 
-    test "the run records EVERY level, so a consumer cannot claim ops-only for a line voice also saw" do
-      {_, run} = Identifier.peel_statusmsg("@+#chan", @bahamut)
-      assert run == "@+"
-      refute run == "@"
-    end
-
     test "collision guard: a modeless +chan is left whole and records no level" do
       # `+chan` is a CHANNEL named `+chan`, not a voice-targeted `+#chan`.
       # Peeling the `+` would leave `chan`, which is not a channel, so the

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -162,6 +162,117 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
+  describe "channel_sigil?/1" do
+    test "true for the four RFC channel sigils" do
+      assert Identifier.channel_sigil?("#chan")
+      assert Identifier.channel_sigil?("&local")
+      assert Identifier.channel_sigil?("!safe")
+      assert Identifier.channel_sigil?("+modeless")
+    end
+
+    test "false for a nick, a statusmsg sigil, and the empty string" do
+      refute Identifier.channel_sigil?("someone")
+      refute Identifier.channel_sigil?("@#chan")
+      refute Identifier.channel_sigil?("")
+    end
+
+    test "first byte only — it does NOT validate the rest of the name" do
+      # Deliberately weaker than `valid_channel?/1`: this is the
+      # "does a channel start here" test the STATUSMSG peel needs, and it
+      # must agree byte-for-byte with the channel-NOTICE dispatch guard in
+      # EventRouter. A name `valid_channel?/1` would reject still answers
+      # true here.
+      assert Identifier.channel_sigil?("#with space")
+      refute Identifier.valid_channel?("#with space")
+    end
+  end
+
+  # #1303 — a STATUSMSG target can carry MORE THAN ONE sigil (`@%#chan` on a
+  # network advertising `@%+`), and the single-sigil peel misrouted both
+  # shapes it can meet: `@%#chan` peeled nothing (the remainder `%#chan` is
+  # not a channel) and landed in `$server`, while `@+#chan` peeled only the
+  # `@` and persisted to `+#chan` — a phantom channel nobody is in.
+  describe "peel_statusmsg/2 (#218 single sigil, #1303 the whole run)" do
+    @bahamut ["@", "+"]
+    @halfop ["@", "%", "+"]
+
+    test "peels one advertised sigil off a channel target — the #218 case" do
+      assert Identifier.peel_statusmsg("@#chan", @bahamut) == {"#chan", "@"}
+      assert Identifier.peel_statusmsg("+#chan", @bahamut) == {"#chan", "+"}
+    end
+
+    test "#1303 case A: @%#chan peels BOTH and records the whole run" do
+      assert Identifier.peel_statusmsg("@%#chan", @halfop) == {"#chan", "@%"}
+    end
+
+    test "#1303 case B: @+#chan resolves to #chan, NOT the phantom +#chan" do
+      # The silent one. `+` is a channel sigil in its own right, so the
+      # single peel accepted `+#chan` as the underlying channel and wrote
+      # scrollback to a window nobody is in.
+      assert Identifier.peel_statusmsg("@+#chan", @bahamut) == {"#chan", "@+"}
+    end
+
+    test "the run records EVERY level, so a consumer cannot claim ops-only for a line voice also saw" do
+      {_, run} = Identifier.peel_statusmsg("@+#chan", @bahamut)
+      assert run == "@+"
+      refute run == "@"
+    end
+
+    test "collision guard: a modeless +chan is left whole and records no level" do
+      # `+chan` is a CHANNEL named `+chan`, not a voice-targeted `+#chan`.
+      # Peeling the `+` would leave `chan`, which is not a channel, so the
+      # whole peel rolls back.
+      assert Identifier.peel_statusmsg("+chan", @bahamut) == {"+chan", nil}
+    end
+
+    test "backtracks to the LONGEST run whose remainder is still a channel: @+chan" do
+      # `+chan` is a real modeless channel and `@` is the level. A peel that
+      # took every advertised sigil greedily without backtracking would
+      # strip `@+`, find `chan` is not a channel, roll the whole thing back,
+      # and misroute an ops-only notice to `$server` — a REGRESSION of what
+      # the single-sigil peel already got right.
+      assert Identifier.peel_statusmsg("@+chan", @bahamut) == {"+chan", "@"}
+    end
+
+    test "backtracks when the sigil and the channel prefix are the same byte: ++chan" do
+      assert Identifier.peel_statusmsg("++chan", @bahamut) == {"+chan", "+"}
+    end
+
+    test "a sigil the network does not advertise is part of the name, not a level" do
+      # Under bahamut's `@+` there is no halfop level, so `%#chan` is not a
+      # STATUSMSG target at all and must not be peeled.
+      assert Identifier.peel_statusmsg("%#chan", @bahamut) == {"%#chan", nil}
+    end
+
+    test "a plain channel and a plain nick pass through untouched" do
+      assert Identifier.peel_statusmsg("#chan", @bahamut) == {"#chan", nil}
+      assert Identifier.peel_statusmsg("someone", @bahamut) == {"someone", nil}
+    end
+
+    test "a sigil with nothing usable behind it is not a peel" do
+      assert Identifier.peel_statusmsg("@", @bahamut) == {"@", nil}
+      assert Identifier.peel_statusmsg("@someone", @bahamut) == {"@someone", nil}
+      assert Identifier.peel_statusmsg("", @bahamut) == {"", nil}
+    end
+
+    test "an empty advertised set peels nothing" do
+      # A network that advertises `STATUSMSG=` with no sigils has no levels;
+      # every target is its own name.
+      assert Identifier.peel_statusmsg("@#chan", []) == {"@#chan", nil}
+    end
+
+    test "the run is the order the sigils arrived on the wire — no sort, no rewrite" do
+      # On a well-formed target the wire order IS the advertised order
+      # (PREFIX is advertised highest-first and clients emit it that way),
+      # which is why no sorting step is needed. What this pins is that we do
+      # not INVENT an order: a target that arrives `%@#chan` records `"%@"`,
+      # the truth of what was delivered, rather than being rewritten into a
+      # canonical spelling we made up.
+      assert Identifier.peel_statusmsg("@%#chan", @halfop) == {"#chan", "@%"}
+      assert Identifier.peel_statusmsg("%@#chan", @halfop) == {"#chan", "%@"}
+    end
+  end
+
   describe "sanitize_ident/1" do
     test "strips a single leading tilde (the identd-verified anti-spoof guard)" do
       # grappa runs no identd; the ircd tilde-prefixes unverified idents.

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -440,6 +440,36 @@ defmodule Grappa.Session.EventRouterPropertyTest do
     end
   end
 
+  # #1303 — the single-sigil peel broke on a target carrying more than one,
+  # and WHICH way it broke depended on the second sigil: `@%#chan` peeled
+  # nothing and landed in `$server`, `@+#chan` peeled one and persisted to a
+  # phantom `+#chan`. The property covers every run the advertised set can
+  # spell, so neither shape depends on a unit example being remembered.
+  property "#1303: a multi-sigil STATUSMSG target routes to the channel and records the whole run" do
+    check all(
+            body <- ascii_nick_gen(),
+            run <- list_of(member_of(["@", "+"]), min_length: 1, max_length: 3)
+          ) do
+      channel = "#" <> body
+      prefix = Enum.join(run)
+
+      m = %Message{
+        command: :notice,
+        params: [prefix <> channel, "ops heads up"],
+        prefix: {:nick, "someuser", "u", "h"},
+        tags: %{}
+      }
+
+      assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, min_state())
+
+      assert attrs.channel == String.downcase(channel),
+             "statusmsg target #{prefix <> channel} should route to #{String.downcase(channel)}, got #{attrs.channel}"
+
+      assert attrs.meta.statusmsg == prefix,
+             "target #{prefix <> channel} should record the whole run #{prefix}, got #{inspect(attrs.meta[:statusmsg])}"
+    end
+  end
+
   property "#218 collision: a bare +channel (no channel sigil after +) is never mis-stripped" do
     check all(body <- ascii_nick_gen()) do
       # `ascii_nick_gen` never starts with a channel sigil, so `+<body>` is

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1482,6 +1482,121 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
+  # #1303 — a target may carry MORE THAN ONE sigil, and the single-sigil peel
+  # broke in two different directions depending on which sigil sat second.
+  # Both are ingress misroutes: one loud (`$server`), one silent (a channel
+  # window nobody is in). The row-level assertions live here because the
+  # peel's whole purpose is where the row LANDS; `IdentifierTest` pins the
+  # peel itself.
+  describe "route/2 — #1303 multi-sigil STATUSMSG targets" do
+    test "case A: @%#chan lands in the channel window, not $server" do
+      # `@` peeled, remainder `%#chan` was not a channel, so the old guard
+      # declined the peel entirely and the non-channel arm took the row.
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:notice, ["@%#italia", "ops and halfops"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      refute attrs.channel == "$server"
+    end
+
+    test "case B: @+#chan lands in #chan, NOT the phantom +#chan" do
+      # The silent one: `+#chan` passes the channel-prefix test, so the row
+      # was persisted and broadcast against a channel nobody is in. It reads
+      # to the operator as "the message vanished".
+      state = base_state()
+
+      m = msg(:notice, ["@+#italia", "ops and voice"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      refute attrs.channel == "+#italia"
+    end
+
+    test "the recorded level is the WHOLE run, not the outermost sigil" do
+      # A STATUSMSG target reaches the UNION of the named levels, so
+      # `@+#chan` was seen by ops AND by voiced members. Recording `"@"`
+      # would badge as ops-only a line half the channel read, and no reader
+      # could correct it because the `+` would simply be gone.
+      state = base_state()
+
+      m = msg(:notice, ["@+#italia", "ops and voice"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "@+"
+    end
+
+    test "the run is per-network: the same target records less where the level is unadvertised" do
+      # Under bahamut's `@+` there is no halfop level, so `@%#chan` peels
+      # only the `@` and `%#italia` is the channel name as far as we know.
+      # `%` not being advertised makes it part of the name, not a level —
+      # and the row must NOT claim a halfop delivery that this network
+      # cannot express.
+      state = base_state()
+
+      m = msg(:notice, ["@%#italia", "ops and halfops"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      refute attrs.meta[:statusmsg] == "@%"
+    end
+
+    test "PRIVMSG takes the same ingress door as NOTICE" do
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:privmsg, ["@%#italia", "ops chatter"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      assert attrs.meta.statusmsg == "@%"
+    end
+
+    test "multi-sigil peel THEN casefold: @%#Italia keys the folded channel" do
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:notice, ["@%#Italia", "casefold me"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, %{channel: "#italia"}}]} =
+               EventRouter.route(m, state)
+    end
+
+    test "regression guard: @+chan still resolves to the modeless channel +chan" do
+      # `+chan` is a real channel and `@` is the level. Peeling every
+      # advertised sigil without backtracking would strip `@+`, find `chan`
+      # is no channel, roll the peel back whole, and send an ops-only notice
+      # to `$server` — breaking a case the single-sigil peel already got
+      # right. Control for the two cases above: it must be green BEFORE the
+      # fix as well as after.
+      state = base_state()
+
+      m = msg(:notice, ["@+chan", "ops of a modeless channel"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "+chan"
+      assert attrs.meta.statusmsg == "@"
+    end
+
+    test "regression guard: ++chan still resolves to +chan at the voice level" do
+      state = base_state()
+
+      m = msg(:notice, ["++chan", "voiced of a modeless channel"], {:nick, "v", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "+chan"
+      assert attrs.meta.statusmsg == "+"
+    end
+  end
+
   describe "route/2 — #127 server-reply modals (INFO/VERSION/MOTD)" do
     # Explicit /motd primes state.motd_pending; the 375/372 burst folds and
     # 376 RPL_ENDOFMOTD drains ONE {:server_reply, :motd, lines} effect in

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -451,6 +451,72 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "statusmsg/2 (#1301)" do
+    # Sibling of `casemapping/2` and for the same reason: the POST boundary
+    # must decide whether `@#chan` is a STATUSMSG target on THIS network, and
+    # only the live session has seen the 005 that says so. Degrades to the
+    # bahamut default (`["@", "+"]`) with no live pid — the same value a
+    # session that has not yet seen a 005 reports, so a parked network answers
+    # what prod has always assumed rather than refusing every sigil.
+
+    test "returns the live session's advertised STATUSMSG set once a 005 carries it" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 005 grappa-test STATUSMSG=@%+ PREFIX=(ohv)@%+ :are supported\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :isupport_changed}
+                     },
+                     1_000
+
+      assert Session.statusmsg({:user, user.id}, network.id) == ["@", "%", "+"]
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "returns the bahamut default before any 005 STATUSMSG" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert Session.statusmsg({:user, user.id}, network.id) == ISupport.default_statusmsg()
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "returns the bahamut default when no session is registered" do
+      assert Session.statusmsg({:user, Ecto.UUID.generate()}, -1) == ISupport.default_statusmsg()
+    end
+  end
+
   describe "init/1 non-blocking (C2)" do
     # Pairs with `Grappa.IRC.ClientTest`'s C2 test. `Session.Server.init/1`
     # must NOT call `Client.start_link/1` synchronously: Bootstrap iterates

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -294,6 +294,62 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#1301: notice_target = @#chan reaches the wire VERBATIM and echoes to the source window",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # `/notice @#sniffo heads up` — the form operators use most, refused as
+      # malformed before #1301 because the raw `@#sniffo` matched neither the
+      # channel regex nor the nick regex at the POST boundary.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "heads up",
+          "notice_target" => "@#sniffo"
+        })
+
+      body = json_response(conn, 201)
+      assert body["channel"] == "#sniffo"
+      assert body["meta"]["notice_target"] == "@#sniffo"
+
+      # VERBATIM on the wire: the sigil is peeled to VALIDATE, never to
+      # rewrite. What `@#sniffo` means is the ircd's ruling, not ours, so a
+      # canonicalised target would be us answering a question we were not
+      # asked — and a refusal would be us inventing one.
+      assert {:ok, "NOTICE @#sniffo :heads up\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE @"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#1301: a sigil is still refused on the URL channel_id — that one IS a window key",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # The control for the test above. On the plain arm the URL channel is
+      # BOTH the wire target and the persist key, so admitting a sigil here
+      # would key scrollback to `@#sniffo` — a window nobody is in, the
+      # outbound twin of #1303 case B. The two arms take deliberately
+      # different validators.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%40%23sniffo/messages", %{
+          "body" => "heads up"
+        })
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "#1225: a /notice to NickServ does not archive a mistyped identify password",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()

--- a/test/grappa_web/validation_test.exs
+++ b/test/grappa_web/validation_test.exs
@@ -87,4 +87,78 @@ defmodule GrappaWeb.ValidationTest do
                %{nick: "vjt"}
     end
   end
+
+  # #1301 — `/notice @#chan` was refused as malformed. The wire recipient of a
+  # NOTICE/CTCP is not a window key: it may carry the network's STATUSMSG
+  # sigils, which are neither a channel prefix nor a nick character, so the
+  # raw target matched neither validator and the POST 400ed.
+  #
+  # This is a SEPARATE validator rather than a widening of
+  # `validate_post_target_name/1`: that one also guards the `channel_id` arm,
+  # where the target IS the persist key, so admitting `@#chan` there would
+  # manufacture a phantom `@#chan` window on the outbound side — the exact
+  # defect #1303 fixes on the inbound side.
+  describe "validate_wire_recipient_name/2 (#1301)" do
+    @bahamut ["@", "+"]
+    @halfop ["@", "%", "+"]
+
+    test "accepts an ops-level channel target — the reported case" do
+      assert Validation.validate_wire_recipient_name("@#chan", @bahamut) == :ok
+    end
+
+    test "accepts a multi-sigil target: the ircd is the authority on what it means" do
+      assert Validation.validate_wire_recipient_name("@%#chan", @halfop) == :ok
+    end
+
+    test "the sigil set is per-network: an unadvertised level is not a sigil" do
+      # A `%` prefix on bahamut (`STATUSMSG=@+`) is not a level — it is a
+      # channel name starting with `%`, which is not a legal channel.
+      assert Validation.validate_wire_recipient_name("%#chan", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("%#chan", @halfop) == :ok
+    end
+
+    test "a plain channel and a plain nick are unaffected" do
+      assert Validation.validate_wire_recipient_name("#chan", @bahamut) == :ok
+      assert Validation.validate_wire_recipient_name("carol", @bahamut) == :ok
+      assert Validation.validate_wire_recipient_name("+chan", @bahamut) == :ok
+    end
+
+    test "a sigil does not smuggle the read-only $server synthetic" do
+      # `validate_post_target_name/1` rejects `$server` because a write to it
+      # is an RFC 2812 server-mask PRIVMSG. Peeling must not open a side door:
+      # `@` in front of it peels nothing (there is no channel behind it), so
+      # the refusal stands on the raw target.
+      assert Validation.validate_wire_recipient_name("$server", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("@$server", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "a sigil in front of a NICK is not a STATUSMSG target" do
+      # STATUSMSG addresses a channel at a membership level. `@carol` is
+      # neither a channel nor a legal nick, and inventing an acceptance for it
+      # would ship a target no ircd can route.
+      assert Validation.validate_wire_recipient_name("@carol", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "the peel does not weaken the channel-shape check behind it" do
+      # The peel tests only the first byte of the remainder; the FULL channel
+      # validator still runs on it. A space or a CRLF behind a sigil must stay
+      # refused — the alternative is a target that splits the wire line.
+      assert Validation.validate_wire_recipient_name("@#with space", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("@#chan\r\nQUIT", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "an empty advertised set falls back to the plain target rules" do
+      assert Validation.validate_wire_recipient_name("#chan", []) == :ok
+      assert Validation.validate_wire_recipient_name("@#chan", []) == {:error, :bad_request}
+    end
+  end
 end


### PR DESCRIPTION
Fixes the two server-side halves of the STATUSMSG group: #1303 (inbound
misroute) and #1301 (outbound refusal). #1302, the cic badge, is
deliberately a separate change.

## #1303 — a multi-sigil target misrouted, one of the two silently

`strip_statusmsg_prefix/2` peeled exactly one sigil and accepted the
result only if what remained started a channel. Two outcomes followed,
depending on which sigil sat second:

- `@%#chan` — `@` peels, `%#chan` is not a channel, the guard declines
  the peel whole, the row lands in `$server`. Loud.
- `@+#chan` — `@` peels and `+#chan` **passes**, because `+` is an RFC
  channel prefix in its own right. The row is persisted and broadcast
  against a channel nobody is in. Silent: it reads as "the message
  vanished", not "the message went to the wrong tab".

The peel now takes the longest leading run of advertised sigils whose
remainder still starts a channel, rolling back whole when no split
works. **Plain greedy was rejected because it regresses two targets
that work today**: on bahamut's `@+`, `@+chan` and `++chan` are
ops-level and voice-level notices to the modeless channel `+chan`, and
a peel with no backtracking strips both bytes, finds `chan` is no
channel, rolls back, and sends them to `$server`. Both are covered by
regression guards that were green before this change.

`meta.statusmsg` now carries the whole peeled run (`"@+"`, not `"@"`).
A STATUSMSG target reaches the union of the named levels, so recording
only the outermost would badge as ops-only a line voiced members also
read. **Consumers must stop assuming length 1** — the field was already
`String.t()`, so no schema change.

## #1301 — `/notice @#chan` was refused as malformed

The POST boundary tested the raw target against the channel regex and
the nick regex, and a membership sigil is neither. `@` and `%` were
rejected; `+#chan` and `&#chan` passed **by accident**, because `+` and
`&` are channel prefixes — so the voice-level notice worked while the
ops-level one, the form operators use most, did not.

This adds a separate `validate_wire_recipient_name/2` rather than
widening `validate_post_target_name/1`, and the measurement is where
the row is keyed: `handle_notice_send/4` keys the echo to the SOURCE
window and carries the recipient in `meta.notice_target`, so a sigil on
a notice recipient never becomes a window key. The plain arm is the
opposite — there the URL channel is both target and key, so admitting
`@#chan` would manufacture a phantom `@#chan` window, the outbound twin
of the defect above. A test pins that the plain arm still refuses it.

The target reaches the wire **verbatim**: peeling to validate is not
permission to rewrite. What `@%#chan` means is the ircd's ruling, and a
refusal on our own authority would hide the ircd's error behind ours.

`Session.statusmsg/2` is the sibling of `casemapping/2` (#537) — the
stateless POST boundary has no `state.isupport`. It degrades to the
bahamut default rather than the empty set, because an empty set would
refuse every sigil on a parked network, which is the reported failure.

## One sigil list

`Identifier.peel_statusmsg/2` is now the single answer to "what is a
STATUSMSG sigil on this network", shared by ingress and egress, with
the set still read from the per-network 005. `EventRouter`'s
`channel_target?/1` delegates to `Identifier.channel_sigil?/1` instead
of keeping a second copy of `#&!+`.

## Gates

- `scripts/check.sh` RC=0 (rc read from the log file): 8 doctests, 61
  properties, 6445 tests, 0 failures; Dialyzer `Total errors: 0`; bats
  0 `not ok`; format, Credo, Sobelow clean.
- Red first, by displacement: with `lib/` checked out at the base and
  the tests committed, the router and controller suites fail by name —
  `@%#chan` to `$server`, `@+#chan` to `+#italia`, the run recorded as
  `"@"`, and `400 bad_request` on the notice. The controls
  (`@+chan`, `++chan`, the per-network run, the URL-arm refusal) were
  green before the fix.
- Seven mutants, none surviving. Three kill exactly one assertion each:
  widening the shared validator onto the plain arm, rewriting the
  target before the wire, and degrading `statusmsg/2` to the empty set.
  A shortest-first peel kills only the `@+#chan` family and leaves
  `@%#chan` green, so the two cases are discriminated rather than
  covered by one blanket assertion.

## Not in this change

The member-prefix sigils are a different, adjacent list, and about ten
sites still spell `@`/`%`/`+` by hand for ranking, glyphs and tier
labels — that is the #1402 class. The badge that renders
`meta.statusmsg` still names two levels and still assumes one
character: #1302.