### PR TITLE
cic+wire(#1302): STATUSMSG badge shows sigils; PREFIX rank comes from the advertised order

### DIFF
--- a/cicchetto/e2e/tests/issue1247-statusmsg-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue1247-statusmsg-badge.spec.ts
@@ -1,5 +1,11 @@
 // #1247 — an ops-only NOTICE (`NOTICE @#chan`) must READ as ops-only.
 //
+// #1302 changed HOW it reads: the visible row carries the SIGIL, and the
+// word moved to the accessible name, derived per network from `PREFIX=`.
+// Both are asserted here — the name is what a screen reader is given, so a
+// spec that checked only the glyph would let the whole point of the badge
+// regress silently.
+//
 // #218 fixed the routing half: the row lands in the channel window. It did
 // NOT record WHICH level delivered it — `strip_statusmsg_target/2` peeled the
 // sigil to route and dropped it, so neither the scrollback row nor the PubSub
@@ -71,10 +77,15 @@ test("#1247 — an ops-only NOTICE is badged on arrival AND after a reload", asy
 
     peer.notice(`@${channel}`, body);
 
-    // LIVE: the badge off the broadcast.
+    // LIVE: the badge off the broadcast. The sigil is what the row shows;
+    // the name is derived from the PREFIX this network really advertised,
+    // so this assertion also proves the 005 reached the badge — on a client
+    // holding no capability table it would read "delivered to @ only".
     const liveRow = scrollbackLine(page, "notice", body);
     await expect(liveRow).toBeVisible({ timeout: 15_000 });
-    await expect(liveRow.getByTestId("statusmsg-badge")).toHaveText("ops-only");
+    const liveBadge = liveRow.getByTestId("statusmsg-badge");
+    await expect(liveBadge).toHaveText("@");
+    await expect(liveBadge).toHaveAccessibleName("delivered to ops only");
 
     // RELOADED: the badge off the persisted row. Pre-fix BOTH of these fail;
     // with the level on the broadcast only, this one alone fails.
@@ -84,7 +95,14 @@ test("#1247 — an ops-only NOTICE is badged on arrival AND after a reload", asy
 
     const reloadedRow = scrollbackLine(page, "notice", body);
     await expect(reloadedRow).toBeVisible({ timeout: 15_000 });
-    await expect(reloadedRow.getByTestId("statusmsg-badge")).toHaveText("ops-only");
+    const reloadedBadge = reloadedRow.getByTestId("statusmsg-badge");
+    await expect(reloadedBadge).toHaveText("@");
+    // The name has to survive the reload too: it is derived from the
+    // ISUPPORT table, which after a reload arrives by a DIFFERENT door (the
+    // cold subscribe snapshot, not the live 005 edge). A badge that named
+    // the level only while the live table was warm would pass the line
+    // above and still be broken for anyone who refreshes.
+    await expect(reloadedBadge).toHaveAccessibleName("delivered to ops only");
   } finally {
     await peer.disconnect("issue1247 done");
     // `/join` persists the channel into vjt's autojoin set; PART restores

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -14,13 +14,14 @@ import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/api";
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
+import { statusmsgDescription } from "./lib/channelModes";
 import { type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
 import { isChannelName } from "./lib/chantypes";
 import { stripCtcpAction } from "./lib/ctcpAction";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
 import { type InviteAckEntry, inviteAckBySlug } from "./lib/inviteAck";
-import { chantypesForNetwork } from "./lib/isupport";
+import { chantypesForNetwork, prefixForNetwork } from "./lib/isupport";
 import { membersByChannel } from "./lib/members";
 import { matchesWatchlist } from "./lib/mentionMatch";
 import {
@@ -634,22 +635,52 @@ const renderNumeric = (raw: NumericEvent): JSX.Element => {
 // (#218). A `@#chan` notice reaches channel ops ONLY; rendered like any other
 // notice it reads as a broadcast everyone saw, which is the reported symptom.
 //
-// The sigil set is per-network and open-ended (ISUPPORT `STATUSMSG=`; bahamut
-// advertises `@+`, others `@%+`), so only the two levels the issue names get a
-// word. An unnamed one renders as its own sigil rather than falling back to no
-// badge — "unknown level" and "everyone" must not look alike.
-const STATUSMSG_LABEL: Record<string, string> = { "@": "ops-only", "+": "voice-only" };
-
+// #1302 — the row shows the SIGILS, always. The sigil set is per-network and
+// open-ended (ISUPPORT `STATUSMSG=`; bahamut advertises `@+`, others `@%+`,
+// UnrealIRCd-style networks `~&@%+`), so a hardcoded word table could only
+// ever name a couple of them: it left a halfop row rendering a bare `%` beside
+// two worded ones — three rows, two vocabularies, which two operators reported
+// as noise. Sigils everywhere means ONE vocabulary on every network, and `@`
+// already says "ops only" to anyone reading IRC.
+//
+// The words survive out of sight, in the `title` AND the accessible name. That
+// is not a hover convenience: this badge carried NEITHER before, so a bare
+// sigil would reach a screen reader as an `@` character and nothing else. The
+// copy is derived per network by mapping each sigil back through `PREFIX=`
+// (see `statusmsgDescription`), never hardcoded.
+//
+// `meta.statusmsg` is the whole peeled RUN (`@+`, not `@`) per #1303 — such a
+// target reaches the union of the levels — so every sigil renders and every
+// level is named. Do not rewrite this as if it were one character.
+//
 // Row-level, not per-kind: a STATUSMSG target is legal on PRIVMSG as well as
 // NOTICE, and the level describes who the line REACHED — a property of the
 // row, not of one render arm.
-const statusmsgBadge = (meta: ScrollbackMessage["meta"]): JSX.Element | null => {
-  const level = meta?.statusmsg;
-  if (typeof level !== "string" || level === "") return null;
+const statusmsgBadge = (
+  meta: ScrollbackMessage["meta"],
+  networkSlug: string,
+): JSX.Element | null => {
+  const run = meta?.statusmsg;
+  if (typeof run !== "string" || run === "") return null;
+  const description = statusmsgDescription(
+    run,
+    prefixForNetwork(networkIdBySlug(networkSlug) ?? null),
+  );
   return (
     <>
-      <span class="scrollback-statusmsg" data-testid="statusmsg-badge">
-        {STATUSMSG_LABEL[level] ?? level}
+      <span
+        class="scrollback-statusmsg"
+        data-testid="statusmsg-badge"
+        // A bare <span> is role=generic, which is name-PROHIBITED: an
+        // `aria-label` on it computes to no accessible name at all, and the
+        // sigil would still reach a screen reader as an `@` character. The
+        // sigil run is a glyph standing for a phrase, so `role="img"` is the
+        // role that both admits a name and makes it REPLACE the glyph.
+        role="img"
+        title={description}
+        aria-label={description}
+      >
+        {run}
       </span>{" "}
     </>
   );
@@ -1039,7 +1070,7 @@ const ScrollbackLine: Component<{
       data-msg-id={props.msg.id}
     >
       <span class="scrollback-time">{formatTime(props.msg.server_time)}</span>{" "}
-      {statusmsgBadge(props.msg.meta)}
+      {statusmsgBadge(props.msg.meta, props.networkSlug)}
       {renderBody(props.msg, handlers)}
     </div>
   );

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -671,11 +671,21 @@ const statusmsgBadge = (
       <span
         class="scrollback-statusmsg"
         data-testid="statusmsg-badge"
-        // A bare <span> is role=generic, which is name-PROHIBITED: an
-        // `aria-label` on it computes to no accessible name at all, and the
-        // sigil would still reach a screen reader as an `@` character. The
-        // sigil run is a glyph standing for a phrase, so `role="img"` is the
-        // role that both admits a name and makes it REPLACE the glyph.
+        // A bare <span> is role=generic, for which ARIA declares "name from
+        // author: PROHIBITED" — a label on it is not a name the spec
+        // guarantees any AT will speak. `role="img"` is a role that admits
+        // one, and it is the truthful role here: the sigil run is a glyph
+        // standing for a phrase, and the name is meant to REPLACE it rather
+        // than annotate it.
+        //
+        // Measured, so nobody re-derives it from this comment: our own
+        // toolchain (dom-accessibility-api) does NOT implement the
+        // prohibition — it computes the name from the label with or without
+        // the role, so the empty accessible names seen while building this
+        // came from the #130 flicker gate hiding the container, not from the
+        // missing role. What the tests pin is therefore the spec-legal
+        // SHAPE, via a byRole query; the prohibition itself is unmeasured
+        // here and is the reason to keep the role, not a thing to assert.
         role="img"
         title={description}
         aria-label={description}

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -147,9 +147,17 @@ describe("ModeModal", () => {
   it("a founder (~) on a PREFIX-rich network can edit even without @", () => {
     // PREFIX=(qaohv)~&@%+ — a founder who does NOT also hold @ must still
     // get an editable modal (editorSigils ranks ~ above op). #216 review.
+    //
+    // #1302 — the map comes from JSON.parse of the serialisation MEASURED
+    // on the production node, and the rank from the field the server now
+    // publishes beside it. Written as a rank-ordered object literal, as it
+    // was, this test passed while the modal it describes was greying that
+    // founder out: an object literal keeps the order it was typed in, and
+    // the wire's is alphabetical by mode letter.
     seedIsupport(1, {
       ...DEFAULT_ISUPPORT,
-      prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      prefix: JSON.parse('{"a":"&","h":"%","o":"@","q":"~","v":"+"}'),
+      prefixOrder: ["q", "a", "o", "h", "v"],
     });
     mockModes[KEY] = { modes: [], params: {} };
     mockMembers[KEY] = [{ nick: "vjt-grappa", modes: ["~"] }];

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -300,6 +300,11 @@ import { type ChannelKey, channelKey } from "../lib/channelKey";
 // entry so ScrollbackPane derives the #237 on-JOIN topic-join line; the #325
 // block proves that line survives the #222 presence-hide filter.
 import { seedTopic } from "../lib/channelTopic";
+// #1302 — the REAL ISUPPORT store (not mocked): the badge derives its level
+// names from the network's own PREFIX, so what these tests seed here IS the
+// input the derivation reads. Network id 1 is what the mocked
+// `networkIdBySlug` above answers for every slug.
+import { DEFAULT_ISUPPORT, seedIsupport } from "../lib/isupport";
 // #222 — the REAL presence-filter module (not mocked). Its per-channel pref
 // signal drives the rows() render filter; these imports let the wiring test
 // seed/clear explicit prefs. `channelKey` is mocked above to `${slug} ${name}`
@@ -355,6 +360,18 @@ const fixture: ScrollbackMessage[] = [
   },
 ];
 
+// #1302 — the #130 flicker gate hides the scrollback container (visibility,
+// NOT display) until the activation scroll has settled, and an accessible name
+// does not compute inside a hidden subtree: every name assertion below would
+// read an empty string for a jsdom render artefact rather than for anything
+// the badge did. Waiting the gate out establishes the durable state in which
+// the name is the badge's own.
+const waitForScrollbackVisible = async (): Promise<void> => {
+  await waitFor(() => {
+    expect(screen.getByTestId("scrollback")).not.toHaveStyle({ visibility: "hidden" });
+  });
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   setScrollback({});
@@ -365,6 +382,9 @@ beforeEach(() => {
   mockMembersByChannel.mockReturnValue({});
   // Reset the C5.0 auto-focus shown-set between tests (test seam, see ScrollbackPane.tsx).
   resetAutoFocusedJoinsForTest();
+  // #1302 — the ISUPPORT store is a module singleton, so a network seeded by
+  // one test would leak into the next. Reseed the bahamut default.
+  seedIsupport(1, DEFAULT_ISUPPORT);
   mockSetSelectedChannel.mockClear();
 });
 
@@ -533,12 +553,19 @@ describe("ScrollbackPane", () => {
     expect(lines[1]?.textContent ?? "").not.toContain("→");
   });
 
-  it("badges an ops-only row from meta.statusmsg and leaves a plain one alone — #1247", () => {
+  it("badges a statusmsg row with its SIGIL and names the level out of sight — #1302", async () => {
     // #1247 — an ops-only NOTICE (`NOTICE @#chan`) is delivered to channel ops
     // only. #218 routes it to the channel window; without a badge it is
     // indistinguishable from the plain channel notice sitting next to it, so
     // the second row here is the control: the discriminator must be the badge,
     // not "it is a notice".
+    //
+    // #1302 — the VISIBLE row now carries the sigil, never a word: a
+    // two-entry word table gave a `%` row a bare sigil next to two worded
+    // ones, three rows with two vocabularies. The word survives in the title
+    // and the accessible name, which this badge did not carry AT ALL before —
+    // so a bare sigil would otherwise have reached a screen reader as an `@`
+    // character and nothing else.
     const notices: ScrollbackMessage[] = [
       {
         id: 1,
@@ -563,11 +590,13 @@ describe("ScrollbackPane", () => {
     ];
     setScrollback({ "freenode #grappa": notices });
     render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    await waitForScrollbackVisible();
     const lines = screen.getAllByTestId("scrollback-line");
 
-    expect(within(lines[0] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent(
-      "ops-only",
-    );
+    const badge = within(lines[0] as HTMLElement).getByTestId("statusmsg-badge");
+    expect(badge.textContent).toBe("@");
+    expect(badge).toHaveAttribute("title", "delivered to ops only");
+    expect(badge).toHaveAccessibleName("delivered to ops only");
     // The body still renders — the badge annotates the row, it does not
     // replace it.
     expect(lines[0]).toHaveTextContent("-carol- rehash in 5");
@@ -575,11 +604,13 @@ describe("ScrollbackPane", () => {
     expect(within(lines[1] as HTMLElement).queryByTestId("statusmsg-badge")).toBeNull();
   });
 
-  it("badges a voice-only row and an unnamed level by its raw sigil — #1247", () => {
-    // `+` is the other level bahamut advertises by default. A network
-    // advertising `STATUSMSG=@%+` can deliver a `%` too, and the sigil set is
-    // per-network and open-ended: an unnamed level renders as itself rather
-    // than silently dropping to "no badge", which would read as "everyone".
+  it("renders EVERY sigil of a multi-level run and names every level — #1302", async () => {
+    // #1303 made `meta.statusmsg` the whole peeled RUN (`@+`, not `@`): a
+    // STATUSMSG target reaches the UNION of the levels, so a badge written as
+    // if the field were one character would silently drop a level from both
+    // the row and the description. The `%` row is the other half of the
+    // report: halfop used to render as a bare sigil with NO description at
+    // all, and it is a NAMED level like any other now.
     const notices: ScrollbackMessage[] = [
       {
         id: 1,
@@ -589,7 +620,7 @@ describe("ScrollbackPane", () => {
         kind: "notice",
         sender: "carol",
         body: "voiced folks",
-        meta: { statusmsg: "+" },
+        meta: { statusmsg: "@+" },
       },
       {
         id: 2,
@@ -604,14 +635,96 @@ describe("ScrollbackPane", () => {
     ];
     setScrollback({ "freenode #grappa": notices });
     render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    await waitForScrollbackVisible();
     const lines = screen.getAllByTestId("scrollback-line");
 
-    expect(within(lines[0] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent(
-      "voice-only",
-    );
+    const run = within(lines[0] as HTMLElement).getByTestId("statusmsg-badge");
+    expect(run.textContent).toBe("@+");
+    expect(run).toHaveAccessibleName("delivered to ops and voice only");
+
     // A PRIVMSG can bear a STATUSMSG target too — the badge is a property of
     // the row, not of the notice arm.
-    expect(within(lines[1] as HTMLElement).getByTestId("statusmsg-badge")).toHaveTextContent("%");
+    const halfop = within(lines[1] as HTMLElement).getByTestId("statusmsg-badge");
+    expect(halfop.textContent).toBe("%");
+    expect(halfop).toHaveAccessibleName("delivered to halfop only");
+  });
+
+  it("derives the level names from the network's OWN advertised PREFIX — #1302", async () => {
+    // The whole point of deleting the hardcoded word table: on a network
+    // advertising `PREFIX=(qaohv)~&@%+` a founder-only message must be named
+    // "founder", which no two-entry constant can do.
+    //
+    // The map is built by JSON.parse of the serialisation MEASURED on the
+    // production node, not by a hand-written literal in rank order: the
+    // server's `Map.new/1` crosses the wire alphabetical by mode letter, and
+    // a fixture written `{q, a, o, h, v}` would quietly test an order the
+    // client never receives.
+    seedIsupport(1, {
+      ...DEFAULT_ISUPPORT,
+      prefix: JSON.parse('{"a":"&","h":"%","o":"@","q":"~","v":"+"}'),
+    });
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "carol",
+        body: "founders only",
+        meta: { statusmsg: "~" },
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "notice",
+        sender: "carol",
+        body: "ops too",
+        meta: { statusmsg: "@" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    await waitForScrollbackVisible();
+    const lines = screen.getAllByTestId("scrollback-line");
+
+    const founder = within(lines[0] as HTMLElement).getByTestId("statusmsg-badge");
+    expect(founder.textContent).toBe("~");
+    expect(founder).toHaveAccessibleName("delivered to founder only");
+
+    // Control: the level every network has still resolves on the rich map.
+    expect(within(lines[1] as HTMLElement).getByTestId("statusmsg-badge")).toHaveAccessibleName(
+      "delivered to ops only",
+    );
+  });
+
+  it("falls back to the bare sigil when the network never advertised it — #1302", async () => {
+    // The control for the test above, differing in ONE variable: the same `~`
+    // row on the bahamut default (`PREFIX=(ohv)@%+`), where `~` maps to no
+    // mode letter at all. There is no name to derive and cic must not invent
+    // one — the description degrades to the sigil, which is still strictly
+    // more than the nothing this badge carried before.
+    const notices: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "carol",
+        body: "founders only",
+        meta: { statusmsg: "~" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": notices });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    await waitForScrollbackVisible();
+    const badge = screen.getByTestId("statusmsg-badge");
+
+    expect(badge.textContent).toBe("~");
+    expect(badge).toHaveAccessibleName("delivered to ~ only");
   });
 
   it("renders a /notice echo to a CHANNEL recipient — #1225", () => {

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -597,6 +597,13 @@ describe("ScrollbackPane", () => {
     expect(badge.textContent).toBe("@");
     expect(badge).toHaveAttribute("title", "delivered to ops only");
     expect(badge).toHaveAccessibleName("delivered to ops only");
+    // …and reachable BY that name through a role that ARIA lets carry one.
+    // The assertion above is not enough on its own: dom-accessibility-api
+    // computes a name from a label on a bare <span> too, even though
+    // role=generic is name-PROHIBITED and no AT owes us that reading. This
+    // query fails on a badge that drops the role, which the name assertion
+    // does not.
+    expect(screen.getByRole("img", { name: "delivered to ops only" })).toBe(badge);
     // The body still renders — the badge annotates the row, it does not
     // replace it.
     expect(lines[0]).toHaveTextContent("-carol- rehash in 5");

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -169,6 +169,7 @@ describe("WireChannelEvent canonical union (H3)", () => {
         chanmodes_d: ["n", "t", "s"],
         list_modes_queryable: ["b", "e", "I"],
         prefix: { o: "@", h: "%", v: "+" },
+        prefix_order: ["o", "h", "v"],
         chantypes: ["#", "&"],
         casemapping: "ascii",
         maxlist: { b: 100 },

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -91,6 +91,7 @@ describe("availableModes", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t", "Z"] },
       prefix: {},
+      prefixOrder: [],
       listModesQueryable: [],
       chantypes: DEFAULT_ISUPPORT.chantypes,
       casemapping: DEFAULT_ISUPPORT.casemapping,
@@ -166,9 +167,20 @@ describe("editorSigils", () => {
 
   it("founder/admin prefixes rank above op → they edit too", () => {
     // PREFIX=(qaohv)~&@%+ — founder ~, admin &, op @, halfop %, voice +.
+    //
+    // #1302 — the map is built by JSON.parse of the serialisation MEASURED
+    // on the production node, NOT by a literal written in rank order. Both
+    // spell the same pairs, and that is the trap: an object literal keeps
+    // the order it was TYPED in, so `{q, a, o, h, v}` quietly tested a rank
+    // ordering the client never receives, and this assertion passed for as
+    // long as the defect it describes has existed. The wire delivers the
+    // keys alphabetical by mode letter, which puts `o` in the middle.
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: ["n", "t"] },
-      prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      prefix: JSON.parse('{"a":"&","h":"%","o":"@","q":"~","v":"+"}'),
+      // The rank the server now publishes ALONGSIDE that map, which the
+      // map's own key order does not spell.
+      prefixOrder: ["q", "a", "o", "h", "v"],
       listModesQueryable: [],
       chantypes: DEFAULT_ISUPPORT.chantypes,
       casemapping: DEFAULT_ISUPPORT.casemapping,
@@ -190,6 +202,7 @@ describe("editorSigils", () => {
     const isupport: IsupportEntry = {
       chanmodes: { a: [], b: [], c: [], d: [] },
       prefix: { v: "+" },
+      prefixOrder: ["v"],
       listModesQueryable: [],
       chantypes: DEFAULT_ISUPPORT.chantypes,
       casemapping: DEFAULT_ISUPPORT.casemapping,

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -9,6 +9,7 @@ import {
   editorSigils,
   modeDescription,
   sanitizeModeParam,
+  statusmsgDescription,
 } from "../lib/channelModes";
 import { DEFAULT_ISUPPORT, type IsupportEntry } from "../lib/isupport";
 
@@ -122,6 +123,36 @@ describe("sanitizeModeParam (#240)", () => {
     // split into two MODE args and set garbage. Reject at the boundary.
     expect(sanitizeModeParam("two words")).toBeNull();
     expect(sanitizeModeParam("a\tb")).toBeNull();
+  });
+});
+
+describe("statusmsgDescription", () => {
+  // The sigils are resolved through the network's own PREFIX in BOTH tests
+  // below, and the two maps disagree about what `%` means — which is the
+  // point: no sigil carries a meaning of its own here.
+  const BAHAMUT = DEFAULT_ISUPPORT.prefix;
+
+  it("names a level through the network's PREFIX", () => {
+    expect(statusmsgDescription("@", BAHAMUT)).toBe("delivered to ops only");
+    expect(statusmsgDescription("%", BAHAMUT)).toBe("delivered to halfop only");
+  });
+
+  it("names EVERY level of a multi-sigil run — #1303", () => {
+    // `meta.statusmsg` carries the whole peeled run because such a target
+    // reaches the union of the levels; a description that named only the
+    // first would understate who read the row.
+    expect(statusmsgDescription("@+", BAHAMUT)).toBe("delivered to ops and voice only");
+    expect(statusmsgDescription("@%+", BAHAMUT)).toBe("delivered to ops, halfop and voice only");
+  });
+
+  it("degrades to the mode letter, then to the sigil, and invents nothing", () => {
+    // A letter nobody named: cic knows a level EXISTS (the network advertised
+    // the pairing) but has no copy for it, so it says which mode it is —
+    // strictly more than the sigil, and honest about what it does not know.
+    expect(statusmsgDescription("!", { y: "!" })).toBe("delivered to mode +y only");
+    // A sigil the network never advertised at all: there is no letter to
+    // name, and guessing one would be inventing a level.
+    expect(statusmsgDescription("~", BAHAMUT)).toBe("delivered to ~ only");
   });
 });
 

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -26,6 +26,7 @@ const WIRE_PAYLOAD = {
   chanmodes_d: ["i", "m", "n", "s", "t"],
   list_modes_queryable: ["b", "e", "I"],
   prefix: { o: "@", v: "+" },
+  prefix_order: ["o", "v"],
   chantypes: ["#", "&"],
   casemapping: "ascii" as const,
   maxlist: { b: 100, e: 100, I: 100 },
@@ -71,6 +72,7 @@ describe("isupport store", () => {
     const entry: IsupportEntry = {
       chanmodes: { a: ["b", "e", "I"], b: ["k"], c: ["l"], d: ["i", "m", "n", "s", "t"] },
       prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      prefixOrder: ["q", "a", "o", "h", "v"],
       listModesQueryable: ["b", "e", "I"],
       chantypes: ["#", "&"],
       casemapping: "ascii",

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -421,6 +421,12 @@ describe("userTopic", () => {
         // server can only ever answer one list. Deriving the set from
         // `chanmodes_a` here would offer +e and +I queries it cannot serve.
         listModesQueryable: ["b"],
+        // #1302 — and no rank either: this envelope predates `prefix_order`,
+        // so the narrower seeds the EMPTY order rather than inferring one
+        // from the map's key sequence. "rank unknown" degrades the mode
+        // editor to the classic op/halfop pair; a guessed rank would go on
+        // mis-ranking founders exactly as before the field existed.
+        prefixOrder: [],
         // #1255 — same story for the widened facts: this envelope predates
         // them, so the narrower supplies exactly what cic assumed while the
         // server was dropping them at ingress — the RFC 2812 sigil class,

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -737,6 +737,12 @@ export type WireChannelEvent =
       // deploy) → `["b"]`, the capability that server does have.
       list_modes_queryable: string[];
       prefix: Record<string, string>;
+      // #1302 — the PREFIX letters in ADVERTISED rank order, highest first.
+      // The map beside it is a lookup table only: it arrives as a JSON
+      // object keyed alphabetically by letter, so rank is not derivable
+      // from it. Absent (a server predating the field) → `[]`, meaning
+      // "rank unknown", never "no levels".
+      prefix_order: string[];
       // #1255 — the per-network facts cic used to open-code as constants.
       // Absent means a server predating the widening (a cic-only bundle
       // deploy again), so each falls back to what cic assumed before it:
@@ -1068,6 +1074,12 @@ export type WireUserEvent =
       // deploy) → `["b"]`, the capability that server does have.
       list_modes_queryable: string[];
       prefix: Record<string, string>;
+      // #1302 — the PREFIX letters in ADVERTISED rank order, highest first.
+      // The map beside it is a lookup table only: it arrives as a JSON
+      // object keyed alphabetically by letter, so rank is not derivable
+      // from it. Absent (a server predating the field) → `[]`, meaning
+      // "rank unknown", never "no levels".
+      prefix_order: string[];
       // #1255 — the per-network facts cic used to open-code as constants.
       // Absent means a server predating the widening (a cic-only bundle
       // deploy again), so each falls back to what cic assumed before it:

--- a/cicchetto/src/lib/channelModes.ts
+++ b/cicchetto/src/lib/channelModes.ts
@@ -213,6 +213,63 @@ export function sanitizeModeParam(value: string): string | null {
  * slightly-permissive gate only avoids wrongly greying out a legit
  * founder.
  */
+// #1302 — the per-USER membership levels PREFIX advertises, named. Kept
+// apart from MODE_DESCRIPTIONS above, which is deliberately channel-mode
+// only (see module doc): a membership mode needs a NAME for the level it
+// grants, not a helpfile paragraph about a channel-wide toggle.
+//
+// The letters are the conventional ones (`q` founder, `a` admin/protected,
+// `o` ops, `h` halfop, `v` voice); the SIGILS are not listed here on
+// purpose. A sigil is per-network and is resolved through the network's own
+// PREFIX map — hardcoding `~&@%+` anywhere is the exact duplication of the
+// 005 this issue exists to delete.
+const MEMBERSHIP_MODE_NAMES: Record<string, string> = {
+  q: "founder",
+  a: "admin",
+  o: "ops",
+  h: "halfop",
+  v: "voice",
+};
+
+/**
+ * Names the membership level a sigil stands for on THIS network, by reverse
+ * lookup through its PREFIX map. Two degradations, both deliberate: a letter
+ * nobody named renders as `mode +<letter>` (the same generic shape
+ * `modeDescription` uses), and a sigil the network never advertised renders
+ * as itself — cic knows nothing about it and must not invent a level.
+ *
+ * A reverse lookup on PREFIX is safe; reading RANK out of it is NOT — the
+ * map crosses the wire alphabetical by mode letter (see `editorSigils`).
+ */
+function membershipLevelName(sigil: string, prefix: Record<string, string>): string {
+  const letter = Object.keys(prefix).find((l) => prefix[l] === sigil);
+  if (letter === undefined) return sigil;
+  return MEMBERSHIP_MODE_NAMES[letter] ?? `mode +${letter}`;
+}
+
+function joinAnd(parts: string[]): string {
+  if (parts.length <= 1) return parts.join("");
+  return `${parts.slice(0, -1).join(", ")} and ${parts.at(-1) ?? ""}`;
+}
+
+/**
+ * The out-of-sight description for a STATUSMSG badge (#1302): what the row's
+ * visible sigils MEAN on this network. The visible row shows the sigils
+ * themselves — one vocabulary on every network, nothing to maintain per
+ * sigil — so this string is the whole of the badge's `title` and its
+ * accessible name, which is all a screen reader would otherwise get from a
+ * bare `@`.
+ *
+ * `run` is the WHOLE peeled STATUSMSG run (`@+`, not `@`) per #1303: such a
+ * target reaches the union of the levels, so every one of them is named.
+ * "only" is the load-bearing word — it says the row did NOT reach the whole
+ * channel, which is the fact the badge exists to carry.
+ */
+export function statusmsgDescription(run: string, prefix: Record<string, string>): string {
+  const names = [...run].map((sigil) => membershipLevelName(sigil, prefix));
+  return `delivered to ${joinAnd(names)} only`;
+}
+
 export function editorSigils(isupport: IsupportEntry): Set<string> {
   const sigils = Object.values(isupport.prefix);
   const opIdx = sigils.indexOf("@");

--- a/cicchetto/src/lib/channelModes.ts
+++ b/cicchetto/src/lib/channelModes.ts
@@ -197,22 +197,6 @@ export function sanitizeModeParam(value: string): string | null {
   return trimmed;
 }
 
-/**
- * The set of membership sigils that grant channel-mode EDITING on a
- * network, derived from its ISUPPORT PREFIX. Editing is allowed for
- * halfop (`%`) and everything that outranks op (`@`) — founder (`~`),
- * admin/protected (`&`), op — but NOT voice (`+`) or plain.
- *
- * PREFIX is advertised highest-rank-first (e.g. `(qaohv)~&@%+`), so the
- * editor set is every sigil at index ≤ the op sigil's index, PLUS the
- * halfop sigil. Deriving from the network's own order (instead of a
- * hardcoded `@`/`%`) means a founder/admin who does NOT also hold `@`
- * still gets an editable modal on networks that separate those roles —
- * the very PREFIX-rich networks this feature adds support for. The ircd
- * remains the real authority (it rejects an unauthorized MODE); a
- * slightly-permissive gate only avoids wrongly greying out a legit
- * founder.
- */
 // #1302 — the per-USER membership levels PREFIX advertises, named. Kept
 // apart from MODE_DESCRIPTIONS above, which is deliberately channel-mode
 // only (see module doc): a membership mode needs a NAME for the level it
@@ -270,21 +254,47 @@ export function statusmsgDescription(run: string, prefix: Record<string, string>
   return `delivered to ${joinAnd(names)} only`;
 }
 
+/**
+ * The set of membership sigils that grant channel-mode EDITING on a
+ * network, derived from its ISUPPORT PREFIX. Editing is allowed for
+ * halfop (`%`) and everything that outranks op (`@`) — founder (`~`),
+ * admin/protected (`&`), op — but NOT voice (`+`) or plain.
+ *
+ * Rank comes from `prefixOrder`, the mode letters in the order the network
+ * ADVERTISED them, so the editor set is every letter at index ≤ op's, plus
+ * halfop. Deriving from the network's own order (instead of a hardcoded
+ * `@`/`%`) means a founder/admin who does NOT also hold `@` still gets an
+ * editable modal on networks that separate those roles — the very
+ * PREFIX-rich networks this feature adds support for. The ircd remains the
+ * real authority (it rejects an unauthorized MODE); a slightly-permissive
+ * gate only avoids wrongly greying out a legit founder.
+ *
+ * #1302 — this used to read `Object.values(isupport.prefix)` as the rank
+ * order, and its docstring said so. It is not one: the map arrives as a
+ * JSON object keyed alphabetically by mode letter, which on
+ * `PREFIX=(qaohv)~&@%+` puts `o` in the MIDDLE — so a founder who was not
+ * also op fell below the cut and got handed the greyed-out modal this
+ * function exists to prevent. It survived unseen because on Azzurra
+ * `(ohv)` sorts to `h,o,v`, which coincides with rank, and the single case
+ * that would differ is re-admitted by the halfop branch below: the network
+ * grappa runs on is precisely the one that hides the defect.
+ */
 export function editorSigils(isupport: IsupportEntry): Set<string> {
-  const sigils = Object.values(isupport.prefix);
-  const opIdx = sigils.indexOf("@");
+  const opIdx = isupport.prefixOrder.indexOf("o");
   const out = new Set<string>();
   if (opIdx === -1) {
-    // No op sigil advertised (non-standard) — fall back to the classic
-    // op/halfop pair so the gate never opens to everyone.
+    // No op mode advertised (non-standard), or no order published at all (a
+    // server older than the field) — fall back to the classic op/halfop
+    // pair so the gate never opens to everyone. Inferring an order from the
+    // map is the bug above; an unknown rank stays unknown.
     out.add("@");
     out.add("%");
     return out;
   }
   // Everything at or above op rank (index ≤ opIdx in the high-first list).
-  for (let i = 0; i <= opIdx; i++) {
-    const s = sigils[i];
-    if (s !== undefined) out.add(s);
+  for (const letter of isupport.prefixOrder.slice(0, opIdx + 1)) {
+    const sigil = isupport.prefix[letter];
+    if (sigil !== undefined) out.add(sigil);
   }
   // Halfop, if the network has one, also edits.
   if (isupport.prefix.h !== undefined) out.add(isupport.prefix.h);

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -170,6 +170,20 @@ export function chantypesForNetwork(networkId: number | null): readonly string[]
 }
 
 /**
+ * The membership letter→sigil map this network advertised (`PREFIX=`), or the
+ * bahamut/Azzurra default for an unseeded network / a null id. Sibling of
+ * `chantypesForNetwork` — a per-fact accessor so a caller that needs one 005
+ * fact does not carry the whole entry around.
+ *
+ * Safe for sigil↔letter lookups in EITHER direction. NOT safe as an order:
+ * the map crosses the wire alphabetical by mode letter (see `editorSigils`).
+ */
+export function prefixForNetwork(networkId: number | null): Record<string, string> {
+  if (networkId === null) return DEFAULT_ISUPPORT.prefix;
+  return isupportForNetwork(networkId).prefix;
+}
+
+/**
  * The per-frame body budget base this network published (#1108), or `null`
  * when none has arrived — an unseeded network, a parked session, or a server
  * older than the field. Callers must treat `null` as "say nothing": the

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -39,6 +39,15 @@ export type IsupportEntry = {
     d: string[];
   };
   prefix: Record<string, string>;
+  // #1302 — the PREFIX mode letters in the order the network ADVERTISED
+  // them, highest rank first. The map above is a lookup table in both
+  // directions and nothing else: it arrives as a JSON object whose key
+  // order is the server runtime's (alphabetical by letter), so rank is
+  // simply not recoverable from it — see `editorSigils`, which used to try.
+  // Empty when the payload carried no order at all (a server predating the
+  // field), which every reader must treat as "rank unknown", never as
+  // "no levels".
+  prefixOrder: string[];
   // #1251 — the type-A (list) modes this network advertises AND the server
   // knows the reply numerics for, in 005 order. The BanlistModal's mode
   // switcher renders exactly this set: a letter the network advertises but
@@ -85,6 +94,7 @@ export const DEFAULT_ISUPPORT: IsupportEntry = {
     d: ["C", "D", "R", "c", "d", "i", "m", "n", "p", "r", "s", "t"],
   },
   prefix: { o: "@", h: "%", v: "+" },
+  prefixOrder: ["o", "h", "v"],
   listModesQueryable: ["b", "e", "I"],
   chantypes: [...DEFAULT_CHANTYPES],
   casemapping: "ascii",
@@ -132,6 +142,7 @@ export function isupportEntryFromWire(payload: {
   chanmodes_d: string[];
   list_modes_queryable: string[];
   prefix: Record<string, string>;
+  prefix_order: string[];
   chantypes: string[];
   casemapping: Casemapping;
   maxlist: Record<string, number>;
@@ -148,6 +159,7 @@ export function isupportEntryFromWire(payload: {
       d: payload.chanmodes_d,
     },
     prefix: payload.prefix,
+    prefixOrder: payload.prefix_order,
     listModesQueryable: payload.list_modes_queryable,
     chantypes: payload.chantypes,
     casemapping: payload.casemapping,

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -254,6 +254,12 @@ export function narrowIsupportChanged(
     // queries that server cannot answer.
     list_modes_queryable: narrowStringArray(r.list_modes_queryable) ?? ["b"],
     prefix,
+    // #1302 — absent means a server predating the field. The empty list is
+    // the honest answer: rank is UNKNOWN, and `editorSigils` degrades to the
+    // classic op/halfop pair, which is exactly what it computed while the
+    // order was being dropped. Falling back to the map's key order instead
+    // would reinstate the very mis-ranking this field exists to end.
+    prefix_order: narrowStringArray(r.prefix_order) ?? [],
     // #1255 — same posture as the two fallbacks around it: absent means a
     // server predating the widening, and the fallback is exactly what cic
     // assumed while the fact was being dropped at ingress — the RFC 2812

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1004,6 +1004,7 @@ export const S_SessionWireIsupportChangedPayload = {
     chanmodes_d: { a: "s" },
     list_modes_queryable: { a: "s" },
     prefix: { r: "s" },
+    prefix_order: { a: "s" },
     chantypes: { a: "s" },
     casemapping: S_SessionISupportCasemapping,
     maxlist: { r: "i" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1003,6 +1003,7 @@ export type SessionWireIsupportChangedPayload = {
   chanmodes_d: string[];
   list_modes_queryable: string[];
   prefix: Record<string, string>;
+  prefix_order: string[];
   chantypes: string[];
   casemapping: SessionISupportCasemapping;
   maxlist: Record<string, number>;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45456,3 +45456,82 @@ exist: it has been a 69-line consumer since #1384 and the six raw
 from `_lib.sh` is not in the file either. A review pinned to a base
 (`575e203a`) that has since moved is a set of claims to re-locate, not a
 map to follow.
+<!-- entry #1302 -->
+
+---
+
+## 2026-08-17 — #1302: STATUSMSG badge shows sigils; PREFIX rank comes from the advertised order
+
+Two operators reported the STATUSMSG badge as noise. It worded exactly
+two levels (`@` → "ops-only", `+` → "voice-only") and rendered every
+other sigil bare, so a network with a halfop level showed three rows in
+two vocabularies, and every PREFIX richer than bahamut fared worse. A
+two-entry constant cannot name a set that is per-network and
+open-ended.
+
+**Ruling (vjt): the row shows the SIGILS, always.** One vocabulary on
+every network and nothing to maintain per sigil. `@` already says "ops
+only" to anyone reading IRC. The words move to the `title` and the
+accessible name, derived by mapping each sigil back to its mode letter
+through the network's own `PREFIX=` — never hardcoded. The badge
+carried neither attribute before, so a bare sigil would otherwise reach
+a screen reader as an `@` character and nothing else. `meta.statusmsg`
+is the whole peeled run per #1303, so every sigil renders and every
+level is named.
+
+### Rank is not in the map, and never was
+
+The constraint that made this issue interesting: **`isupport.prefix`
+cannot be read as a rank order.** `parse_prefix/1` closed on
+`Map.new/1`, and the map crosses the cic wire as a JSON object whose
+key order is the runtime's — alphabetical by mode letter for a small
+map. Measured on the production node, `(qaohv)~&@%+` serialises
+`{"a":"&","h":"%","o":"@","q":"~","v":"+"}`.
+
+`editorSigils` in cic read `Object.values(prefix)` AS that ranking and
+said so in its docstring, cutting the mode-editor set at
+`indexOf("@")`. With `o` sitting in the middle of the alphabetical
+sequence, a founder (`~`, mode `q`) who is not also op fell below the
+cut and got the greyed-out modal the function exists to prevent. **It
+survived because of where we run it:** on Azzurra `(ohv)` sorts to
+`h,o,v`, which coincides with rank, and the one case that would differ
+is re-admitted by the halfop branch. The network grappa runs on is
+precisely the one that hides the defect.
+
+So the rank had to be published: `prefix_order`, the mode letters
+highest-rank-first, additive and snake_case, riding BESIDE the map
+rather than reshaping it — `prefix` is a published field and the
+additive-only contract cannot express repurposing one, and a lookup
+wants a map while a rank wants a list. Both projections come out of the
+same zip in the same parse, so they cannot disagree about which letters
+exist. A second hardcoded `~&@%+` was refused outright: reproducing by
+hand what the 005 already says is the class #1402 is closing.
+
+An absent `prefix_order` (a server older than the field) narrows to the
+EMPTY list, and `editorSigils` degrades to the classic op/halfop pair.
+Rank unknown stays unknown; inferring it from the map's key order is
+the defect itself.
+
+### Two green tests were asserting the defect
+
+`channelModes`' founder case and `ModeModal`'s founder-without-`@` case
+both described the RIGHT behaviour and passed for as long as the bug
+existed, because their fixtures were object literals written in rank
+order — and an object literal preserves the order it was typed in,
+which is not the order the wire delivers. Both are rebuilt from
+`JSON.parse` of the measured production serialisation. **A fixture that
+spells a wire shape by hand is testing the author's mental model of the
+wire, not the wire.**
+
+### Retracted mid-flight
+
+The first pass claimed a bare `<span>` is name-prohibited (role=generic)
+and therefore that `aria-label` on it computes to no accessible name. A
+mutant that dropped `role="img"` SURVIVED: our toolchain
+(dom-accessibility-api) does not implement the prohibition and names the
+span either way. The empty accessible names observed while building came
+entirely from the #130 flicker gate hiding the scrollback container in
+jsdom. `role="img"` stays — ARIA does prohibit the name there, so no AT
+owes us the reading — but that is the spec, not a measurement, and the
+tests now pin the spec-legal SHAPE with a byRole query instead of
+pretending the name assertion proves it.

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -515,7 +515,7 @@ defmodule Grappa.Session.ISupport do
   # reason `STATUSMSG=` below uses it.
   defp merge_token("PREFIX=" <> rest, acc) do
     case parse_prefix(rest) do
-      {:ok, {prefix, order}} -> %{acc | prefix: prefix} |> Map.put(:prefix_order, order)
+      {:ok, {prefix, order}} -> Map.put(%{acc | prefix: prefix}, :prefix_order, order)
       :error -> acc
     end
   end

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -124,6 +124,7 @@ defmodule Grappa.Session.ISupport do
   @type t :: %{
           chanmodes: chanmodes(),
           prefix: prefix(),
+          prefix_order: [String.t()],
           statusmsg: [String.t()],
           monitor: presence_limit() | nil,
           watch: presence_limit() | nil,
@@ -154,6 +155,12 @@ defmodule Grappa.Session.ISupport do
   # dialyzer-transparent (MapSet is opaque — a composite type embedding it
   # trips `contract_with_opaque` on the literal `default/0` return).
   @default_prefix %{"o" => "@", "h" => "%", "v" => "+"}
+
+  # #1302 — the SAME token's mode letters, in the order PREFIX advertised
+  # them: highest rank first. `@default_prefix` is a map and a map has no
+  # order, so rank is a second projection of one parse rather than a fact
+  # anyone can recover from the table beside it.
+  @default_prefix_order ["o", "h", "v"]
   @default_chanmodes %{
     a: ["b", "e", "I"],
     b: ["k"],
@@ -202,6 +209,7 @@ defmodule Grappa.Session.ISupport do
     %{
       chanmodes: @default_chanmodes,
       prefix: @default_prefix,
+      prefix_order: @default_prefix_order,
       statusmsg: @default_statusmsg,
       # #247 — no presence mechanism ADVERTISED pre-005. This table only
       # records what 005 said; the arm policy (advertised pick, else an
@@ -291,6 +299,37 @@ defmodule Grappa.Session.ISupport do
   def user_prefix(%{prefix: prefix}, mode) when is_binary(mode) do
     Map.fetch(prefix, mode)
   end
+
+  @doc """
+  The membership mode letters this network advertised, HIGHEST RANK FIRST —
+  the order `PREFIX=(qaohv)~&@%+` states and `prefix` cannot hold.
+
+  This is the only place rank may be read from. The sibling map is a lookup
+  table in both directions and nothing more: it is built with `Map.new/1`
+  and crosses the cic wire as a JSON object, whose key order is the
+  runtime's (alphabetical by letter, for a small map) rather than the
+  ircd's. Those two coincide on bahamut/Azzurra — `(ohv)` sorts to `h,o,v`,
+  and the only pair that would differ is re-admitted by the halfop branch
+  in cic's `editorSigils` — which is why reading rank out of the map
+  survived undetected on the network grappa runs on, and mis-ranked
+  founders everywhere else.
+
+  Read via `Map.get` for the same hot-reload safety as `statusmsg/1`: a
+  live `Session.Server` state seeded before this field existed and read
+  after the module is reloaded degrades to the bahamut order instead of
+  raising.
+  """
+  @spec prefix_order(t()) :: [String.t()]
+  def prefix_order(isupport) when is_map(isupport),
+    do: Map.get(isupport, :prefix_order, @default_prefix_order)
+
+  @doc """
+  The pre-005 default PREFIX rank order (bahamut/Azzurra `(ohv)`). Exposed
+  so callers and tests reference the seed through production code rather
+  than duplicating the literal.
+  """
+  @spec default_prefix_order() :: [String.t()]
+  def default_prefix_order, do: @default_prefix_order
 
   @doc """
   The advertised STATUSMSG membership sigils for this network — the set a
@@ -470,9 +509,13 @@ defmodule Grappa.Session.ISupport do
     end
   end
 
+  # #1302 — one parse writes BOTH projections. `Map.put` for the order (not
+  # the update syntax used for the map) because `acc` may be a table that
+  # predates the `:prefix_order` field during a hot-reload window, the same
+  # reason `STATUSMSG=` below uses it.
   defp merge_token("PREFIX=" <> rest, acc) do
     case parse_prefix(rest) do
-      {:ok, prefix} -> %{acc | prefix: prefix}
+      {:ok, {prefix, order}} -> %{acc | prefix: prefix} |> Map.put(:prefix_order, order)
       :error -> acc
     end
   end
@@ -656,14 +699,18 @@ defmodule Grappa.Session.ISupport do
   # PREFIX=(modes)sigils — parenthesised mode letters paired positionally
   # with the sigils that follow. `(ohv)@%+` → %{"o"=>"@","h"=>"%","v"=>"+"}.
   # The two runs MUST be equal length or the token is malformed.
-  @spec parse_prefix(String.t()) :: {:ok, prefix()} | :error
+  # #1302 — returns the lookup MAP and the advertised ORDER of the same
+  # letters. `Map.new/1` destroys that order and nothing downstream can
+  # reconstruct it, so the zip is kept: two projections, one parse, no way
+  # for them to disagree about which letters exist.
+  @spec parse_prefix(String.t()) :: {:ok, {prefix(), [String.t()]}} | :error
   defp parse_prefix(rest) do
     with ["", tail] <- String.split(rest, "(", parts: 2),
          [modes, sigils] <- String.split(tail, ")", parts: 2),
          mode_list = String.graphemes(modes),
          sigil_list = String.graphemes(sigils),
          true <- mode_list != [] and length(mode_list) == length(sigil_list) do
-      {:ok, mode_list |> Enum.zip(sigil_list) |> Map.new()}
+      {:ok, {mode_list |> Enum.zip(sigil_list) |> Map.new(), mode_list}}
     else
       _ -> :error
     end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -167,6 +167,7 @@ defmodule Grappa.Session.Wire do
           chanmodes_d: [String.t()],
           list_modes_queryable: [String.t()],
           prefix: %{String.t() => String.t()},
+          prefix_order: [String.t()],
           chantypes: [String.t()],
           casemapping: ISupport.casemapping(),
           maxlist: %{String.t() => integer()},
@@ -948,6 +949,17 @@ defmodule Grappa.Session.Wire do
   does not rewrite process state — publishes the seed instead of crashing
   the fan-out.
 
+  `prefix_order` (#1302) is the PREFIX letters highest-rank-first. It rides
+  BESIDE the map rather than reshaping it, because the map is a published
+  field and repurposing one is not something the additive-only contract can
+  express — and because a lookup wants a map while a rank wants a list.
+  Publishing it is not a convenience: `prefix` reaches the client as a JSON
+  object whose key order is the runtime's, not the ircd's, so rank is
+  simply absent from the client's copy and cannot be derived there. A
+  client that read `Object.values(prefix)` as the ranking mis-ranked every
+  network whose advertised order disagrees — which is every network richer
+  than the one grappa runs on.
+
   What does NOT cross: `ISupport.raw/1`, the verbatim token archive. That
   is a Phase 6 listener-facade input; a bag of IRC tokens on this wire
   would be IRC protocol re-entering the web client through the window
@@ -965,6 +977,7 @@ defmodule Grappa.Session.Wire do
       chanmodes_d: Enum.sort(cm.d),
       list_modes_queryable: ListModes.queryable(isupport),
       prefix: prefix,
+      prefix_order: ISupport.prefix_order(isupport),
       chantypes: ISupport.chantypes(isupport),
       casemapping: ISupport.casemapping(isupport),
       maxlist: ISupport.maxlist(isupport),

--- a/test/grappa/session/isupport_test.exs
+++ b/test/grappa/session/isupport_test.exs
@@ -158,6 +158,65 @@ defmodule Grappa.Session.ISupportTest do
       assert ISupport.user_prefix(isupport, "q") == {:ok, "~"}
       assert ISupport.user_prefix(isupport, "v") == {:ok, "+"}
     end
+
+    # #1302 — PREFIX advertises its letters highest-rank-first, and that
+    # ORDER is a fact of its own: `Map.new/1` throws it away, so a consumer
+    # holding only the map cannot tell a founder from a voice. The order is
+    # captured from the same parse that builds the map — one zip, two
+    # projections — so the two cannot drift apart.
+    test "captures the ADVERTISED rank order, which the map itself cannot carry" do
+      isupport =
+        ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      assert ISupport.prefix_order(isupport) == ["q", "a", "o", "h", "v"]
+
+      # The map from the SAME token still resolves every letter — a lookup
+      # was never the broken part...
+      assert ISupport.user_prefix(isupport, "q") == {:ok, "~"}
+      assert ISupport.user_prefix(isupport, "v") == {:ok, "+"}
+
+      # ...but its own key order is NOT the advertised one, which is the
+      # whole reason the order has to travel separately.
+      refute Map.keys(isupport.prefix) == ["q", "a", "o", "h", "v"]
+    end
+
+    test "a re-advertised PREFIX replaces the rank order too" do
+      # The order must follow the same last-wins rule as the map beside it:
+      # a table left holding line 1's order and line 2's map would rank
+      # letters that are no longer in it.
+      isupport =
+        ISupport.default()
+        |> then(&ISupport.merge_isupport(["grappa-test", "PREFIX=(ov)@+"], &1))
+        |> then(&ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@%+"], &1))
+
+      assert ISupport.prefix_order(isupport) == ["q", "a", "o", "h", "v"]
+    end
+
+    test "a malformed PREFIX leaves the previous rank order standing" do
+      # Same posture as the map: an unbalanced token is ignored rather than
+      # blanking the table, so a misbehaving server cannot strip rank.
+      isupport =
+        ISupport.default()
+        |> then(&ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@"], &1))
+
+      assert ISupport.prefix_order(isupport) == ISupport.default_prefix_order()
+    end
+  end
+
+  describe "prefix_order/1" do
+    test "pre-005 default is the bahamut/Azzurra order" do
+      assert ISupport.prefix_order(ISupport.default()) == ["o", "h", "v"]
+      assert ISupport.default_prefix_order() == ["o", "h", "v"]
+    end
+
+    test "a table predating the field reads the default instead of raising" do
+      # Hot-reload safety, exactly as `statusmsg/1` has it: a live
+      # Session.Server state seeded before this field exists and read after
+      # the new module is loaded must degrade, not KeyError.
+      legacy = Map.delete(ISupport.default(), :prefix_order)
+
+      assert ISupport.prefix_order(legacy) == ISupport.default_prefix_order()
+    end
   end
 
   describe "takes_param?/3 type-C sign sensitivity" do

--- a/test/grappa/session/isupport_test.exs
+++ b/test/grappa/session/isupport_test.exs
@@ -196,8 +196,7 @@ defmodule Grappa.Session.ISupportTest do
       # Same posture as the map: an unbalanced token is ignored rather than
       # blanking the table, so a misbehaving server cannot strip rank.
       isupport =
-        ISupport.default()
-        |> then(&ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@"], &1))
+        ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@"], ISupport.default())
 
       assert ISupport.prefix_order(isupport) == ISupport.default_prefix_order()
     end

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -98,6 +98,29 @@ defmodule Grappa.Session.WireTest do
       assert payload.prefix == %{"o" => "@", "h" => "%", "v" => "+"}
     end
 
+    # #1302 — the map is a LOOKUP table and nothing more. It reaches the
+    # client as a JSON object whose key order is the runtime's, not the
+    # ircd's, so a client reading rank out of it mis-ranks every network
+    # whose advertised order disagrees with that — which is every network
+    # richer than bahamut. The order is published as its own field.
+    test "publishes prefix_order, the rank the serialised map destroys" do
+      isupport =
+        ISupport.merge_isupport(["s", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      payload = Wire.isupport_changed(7, isupport, 512)
+
+      assert payload.prefix_order == ["q", "a", "o", "h", "v"]
+
+      # The measurement this field exists for, re-exhibited on the encoder
+      # that actually ships it: the map does NOT serialise in rank order, so
+      # `Object.values(prefix)` is not a ranking anywhere.
+      assert Jason.encode!(payload.prefix) ==
+               ~s({"a":"&","h":"%","o":"@","q":"~","v":"+"})
+
+      # And the field survives encoding in the advertised order.
+      assert Jason.encode!(payload.prefix_order) == ~s(["q","a","o","h","v"])
+    end
+
     # #1251 — the queryable set is PUBLISHED, not left for the client to
     # derive: it is `chanmodes_a` minus the letters grappa knows no reply
     # numerics for. The difference between the two lists is the quiet


### PR DESCRIPTION
Addresses #1302 (both halves of it).

## The badge

`STATUSMSG_LABEL` worded exactly two levels, so a network advertising a
halfop level rendered `%` bare beside `@`'s "ops-only" and `+`'s
"voice-only" — three rows, two vocabularies — and every PREFIX richer than
bahamut fared worse. A two-entry constant cannot name a set that is
per-network and open-ended.

Per the ruling, the visible row now shows the **sigils, always**: one
vocabulary on every network, nothing to maintain per sigil. The words move
to the `title` and the accessible name, **derived** by mapping each sigil
back to its mode letter through the network's own `PREFIX=`. Worth stating
plainly: the span carried **neither** attribute before, so a bare sigil
would have reached a screen reader as an `@` character and nothing else.

`meta.statusmsg` is the whole peeled run per #1303, so every sigil renders
and every level is named — the badge is not written as if `level` were one
character.

## Rank is not in the map, and never was

`editorSigils` read `Object.values(isupport.prefix)` **as** the high-to-low
rank order — its own docstring said so — and cut at `indexOf("@")`. That
sequence is not a ranking: `parse_prefix/1` closed on `Map.new/1`, and the
map crosses the wire as a JSON object keyed alphabetically by mode letter.
On `PREFIX=(qaohv)~&@%+` that puts `o` in the **middle**, so a founder
(`~`, mode `q`) who is not also op fell below the cut and got the
greyed-out mode modal the function exists to prevent.

It survived because of where we run it: on Azzurra `(ohv)` sorts to
`h,o,v`, which coincides with rank, and the single case that would differ
is re-admitted by the halfop branch. The network grappa runs on is exactly
the one that hides the defect.

The order was not merely hard to read client-side — **it did not exist**,
on either side of the wire. So this publishes it: `prefix_order`, the mode
letters highest-rank-first, additive and snake_case, riding **beside** the
map rather than reshaping it (`prefix` is a published field and the
additive-only contract cannot express repurposing one; a lookup wants a
map, a rank wants a list). Both projections come out of the same zip in the
same parse, so they cannot disagree about which letters exist.
`prefix_order/1` reads through `Map.get` like `statusmsg/1` beside it, so a
session state seeded before the field survives a hot reload.

Absent on the wire narrows to the **empty list**, never a guessed order:
`editorSigils` then degrades to the classic op/halfop pair, which is
exactly what it computed while the order was being dropped. Rank unknown
stays unknown — inferring it from the map is the defect. No second
hardcoded `~&@%+` anywhere.

## Two green tests were asserting the defect

`channelModes`' founder case and `ModeModal`'s founder-without-`@` case
both mounted `(qaohv)~&@%+` and asserted the **right** behaviour. They
passed anyway, for as long as the bug existed, because their fixtures were
object literals written in rank order — and a literal preserves the order
it was *typed* in, which is not what the wire delivers. Both are rebuilt
from `JSON.parse` of the serialisation measured on the production node, so
no source reordering can accidentally repair them. With the corrected
fixture and production at base, `e.has("~")` is false.

A fixture that spells a wire shape by hand tests the author's mental model
of the wire, not the wire.

## A claim retracted mid-flight

The first pass asserted that a bare `<span>` is role=generic, therefore
name-prohibited, therefore an `aria-label` there computes to no accessible
name. **A mutant that dropped `role="img"` survived**: every name assertion
stayed green. The empty names observed while building came entirely from
the #130 flicker gate hiding the scrollback container in jsdom;
`dom-accessibility-api` does not implement the prohibition. `role="img"`
stays — ARIA does prohibit the name there, so no AT owes us the reading —
but that is the spec, not a measurement, and the tests now pin the
spec-legal shape with a `byRole` query. Commit `test(#1302): pin the
badge's ROLE, and retract what the name proved` carries it in the open.

## Gates

Run locally, rc read from the log file, on the **previous** base
(`8a616a3d`) unless noted:

| gate | result |
|---|---|
| `scripts/check.sh` | RC=0 — 8 doctests, 60 properties, **6417 tests, 0 failures**; Dialyzer `Total errors: 0`; bats 0 `not ok` |
| `mix grappa.gen_wire_types --check` | RC=0 — `wireTypes.ts` and `wireSchema.ts` in sync |
| `scripts/bun.sh run check` | RC=0, 59 warnings (baseline unchanged) |
| `scripts/bun.sh run test` | RC=0 — 289 files, **5574 tests** |
| `scripts/integration.sh` (**full suite**) | RC=0 — **754 passed** (29.4m) |
| `scripts/design-notes-gate.sh` | RC=0 — re-run **after** this rebase; marker unique, boundary shape re-read on the file |

Red proven by displacement with the tests already committed (never
`git stash`): 4 reds on the badge half for the right reason
(`Received: "ops-only"`, empty accessible name) with 199 greens beside them
in the same file; 6 reds server-side with 137 greens beside them; plus the
`editorSigils` red above. Six mutants, **zero survivors** — one of which is
the retraction above.

### NOT re-run after this rebase

Stated plainly rather than implied. This branch was rebased from
`8a616a3d` onto `f59b0c7e` (which brings #1301, #1303, #1406-X-S8, #1409),
and the host's compile lane belongs to another worker, so **only
`design-notes-gate.sh` was re-run on the new base**. Everything else in the
table above was measured before the rebase. Specifically unverified here:

- **`grappa.gen_wire_types --check`.** The union also touched
  `cicchetto/src/lib/wireTypes.ts`, a GENERATED file. This rebase produced
  no conflict, but a clean textual merge of generated output proves
  nothing — the drift gate is the only thing that does, and CI runs it.
- **`scripts/integration.sh`.** The e2e ran on a tree without #1303, which
  has since landed and made `meta.statusmsg` the whole run.
- `check.sh` and the cic suites, likewise pre-rebase.

The two-sided numstat check across the rebase is clean: additions
unchanged, deletions zero, `docs/DESIGN_NOTES.md` at `79 0`, and my
`<!-- entry #1302 -->` is unique against a base that now carries #1303,
#1406 X-S8 and #1409.