### PR TITLE
cic(#1411): pull the two invariant outliers back inside (K-S4, K-S5)

### DIFF
--- a/cicchetto/src/AdminSettingsTab.tsx
+++ b/cicchetto/src/AdminSettingsTab.tsx
@@ -3,6 +3,7 @@ import AdminCard from "./admin/AdminCard";
 import AdminField from "./admin/AdminField";
 import { AdminLoading } from "./admin/AdminStatus";
 import AdminToolbar from "./admin/AdminToolbar";
+import { useRefreshSlot } from "./admin/refreshSlot";
 import { type AdminSettingsView, ApiError, adminGetSettings, adminPutSettings } from "./lib/api";
 import { token } from "./lib/auth";
 
@@ -168,27 +169,34 @@ const AdminSettingsTab: Component = () => {
     }
   };
 
+  // #1411 — Settings acquired its refresh AFTER the shared extraction and got
+  // a hand-rolled copy of the button rather than the slot the other fetching
+  // tabs use. The copy carried no `aria-label`, so its accessible name was the
+  // literal text and swapped to "loading…" mid-fetch — a screen reader
+  // announces that as the control being renamed, not as a busy state — and it
+  // never reached the rail's ☰ actions, so the operator's mobile refresh path
+  // failed on this one tab alone. Registration is the fix for both: the shared
+  // button names itself once and sets `aria-busy`, and the slot is what the
+  // rail renders from on a phone.
+  useRefreshSlot({
+    onRefresh: () => {
+      void refresh();
+    },
+    busy: loading,
+    label: "refresh settings",
+    testId: "admin-settings-refresh",
+  });
+
   onMount(() => {
     void refresh();
   });
 
   return (
     <div class="admin-settings-tab" data-testid="admin-settings-tab">
-      <AdminToolbar
-        title="Settings"
-        subtitle="Server-wide upload limits"
-        actions={
-          <button
-            type="button"
-            class="adm-btn adm-refresh-btn"
-            onClick={() => void refresh()}
-            disabled={loading()}
-            data-testid="admin-settings-refresh"
-          >
-            {loading() ? "loading…" : "↻ refresh"}
-          </button>
-        }
-      />
+      {/* The toolbar stays: unlike the tabs whose band was title-plus-refresh
+          and nothing else, its subtitle names the scope of everything below
+          (server-wide, not per-network), which the nav above does not say. */}
+      <AdminToolbar title="Settings" subtitle="Server-wide upload limits" />
 
       <div class="adm-scroll">
         <Show when={error()}>
@@ -199,7 +207,11 @@ const AdminSettingsTab: Component = () => {
 
         <Show when={settings() !== null} fallback={<AdminLoading message="loading settings…" />}>
           <form onSubmit={(e) => void onSave(e)} class="admin-settings-form" noValidate>
-            <AdminCard title="Uploads" subtitle="Applies to every network on this server">
+            <AdminCard
+              hostsRefresh
+              title="Uploads"
+              subtitle="Applies to every network on this server"
+            >
               {/* Two columns per field — label left, control right —
                   instead of the stacked default. The fields are short
                   numbers with long names, so stacking wasted a full row

--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -1,6 +1,7 @@
-import { type Component, createEffect, createSignal, For, on, onCleanup, Show } from "solid-js";
+import { type Component, createEffect, createSignal, For, on, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { computeMenuPosition } from "./lib/menuPosition";
+import { createOverlayEscape } from "./lib/overlayScrollLock";
 
 // The context-menu SHELL: portal, backdrop, Escape, and the measured
 // flip/clamp placement. Extracted from `UserContextMenu` when #1067 needed a
@@ -62,14 +63,24 @@ export type Props = {
 };
 
 const ContextMenu: Component<Props> = (props) => {
-  const onKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === "Escape") props.onClose();
-  };
-
-  createEffect(() => {
-    document.addEventListener("keydown", onKeyDown);
-    onCleanup(() => document.removeEventListener("keydown", onKeyDown));
-  });
+  // #1411 — Escape goes through the ONE shared ESC stack (#232), not a private
+  // `document` listener. The private one was a second global ESC authority,
+  // which is the exact thing #232 deleted `MediaViewerModal`'s copy to prevent:
+  // it closed the menu and left the stack empty, so the SAME keypress fell
+  // through `keybindings.ts` to `closeDrawer()` — on a phone, where MembersPane
+  // IS the members drawer, a long-press menu and its drawer went together.
+  // Stack membership also gives the menu LIFO precedence, so a modal opened
+  // over it closes first.
+  //
+  // The ESC-only variant (#1199), not `createOverlayLock`: the menu is a
+  // dismissable surface that holds no scroll-lock refcount today, and taking
+  // one would freeze the scrollback snapshot behind it and arm the iOS
+  // `overlay-open` touch lock. The predicate is the constant `true` because all
+  // three hosts mount this component behind a `<Show>` on their own open state.
+  createOverlayEscape(
+    () => true,
+    () => props.onClose(),
+  );
 
   // #1192 — the drill-down level, held as an INDEX into `props.items` rather
   // than as the submenu object itself. The caller rebuilds its item array on

--- a/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSettingsTab.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../lib/api", async () => {
 });
 
 import AdminSettingsTab from "../AdminSettingsTab";
+import { refreshSlot } from "../admin/refreshSlot";
 
 // UX-6-B2 (2026-05-21) — AdminSettingsTab unit suite. Covers:
 //   * GET /admin/settings on mount + form pre-population
@@ -270,10 +271,40 @@ describe("AdminSettingsTab — refresh", () => {
       expect(api.adminGetSettings).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent.click(screen.getByTestId("admin-settings-refresh"));
+    fireEvent.click(await screen.findByTestId("admin-settings-refresh"));
 
     await waitFor(() => {
       expect(api.adminGetSettings).toHaveBeenCalledTimes(2);
     });
+  });
+
+  // #1411 (review K-S5) — Settings was the eighth tab, and the only one whose
+  // refresh stayed a hand-rolled `<button>` after the extraction; the
+  // `AdminToolbar` moduledoc still claimed it had no refresh at all. The copy
+  // cost it the shared button's `aria-label`/`aria-busy` (its accessible name
+  // was the literal text, which swaps to "loading…" mid-fetch, so a screen
+  // reader announces a state change as a control rename) and kept it out of
+  // the slot the rail's ☰ renders from on a phone.
+  it("publishes its refresh through the shared slot", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminGetSettings).mockResolvedValue(DEFAULTS);
+
+    render(() => <AdminSettingsTab />);
+
+    await waitFor(() => {
+      expect(refreshSlot()).not.toBeNull();
+    });
+    expect(refreshSlot()?.testId).toBe("admin-settings-refresh");
+    expect(refreshSlot()?.label).toBe("refresh settings");
+  });
+
+  it("names the button once, so the name does not change mid-fetch", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminGetSettings).mockResolvedValue(DEFAULTS);
+
+    render(() => <AdminSettingsTab />);
+
+    const button = await screen.findByTestId("admin-settings-refresh");
+    expect(button).toHaveAccessibleName("refresh settings");
   });
 });

--- a/cicchetto/src/__tests__/UserContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/UserContextMenu.test.tsx
@@ -61,6 +61,11 @@ vi.mock("../lib/selection", () => ({
 // We also need to mock pushWhois — UserContextMenu uses pushWhois from socket.ts.
 // The mock above covers it.
 
+import {
+  __resetForTest,
+  overlayEscapeDepth,
+  runTopmostOverlayEscape,
+} from "../lib/overlayScrollLock";
 import UserContextMenu from "../UserContextMenu";
 
 const baseProps = {
@@ -76,6 +81,7 @@ const baseProps = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockSendCtcpQuery.mockResolvedValue(undefined);
+  __resetForTest();
 });
 
 describe("UserContextMenu", () => {
@@ -256,10 +262,18 @@ describe("UserContextMenu", () => {
       expect(onClose).toHaveBeenCalled();
     });
 
-    it("calls onClose when Escape is pressed", async () => {
+    // #1411 — this used to fire a keydown at `document` and catch the menu's
+    // own private listener. That listener is gone: Escape now arrives through
+    // the ONE shared ESC stack, so the host-level assertion is that the menu
+    // ENROLLED. The full door (real keypress → keybindings → stack, and the
+    // drawer that no longer closes with it) is driven in cardEscape.test.tsx.
+    it("enrols in the shared ESC stack, and dismisses when it is run", async () => {
       const onClose = vi.fn();
       render(() => <UserContextMenu {...baseProps} onClose={onClose} />);
-      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(overlayEscapeDepth()).toBe(1);
+      expect(runTopmostOverlayEscape()).toBe(true);
+
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ConfirmModal from "../ConfirmModal";
+import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
 import LusersCard from "../LusersCard";
 import type { ConnectionInfo, Network, WhoisBundle } from "../lib/api";
 import { type ConfirmRequest, confirmRequest, requestConfirm } from "../lib/confirmDialog";
@@ -13,7 +14,8 @@ import WhoisCard from "../WhoisCard";
 import WhowasCard from "../WhowasCard";
 
 // #1199 — the scrollback cards' Escape contract, in one place because it is
-// one contract across four components (three that enrol, one that must not).
+// one contract across four components (three that enrol, one that must not) —
+// and, since #1411, across the context-menu shell as well.
 //
 // Escape reaches the cards through the SAME door every modal uses: the single
 // window keydown listener in `lib/keybindings` → `runTopmostOverlayEscape` →
@@ -277,5 +279,65 @@ describe("#1199 Escape ordering: a modal over a card", () => {
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(handlers.closeDrawer).not.toHaveBeenCalled();
+  });
+});
+
+// #1411 (review K-S4) — the context-menu shell is the same contract as the
+// cards above: dismissable, covering nothing, therefore an ESC-stack member
+// with no scroll-lock refcount. It was never enumerated among #232's twelve
+// and kept the private `document` keydown listener that #232 ("ONE global
+// listener, the sole ESC authority") and `createOverlayEscape`'s own doc both
+// state cannot exist. The cost is not theoretical: on a phone `MembersPane`
+// IS the members drawer, so one Escape closed the menu through the private
+// listener AND, the shared stack being empty, fell through to `closeDrawer`.
+//
+// The menu mounts only while open — all three hosts gate it behind a `<Show>`
+// (MembersPane, ScrollbackPane, MessageContextMenu) — so its enrolment
+// predicate is the constant `true`, unlike the cards' bundle checks.
+describe("#1411 the context menu closes on Escape through the shared stack", () => {
+  const MENU_ITEMS: ContextMenuItem[] = [{ label: "whois", enabled: true, action: vi.fn() }];
+
+  it("closes the menu without ALSO reaching the drawer fallback", async () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={onClose} />);
+    await flush();
+
+    dispatchEscape();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // The double-close: a private listener closes the menu and leaves the
+    // shared stack empty, so the drawer underneath goes with it.
+    expect(handlers.closeDrawer).not.toHaveBeenCalled();
+  });
+
+  it("holds no scroll-lock refcount while it is up", async () => {
+    render(() => <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    await flush();
+
+    expect(overlayEscapeDepth()).toBe(1);
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("yields to a modal opened over it — the modal closes on the first Escape", async () => {
+    const onClose = vi.fn();
+    render(() => (
+      <>
+        <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={onClose} />
+        <ConfirmModal />
+      </>
+    ));
+    await flush();
+    requestConfirm(leaveChannelRequest(vi.fn()));
+    await flush();
+
+    dispatchEscape();
+    await flush();
+
+    expect(onClose).not.toHaveBeenCalled(); // the menu did NOT jump the queue
+    expect(confirmRequest()).toBeNull();
+
+    dispatchEscape();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/cicchetto/src/admin/AdminToolbar.tsx
+++ b/cicchetto/src/admin/AdminToolbar.tsx
@@ -3,8 +3,15 @@ import type { Component, JSX } from "solid-js";
 // Admin redesign Layer 2 — shared page-level toolbar (title + context
 // line + right-aligned actions), absorbing the 8 bespoke
 // `header.admin-X-header` blocks. `AdminRefreshButton` below absorbs
-// the 7 byte-identical copies of the `↻ refresh` button (the 8th,
-// Settings, has no refresh action and is unaffected).
+// the byte-identical copies of the `↻ refresh` button.
+//
+// #1411 — this doc used to except Settings as the one tab with "no refresh
+// action". It grew one after that sentence was written and hand-rolled the
+// button, losing the accessible name and the mobile ☰ placement; the sentence
+// is what let it land. There is no exception now: EVERY tab that re-fetches
+// goes through this component, reached either from the tab's slot
+// registration (`admin/refreshSlot.ts`) or, where the toolbar survives for
+// reasons of its own, directly — see `AdminNetworksTab`.
 
 export type Props = {
   title: string;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45717,3 +45717,96 @@ test; that witness had to withhold the 001 welcome, because the shared
 fixture's welcome runs `run_perform_and_identify/1`, whose own capture site
 re-stages the same secret and would have left the witness green with the
 sniff removed from the door.
+<!-- entry #1411 -->
+
+---
+
+## 2026-08-17 — #1411 (review K-S4 + K-S5): two cic invariants each had one member outside them
+
+Both gating MEDIUMs of the 2026-08-15 review, both cicchetto-only, both
+the same shape: a documented invariant with exactly one member outside
+it. They are one entry because the shape is the lesson, not the two
+components.
+
+### Which of the three sources was lying
+
+The issue text, the docs and the code disagreed, so each was measured
+against `origin/main` at `60657249` before anything was written.
+
+**K-S5 — the DOC was wrong.** `AdminToolbar`'s moduledoc excepted
+Settings as the tab with "no refresh action"; `AdminSettingsTab` had
+grown one at `:120`, rendered as a hand-rolled `<button>`. The sentence
+predates the button, and it is what let the copy land unreviewed. Both
+sides corrected: the tab registers with `admin/refreshSlot` like the
+four conforming tabs, and the moduledoc now excepts nothing.
+
+**K-S4 — the CODE was wrong, and the issue's framing of it was
+imprecise.** #232 does not say context menus do not exist; it says
+something stronger and still true — "ONE global listener, the sole ESC
+authority". It simply never enumerated menus among its twelve modals.
+So no doc needed correcting here: the fix is what makes the standing
+claim true. And the claim is asserted in THREE places, not the two the
+issue counts — #232 above, `createOverlayEscape`'s own doc (#1199, which
+names a private `document` keydown listener as "the second global ESC
+listener this stack exists to prevent"), and `cardEscape.test.tsx`'s
+header. Measured: at `60657249` cic carried exactly two global keydown
+listeners, `lib/keybindings.ts:144` (the authority) and
+`ContextMenu.tsx:70` (the outlier).
+
+### K-S4 — the double-close was real, and it is a drawer, not a modal
+
+The two drawers stay deliberately OUT of the ESC stack: they are the
+`closeDrawer` fallback #232 preserved. On a phone `MembersPane` IS the
+members drawer, so a long-press menu over it made one keypress do two
+jobs — the private listener closed the menu, and the same keypress
+reached `keybindings.ts`, found an empty stack, and closed the drawer
+underneath. That is why the outlier cost something rather than merely
+being inconsistent: a second ESC authority is invisible until a
+FIRST-authority fallback sits behind it.
+
+`createOverlayEscape`, not `createOverlayLock`: the menu holds no
+scroll-lock refcount today and taking one would freeze the scrollback
+snapshot behind it and arm the iOS `overlay-open` touch lock — the
+#1199 argument for the inline cards, applying unchanged. The enrolment
+predicate is the constant `true` because all three hosts (MembersPane,
+ScrollbackPane, MessageContextMenu) mount the component behind a
+`<Show>` on their own open state.
+
+### The test that was a mirror
+
+`UserContextMenu.test.tsx` already had "calls onClose when Escape is
+pressed" — and it passed for the wrong reason: it fired `keyDown` at
+`document` with the keybindings listener never installed, so it could
+only ever have been driving the private listener. It is the exact
+betrayal `cardEscape.test.tsx`'s header warns about ("a card that
+registered on a private `document` listener instead would satisfy 'Esc
+dismisses the card' and betray itself only on the ordering arm"), found
+in the wild. The contract now lives in `cardEscape.test.tsx`, driving
+the real door: install, a bubbling KeyboardEvent from an in-document
+target, and an assertion that `closeDrawer` was NOT reached.
+
+### What the tests buy, priced by mutation
+
+Six mutants, all killed, each reverted with `git checkout HEAD --`:
+never enrolling; enrolling via `createOverlayLock` instead (killed ONLY
+by the `overlayCount() === 0` arm); keeping the private listener
+ALONGSIDE the stack (killed by the call-count and ordering arms — the
+mutant that a depth-only assertion would have missed); dropping the slot
+registration; dropping `hostsRefresh` on the card (the registration arm
+SURVIVES it, which is the separation that proves that arm does not
+secretly depend on rendering); and a wrong `label`.
+
+### Held, and not claimed
+
+The review asked for a device reproduction of the double-close before
+and after. **DEVICE-VERIFY HELD** — it rides the pending device batch,
+per the same discipline as #1358. What is measured here is the
+mechanism, in jsdom: `closeDrawer` invoked by the same keypress that
+closed the menu, and not invoked afterwards. Nothing was opened in a
+browser, and no claim is made about the felt behaviour on a phone.
+
+Also not claimed: the third K-S5 consequence, that the CSS class copy
+matters. It is gone as a side effect of the fix, and no test asserts
+it — `default.css` was not touched.
+
+_Deploy: **--cic HOT, client-only.** No server, schema or wire change._


### PR DESCRIPTION
Both gating MEDIUMs of the 2026-08-15 codebase review, both cicchetto-only,
both the same shape: a documented invariant with exactly one member outside it.

Measured alive on `origin/main` at `60657249` before anything was written, and
no open PR touches these files.

## K-S4 — the context menu was the second global ESC authority

`ContextMenu.tsx:70` carried its own `document` keydown listener. Enumerated
across `cicchetto/src` (tests excluded), cic held **exactly two** global keydown
listeners at `60657249`: `lib/keybindings.ts:144` (the authority) and this one.

The cost is a double-close, not an inconsistency. The two drawers stay
deliberately OUT of the ESC stack — they are the `closeDrawer` fallback #232
preserved. On a phone `MembersPane` IS the members drawer, so one Escape over a
long-press menu did two jobs: the private listener closed the menu, and the SAME
keypress reached `keybindings.ts`, found an empty stack, and closed the drawer
underneath. A second ESC authority is invisible until a first-authority fallback
sits behind it.

`createOverlayEscape`, not `createOverlayLock`: the menu holds no scroll-lock
refcount today, and taking one would freeze the scrollback snapshot behind it
and arm the iOS `overlay-open` touch lock — the #1199 argument for the inline
cards, unchanged. The predicate is the constant `true` because all three hosts
mount the component behind a `<Show>` on their own open state.

## K-S5 — the Settings refresh was the eighth, hand-rolled copy

`AdminSettingsTab` grew a refresh AFTER the extraction that absorbed the other
seven, and hand-rolled the button. Two consequences, both confined to this tab:
its accessible name was the literal text, which swaps to "loading…" mid-fetch,
so a screen reader announces a busy state as a control rename; and it never
registered with `admin/refreshSlot`, which is what the rail's ☰ renders from on
a phone, so the operator's mobile refresh path failed on exactly one tab.

Now `useRefreshSlot` + `hostsRefresh` on the Uploads card, like the four
conforming tabs. The toolbar itself stays: unlike the bands that were
title-plus-refresh and nothing else, its subtitle says the settings below are
server-wide rather than per-network, which the nav above does not.

## The three sources that asserted the ESC invariant, and the one that asserted a falsehood

Precisely, because the issue text, the docs and the code disagreed and each was
measured rather than believed:

1. `DESIGN_NOTES` #232 — "ONE global listener, the sole ESC authority".
2. `createOverlayEscape`'s own doc (#1199) — a private `document` keydown
   listener "would be the second global ESC listener this stack exists to
   prevent".
3. `cardEscape.test.tsx`'s header — the same contract, stated as the reason the
   ordering arm exists.

All three were RIGHT; the code violated them. #232 never says context menus do
not exist, it says something stronger and still true — it simply never
enumerated menus among its twelve modals. So K-S4 needed no doc correction: the
fix is what makes the standing claim true. The issue's framing ("both docs
assert that member does not exist") holds for K-S5 only, and undercounts the
sources at two.

The one source that asserted a falsehood is `AdminToolbar`'s moduledoc: "the
8th, Settings, has no refresh action and is unaffected". That sentence predates
the button and is what let the copy land unreviewed. Corrected in the same
commit; no excepted tab remains.

No automated gate reads either doc — `scripts/design-notes-gate.sh` judges only
the boundary SHAPE of added entries, never content. Humans and future sessions
read them, which is exactly how the stale sentence did damage.

## The pre-existing test that passed for the wrong reason

`UserContextMenu.test.tsx` already had "calls onClose when Escape is pressed".
It fired `keyDown` at `document` with the keybindings listener never installed,
so it could only ever have been driving the private listener. That is the exact
betrayal `cardEscape.test.tsx`'s header warns about — "a card that registered on
a private `document` listener instead would satisfy 'Esc dismisses the card' and
betray itself only on the ordering arm" — found in the wild. It now asserts
enrolment; the real door (install, a bubbling KeyboardEvent from an in-document
target, and `closeDrawer` NOT reached) is driven in `cardEscape.test.tsx`.

## Gates RUN, with numbers

| gate | result |
|---|---|
| `scripts/bun.sh run test` | **RC=0 — 289 files, 5579 tests, 0 failures** |
| `scripts/bun.sh run check` | **RC=0 — 59 warnings, identical to the declared baseline** (biome green, so tsc ran) |
| `scripts/design-notes-gate.sh` | **RC=0 — "1 new entry heading(s), separator and marker present"** |
| RED before GREEN | **5 failures, 17 passing beside them**, each failure line read |
| mutation | **6 mutants, 6 killed, 0 survivors** |

The first full-suite run was 1 red: the pre-existing test above, which the fix
correctly exposed.

Mutants, and what each killed: never enrolling (3 cardEscape arms + the
enrolment arm); `createOverlayLock` instead of `createOverlayEscape` (killed
ONLY by the `overlayCount() === 0` arm); the private listener kept ALONGSIDE the
stack (killed by the call-count and ordering arms — the one a depth-only
assertion would have missed, since depth stays 1); dropping the slot
registration; dropping `hostsRefresh` (the registration arm SURVIVES, which is
what proves that arm does not secretly depend on rendering); a wrong `label`.

Branched from `origin/main` = `60657249`, which had not moved when re-fetched at
the end — no rebase, so every gate above ran on the live base.

## Gates NOT run, and claims not made

- **No e2e, no `scripts/integration.sh`, no Elixir gate** (`check.sh`, Dialyzer,
  Credo, Sobelow, bats): this branch touches no `lib/grappa/**` and holds no
  lane. Cic-only gates and pure bash.
- **DEVICE-VERIFY HELD.** The review asks for a device reproduction of the
  double-close before and after. What is measured here is the mechanism, in
  jsdom — `closeDrawer` invoked by the same keypress that closed the menu, and
  not invoked after the fix. Nothing was opened in a browser and no claim is
  made about the felt behaviour on a phone; it rides the pending device batch,
  same discipline as #1358.
- **The third K-S5 consequence (the duplicated CSS class) is not proven.** It
  goes away as a side effect, but no test asserts it and `default.css` was not
  touched.
- **The ESC enumeration covers GLOBAL keydown listeners only.** An element-scoped
  ESC handler — what #232 calls an "inner-widget Esc" — is outside the invariant
  by #232's own construction and was neither searched for nor claimed about.

Refs #1411.