### PR TITLE
wire(#1406): pin the closed sets that never reached the codegen (X-S8 + X-S9)

### DIFF
--- a/cicchetto/src/lib/themesApi.ts
+++ b/cicchetto/src/lib/themesApi.ts
@@ -17,23 +17,22 @@
 import { buildHeaders, readError } from "./api";
 import { getOrCreateClientId } from "./clientId";
 import { narrowThemeResponse } from "./wireNarrow";
-import type { ThemesWireT } from "./wireTypes";
+import type { ThemesWireBackgroundSize, ThemesWireFontFamily, ThemesWireT } from "./wireTypes";
 
-// The closed font-family allow-list — mirror of
-// `Grappa.Themes.TokenModel.font_families/0`. `mono-default` maps to the
-// existing `--font-mono` stack (no font file); the rest each get a
-// self-hosted `@font-face` (sub-task 8, deferred).
-export type ThemeFontFamily =
-  | "mono-default"
-  | "jetbrains-mono"
-  | "fira-code"
-  | "iosevka"
-  | "hack"
-  | "cascadia-code"
-  | "source-code-pro"
-  | "ibm-plex-mono";
+// The closed font-family allow-list — #1406 X-S9, DERIVED from
+// `Grappa.Themes.TokenModel.font_families/0` (the same list `sanitize_font/1`
+// guards with) instead of mirrored by hand. `mono-default` maps to the existing
+// `--font-mono` stack (no font file); the rest each get a self-hosted
+// `@font-face` (sub-task 8, deferred).
+export type ThemeFontFamily = ThemesWireFontFamily;
 
-// The 27 color keys — mirror of `Grappa.Themes.TokenModel.color_keys/0`.
+// The 27 color keys — still a HAND mirror of
+// `Grappa.Themes.TokenModel.color_keys/0`, and the one vocabulary #1406 X-S9
+// leaves unpinned: `nick_${number}` is a pattern template literal that TS
+// degrades to an index signature, so narrowing it to the server's exact 16
+// nick slots is a behaviour change (a payload missing `nick_5` type-checks
+// today and would stop) with real consumer fallout, not a re-export. Declared
+// debt, tracked on #1406, deliberately out of this slice.
 // Each value is a strict `#rrggbb` string (validated server-side; cic
 // treats them as opaque CSS color literals via `customTheme.ts`).
 export type ThemeColorKey =
@@ -56,10 +55,11 @@ export type TokenColors = Record<ThemeColorKey, string>;
 // Producers can only express what this allows; anything else is dropped
 // server-side (safe-by-construction). `customTheme.ts` consumes this to
 // generate scoped CSS custom properties.
-// Background sizing — mirror of `Grappa.Themes.TokenModel.size_modes/0`.
-// `cover` = full-bleed (the v1 built-in set + every upload); `repeat` =
-// seamless tile (the deferred #294 pattern set).
-export type ThemeBackgroundSize = "cover" | "repeat";
+// Background sizing — #1406 X-S9, derived from
+// `Grappa.Themes.TokenModel.size_modes/0`. `cover` = full-bleed (the v1
+// built-in set + every upload); `repeat` = seamless tile (the deferred #294
+// pattern set).
+export type ThemeBackgroundSize = ThemesWireBackgroundSize;
 
 export type TokenPayload = {
   colors: TokenColors;
@@ -79,7 +79,15 @@ export type TokenPayload = {
 };
 
 // One entry in the built-in background catalog (`GET /themes/backgrounds`) —
-// mirror of `Grappa.Themes.BuiltinBackgrounds.t`. The picker consumes this;
+// still a HAND mirror of `Grappa.Themes.BuiltinBackgrounds.t`, and the second
+// vocabulary #1406 X-S9 leaves unpinned. Not for lack of trying: the
+// re-export was written and MEASURED, and the codegen cannot render that type
+// — `t/0`'s `variant: variant()` is a same-module ref the external-type path
+// has no registry for, so the generated files came out with `variant: Variant`
+// (TS2304, a name nothing declares) and a `THEMES_BUILTIN_BACKGROUNDS_VARIANT`
+// import (TS2724, a const neither emitter declares). The fix belongs to the
+// emitter; restating the four fields server-side to route around it would have
+// been the same twin this slice exists to delete. The picker consumes this;
 // `path` is the static /backgrounds/<key>.webp URL the asset is served at.
 export type BuiltinBackground = {
   key: string;

--- a/cicchetto/src/lib/windowState.ts
+++ b/cicchetto/src/lib/windowState.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
 import { selectedChannel } from "./selection";
+import type { SessionWireWindowState } from "./wireTypes";
 
 // CP15 B5: cic mirror of the server-side per-(network, channel) window
 // state machine. The server splits state across three maps so each
@@ -29,7 +30,15 @@ import { selectedChannel } from "./selection";
 // all three maps are emptied so a new bearer doesn't see the prior
 // tenant's window states.
 
-export type WindowState = "pending" | "invited" | "joined" | "failed" | "kicked" | "parked";
+// #1406 X-S8 — DERIVED from the server SSOT, not transcribed. This used to be
+// a hand-written six-token union: CLAUDE.md says adding a state is a server
+// change cic just mirrors, but the mirror was a copy nothing would have
+// widened. `Grappa.Session.Wire` now re-exports
+// `Grappa.Session.WindowState.window_state/0`, so a seventh state arrives here
+// on the next `grappa.gen_wire_types` run and tsc reports every site that does
+// not handle it. Aliasing (rather than pinning a copy with `Equal<>`) is the
+// #410 / `WireAdminEvent` posture: a derived type cannot drift by construction.
+export type WindowState = SessionWireWindowState;
 
 export type WindowFailure = {
   reason: string | null;

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -25,12 +25,15 @@ import {
   NETWORKS_NETWORK_SERVICES_FLAVOR,
   SCROLLBACK_MESSAGE_KIND,
   SESSION_LOG_EVENT,
+  SESSION_WINDOW_STATE_WINDOW_STATE,
   SESSION_WIRE_RECOVER_OUTCOME,
   SESSION_WIRE_RECOVER_REASON,
   SESSION_WIRE_RECOVER_STATUS,
   SESSION_WIRE_RECOVER_STEP,
   SESSION_WIRE_SERVER_REPLY_SOURCE,
   SESSION_WIRE_WIRE_EVENT_KIND,
+  THEMES_TOKEN_MODEL_FONT_FAMILY,
+  THEMES_TOKEN_MODEL_SIZE_MODE,
   WINDOW_COUNTS_SEVERITY,
 } from "./wireTypes";
 
@@ -910,6 +913,11 @@ export const S_ServerSettingsWireChangedPayload = {
 // Grappa.Session.ISupport.casemapping/0
 export const S_SessionISupportCasemapping = S_IRCIdentifierCasemapping;
 
+// Grappa.Session.WindowState.window_state/0
+export const S_SessionWindowStateWindowState = {
+  e: [...SESSION_WINDOW_STATE_WINDOW_STATE],
+} as const;
+
 // Grappa.Session.Wire.away_confirmed_payload/0
 export const S_SessionWireAwayConfirmedPayload = {
   o: { kind: { l: "away_confirmed" }, network: "s", state: { e: ["present", "away"] } },
@@ -1339,6 +1347,9 @@ export const S_SessionWireWindowPendingPayload = {
   o: { kind: { l: "window_pending" }, network: "s", channel: "s", state: { l: "pending" } },
 } as const;
 
+// Grappa.Session.Wire.window_state/0
+export const S_SessionWireWindowState = S_SessionWindowStateWindowState;
+
 // Grappa.Session.Wire.wire_event_kind/0
 export const S_SessionWireWireEventKind = { e: [...SESSION_WIRE_WIRE_EVENT_KIND] } as const;
 
@@ -1382,6 +1393,18 @@ export const S_SessionLogWireSessionsResult = {
 export const S_SubjectSearchAdminWireResultJson = {
   o: { type: { e: ["user", "visitor"] }, id: "s", network: { u: ["s", "z"] }, nick: "s" },
 } as const;
+
+// Grappa.Themes.TokenModel.font_family/0
+export const S_ThemesTokenModelFontFamily = { e: [...THEMES_TOKEN_MODEL_FONT_FAMILY] } as const;
+
+// Grappa.Themes.TokenModel.size_mode/0
+export const S_ThemesTokenModelSizeMode = { e: [...THEMES_TOKEN_MODEL_SIZE_MODE] } as const;
+
+// Grappa.Themes.Wire.background_size/0
+export const S_ThemesWireBackgroundSize = S_ThemesTokenModelSizeMode;
+
+// Grappa.Themes.Wire.font_family/0
+export const S_ThemesWireFontFamily = S_ThemesTokenModelFontFamily;
 
 // Grappa.Themes.Wire.t/0
 export const S_ThemesWireT = {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -65,6 +65,16 @@ export type ScrollbackMetaT = Record<string, unknown>;
 
 export type SessionISupportCasemapping = IRCIdentifierCasemapping;
 
+export const SESSION_WINDOW_STATE_WINDOW_STATE = [
+  "pending",
+  "invited",
+  "joined",
+  "failed",
+  "kicked",
+  "parked",
+] as const;
+export type SessionWindowStateWindowState = (typeof SESSION_WINDOW_STATE_WINDOW_STATE)[number];
+
 export const SESSION_LOG_EVENT = [
   "connected",
   "registered",
@@ -75,6 +85,21 @@ export const SESSION_LOG_EVENT = [
   "nick_changed",
 ] as const;
 export type SessionLogEvent = (typeof SESSION_LOG_EVENT)[number];
+
+export const THEMES_TOKEN_MODEL_FONT_FAMILY = [
+  "mono-default",
+  "jetbrains-mono",
+  "fira-code",
+  "iosevka",
+  "hack",
+  "cascadia-code",
+  "source-code-pro",
+  "ibm-plex-mono",
+] as const;
+export type ThemesTokenModelFontFamily = (typeof THEMES_TOKEN_MODEL_FONT_FAMILY)[number];
+
+export const THEMES_TOKEN_MODEL_SIZE_MODE = ["cover", "repeat"] as const;
+export type ThemesTokenModelSizeMode = (typeof THEMES_TOKEN_MODEL_SIZE_MODE)[number];
 
 export const WINDOW_COUNTS_SEVERITY = ["mention", "message", "event", "none"] as const;
 export type WindowCountsSeverity = (typeof WINDOW_COUNTS_SEVERITY)[number];
@@ -930,6 +955,8 @@ export const SESSION_WIRE_WIRE_EVENT_KIND = [
 ] as const;
 export type SessionWireWireEventKind = (typeof SESSION_WIRE_WIRE_EVENT_KIND)[number];
 
+export type SessionWireWindowState = SessionWindowStateWindowState;
+
 export type SessionWireChannelsChangedPayload = {
   kind: "channels_changed";
 };
@@ -1405,6 +1432,10 @@ export type SubjectSearchAdminWireResultJson = {
 };
 
 // === Grappa.Themes.Wire ===
+
+export type ThemesWireFontFamily = ThemesTokenModelFontFamily;
+
+export type ThemesWireBackgroundSize = ThemesTokenModelSizeMode;
 
 export type ThemesWireT = {
   id: number;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45042,3 +45042,70 @@ setup-beam call sites read back from the parse tree, which proves the
 files are well-formed and wired, not that the runner resolves the
 versions. `scripts/shellcheck.sh` was not run and did not need to be —
 no shell script changed.
+<!-- entry #1406 X-S8 -->
+
+---
+
+## 2026-08-16 — #1406: three closed sets reach the codegen by re-export, and the spec is derived from the allowlist
+
+`grappa.gen_wire_types` only walks `lib/grappa/**/*wire.ex`. Three closed sets
+that cic depends on live outside that glob — the window states
+(`session/window_state.ex`), the theme token vocabularies
+(`themes/token_model.ex`) and the built-in background catalog
+(`themes/builtin_backgrounds.ex`) — so nothing generated ever referenced them
+and cic held a hand transcription of each, with a "mirror of …" comment and no
+gate. CLAUDE.md's rule that adding a window state is a server change cic just
+mirrors was true as prose and unenforced as code: the server could add a
+seventh state and `tsc` would say nothing.
+
+### The mechanism: name the type at the wire boundary
+
+`Grappa.Session.Wire` re-exports `WindowState.window_state/0`, and
+`Grappa.Themes.Wire` re-exports the font-family / background-size vocabularies
+plus `BuiltinBackgrounds.t/0`. Nothing moves modules; a `@type` at the boundary
+that already publishes the payload is enough for the walk to see it, and it is
+the boundary-preserving widen `@extra_globs` used for `GrappaWeb.ErrorTokens`
+in #411, one level down.
+
+A re-export was needed rather than a field annotation because **no payload
+carries the window-state union**: each event pins its own literal (`state:
+:joined`, `state: :failed`, …) and `:parked` never rides a `state` field at
+all. The set exists as a set nowhere on the wire, which is exactly why it was
+invisible to a codegen that walks payloads.
+
+### The spec is DERIVED from the allowlist, not written beside it
+
+`TokenModel`'s SSOT is `@font_families` / `@size_modes` — string lists that
+`sanitize_font/1` and `sanitize_size/1` guard with. Writing an atom-union
+`@type` next to them would have created a second closed set to keep in step:
+the very defect this issue series exists to close. The specs are therefore
+spliced out of the attributes at compile time with `unquote/1`, so the
+sanitiser's list and the generated const are one list. If the two ever
+disagree, the codegen test says so by name — it compares the emitted array to
+`TokenModel.font_families/0` rather than to a hardcoded expectation.
+
+The window states have no runtime enumerator (the SSOT is the typespec), so
+their test does hardcode the six. That is deliberate: it is the one thing that
+makes a seventh state a conscious edit instead of a silent widen.
+
+### cic ALIASES the generated type; it does not pin a copy
+
+`windowState.ts` and `themesApi.ts` now alias the generated types
+(`export type WindowState = SessionWireWindowState;`) rather than keeping a
+transcription guarded by an `Equal<>` assert. This is the #410 / `WireAdminEvent`
+posture: a derived type cannot drift, so the assert would be an identity — the
+same finding this issue's X-S1 slice measured on the five `Omit<…, "kind">`
+pins. The pin that matters is the one that still bites: every member of all
+three sets appears as a literal in cic source (`"parked"` at 21 sites,
+`"cover"` at 22), so narrowing the server set narrows the client union and
+`tsc` names every site that assigned the removed member.
+
+### The hole this leaves, on purpose
+
+`ThemeColorKey` stays a hand mirror. Its nick slots are the pattern template
+literal `nick_${number}`, which TS degrades to an index signature — so a
+payload missing `nick_5` type-checks today while the server sanitiser requires
+all 27 keys. Narrowing it to the server's exact set is a behaviour change with
+consumer fallout across the theme editor and its tests, not a re-export, and it
+is tracked on #1406 rather than smuggled in here. Three vocabularies of four
+are pinned; the fourth is declared debt.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45095,17 +45095,57 @@ makes a seventh state a conscious edit instead of a silent widen.
 transcription guarded by an `Equal<>` assert. This is the #410 / `WireAdminEvent`
 posture: a derived type cannot drift, so the assert would be an identity — the
 same finding this issue's X-S1 slice measured on the five `Omit<…, "kind">`
-pins. The pin that matters is the one that still bites: every member of all
-three sets appears as a literal in cic source (`"parked"` at 21 sites,
-`"cover"` at 22), so narrowing the server set narrows the client union and
-`tsc` names every site that assigned the removed member.
+pins.
 
-### The hole this leaves, on purpose
+**How much each alias then DETECTS is not uniform, and a mutation campaign is
+the only thing that tells you which.** Removing a member from the server SSOT
+and regenerating:
+
+  * the theme vocabularies FAIL LOUDLY. Dropping `iosevka` from
+    `@font_families` is `TS2322` at `ThemeEditor.tsx:44` — the surviving hand
+    list `FONT_FAMILIES: ThemeFontFamily[]` cannot outlive a font the server
+    drops. Dropping `repeat` from `@size_modes` is `TS2367` at
+    `customTheme.ts:107`, the comparison losing its overlap.
+  * the window states detect NOTHING. `"parked"` has no writer at all
+    (`setParted` deletes the key), and the five that are written go in through
+    a COMPUTED key — `{...prev, [key]: "kicked"}` — which TypeScript does not
+    check against `Record<ChannelKey, WindowState>`. Dropping `:kicked` from
+    the SSOT, regenerating, and confirming the generated array had really lost
+    it left `bun run check` green.
+
+So for `window_state` the alias buys the derivation (one source, no hand copy
+to update) and nothing else; the detection lives in the codegen test that
+hardcodes the six states. That asymmetry is worth knowing before trusting a
+future alias to be a gate: a derived type is only a tripwire where the client
+actually spells the members out in a checked position. An earlier draft of this
+entry claimed the opposite from a `grep` count of `"parked"` — the count was
+conflating two different closed sets, since `parked` is also a
+`NetworksCredentialConnectionState`.
+
+### The two holes this leaves
 
 `ThemeColorKey` stays a hand mirror. Its nick slots are the pattern template
 literal `nick_${number}`, which TS degrades to an index signature — so a
 payload missing `nick_5` type-checks today while the server sanitiser requires
 all 27 keys. Narrowing it to the server's exact set is a behaviour change with
 consumer fallout across the theme editor and its tests, not a re-export, and it
-is tracked on #1406 rather than smuggled in here. Three vocabularies of four
-are pinned; the fourth is declared debt.
+is tracked on #1406 rather than smuggled in here.
+
+`BuiltinBackground` stays a hand mirror too, and that one is not a choice: **the
+codegen cannot render it.** The re-export was written and run.
+`BuiltinBackgrounds.t/0` carries `variant: variant()`, a same-module
+`user_type`, and the EXTERNAL-type path renders one type at a time with no
+sibling registry — so the types half fell back to `camelize/1` and emitted
+`variant: Variant` (`TS2304`, a name nothing declares) while the schema half
+computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and imported it (`TS2724`, a const
+neither half emits). The two emitters disagree, and the whole failure surfaces
+on the CLIENT compiler rather than on the generator. `gen_wire_types.ex`'s own
+comment already forbids the tempting cure — promote the type into a wire module
+rather than teach the external path to resolve refs — and restating the four
+fields in `Themes.Wire` to route around it would have rebuilt the twin this
+slice deletes. The emitter's job is to FAIL LOUDLY there instead of inventing
+an identifier, which is a typographic silent-swallow; that fix travels with the
+other codegen work, and a test here pins the absence meanwhile.
+
+Two vocabularies of four are pinned. Both holes are declared in the code that
+carries them, not only here.

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -68,7 +68,8 @@ defmodule Grappa.Session.Wire do
     ListModes,
     LusersAccum,
     WhoisAccum,
-    WhowasAccum
+    WhowasAccum,
+    WindowState
   }
 
   @typedoc """
@@ -114,6 +115,21 @@ defmodule Grappa.Session.Wire do
           | :presence_changed
           | :presence_error
           | :presence_snapshot
+
+  @typedoc """
+  The closed set of per-channel window states, re-exported from
+  `Grappa.Session.WindowState` so it reaches the codegen (#1406 X-S8).
+
+  No single payload carries the whole union — each event pins its own literal
+  (`state: :joined`, `state: :failed`, …) and `:parked` never rides a `state`
+  field at all — so nothing under `@wire_glob` referenced the SSOT and cic's
+  `windowState.ts` restated all six states by hand. CLAUDE.md says adding a
+  state is a server change cic just mirrors; naming the type here is what makes
+  that true mechanically, because `mix grappa.gen_wire_types` then emits the
+  set as a generated const and a seventh state widens the client union on
+  regeneration instead of on someone remembering.
+  """
+  @type window_state :: WindowState.window_state()
 
   @type channels_changed_payload :: %{kind: :channels_changed}
 

--- a/lib/grappa/themes/token_model.ex
+++ b/lib/grappa/themes/token_model.ex
@@ -85,6 +85,36 @@ defmodule Grappa.Themes.TokenModel do
 
   @type token_map :: %{String.t() => term()}
 
+  @typedoc """
+  The closed font-family allowlist, as a type. **Derived from
+  `@font_families`** — the same list `sanitize_font/1` guards with, spliced
+  into the spec at compile time instead of restated beside it (#1406 X-S9).
+
+  A hand-written twin union would be a SECOND closed set to keep in step, which
+  is precisely the defect being closed here: `Grappa.Themes.Wire` re-exports
+  this type so `mix grappa.gen_wire_types` emits the vocabulary as a generated
+  const, and cic stops transcribing it by hand.
+  """
+  @type font_family ::
+          unquote(
+            @font_families
+            |> Enum.map(&String.to_atom/1)
+            |> Enum.reverse()
+            |> Enum.reduce(fn arm, acc -> quote(do: unquote(arm) | unquote(acc)) end)
+          )
+
+  @typedoc """
+  The closed background sizing modes (#294), as a type. Derived from
+  `@size_modes` on the same terms as `font_family/0` above.
+  """
+  @type size_mode ::
+          unquote(
+            @size_modes
+            |> Enum.map(&String.to_atom/1)
+            |> Enum.reverse()
+            |> Enum.reduce(fn arm, acc -> quote(do: unquote(arm) | unquote(acc)) end)
+          )
+
   @doc "The frozen list of 27 color token keys (string form)."
   @spec color_keys() :: [String.t()]
   def color_keys, do: @color_keys

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,13 +42,38 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
+  alias Grappa.Themes.BuiltinBackgrounds
   alias Grappa.Themes.Theme
+  alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
 
   # #299 author model A — the fallback attribution label, used only when a
   # theme carries no `author_nick` snapshot (legacy / never-published visitor
   # themes). A closed constant.
   @guest_author "guest"
+
+  @typedoc """
+  The closed font-family vocabulary, re-exported from
+  `Grappa.Themes.TokenModel` so it reaches the codegen (#1406 X-S9).
+
+  `token_model.ex` is not a `*wire.ex` file, so nothing under
+  `@wire_glob` used to see the vocabulary and cic transcribed it by hand
+  (`themesApi.ts`, four "mirror of …" comments and no gate). Naming the type
+  HERE — at the wire boundary that already publishes the payload it belongs to
+  — makes `mix grappa.gen_wire_types` emit it as a generated const, and the
+  `--check` drift gate then guards a copy nobody has to remember to update.
+  """
+  @type font_family :: TokenModel.font_family()
+
+  @typedoc "The closed background sizing modes (#294), re-exported per `font_family/0`."
+  @type background_size :: TokenModel.size_mode()
+
+  @typedoc """
+  One entry of the built-in background catalog, re-exported per `font_family/0`.
+  `GET /themes/backgrounds` serves a list of these and had no generated
+  counterpart at all before #1406 X-S9.
+  """
+  @type builtin_background :: BuiltinBackgrounds.t()
 
   # The rich viewer subject (as carried in `conn.assigns.current_subject`) is
   # inlined into `to_wire/2`'s spec rather than exposed as a public `@type` — a
@@ -67,10 +92,12 @@ defmodule Grappa.Themes.Wire do
           mine: boolean(),
           # The sanitized closed-token map (`Grappa.Themes.TokenModel.token_map()`
           # — string-keyed: `"colors"` / `"font_family"` / `"background"`). Typed
-          # as an open string-keyed map, NOT a bare `map()`: cic owns the closed
-          # token vocabulary in `themesApi.ts`, so the wire codegen emits
-          # `Record<string, unknown>` (a bare `map()` would trip the
-          # gen_wire_types "defeats codegen" warning for the same output).
+          # as an open string-keyed map, NOT a bare `map()`, so the wire codegen
+          # emits `Record<string, unknown>` (a bare `map()` would trip the
+          # gen_wire_types "defeats codegen" warning for the same output). The
+          # VALUE vocabularies are pinned separately, as `font_family/0` and
+          # `background_size/0` above (#1406 X-S9); the 27 color KEYS stay
+          # cic-owned in `themesApi.ts` and remain UNpinned.
           payload: %{optional(String.t()) => term()},
           inserted_at: String.t()
         }

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,7 +42,6 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
-  alias Grappa.Themes.BuiltinBackgrounds
   alias Grappa.Themes.Theme
   alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
@@ -68,12 +67,19 @@ defmodule Grappa.Themes.Wire do
   @typedoc "The closed background sizing modes (#294), re-exported per `font_family/0`."
   @type background_size :: TokenModel.size_mode()
 
-  @typedoc """
-  One entry of the built-in background catalog, re-exported per `font_family/0`.
-  `GET /themes/backgrounds` serves a list of these and had no generated
-  counterpart at all before #1406 X-S9.
-  """
-  @type builtin_background :: BuiltinBackgrounds.t()
+  # `Grappa.Themes.BuiltinBackgrounds.t/0` is DELIBERATELY not re-exported here,
+  # and `GET /themes/backgrounds` therefore still has no generated counterpart.
+  # Measured on #1406: the codegen cannot render it. `t/0` carries
+  # `variant: variant()`, a same-module `user_type`, and the EXTERNAL-type path
+  # renders one type at a time with no sibling registry — so the types half
+  # emits `variant: Variant` (the `camelize` fallback, a name nothing declares:
+  # `TS2304`) while the schema half imports `THEMES_BUILTIN_BACKGROUNDS_VARIANT`
+  # (`TS2724`), a const neither half emits. The two emitters disagree, and the
+  # failure lands on the CLIENT compiler rather than on the generator.
+  # `gen_wire_types.ex`'s own comment rules out teaching the external path to
+  # resolve refs, so the fix is the emitter's to make (fail loudly first), not
+  # a shape restated here — a hand copy of the four fields would reintroduce
+  # exactly the twin this issue removes.
 
   # The rich viewer subject (as carried in `conn.assigns.current_subject`) is
   # inlined into `to_wire/2`'s spec rather than exposed as a public `@type` — a

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,8 +42,7 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
-  alias Grappa.Themes.Theme
-  alias Grappa.Themes.TokenModel
+  alias Grappa.Themes.{Theme, TokenModel}
   alias Grappa.Visitors.Visitor
 
   # #299 author model A — the fallback attribution label, used only when a

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -396,11 +396,17 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
                TokenModel.size_modes()
     end
 
-    test "the built-in background catalog entry reaches the wire boundary" do
+    # The third theme vocabulary, `BuiltinBackgrounds.t/0`, is NOT re-exported —
+    # the codegen cannot render it (its `variant: variant()` is a same-module
+    # ref the external-type path has no registry for, so the two emitters
+    # disagree and both emit a dangling name). This pins the ABSENCE so the
+    # next attempt starts from the measurement rather than rediscovering the
+    # TS2304 through the client compiler.
+    test "the built-in background catalog is absent from the generated file" do
       full = GenWireTypes.generate()
 
-      assert full =~ ~s|export type ThemesWireBuiltinBackground = ThemesBuiltinBackgroundsT;|
-      assert const_arms(full, "THEMES_BUILTIN_BACKGROUNDS_VARIANT") == ~w(dark light)
+      refute full =~ "ThemesWireBuiltinBackground"
+      refute full =~ "ThemesBuiltinBackgroundsT"
     end
   end
 

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Grappa.GenWireTypesTest do
   use ExUnit.Case, async: true
 
+  alias Grappa.Themes.TokenModel
   alias Mix.Tasks.Grappa.GenWireTypes
 
   describe "type mapping" do
@@ -361,6 +362,58 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
        "NetworksServersAdminWireT"},
       {Grappa.Visitors.AdminWire, "VisitorsAdminWireIndexPayload", "visitors", "VisitorsAdminWireT"}
     ]
+  end
+
+  # #1406 X-S8/X-S9 — three closed sets whose SSOT lives OUTSIDE `@wire_glob`
+  # (`session/window_state.ex`, `themes/token_model.ex`,
+  # `themes/builtin_backgrounds.ex`). Nothing generated referenced them, so cic
+  # transcribed all three by hand and no gate would have reported a widen. The
+  # fix is a re-export at the wire boundary; these pin that the re-export
+  # actually reaches the emitted file, and — for the two vocabularies that HAVE
+  # a runtime allowlist — that the emitted array IS that allowlist rather than a
+  # typespec twin of it, which is the whole reason the specs are `unquote`d out
+  # of the attribute instead of written twice.
+  describe "closed sets re-exported to reach the codegen (#1406 X-S8/X-S9)" do
+    test "the window-state SSOT is emitted as a const and aliased at the wire boundary" do
+      full = GenWireTypes.generate()
+
+      # Hardcoded deliberately: `Grappa.Session.WindowState` publishes the set
+      # as a typespec with no runtime enumerator, so this list is the only thing
+      # that makes a SEVENTH state a conscious edit instead of a silent widen.
+      assert const_arms(full, "SESSION_WINDOW_STATE_WINDOW_STATE") ==
+               ~w(pending invited joined failed kicked parked)
+
+      assert full =~ ~s|export type SessionWireWindowState = SessionWindowStateWindowState;|
+    end
+
+    test "the derived font-family spec emits EXACTLY the sanitizer's allowlist" do
+      assert const_arms(GenWireTypes.generate(), "THEMES_TOKEN_MODEL_FONT_FAMILY") ==
+               TokenModel.font_families()
+    end
+
+    test "the derived size-mode spec emits EXACTLY the sanitizer's allowlist" do
+      assert const_arms(GenWireTypes.generate(), "THEMES_TOKEN_MODEL_SIZE_MODE") ==
+               TokenModel.size_modes()
+    end
+
+    test "the built-in background catalog entry reaches the wire boundary" do
+      full = GenWireTypes.generate()
+
+      assert full =~ ~s|export type ThemesWireBuiltinBackground = ThemesBuiltinBackgroundsT;|
+      assert const_arms(full, "THEMES_BUILTIN_BACKGROUNDS_VARIANT") == ~w(dark light)
+    end
+  end
+
+  # The quoted elements of an emitted `as const` array, in order. Tolerates
+  # biome's inline-vs-one-per-line wrapping (the `bun run check` gate owns the
+  # whitespace) by cutting at the array's own closing bracket.
+  defp const_arms(output, const_name) do
+    [_, tail] = String.split(output, "export const #{const_name} = [", parts: 2)
+    [body, _] = String.split(tail, "]", parts: 2)
+
+    ~r/"([^"]+)"/
+    |> Regex.scan(body, capture: :all_but_first)
+    |> List.flatten()
   end
 
   describe "--check exit code helper" do


### PR DESCRIPTION
Third slice of #1406, covering **X-S8** and the pin-able part of **X-S9**. X-S1
landed in #1443; X-S4 is #1448. X-S10 follows in its own PR.

## The defect

`grappa.gen_wire_types` walks `lib/grappa/**/*wire.ex` only. Two closed sets cic
depends on live outside that glob — the window states
(`session/window_state.ex`) and the theme token vocabularies
(`themes/token_model.ex`) — so nothing generated referenced them and cic held a
hand transcription of each, with a "mirror of …" comment and no gate. CLAUDE.md
says adding a window state is a server change cic just mirrors: true as prose,
unenforced as code.

## The mechanism

`Grappa.Session.Wire` re-exports `WindowState.window_state/0`;
`Grappa.Themes.Wire` re-exports the font-family and background-size
vocabularies. No module moves and the glob is untouched — a `@type` at the wire
boundary is enough for the walk to see it.

A re-export rather than a field annotation because **no payload carries the
window-state union**: each event pins its own literal (`state: :joined`,
`state: :failed`, …) and `:parked` never rides a `state` field at all. The set
exists as a set nowhere on the wire, which is why a payload-walking codegen
could not see it.

**The theme specs are DERIVED, not restated.** `TokenModel`'s source of truth is
`@font_families` / `@size_modes`, the string lists `sanitize_font/1` and
`sanitize_size/1` guard with. An atom-union `@type` written next to them would
be a second closed set to keep in step — the defect this issue series exists to
close — so the specs are spliced out of the attributes at compile time with
`unquote/1`. One list, two consumers.

cic then **aliases** the generated types rather than pinning a transcription
with `Equal<>`: the #410 / `WireAdminEvent` posture, since a derived type cannot
drift and the assert would be an identity — the finding X-S1 already measured on
the five `Omit<…, "kind">` pins.

## Evidence: the mutation campaign

Each mutant was applied one at a time with a one-shot injector, the artifact was
checked to confirm the mutation actually arrived, and the tree was restored
after each.

| mutant | layer | outcome |
|---|---|---|
| `:parked` out of the window-state SSOT | ExUnit | **killed** — `the window-state SSOT is emitted as a const…`, one assertion, `left` missing `"parked"` |
| the derived font spec replaced by a hand twin list | ExUnit | **killed** — `the derived font-family spec emits EXACTLY the sanitizer's allowlist`, one assertion |
| `iosevka` out of `@font_families` | tsc | **killed** — `ThemeEditor.tsx(44,3) TS2322` |
| `repeat` out of `@size_modes` | tsc | **killed** — `customTheme.ts(107,16) TS2367`, the comparison losing its overlap |
| `iosevka` out of `@font_families` | ExUnit | **survives, by design** — both sides derive from the attribute, so the test is a construction proof, not a drift detector. Its detector is the twin-list mutant above |
| `:kicked` out of the window-state SSOT | tsc | **survives** — see below |

## What this does NOT buy, stated plainly

**The `WindowState` alias detects nothing at the TypeScript layer.** Dropping
`:kicked` from the server SSOT and regenerating (the generated array verifiably
lost the member) left `bun run check` green: `"parked"` has no writer at all
(`setParted` deletes the key) and the five states cic does write go in through a
computed key — `{...prev, [key]: "kicked"}` — which TypeScript does not check
against `Record<ChannelKey, WindowState>`. For `window_state` the alias buys the
derivation and the codegen test does the detecting. The theme vocabularies are
the opposite: they fail loudly, as the table shows.

**Two of the four theme vocabularies stay unpinned, both declared in the code
that carries them.**

`ThemeColorKey` keeps its hand mirror: the nick slots are the pattern template
literal `nick_${number}`, which TS degrades to an index signature — a payload
missing `nick_5` type-checks today while the server sanitiser requires all 27
keys. Narrowing it is a behaviour change with consumer fallout across the theme
editor and its tests, not a re-export.

`BuiltinBackground` keeps its hand mirror too, and that one is not a choice:
**the codegen cannot render it.** The re-export was written and run.
`BuiltinBackgrounds.t/0` carries `variant: variant()`, a same-module
`user_type`, and the external-type path renders one type at a time with no
sibling registry — so the types half fell back to `camelize/1` and emitted
`variant: Variant` (`TS2304`, a name nothing declares) while the schema half
computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and imported it (`TS2724`, a const
neither half emits). The generator exited 0; the breakage surfaced on the client
compiler. `gen_wire_types.ex` already rules out teaching the external path to
resolve refs, and restating the four fields server-side would have rebuilt the
twin this slice deletes — so the emitter's fail-loud travels with the other
codegen work, and a test here pins the ABSENCE meanwhile.

## Gates

`scripts/check.sh` RC=0 (format, credo, dialyzer `Total errors: 0`, sobelow,
520 bats, and the codegen drift check reporting both `wireTypes.ts` and
`wireSchema.ts` "is in sync") · `scripts/test.sh` RC=0, 6413 tests, 0 failures ·
`scripts/bun.sh run check` RC=0 · `scripts/design-notes-gate.sh origin/main`
RC=0. Rebased onto `651aa289`, contribution numstat identical either side of the
rebase and the entry boundary read on the file.

The first `check.sh` was red, by name: Credo consistency at `themes/wire.ex:46`,
because dropping the `BuiltinBackgrounds` alias left two single directives under
one prefix. Fixed in its own commit and the whole gate re-run, not resumed.
