### PR TITLE
session(#1394): one outbound door, so the NickServ sniff covers the free-form arm

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -377,6 +377,12 @@ config :logger, :console,
     # #523/#518 — BusyRetry tags the transient fault kind (:queue_timeout |
     # :busy_locked) on the warning it logs as a saturating write degrades to 503.
     :fault,
+    # #1394 — which outbound path dropped a line at the `send_outbound/3`
+    # door (`:ghost_recovery | :event_router_reply`). One warning serves both
+    # callers so the message stays a single greppable string; without this
+    # key the operator cannot tell a NickServ IDENTIFY that never went out
+    # from a lost CTCP reply, which are not the same incident.
+    :origin,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45645,3 +45645,75 @@ GENERATED artefact looks like someone else's red precisely because no hand
 edited it.** The cheap discriminator that would have caught it in one step:
 biome names the failing file, and `src/lib/wireTypes.ts` was in this
 branch's diff.
+<!-- entry #1394 -->
+
+---
+
+## 2026-08-17 — #1394: one outbound door, bought before the path that needs it exists
+
+`Grappa.Session.Server` now sends an already-assembled wire line through a
+single private `send_outbound/3`: sniff (`capture_outbound_ns_secret/2`),
+then send, then return the threaded state. Its two callers are
+`flush_lines/2` (GhostRecovery / RecoverIdentity) and the
+`apply_effects([{:reply, _} | _], _)` arm.
+
+### The defect was the absence of a signal, not a leak
+
+Nothing was leaking. Both spellings a user has for authenticating already
+cross the capture, one frame up, at their `handle_call`. What was missing
+is that nothing *forced* a new outbound path through the sniff — the
+enforcement mechanism was two comments asking the next author to remember.
+A path that forgets does not fail: it stages nothing, the `+r` rendezvous
+never fires, and the symptom arrives later and elsewhere as a saved
+password that stopped updating.
+
+The `{:reply, _}` arm was the one free-form path already outside the sniff.
+It is also unreachable with a secret today, and that is the reason to fix
+it NOW rather than later: #1390 moves the GhostRecovery / RecoverIdentity
+lines onto this exact grammar, and those lines carry `GHOST <nick> <pwd>`
+and `IDENTIFY <pwd>`. In that order the merge is safe by construction; in
+the reverse order it opens the hole with **no test turning red**, because
+the path does not exist yet to be tested. The arm also discarded the state
+it was handed, so even a capture placed there would have been invisible —
+the door threads.
+
+### The issue's own numbers did not survive recounting
+
+Two, both stated in the PR. The free-form send sites are **17, not 24**
+(counted outside `irc/client.ex`, whose 36 internal calls are the bodies of
+the typed verb helpers). And "24 against 6" mis-frames the shape: the
+capture is not sprinkled across send sites, it sits where the line is
+ASSEMBLED, so the door was already built for every user-driven path and
+the genuinely uncovered free-form arm was **one**.
+
+### What routing the arm through the sniff does NOT open
+
+The arm carries the CTCP PING reply, whose echoed token is chosen by a
+stranger — so sniffing it invites the question of whether an attacker can
+have their own text staged as our NickServ password and committed on the
+next `+r`. Measured: no. Every `NSInterceptor` pattern is anchored at line
+start, and both replies this arm can carry are built as
+`NOTICE <sender> :…`. No prefix of a NOTICE can match `IDENTIFY`, `PASS`,
+`SET PASSWD` or the `PRIVMSG NickServ` family.
+
+### Why the door stops at two callers
+
+The typed verb helpers are left alone deliberately. They assemble the line
+inside `IRC.Client`, where this sniff cannot see it, and their lines
+already cross the capture one frame up. Widening the door to them would
+sniff the same line twice — harmless for `:identify`, whose staging is
+idempotent, but not for `:set_passwd` / `:reset_passwd`, which commit
+on-send. That distinction is the domain boundary, not an exemption.
+
+### The test is a source pin, and the limit is the point
+
+The arm is pinned by asserting the shape of its body in
+`lib/grappa/session/server.ex`. A behavioural oracle for it does not exist
+and cannot be manufactured honestly — by the anchoring argument above, no
+secret reaches the arm from the wire, so there is no state difference to
+observe. The pin is what makes #1390's merge loud. The door's *behaviour*
+is witnessed separately, on the one reachable path, by a ghost-recovery
+test; that witness had to withhold the 001 welcome, because the shared
+fixture's welcome runs `run_perform_and_identify/1`, whose own capture site
+re-stages the same secret and would have left the witness green with the
+sniff removed from the door.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4480,6 +4480,51 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # #1394 — the outbound door for an ALREADY-ASSEMBLED wire line: sniff, then
+  # send. The sniff above is a choke point only where something calls it, and
+  # until now what called it was the author of each new send site remembering
+  # to — two comments were the whole enforcement mechanism. A path that
+  # forgets does not fail; it stages nothing, the `+r` rendezvous never fires,
+  # and the symptom surfaces later and elsewhere as a saved password that
+  # stopped updating. Pairing the two here means a future path inherits the
+  # capture by calling the ordinary sender.
+  #
+  # Scope is deliberately the two paths that hand over a RAW assembled line.
+  # The typed verb helpers (`Client.send_privmsg` and friends) are left alone:
+  # they build the line inside `IRC.Client`, so the sniff cannot see it here,
+  # and every user-authored line already crosses the capture one frame up at
+  # its `handle_call`. Widening the door to them would sniff the same line
+  # TWICE — harmless for `:identify` (idempotent staging) but not for
+  # `:set_passwd`/`:reset_passwd`, which commit on-send.
+  #
+  # `origin` is not decoration: the two callers fail in different incidents —
+  # a dropped ghost-recovery line means an IDENTIFY never went out, a dropped
+  # reply means an answer to a stranger was lost — and one message for both
+  # would erase which. It rides as Logger metadata rather than as prose so the
+  # message itself stays one greppable string.
+  #
+  # Fire-and-forget on send failure (REV-E H11): a dead socket must not
+  # MatchError the Session, which a strict `:ok =` bind used to do on both
+  # paths. Supervisor restart owns reconnect. The line is never logged — it
+  # may BE the secret.
+  @spec send_outbound(t(), String.t(), :ghost_recovery | :event_router_reply) :: t()
+  defp send_outbound(state, line, origin) do
+    state = capture_outbound_ns_secret(state, line)
+
+    case Client.send_line(state.client, line) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("outbound line dropped: send_line failed",
+          origin: origin,
+          reason: inspect(reason)
+        )
+    end
+
+    state
+  end
+
   # #540 B1 — if the raw `/quote` line is a WHO command, prime the WHO
   # accumulator so its 352/315 reply drains into a WhoModal, exactly like the
   # structured `:send_who` verb (`who_pending` keyed by the folded target;
@@ -4697,35 +4742,16 @@ defmodule Grappa.Session.Server do
   end
 
   # Lines emitted by GhostRecovery bypass `handle_call({:send_privmsg,
-  # ...})`, so manually run NSInterceptor over each line and stage
-  # `pending_auth` on capture. This is what keeps the +r MODE rendezvous
-  # (Task 15) firing for the `IDENTIFY` GhostRecovery emits on
-  # `:succeeded` — same one-feature-one-code-path discipline as the #189
-  # built-in IDENTIFY at 001 (routed through the choke point by
-  # `run_perform_and_identify/1`).
+  # ...})`, so they reach the wire through the #1394 door, which runs
+  # NSInterceptor over each one and stages `pending_auth` on capture. This is
+  # what keeps the +r MODE rendezvous (Task 15) firing for the `IDENTIFY`
+  # GhostRecovery emits on `:succeeded` — same one-feature-one-code-path
+  # discipline as the #189 built-in IDENTIFY at 001 (routed through the same
+  # choke point by `run_perform_and_identify/1`). A dead socket mid-recovery
+  # is survivable: the next reconnect retries GHOST + IDENTIFY from scratch,
+  # and the staging that already happened is discarded on terminate/2.
   defp flush_lines(state, lines) do
-    Enum.reduce(lines, state, fn line, acc ->
-      acc = capture_outbound_ns_secret(acc, line)
-
-      # REV-E (H11): pre-fix this strict-bound `:ok =` and MatchError'd
-      # on a dead socket mid-recovery (e.g., NickServ ghost dance racing
-      # an upstream RST). Fire-and-forget + Logger: ghost recovery is
-      # already a fragile rendezvous; a dead socket mid-flow means the
-      # next reconnect will retry GHOST + IDENTIFY from scratch. The
-      # `pending_auth` staging that already happened in `acc` is
-      # discarded harmlessly on terminate/2.
-      case Client.send_line(acc.client, line) do
-        :ok ->
-          :ok
-
-        {:error, reason} ->
-          Logger.warning("ghost-recovery flush_lines: send_line failed",
-            reason: inspect(reason)
-          )
-      end
-
-      acc
-    end)
+    Enum.reduce(lines, state, fn line, acc -> send_outbound(acc, line, :ghost_recovery) end)
   end
 
   # #581 — resolve the PERSISTENT recover target (the registered nick + the
@@ -6087,27 +6113,25 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # EventRouter-emitted outbound (today: the CTCP VERSION / PING NOTICE
+  # replies). #1394 routes it through the outbound door rather than calling
+  # the sender directly — this arm was the one free-form path that reached
+  # the wire without the NickServ sniff. Nothing emits a secret onto it
+  # today, which is precisely why it had to be wired before something does:
+  # #1390 moves the GhostRecovery/RecoverIdentity lines onto this grammar,
+  # and those lines carry `GHOST <nick> <pwd>` and `IDENTIFY <pwd>`. Done in
+  # the other order, that merge opens the hole with no test turning red.
+  #
+  # The door THREADS state, so the recursion continues with what the sniff
+  # staged; the pre-#1394 arm discarded it, which would have made a capture
+  # here invisible even once one was possible.
+  #
+  # REV-E (H11) still holds through the door: a dead socket does not stop the
+  # paired `:persist` effect (EventRouter emits `[{:reply, _}, {:persist, _,
+  # _}]` in the SAME list) from running on the next recursion, so the
+  # user-visible scrollback row lands either way.
   defp apply_effects([{:reply, line} | rest], state) do
-    # REV-E (H11): EventRouter-emitted outbound (e.g., CTCP VERSION NOTICE
-    # reply). Fire-and-forget: a dead socket here means the reply doesn't
-    # land on the wire, but the paired `:persist` effect (emitted in the
-    # SAME effect list — EventRouter.do_route/2 emits `[{:reply, _},
-    # {:persist, _, _}]`) will run on the NEXT recursion regardless of
-    # send_line's outcome, so the user-visible scrollback row lands
-    # either way. Pre-fix this strict-bound `:ok =` and MatchError-
-    # crashed the Session on dead socket, swallowing the persist too.
-    # Supervisor restart owns reconnect.
-    case Client.send_line(state.client, line) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("event-router reply dropped: send_line failed",
-          reason: inspect(reason)
-        )
-    end
-
-    apply_effects(rest, state)
+    apply_effects(rest, send_outbound(state, line, :event_router_reply))
   end
 
   # S3.4: 305 RPL_UNAWAY / 306 RPL_NOWAWAY confirmed by the upstream.

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -7690,7 +7690,12 @@ defmodule Grappa.Session.ServerTest do
       [_, after_head] =
         String.split(source, "defp apply_effects([{:reply, line} | rest], state) do", parts: 2)
 
-      [arm, _] = String.split(after_head, "\n  defp ", parts: 2)
+      # Cut at the function's own `end` (two-space indent), not at the next
+      # `defp`: the latter would drag the FOLLOWING arm's comment block into
+      # the window, and a comment that merely names `Client.send_line/2`
+      # would then fail the refute for no reason. A nested `case ... end`
+      # inside the arm is indented four, so it cannot be mistaken for it.
+      [arm, _] = String.split(after_head, "\n  end\n", parts: 2)
 
       assert arm =~ "send_outbound(",
              "the {:reply, _} arm must send through send_outbound/3, the one sniff-then-send door"

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -7667,6 +7667,87 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #1394 — the outbound door. Every path that puts an ASSEMBLED line on the
+    # wire must cross `capture_outbound_ns_secret/2`; a secret that travels a
+    # path which does not never stages the `+r` rendezvous, and the symptom
+    # arrives later and elsewhere as "my saved password stopped updating".
+    #
+    # This is a SOURCE-shape assertion, and that is a deliberate limit rather
+    # than a shortcut. A behavioural oracle for this arm does not exist and
+    # cannot be manufactured honestly: the only producer of `{:reply, _}` is
+    # the `:auto_reply` expansion, whose two lines are built by
+    # `ctcp_version_reply/…` and `ctcp_ping_reply/4` as `NOTICE <sender> :…`,
+    # while every NSInterceptor pattern is anchored at line start — so no
+    # secret can reach the arm from the wire today (and, by the same
+    # anchoring, no attacker-chosen CTCP PING token can be mis-captured as
+    # one either). What the arm needs is to be WIRED to the door BEFORE #1390
+    # moves the GhostRecovery/RecoverIdentity lines onto it, because at that
+    # moment the hole becomes reachable with no test turning red. The pin is
+    # what makes that moment loud.
+    test "#1394 the EventRouter {:reply, _} arm sends through the outbound door" do
+      source = File.read!("lib/grappa/session/server.ex")
+
+      [_, after_head] =
+        String.split(source, "defp apply_effects([{:reply, line} | rest], state) do", parts: 2)
+
+      [arm, _] = String.split(after_head, "\n  defp ", parts: 2)
+
+      assert arm =~ "send_outbound(",
+             "the {:reply, _} arm must send through send_outbound/3, the one sniff-then-send door"
+
+      refute arm =~ "Client.send_line(",
+             "the {:reply, _} arm must not reach Client.send_line/2 around the door"
+    end
+
+    # #1394 — the ghost-recovery flush is the one outbound path that carries a
+    # NickServ secret without crossing a `handle_call`: GhostRecovery emits
+    # `PRIVMSG NickServ :GHOST <nick> <pwd>` (the interceptor captures the
+    # LAST token, so the GHOST stages too, not just the `:succeeded`
+    # IDENTIFY). It is the door's only behavioural witness, so it is pinned
+    # here rather than left implied by the ghost-recovery describe, which
+    # asserts nothing about capture.
+    #
+    # Attribution is bought by feeding NO 001: the shared `ghost_handler/1`
+    # answers the underscore NICK with a welcome, and that welcome runs
+    # `run_perform_and_identify/1`, whose OWN capture site would re-stage the
+    # same "s3cret" and leave this test green even with the sniff removed
+    # from the door. Withholding the welcome leaves the flush as the only
+    # possible source. The GHOST appearing on the wire is the barrier: the
+    # door sniffs BEFORE it sends, and `:sys.get_state` serialises after the
+    # callback that did both.
+    test "#1394 the ghost-recovery flush crosses the outbound NickServ sniff" do
+      nick = "v1394_#{System.unique_integer([:positive])}"
+      counter = :counters.new(1, [])
+
+      handler = fn state, line ->
+        if String.starts_with?(line, "NICK ") and :counters.get(counter, 1) == 0 do
+          :counters.add(counter, 1, 1)
+          {:reply, ":server 433 * #{nick} :Nickname is already in use.\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {anon_visitor, network} = visitor_with_network(port, nick: nick)
+      {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
+      visitor = Grappa.Repo.reload!(anon_visitor)
+
+      pid = start_visitor_session_for(visitor, network)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :GHOST #{nick} s3cret\r\n"),
+          1_000
+        )
+
+      state = SessionStateHelpers.fetch(pid)
+      assert match?({"s3cret", _deadline}, SessionStateHelpers.pending_auth(state))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "second IDENTIFY overwrites first (latest-wins via mailbox FIFO, W8)" do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
@@ -12659,8 +12740,14 @@ defmodule Grappa.Session.ServerTest do
       # test inspects the source for the structural invariant instead.
       source = File.read!("lib/grappa/session/server.ex")
 
-      assert source =~ "event-router reply dropped",
-             "apply_effects :reply arm must log on send failure (H11 fire-and-forget pattern)"
+      # #1394 repointed this at the same intention. The arm no longer owns a
+      # log message of its own: it sends through `send_outbound/3`, the one
+      # sniff-then-send door, and the door carries the H11 warning for both
+      # its callers (which one failed rides as `origin:` metadata). What is
+      # pinned is unchanged — this path logs on send failure instead of
+      # crashing on it.
+      assert source =~ "outbound line dropped: send_line failed",
+             "the outbound door must log on send failure (H11 fire-and-forget pattern)"
 
       # And the strict-bind is gone everywhere:
       refute Regex.match?(~r/:ok = .*\.send_/, source),


### PR DESCRIPTION
## Summary

`Grappa.Session.Server` now puts an already-assembled wire line on the wire
through one private `send_outbound/3`: sniff (`capture_outbound_ns_secret/2`),
send, return the threaded state. Its two callers are `flush_lines/2`
(GhostRecovery / RecoverIdentity) and the `apply_effects([{:reply, _} | _], _)`
arm — the one free-form path that reached the wire without the NickServ sniff.

Nothing leaks today. The defect is that nothing *forced* a new outbound path
through the sniff: two comments were the enforcement mechanism, and a path that
forgets does not fail — it stages nothing, the `+r` rendezvous never fires, and
the symptom arrives later and elsewhere as a saved password that stopped
updating.

**The sequencing is the point.** #1390 moves the GhostRecovery /
RecoverIdentity lines onto this exact grammar, and those lines carry
`GHOST <nick> <pwd>` and `IDENTIFY <pwd>`. In this order that merge is safe by
construction. In the reverse order it opens the hole with **no test able to
turn red**, because the path does not exist yet to be tested.

The arm also discarded the state it was handed, so a capture placed there would
have been invisible regardless. The door threads.

## Two numbers in the issue did not survive recounting

1. **The free-form send sites are 17, not 24** — counted outside
   `irc/client.ex`, whose 36 internal calls are the bodies of the typed verb
   helpers this issue leaves alone. No basis yielding 24 was found, and none
   was reverse-engineered.
2. **"24 against 6" mis-frames the shape.** The capture is not sprinkled across
   send sites; it sits where the line is ASSEMBLED. The door was therefore
   already built for every user-driven path, and the genuinely uncovered
   free-form arm was **one**.

## What routing the arm through the sniff does not open

The arm carries the CTCP PING reply, whose echoed token is chosen by a
stranger — so sniffing it raises the question of whether attacker-chosen text
can be staged as our NickServ password and committed on the next `+r`.
Measured: no. Every `NSInterceptor` pattern is anchored at line start, and both
lines this arm can carry are built as `NOTICE <sender> :…`. No prefix of a
NOTICE can match. If that anchoring ever weakens, so does this conclusion.

## Why the door stops at two callers

The typed verb helpers are left alone deliberately: they assemble the line
inside `IRC.Client`, where this sniff cannot see it, and their lines already
cross the capture one frame up at their `handle_call`. Widening the door to
them would sniff the same line twice — idempotent for `:identify`, not for
`:set_passwd` / `:reset_passwd`, which commit on-send. That distinction is the
domain boundary, not an exemption.

## The test evidence, and what each piece is worth

- **Red by displacement**, tests committed first, production reverted to the
  base, whole file run: `2 failures and 421 passing alongside`
  (`1 property, 423 tests, 2 failures`). Both fell on the intended line.
- **Green**: `1 property, 423 tests, 0 failures`.
- **Three mutants, one assertion each, no survivors.** The door stops sniffing
  → only the ghost-recovery witness dies. The arm bypasses the door with a bare
  `send_raw`, behaviour intact → only the pin's `assert` dies. A stray
  `send_line` is added beside a working door → only the pin's `refute` dies.

**The arm's test is a source-shape pin, and the limit is stated in the test.** A
behavioural oracle for that arm does not exist: by the anchoring argument
above, no secret reaches it from the wire, so there is no state difference to
observe. The pin exists to make #1390's merge loud, not to prove a present-day
loss.

**The behavioural witness had to buy its own attribution.** It runs on the
ghost-recovery flush, the one reachable path. The shared `ghost_handler/1`
answers the underscore NICK with a 001, and that welcome runs
`run_perform_and_identify/1`, whose own capture site re-stages the same secret —
so on the stock fixture the witness would have stayed green with the sniff
removed from the door. Green, and vacuous. Withholding the welcome leaves the
flush as the only possible source, which is exactly what mutant 1 confirms by
killing it.

## Collateral, declared before it was paid

The REV-E pin in `server_test.exs` asserted `source =~ "event-router reply
dropped"`. Unifying the message into the door removes that string, so the pin is
**repointed at the same intention** — this path logs on send failure instead of
crashing on it — at the new target. Its sibling assertion, the global refute on
strict `:ok = .*\.send_` binds, is untouched and still passes.

`:origin` is added to the `config/config.exs` Logger metadata allowlist. Credo's
strict check refuses a key the console formatter would silently drop, and it is
right to: one warning serves both callers, and an operator who cannot tell a
lost IDENTIFY from a lost CTCP reply is reading a log that lies by omission.
Sibling of `:fault`. The `Meta.known_keys` sync test only requires known_keys to
be a subset of that list, so a metadata-only key adds nothing there.

## What was measured, and against which base

Everything below ran on a tree branched from **`f59b0c7e`**. The branch was
then rebased twice and now sits on **`f3c37191`** (#1406), so **none of these
results is a gate on the tree this PR actually pushes** — CI here is the first
place that green exists. Stated rather than implied, because a gate whose base
has moved is not a gate.

The exposure is small but it is not zero, and it is not "the files are
disjoint": #1302 touched `session/isupport.ex`, `session/wire.ex` and cic while
this touches `session/server.ex`, `config/config.exs` and the session tests, so
nothing overlaps by file — but Credo and Dialyzer run over the whole
application, and `server.ex` calls into `SessionWire`.

- [x] `scripts/test.sh test/grappa/session/server_test.exs` — 423 tests, 0 failures
- [x] Red bought by displacement on the whole file, both failures read
- [x] Three mutants, one assertion killed each, no survivors
- [x] `scripts/design-notes-gate.sh` — new entry, unique `<!-- entry #1394 -->` marker
- [x] `scripts/check.sh` — full gate, pre-rebase
- [ ] `scripts/integration.sh` — owned by the orchestrator; not run here

