### PR TITLE
union: replay #1449 + #1450 + #1444 onto a single gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,18 @@ VAPID_PRIVATE_KEY=
 POOL_SIZE=10
 
 # Phoenix HTTP listener port. Defaults to 4000.
+#
+# 🔴 NOT SUPPORTED ON DOCKER (#1409 D-S6). Compose passes this into the app,
+# but every other Docker-side consumer hardcodes 4000: the container side of
+# the publish, the compose healthcheck, the Dockerfile EXPOSE + HEALTHCHECK,
+# scripts/healthcheck.sh, and the /admin/reload + /admin/cic-bundle-changed
+# POSTs. Set it to anything else and the container is healthy while reported
+# unhealthy, `depends_on: service_healthy` never resolves, and the deploy
+# fails at the reload POST. To move the port on Docker, change
+# GRAPPA_PUBLISH (the HOST side) and leave this alone.
+#
+# It IS honoured on the Docker-free substrates — infra/linux/install.sh and
+# the release image both thread ${PORT} end to end.
 PORT=4000
 
 # UX-6-B1 (2026-05-20): embedded image uploader storage directory.

--- a/cicchetto/src/lib/themesApi.ts
+++ b/cicchetto/src/lib/themesApi.ts
@@ -17,23 +17,22 @@
 import { buildHeaders, readError } from "./api";
 import { getOrCreateClientId } from "./clientId";
 import { narrowThemeResponse } from "./wireNarrow";
-import type { ThemesWireT } from "./wireTypes";
+import type { ThemesWireBackgroundSize, ThemesWireFontFamily, ThemesWireT } from "./wireTypes";
 
-// The closed font-family allow-list — mirror of
-// `Grappa.Themes.TokenModel.font_families/0`. `mono-default` maps to the
-// existing `--font-mono` stack (no font file); the rest each get a
-// self-hosted `@font-face` (sub-task 8, deferred).
-export type ThemeFontFamily =
-  | "mono-default"
-  | "jetbrains-mono"
-  | "fira-code"
-  | "iosevka"
-  | "hack"
-  | "cascadia-code"
-  | "source-code-pro"
-  | "ibm-plex-mono";
+// The closed font-family allow-list — #1406 X-S9, DERIVED from
+// `Grappa.Themes.TokenModel.font_families/0` (the same list `sanitize_font/1`
+// guards with) instead of mirrored by hand. `mono-default` maps to the existing
+// `--font-mono` stack (no font file); the rest each get a self-hosted
+// `@font-face` (sub-task 8, deferred).
+export type ThemeFontFamily = ThemesWireFontFamily;
 
-// The 27 color keys — mirror of `Grappa.Themes.TokenModel.color_keys/0`.
+// The 27 color keys — still a HAND mirror of
+// `Grappa.Themes.TokenModel.color_keys/0`, and the one vocabulary #1406 X-S9
+// leaves unpinned: `nick_${number}` is a pattern template literal that TS
+// degrades to an index signature, so narrowing it to the server's exact 16
+// nick slots is a behaviour change (a payload missing `nick_5` type-checks
+// today and would stop) with real consumer fallout, not a re-export. Declared
+// debt, tracked on #1406, deliberately out of this slice.
 // Each value is a strict `#rrggbb` string (validated server-side; cic
 // treats them as opaque CSS color literals via `customTheme.ts`).
 export type ThemeColorKey =
@@ -56,10 +55,11 @@ export type TokenColors = Record<ThemeColorKey, string>;
 // Producers can only express what this allows; anything else is dropped
 // server-side (safe-by-construction). `customTheme.ts` consumes this to
 // generate scoped CSS custom properties.
