### PR TITLE
cic(#1396): fold the channel key at the selection boundary (bucket G, A9)

### DIFF
--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -1855,6 +1855,78 @@ describe("selection store", () => {
     });
   });
 
+  // #1396 (review bucket G, A9) — the channel KEY folds at THIS boundary, not
+  // in each caller. Every join door already folded before calling
+  // (`DirectoryPane`, `compose.ts` `/join`, `channelJoin.ts`) except one, and
+  // the store paid for that asymmetry twice: `sameSelection` compares
+  // `channelName` byte-wise, so two spellings of one channel were two
+  // selections, and `stillLive` carries a defensive decode-through-the-key
+  // whose comment names "a stray non-canonical setSelectedChannel" as the
+  // thing it is defending against. Folding at the setter is what makes the
+  // stray impossible instead of survivable.
+  //
+  // ONLY `kind: "channel"`. A channel has no display column — the folded key
+  // IS the display (CLAUDE.md, option B) — so nothing is lost. A query's name
+  // is a peer NICK, whose raw casing is both display and WIRE: `compose.ts`'s
+  // `resolveBareWhoisNick` returns `sel.channelName` straight into a WHOIS
+  // frame. Folding that would fold a wire builder, which the key/display/wire
+  // split forbids. The last arm here is that boundary, pinned.
+  describe("#1396 — the channel key folds at the selection boundary", () => {
+    it("folds a mixed-case channel name on the way in", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      const selection = await import("../lib/selection");
+
+      selection.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "#Grappa",
+        kind: "channel",
+      });
+
+      expect(selection.selectedChannel()?.channelName).toBe("#grappa");
+    });
+
+    it("treats the two spellings of one channel as the SAME selection", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      const selection = await import("../lib/selection");
+
+      selection.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "#Grappa",
+        kind: "channel",
+      });
+
+      // The #243 re-tap predicate and the idempotent setter share
+      // `sameSelection`, so this is both "a re-tap is recognised" and "the
+      // setter does not re-fire the effect for a casing".
+      expect(
+        selection.isActiveSelection({
+          networkSlug: "freenode",
+          channelName: "#grappa",
+          kind: "channel",
+        }),
+      ).toBe(true);
+    });
+
+    it("leaves a query target RAW — it is a display name and a wire target", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      const selection = await import("../lib/selection");
+
+      selection.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "Guest",
+        kind: "query",
+      });
+
+      expect(selection.selectedChannel()?.channelName).toBe("Guest");
+    });
+  });
+
   // #359 — Alt+0 jumps to the status/server window. The verb resolves WHICH
   // network's status window purely from live state (the selection's own
   // network, else the first one in the sidebar's order) — no parallel
@@ -2003,9 +2075,12 @@ describe("selection store", () => {
 
       selection.followQueryNick("azzurra", "Guest87449", "NickTemporaneo");
 
+      // Unchanged by `followQueryNick`, which is what this arm is about. The
+      // lower case is the #1396 boundary fold applied on the way IN, not a
+      // rename: this window is `kind: "channel"`, so its name is a KEY.
       expect(selection.selectedChannel()).toEqual({
         networkSlug: "azzurra",
-        channelName: "Guest87449",
+        channelName: "guest87449",
         kind: "channel",
       });
     });

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -1911,6 +1911,32 @@ describe("selection store", () => {
       ).toBe(true);
     });
 
