### PR TITLE
codegen(#1406) X-S10: close the last two String.t() discriminators, and stop the codegen guessing

### DIFF
--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT
 // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-// Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
 //
 // #429 — the RUNTIME twin of `wireTypes.ts`: the same typespecs, emitted
 // as schema literals `wireValidate.ts` interprets. `wireTypes.ts` is
@@ -1519,6 +1519,21 @@ export const S_WindowCountsWireEvent = {
   },
 } as const;
 
+// GrappaWeb.AuthJSON.user_subject_wire/0
+export const S_AuthJSONUserSubjectWire = {
+  o: { kind: { l: "user" }, id: "s", name: "s" },
+} as const;
+
+// GrappaWeb.AuthJSON.visitor_subject_wire/0
+export const S_AuthJSONVisitorSubjectWire = {
+  o: { kind: { l: "visitor" }, id: "s", registered: "b", incognito: "b" },
+} as const;
+
+// GrappaWeb.AuthJSON.subject_wire/0
+export const S_AuthJSONSubjectWire = {
+  u: [S_AuthJSONUserSubjectWire, S_AuthJSONVisitorSubjectWire],
+} as const;
+
 // GrappaWeb.ErrorTokens.shared_error_token/0
 export const S_ErrorTokensSharedErrorToken = { e: [...ERROR_TOKENS_SHARED_ERROR_TOKEN] } as const;
 
@@ -1624,3 +1639,53 @@ export const S_ErrorTokensRestErrorToken = {
     { l: "validation_failed" },
   ],
 } as const;