-// Background sizing — mirror of `Grappa.Themes.TokenModel.size_modes/0`.
-// `cover` = full-bleed (the v1 built-in set + every upload); `repeat` =
-// seamless tile (the deferred #294 pattern set).
-export type ThemeBackgroundSize = "cover" | "repeat";
+// Background sizing — #1406 X-S9, derived from
+// `Grappa.Themes.TokenModel.size_modes/0`. `cover` = full-bleed (the v1
+// built-in set + every upload); `repeat` = seamless tile (the deferred #294
+// pattern set).
+export type ThemeBackgroundSize = ThemesWireBackgroundSize;
 
 export type TokenPayload = {
   colors: TokenColors;
@@ -79,7 +79,15 @@ export type TokenPayload = {
 };
 
 // One entry in the built-in background catalog (`GET /themes/backgrounds`) —
-// mirror of `Grappa.Themes.BuiltinBackgrounds.t`. The picker consumes this;
+// still a HAND mirror of `Grappa.Themes.BuiltinBackgrounds.t`, and the second
+// vocabulary #1406 X-S9 leaves unpinned. Not for lack of trying: the
+// re-export was written and MEASURED, and the codegen cannot render that type
+// — `t/0`'s `variant: variant()` is a same-module ref the external-type path
+// has no registry for, so the generated files came out with `variant: Variant`
+// (TS2304, a name nothing declares) and a `THEMES_BUILTIN_BACKGROUNDS_VARIANT`
+// import (TS2724, a const neither emitter declares). The fix belongs to the
+// emitter; restating the four fields server-side to route around it would have
+// been the same twin this slice exists to delete. The picker consumes this;
 // `path` is the static /backgrounds/<key>.webp URL the asset is served at.
 export type BuiltinBackground = {
   key: string;

--- a/cicchetto/src/lib/windowState.ts
+++ b/cicchetto/src/lib/windowState.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
 import { selectedChannel } from "./selection";
+import type { SessionWireWindowState } from "./wireTypes";
 
 // CP15 B5: cic mirror of the server-side per-(network, channel) window
 // state machine. The server splits state across three maps so each
@@ -29,7 +30,15 @@ import { selectedChannel } from "./selection";
 // all three maps are emptied so a new bearer doesn't see the prior
 // tenant's window states.
 
-export type WindowState = "pending" | "invited" | "joined" | "failed" | "kicked" | "parked";
+// #1406 X-S8 — DERIVED from the server SSOT, not transcribed. This used to be
+// a hand-written six-token union: CLAUDE.md says adding a state is a server
+// change cic just mirrors, but the mirror was a copy nothing would have
+// widened. `Grappa.Session.Wire` now re-exports
+// `Grappa.Session.WindowState.window_state/0`, so a seventh state arrives here
+// on the next `grappa.gen_wire_types` run and tsc reports every site that does
+// not handle it. Aliasing (rather than pinning a copy with `Equal<>`) is the
+// #410 / `WireAdminEvent` posture: a derived type cannot drift by construction.
+export type WindowState = SessionWireWindowState;
 
 export type WindowFailure = {
   reason: string | null;

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -25,12 +25,15 @@ import {
   NETWORKS_NETWORK_SERVICES_FLAVOR,
   SCROLLBACK_MESSAGE_KIND,
   SESSION_LOG_EVENT,
+  SESSION_WINDOW_STATE_WINDOW_STATE,
   SESSION_WIRE_RECOVER_OUTCOME,
   SESSION_WIRE_RECOVER_REASON,
   SESSION_WIRE_RECOVER_STATUS,
   SESSION_WIRE_RECOVER_STEP,
   SESSION_WIRE_SERVER_REPLY_SOURCE,
   SESSION_WIRE_WIRE_EVENT_KIND,
+  THEMES_TOKEN_MODEL_FONT_FAMILY,
+  THEMES_TOKEN_MODEL_SIZE_MODE,
   WINDOW_COUNTS_SEVERITY,
 } from "./wireTypes";
 
@@ -910,6 +913,11 @@ export const S_ServerSettingsWireChangedPayload = {
 // Grappa.Session.ISupport.casemapping/0
 export const S_SessionISupportCasemapping = S_IRCIdentifierCasemapping;
 
+// Grappa.Session.WindowState.window_state/0
+export const S_SessionWindowStateWindowState = {
+  e: [...SESSION_WINDOW_STATE_WINDOW_STATE],
+} as const;
+
 // Grappa.Session.Wire.away_confirmed_payload/0
 export const S_SessionWireAwayConfirmedPayload = {
   o: { kind: { l: "away_confirmed" }, network: "s", state: { e: ["present", "away"] } },
@@ -1339,6 +1347,9 @@ export const S_SessionWireWindowPendingPayload = {
   o: { kind: { l: "window_pending" }, network: "s", channel: "s", state: { l: "pending" } },
 } as const;
 
+// Grappa.Session.Wire.window_state/0
+export const S_SessionWireWindowState = S_SessionWindowStateWindowState;
+
 // Grappa.Session.Wire.wire_event_kind/0
 export const S_SessionWireWireEventKind = { e: [...SESSION_WIRE_WIRE_EVENT_KIND] } as const;
 
@@ -1382,6 +1393,18 @@ export const S_SessionLogWireSessionsResult = {
 export const S_SubjectSearchAdminWireResultJson = {
   o: { type: { e: ["user", "visitor"] }, id: "s", network: { u: ["s", "z"] }, nick: "s" },
 } as const;
+
+// Grappa.Themes.TokenModel.font_family/0
+export const S_ThemesTokenModelFontFamily = { e: [...THEMES_TOKEN_MODEL_FONT_FAMILY] } as const;
+
+// Grappa.Themes.TokenModel.size_mode/0
+export const S_ThemesTokenModelSizeMode = { e: [...THEMES_TOKEN_MODEL_SIZE_MODE] } as const;
+
+// Grappa.Themes.Wire.background_size/0
+export const S_ThemesWireBackgroundSize = S_ThemesTokenModelSizeMode;
+
+// Grappa.Themes.Wire.font_family/0
+export const S_ThemesWireFontFamily = S_ThemesTokenModelFontFamily;
 
 // Grappa.Themes.Wire.t/0
 export const S_ThemesWireT = {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -92,6 +92,16 @@ export type ScrollbackMetaT = Partial<Record<ScrollbackMetaTKey, unknown>>;
 
 export type SessionISupportCasemapping = IRCIdentifierCasemapping;
 
+export const SESSION_WINDOW_STATE_WINDOW_STATE = [
+  "pending",
+  "invited",
+  "joined",
+  "failed",
+  "kicked",
+  "parked",
+] as const;
+export type SessionWindowStateWindowState = (typeof SESSION_WINDOW_STATE_WINDOW_STATE)[number];
+
 export const SESSION_LOG_EVENT = [
   "connected",
   "registered",
@@ -102,6 +112,21 @@ export const SESSION_LOG_EVENT = [
   "nick_changed",
 ] as const;
 export type SessionLogEvent = (typeof SESSION_LOG_EVENT)[number];
+
+export const THEMES_TOKEN_MODEL_FONT_FAMILY = [
+  "mono-default",
+  "jetbrains-mono",
+  "fira-code",
+  "iosevka",
+  "hack",
+  "cascadia-code",
+  "source-code-pro",
+  "ibm-plex-mono",
+] as const;
+export type ThemesTokenModelFontFamily = (typeof THEMES_TOKEN_MODEL_FONT_FAMILY)[number];
+
+export const THEMES_TOKEN_MODEL_SIZE_MODE = ["cover", "repeat"] as const;
+export type ThemesTokenModelSizeMode = (typeof THEMES_TOKEN_MODEL_SIZE_MODE)[number];
 
 export const WINDOW_COUNTS_SEVERITY = ["mention", "message", "event", "none"] as const;
 export type WindowCountsSeverity = (typeof WINDOW_COUNTS_SEVERITY)[number];
@@ -957,6 +982,8 @@ export const SESSION_WIRE_WIRE_EVENT_KIND = [
 ] as const;
 export type SessionWireWireEventKind = (typeof SESSION_WIRE_WIRE_EVENT_KIND)[number];
 
+export type SessionWireWindowState = SessionWindowStateWindowState;
+
 export type SessionWireChannelsChangedPayload = {
   kind: "channels_changed";
 };
@@ -1432,6 +1459,10 @@ export type SubjectSearchAdminWireResultJson = {
 };
 
 // === Grappa.Themes.Wire ===
+
+export type ThemesWireFontFamily = ThemesTokenModelFontFamily;
+
+export type ThemesWireBackgroundSize = ThemesTokenModelSizeMode;
 
 export type ThemesWireT = {
   id: number;

--- a/compose.oneshot.yaml
+++ b/compose.oneshot.yaml
@@ -2,14 +2,20 @@
 # `in_oneshot()` for ephemeral mix tasks (test, credo, dialyzer, format,
 # deps.get, ecto.migrate) that have to coexist with a running container.
 #
-# Without it a oneshot inherits `container_name: grappa` and the host
-# port-publishes, and both collide with the long-lived copy.
+# ONE key, because one is all that is needed (#1409 D-S7). This file used to
+# also `!reset` `container_name` and `ports` against a stated collision with
+# the long-lived copy. Measured 2026-08-16 with `grappa` up and holding
+# 192.168.53.12:4000: `compose run` names its container
+# `grappa-grappa-run-<hash>` and never `grappa`, creates it with
+# `PortBindings: {}` (with `--service-ports` as the positive control, which
+# DOES bind), and sets `RestartPolicy: no` on its own. Three no-ops guarding
+# a hazard that does not exist — which is why six deploy-path `run --rm`
+# invocations never layered this file and never collided.
+#
+# The healthcheck is the exception: it IS inherited in full, and a oneshot
+# never boots phx.server, so the /healthz probe would fail forever.
 
 services:
   grappa:
-    container_name: !reset null
-    ports: !reset []
-    # A oneshot never boots phx.server, so the /healthz probe would always fail.
     healthcheck:
       disable: true
-    restart: "no"

--- a/compose.yaml
+++ b/compose.yaml
@@ -95,6 +95,13 @@ services:
       # Literal defaults, NOT the empty-default form used above: an empty
       # string reaches String.to_integer/1 and crashes at boot (#369 X1).
       POOL_SIZE: ${POOL_SIZE:-10}
+      # PORT is NOT SUPPORTED on this substrate (#1409 D-S6): this line is
+      # the only Docker-side consumer. The container side of the publish
+      # above, the healthcheck below, the Dockerfile probe, and the deploy
+      # POSTs all hardcode 4000, so an override makes the app listen
+      # somewhere nothing looks. Move the port with GRAPPA_PUBLISH (host
+      # side) instead. Honoured end to end only on the Docker-free
+      # substrates.
       PORT: ${PORT:-4000}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     healthcheck:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45220,3 +45220,70 @@ ranking, glyphs and tier labels. None of them is STATUSMSG and none is
 touched here; they belong to the #1402 class of hand-narrowed closed sets.
 The badge that renders `meta.statusmsg` still names only two levels and still
 assumes one character — that is #1302, deliberately a separate change.
+<!-- entry #1406 X-S8 -->
+
+---
+
+## 2026-08-16 — #1406: three closed sets reach the codegen by re-export, and the spec is derived from the allowlist
+
+`grappa.gen_wire_types` only walks `lib/grappa/**/*wire.ex`. Three closed sets
+that cic depends on live outside that glob — the window states
+(`session/window_state.ex`), the theme token vocabularies
+(`themes/token_model.ex`) and the built-in background catalog
+(`themes/builtin_backgrounds.ex`) — so nothing generated ever referenced them
+and cic held a hand transcription of each, with a "mirror of …" comment and no
+gate. CLAUDE.md's rule that adding a window state is a server change cic just
+mirrors was true as prose and unenforced as code: the server could add a
+seventh state and `tsc` would say nothing.
+
+### The mechanism: name the type at the wire boundary
+
+`Grappa.Session.Wire` re-exports `WindowState.window_state/0`, and
+`Grappa.Themes.Wire` re-exports the font-family / background-size vocabularies
+plus `BuiltinBackgrounds.t/0`. Nothing moves modules; a `@type` at the boundary
+that already publishes the payload is enough for the walk to see it, and it is
+the boundary-preserving widen `@extra_globs` used for `GrappaWeb.ErrorTokens`
+in #411, one level down.
+
+A re-export was needed rather than a field annotation because **no payload
+carries the window-state union**: each event pins its own literal (`state:
+:joined`, `state: :failed`, …) and `:parked` never rides a `state` field at
+all. The set exists as a set nowhere on the wire, which is exactly why it was
+invisible to a codegen that walks payloads.
+
+### The spec is DERIVED from the allowlist, not written beside it
+
+`TokenModel`'s SSOT is `@font_families` / `@size_modes` — string lists that
+`sanitize_font/1` and `sanitize_size/1` guard with. Writing an atom-union
+`@type` next to them would have created a second closed set to keep in step:
+the very defect this issue series exists to close. The specs are therefore
+spliced out of the attributes at compile time with `unquote/1`, so the
+sanitiser's list and the generated const are one list. If the two ever
+disagree, the codegen test says so by name — it compares the emitted array to
+`TokenModel.font_families/0` rather than to a hardcoded expectation.
+
+The window states have no runtime enumerator (the SSOT is the typespec), so
+their test does hardcode the six. That is deliberate: it is the one thing that
+makes a seventh state a conscious edit instead of a silent widen.
+
+### cic ALIASES the generated type; it does not pin a copy
+
+`windowState.ts` and `themesApi.ts` now alias the generated types
+(`export type WindowState = SessionWireWindowState;`) rather than keeping a
+transcription guarded by an `Equal<>` assert. This is the #410 / `WireAdminEvent`
+posture: a derived type cannot drift, so the assert would be an identity — the
+same finding this issue's X-S1 slice measured on the five `Omit<…, "kind">`
+pins. The pin that matters is the one that still bites: every member of all
+three sets appears as a literal in cic source (`"parked"` at 21 sites,
+`"cover"` at 22), so narrowing the server set narrows the client union and
+`tsc` names every site that assigned the removed member.
+
+### The hole this leaves, on purpose
+
+`ThemeColorKey` stays a hand mirror. Its nick slots are the pattern template
+literal `nick_${number}`, which TS degrades to an index signature — so a
+payload missing `nick_5` type-checks today while the server sanitiser requires
+all 27 keys. Narrowing it to the server's exact set is a behaviour change with
+consumer fallout across the theme editor and its tests, not a re-export, and it
+is tracked on #1406 rather than smuggled in here. Three vocabularies of four
+are pinned; the fourth is declared debt.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45371,6 +45371,45 @@ else's product, break on their upgrade with our tree unchanged, and cost
 a docker run inside a CI already near forty minutes (#1331 cost
 tiebreak).
 
+### D-S7, fourth piece: the cache id this substrate cannot honour
+
+The review's other branch for the same finding was to route the six
+`run --rm` through `in_oneshot`, which would hand them `CACHE_ENV` and
+`CACHE_VOLUMES` — the per-worker caches of #1263, which they currently
+lack under `GRAPPA_CACHE_ID`. Declined, on one measured asymmetry:
+**`docker compose up` exposes no `-v`** (its only `-V` is
+`--renew-anon-volumes`) while `run` does. The oneshots could therefore
+take the per-id binds and the long-running container they migrate FOR
+could not. The operator would get a deploy that migrated the database
+inside `.caches/<id>` and then booted the box from the shared
+`_build`/`deps` — not isolation, a deploy split across two caches, with
+nothing in the output to say which half it was on. Half an isolation is
+a worse outcome than none, so passing the arrays to the oneshots alone
+is not the smaller version of the fix; it is a different, worse fix.
+
+What is left is to say so. One guard, in the hook set both Docker doors
+have shared since #1384, so the answer does not depend on which door the
+operator walked through — `scripts/deploy.sh` and `infra/docker/deploy.sh
+update` alike refuse when `GRAPPA_CACHE_ID` is set, naming the variable
+and the reason. It sits first in `establish_deploy_env`, ahead of the
+`.env` check, because it is about the environment being incompatible
+with the substrate at all rather than about the box being installed; it
+stays inside the hook rather than at source time so the flag parse still
+runs first and `--bogus` remains a usage error. **Unset — every deploy
+that runs today — the path is byte for byte the previous one**, one
+`[ -n ]` and nothing else. `scripts/deploy-cic.sh` is out of scope: it
+touches no Elixir cache.
+
+**Never observed. This was deduced by reading the two compose surfaces,
+not reproduced from an incident** — no operator has reported a deploy
+gone half-isolated, and none is known to have run one.
+
+One consequence worth writing down, because it bit the suites before it
+could bite an operator: bats runs on the HOST and inherits the caller's
+environment whole, so `GRAPPA_CACHE_ID=w2 scripts/bats.sh` would now turn
+every deploy case in the two Docker suites red. Both `setup()`s unset it,
+the way `cache_id_isolation_test.bats` already did.
+
 ### D-S11: the fallback was dead code, and the tool died mute
 
 The review had `db.sh` "silently reporting `dev`" and then failing on the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45122,3 +45122,101 @@ vocabularies, X-S10 the `/me` and `/auth/login` discriminators) are untouched.
 They are one class — a closed set that never reaches codegen, either because
 its module sits outside the glob or because no `*wire.ex` re-exports it — and
 that class is a different change from teaching the renderer a new shape.
+<!-- entry #1303 -->
+
+---
+
+## 2026-08-16 — #1303 + #1301: STATUSMSG is a run, the 005 is the only sigil list, and a recipient is not a window key
+
+Three operator reports on a self-hosted 1.1.0 landed in the same place: the
+STATUSMSG prefix. `@#chan` was refused on send, `@%#chan` misrouted on
+receive, and `@+#chan` misrouted silently. They are one defect class — every
+place that has to decide "is this a membership sigil?" had its own answer,
+and only one of them read the network's 005.
+
+### The peel is the longest run whose remainder is still a channel
+
+`@%#chan` peeled the `@`, found `%#chan` was not a channel, declined the peel
+whole and landed in `$server`. `@+#chan` peeled the `@` and accepted `+#chan`
+as the underlying channel — `+` is an RFC channel prefix in its own right —
+so the row was persisted and broadcast against a channel nobody is in. The
+second is the one that matters more, precisely because nobody reported it:
+it reads as "the message vanished", not "the message went to the wrong tab".
+
+The fix peels every leading sigil the network advertises, and rolls the peel
+back **whole** when what remains is not a channel. Plain greedy was tried on
+paper and rejected, because the `+` collision turns it into a regression:
+on bahamut's `@+` it strips both bytes of `@+chan` — an ops-level notice to
+the modeless channel `+chan` — finds `chan` is no channel, rolls back, and
+sends the row to `$server`. That target routes correctly today under the
+single-sigil peel, so plain greedy would have traded two fixed shapes for two
+broken ones. Backtracking one sigil at a time until the remainder is a
+channel resolves `@+chan`, `++chan`, `@+#chan` and `@%#chan` with no special
+case for any of them, and leaves the modeless-`+chan` guard where it was.
+
+### `meta.statusmsg` is the whole run, because delivery is a union
+
+`@+#chan` records `"@+"`, not `"@"`. A STATUSMSG target reaches the union of
+the named levels, so that line was seen by ops **and** by voiced members.
+Recording only the outermost sigil would let a consumer badge as ops-only a
+line half the channel read — wrong in the direction that matters, and
+uncorrectable downstream because the `+` would simply be gone. The field was
+already typed `String.t()`, so this needs no schema change; what it changes
+is that consumers must stop assuming length 1.
+
+No sorting step, and none is needed: PREFIX is advertised highest-first and
+clients emit sigils in that order, so a well-formed target arrives already
+ordered. A perverse spelling is recorded as it arrived rather than rewritten.
+Rank could not have been recovered anyway — `parse_prefix/1` ends in
+`Map.new/1` and the map crosses the wire as a JSON object, alphabetical by
+mode letter, so the advertised order is destroyed at parse time and never
+reaches a client. The STATUSMSG list is the one place order survives.
+
+### A wire recipient may carry a sigil; a window key may not
+
+`/notice @#chan` 400ed because the POST boundary tested the raw target
+against the channel regex and the nick regex. `@` and `%` were rejected;
+`+#chan` and `&#chan` passed **by accident**, because `+` and `&` are channel
+prefixes — so the voice-level notice worked while the ops-level one, the form
+operators use most, did not.
+
+The fix is a separate validator rather than a widening of
+`validate_post_target_name/1`, and the deciding measurement is where the row
+is keyed. `handle_notice_send/4` keys the echo to the SOURCE window and
+carries the recipient in `meta.notice_target`, so a sigil on a notice
+recipient never becomes a window key. The plain arm is the opposite: there
+the URL channel is both the wire target and the persist key, so admitting
+`@#chan` would manufacture a phantom `@#chan` window — the outbound twin of
+the very defect fixed above. Two arms, two meanings of "target", two doors.
+
+The target reaches the wire **verbatim**. Peeling to validate is not
+permission to rewrite: what `@%#chan` means is the ircd's ruling, so a
+canonicalised target would answer a question nobody asked, and a refusal on
+our own authority would hide the ircd's error behind ours. If the network
+rejects it, the operator sees the truth.
+
+### One sigil list, from the 005, in one place
+
+`Identifier.peel_statusmsg/2` is now the single answer to "what is a STATUSMSG
+sigil on this network", shared by ingress and egress; the SET still arrives
+from the per-network 005 and is never hardcoded. `EventRouter`'s
+`channel_target?/1` delegates to `Identifier.channel_sigil?/1` rather than
+keeping a second copy of `#&!+`: the peel's contract is that what it returns
+is something the dispatch recognises as a channel, and two independent lists
+would drift into a target that peels in one place and lands in `$server` in
+the other.
+
+`Session.statusmsg/2` is the sibling of `casemapping/2` (#537) and exists for
+the same reason — the stateless POST boundary has no `state.isupport`, and
+only the live session has seen the 005. It degrades to the bahamut default
+rather than the empty set: an empty set would refuse every sigil on a parked
+network, which is precisely the failure this issue reported.
+
+### What this does not reach
+
+The member-prefix sigils are a different, adjacent list, and roughly ten
+sites in `lib/` and `cicchetto/src/` still spell `@`/`%`/`+` by hand for
+ranking, glyphs and tier labels. None of them is STATUSMSG and none is
+touched here; they belong to the #1402 class of hand-narrowed closed sets.
+The badge that renders `meta.statusmsg` still names only two levels and still
+assumes one character — that is #1302, deliberately a separate change.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45273,17 +45273,57 @@ makes a seventh state a conscious edit instead of a silent widen.
 transcription guarded by an `Equal<>` assert. This is the #410 / `WireAdminEvent`
 posture: a derived type cannot drift, so the assert would be an identity — the
 same finding this issue's X-S1 slice measured on the five `Omit<…, "kind">`
-pins. The pin that matters is the one that still bites: every member of all
-three sets appears as a literal in cic source (`"parked"` at 21 sites,
-`"cover"` at 22), so narrowing the server set narrows the client union and
-`tsc` names every site that assigned the removed member.
+pins.
 
-### The hole this leaves, on purpose
+**How much each alias then DETECTS is not uniform, and a mutation campaign is
+the only thing that tells you which.** Removing a member from the server SSOT
+and regenerating:
+
+  * the theme vocabularies FAIL LOUDLY. Dropping `iosevka` from
+    `@font_families` is `TS2322` at `ThemeEditor.tsx:44` — the surviving hand
+    list `FONT_FAMILIES: ThemeFontFamily[]` cannot outlive a font the server
+    drops. Dropping `repeat` from `@size_modes` is `TS2367` at
+    `customTheme.ts:107`, the comparison losing its overlap.
+  * the window states detect NOTHING. `"parked"` has no writer at all
+    (`setParted` deletes the key), and the five that are written go in through
+    a COMPUTED key — `{...prev, [key]: "kicked"}` — which TypeScript does not
+    check against `Record<ChannelKey, WindowState>`. Dropping `:kicked` from
+    the SSOT, regenerating, and confirming the generated array had really lost
+    it left `bun run check` green.
+
+So for `window_state` the alias buys the derivation (one source, no hand copy
+to update) and nothing else; the detection lives in the codegen test that
+hardcodes the six states. That asymmetry is worth knowing before trusting a
+future alias to be a gate: a derived type is only a tripwire where the client
+actually spells the members out in a checked position. An earlier draft of this
+entry claimed the opposite from a `grep` count of `"parked"` — the count was
+conflating two different closed sets, since `parked` is also a
+`NetworksCredentialConnectionState`.
+
+### The two holes this leaves
 
 `ThemeColorKey` stays a hand mirror. Its nick slots are the pattern template
 literal `nick_${number}`, which TS degrades to an index signature — so a
 payload missing `nick_5` type-checks today while the server sanitiser requires
 all 27 keys. Narrowing it to the server's exact set is a behaviour change with
 consumer fallout across the theme editor and its tests, not a re-export, and it
-is tracked on #1406 rather than smuggled in here. Three vocabularies of four
-are pinned; the fourth is declared debt.
+is tracked on #1406 rather than smuggled in here.
+
+`BuiltinBackground` stays a hand mirror too, and that one is not a choice: **the
+codegen cannot render it.** The re-export was written and run.
+`BuiltinBackgrounds.t/0` carries `variant: variant()`, a same-module
+`user_type`, and the EXTERNAL-type path renders one type at a time with no
+sibling registry — so the types half fell back to `camelize/1` and emitted
+`variant: Variant` (`TS2304`, a name nothing declares) while the schema half
+computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and imported it (`TS2724`, a const
+neither half emits). The two emitters disagree, and the whole failure surfaces
+on the CLIENT compiler rather than on the generator. `gen_wire_types.ex`'s own
+comment already forbids the tempting cure — promote the type into a wire module
+rather than teach the external path to resolve refs — and restating the four
+fields in `Themes.Wire` to route around it would have rebuilt the twin this
+slice deletes. The emitter's job is to FAIL LOUDLY there instead of inventing
+an identifier, which is a typographic silent-swallow; that fix travels with the
+other codegen work, and a test here pins the absence meanwhile.
+
+Two vocabularies of four are pinned. Both holes are declared in the code that
+carries them, not only here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45327,3 +45327,93 @@ other codegen work, and a test here pins the absence meanwhile.
 
 Two vocabularies of four are pinned. Both holes are declared in the code that
 carries them, not only here.
+<!-- entry #1409 -->
+
+---
+
+## 2026-08-16 — #1409: three infra findings, and what measurement did to their premises
+
+Bucket I of the 2026-08-15 review. All three findings survive; none of
+the three survives in the shape the review wrote it, and one of them was
+posed as an either/or that only an experiment could settle.
+
+### D-S7: the collision the overlay guarded against does not happen
+
+`compose.oneshot.yaml` and `_lib.sh` both stated that a oneshot without
+the overlay "inherits `container_name: grappa` and the host
+port-publishes, and both collide with the long-lived copy". Six
+`compose run --rm` invocations on the deploy path never layered it and
+never collided. Both could not be true.
+
+The first experiment was worthless and is recorded because of it. With
+`grappa` up and holding `192.168.53.12:4000`, the raw `run --rm`
+succeeded — but the falsification step, the same run with
+`--service-ports`, ALSO succeeded. A collision oracle cannot separate
+"`run` suppresses the publish" from "this host tolerates a double bind",
+so the pass proved nothing.
+
+Measuring the thing itself instead, via `docker inspect` on the
+ephemeral container, with `--service-ports` as the positive control:
+
+| overlay key | measured without it | verdict |
+|---|---|---|
+| `container_name: !reset null` | `/grappa-grappa-run-3f90d538d15f` | no-op |
+| `ports: !reset []` | `PortBindings: {}` (control: binds `192.168.53.12:4000`) | no-op |
+| `restart: "no"` | `RestartPolicy: no` already | no-op |
+| `healthcheck: disable: true` | full `curl /healthz`, 5 retries, INHERITED | load-bearing |
+
+So the prose was the defect and the file reduces to one key. **Scope of
+that measurement, which bounds the claim: Docker Desktop on macOS, one
+Compose version, one host, on 2026-08-16. It was not verified on the
+Linux the CI runs.** The bats suite deliberately pins OUR file and not
+Compose's semantics — a test asserting `PortBindings` would pin someone
+else's product, break on their upgrade with our tree unchanged, and cost
+a docker run inside a CI already near forty minutes (#1331 cost
+tiebreak).
+
+### D-S11: the fallback was dead code, and the tool died mute
+
+The review had `db.sh` "silently reporting `dev`" and then failing on the
+next `in_container` call. Measured from a real worktree, it exits 1
+having written nothing to either stream, and never reaches the second
+call.
+
+`die` is an `exit 1`. An `exit` inside a command substitution terminates
+the SUBSHELL, so in
+
+    env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+
+the `|| echo dev` could never run — it was dead the day it was written.
+`env` came back empty, `set -e` ended the script on the assignment, and
+the message was already inside `2>/dev/null`. General rule worth
+carrying: **a `|| fallback` on a command substitution whose command can
+`exit` is not a fallback.** It only catches a non-zero RETURN.
+
+The repair the review advised — quote `$MODE_ARG` — would have added a
+second bug: quoting an empty scalar hands sqlite3 `""` as its first
+argument, which it reads as a filename. The unquoted form was getting
+that right by accident, so the mode became an array, which gets it right
+on purpose. A green-before-and-after test pins it, and the mutant that
+applies the review's advice is what makes that test worth its line.
+
+### D-S6: honest documentation beats a knob with no user
+
+`PORT` is honoured by exactly one Docker-side consumer, the compose line
+that passes it into the app; everything else hardcodes 4000. Docker is
+the local dev stack, so threading it would mean the publish, two
+healthchecks, three probes and two POSTs for no user. It is marked
+unsupported in the two places an operator reads, with `GRAPPA_PUBLISH`
+named as the knob that does work. The drift gate that pins "no consumer"
+first points the same grep at `infra/linux/install.sh`, the substrate
+that DOES honour `${PORT}`: if that known-positive stops matching, the
+probe is broken and every absence assertion is vacuous.
+
+### What the review's line numbers cost
+
+Two of the three findings cite `scripts/deploy.sh` lines that do not
+exist: it has been a 69-line consumer since #1384 and the six raw
+`run --rm` now live in `infra/lib/deploy_docker.sh` plus
+`scripts/deploy-cic.sh`. The "one-character-edit hazard" phrase quoted
+from `_lib.sh` is not in the file either. A review pinned to a base
+(`575e203a`) that has since moved is a set of claims to re-locate, not a
+map to follow.

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -74,6 +74,25 @@ COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 # installed that way was covered and a hand-installed one was not. One
 # mechanism now, for both doors.
 establish_deploy_env() {
+	# GRAPPA_CACHE_ID (#1263) is honourable by `compose run` and by nothing
+	# else: `run` is the only compose verb that takes `-v`, and `up` — which
+	# is how the long-running container is created — takes none. Threading
+	# the per-id binds through this substrate's oneshots would therefore
+	# migrate the database inside `.caches/<id>` and then boot the box from
+	# the shared `_build`/`deps`, which is not isolation but a deploy split
+	# across two caches with nothing in the output to say so. Refuse instead:
+	# an operator who set the variable asked for isolation, and silently
+	# giving them half of it is the failure mode, not the fix.
+	#
+	# First in the function, ahead of the .env check: this one is about the
+	# operator's environment being incompatible with the substrate at all,
+	# and it holds whether or not the box is installed. Still inside the
+	# hook (not at source time), for the reason the file header gives — the
+	# flag parse must run first, so `--bogus` stays a usage error.
+	if [ -n "${GRAPPA_CACHE_ID:-}" ]; then
+		die "GRAPPA_CACHE_ID is set ('$GRAPPA_CACHE_ID') and the Docker deploy substrate cannot honour it: only 'compose run' accepts -v, so the oneshots would use the per-id caches while 'compose up' boots the container from the shared ones. Unset GRAPPA_CACHE_ID to deploy."
+	fi
+
 	if [ ! -f .env ]; then
 		die "no .env file. Copy .env.example and fill in SECRET_KEY_BASE + SECRET_SIGNING_SALT + GRAPPA_ENCRYPTION_KEY."
 	fi

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -224,6 +224,98 @@ defmodule Grappa.IRC.Identifier do
   def valid_channel?(s) when is_binary(s), do: Regex.match?(@channel_regex, s)
   def valid_channel?(_), do: false
 
+  # RFC 2812 §1.3 channel sigils, as a first-BYTE test. Deliberately the
+  # same four characters `@channel_regex` opens with, and deliberately
+  # weaker than the regex: "does a channel start here" is a different
+  # question from "is this a well-formed channel name", and the STATUSMSG
+  # peel needs the former to decide where a target's name begins.
+  @channel_sigils ["#", "&", "!", "+"]
+
+  @doc """
+  True iff `s` STARTS with an RFC 2812 channel sigil (`#`, `&`, `!`, `+`).
+
+  First byte only — it does not validate the rest of the name. This is the
+  "a channel starts here" test, the single source of truth shared by
+  `EventRouter`'s channel-NOTICE dispatch guard and `peel_statusmsg/2`.
+  The two MUST agree byte-for-byte: the peel's whole contract is that what
+  it hands back is something the dispatch will recognise as a channel, and
+  two independent sigil lists would drift into a target that peels here and
+  routes to `$server` there.
+  """
+  @spec channel_sigil?(term()) :: boolean()
+  def channel_sigil?(<<c::binary-size(1), _::binary>>), do: c in @channel_sigils
+  def channel_sigil?(_), do: false
+
+  @doc """
+  Peels a STATUSMSG prefix off an IRC message target.
+
+  Returns `{underlying channel, peeled run}` when `target` is a channel
+  addressed at one or more membership levels, else `{target unchanged,
+  nil}`. `statusmsg` is the network's advertised sigil set
+  (`ISupport.statusmsg/1`) — never a hardcoded list, because the set is
+  per-network (bahamut `@+`, others `@%+`, UnrealIRCd-shaped networks add
+  owner/admin).
+
+  ## What gets peeled (#218, #1303)
+
+  The LONGEST leading run of advertised sigils whose remainder still starts
+  a channel. A character outside the advertised set is not a sigil — it is
+  part of the name, and the walk stops there.
+
+  Greedy alone is not enough, and the reason is the `+` collision: `+` is
+  both the voice sigil and an RFC channel sigil. On bahamut's `@+`, a plain
+  greedy peel of `@+chan` (an ops-level notice to the modeless channel
+  `+chan`) takes both bytes, finds `chan` is no channel, and has to roll the
+  whole peel back to `$server` — regressing a target the single-sigil peel
+  already routed correctly. Backtracking one sigil at a time until the
+  remainder is a channel resolves `@+chan` to `+chan` at level `@`, and
+  `@+#chan` to `#chan` at level `@+`, without a special case for either.
+
+  Rolling the peel back WHOLE when no split works is what keeps the
+  collision guard honest: `+chan` peels to `chan`, which is no channel, so
+  nothing is peeled and no voice level is invented on a channel anyone can
+  read.
+
+  ## What the run means (#1303 ruling)
+
+  Every peeled sigil, in the order it arrived on the wire — `"@+"`, not
+  `"@"`. A STATUSMSG target reaches the UNION of the named levels, so
+  `@+#chan` was seen by ops AND by voiced members; recording only the
+  outermost would let a consumer claim ops-only for a line half the channel
+  read, with the `+` gone and no reader able to correct it. Consumers MUST
+  NOT assume the run is one character.
+
+  No sorting step: PREFIX is advertised highest-first and clients emit
+  sigils in that order, so a well-formed target arrives already ordered.
+  A perverse spelling is recorded as it arrived rather than rewritten —
+  what was delivered is a fact, and a canonical spelling would be our
+  invention.
+  """
+  @spec peel_statusmsg(binary(), [String.t()]) :: {binary(), String.t() | nil}
+  def peel_statusmsg(target, statusmsg) when is_binary(target) and is_list(statusmsg) do
+    case longest_peel(target, statusmsg, "") do
+      {run, channel} -> {channel, run}
+      nil -> {target, nil}
+    end
+  end
+
+  # Longest-first walk: recurse past this sigil before considering a split
+  # here, so the deepest viable split wins and shorter ones are the fallback.
+  @spec longest_peel(binary(), [String.t()], String.t()) :: {String.t(), binary()} | nil
+  defp longest_peel(rest, statusmsg, run) do
+    case deeper_peel(rest, statusmsg, run) do
+      nil -> if run != "" and channel_sigil?(rest), do: {run, rest}, else: nil
+      deeper -> deeper
+    end
+  end
+
+  @spec deeper_peel(binary(), [String.t()], String.t()) :: {String.t(), binary()} | nil
+  defp deeper_peel(<<sigil::binary-size(1), rest::binary>>, statusmsg, run) do
+    if sigil in statusmsg, do: longest_peel(rest, statusmsg, run <> sigil), else: nil
+  end
+
+  defp deeper_peel(_, _, _), do: nil
+
   @doc """
   Strips a SINGLE leading `~` from a user-supplied IRC ident (GH #152).
 

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -140,12 +140,12 @@ defmodule Grappa.Scrollback.Meta do
                                                                   Its ABSENCE on a :notice row is what
                                                                   marks the row INBOUND.)
       :notice  | :privmsg           →  + %{statusmsg: String.t()}
-                                                                 (#1247: the STATUSMSG membership sigil
+                                                                 (#1247: the STATUSMSG membership level
                                                                   the message was DELIVERED at —
                                                                   `@#chan` reaches channel ops only,
                                                                   `+#chan` voiced members. #218 peels the
-                                                                  sigil to route the row to the channel
-                                                                  window; this is the peeled sigil kept
+                                                                  sigils to route the row to the channel
+                                                                  window; this is what was peeled, kept
                                                                   rather than dropped, so a consumer can
                                                                   tell an ops-only broadcast from one the
                                                                   whole channel saw. Verbatim from the
@@ -155,7 +155,14 @@ defmodule Grappa.Scrollback.Meta do
                                                                   `@%+`) — NOT a closed set this end can
                                                                   enumerate. ABSENT on an ordinary
                                                                   channel message; there is no nil form,
-                                                                  presence IS the test.)
+                                                                  presence IS the test.
+                                                                  #1303: the WHOLE peeled run, not one
+                                                                  character — `@+#chan` records `"@+"`.
+                                                                  A STATUSMSG target reaches the UNION of
+                                                                  the named levels, so recording only the
+                                                                  outermost would badge as ops-only a line
+                                                                  voiced members also read. Consumers MUST
+                                                                  NOT assume length 1.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -84,7 +84,7 @@ defmodule Grappa.Session do
     exports: [Backoff, NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
-  alias Grappa.Session.{FloodAllowance, Server}
+  alias Grappa.Session.{FloodAllowance, ISupport, Server}
 
   require Logger
 
@@ -1308,6 +1308,33 @@ defmodule Grappa.Session do
     case call_session(subject, network_id, :casemapping) do
       mapping when mapping in [:ascii, :rfc1459, :rfc1459_strict] -> mapping
       _ -> :ascii
+    end
+  end
+
+  @doc """
+  Returns the network's IRC `STATUSMSG` sigil set as observed by the LIVE
+  session at `(subject, network_id)` — e.g. `["@", "+"]`, `["@", "%", "+"]`.
+
+  #1301 — sibling of `casemapping/2`, and there for the same reason: the
+  stateless POST boundary has to decide whether `@#chan` is a channel
+  addressed at a membership level or a malformed name, and only the live
+  session has seen the 005 that says which sigils this network has. This is
+  the ingress source `GrappaWeb.Validation.validate_wire_recipient_name/2`
+  feeds into `Identifier.peel_statusmsg/2`.
+
+  Returns the bahamut default (`ISupport.default_statusmsg/0`) whenever there
+  is no live session or the call cannot complete. That is the SAME value a
+  live session reports before its 005 arrives, so a parked network answers
+  what every prod network has always advertised rather than refusing every
+  sigil — and a refusal is the failure mode that matters here, since it is
+  what #1301 reported.
+  """
+  @spec statusmsg(subject(), integer()) :: [String.t()]
+  def statusmsg(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    case call_session(subject, network_id, :statusmsg) do
+      sigils when is_list(sigils) -> sigils
+      _ -> ISupport.default_statusmsg()
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -388,7 +388,7 @@ defmodule Grappa.Session.EventRouter do
   # #218 — a STATUSMSG target (`@#chan` ops-only, `+#chan` voice) is a
   # channel message prefixed with a membership sigil; it belongs in the
   # underlying channel window, NOT the network/`$server` tab or a query
-  # window. Strip a leading statusmsg sigil from a `:notice`/`:privmsg`
+  # window. Strip the statusmsg sigils from a `:notice`/`:privmsg`
   # param-0 target BEFORE canonicalisation + the channel-prefix dispatch,
   # so `build_persist` / `normalize_channel/2` receive a clean `#chan` (no
   # need to widen that head's sigil set, which mirrors
@@ -409,30 +409,20 @@ defmodule Grappa.Session.EventRouter do
   # peeling it to route the row and then discarding it destroys the level at
   # ingress, so no consumer downstream can badge what never reached the store.
   # `nil` when nothing was peeled — the vast majority of traffic.
+  #
+  # #1303 — the peel itself moved to `Identifier.peel_statusmsg/2`, which the
+  # POST boundary needs too (`/notice @#chan` was refused as malformed because
+  # nothing outside this module knew what a sigil was). One definition of
+  # "what is a STATUSMSG sigil on this network" for ingress and egress; the
+  # sigil SET still arrives from the per-network 005, never hardcoded.
   @spec strip_statusmsg_target(Message.t(), [String.t()]) :: {Message.t(), String.t() | nil}
   defp strip_statusmsg_target(%Message{command: cmd, params: [target | rest]} = msg, statusmsg)
        when cmd in [:notice, :privmsg] and is_binary(target) do
-    {stripped, level} = strip_statusmsg_prefix(target, statusmsg)
+    {stripped, level} = Identifier.peel_statusmsg(target, statusmsg)
     {%{msg | params: [stripped | rest]}, level}
   end
 
   defp strip_statusmsg_target(msg, _), do: {msg, nil}
-
-  # Peels ONE leading statusmsg sigil iff (a) it is in the network's
-  # advertised set AND (b) a channel sigil (`#&!+`) immediately follows —
-  # so a real `+chan` (voice-typed channel, `+` NOT followed by a channel
-  # sigil) is never mis-stripped (the `+` collision: `+` is both a channel
-  # sigil and the voice membership sigil). Returns `{underlying channel,
-  # peeled sigil}`, else `{target unchanged, nil}` — the `nil` is what keeps
-  # the collision guard from inventing a voice level on a modeless `+chan`.
-  # Reuses `channel_target?/1` so the "what follows is a channel" test agrees
-  # byte-for-byte with the channel-NOTICE dispatch guard.
-  @spec strip_statusmsg_prefix(binary(), [String.t()]) :: {binary(), String.t() | nil}
-  defp strip_statusmsg_prefix(<<sigil::binary-size(1), rest::binary>> = target, statusmsg) do
-    if sigil in statusmsg and channel_target?(rest), do: {rest, sigil}, else: {target, nil}
-  end
-
-  defp strip_statusmsg_prefix(target, _), do: {target, nil}
 
   # #1247 — record the delivery level on the rows this message produced.
   #
@@ -3092,9 +3082,13 @@ defmodule Grappa.Session.EventRouter do
   # prefix check (not `Identifier.valid_channel?/1`) because the NOTICE
   # site needs it inside a `when` guard where Regex.match? is illegal;
   # routing must not diverge between the two arms for a pathological name.
+  #
+  # #1303 — delegates rather than holding its own copy of the four sigils.
+  # `Identifier.peel_statusmsg/2` hands back a target this arm has to
+  # recognise as a channel; two independent lists would drift into a target
+  # that peels there and lands in `$server` here.
   @spec channel_target?(binary()) :: boolean()
-  defp channel_target?(<<c::binary-size(1), _::binary>>), do: c in ["#", "&", "!", "+"]
-  defp channel_target?(_), do: false
+  defp channel_target?(target), do: Identifier.channel_sigil?(target)
 
   @spec channels_with_member(members(), String.t()) :: [String.t()]
   defp channels_with_member(members, nick) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2552,6 +2552,15 @@ defmodule Grappa.Session.Server do
     {:reply, session_casemapping(state), state}
   end
 
+  # #1301 — the network's advertised STATUSMSG sigil set, for the stateless
+  # POST boundary to tell `@#chan` (a channel at ops level) from a malformed
+  # target. Same `Map.get` hot-reload safety as `:casemapping`. Public via
+  # `Grappa.Session.statusmsg/2`, which degrades to the bahamut default when
+  # there is no live pid.
+  def handle_call(:statusmsg, _, state) do
+    {:reply, ISupport.statusmsg(Map.get(state, :isupport, ISupport.default())), state}
+  end
+
   # #247 — the authoritative /notify presence map for this session.
   # Public via `Grappa.Session.presence_snapshot/2`; consumed by the
   # channel after-join snapshot and the REST notify listing (DB list +

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -68,7 +68,8 @@ defmodule Grappa.Session.Wire do
     ListModes,
     LusersAccum,
     WhoisAccum,
-    WhowasAccum
+    WhowasAccum,
+    WindowState
   }
 
   @typedoc """
@@ -114,6 +115,21 @@ defmodule Grappa.Session.Wire do
           | :presence_changed
           | :presence_error
           | :presence_snapshot
+
+  @typedoc """
+  The closed set of per-channel window states, re-exported from
+  `Grappa.Session.WindowState` so it reaches the codegen (#1406 X-S8).
+
+  No single payload carries the whole union — each event pins its own literal
+  (`state: :joined`, `state: :failed`, …) and `:parked` never rides a `state`
+  field at all — so nothing under `@wire_glob` referenced the SSOT and cic's
+  `windowState.ts` restated all six states by hand. CLAUDE.md says adding a
+  state is a server change cic just mirrors; naming the type here is what makes
+  that true mechanically, because `mix grappa.gen_wire_types` then emits the
+  set as a generated const and a seventh state widens the client union on
+  regeneration instead of on someone remembering.
+  """
+  @type window_state :: WindowState.window_state()
 
   @type channels_changed_payload :: %{kind: :channels_changed}
 

--- a/lib/grappa/themes/token_model.ex
+++ b/lib/grappa/themes/token_model.ex
@@ -85,6 +85,36 @@ defmodule Grappa.Themes.TokenModel do
 
   @type token_map :: %{String.t() => term()}
 
+  @typedoc """
+  The closed font-family allowlist, as a type. **Derived from
+  `@font_families`** — the same list `sanitize_font/1` guards with, spliced
+  into the spec at compile time instead of restated beside it (#1406 X-S9).
+
+  A hand-written twin union would be a SECOND closed set to keep in step, which
+  is precisely the defect being closed here: `Grappa.Themes.Wire` re-exports
+  this type so `mix grappa.gen_wire_types` emits the vocabulary as a generated
+  const, and cic stops transcribing it by hand.
+  """
+  @type font_family ::
+          unquote(
+            @font_families
+            |> Enum.map(&String.to_atom/1)
+            |> Enum.reverse()
+            |> Enum.reduce(fn arm, acc -> quote(do: unquote(arm) | unquote(acc)) end)
+          )
+
+  @typedoc """
+  The closed background sizing modes (#294), as a type. Derived from
+  `@size_modes` on the same terms as `font_family/0` above.
+  """
+  @type size_mode ::
+          unquote(
+            @size_modes
+            |> Enum.map(&String.to_atom/1)
+            |> Enum.reverse()
+            |> Enum.reduce(fn arm, acc -> quote(do: unquote(arm) | unquote(acc)) end)
+          )
+
   @doc "The frozen list of 27 color token keys (string form)."
   @spec color_keys() :: [String.t()]
   def color_keys, do: @color_keys

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,13 +42,38 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
+  alias Grappa.Themes.BuiltinBackgrounds
   alias Grappa.Themes.Theme
+  alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
 
   # #299 author model A — the fallback attribution label, used only when a
   # theme carries no `author_nick` snapshot (legacy / never-published visitor
   # themes). A closed constant.
   @guest_author "guest"
+
+  @typedoc """
+  The closed font-family vocabulary, re-exported from
+  `Grappa.Themes.TokenModel` so it reaches the codegen (#1406 X-S9).
+
+  `token_model.ex` is not a `*wire.ex` file, so nothing under
+  `@wire_glob` used to see the vocabulary and cic transcribed it by hand
+  (`themesApi.ts`, four "mirror of …" comments and no gate). Naming the type
+  HERE — at the wire boundary that already publishes the payload it belongs to
+  — makes `mix grappa.gen_wire_types` emit it as a generated const, and the
+  `--check` drift gate then guards a copy nobody has to remember to update.
+  """
+  @type font_family :: TokenModel.font_family()
+
+  @typedoc "The closed background sizing modes (#294), re-exported per `font_family/0`."
+  @type background_size :: TokenModel.size_mode()
+
+  @typedoc """
+  One entry of the built-in background catalog, re-exported per `font_family/0`.
+  `GET /themes/backgrounds` serves a list of these and had no generated
+  counterpart at all before #1406 X-S9.
+  """
+  @type builtin_background :: BuiltinBackgrounds.t()
 
   # The rich viewer subject (as carried in `conn.assigns.current_subject`) is
   # inlined into `to_wire/2`'s spec rather than exposed as a public `@type` — a
@@ -67,10 +92,12 @@ defmodule Grappa.Themes.Wire do
           mine: boolean(),
           # The sanitized closed-token map (`Grappa.Themes.TokenModel.token_map()`
           # — string-keyed: `"colors"` / `"font_family"` / `"background"`). Typed
-          # as an open string-keyed map, NOT a bare `map()`: cic owns the closed
-          # token vocabulary in `themesApi.ts`, so the wire codegen emits
-          # `Record<string, unknown>` (a bare `map()` would trip the
-          # gen_wire_types "defeats codegen" warning for the same output).
+          # as an open string-keyed map, NOT a bare `map()`, so the wire codegen
+          # emits `Record<string, unknown>` (a bare `map()` would trip the
+          # gen_wire_types "defeats codegen" warning for the same output). The
+          # VALUE vocabularies are pinned separately, as `font_family/0` and
+          # `background_size/0` above (#1406 X-S9); the 27 color KEYS stay
+          # cic-owned in `themesApi.ts` and remain UNpinned.
           payload: %{optional(String.t()) => term()},
           inserted_at: String.t()
         }

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,7 +42,6 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
-  alias Grappa.Themes.BuiltinBackgrounds
   alias Grappa.Themes.Theme
   alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
@@ -68,12 +67,19 @@ defmodule Grappa.Themes.Wire do
   @typedoc "The closed background sizing modes (#294), re-exported per `font_family/0`."
   @type background_size :: TokenModel.size_mode()
 
-  @typedoc """
-  One entry of the built-in background catalog, re-exported per `font_family/0`.
-  `GET /themes/backgrounds` serves a list of these and had no generated
-  counterpart at all before #1406 X-S9.
-  """
-  @type builtin_background :: BuiltinBackgrounds.t()
+  # `Grappa.Themes.BuiltinBackgrounds.t/0` is DELIBERATELY not re-exported here,
+  # and `GET /themes/backgrounds` therefore still has no generated counterpart.
+  # Measured on #1406: the codegen cannot render it. `t/0` carries
+  # `variant: variant()`, a same-module `user_type`, and the EXTERNAL-type path
+  # renders one type at a time with no sibling registry — so the types half
+  # emits `variant: Variant` (the `camelize` fallback, a name nothing declares:
+  # `TS2304`) while the schema half imports `THEMES_BUILTIN_BACKGROUNDS_VARIANT`
+  # (`TS2724`), a const neither half emits. The two emitters disagree, and the
+  # failure lands on the CLIENT compiler rather than on the generator.
+  # `gen_wire_types.ex`'s own comment rules out teaching the external path to
+  # resolve refs, so the fix is the emitter's to make (fail loudly first), not
+  # a shape restated here — a hand copy of the four fields would reintroduce
+  # exactly the twin this issue removes.
 
   # The rich viewer subject (as carried in `conn.assigns.current_subject`) is
   # inlined into `to_wire/2`'s spec rather than exposed as a public `@type` — a

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -42,8 +42,7 @@ defmodule Grappa.Themes.Wire do
 
   alias Grappa.Accounts.User
   alias Grappa.Themes
-  alias Grappa.Themes.Theme
-  alias Grappa.Themes.TokenModel
+  alias Grappa.Themes.{Theme, TokenModel}
   alias Grappa.Visitors.Visitor
 
   # #299 author model A — the fallback attribution label, used only when a

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -57,7 +57,12 @@ defmodule GrappaWeb.MessagesController do
   """
   use GrappaWeb, :controller
 
-  import GrappaWeb.Validation, only: [validate_target_name: 1, validate_post_target_name: 1]
+  import GrappaWeb.Validation,
+    only: [
+      validate_target_name: 1,
+      validate_post_target_name: 1,
+      validate_wire_recipient_name: 2
+    ]
 
   alias Grappa.IRC.Identifier
   alias Grappa.PresenceFilter.Resolver
@@ -263,14 +268,15 @@ defmodule GrappaWeb.MessagesController do
     # #640 — a CTCP QUERY (/ctcp, /ping). `channel` (the URL) is the SOURCE
     # window the echo renders in — `validate_target_name` (NOT the post variant)
     # so `$server` is allowed (a /ping typed in the server window is legit).
-    # `ctcp_target` is the wire recipient — `validate_post_target_name` (a real
-    # channel/nick, never the read-only `$server`). The session persists the
-    # echo to `source`, relays the frame to `ctcp_target`, and NEVER opens a
-    # query window for it (the phantom-window bug). One send-token as for a
-    # plain PRIVMSG. `send_ctcp` always persists a row (no `:no_persist` arm).
+    # `ctcp_target` is the wire recipient — `validate_wire_recipient_name` (a
+    # real channel/nick, a channel at a membership level, never the read-only
+    # `$server`). The session persists the echo to `source`, relays the frame
+    # to `ctcp_target`, and NEVER opens a query window for it (the
+    # phantom-window bug). One send-token as for a plain PRIVMSG. `send_ctcp`
+    # always persists a row (no `:no_persist` arm).
     with :ok <- BodyLimit.check(body),
          :ok <- validate_target_name(channel),
-         :ok <- validate_post_target_name(ctcp_target),
+         :ok <- validate_wire_recipient_name(ctcp_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_ctcp(subject, network.id, channel, ctcp_target, body) do
       render_send_result(conn, result)
@@ -285,13 +291,15 @@ defmodule GrappaWeb.MessagesController do
     # #1225 — `/notice <target> <text>`. Same door shape as the #640 CTCP arm
     # above: `channel` (the URL) is the SOURCE window the echo renders in, so it
     # takes `validate_target_name` (a `/notice` typed in `$server` is legit);
-    # `notice_target` is the wire recipient, so it takes the POST variant (a
-    # real nick or channel, never the read-only `$server`). One send-token, as
-    # for a plain PRIVMSG. A *serv recipient answers `{:ok, :no_persist}` (W12),
-    # which `render_send_result/2` already renders as 202.
+    # `notice_target` is the wire recipient, so it takes the recipient variant
+    # (a real nick or channel, or a channel at a membership level per #1301,
+    # never the read-only `$server`). One send-token, as for a plain PRIVMSG.
+    # A *serv recipient answers `{:ok, :no_persist}` (W12), which
+    # `render_send_result/2` already renders as 202.
     with :ok <- BodyLimit.check(body),
          :ok <- validate_target_name(channel),
-         :ok <- validate_post_target_name(notice_target),
+         :ok <-
+           validate_wire_recipient_name(notice_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_notice(subject, network.id, channel, notice_target, body) do
       render_send_result(conn, result)

--- a/lib/grappa_web/validation.ex
+++ b/lib/grappa_web/validation.ex
@@ -134,7 +134,7 @@ defmodule GrappaWeb.Validation do
   @spec validate_wire_recipient_name(String.t(), [String.t()]) :: :ok | {:error, :bad_request}
   def validate_wire_recipient_name(name, statusmsg)
       when is_binary(name) and is_list(statusmsg) do
-    {peeled, _run} = Identifier.peel_statusmsg(name, statusmsg)
+    {peeled, _} = Identifier.peel_statusmsg(name, statusmsg)
     validate_post_target_name(peeled)
   end
 

--- a/lib/grappa_web/validation.ex
+++ b/lib/grappa_web/validation.ex
@@ -92,12 +92,51 @@ defmodule GrappaWeb.Validation do
   bytes upstream, pollute the synthetic Server-window scrollback via the
   single-source echo path, and probe operator privileges. The synthetic
   is for *reading* server-window scrollback, never for *writing*.
-  Used by `MessagesController.create/2`.
+
+  Used by `MessagesController.create/2`'s plain arm, where the target is
+  ALSO the persist key. The notice/CTCP arms take
+  `validate_wire_recipient_name/2` instead — see there for why a wire
+  recipient may carry a STATUSMSG sigil and a window key may not.
   """
   @spec validate_post_target_name(String.t()) :: :ok | {:error, :bad_request}
   def validate_post_target_name("$server"), do: {:error, :bad_request}
 
   def validate_post_target_name(name), do: validate_target_name(name)
+
+  @doc """
+  Like `validate_post_target_name/1` but for a WIRE RECIPIENT: additionally
+  accepts a channel addressed at a membership level (`@#chan`, `@%#chan`),
+  peeling the network's advertised STATUSMSG sigils before testing the name
+  behind them. `statusmsg` comes from `Grappa.Session.statusmsg/2`.
+
+  #1301 — `/notice @#chan` was refused as malformed. A STATUSMSG sigil is
+  neither a channel prefix nor a nick character, so the raw target matched
+  neither validator and the POST 400ed. `@` and `%` were refused outright;
+  `+#chan` and `&#chan` passed, but by accident — `+` and `&` are RFC
+  channel prefixes, so the voice-level notice worked while the ops-level
+  one, the common case, did not.
+
+  ## Why this is a separate validator, not a widening
+
+  `validate_post_target_name/1` also guards the plain `channel_id` arm,
+  where the target IS the persist key. Admitting `@#chan` there would key
+  scrollback to a window nobody is in — the outbound twin of the phantom
+  `+#chan` window #1303 fixes on the inbound side. On the notice/CTCP arms
+  the recipient is not a key: the echo row is keyed to the SOURCE window and
+  the recipient rides `meta.notice_target`, so a sigil costs nothing there.
+  The two arms differ in what the target IS, so they take different doors.
+
+  The peeled remainder is what gets validated; the target reaches the wire
+  **verbatim**. Peeling to validate is not permission to rewrite — what
+  `@%#chan` means is the ircd's ruling, and a target we canonicalised (or
+  refused on our own authority) would answer a question nobody asked.
+  """
+  @spec validate_wire_recipient_name(String.t(), [String.t()]) :: :ok | {:error, :bad_request}
+  def validate_wire_recipient_name(name, statusmsg)
+      when is_binary(name) and is_list(statusmsg) do
+    {peeled, _run} = Identifier.peel_statusmsg(name, statusmsg)
+    validate_post_target_name(peeled)
+  end
 
   @doc """
   Atomizes a whitelisted subset of string-keyed `params` into an

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -246,10 +246,13 @@ in_container() {
 # Run a one-shot mix task without the long-running container (e.g. `mix
 # deps.get` before first boot), layering worktree source overrides.
 #
-# `compose.oneshot.yaml` MUST stay layered LAST — its `ports: !reset []` +
-# `container_name: !reset null` drop host-side bindings inherited from the
-# base file or the personal override. Its path is absolute via $SRC_ROOT so
-# it resolves to the worktree copy, like the WORKTREE_VOLUMES mounts.
+# `compose.oneshot.yaml` carries ONE key, `healthcheck: disable: true`, and
+# it is layered here because `run` DOES inherit the service healthcheck
+# while a oneshot never boots phx.server. It used to also reset
+# `container_name` and `ports` against a collision that measurement showed
+# does not happen — see that file for the numbers. Its path is absolute via
+# $SRC_ROOT so it resolves to the worktree copy, like the WORKTREE_VOLUMES
+# mounts.
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)".
 in_oneshot() {
     docker compose "${COMPOSE_ARGS[@]}" -f "$SRC_ROOT/compose.oneshot.yaml" \

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -6,24 +6,45 @@
 #   scripts/db.sh "SELECT * FROM messages LIMIT 5;"   # one-shot query
 #
 # Reads MIX_ENV from the running container to pick the right db file (dev when
-# there is none). Prod DBs open read-only.
+# there is none). Prod DBs open read-only. Works from a worktree: the sqlite3
+# invocation goes through in_container_or_oneshot, which falls back to a
+# oneshot rather than dying (#1409).
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"
 
-env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+# `detect_mix_env` is the SoT for this probe (#1409 D-S11). The hand-rolled
+# `in_container printenv MIX_ENV 2>/dev/null || echo dev` it replaces was
+# broken two ways: it dropped the `tr -d '\r'` normalisation, so a `\r`
+# produced a path nothing could open, and `in_container` DIES from a
+# worktree — where, by rule, every code change happens. `die` is an
+# `exit 1`, and an `exit` inside a command substitution kills the subshell,
+# so the `|| echo dev` fallback never ran: the probe came back empty and
+# `set -e` ended the script with no message at all, the `die` having gone
+# into `2>/dev/null`.
+env="$(detect_mix_env)"
+# Empty means no container is up. dev is the documented default and is
+# applied HERE, in the open, instead of riding a fallback that could not fire.
+[ -n "$env" ] || env=dev
+
 # Path shape via the _lib.sh SoT — never hardcode it, or it drifts from
 # compose.yaml / scripts/mix.sh (#364).
 DB="$(db_path_for_env "$env")"
-MODE_ARG=""
+
+# An ARRAY, not a quoted scalar: quoting an empty `$MODE_ARG` would hand
+# sqlite3 "" as its first argument, which it reads as a filename. Empty
+# array expands to nothing, exactly as the unquoted form did by accident.
+mode_args=()
 if [ "$env" = "prod" ]; then
-    MODE_ARG="-readonly"
+    mode_args=(-readonly)
 fi
 
+# `in_container_or_oneshot`, so the tool CLAUDE.md calls first-resort works
+# from the worktree it is meant to be used in.
 if [ $# -eq 0 ]; then
-    in_container sqlite3 $MODE_ARG "$DB"
+    in_container_or_oneshot sqlite3 "${mode_args[@]}" "$DB"
 else
-    in_container sqlite3 $MODE_ARG "$DB" "$*"
+    in_container_or_oneshot sqlite3 "${mode_args[@]}" "$DB" "$*"
 fi

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -212,12 +212,6 @@ defmodule Grappa.IRC.IdentifierTest do
       assert Identifier.peel_statusmsg("@+#chan", @bahamut) == {"#chan", "@+"}
     end
 
-    test "the run records EVERY level, so a consumer cannot claim ops-only for a line voice also saw" do
-      {_, run} = Identifier.peel_statusmsg("@+#chan", @bahamut)
-      assert run == "@+"
-      refute run == "@"
-    end
-
     test "collision guard: a modeless +chan is left whole and records no level" do
       # `+chan` is a CHANNEL named `+chan`, not a voice-targeted `+#chan`.
       # Peeling the `+` would leave `chan`, which is not a channel, so the

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -162,6 +162,117 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
+  describe "channel_sigil?/1" do
+    test "true for the four RFC channel sigils" do
+      assert Identifier.channel_sigil?("#chan")
+      assert Identifier.channel_sigil?("&local")
+      assert Identifier.channel_sigil?("!safe")
+      assert Identifier.channel_sigil?("+modeless")
+    end
+
+    test "false for a nick, a statusmsg sigil, and the empty string" do
+      refute Identifier.channel_sigil?("someone")
+      refute Identifier.channel_sigil?("@#chan")
+      refute Identifier.channel_sigil?("")
+    end
+
+    test "first byte only — it does NOT validate the rest of the name" do
+      # Deliberately weaker than `valid_channel?/1`: this is the
+      # "does a channel start here" test the STATUSMSG peel needs, and it
+      # must agree byte-for-byte with the channel-NOTICE dispatch guard in
+      # EventRouter. A name `valid_channel?/1` would reject still answers
+      # true here.
+      assert Identifier.channel_sigil?("#with space")
+      refute Identifier.valid_channel?("#with space")
+    end
+  end
+
+  # #1303 — a STATUSMSG target can carry MORE THAN ONE sigil (`@%#chan` on a
+  # network advertising `@%+`), and the single-sigil peel misrouted both
+  # shapes it can meet: `@%#chan` peeled nothing (the remainder `%#chan` is
+  # not a channel) and landed in `$server`, while `@+#chan` peeled only the
+  # `@` and persisted to `+#chan` — a phantom channel nobody is in.
+  describe "peel_statusmsg/2 (#218 single sigil, #1303 the whole run)" do
+    @bahamut ["@", "+"]
+    @halfop ["@", "%", "+"]
+
+    test "peels one advertised sigil off a channel target — the #218 case" do
+      assert Identifier.peel_statusmsg("@#chan", @bahamut) == {"#chan", "@"}
+      assert Identifier.peel_statusmsg("+#chan", @bahamut) == {"#chan", "+"}
+    end
+
+    test "#1303 case A: @%#chan peels BOTH and records the whole run" do
+      assert Identifier.peel_statusmsg("@%#chan", @halfop) == {"#chan", "@%"}
+    end
+
+    test "#1303 case B: @+#chan resolves to #chan, NOT the phantom +#chan" do
+      # The silent one. `+` is a channel sigil in its own right, so the
+      # single peel accepted `+#chan` as the underlying channel and wrote
+      # scrollback to a window nobody is in.
+      assert Identifier.peel_statusmsg("@+#chan", @bahamut) == {"#chan", "@+"}
+    end
+
+    test "the run records EVERY level, so a consumer cannot claim ops-only for a line voice also saw" do
+      {_, run} = Identifier.peel_statusmsg("@+#chan", @bahamut)
+      assert run == "@+"
+      refute run == "@"
+    end
+
+    test "collision guard: a modeless +chan is left whole and records no level" do
+      # `+chan` is a CHANNEL named `+chan`, not a voice-targeted `+#chan`.
+      # Peeling the `+` would leave `chan`, which is not a channel, so the
+      # whole peel rolls back.
+      assert Identifier.peel_statusmsg("+chan", @bahamut) == {"+chan", nil}
+    end
+
+    test "backtracks to the LONGEST run whose remainder is still a channel: @+chan" do
+      # `+chan` is a real modeless channel and `@` is the level. A peel that
+      # took every advertised sigil greedily without backtracking would
+      # strip `@+`, find `chan` is not a channel, roll the whole thing back,
+      # and misroute an ops-only notice to `$server` — a REGRESSION of what
+      # the single-sigil peel already got right.
+      assert Identifier.peel_statusmsg("@+chan", @bahamut) == {"+chan", "@"}
+    end
+
+    test "backtracks when the sigil and the channel prefix are the same byte: ++chan" do
+      assert Identifier.peel_statusmsg("++chan", @bahamut) == {"+chan", "+"}
+    end
+
+    test "a sigil the network does not advertise is part of the name, not a level" do
+      # Under bahamut's `@+` there is no halfop level, so `%#chan` is not a
+      # STATUSMSG target at all and must not be peeled.
+      assert Identifier.peel_statusmsg("%#chan", @bahamut) == {"%#chan", nil}
+    end
+
+    test "a plain channel and a plain nick pass through untouched" do
+      assert Identifier.peel_statusmsg("#chan", @bahamut) == {"#chan", nil}
+      assert Identifier.peel_statusmsg("someone", @bahamut) == {"someone", nil}
+    end
+
+    test "a sigil with nothing usable behind it is not a peel" do
+      assert Identifier.peel_statusmsg("@", @bahamut) == {"@", nil}
+      assert Identifier.peel_statusmsg("@someone", @bahamut) == {"@someone", nil}
+      assert Identifier.peel_statusmsg("", @bahamut) == {"", nil}
+    end
+
+    test "an empty advertised set peels nothing" do
+      # A network that advertises `STATUSMSG=` with no sigils has no levels;
+      # every target is its own name.
+      assert Identifier.peel_statusmsg("@#chan", []) == {"@#chan", nil}
+    end
+
+    test "the run is the order the sigils arrived on the wire — no sort, no rewrite" do
+      # On a well-formed target the wire order IS the advertised order
+      # (PREFIX is advertised highest-first and clients emit it that way),
+      # which is why no sorting step is needed. What this pins is that we do
+      # not INVENT an order: a target that arrives `%@#chan` records `"%@"`,
+      # the truth of what was delivered, rather than being rewritten into a
+      # canonical spelling we made up.
+      assert Identifier.peel_statusmsg("@%#chan", @halfop) == {"#chan", "@%"}
+      assert Identifier.peel_statusmsg("%@#chan", @halfop) == {"#chan", "%@"}
+    end
+  end
+
   describe "sanitize_ident/1" do
     test "strips a single leading tilde (the identd-verified anti-spoof guard)" do
       # grappa runs no identd; the ircd tilde-prefixes unverified idents.

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -440,6 +440,36 @@ defmodule Grappa.Session.EventRouterPropertyTest do
     end
   end
 
+  # #1303 — the single-sigil peel broke on a target carrying more than one,
+  # and WHICH way it broke depended on the second sigil: `@%#chan` peeled
+  # nothing and landed in `$server`, `@+#chan` peeled one and persisted to a
+  # phantom `+#chan`. The property covers every run the advertised set can
+  # spell, so neither shape depends on a unit example being remembered.
+  property "#1303: a multi-sigil STATUSMSG target routes to the channel and records the whole run" do
+    check all(
+            body <- ascii_nick_gen(),
+            run <- list_of(member_of(["@", "+"]), min_length: 1, max_length: 3)
+          ) do
+      channel = "#" <> body
+      prefix = Enum.join(run)
+
+      m = %Message{
+        command: :notice,
+        params: [prefix <> channel, "ops heads up"],
+        prefix: {:nick, "someuser", "u", "h"},
+        tags: %{}
+      }
+
+      assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, min_state())
+
+      assert attrs.channel == String.downcase(channel),
+             "statusmsg target #{prefix <> channel} should route to #{String.downcase(channel)}, got #{attrs.channel}"
+
+      assert attrs.meta.statusmsg == prefix,
+             "target #{prefix <> channel} should record the whole run #{prefix}, got #{inspect(attrs.meta[:statusmsg])}"
+    end
+  end
+
   property "#218 collision: a bare +channel (no channel sigil after +) is never mis-stripped" do
     check all(body <- ascii_nick_gen()) do
       # `ascii_nick_gen` never starts with a channel sigil, so `+<body>` is

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1482,6 +1482,121 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
+  # #1303 — a target may carry MORE THAN ONE sigil, and the single-sigil peel
+  # broke in two different directions depending on which sigil sat second.
+  # Both are ingress misroutes: one loud (`$server`), one silent (a channel
+  # window nobody is in). The row-level assertions live here because the
+  # peel's whole purpose is where the row LANDS; `IdentifierTest` pins the
+  # peel itself.
+  describe "route/2 — #1303 multi-sigil STATUSMSG targets" do
+    test "case A: @%#chan lands in the channel window, not $server" do
+      # `@` peeled, remainder `%#chan` was not a channel, so the old guard
+      # declined the peel entirely and the non-channel arm took the row.
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:notice, ["@%#italia", "ops and halfops"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      refute attrs.channel == "$server"
+    end
+
+    test "case B: @+#chan lands in #chan, NOT the phantom +#chan" do
+      # The silent one: `+#chan` passes the channel-prefix test, so the row
+      # was persisted and broadcast against a channel nobody is in. It reads
+      # to the operator as "the message vanished".
+      state = base_state()
+
+      m = msg(:notice, ["@+#italia", "ops and voice"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      refute attrs.channel == "+#italia"
+    end
+
+    test "the recorded level is the WHOLE run, not the outermost sigil" do
+      # A STATUSMSG target reaches the UNION of the named levels, so
+      # `@+#chan` was seen by ops AND by voiced members. Recording `"@"`
+      # would badge as ops-only a line half the channel read, and no reader
+      # could correct it because the `+` would simply be gone.
+      state = base_state()
+
+      m = msg(:notice, ["@+#italia", "ops and voice"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.meta.statusmsg == "@+"
+    end
+
+    test "the run is per-network: the same target records less where the level is unadvertised" do
+      # Under bahamut's `@+` there is no halfop level, so `@%#chan` peels
+      # only the `@` and `%#italia` is the channel name as far as we know.
+      # `%` not being advertised makes it part of the name, not a level —
+      # and the row must NOT claim a halfop delivery that this network
+      # cannot express.
+      state = base_state()
+
+      m = msg(:notice, ["@%#italia", "ops and halfops"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      refute attrs.meta[:statusmsg] == "@%"
+    end
+
+    test "PRIVMSG takes the same ingress door as NOTICE" do
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:privmsg, ["@%#italia", "ops chatter"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "#italia"
+      assert attrs.meta.statusmsg == "@%"
+    end
+
+    test "multi-sigil peel THEN casefold: @%#Italia keys the folded channel" do
+      isupport = ISupport.merge_isupport(["x", "STATUSMSG=@%+"], ISupport.default())
+      state = base_state(%{isupport: isupport})
+
+      m = msg(:notice, ["@%#Italia", "casefold me"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, %{channel: "#italia"}}]} =
+               EventRouter.route(m, state)
+    end
+
+    test "regression guard: @+chan still resolves to the modeless channel +chan" do
+      # `+chan` is a real channel and `@` is the level. Peeling every
+      # advertised sigil without backtracking would strip `@+`, find `chan`
+      # is no channel, roll the peel back whole, and send an ops-only notice
+      # to `$server` — breaking a case the single-sigil peel already got
+      # right. Control for the two cases above: it must be green BEFORE the
+      # fix as well as after.
+      state = base_state()
+
+      m = msg(:notice, ["@+chan", "ops of a modeless channel"], {:nick, "op", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "+chan"
+      assert attrs.meta.statusmsg == "@"
+    end
+
+    test "regression guard: ++chan still resolves to +chan at the voice level" do
+      state = base_state()
+
+      m = msg(:notice, ["++chan", "voiced of a modeless channel"], {:nick, "v", "u", "h.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "+chan"
+      assert attrs.meta.statusmsg == "+"
+    end
+  end
+
   describe "route/2 — #127 server-reply modals (INFO/VERSION/MOTD)" do
     # Explicit /motd primes state.motd_pending; the 375/372 burst folds and
     # 376 RPL_ENDOFMOTD drains ONE {:server_reply, :motd, lines} effect in

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -451,6 +451,72 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "statusmsg/2 (#1301)" do
+    # Sibling of `casemapping/2` and for the same reason: the POST boundary
+    # must decide whether `@#chan` is a STATUSMSG target on THIS network, and
+    # only the live session has seen the 005 that says so. Degrades to the
+    # bahamut default (`["@", "+"]`) with no live pid — the same value a
+    # session that has not yet seen a 005 reports, so a parked network answers
+    # what prod has always assumed rather than refusing every sigil.
+
+    test "returns the live session's advertised STATUSMSG set once a 005 carries it" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 005 grappa-test STATUSMSG=@%+ PREFIX=(ohv)@%+ :are supported\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :isupport_changed}
+                     },
+                     1_000
+
+      assert Session.statusmsg({:user, user.id}, network.id) == ["@", "%", "+"]
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "returns the bahamut default before any 005 STATUSMSG" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert Session.statusmsg({:user, user.id}, network.id) == ISupport.default_statusmsg()
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "returns the bahamut default when no session is registered" do
+      assert Session.statusmsg({:user, Ecto.UUID.generate()}, -1) == ISupport.default_statusmsg()
+    end
+  end
+
   describe "init/1 non-blocking (C2)" do
     # Pairs with `Grappa.IRC.ClientTest`'s C2 test. `Session.Server.init/1`
     # must NOT call `Client.start_link/1` synchronously: Bootstrap iterates

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -294,6 +294,62 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#1301: notice_target = @#chan reaches the wire VERBATIM and echoes to the source window",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # `/notice @#sniffo heads up` — the form operators use most, refused as
+      # malformed before #1301 because the raw `@#sniffo` matched neither the
+      # channel regex nor the nick regex at the POST boundary.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "heads up",
+          "notice_target" => "@#sniffo"
+        })
+
+      body = json_response(conn, 201)
+      assert body["channel"] == "#sniffo"
+      assert body["meta"]["notice_target"] == "@#sniffo"
+
+      # VERBATIM on the wire: the sigil is peeled to VALIDATE, never to
+      # rewrite. What `@#sniffo` means is the ircd's ruling, not ours, so a
+      # canonicalised target would be us answering a question we were not
+      # asked — and a refusal would be us inventing one.
+      assert {:ok, "NOTICE @#sniffo :heads up\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NOTICE @"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#1301: a sigil is still refused on the URL channel_id — that one IS a window key",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # The control for the test above. On the plain arm the URL channel is
+      # BOTH the wire target and the persist key, so admitting a sigil here
+      # would key scrollback to `@#sniffo` — a window nobody is in, the
+      # outbound twin of #1303 case B. The two arms take deliberately
+      # different validators.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%40%23sniffo/messages", %{
+          "body" => "heads up"
+        })
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "#1225: a /notice to NickServ does not archive a mistyped identify password",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()

--- a/test/grappa_web/validation_test.exs
+++ b/test/grappa_web/validation_test.exs
@@ -87,4 +87,78 @@ defmodule GrappaWeb.ValidationTest do
                %{nick: "vjt"}
     end
   end
+
+  # #1301 — `/notice @#chan` was refused as malformed. The wire recipient of a
+  # NOTICE/CTCP is not a window key: it may carry the network's STATUSMSG
+  # sigils, which are neither a channel prefix nor a nick character, so the
+  # raw target matched neither validator and the POST 400ed.
+  #
+  # This is a SEPARATE validator rather than a widening of
+  # `validate_post_target_name/1`: that one also guards the `channel_id` arm,
+  # where the target IS the persist key, so admitting `@#chan` there would
+  # manufacture a phantom `@#chan` window on the outbound side — the exact
+  # defect #1303 fixes on the inbound side.
+  describe "validate_wire_recipient_name/2 (#1301)" do
+    @bahamut ["@", "+"]
+    @halfop ["@", "%", "+"]
+
+    test "accepts an ops-level channel target — the reported case" do
+      assert Validation.validate_wire_recipient_name("@#chan", @bahamut) == :ok
+    end
+
+    test "accepts a multi-sigil target: the ircd is the authority on what it means" do
+      assert Validation.validate_wire_recipient_name("@%#chan", @halfop) == :ok
+    end
+
+    test "the sigil set is per-network: an unadvertised level is not a sigil" do
+      # A `%` prefix on bahamut (`STATUSMSG=@+`) is not a level — it is a
+      # channel name starting with `%`, which is not a legal channel.
+      assert Validation.validate_wire_recipient_name("%#chan", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("%#chan", @halfop) == :ok
+    end
+
+    test "a plain channel and a plain nick are unaffected" do
+      assert Validation.validate_wire_recipient_name("#chan", @bahamut) == :ok
+      assert Validation.validate_wire_recipient_name("carol", @bahamut) == :ok
+      assert Validation.validate_wire_recipient_name("+chan", @bahamut) == :ok
+    end
+
+    test "a sigil does not smuggle the read-only $server synthetic" do
+      # `validate_post_target_name/1` rejects `$server` because a write to it
+      # is an RFC 2812 server-mask PRIVMSG. Peeling must not open a side door:
+      # `@` in front of it peels nothing (there is no channel behind it), so
+      # the refusal stands on the raw target.
+      assert Validation.validate_wire_recipient_name("$server", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("@$server", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "a sigil in front of a NICK is not a STATUSMSG target" do
+      # STATUSMSG addresses a channel at a membership level. `@carol` is
+      # neither a channel nor a legal nick, and inventing an acceptance for it
+      # would ship a target no ircd can route.
+      assert Validation.validate_wire_recipient_name("@carol", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "the peel does not weaken the channel-shape check behind it" do
+      # The peel tests only the first byte of the remainder; the FULL channel
+      # validator still runs on it. A space or a CRLF behind a sigil must stay
+      # refused — the alternative is a target that splits the wire line.
+      assert Validation.validate_wire_recipient_name("@#with space", @bahamut) ==
+               {:error, :bad_request}
+
+      assert Validation.validate_wire_recipient_name("@#chan\r\nQUIT", @bahamut) ==
+               {:error, :bad_request}
+    end
+
+    test "an empty advertised set falls back to the plain target rules" do
+      assert Validation.validate_wire_recipient_name("#chan", []) == :ok
+      assert Validation.validate_wire_recipient_name("@#chan", []) == {:error, :bad_request}
+    end
+  end
 end

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -440,3 +440,17 @@ seed_mix_env() {
     [ "$status" -eq 0 ]
     grep -q "docker" "$ARGV_LOG"
 }
+
+@test "GRAPPA_CACHE_ID outranks the .env check — it holds on an uninstalled box too (#1409)" {
+    # The guard is about the operator's environment being incompatible with
+    # this substrate, which is true whether or not the box was ever
+    # installed. Without this case the placement is only a comment: moving
+    # the guard below the .env check leaves every other case green.
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+    rm -f "$REPO_ROOT/.env"
+
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+}

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -93,8 +93,10 @@ EOF
     # it again.
     make_env
     # An ambient MIX_ENV from the developer's shell would satisfy the D-S3
-    # cases without the script having established anything.
-    unset MIX_ENV
+    # cases without the script having established anything. An ambient
+    # GRAPPA_CACHE_ID would make every case in this file refuse (#1409): bats
+    # runs on the host and inherits the caller's environment whole.
+    unset MIX_ENV GRAPPA_CACHE_ID
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -403,4 +405,38 @@ seed_mix_env() {
     [ "$status" -ne 0 ]
     [[ "$output" == *".env"* ]]
     refute grep -q "docker" "$ARGV_LOG"           # died before any side effect
+}
+
+# --- GRAPPA_CACHE_ID is not honourable on this substrate (#1409) -------------
+#
+# GRAPPA_CACHE_ID (#1263) binds `.caches/<id>` over `_build`, `deps` and
+# `priv/plts` — on `compose run`, which is the only compose verb that takes
+# `-v`. A deploy is not made of oneshots alone: the long-running container
+# comes up through `compose up`, which has no `-v` at all. Threading the binds
+# through the six oneshots would migrate the database inside the isolated cache
+# and then boot the box from the shared one, so the operator would get HALF an
+# isolation and no way to see it. The substrate says so instead, once, in the
+# hook set both doors source.
+#
+# The two cases below are a PAIR. The second is not a duplicate of the auto-mode
+# case above: it is the control that stops the first from passing because the
+# fixture died of something else, and it is also the ⛔ pin — with the variable
+# absent, this deploy is the one that shipped before the guard existed.
+
+@test "GRAPPA_CACHE_ID set: the deploy is refused by name, before any docker call (#1409)" {
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    refute grep -q "docker" "$ARGV_LOG"
+}
+
+@test "GRAPPA_CACHE_ID unset: the same deploy runs — the refusal is the variable (#1409)" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    grep -q "docker" "$ARGV_LOG"
 }

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -76,6 +76,9 @@ GRAPPA_PUBLISH=127.0.0.1:3100
 EOF
 
     # ---- env the script needs ------------------------------------------
+    # An ambient GRAPPA_CACHE_ID would make every case in this file refuse
+    # (#1409): bats runs on the host and inherits the caller's environment.
+    unset GRAPPA_CACHE_ID
     export PREFLIGHT_RC=0
     export RELOAD_FAILS=0
     export HOT_HEALTHCHECK_RETRIES=2 HOT_HEALTHCHECK_SLEEP=0
@@ -185,6 +188,23 @@ run_update() {
     run_update
     [ "$status" -ne 0 ]
     refute grep -q "force-recreate" "$ARGV_LOG"
+}
+
+@test "update: GRAPPA_CACHE_ID is refused on this door too — one guard, both doors (#1409)" {
+    # The refusal lives in the hook set this door SHARES with
+    # scripts/deploy.sh (#1384), so it must fire identically here. Control for
+    # this case: "box up + code change + HOT verdict reloads" below is this
+    # exact body with the variable absent, and it stays green.
+    export GRAPPA_CACHE_ID=w9
+    commit_upstream lib/base.txt > /dev/null
+
+    run_update
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+    # Refused at the top of substrate_pull: nothing pulled, nothing recreated.
+    [ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
+    refute grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 @test "update: a box owned by another checkout is refused, and the owner is named" {

--- a/test/infra/port_docker_unsupported_test.bats
+++ b/test/infra/port_docker_unsupported_test.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Bats suite for the `PORT` knob on the Docker substrate (#1409 D-S6).
+#
+# WHY THIS EXISTS
+#
+# `.env.example` presented `PORT` as an ordinary knob with no caveat and
+# `compose.yaml` gave it a literal default specifically so the override would
+# not be a silent no-op (#369 X1). But on the Docker substrate NOTHING
+# consumes it: the container side of the publish, the compose healthcheck,
+# the Dockerfile EXPOSE + HEALTHCHECK, `scripts/healthcheck.sh`, the
+# `/admin/reload` and `/admin/cic-bundle-changed` POSTs all hardcode 4000.
+# `PORT=4001` therefore yields a container that is healthy and reported
+# unhealthy, a `depends_on: service_healthy` that never resolves, and a
+# deploy that fails at the reload POST.
+#
+# Docker is the LOCAL DEV stack (CLAUDE.md: nothing production runs on it),
+# so threading the port through it is work with no user. The knob is marked
+# unsupported there instead, and this suite pins BOTH halves of that: the
+# prose that says so, and the absence of the consumer that would make the
+# prose a lie.
+#
+# The absence half needs a probe that can be trusted, so the same grep is
+# first pointed at `infra/linux/install.sh`, the Docker-free substrate that
+# DOES honour `${PORT}`. If that known-positive stops matching, the probe is
+# broken and every "absent" assertion below is vacuous.
+
+load ../bats_helpers
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "the PORT probe finds the substrate that does honour it (falsification)" {
+    # Positive control for every "no consumer" assertion in this file.
+    grep -qE '\$\{PORT' "$ROOT/infra/linux/install.sh"
+}
+
+@test ".env.example marks PORT unsupported on Docker" {
+    grep -A4 '^PORT=' "$ROOT/.env.example" > "$BATS_TEST_TMPDIR/port_block" || true
+    grep -B6 '^PORT=' "$ROOT/.env.example" >> "$BATS_TEST_TMPDIR/port_block" || true
+    grep -qi 'docker' "$BATS_TEST_TMPDIR/port_block"
+}
+
+@test "the compose PORT line carries the same caveat" {
+    grep -B6 'PORT: \${PORT' "$ROOT/compose.yaml" > "$BATS_TEST_TMPDIR/compose_block"
+    grep -qi 'docker' "$BATS_TEST_TMPDIR/compose_block"
+}
+
+@test "no Docker-side consumer reads PORT" {
+    # compose.yaml:98 passes it INTO the app and is the one legitimate
+    # mention; everything else on this substrate must not pretend to read it.
+    for f in "$ROOT/Dockerfile" "$ROOT/scripts/healthcheck.sh" \
+             "$ROOT/scripts/deploy-cic.sh" "$ROOT/infra/lib/deploy_docker.sh"; do
+        refute grep -qE '\$\{?PORT' "$f"
+    done
+}
+
+@test "the Docker substrate still hardcodes 4000, so the caveat is not stale" {
+    # The inverse pin: the day someone threads PORT for real, these fail and
+    # the caveat must be revisited rather than left lying.
+    grep -q 'localhost:4000/healthz' "$ROOT/scripts/healthcheck.sh"
+    grep -q 'localhost:4000/admin/reload' "$ROOT/infra/lib/deploy_docker.sh"
+}

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Grappa.GenWireTypesTest do
   use ExUnit.Case, async: true
 
+  alias Grappa.Themes.TokenModel
   alias Mix.Tasks.Grappa.GenWireTypes
 
   describe "type mapping" do
@@ -403,6 +404,58 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
        "NetworksServersAdminWireT"},
       {Grappa.Visitors.AdminWire, "VisitorsAdminWireIndexPayload", "visitors", "VisitorsAdminWireT"}
     ]
+  end
+
+  # #1406 X-S8/X-S9 — three closed sets whose SSOT lives OUTSIDE `@wire_glob`
+  # (`session/window_state.ex`, `themes/token_model.ex`,
+  # `themes/builtin_backgrounds.ex`). Nothing generated referenced them, so cic
+  # transcribed all three by hand and no gate would have reported a widen. The
+  # fix is a re-export at the wire boundary; these pin that the re-export
+  # actually reaches the emitted file, and — for the two vocabularies that HAVE
+  # a runtime allowlist — that the emitted array IS that allowlist rather than a
+  # typespec twin of it, which is the whole reason the specs are `unquote`d out
+  # of the attribute instead of written twice.
+  describe "closed sets re-exported to reach the codegen (#1406 X-S8/X-S9)" do
+    test "the window-state SSOT is emitted as a const and aliased at the wire boundary" do
+      full = GenWireTypes.generate()
+
+      # Hardcoded deliberately: `Grappa.Session.WindowState` publishes the set
+      # as a typespec with no runtime enumerator, so this list is the only thing
+      # that makes a SEVENTH state a conscious edit instead of a silent widen.
+      assert const_arms(full, "SESSION_WINDOW_STATE_WINDOW_STATE") ==
+               ~w(pending invited joined failed kicked parked)
+
+      assert full =~ ~s|export type SessionWireWindowState = SessionWindowStateWindowState;|
+    end
+
+    test "the derived font-family spec emits EXACTLY the sanitizer's allowlist" do
+      assert const_arms(GenWireTypes.generate(), "THEMES_TOKEN_MODEL_FONT_FAMILY") ==
+               TokenModel.font_families()
+    end
+
+    test "the derived size-mode spec emits EXACTLY the sanitizer's allowlist" do
+      assert const_arms(GenWireTypes.generate(), "THEMES_TOKEN_MODEL_SIZE_MODE") ==
+               TokenModel.size_modes()
+    end
+
+    test "the built-in background catalog entry reaches the wire boundary" do
+      full = GenWireTypes.generate()
+
+      assert full =~ ~s|export type ThemesWireBuiltinBackground = ThemesBuiltinBackgroundsT;|
+      assert const_arms(full, "THEMES_BUILTIN_BACKGROUNDS_VARIANT") == ~w(dark light)
+    end
+  end
+
+  # The quoted elements of an emitted `as const` array, in order. Tolerates
+  # biome's inline-vs-one-per-line wrapping (the `bun run check` gate owns the
+  # whitespace) by cutting at the array's own closing bracket.
+  defp const_arms(output, const_name) do
+    [_, tail] = String.split(output, "export const #{const_name} = [", parts: 2)
+    [body, _] = String.split(tail, "]", parts: 2)
+
+    ~r/"([^"]+)"/
+    |> Regex.scan(body, capture: :all_but_first)
+    |> List.flatten()
   end
 
   describe "--check exit code helper" do

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -438,11 +438,17 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
                TokenModel.size_modes()
     end
 
-    test "the built-in background catalog entry reaches the wire boundary" do
+    # The third theme vocabulary, `BuiltinBackgrounds.t/0`, is NOT re-exported —
+    # the codegen cannot render it (its `variant: variant()` is a same-module
+    # ref the external-type path has no registry for, so the two emitters
+    # disagree and both emit a dangling name). This pins the ABSENCE so the
+    # next attempt starts from the measurement rather than rediscovering the
+    # TS2304 through the client compiler.
+    test "the built-in background catalog is absent from the generated file" do
       full = GenWireTypes.generate()
 
-      assert full =~ ~s|export type ThemesWireBuiltinBackground = ThemesBuiltinBackgroundsT;|
-      assert const_arms(full, "THEMES_BUILTIN_BACKGROUNDS_VARIANT") == ~w(dark light)
+      refute full =~ "ThemesWireBuiltinBackground"
+      refute full =~ "ThemesBuiltinBackgroundsT"
     end
   end
 

--- a/test/scripts/db_worktree_test.bats
+++ b/test/scripts/db_worktree_test.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/db.sh — the MIX_ENV probe and the worktree door
+# (#1409 D-S11).
+#
+# WHY THIS EXISTS
+#
+# CLAUDE.md names `scripts/db.sh` a first-resort investigation tool, and it
+# also rules that every code change happens in a worktree. The tool was
+# therefore broken exactly where it is meant to be used, and it broke MUTE:
+# measured from a real worktree, `scripts/db.sh "SELECT 1;"` exited 1 having
+# written nothing at all, to either stream.
+#
+# The mechanism is worth stating, because it is not the one the review
+# guessed. `db.sh` probed the env with
+#
+#     env="$(in_container printenv MIX_ENV 2>/dev/null || echo dev)"
+#
+# and `in_container` calls `die`, which is an `exit 1`. An `exit` inside a
+# command substitution terminates the SUBSHELL — so `|| echo dev` never ran
+# and the fallback was dead code. `env` came back empty, `set -e` killed the
+# script on the assignment, and `die`'s message had already gone into
+# `2>/dev/null`. It never reported `dev`, and it never reached the second
+# `in_container` call the review expected to fail.
+#
+# Scope: asserts the SHAPE of the docker invocation — which door is used and
+# which db path is opened. Stubs `docker` on PATH so no container is touched;
+# `git` is real, so `_lib.sh` derives a genuine SRC_ROOT != REPO_ROOT from an
+# actual `git worktree add`.
+
+load ../bats_helpers
+
+setup() {
+    DB_SH="$BATS_TEST_DIRNAME/../../scripts/db.sh"
+    LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Physical base so _lib.sh's `pwd`-derived SRC_ROOT and its
+    # `git rev-parse`-derived REPO_ROOT agree on macOS (/var → /private/var).
+    TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
+
+    MAIN="$TMP/main"
+    git init -q -b main "$MAIN"
+    git -C "$MAIN" config user.email test@grappa.local
+    git -C "$MAIN" config user.name "bats"
+    mkdir -p "$MAIN/scripts" "$MAIN/lib"
+    cp "$DB_SH" "$MAIN/scripts/db.sh"
+    cp "$LIB_SH" "$MAIN/scripts/_lib.sh"
+    : > "$MAIN/compose.yaml"
+    echo base > "$MAIN/lib/base.ex"
+    git -C "$MAIN" add -A
+    git -C "$MAIN" commit -qm base
+
+    WT="$TMP/wt"
+    git -C "$MAIN" worktree add -q -b wt "$WT"
+
+    # `MIX_ENV` the probe will read, and whether a live container exists.
+    # Per-test overridable via the environment the stub re-reads at run time.
+    STUB_ENV_FILE="$FAKE_DIR/mixenv"
+    STUB_CID_FILE="$FAKE_DIR/cid"
+    printf 'dev' > "$STUB_ENV_FILE"
+    printf 'fakecontainerid\n' > "$STUB_CID_FILE"
+
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+args="\$*"
+case "\$args" in
+    *"ps -q grappa"*)   cat "$STUB_CID_FILE"; exit 0 ;;
+    *"printenv MIX_ENV"*)
+        # No container up → compose exec fails, exactly as it would live.
+        if [ ! -s "$STUB_CID_FILE" ]; then exit 1; fi
+        cat "$STUB_ENV_FILE"
+        exit 0
+        ;;
+    *)                  exit 0 ;;
+esac
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+@test "db.sh from a worktree opens the db instead of dying mute" {
+    cd "$WT"
+    run "$WT/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    # A oneshot, because the live container carries main's source, not ours.
+    grep -q "run --rm" "$ARGV_LOG"
+    grep -q "sqlite3" "$ARGV_LOG"
+}
+
+@test "db.sh from a worktree that cannot reach the db says so out loud" {
+    # The residual failure mode must still be legible: whatever goes wrong,
+    # it may not go wrong in silence the way the swallowed `die` did.
+    printf '' > "$STUB_CID_FILE"
+    cd "$WT"
+    run "$WT/scripts/db.sh" "SELECT 1;"
+    # Either it works through the oneshot or it fails — but a non-zero exit
+    # with an empty message is the one outcome this test forbids.
+    if [ "$status" -ne 0 ]; then
+        [ -n "$output" ]
+    fi
+}
+
+@test "no live container falls back to dev, not to an empty db path" {
+    printf '' > "$STUB_CID_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q "grappa_dev.db" "$ARGV_LOG"
+    refute grep -q "grappa_.db" "$ARGV_LOG"
+}
+
+@test "a CR from the container never reaches the db path" {
+    # `detect_mix_env` strips it; the hand-rolled probe db.sh used did not,
+    # so a `\r` produced db_path_for_env "prod\r" and a nonexistent file.
+    printf 'prod\r' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q "grappa_prod.db" "$ARGV_LOG"
+    refute grep -q 'grappa_prod\$' "$ARGV_LOG"
+}
+
+@test "prod passes -readonly as one argument" {
+    printf 'prod' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    grep -q " -readonly " "$ARGV_LOG"
+}
+
+@test "dev passes no empty argument to sqlite3" {
+    # Guards the naive repair of the unquoted `$MODE_ARG`: quoting it as a
+    # scalar hands sqlite3 an empty string as its FIRST argument, which it
+    # reads as a filename. The mode has to be an array, not a quoted scalar.
+    printf 'dev' > "$STUB_ENV_FILE"
+    cd "$MAIN"
+    run "$MAIN/scripts/db.sh" "SELECT 1;"
+    [ "$status" -eq 0 ]
+    refute grep -q "sqlite3 ''" "$ARGV_LOG"
+}

--- a/test/scripts/oneshot_overlay_test.bats
+++ b/test/scripts/oneshot_overlay_test.bats
@@ -37,18 +37,24 @@ setup() {
     ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
     OVERLAY="$ROOT/compose.oneshot.yaml"
     LIB="$ROOT/scripts/_lib.sh"
+
+    # The claim is about the KEYS the overlay SETS, not about whether the
+    # file may explain why they are gone. Grepping the comments too would
+    # make the explanation itself a failure, so strip them first.
+    KEYS="$BATS_TEST_TMPDIR/keys"
+    grep -v '^[[:space:]]*#' "$OVERLAY" > "$KEYS"
 }
 
 @test "the overlay still disables the healthcheck — the one key that is load-bearing" {
-    grep -q 'disable: true' "$OVERLAY"
+    grep -q 'disable: true' "$KEYS"
 }
 
 @test "the overlay no longer claims a container_name collision" {
-    refute grep -q 'container_name' "$OVERLAY"
+    refute grep -q 'container_name' "$KEYS"
 }
 
 @test "the overlay no longer resets ports it never inherited" {
-    refute grep -q 'ports' "$OVERLAY"
+    refute grep -q 'ports' "$KEYS"
 }
 
 @test "_lib.sh no longer claims the overlay drops inherited host bindings" {

--- a/test/scripts/oneshot_overlay_test.bats
+++ b/test/scripts/oneshot_overlay_test.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+#
+# Bats suite for compose.oneshot.yaml — what the overlay actually buys
+# (#1409 D-S7).
+#
+# WHY THIS EXISTS
+#
+# The overlay and `_lib.sh` both claimed a hazard: "without it a oneshot
+# inherits `container_name: grappa` and the host port-publishes, and both
+# collide with the long-lived copy", with a misplaced `-f` called a
+# "one-character-edit hazard". Meanwhile six `compose run --rm` invocations
+# on the deploy path do not layer the overlay at all and run against a live
+# `grappa` by design. Both could not be true.
+#
+# Measured on 2026-08-16, with the long-lived `grappa` up and holding
+# `192.168.53.12:4000`, by inspecting the ephemeral container `compose run`
+# creates:
+#
+#   container_name  →  /grappa-grappa-run-3f90d538d15f, never `grappa`
+#   PortBindings    →  {} (with --service-ports as the positive control:
+#                      {"4000/tcp":[{"HostIp":"192.168.53.12",...}]})
+#   RestartPolicy   →  "no", without the overlay's help
+#   Healthcheck     →  INHERITED in full, curl /healthz, 5 retries
+#
+# So three of the four overlay keys were no-ops and the hazard prose was
+# false. Only `healthcheck: disable: true` earns its keep, and this suite
+# pins that reduction so the prose cannot grow back.
+#
+# Scope caveat, deliberately narrow: that measurement is Docker Desktop on
+# macOS, one Compose version, one host. This suite pins OUR file, not
+# Compose's semantics — a bats that asserted PortBindings would pin someone
+# else's product and break on their upgrade with our tree unchanged.
+
+load ../bats_helpers
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    OVERLAY="$ROOT/compose.oneshot.yaml"
+    LIB="$ROOT/scripts/_lib.sh"
+}
+
+@test "the overlay still disables the healthcheck — the one key that is load-bearing" {
+    grep -q 'disable: true' "$OVERLAY"
+}
+
+@test "the overlay no longer claims a container_name collision" {
+    refute grep -q 'container_name' "$OVERLAY"
+}
+
+@test "the overlay no longer resets ports it never inherited" {
+    refute grep -q 'ports' "$OVERLAY"
+}
+
+@test "_lib.sh no longer claims the overlay drops inherited host bindings" {
+    # The review quoted a "one-character-edit hazard" phrase at :249-252 that
+    # is not in the file — what IS there is the same falsified claim, that
+    # `ports: !reset []` + `container_name: !reset null` "drop host-side
+    # bindings inherited from the base file or the personal override". They
+    # drop nothing: `run` never applied either.
+    refute grep -q 'drop host-side bindings' "$LIB"
+    refute grep -q 'container_name: !reset null' "$LIB"
+}
+
+@test "in_oneshot still layers the overlay last" {
+    # The reduction is about what the file CONTAINS, not about dropping it:
+    # the healthcheck override only applies if it is still layered.
+    grep -q 'compose.oneshot.yaml' "$LIB"
+}


### PR DESCRIPTION
Union branch: the three open branches replayed onto one base so the SUM of
them is gated once, rather than each pair of branch-and-base being gated
separately. With an FF-only policy the alternative was three rebases and
three full integration runs.

## Sources

| source PR | branch | carries |
|---|---|---|
| #1449 | `w1-1303-1301-statusmsg` | #1303 + #1301 — STATUSMSG peel and wire recipient |
| #1450 | `w2-1406-closed-sets` | #1406 slice 3a — closed sets re-exported to codegen |
| #1444 | `w1-1409-infra-simplify` | #1409 — cache-id guard on the Docker deploy doors |

These three are listed for provenance only. They are not closed by this PR.

## How it was built

Each source was replayed with `git cherry-pick $base..$head`, where `$base`
is that source's OWN merge-base against `origin/main`, in the order
#1449 → #1450 → #1444. All three merge-bases resolved to the same commit, and
no range contained a merge commit (checked before starting). All 18
cherry-picks applied with rc=0 and **no conflicts**. Git auto-merged in five
places, all clean and all expected: `docs/DESIGN_NOTES.md` four times, plus
`test/mix/tasks/grappa/gen_wire_types_test.exs` and
`cicchetto/src/lib/wireTypes.ts`, which the base already touches.

## Verification performed before pushing

* **18 commits** (5 + 6 + 7), fast-forwardable from `main`
  (`git merge-base --is-ancestor` rc=0), working tree clean.
* **Numstat is the exact sum of the three contributions, file by file.**
  33 files expected, 33 in the union, **zero mismatches** on additions AND
  deletions. `docs/DESIGN_NOTES.md` is 334/0, which is 98 + 107 + 129. The two
  files that auto-merged are among those checked, so the auto-merge neither
  dropped nor duplicated a line.
* **Three DESIGN_NOTES markers**, each unique and each with zero occurrences
  on the base: `<!-- entry #1303 -->`, `<!-- entry #1406 X-S8 -->`,
  `<!-- entry #1409 -->`. The 3a marker differs from both `#1406` and
  `#1406 X-S4`, which the base already carries — a suffix only counts when it
  differs from what the BASE brings.
* `scripts/design-notes-gate.sh origin/main` → **RC=0**, reporting three new
  entry headings with separator and marker present. The boundary shape was
  also read on the file itself for all three.

## Not claimed

No build, test, dialyzer, bats or cic gate was run on this branch. The
verification above is structural: it establishes that the union is exactly
the three contributions and nothing else, not that the result is green.