+    // Found by a SURVIVING mutant, not by design: dropping the fold from
+    // `isActiveSelection` left every assertion above green, because the arm
+    // that exercises the predicate hands it an already-folded name. The
+    // predicate folds its ARGUMENT, so the case that bites is the mirror of
+    // the one above — a caller spelling the name the way it renders it.
+    it("recognises a re-tap spelled with the display casing", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      const selection = await import("../lib/selection");
+
+      selection.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "#grappa",
+        kind: "channel",
+      });
+
+      expect(
+        selection.isActiveSelection({
+          networkSlug: "freenode",
+          channelName: "#Grappa",
+          kind: "channel",
+        }),
+      ).toBe(true);
+    });
+
     it("leaves a query target RAW — it is a display name and a wire target", async () => {
       localStorage.setItem("grappa-token", "tok");
       const api = await import("../lib/api");

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
 import { isContentKind, ownNickForNetwork } from "./api";
 import { token } from "./auth";
-import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
+import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
 import { saveLastFocused } from "./lastFocusedChannel";
 import { membersByChannel } from "./members";
@@ -97,6 +97,36 @@ const sameSelection = (a: SelectedChannel, b: SelectedChannel): boolean => {
   return a.networkSlug === b.networkSlug && a.channelName === b.channelName && a.kind === b.kind;
 };
 
+// #1396 (review bucket G, A9) — the channel KEY folds HERE, once, instead of
+// in every caller. Four doors open a channel window and each spelled the fold
+// itself; the one that did not (`HomePane`'s featured-link tap) was correct
+// only because the server happens to canonicalise
+// `network_featured_channels` at write. The store paid for that asymmetry
+// twice: `sameSelection` compares byte-wise, so two spellings of one channel
+// were two selections, and `stillLive` below carries a defensive
+// decode-through-the-key whose comment names "a stray non-canonical
+// setSelectedChannel" as its reason. Folding at the boundary is what makes
+// the stray impossible rather than survivable, and it is where CLAUDE.md puts
+// the fold anyway: at the KEY boundary, once.
+//
+// ONLY `kind: "channel"`. A channel has no display column — the folded key IS
+// the display (option B) — so nothing is lost by folding on the way in. The
+// other kinds must NOT fold:
+//
+//   * `query` — the name is a peer NICK, and its raw casing is both display
+//     AND WIRE. `compose.ts`'s `resolveBareWhoisNick` hands `sel.channelName`
+//     straight into a WHOIS frame, so folding here would fold a wire builder,
+//     which the key/display/wire split forbids. Query focus sites already
+//     fold their own KEY via `canonicalQueryNick` before calling.
+//   * the synthetic kinds (`$server`, `$list`, `$home`, `$admin`) — not
+//     identifiers at all. They are fold-invariant today, which is exactly why
+//     folding them would be a silent no-op that stops being one the day a
+//     synthetic name gains a capital.
+const foldChannelKey = (sel: SelectedChannel): SelectedChannel =>
+  sel !== null && sel.kind === "channel"
+    ? { ...sel, channelName: canonicalChannel(sel.channelName) }
+    : sel;
+
 /**
  * Per-channel seed count pair: `messages` (content kinds) + `events`
  * (presence kinds). Hydrated from the server's join reply (`unread_count`
@@ -152,7 +182,8 @@ const exports = identityScopedStore((onIdentityChange) => {
     backTarget = null;
   });
 
-  const setSelectedChannel = (next: SelectedChannel): void => {
+  const setSelectedChannel = (input: SelectedChannel): void => {
+    const next = foldChannelKey(input);
     const cur = untrack(selectedChannel);
     if (sameSelection(cur, next)) return;
     // Entering a transient overlay — the $list directory pane or the #188
@@ -179,8 +210,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   // no-op-transition rule. Untracked: callers are event handlers (a
   // Sidebar / BottomBar tap), not reactive scopes — reading the selection
   // signal here must not subscribe them.
+  //
+  // #1396 — through `foldChannelKey` for the same reason the setter is: the
+  // two must agree on what "the same window" means, and the setter now stores
+  // the folded name. Skipping the fold here would answer "not a re-tap" for a
+  // tap on the very window it just focused.
   const isActiveSelection = (next: SelectedChannel): boolean =>
-    sameSelection(untrack(selectedChannel), next);
+    sameSelection(untrack(selectedChannel), foldChannelKey(next));
 
   // Resolve the window to focus when a window closes or a transient
   // overlay is dismissed: most-recently-used live channel/query (MRU) →

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45810,3 +45810,110 @@ matters. It is gone as a side effect of the fix, and no test asserts
 it — `default.css` was not touched.
 
 _Deploy: **--cic HOT, client-only.** No server, schema or wire change._
+<!-- entry #1396 -->
+
+---
+
+## 2026-08-17 — #1396 (bucket G, A9): the channel key folds at the selection boundary
+
+First slice of bucket G, and deliberately NOT the dispatch move. Slice 1
+of that (the `requireNetworkId` collapse) landed as PR #1418 on
+2026-08-16; slice 2 moves 59 switch arms and buys no red, only
+characterization. This slice was chosen by the opposite criterion: the
+part of bucket G where a real assertion could go from red to green.
+
+### What A9 actually is, here
+
+The review calls it "the shared-verb rule is already fraying: four
+spellings of the join verb, two of which differ on whether the channel
+is folded". Measured on `60657249`, the four doors that open a channel
+window are `DirectoryPane`, `compose.ts` `/join`, `lib/channelJoin.ts`
+and `HomePane`'s featured-link tap. The first three call
+`canonicalChannel` before `setSelectedChannel`. The fourth does not —
+and it is correct anyway, because `Networks.FeaturedChannel`
+canonicalises at write (`featured_channel.ex:69`), so the raw name it
+forwards has already been folded by the server.
+
+That is the finding, stated honestly: **the client's correctness rests
+on a server storage detail rather than on the client's own rule.** The
+defect is that the invariant is not IMPOSED, not that it is violated —
+the same shape as #1394's outbound door.
+
+### The store was already paying for it
+
+Two places, both measurable before the change:
+
+1. `sameSelection` compares `channelName` byte-wise, so two spellings of
+   one channel were two different selections. The #243 re-tap predicate
+   and the idempotent setter share that compare, so both answered
+   "different window" for a casing.
+2. `stillLive` carries a defensive decode-through-the-key, and its
+   comment names the reason: *"a stray non-canonical
+   setSelectedChannel would otherwise stale-fire this check"*. The
+   codebase had already anticipated the stray and chosen to survive it
+   per-consumer.
+
+Folding at the setter makes the stray impossible rather than
+survivable, and it puts the fold where CLAUDE.md puts every other one:
+at the KEY boundary, once. The per-caller `canonicalChannel` calls stay
+— after this they are belt-and-braces, not a second pattern, because
+the boundary is authoritative.
+
+### Why ONLY `kind: "channel"`
+
+A channel has no display column — the folded key IS the display (option
+B) — so folding on the way in loses nothing. The other kinds must not:
+
+- **`query`** — the name is a peer NICK, and its raw casing is display
+  AND WIRE. `compose.ts`'s `resolveBareWhoisNick` returns
+  `sel.channelName` straight into a WHOIS frame, so folding it would
+  fold a wire builder, which the key/display/wire split forbids. Query
+  focus sites already fold their own KEY via `canonicalQueryNick`
+  before calling. This was the fork put to vjt and ruled on: only KEYs
+  fold, never a wire builder.
+- **the synthetic kinds** (`$server`, `$list`, `$home`, `$admin`) — not
+  identifiers. They are fold-invariant today, which is precisely why
+  folding them would be a silent no-op that stops being one the day a
+  synthetic name gains a capital.
+
+### A mutant found a production edit with no assert behind it
+
+Three mutants, and the third earned its keep by SURVIVING: removing the
+fold from `isActiveSelection` left the entire suite green, because every
+existing arm hands that predicate an already-folded name. The fold was
+right — the predicate and the setter must not disagree about what one
+window is — but nothing observed it. The arm that bites is the mirror of
+the setter's: a caller spelling the channel the way it renders it, which
+is exactly what a sidebar re-tap does. Written after the survival, and
+it is what kills M3 now, alone.
+
+The other two: no fold at all (kills the two positive arms plus a
+pre-existing `followQueryNick` arm), and folding EVERY kind (kills only
+the query arm and two pre-existing `followQueryNick` arms — the
+wire-safety guard, which passes on the base and exists solely to be
+killed by over-folding).
+
+One pre-existing arm was re-spelled, not weakened: `followQueryNick`'s
+same-named-CHANNEL case sets up a channel window called `Guest87449` and
+asserts the tuple is untouched. It still asserts that; the expectation
+reads the folded name now, with a comment saying which side folded it.
+
+### Not established
+
+The slice as proposed also moved `HomePane` onto the shared focus verb.
+**Dropped after the boundary fold, deliberately:** with the fold at the
+setter, HomePane's raw call is correct by construction, and the only
+remaining difference is which helper it spells. A test for that would
+assert a call sequence, not an outcome — and with `lib/selection`
+mocked in `HomePane.test.tsx` the outcome is not even observable there.
+HomePane cannot be merged into `channelJoin.performJoin` either: it
+surfaces join errors inline, where that verb console-warns. So the
+fourth spelling survives this slice, as a spelling and no longer as a
+hazard.
+
+Also not established: no e2e, no browser. The mixed-case channel focus
+is unreachable from the live server today (both the featured table and
+the channel list are folded upstream), so what is measured is the
+boundary, not a user-visible regression.
+
+_Deploy: **--cic HOT, client-only.** No server, schema or wire change._


### PR DESCRIPTION
First slice of bucket G, and deliberately not the dispatch move. Slice 1 of
that (the `requireNetworkId` collapse) already landed as **PR #1418**; slice 2
moves 59 switch arms and buys no red, only characterization. This slice was
picked by the opposite criterion — the part of bucket G where a real assertion
could go from red to green.

## What A9 is, measured on `60657249`

The review calls it "the shared-verb rule is already fraying: four spellings of
the join verb, two of which differ on whether the channel is folded".

The four doors that open a channel window are `DirectoryPane`, `compose.ts`
`/join`, `lib/channelJoin.ts`, and `HomePane`'s featured-link tap. The first
three call `canonicalChannel` before `setSelectedChannel`. The fourth does not
— and it is correct anyway, because `Networks.FeaturedChannel` canonicalises at
write (`featured_channel.ex:69`), so the name it forwards has already been
folded by the server.

**So this PR IMPOSES an invariant; it does not repair a regression.** Nothing
is broken for an operator today: both the featured table and the channel list
arrive folded from upstream, so a mixed-case channel focus is currently
unreachable. What was wrong is that the client's correctness rested on a
**server storage detail** rather than on the client's own rule — the same shape
as #1394's outbound door, where nothing was being lost either.

## The store was already paying for it, in two measurable places

1. `sameSelection` compares `channelName` byte-wise, so two spellings of one
   channel were two different selections. The #243 re-tap predicate and the
   idempotent setter share that compare, so both answered "different window"
   for a casing.
2. `stillLive` carries a defensive decode-through-the-key, and its comment
   names the reason: *"a stray non-canonical setSelectedChannel would otherwise
   stale-fire this check"*. The codebase had already anticipated the stray and
   chosen to survive it per-consumer.

Folding at the setter makes the stray impossible instead, and puts the fold
where CLAUDE.md puts every other one: at the KEY boundary, once.
`isActiveSelection` folds its argument through the same helper, because the
predicate and the setter must not disagree about what one window is. The
per-caller folds stay — after this they are belt-and-braces, not a second
pattern, because the boundary is authoritative.

## Only `kind: "channel"`

A channel has no display column — the folded key IS the display — so folding on
the way in loses nothing. The others must not fold:

- **`query`** — the name is a peer NICK whose raw casing is display AND WIRE:
  `compose.ts`'s `resolveBareWhoisNick` returns `sel.channelName` straight into
  a WHOIS frame. Folding it would fold a wire builder, which the
  key/display/wire split forbids.
- **the synthetic kinds** (`$server`, `$list`, `$home`, `$admin`) — not
  identifiers. They are fold-invariant today, which is exactly why folding them
  would be a silent no-op that stops being one the day one gains a capital.

## A mutant SURVIVED, and wrote a test

Three mutants. The third earned its keep by surviving: removing the fold from
`isActiveSelection` left **the entire suite green**, because every pre-existing
arm hands that predicate a name that is already folded. The fold was right —
predicate and setter must agree — but nothing observed it. That is a production
edit with no assert behind it.

The arm that bites is the mirror of the setter's: a caller spelling the channel
the way it renders it, which is what a sidebar re-tap does. It was written
**after** the survival, not before, and it is what kills that mutant now —
alone.

Re-run after the arm landed, all three killed:

| Mutant | Killed by |
|---|---|
| no fold at all | the 2 positive arms + 1 pre-existing `followQueryNick` arm |
| folds EVERY kind | **only** the query-stays-RAW arm + 2 pre-existing `followQueryNick` arms |
| the predicate skips the fold | **exactly 1** — the arm its own survival forced |

The query-stays-RAW arm passes on the base by construction: it is the
over-folding guard, and exists solely to be killed by the second mutant.

One pre-existing arm was **re-spelled, not weakened**: `followQueryNick`'s
same-named-CHANNEL case sets up a channel window called `Guest87449` and
asserts the tuple is untouched. It still asserts the whole tuple; only the
expected spelling changes, with a comment naming which side folded it. The
subject under test was not modified.

## Gates, with numbers

| gate | result |
|---|---|
| `scripts/bun.sh run test` | **RC=0 — 289 files, 5578 tests, 0 failures** |
| `scripts/bun.sh run check` | **RC=0 — 59 warnings, identical to the declared baseline** (biome green, so tsc ran) |
| `scripts/design-notes-gate.sh` | **RC=0** — marker `<!-- entry #1396 -->` verified ABSENT on the base first |
| RED before GREEN | **2 failures, 61 passing beside them**, each failure line read |
| mutation | **3 mutants — 1 survived, was fixed by a new assert, then 3/3 killed** |

**5574 → 5578.** The branch adds exactly four `it` blocks and removes none
(counted from the diff, not estimated), and the suite reports 5578, so the four
new specs were collected and run rather than skipped. The stronger evidence
that they BITE is the mutation table above: each mutant is killed by the new
arms **by name**.

**Rebased — the numbers above are the pre-rebase measurement.** This branch was
written on `origin/main` = `60657249`, and every figure in the table was taken
there. It has since been rebased onto **`2617474b`** (after #1394 and #1411
landed) and force-pushed.

Re-run on `2617474b`: `scripts/bun.sh run test` **RC=0 — 289 files, 5583 tests,
0 failures** (5583 rather than 5578 because the base itself gained tests),
`scripts/bun.sh run check` **RC=0 — 59 warnings + 6 infos**, and
`scripts/design-notes-gate.sh` **RC=0**, with the marker re-verified absent on
the new base and unique in the document afterwards. The RED-before-GREEN row and
the mutation row were **not** re-run: those attest `60657249`.

The rebase reported no conflict but silently dropped two lines from
`docs/DESIGN_NOTES.md` — the branch's contribution to that file went from 107
added lines to 105. The lost pair was a blank line plus the `_Deploy:` footer
that closed the PRECEDING entry (#1411), whose last two lines are byte-identical
to this entry's last two; `merge=union` aligned them as one common addition and
emitted a single copy, leaving #1411 without its footer. Both lines were
restored in place and folded into the same docs commit by amend, rather than a
separate restoration commit, which a later rebase would drop as already-upstream
for the same reason. The two-sided `--numstat` is byte-identical again
(107/0 for `DESIGN_NOTES.md`; 248 additions and 4 deletions overall, unchanged).

Worth recording for whoever rebases next: the boundary-shape gate stayed green
through all of this. It judges the head of an entry a branch ADDS — marker,
separator, heading — and the footer of the entry before it is outside its scope.
What caught the loss was the pinned two-sided `--numstat`, not the gate.

## Not run, and not claimed

- **No e2e, no `scripts/integration.sh`, no Elixir gate.** This branch touches
  no `lib/grappa/**` and holds no lane; cic-only gates and pure bash.
- **This does not close #1396.** It is one slice of bucket G. Still open: the
  59-arm dispatch move, the `api.ts` domain-derivation split (A8 + A5), the
  `lib/` layer rule, and the admin-component store layer.
- **The `HomePane` half of the original plan was dropped, deliberately.** With
  the fold at the boundary its raw call is correct by construction, and the
  only difference left is which helper it spells — a test for that asserts a
  call sequence, not an outcome, and `HomePane.test.tsx` mocks `lib/selection`
  so the outcome is not observable there anyway. It cannot be merged into
  `channelJoin.performJoin` either: HomePane surfaces join errors inline where
  that verb console-warns. The fourth spelling survives as a spelling, no
  longer as a hazard.
- **The per-caller folds are redundant now, not dead.** They were left in place
  and removing them was not measured.
- **Query focus sites were not audited.** The two read (`canonicalQueryNick`)
  fold their own key; the class was not swept. Separate slice.

Refs #1396.