+
+// GrappaWeb.MeJSON.read_cursors/0
+export const S_MeJSONReadCursors = { r: { r: "i" } } as const;
+
+// GrappaWeb.MeJSON.unread_counts/0
+export const S_MeJSONUnreadCounts = {
+  r: {
+    r: {
+      o: {
+        messages: "i",
+        mentions: "i",
+        events: "i",
+        severity: { e: ["mention", "message", "event", "none"] },
+      },
+    },
+  },
+} as const;
+
+// GrappaWeb.MeJSON.user_me_json/0
+export const S_MeJSONUserMeJson = {
+  o: {
+    kind: { l: "user" },
+    id: "s",
+    name: "s",
+    is_admin: "b",
+    inserted_at: "s",
+    read_cursors: S_MeJSONReadCursors,
+    unread_counts: S_MeJSONUnreadCounts,
+    badge_count: "i",
+    home_data: S_NetworksWireHomeData,
+  },
+} as const;
+
+// GrappaWeb.MeJSON.visitor_me_json/0
+export const S_MeJSONVisitorMeJson = {
+  o: {
+    kind: { l: "visitor" },
+    id: "s",
+    expires_at: { u: ["s", "z"] },
+    registered: "b",
+    incognito: "b",
+    read_cursors: S_MeJSONReadCursors,
+    unread_counts: S_MeJSONUnreadCounts,
+    badge_count: "i",
+    home_data: S_NetworksWireHomeData,
+  },
+} as const;
+
+// GrappaWeb.MeJSON.me_json/0
+export const S_MeJSONMeJson = { u: [S_MeJSONUserMeJson, S_MeJSONVisitorMeJson] } as const;

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1643,19 +1643,18 @@ export const S_ErrorTokensRestErrorToken = {
 // GrappaWeb.MeJSON.read_cursors/0
 export const S_MeJSONReadCursors = { r: { r: "i" } } as const;
 
-// GrappaWeb.MeJSON.unread_counts/0
-export const S_MeJSONUnreadCounts = {
-  r: {
-    r: {
-      o: {
-        messages: "i",
-        mentions: "i",
-        events: "i",
-        severity: { e: ["mention", "message", "event", "none"] },
-      },
-    },
+// GrappaWeb.MeJSON.window_counts/0
+export const S_MeJSONWindowCounts = {
+  o: {
+    messages: "i",
+    mentions: "i",
+    events: "i",
+    severity: { e: ["mention", "message", "event", "none"] },
   },
 } as const;
+
+// GrappaWeb.MeJSON.unread_counts/0
+export const S_MeJSONUnreadCounts = { r: { r: S_MeJSONWindowCounts } } as const;
 
 // GrappaWeb.MeJSON.user_me_json/0
 export const S_MeJSONUserMeJson = {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1695,16 +1695,14 @@ export type ErrorTokensChannelErrorToken = (typeof ERROR_TOKENS_CHANNEL_ERROR_TO
 
 export type MeJSONReadCursors = Record<string, Record<string, number>>;
 
-export type MeJSONUnreadCounts =
-  | Record<string, Record<string, {
+export type MeJSONUnreadCounts = Record<string, Record<string, MeJSONWindowCounts>>;
+
+export type MeJSONWindowCounts = {
   messages: number;
   mentions: number;
   events: number;
-  severity: "mention"
-  | "message"
-  | "event"
-  | "none";
-}>>;
+  severity: "mention" | "message" | "event" | "none";
+};
 
 export type MeJSONUserMeJson = {
   kind: "user";

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT
 // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-// Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
 
 // === External types (referenced by Wire modules) ===
 
@@ -1565,6 +1565,23 @@ export type WindowCountsWireEvent = {
   severity: WindowCountsSeverity;
 };
 
+// === GrappaWeb.AuthJSON ===
+
+export type AuthJSONUserSubjectWire = {
+  kind: "user";
+  id: string;
+  name: string;
+};
+
+export type AuthJSONVisitorSubjectWire = {
+  kind: "visitor";
+  id: string;
+  registered: boolean;
+  incognito: boolean;
+};
+
+export type AuthJSONSubjectWire = AuthJSONUserSubjectWire | AuthJSONVisitorSubjectWire;
+
 // === GrappaWeb.ErrorTokens ===
 
 export const ERROR_TOKENS_SHARED_ERROR_TOKEN = [
@@ -1673,3 +1690,44 @@ export const ERROR_TOKENS_CHANNEL_ERROR_TOKEN = [
   "rate_limited",
 ] as const;
 export type ErrorTokensChannelErrorToken = (typeof ERROR_TOKENS_CHANNEL_ERROR_TOKEN)[number];
+
+// === GrappaWeb.MeJSON ===
+
+export type MeJSONReadCursors = Record<string, Record<string, number>>;
+
+export type MeJSONUnreadCounts =
+  | Record<string, Record<string, {
+  messages: number;
+  mentions: number;
+  events: number;
+  severity: "mention"
+  | "message"
+  | "event"
+  | "none";
+}>>;
+
+export type MeJSONUserMeJson = {
+  kind: "user";
+  id: string;
+  name: string;
+  is_admin: boolean;
+  inserted_at: string;
+  read_cursors: MeJSONReadCursors;
+  unread_counts: MeJSONUnreadCounts;
+  badge_count: number;
+  home_data: NetworksWireHomeData;
+};
+
+export type MeJSONVisitorMeJson = {
+  kind: "visitor";
+  id: string;
+  expires_at: string | null;
+  registered: boolean;
+  incognito: boolean;
+  read_cursors: MeJSONReadCursors;
+  unread_counts: MeJSONUnreadCounts;
+  badge_count: number;
+  home_data: NetworksWireHomeData;
+};
+
+export type MeJSONMeJson = MeJSONUserMeJson | MeJSONVisitorMeJson;

--- a/cicchetto/src/lib/wireTypesAssert.ts
+++ b/cicchetto/src/lib/wireTypesAssert.ts
@@ -55,9 +55,11 @@ import type {
   HomeNetworkRow,
   LinksEntry,
   MentionsBundleMessage,
+  MeResponse,
   NotifyEntry,
   QueryWindowEntry,
   ScrollbackMessage,
+  Subject,
   WhoUser,
   WireChannelEvent,
   WireUserEvent,
@@ -65,8 +67,10 @@ import type {
 import type { ModesEntry, TopicEntry } from "./channelTopic";
 import type { MemberEntry } from "./memberTypes";
 import type {
+  AuthJSONSubjectWire,
   ChannelDirectoryWireEntry,
   CicWireBundleHashPayload,
+  MeJSONMeJson,
   NetworksFeaturedChannelsWireLink,
   NetworksWireConnectionStateEvent,
   NetworksWireCredentialJson,
@@ -359,3 +363,16 @@ export type _Assert_NoWideningOverrunChannel = Assert<
     WideningOverrunIn<WireChannelEvent>
   >
 >;
+
+// === #1406 X-S10 — the subject discriminator, both doors ===
+// `GET /me` and `POST /auth/login` carried `kind` as a bare string on the
+// server until X-S10; the literals lived here by hand with nothing tying
+// them to the source. Now that both are closed sets the codegen can see,
+// pin them — but pin the DISCRIMINATOR ONLY. cic's `MeResponse` and
+// `Subject` deliberately mark the post-#363/#126 fields optional so a
+// subject persisted in localStorage before those fields landed still
+// validates, and `MeResponse` carries envelopes the tests mock away, so a
+// full-shape `Equal` cannot hold on either. The `kind` set is the part that
+// must never drift silently — the same posture as `_Assert_BundleHashKind`.
+export type _Assert_MeResponseKind = Assert<Equal<MeResponse["kind"], MeJSONMeJson["kind"]>>;
+export type _Assert_LoginSubjectKind = Assert<Equal<Subject["kind"], AuthJSONSubjectWire["kind"]>>;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45535,3 +45535,94 @@ jsdom. `role="img"` stays — ARIA does prohibit the name there, so no AT
 owes us the reading — but that is the spec, not a measurement, and the
 tests now pin the spec-legal SHAPE with a byRole query instead of
 pretending the name assertion proves it.
+<!-- entry #1406 X-S10 -->
+
+---
+
+## 2026-08-17 — #1406 X-S10: a codegen that guessed module names, and guessed identifiers
+
+Slice 3b of #1406 closes the last two `kind: String.t()` doors in `lib/`
+(`GET /me`, `POST /auth/login`) and, on the way, fixes two places where the
+wire codegen answered a question by GUESSING.
+
+### The briefed fix did not work, and the measurement is the point
+
+The plan said "widen `@extra_globs`", mirroring what #411 did for
+`GrappaWeb.ErrorTokens`. Measured: it delivers **zero coverage while looking
+widened**. `module_from_path/1` derives the module from the PATH, camelizing
+each segment, so `lib/grappa_web/controllers/me_json.ex` yields
+`GrappaWeb.Controllers.MeJson` — wrong on two counts, the `controllers/`
+segment and the `JSON`/`Json` casing. That module fails `Code.ensure_loaded?`,
+becomes `nil`, and is dropped by the `Enum.reject(&is_nil/1)` in
+`wire_modules/0` **in silence**. With both controller paths added to
+`@extra_globs`, `mix grappa.gen_wire_types` exits **0** and
+`cicchetto/src/lib/wireTypes.ts` is **byte-identical** — no marker, no diff,
+no warning. `error_tokens.ex` only ever worked because it sits directly under
+`grappa_web/` and camelizes exactly; the glob mechanism was never general.
+
+So `@extra_globs` becomes `@extra_modules`, a list of MODULES. There is no
+path→name guess left to get wrong. The `// Source:` header is now derived
+from `@wire_glob` + `@extra_modules` rather than being the same string typed
+by hand in two places.
+
+**The wider hazard is still standing and is deliberately left alone:** the
+`nil`-reject also swallows a glob-matched file whose module fails to load.
+Inside `lib/grappa/**` the derivation is reliable, so nothing is lost today —
+but the silence is the same silence, and the day that stops holding it will
+look exactly like this did.
+
+### A codegen hole is now a codegen error
+
+The EXTERNAL type path renders one alias at a time and never sets
+`:wire_current_module`, so `do_render/1`'s `user_type` clause had nothing to
+resolve a SAME-module reference against and fell back to `camelize/1`. The
+two emitters then disagreed: the typedef emitted `Variant` while the runtime
+schema computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and imported that, so
+neither artefact declared what the other referenced. The generator exited 0
+and the breakage surfaced in the CLIENT compiler as `TS2304` + `TS2724` with
+no named culprit.
+
+Teaching the external path to resolve siblings is refused by
+`format_external_typedef/2`'s own contract (one alias at a time, no sibling
+registry). So the clause raises instead, naming module and type — the posture
+the unmapped Erlang remote type and the cyclic enum reference already take.
+`render_external_type/3` records `{mod, type_name}` in a second process key,
+consistent with the `:wire_current_module` / `:wire_external_refs` /
+`:wire_schema_deps` the module already uses.
+
+The old test asserting the guess (`render_type({:user_type, [], [:my_payload]})
+== "MyPayload"`) was DELETED, not adapted: it encoded the defect as contract.
+The clause's positive direction stays covered by the WireFixture test.
+
+### The wire does not move a byte, and that was bought before the change
+
+`kind` becomes `:user` / `:visitor` — atoms in the typespec AND at runtime.
+Jason encodes an atom as its string, so the JSON is unchanged. That is not an
+argument, it is a pin: `subject_kind_json_pin_test` was written and shown
+GREEN before any production line changed, and is still green after. It
+compares the DECODED structure (key order is not contract) plus a byte-exact
+encode of the discriminator alone.
+
+`incognito` joins both visitor arms. Both renderers have emitted it since
+#363 while neither typespec declared it — invisible to codegen that was a
+stale comment; as a codegen SOURCE it would generate a type that denies a
+field the server sends on every request.
+
+Both unions are split into NAMED arms (`user_me_json` / `visitor_me_json`,
+`user_subject_wire` / `visitor_subject_wire`) with the union kept as `A | B`
+of aliases. Reason: the committed `wireTypes.ts` contains **zero** `} | {`
+object unions, so emitting one would be unbroken ground for biome on a file
+no human may hand-correct, while `A | B` is a shape the generator already
+produces. cic pins the discriminator only (`_Assert_MeResponseKind`,
+`_Assert_LoginSubjectKind`) because `MeResponse` and `Subject` carry
+deliberate optionals a full `Equal` cannot survive.
+
+### Gate note, not a finding of this slice
+
+`bun run check` is RED on `origin/main` independently of this work:
+dependabot `8f252497` (2026-08-16) moved `@biomejs/biome` to 2.5.8 while
+`biome.json`'s `$schema` still declares 2.5.6, which biome 2.5.8 reports as
+an error on a full-project scan. The three cic files this slice touches
+produce zero diagnostics, and both `tsc` passes are green — but biome
+short-circuits `tsc` in the `check` script, so anyone reading a red there is
+NOT reading a type failure.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45617,12 +45617,31 @@ produces. cic pins the discriminator only (`_Assert_MeResponseKind`,
 `_Assert_LoginSubjectKind`) because `MeResponse` and `Subject` carry
 deliberate optionals a full `Equal` cannot survive.
 
-### Gate note, not a finding of this slice
+### The generator had never met this shape, and said so in the wrong place
 
-`bun run check` is RED on `origin/main` independently of this work:
-dependabot `8f252497` (2026-08-16) moved `@biomejs/biome` to 2.5.8 while
-`biome.json`'s `$schema` still declares 2.5.6, which biome 2.5.8 reports as
-an error on a full-project scan. The three cic files this slice touches
-produce zero diagnostics, and both `tsc` passes are green — but biome
-short-circuits `tsc` in the `check` script, so anyone reading a red there is
-NOT reading a type failure.
+Emitting `MeJSON` put `unread_counts` through the renderer: a nested
+`Record<…>` long enough to miss the inline branch, whose innermost object
+carries a union. `format_plain_typedef/2` decides "this is a union" by
+testing the RENDERED STRING for `" | "`, so a `Record<…>` got the
+leading-pipe multi-line union shape — and biome reported a `format` error on
+a generated file no human may hand-correct. Fixed at the SOURCE: the
+per-channel counts are now a named `window_counts` type, so the envelope
+renders short and inline.
+
+The string-sniffing test itself is left alone deliberately. An AST check
+(`{:|, _, _}`) is the right test and was measured to fix this case, but with
+the source corrected nothing exercises it, and an unexercised behaviour
+change to the emitter is worse than a recorded one. **The next long
+non-union body whose interior contains a union will hit it again.**
+
+Recorded because the reasoning failed first: this red was initially
+attributed to `origin/main` — dependabot `8f252497` moved `@biomejs/biome`
+to 2.5.8 while `biome.json` still declares schema 2.5.6 — and that
+attribution was WRONG. CI was green on the same commit. The mismatch is an
+INFO, not an error; both sides resolve 2.5.8 (package.json pins it exactly,
+the tracked `bun.lock` names it, and CI's cache is the download cache, not
+`node_modules`), so the version was never the difference. **A red inside a
+GENERATED artefact looks like someone else's red precisely because no hand
+edited it.** The cheap discriminator that would have caught it in one step:
+biome names the failing file, and `src/lib/wireTypes.ts` was in this
+branch's diff.

--- a/lib/grappa_web/controllers/auth_json.ex
+++ b/lib/grappa_web/controllers/auth_json.ex
@@ -22,13 +22,34 @@ defmodule GrappaWeb.AuthJSON do
   alias Grappa.Visitors.Visitor
   alias Grappa.Visitors.Wire, as: VisitorsWire
 
-  @type subject_wire ::
-          %{kind: String.t(), id: Ecto.UUID.t(), name: String.t()}
-          | %{
-              kind: String.t(),
-              id: Ecto.UUID.t(),
-              registered: boolean()
-            }
+  @typedoc """
+  The user arm of the login subject. The discriminator is the atom `:user`,
+  which Jason encodes as the string `"user"` — byte-identical on the wire to
+  the string literal it replaces, but a closed set the codegen can see.
+  """
+  @type user_subject_wire :: %{
+          kind: :user,
+          id: Ecto.UUID.t(),
+          name: String.t()
+        }
+
+  @typedoc """
+  The visitor arm of the login subject. `incognito` is declared here because
+  `VisitorsWire.visitor_to_credential_json/2` has always emitted it (#363)
+  while no typespec named it — as a codegen SOURCE the omission would
+  generate a type that denies a field the server sends.
+  """
+  @type visitor_subject_wire :: %{
+          kind: :visitor,
+          id: Ecto.UUID.t(),
+          registered: boolean(),
+          incognito: boolean()
+        }
+
+  # Named arms, not an inline object union: the committed `wireTypes.ts` has
+  # zero `} | {` unions, and `A | B` of aliases is a shape the generator
+  # already emits (see the sibling note in `GrappaWeb.MeJSON`).
+  @type subject_wire :: user_subject_wire() | visitor_subject_wire()
 
   @doc "Renders the `:login` action — `{token, subject}`."
   @spec login(%{
@@ -37,14 +58,14 @@ defmodule GrappaWeb.AuthJSON do
         }) :: %{token: String.t(), subject: subject_wire()}
   def login(%{token: token, subject: {:user, %User{} = user}}) do
     %{id: id, name: name} = Wire.user_to_credential_json(user)
-    %{token: token, subject: %{kind: "user", id: id, name: name}}
+    %{token: token, subject: %{kind: :user, id: id, name: name}}
   end
 
   def login(%{token: token, subject: {:visitor, %Visitor{} = v}}) do
     subject =
       v
       |> VisitorsWire.visitor_to_credential_json(Credentials.visitor_registered?(v.id))
-      |> Map.put(:kind, "visitor")
+      |> Map.put(:kind, :visitor)
 
     %{token: token, subject: subject}
   end

--- a/lib/grappa_web/controllers/me_json.ex
+++ b/lib/grappa_web/controllers/me_json.ex
@@ -92,28 +92,49 @@ defmodule GrappaWeb.MeJSON do
           }
         }
 
-  @type me_json ::
-          %{
-            kind: String.t(),
-            id: Ecto.UUID.t(),
-            name: String.t(),
-            is_admin: boolean(),
-            inserted_at: DateTime.t(),
-            read_cursors: read_cursors(),
-            unread_counts: unread_counts(),
-            badge_count: non_neg_integer(),
-            home_data: NetworksWire.home_data()
-          }
-          | %{
-              kind: String.t(),
-              id: Ecto.UUID.t(),
-              expires_at: DateTime.t() | nil,
-              registered: boolean(),
-              read_cursors: read_cursors(),
-              unread_counts: unread_counts(),
-              badge_count: non_neg_integer(),
-              home_data: NetworksWire.home_data()
-            }
+  @typedoc """
+  The user arm of `GET /me`. The discriminator is the atom `:user`, which
+  Jason encodes as the string `"user"` — the wire is byte-identical to the
+  string literal it replaces, and the closed set is now something the
+  codegen can see and the client can narrow on.
+  """
+  @type user_me_json :: %{
+          kind: :user,
+          id: Ecto.UUID.t(),
+          name: String.t(),
+          is_admin: boolean(),
+          inserted_at: DateTime.t(),
+          read_cursors: read_cursors(),
+          unread_counts: unread_counts(),
+          badge_count: non_neg_integer(),
+          home_data: NetworksWire.home_data()
+        }
+
+  @typedoc """
+  The visitor arm of `GET /me`. `incognito` is declared here because
+  `VisitorsWire.visitor_to_json/2` has always emitted it (#363) while no
+  typespec named it — invisible to codegen that was a stale comment; as a
+  codegen SOURCE it would be a generated type denying a field the server
+  sends on every request.
+  """
+  @type visitor_me_json :: %{
+          kind: :visitor,
+          id: Ecto.UUID.t(),
+          expires_at: DateTime.t() | nil,
+          registered: boolean(),
+          incognito: boolean(),
+          read_cursors: read_cursors(),
+          unread_counts: unread_counts(),
+          badge_count: non_neg_integer(),
+          home_data: NetworksWire.home_data()
+        }
+
+  # Split into NAMED arms rather than left as an inline union of object
+  # literals: the committed `wireTypes.ts` contains zero `} | {` object
+  # unions, so emitting one would be unbroken ground for biome on a file no
+  # human may hand-correct. `A | B` of two aliases is a shape the generator
+  # already produces.
+  @type me_json :: user_me_json() | visitor_me_json()
 
   @doc "Renders the `:show` action — discriminated union per subject kind."
   @spec show(
@@ -143,7 +164,7 @@ defmodule GrappaWeb.MeJSON do
       when is_map(home_data) do
     user
     |> Wire.user_to_json()
-    |> Map.put(:kind, "user")
+    |> Map.put(:kind, :user)
     |> Map.put(:read_cursors, cursors)
     |> Map.put(:unread_counts, unread_counts)
     |> Map.put(:badge_count, badge_count)
@@ -161,7 +182,7 @@ defmodule GrappaWeb.MeJSON do
       when is_boolean(registered) and is_map(home_data) do
     visitor
     |> VisitorsWire.visitor_to_json(registered)
-    |> Map.put(:kind, "visitor")
+    |> Map.put(:kind, :visitor)
     |> Map.put(:read_cursors, cursors)
     |> Map.put(:unread_counts, unread_counts)
     |> Map.put(:badge_count, badge_count)

--- a/lib/grappa_web/controllers/me_json.ex
+++ b/lib/grappa_web/controllers/me_json.ex
@@ -81,15 +81,25 @@ defmodule GrappaWeb.MeJSON do
   any client-side count derivation. Mirrors cic `selection.ts`'s
   `ServerWindowCounts` type byte-for-byte.
   """
-  @type unread_counts :: %{
-          String.t() => %{
-            String.t() => %{
-              messages: non_neg_integer(),
-              mentions: non_neg_integer(),
-              events: non_neg_integer(),
-              severity: :mention | :message | :event | :none
-            }
-          }
+  @type unread_counts :: %{String.t() => %{String.t() => window_counts()}}
+
+  @typedoc """
+  The per-channel counts inside `unread_counts`. Named rather than inlined
+  because the codegen renders a long nested `Record<…>` on one line and biome
+  then wants to reformat the GENERATED file, which no human may hand-fix; a
+  named inner type keeps the envelope short and the object literal in the
+  shape every other emitted map already takes.
+
+  Still a longhand re-spelling of `Grappa.WindowCounts.t()` — one shape, three
+  declarations, no reference between them (2026-08-15 architecture review,
+  type-leverage A8 third leg). Naming it here makes the duplication visible;
+  collapsing it is that finding's work, not X-S10's.
+  """
+  @type window_counts :: %{
+          messages: non_neg_integer(),
+          mentions: non_neg_integer(),
+          events: non_neg_integer(),
+          severity: :mention | :message | :event | :none
         }
 
   @typedoc """

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -1352,6 +1352,12 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   def render_module_for_test(mod), do: render_module(mod)
 
   @doc false
+  @spec render_external_type_for_test(module(), atom(), String.t()) :: String.t()
+  def render_external_type_for_test(mod, type_name, alias_name) do
+    render_external_type(mod, type_name, alias_name)
+  end
+
+  @doc false
   @spec generate_for_test([module()]) :: String.t()
   def generate_for_test(mods) do
     mods

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -90,13 +90,25 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # skips modules looks like coverage but isn't a real gate.
   @wire_glob "lib/grappa/**/*wire.ex"
 
-  # #411 D6b — the wire-token error space (`GrappaWeb.ErrorTokens`) is the
-  # codegen source for the cicchetto client's error unions, but it lives in
-  # the WEB layer on purpose (HTTP/Channel wire tokens are not domain data),
-  # so it sits outside `@wire_glob`. Widen the source set to reach it
-  # WITHOUT relocating the module into `lib/grappa/**/wire.ex` — a
-  # boundary-preserving glob widen, not a file move.
-  @extra_globs ["lib/grappa_web/error_tokens.ex"]
+  # Codegen sources that live in the WEB layer on purpose (HTTP/Channel wire
+  # shapes are not domain data), so they sit outside `@wire_glob`. Naming the
+  # MODULES rather than their paths is deliberate: `module_from_path/1`
+  # camelizes each path segment, so `controllers/me_json.ex` derives
+  # `GrappaWeb.Controllers.MeJson` — a module that does not exist, on two
+  # counts (the `controllers/` segment and the `JSON`/`Json` casing). It
+  # would fail `Code.ensure_loaded?`, become `nil`, and be dropped SILENTLY,
+  # delivering zero coverage while looking widened. `error_tokens.ex` only
+  # ever worked because it sits directly under `grappa_web/` and camelizes
+  # exactly. A module list has no path→name guess to get wrong.
+  @extra_modules [
+    GrappaWeb.AuthJSON,
+    GrappaWeb.ErrorTokens,
+    GrappaWeb.MeJSON
+  ]
+
+  # Derived, so the artefact header cannot drift from the source set it
+  # describes — it used to be the same string typed by hand in two places.
+  @source_description "#{@wire_glob} + #{Enum.map_join(@extra_modules, " + ", &inspect/1)}"
 
   @impl Mix.Task
   def run(argv) do
@@ -137,10 +149,12 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   end
 
   defp wire_modules do
-    (Path.wildcard(@wire_glob) ++ Enum.flat_map(@extra_globs, &Path.wildcard/1))
+    @wire_glob
+    |> Path.wildcard()
     |> Enum.sort()
     |> Enum.map(&module_from_path/1)
     |> Enum.reject(&is_nil/1)
+    |> Enum.concat(@extra_modules)
     |> Enum.sort_by(&inspect/1)
   end
 
@@ -204,6 +218,20 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   end
 
   defp render_external_type(mod, type_name, alias_name) do
+    # The external path renders one alias at a time and never sets
+    # `:wire_current_module`, so `do_render/1`'s `user_type` clause has
+    # nothing to resolve a SAME-module reference against. Record who is
+    # being rendered so that clause can name the culprit instead of
+    # inventing an identifier — see `unresolvable_user_type!/1`.
+    Process.put(:wire_external_typedef, {mod, type_name})
+
+    result = do_render_external_type(mod, type_name, alias_name)
+
+    Process.delete(:wire_external_typedef)
+    result
+  end
+
+  defp do_render_external_type(mod, type_name, alias_name) do
     with {:ok, types} <- Code.Typespec.fetch_types(mod),
          {_, {_, ast, _}} <-
            Enum.find(types, :error, fn {_, {name, _, _}} -> name == type_name end) do
@@ -313,7 +341,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     """
     // GENERATED FILE — DO NOT EDIT
     // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-    // Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+    // Source: #{@source_description}
 
     #{body}
     """
@@ -720,7 +748,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # render_typedef/2 invocation).
   defp do_render({:user_type, _, [name]}) when is_atom(name) do
     case Process.get(:wire_current_module) do
-      nil -> camelize(Atom.to_string(name))
+      nil -> unresolvable_user_type!(name)
       mod -> render_alias_name(mod, name)
     end
   end
@@ -774,6 +802,35 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
       end)
 
     "{\n#{body}\n}"
+  end
+
+  # Reachable only from the EXTERNAL type path, which is the one place that
+  # never sets `:wire_current_module` (`render_typedef/3` is the sole setter).
+  # This used to fall back to `camelize/1`, which is a GUESS: the two
+  # emitters then disagreed — the typedef emitted `Variant` while the runtime
+  # schema computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and imported that —
+  # so neither artefact declared what the other referenced. The generator
+  # exited 0 and the client compiler reported the breakage as TS2304 + TS2724
+  # with no named culprit. Teaching the external path to resolve siblings is
+  # not the fix (`format_external_typedef/2` documents why it renders one
+  # alias at a time); a codegen hole must be a codegen ERROR, as the unmapped
+  # Erlang remote type and the cyclic enum reference already are.
+  defp unresolvable_user_type!(name) do
+    {mod, type} = Process.get(:wire_external_typedef)
+
+    raise """
+    gen_wire_types: cannot resolve `#{name}/0`, referenced by the external \
+    type #{inspect(mod)}.#{type}/0.
+
+    External types are rendered one alias at a time with no same-module \
+    sibling registry, so a `user_type` reference has nothing to resolve \
+    against. Emitting a camelized guess produces an identifier no \
+    declaration backs.
+
+    Fix the SOURCE: give #{inspect(mod)} a `*wire.ex` home (or add it to \
+    `@extra_modules`) so its types are rendered as a module, or inline \
+    `#{name}/0` into #{type}/0.
+    """
   end
 
   defp register_external_ref(mod, type, alias_name) do
@@ -1272,7 +1329,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     """
     // GENERATED FILE — DO NOT EDIT
     // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-    // Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+    // Source: #{@source_description}
     //
     // #429 — the RUNTIME twin of `wireTypes.ts`: the same typespecs, emitted
     // as schema literals `wireValidate.ts` interprets. `wireTypes.ts` is

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -815,6 +815,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # not the fix (`format_external_typedef/2` documents why it renders one
   # alias at a time); a codegen hole must be a codegen ERROR, as the unmapped
   # Erlang remote type and the cyclic enum reference already are.
+  @spec unresolvable_user_type!(atom()) :: no_return()
   defp unresolvable_user_type!(name) do
     {mod, type} = Process.get(:wire_external_typedef)
 

--- a/test/grappa_web/controllers/subject_kind_json_pin_test.exs
+++ b/test/grappa_web/controllers/subject_kind_json_pin_test.exs
@@ -1,0 +1,132 @@
+defmodule GrappaWeb.SubjectKindJSONPinTest do
+  @moduledoc """
+  #1406 X-S10 — byte pin on the two subject-discriminated render doors.
+
+  `MeJSON.show/1` and `AuthJSON.login/1` used to put the STRINGS `"user"` /
+  `"visitor"` into `:kind`; the closed-set rule types them as atoms instead.
+  Jason renders an atom value as the same JSON string, so the change is
+  supposed to be invisible on the wire — but "Jason emits the same bytes" is
+  a prediction until something asserts it. These tests are that assertion:
+  they were written and run GREEN against the string implementation, so a
+  post-change green means the wire did not move.
+
+  Structural equality over the DECODED body, plus a byte-exact encode of the
+  discriminator alone. Object member order is deliberately NOT pinned: it is
+  insignificant per RFC 8259, and Erlang's small-map key order follows atom
+  term order, which shifts as the atom table changes between builds — a
+  full-body byte pin would be a flake, not a gate.
+  """
+  use Grappa.DataCase, async: true
+
+  alias Grappa.Accounts.User
+  alias Grappa.Visitors.Visitor
+  alias GrappaWeb.{AuthJSON, MeJSON}
+
+  @user %User{
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "vjt",
+    is_admin: true,
+    inserted_at: ~U[2026-08-17 09:00:00Z]
+  }
+
+  @visitor %Visitor{
+    id: "22222222-2222-4222-8222-222222222222",
+    expires_at: ~U[2026-08-17 10:00:00Z],
+    incognito: false
+  }
+
+  @home_data %{networks: [], available_networks: []}
+
+  describe "GET /me body" do
+    test "the user body is byte-identical, discriminator included" do
+      body =
+        MeJSON.show(%{
+          user: @user,
+          read_cursors: %{},
+          unread_counts: %{},
+          badge_count: 0,
+          home_data: @home_data
+        })
+
+      assert decode(body) == %{
+               "kind" => "user",
+               "id" => "11111111-1111-4111-8111-111111111111",
+               "name" => "vjt",
+               "is_admin" => true,
+               "inserted_at" => "2026-08-17T09:00:00Z",
+               "read_cursors" => %{},
+               "unread_counts" => %{},
+               "badge_count" => 0,
+               "home_data" => %{"networks" => [], "available_networks" => []}
+             }
+
+      assert encoded_kind(body) == ~s({"kind":"user"})
+    end
+
+    test "the visitor body is byte-identical, discriminator included" do
+      body =
+        MeJSON.show(%{
+          visitor: @visitor,
+          registered: true,
+          read_cursors: %{},
+          unread_counts: %{},
+          badge_count: 0,
+          home_data: @home_data
+        })
+
+      assert decode(body) == %{
+               "kind" => "visitor",
+               "id" => "22222222-2222-4222-8222-222222222222",
+               "expires_at" => "2026-08-17T10:00:00Z",
+               "registered" => true,
+               "incognito" => false,
+               "read_cursors" => %{},
+               "unread_counts" => %{},
+               "badge_count" => 0,
+               "home_data" => %{"networks" => [], "available_networks" => []}
+             }
+
+      assert encoded_kind(body) == ~s({"kind":"visitor"})
+    end
+  end
+
+  describe "POST /auth/login body" do
+    test "the user subject is byte-identical, discriminator included" do
+      body = AuthJSON.login(%{token: "tok", subject: {:user, @user}})
+
+      assert decode(body) == %{
+               "token" => "tok",
+               "subject" => %{
+                 "kind" => "user",
+                 "id" => "11111111-1111-4111-8111-111111111111",
+                 "name" => "vjt"
+               }
+             }
+
+      assert encoded_kind(body.subject) == ~s({"kind":"user"})
+    end
+
+    # `registered` is DERIVED from the credentials at render time, so this
+    # clause reaches the Repo — a visitor with no credential row is not
+    # registered. That is why the case runs under DataCase.
+    test "the visitor subject is byte-identical, discriminator included" do
+      body = AuthJSON.login(%{token: "tok", subject: {:visitor, @visitor}})
+
+      assert decode(body) == %{
+               "token" => "tok",
+               "subject" => %{
+                 "kind" => "visitor",
+                 "id" => "22222222-2222-4222-8222-222222222222",
+                 "registered" => false,
+                 "incognito" => false
+               }
+             }
+
+      assert encoded_kind(body.subject) == ~s({"kind":"visitor"})
+    end
+  end
+
+  defp decode(body), do: body |> Jason.encode!() |> Jason.decode!()
+
+  defp encoded_kind(%{kind: kind}), do: Jason.encode!(%{kind: kind})
+end

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -79,10 +79,6 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
       assert GenWireTypes.render_type({:map, [], []}) == "Record<string, unknown>"
     end
 
-    test "renders user_type reference as camelCased alias name" do
-      assert GenWireTypes.render_type({:user_type, [], [:my_payload]}) == "MyPayload"
-    end
-
     test "renders remote_type cross-module reference as ModName + typeName" do
       # e.g. Grappa.Networks.Wire.connection_state_event → NetworksWireConnectionStateEvent
       mod = Grappa.Networks.Wire
@@ -296,6 +292,30 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
       assert err.message =~ "cyclic enum reference"
       assert err.message =~ "enum_a"
       assert err.message =~ "enum_b"
+    end
+  end
+
+  # #1406 3b — the EXTERNAL type path renders one alias at a time and keeps no
+  # sibling registry, so a same-module `user_type` ref has nothing to resolve
+  # against. It used to fall back to `camelize/1` and emit an identifier
+  # NOTHING declares, while the runtime emitter computed a DIFFERENT name for
+  # the same type and imported it. The generator exited 0 and the breakage
+  # surfaced in the client compiler as TS2304 + TS2724 with no named culprit.
+  # A codegen hole must be a codegen error, like the unmapped Erlang remote
+  # type and the cyclic enum reference already are.
+  describe "external types referencing a same-module type (#1406 3b)" do
+    test "raise names the external module and the type it cannot resolve" do
+      err =
+        assert_raise RuntimeError, fn ->
+          GenWireTypes.render_external_type_for_test(
+            Grappa.WireExternalRefFixture,
+            :t,
+            "WireExternalRefFixtureT"
+          )
+        end
+
+      assert err.message =~ "Grappa.WireExternalRefFixture.t/0"
+      assert err.message =~ "variant/0"
     end
   end
 

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -295,6 +295,51 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
     end
   end
 
+  # #1406 X-S10 — `GET /me` and `POST /auth/login` are the last two doors
+  # whose subject discriminator was typed `String.t()`: a closed set carried
+  # as an untyped string, with the literals restated by hand on the cic side
+  # and nothing tying the two together. Both render modules live in the web
+  # layer, outside `@wire_glob`, so reaching them is a source-set widen —
+  # the same move #411 made for `GrappaWeb.ErrorTokens`.
+  describe "subject-discriminated JSON views (#1406 X-S10)" do
+    test "the extra source set reaches both subject render modules in generate/0" do
+      full = GenWireTypes.generate()
+
+      assert full =~ "// === GrappaWeb.AuthJSON ==="
+      assert full =~ "// === GrappaWeb.MeJSON ==="
+    end
+
+    test "the /me discriminator is a closed set, not a bare string" do
+      output = GenWireTypes.render_module_for_test(GrappaWeb.MeJSON)
+
+      assert output =~ ~s|export type MeJSONUserMeJson = {|
+      assert output =~ ~s|export type MeJSONVisitorMeJson = {|
+      assert output =~ ~s|  kind: "user";|
+      assert output =~ ~s|  kind: "visitor";|
+      refute output =~ ~s|  kind: string;|
+    end
+
+    test "the login subject discriminator is a closed set, not a bare string" do
+      output = GenWireTypes.render_module_for_test(GrappaWeb.AuthJSON)
+
+      assert output =~ ~s|export type AuthJSONUserSubjectWire = {|
+      assert output =~ ~s|export type AuthJSONVisitorSubjectWire = {|
+      assert output =~ ~s|  kind: "user";|
+      assert output =~ ~s|  kind: "visitor";|
+      refute output =~ ~s|  kind: string;|
+    end
+
+    # Both visitor renderers emit `incognito`, and neither typespec declared
+    # it. Invisible to codegen that was a stale comment; as a codegen SOURCE
+    # it would be a generated type that denies a field the server sends.
+    test "the visitor arms declare the incognito flag both renderers emit" do
+      assert GenWireTypes.render_module_for_test(GrappaWeb.MeJSON) =~ ~s|  incognito: boolean;|
+
+      assert GenWireTypes.render_module_for_test(GrappaWeb.AuthJSON) =~
+               ~s|  incognito: boolean;|
+    end
+  end
+
   # #1406 3b — the EXTERNAL type path renders one alias at a time and keeps no
   # sibling registry, so a same-module `user_type` ref has nothing to resolve
   # against. It used to fall back to `camelize/1` and emit an identifier

--- a/test/support/wire_external_ref_fixture.ex
+++ b/test/support/wire_external_ref_fixture.ex
@@ -1,0 +1,19 @@
+defmodule Grappa.WireExternalRefFixture do
+  @moduledoc """
+  Fixture for the gen_wire_types external-type guard test. Not used in
+  production.
+
+  Mirrors `Grappa.Themes.BuiltinBackgrounds`: a module OUTSIDE the wire
+  glob whose public type references a SAME-MODULE `user_type`. The
+  external renderer works one alias at a time and keeps no sibling
+  registry, so it cannot resolve `variant()` — and must say so by name
+  rather than invent an identifier nothing declares.
+  """
+
+  @type variant :: :light | :dark
+
+  @type t :: %{
+          key: String.t(),
+          variant: variant()
+        }
+end


### PR DESCRIPTION
Slice 3b of #1406. Closes the last two `kind: String.t()` doors in `lib/`
(`GET /me`, `POST /auth/login`) and fixes two places where the wire codegen
answered a question by **guessing**.

## What this brings

**1. `@extra_globs` → `@extra_modules`.** The briefed plan was "widen the
glob", mirroring what #411 did for `GrappaWeb.ErrorTokens`. Measured, it does
not work: `module_from_path/1` derives the module from the PATH, camelizing
each segment, so `lib/grappa_web/controllers/me_json.ex` yields
`GrappaWeb.Controllers.MeJson` — wrong on two counts (the `controllers/`
segment, the `JSON`/`Json` casing). It fails `Code.ensure_loaded?`, becomes
`nil`, and is dropped by `Enum.reject(&is_nil/1)` **in silence**.

Bought with a real red before writing anything: with both controller paths
added to `@extra_globs`, `mix grappa.gen_wire_types` exits **0** and
`wireTypes.ts` is **byte-identical** — no marker, no diff, no warning. The
widen delivers zero coverage while looking widened. `error_tokens.ex` only
ever worked because it sits directly under `grappa_web/` and camelizes
exactly. Naming modules removes the guess. The `// Source:` header is now
derived instead of being the same string typed by hand in two places.

**2. A codegen hole is now a codegen error.** The external-type path renders
one alias at a time and never sets `:wire_current_module`, so a same-module
`user_type` reference had nothing to resolve against and fell back to
`camelize/1`. The two emitters then disagreed — the typedef emitted `Variant`
while the runtime schema computed `THEMES_BUILTIN_BACKGROUNDS_VARIANT` and
imported that — so neither artefact declared what the other referenced, the
generator exited 0, and the breakage surfaced in the CLIENT compiler as
`TS2304` + `TS2724` with no named culprit. Teaching the external path to
resolve siblings is refused by `format_external_typedef/2`'s own contract, so
it raises instead, naming module and type — the posture the unmapped Erlang
remote type and the cyclic enum reference already take.

The old test asserting the guess (`render_type({:user_type, [], [:my_payload]})
== "MyPayload"`) was **deleted, not adapted**: it encoded the defect as
contract.

**3. The discriminator becomes a closed set, and the wire does not move.**
`kind` is now `:user` / `:visitor` in the typespec AND at runtime. Jason
encodes an atom as its string, so the JSON is unchanged — and that is a pin,
not an argument: `subject_kind_json_pin_test` was written and shown GREEN
before any production line changed, and is still green after. It compares the
DECODED structure (key order is not contract) plus a byte-exact encode of the
discriminator alone.

`incognito` joins both visitor arms: both renderers have emitted it since
#363 while neither typespec declared it. Invisible to codegen that was a
stale comment; as a codegen SOURCE it would generate a type that denies a
field the server sends on every request.

Both unions are split into NAMED arms, with the union kept as `A | B` of
aliases, because the committed `wireTypes.ts` contains **zero** `} | {`
object unions — emitting one would be unbroken ground for biome on a file no
human may hand-correct. cic pins the discriminator only
(`_Assert_MeResponseKind`, `_Assert_LoginSubjectKind`): `MeResponse` and
`Subject` carry deliberate optionals (#126, #363) that a full-shape `Equal`
cannot survive.

## The latent defect this surfaced, and why it is NOT in this PR

Emitting `MeJSON` put a shape through the renderer that no committed source
had reached: `unread_counts`, a nested `Record<…>` long enough to miss the
inline branch, whose innermost object carries a union.
`format_plain_typedef/2` decides "this is a union" by testing the **rendered
string** for `" | "`, so a `Record<…>` got the leading-pipe multi-line union
shape — which biome reports as a `format` error on a generated file.

Fixed at the SOURCE (the per-channel counts become a named `window_counts`
type, so the envelope renders short and inline). The string-sniffing test in
the emitter is deliberately **left alone**. An AST check (`{:|, _, _}`) is
the right test and was measured to fix this case, but with the source
corrected **nothing exercises it**, and shipping an unexercised behaviour
change to the emitter is worse than recording it. The next long non-union
body whose interior contains a union will hit it again; it is written up in
the DESIGN_NOTES entry rather than silently patched.

## Verification

Mutation-tested, one mutant killing exactly one assertion:

- restore the `camelize/1` fallback → **only** the fail-loud `assert_raise`
  dies (51 tests, 1 failure). Mutant confirmed to have reached the artefact
  (module recompiled).
- point the cic pin at the user arm alone → `TS2344: Type 'false' does not
  satisfy the constraint 'true'`. The pin is live, not decorative.

Gates run, **at `04befba8` (base `8a616a3d`)**:

| gate | result |
|---|---|
| `scripts/check.sh` (whole, clean tree) | RC=0 — 8 doctests, 60 properties, **6419 tests, 0 failures**; Dialyzer **0 errors**; Credo **no issues**; Sobelow ran |
| `bun run check` | RC=0 — 59 pre-existing warnings, **0 errors** |
| `tsc --noEmit` (src and e2e) | RC=0 both |
| `grappa.gen_wire_types --check` | RC=0 |
| `scripts/design-notes-gate.sh origin/main` | RC=0 |

After rebasing onto `f59b0c7e` — which touched the same two generated
artefacts and the same codegen test file — re-run:

| gate | result |
|---|---|
| `grappa.gen_wire_types --check` | RC=0, both artefacts **in sync** |
| the two overlapping test files | **55 tests, 0 failures** (51 before the rebase; the union added 4) |

**Not run, stated plainly:** `scripts/integration.sh` and the Playwright e2e
suite were **not** run for this slice, at either revision. Nothing here
touches a runtime path — the changes are a build-time codegen task, two view
typespecs whose encoded output is byte-pinned, and two generated artefacts —
but that is an argument, not a measurement, and CI is the gate that settles
it. The full `scripts/check.sh` was also **not** re-run after the rebase;
only the drift gate and the two overlapping test files were.

## What I decline to assert

- That `window_counts` closes the type-leverage A8 third leg. It is still a
  longhand re-spelling of `Grappa.WindowCounts.t()` — naming it only makes
  the duplication visible.
- That the 59 cic warnings are individually harmless. They were verified as
  an **unchanged baseline**, not read one by one.
- That the `nil`-reject in `wire_modules/0` is safe for glob-matched files.
  Inside `lib/grappa/**` the derivation is reliable today, so nothing is lost
  — but it is the same silence, noted in the entry.