### PR TITLE
arch(#1392): fold the two private subject predicates into Grappa.Subject

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45535,3 +45535,122 @@ jsdom. `role="img"` stays — ARIA does prohibit the name there, so no AT
 owes us the reading — but that is the spec, not a measurement, and the
 tests now pin the spec-legal SHAPE with a byRole query instead of
 pretending the name assertion proves it.
+<!-- entry #1392 -->
+
+---
+
+## 2026-08-17 — #1392: three spellings of one subject predicate, and the claims measurement retired
+
+Bucket C of the 2026-08-15 architecture review. `Grappa.Subject`'s moduledoc
+has declared it the single source of truth for the
+`{:user, uuid} | {:visitor, uuid}` discriminator since the V1 visitor-parity
+promotion, and named `Grappa.Scrollback` and `Grappa.ReadCursor` as the
+contexts it was promoted OUT of. Neither of them referenced `Grappa.Subject`
+at all. The promotion reached nine modules and stopped one short of the two it
+was named after.
+
+Counted at `f59b0c7e`: `Subject.subject_where/2` served 19 call sites across
+seven modules, `Scrollback.subject_where/2` (private) 12, and
+`ReadCursor.subject_filter/2` (private) 7. A fourth spelling sat on the write
+side — `ReadCursor.subject_attrs/1`, one call site, duplicating
+`Subject.put_subject_id/2`.
+
+### The predicate did not diverge; the diagnostic did
+
+All three built the same clause: the same `is_binary/1` guards on both
+branches, the same equality against the same FK column, and the same
+**positional** binding — `[m]` in one, `[row]` in the other two, both index 0.
+That last detail is what makes the fold a substitution rather than a rewrite:
+no call site's query shape can change the result, because the binding is
+resolved by position and the position is identical. No value in the valid
+domain makes any two of them build a different query.
+
+They differed OFF the domain, and there the difference is real.
+`Scrollback` carried an explicit fall-through raising `ArgumentError` with the
+inspected subject, added by B5.4 L-pers-2 precisely because a
+`FunctionClauseError` hides both the offending value and the function name.
+`Subject` and `ReadCursor` had no such clause.
+
+So the fold could not be a deletion. Dropping the two privates and letting
+`Subject.subject_where/2` answer would have removed that diagnostic from 12
+call sites; the clause was promoted **with** the function instead. That is a
+behaviour change and the commit says so rather than claiming none: 19 existing
+`Subject.subject_where/2` call sites and 7 former `subject_filter/2` ones move
+from `FunctionClauseError` to `ArgumentError`. Nothing in `test/` asserted
+`FunctionClauseError` on these functions, and the two pins that already
+existed (`scrollback_test.exs`, `~r/unknown subject:/`) stay green untouched —
+which is the evidence the fold is transparent at the Scrollback boundary.
+
+### What the issue text claimed and the code did not
+
+Two figures in the issue body do not reproduce, and the code wins:
+
+`subject_filter/2` has **7** call sites, not 8. Classifying all twelve
+occurrences of the token in `read_cursor.ex`: seven calls, two clauses, one
+`@spec`, and two mentions in prose. The likeliest source of the eighth is the
+`@spec` or the cross-reference comment, but no base was constructed that
+yields 8, so that stays a guess.
+
+"Seven modules re-declare the type literal" merges three different types. Only
+**four** declarations are verbatim clones of `Subject.t()` (`accounts.ex`,
+`read_cursor.ex`, `scrollback.ex`, `session.ex`). Two more —
+`accounts/revocations.ex`, `rate_limit/request_budget.ex` — spell the id as
+`String.t()`, which is strictly WIDER than `Ecto.UUID.t() :: <<_::288>>`;
+substituting `Subject.t()` there narrows a type rather than deduplicating one.
+Three others (`account_deletion.ex`, `themes.ex`, `grappa_web/subject.ex`) are
+the rich-struct shape. The issue excluded `account_deletion.ex` for exactly
+that reason but did not name `themes.ex`, which is the same animal and equally
+uncollapsible: a core context cannot depend on `GrappaWeb`.
+
+Three of the four true clones collapse here. `accounts.ex:103` does not:
+`Grappa.Accounts` is a DEP of `Grappa.Subject`, so referencing `Subject.t()`
+from inside it would close `Subject → Accounts → Subject` if Boundary tracks
+remote type references. Whether it does was not established — the repo
+contains no discriminating case, since every remote `Grappa.X.t()` in a core
+`@spec` sits in a boundary that already declares `X`. The declaration is worth
+two `@spec` sites, so the cheap move is to leave it and say why.
+
+### The write-side asymmetry is real and unreachable
+
+`Subject.put_subject_id/2` guards `is_map(attrs) and is_binary(uid)`.
+`ReadCursor.subject_attrs/1` had no guard at all, so `{:user, nil}` returned
+`%{user_id: nil}` — a value where every sibling raises, flowing into
+`Cursor.changeset/2` and failing late at the XOR CHECK instead of early at the
+call site.
+
+Tracing it settled the question the other way, and that is worth recording:
+both paths into `upsert_cursor/5` (`do_set/4` and `force_write/4`) call
+`get/3` first, and every public entry passes through `message_belongs?/4` as
+well — all of them subject-guarded. A malformed subject raises before
+`subject_attrs/1` is ever reached. The asymmetry was measured; the exploit path
+does not exist. Folding it into `put_subject_id/2` is therefore deduplication,
+not a fix, and it is recorded as such rather than dressed up as one.
+
+`put_subject_id/2` keeps its `FunctionClauseError` posture deliberately. Giving
+it the same `ArgumentError` fall-through would be a second behaviour change
+across 24 call sites that nothing here asks for; a hard failure on a malformed
+shape is already the right answer, and uniformity for its own sake can be its
+own change.
+
+### Two sentences in the moduledoc that were not true
+
+`subject_where/2`'s `@doc` promised a
+`WHERE user_id = ? AND visitor_id IS NULL`-shaped clause. None of the three
+spellings ever emitted the second conjunct — all three emit the single
+equality, and the DB-level XOR CHECK is what makes it redundant. Harmless at
+runtime, but it is the sentence a reader would use to reason about subject
+isolation, so it stated a guarantee the code did not provide.
+
+The same `@doc` told multi-join callers to write the where-clause themselves.
+`ReadCursor.bulk_for_subject/1` has always been a multi-join caller and has
+always been correct, because the real precondition is narrower than "no
+joins": binding 0 must be the table carrying the subject FK. Stated as written,
+the caveat would have forbidden a fold that is exactly equivalent.
+
+### Left out, and named so nobody has to re-derive it
+
+`request_budget.ex:58-63` justifies its local declaration as keeping "the
+`Grappa.RateLimit` boundary free of a `Grappa.Session` dep". That reason is
+stale — the type has lived in `Grappa.Subject`, not `Grappa.Session`, since the
+V1 promotion. It is left alone anyway, because its `String.t()` is the wider
+type and narrowing it is a separate judgement with its own risk.

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -96,9 +96,8 @@ defmodule Grappa.ReadCursor do
   alias Grappa.Networks.Network
   alias Grappa.PubSub.Topic
   alias Grappa.ReadCursor.{Cursor, Wire}
-  alias Grappa.Repo
   alias Grappa.Scrollback.Message
-  alias Grappa.Subject
+  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -830,5 +830,4 @@ defmodule Grappa.ReadCursor do
     |> Grappa.Scrollback.channel_or_dm_where(channel, nil)
     |> Repo.exists?()
   end
-
 end

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -40,9 +40,11 @@ defmodule Grappa.ReadCursor do
 
   Mirrors `Grappa.Scrollback.Message`'s convention. The subject
   discriminated union (`{:user, uuid}` | `{:visitor, uuid}`) is the
-  same tagged-tuple shape Scrollback's `fetch/6` accepts. Same predicate
-  helpers (`subject_filter/1`, `subject_attrs/1`) keep the per-subject
-  iso boundary uniform across contexts.
+  same tagged-tuple shape Scrollback's `fetch/6` accepts, and since
+  #1392 it is the same CODE: the private `subject_filter/2` and
+  `subject_attrs/1` this module used to carry were synonyms of
+  `Grappa.Subject.subject_where/2` and `Grappa.Subject.put_subject_id/2`,
+  and now call them.
 
   ## Boundary
 
@@ -58,6 +60,9 @@ defmodule Grappa.ReadCursor do
       `messages` table by id.
     * `Grappa.PubSub` — `Topic.channel/3` for the `read_cursor_set`
       cross-device broadcast.
+    * `Grappa.Subject` — the subject discriminator itself: `t/0`,
+      `subject_where/2` for every read, `put_subject_id/2` for the
+      insert (#1392).
 
   The `Cursor` schema module is internal; callers receive `%Cursor{}`
   structs by type but MUST NOT alias or import the schema module
@@ -66,7 +71,15 @@ defmodule Grappa.ReadCursor do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Scrollback, Grappa.Visitors.Visitor],
+    deps: [
+      Grappa.Accounts,
+      Grappa.IRC,
+      Grappa.PubSub,
+      Grappa.Repo,
+      Grappa.Scrollback,
+      Grappa.Subject,
+      Grappa.Visitors.Visitor
+    ],
     # `Networks.Network` is referenced ONLY as a schema — the
     # `belongs_to :network` FK association + the `join: n in Network`
     # slug lookup in `bulk_for_subject/1` (field access, no Networks
@@ -85,6 +98,7 @@ defmodule Grappa.ReadCursor do
   alias Grappa.ReadCursor.{Cursor, Wire}
   alias Grappa.Repo
   alias Grappa.Scrollback.Message
+  alias Grappa.Subject
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.
@@ -99,7 +113,7 @@ defmodule Grappa.ReadCursor do
   tagged-tuple shape across both contexts so callers don't need to
   re-encode the principal at every boundary.
   """
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Subject.t()
 
   @typedoc """
   Bulk envelope shape: nested `%{network_slug => %{channel => message_id}}`.
@@ -131,7 +145,7 @@ defmodule Grappa.ReadCursor do
     channel = Identifier.canonical_target(channel)
 
     Cursor
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([c], c.network_id == ^network_id and c.channel == ^channel)
     |> Repo.one()
   end
@@ -209,7 +223,7 @@ defmodule Grappa.ReadCursor do
       )
 
     base
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> Repo.all()
     |> Enum.reduce(%{}, fn {slug, channel, id}, acc ->
       Map.update(acc, slug, %{channel => id}, &Map.put(&1, channel, id))
@@ -346,7 +360,7 @@ defmodule Grappa.ReadCursor do
       )
 
     query
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> Repo.all()
     |> Enum.reduce(%{}, fn {slug, channel, bucket, n}, acc ->
       key = if bucket == 1, do: :messages, else: :events
@@ -408,12 +422,12 @@ defmodule Grappa.ReadCursor do
       )
 
     # Scope the DRIVING `read_cursors` to the subject via the shared
-    # `subject_filter/2` (binding 0 == `rc`), identical to
+    # `Subject.subject_where/2` (binding 0 == `rc`), identical to
     # `bulk_unread_split/3` + `bulk_for_subject/1` — one way to express
     # "these cursors are mine". `subject_pair/1` is still needed for the
     # `on:`-clause match on `messages` (a join-side filter belongs in `on:`,
     # not `where`, so the JOIN keeps its driving row).
-    scoped = subject_filter(ranked, subject)
+    scoped = Subject.subject_where(ranked, subject)
 
     capped =
       from(r in subquery(scoped),
@@ -662,7 +676,7 @@ defmodule Grappa.ReadCursor do
     else
       old_query =
         Cursor
-        |> subject_filter(subject)
+        |> Subject.subject_where(subject)
         |> where(
           [c],
           c.network_id == ^network_id and Identifier.nick_fold(c.channel) == ^folded_old
@@ -701,7 +715,7 @@ defmodule Grappa.ReadCursor do
   @spec cursor_folds_to?(subject(), integer(), String.t()) :: boolean()
   defp cursor_folds_to?(subject, network_id, folded) do
     Cursor
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([c], c.network_id == ^network_id and Identifier.nick_fold(c.channel) == ^folded)
     |> Repo.exists?()
   end
@@ -776,11 +790,14 @@ defmodule Grappa.ReadCursor do
 
   defp upsert_cursor(nil, subject, network_id, channel, message_id) do
     attrs =
-      Map.merge(subject_attrs(subject), %{
-        network_id: network_id,
-        channel: channel,
-        last_read_message_id: message_id
-      })
+      Subject.put_subject_id(
+        %{
+          network_id: network_id,
+          channel: channel,
+          last_read_message_id: message_id
+        },
+        subject
+      )
 
     %Cursor{}
     |> Cursor.changeset(attrs)
@@ -808,27 +825,10 @@ defmodule Grappa.ReadCursor do
     # narrowing is a read-time concern (scrollback display), not a
     # write-time concern (cursor validity).
     Message
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.id == ^message_id and m.network_id == ^network_id)
     |> Grappa.Scrollback.channel_or_dm_where(channel, nil)
     |> Repo.exists?()
   end
 
-  # Mirrors `Grappa.Scrollback.subject_where/2` — same tagged-tuple
-  # discriminator, same `m.user_id` / `m.visitor_id` partition. Reused
-  # across `Cursor` queries (binding name `c`) and `Message` existence
-  # queries (binding name `m`); Ecto's binding-by-position lookup
-  # works on both since each query has a single from-binding.
-  @spec subject_filter(Ecto.Queryable.t(), subject()) :: Ecto.Query.t()
-  defp subject_filter(queryable, {:user, user_id}) when is_binary(user_id) do
-    where(queryable, [row], row.user_id == ^user_id)
-  end
-
-  defp subject_filter(queryable, {:visitor, visitor_id}) when is_binary(visitor_id) do
-    where(queryable, [row], row.visitor_id == ^visitor_id)
-  end
-
-  @spec subject_attrs(subject()) :: %{atom() => Ecto.UUID.t()}
-  defp subject_attrs({:user, user_id}), do: %{user_id: user_id}
-  defp subject_attrs({:visitor, visitor_id}), do: %{visitor_id: visitor_id}
 end

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -96,8 +96,8 @@ defmodule Grappa.ReadCursor do
   alias Grappa.Networks.Network
   alias Grappa.PubSub.Topic
   alias Grappa.ReadCursor.{Cursor, Wire}
-  alias Grappa.Scrollback.Message
   alias Grappa.{Repo, Subject}
+  alias Grappa.Scrollback.Message
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -50,10 +50,9 @@ defmodule Grappa.Scrollback do
   import Ecto.Query
 
   alias Grappa.IRC.Identifier
-  alias Grappa.Repo
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
-  alias Grappa.Subject
+  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,7 +33,7 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Visitors.Visitor],
+    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # `Networks.Network` is referenced by `Scrollback.Message` (the
     # `belongs_to :network` association) and `Scrollback.Wire` (the
     # `%Network{slug: _}` pattern that A1+A26 made the wire-shape
@@ -53,6 +53,7 @@ defmodule Grappa.Scrollback do
   alias Grappa.Repo
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
+  alias Grappa.Subject
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier
@@ -334,7 +335,7 @@ defmodule Grappa.Scrollback do
   defp nick_shaped?("$server"), do: false
   defp nick_shaped?(name) when is_binary(name), do: target_kind(name) == :query
 
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Subject.t()
 
   @doc """
   Fetches up to `limit` messages for `(subject, network_id, channel)`,
@@ -421,7 +422,7 @@ defmodule Grappa.Scrollback do
     capped = min(limit, @max_limit)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -499,7 +500,7 @@ defmodule Grappa.Scrollback do
     capped = min(limit, @max_limit)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -565,7 +566,7 @@ defmodule Grappa.Scrollback do
       when is_integer(network_id) and is_integer(after_id) and
              (is_binary(own_nick) or is_nil(own_nick)) and is_boolean(hide_presence) do
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -643,7 +644,7 @@ defmodule Grappa.Scrollback do
 
     query =
       Message
-      |> subject_where(subject)
+      |> Subject.subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
       |> maybe_exclude_presence(hide_presence)
@@ -783,7 +784,7 @@ defmodule Grappa.Scrollback do
              (is_binary(own_nick) or is_nil(own_nick)) and
              is_integer(limit) and limit > 0 do
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> where([m], m.id > ^after_id)
@@ -851,7 +852,7 @@ defmodule Grappa.Scrollback do
 
     base =
       Message
-      |> subject_where(subject)
+      |> Subject.subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
       |> maybe_exclude_presence(hide_presence)
@@ -939,7 +940,7 @@ defmodule Grappa.Scrollback do
     folded_active = MapSet.new(active_keyset, &Identifier.canonical_target/1)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> group_by([m], Identifier.nick_fold(fragment("COALESCE(?, ?)", m.dm_with, m.channel)))
     |> select([m], %{
@@ -1132,22 +1133,6 @@ defmodule Grappa.Scrollback do
     )
   end
 
-  defp subject_where(query, {:user, user_id}) when is_binary(user_id),
-    do: where(query, [m], m.user_id == ^user_id)
-
-  defp subject_where(query, {:visitor, visitor_id}) when is_binary(visitor_id),
-    do: where(query, [m], m.visitor_id == ^visitor_id)
-
-  # B5.4 L-pers-2: explicit fall-through replaces an implicit
-  # FunctionClauseError (Erlang-level message hides both the
-  # offending value and the function name). ArgumentError carries
-  # the inspected subject so caller bugs (typo `:users` for `:user`,
-  # `nil` from a stale ref, leftover atom from a refactor) surface
-  # with actionable diagnostics. Same fail-loud behaviour, better
-  # post-mortem.
-  defp subject_where(_, other),
-    do: raise(ArgumentError, "unknown subject: #{inspect(other)}")
-
   defp maybe_before(query, nil), do: query
 
   # Cursor key is monotonic id post-CP29 R-2 — was server_time, but
@@ -1225,7 +1210,7 @@ defmodule Grappa.Scrollback do
     case BusyRetry.run(fn ->
            {:ok,
             Message
-            |> subject_where(subject)
+            |> Subject.subject_where(subject)
             |> where([m], m.network_id == ^network_id)
             |> where_dm_peer(folded_peer)
             |> Repo.delete_all()}
@@ -1278,7 +1263,7 @@ defmodule Grappa.Scrollback do
     else
       base =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
 
       # DISTINCT migrated-row count via the shared DM-peer predicate — the
@@ -1400,7 +1385,7 @@ defmodule Grappa.Scrollback do
     else
       {count, _} =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
         |> where(
           [m],
@@ -1510,7 +1495,7 @@ defmodule Grappa.Scrollback do
     else
       {count, _} =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
         |> where(
           [m],
@@ -1565,7 +1550,7 @@ defmodule Grappa.Scrollback do
     case BusyRetry.run(fn ->
            {:ok,
             Message
-            |> subject_where(subject)
+            |> Subject.subject_where(subject)
             |> where([m], m.network_id == ^network_id)
             |> where([m], m.channel == ^canonical)
             |> Repo.delete_all()}

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -50,9 +50,9 @@ defmodule Grappa.Scrollback do
   import Ecto.Query
 
   alias Grappa.IRC.Identifier
+  alias Grappa.{Repo, Subject}
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
-  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -117,7 +117,7 @@ defmodule Grappa.Session do
   `(visitor, network_id)` for the same `network_id` and even the
   same UUID never collide.
   """
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Grappa.Subject.t()
 
   @typedoc """
   #1088 — the connection an informational reply is addressed to: the

--- a/lib/grappa/subject.ex
+++ b/lib/grappa/subject.ex
@@ -73,18 +73,27 @@ defmodule Grappa.Subject do
     do: Map.put(attrs, :visitor_id, vid)
 
   @doc """
-  Adds a `WHERE user_id = ? AND visitor_id IS NULL`-shaped clause
-  (or its visitor mirror) to `queryable`.
+  Adds a `WHERE user_id = ?` clause (or its visitor mirror) to
+  `queryable`.
 
-  Mirror of the per-context private `subject_where/2` helpers in
-  `Grappa.Scrollback` and `Grappa.ReadCursor` — promoted to the
-  shared boundary so new contexts (V1: query_windows, push,
-  user_settings) don't each grow their own copy.
+  Only the one equality — NOT the `AND visitor_id IS NULL` this
+  docstring used to promise, which no spelling of the helper has ever
+  emitted. The second conjunct is redundant under the DB-level XOR
+  CHECK, so the omission is correct; the sentence was not, and it is
+  the sentence a reader reaches for when reasoning about subject
+  isolation (#1392).
 
-  Uses positional binding `[row]` — the queryable must have a
-  single from-binding (the common case for context-internal
-  filters). Multi-join callers should write the where-clause
-  directly.
+  The only spelling of this predicate. `Grappa.Scrollback` and
+  `Grappa.ReadCursor` kept private synonyms until #1392 folded them
+  here, which is what the V1 promotion had claimed since it landed.
+
+  Uses positional binding `[row]`, so the precondition is that
+  **binding 0 carries the subject FK** — not that the query has a
+  single from-binding, as this docstring used to say.
+  `ReadCursor.bulk_for_subject/1` joins `networks` and has always been
+  a correct caller: the join is at position 1, the cursor at 0. A
+  caller whose subject-scoped table is NOT the from-binding must write
+  the where-clause directly.
   """
   @spec subject_where(Ecto.Queryable.t(), t()) :: Ecto.Query.t()
   def subject_where(queryable, {:user, user_id}) when is_binary(user_id),
@@ -92,6 +101,26 @@ defmodule Grappa.Subject do
 
   def subject_where(queryable, {:visitor, visitor_id}) when is_binary(visitor_id),
     do: where(queryable, [row], row.visitor_id == ^visitor_id)
+
+  # B5.4 L-pers-2, promoted from `Grappa.Scrollback` by #1392: explicit
+  # fall-through replaces an implicit FunctionClauseError (Erlang-level
+  # message hides both the offending value and the function name).
+  # ArgumentError carries the inspected subject so caller bugs (typo
+  # `:users` for `:user`, `nil` from a stale ref, leftover atom from a
+  # refactor) surface with actionable diagnostics.
+  #
+  # This clause is why the fold is not a deletion. Retiring the two
+  # private spellings without it would have stripped the diagnostic
+  # from Scrollback's 12 call sites; carrying it along instead moves
+  # the other 26 UP to it, which is a behaviour change in the fail-loud
+  # direction and is named as one.
+  #
+  # `put_subject_id/2` deliberately keeps the bare FunctionClauseError:
+  # giving it this clause too is a second behaviour change across its
+  # own call sites that nothing has asked for, and a hard failure on a
+  # malformed shape is already the right answer.
+  def subject_where(_, other),
+    do: raise(ArgumentError, "unknown subject: #{inspect(other)}")
 
   @doc """
   Resolves the bare-id subject from `Plug.Conn.assigns`.

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -113,6 +113,30 @@ defmodule Grappa.ReadCursorTest do
     end
   end
 
+  # #1392 — `ReadCursor` kept a private `subject_filter/2`, the third
+  # spelling of one predicate. Its two clauses were exact synonyms of
+  # `Grappa.Subject.subject_where/2` on the whole valid domain; they
+  # differed only OFF it, where this module fell through to a
+  # `FunctionClauseError` while `Grappa.Scrollback` raised an
+  # `ArgumentError` naming the value. Folding the spelling away carries
+  # the better diagnostic here too, so these pin a real behaviour
+  # change, not the fold's transparency.
+  describe "malformed subject — fail-loud (#1392)" do
+    test "get/3 raises ArgumentError naming the subject" do
+      net = network_fixture()
+
+      assert_raise ArgumentError, ~r/unknown subject: \{:typo, "x"\}/, fn ->
+        ReadCursor.get({:typo, "x"}, net.id, "#sniffo")
+      end
+    end
+
+    test "bulk_for_subject/1 raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: nil/, fn ->
+        ReadCursor.bulk_for_subject(nil)
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # DM-window nick fold — one window ⇒ one cursor row (#532 D)
   # ---------------------------------------------------------------------------

--- a/test/grappa/subject_test.exs
+++ b/test/grappa/subject_test.exs
@@ -1,6 +1,7 @@
 defmodule Grappa.SubjectTest do
   @moduledoc """
-  Tests for the subject-label codec (#413).
+  Tests for the subject-label codec (#413) and the fail-loud posture of
+  `subject_where/2` (#1392).
 
   `label/1` + `from_label/1` are the single source of truth for the
   user-rooted topic-label encoding — `user.name` for users,
@@ -9,10 +10,17 @@ defmodule Grappa.SubjectTest do
   silent dead-drop on drift: a subject that no longer round-trips
   does not raise, it just stops matching, far from the cause. The
   property test is exactly the shape an encode/decode pair calls for.
+
+  `subject_where/2`'s happy path is not restated here: it is exercised
+  by the 38 call sites across nine contexts, whose own context tests
+  run real queries and would go red on a swapped FK column. What those
+  call sites do NOT pin is the off-domain clause, which is the one
+  `Grappa.Scrollback` used to own alone.
   """
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  alias Grappa.ReadCursor.Cursor
   alias Grappa.Subject
 
   describe "label/1" do
@@ -45,6 +53,39 @@ defmodule Grappa.SubjectTest do
     property "visitor ids survive label |> from_label" do
       check all(id <- visitor_id()) do
         assert Subject.from_label(Subject.label({:visitor, id})) == {:visitor, id}
+      end
+    end
+  end
+
+  # #1392 — the fall-through promoted here from
+  # `Grappa.Scrollback.subject_where/2` (added by B5.4 L-pers-2). It is
+  # the ONE clause the three former spellings disagreed on: `Scrollback`
+  # raised `ArgumentError` naming the offending value, `Grappa.Subject`
+  # and `Grappa.ReadCursor` fell through to a `FunctionClauseError`
+  # whose Erlang-level message hides both the value and the function.
+  # Folding the two privates into this module without the fall-through
+  # would have been a diagnostic regression at 12 call sites, so the
+  # clause travels WITH the function.
+  #
+  # These assert the inspected value is IN the message, not merely that
+  # something raised: naming the subject is the entire reason the clause
+  # exists over a bare pattern-match failure.
+  describe "subject_where/2 — fail-loud off the valid domain (#1392)" do
+    test "an unknown discriminator raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: \{:typo, "x"\}/, fn ->
+        Subject.subject_where(Cursor, {:typo, "x"})
+      end
+    end
+
+    test "a nil subject raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: nil/, fn ->
+        Subject.subject_where(Cursor, nil)
+      end
+    end
+
+    test "a well-tagged subject with a non-binary id raises ArgumentError naming it" do
+      assert_raise ArgumentError, ~r/unknown subject: \{:user, nil\}/, fn ->
+        Subject.subject_where(Cursor, {:user, nil})
       end
     end
   end


### PR DESCRIPTION
Bucket C subject-SSOT of the 2026-08-15 architecture review. Issue #1392.

`Grappa.Subject` has claimed to be the single source of truth for the
`{:user, uuid} | {:visitor, uuid}` discriminator since the V1 visitor-parity
promotion, and its docstring named `Grappa.Scrollback` and `Grappa.ReadCursor`
as the contexts it was promoted out of. Neither referenced `Grappa.Subject` at
all. This finishes the promotion.

## What changed

- `Scrollback.subject_where/2` (private, 12 call sites) and
  `ReadCursor.subject_filter/2` (private, 7) deleted; both now call
  `Subject.subject_where/2`.
- `ReadCursor.subject_attrs/1` (1 call site) folded into
  `Subject.put_subject_id/2`.
- Scrollback's `ArgumentError` fall-through promoted INTO `Grappa.Subject`,
  because the fold could not be a deletion — see below.
- Three of the four verbatim `@type` clones collapse to `Subject.t()`
  (`scrollback.ex`, `read_cursor.ex`, `session.ex`).
- Two false docstring sentences corrected.

## This is a behaviour change, and the issue's "no behaviour change" is retired

The predicate never diverged: all three spellings emitted the same equality
against the same FK column under the same `is_binary/1` guards, and all three
bound POSITIONALLY at index 0 (`[m]` in one, `[row]` in the other two). That is
what makes the 19 replacements a substitution rather than a rewrite — no call
site's query shape can change the result.

The DIAGNOSTIC diverged. Scrollback carried an explicit fall-through raising
`ArgumentError` with the inspected subject (B5.4 L-pers-2), precisely because a
`FunctionClauseError` hides both the offending value and the function name. The
other two had none. Deleting the privates would have stripped that from 12 call
sites, so the clause travels WITH the function — which moves 19 existing
`Subject.subject_where/2` call sites and the 7 former `subject_filter/2` ones
from `FunctionClauseError` to `ArgumentError`.

Nothing in `test/` asserted `FunctionClauseError` on these functions, and the
two pins that already existed in `scrollback_test.exs` pass **untouched** —
measured, not predicted. That is the evidence the fold is transparent at the
Scrollback boundary.

`put_subject_id/2` deliberately keeps its bare `FunctionClauseError`: giving it
the same clause is a second behaviour change across its own call sites that
nothing here asks for.

## Two figures in the issue do not reproduce at this base

- `subject_filter/2` has **7** call sites, not 8. All twelve occurrences of the
  token classified: 7 calls, 2 clauses, 1 `@spec`, 2 in prose.
- "Seven modules re-declare the type literal" merges three different types.
  Only **four** are verbatim clones. `revocations.ex` and `request_budget.ex`
  spell the id as `String.t()`, strictly WIDER than `Ecto.UUID.t()`;
  substituting `Subject.t()` there narrows rather than deduplicates.
  `themes.ex` is the rich-struct shape the issue excluded `account_deletion.ex`
  for, but did not name.

## Deliberately left out

- `accounts.ex:103`, the fourth clone. `Grappa.Accounts` is a DEP of
  `Grappa.Subject`, so referencing `Subject.t()` from inside it would close
  `Subject -> Accounts -> Subject` **if** Boundary tracks remote type
  references. That is not established — the repo has no discriminating case —
  and the declaration is worth two spec sites.
- The two wider `String.t()` spellings and the rich-struct clones, per above.
  `request_budget.ex`'s own typedoc justifies staying local to avoid a
  `Grappa.Session` dep, which is stale (the type lives in `Grappa.Subject`);
  noted in DESIGN_NOTES, not acted on.

## The write-side asymmetry is real and unreachable

`subject_attrs/1` had no guard, so `{:user, nil}` returned `%{user_id: nil}`
where every sibling raises. Traced: both paths into `upsert_cursor/5` call
`get/3` first, and both public entries also pass `message_belongs?/4`, all
subject-guarded — a malformed subject raises before `subject_attrs/1` is
reached. So the fold is deduplication, not a fix, and no boundary test was
fabricated for a path that does not exist.

## Gates — run, with numbers

Measured at `b10bb29d`, rebased onto `60657249`.

- `WRITABLE_CIC=1 scripts/check.sh` — **RC=0**: 8 doctests, 61 properties,
  **6461 tests, 0 failures**; Dialyzer `Total errors: 0`; Credo `found no
  issues`; `deps.audit` `No vulnerabilities found`; Sobelow clean; bats
  **540 ok / 0 not ok**. Includes the `grappa.gen_wire_types --check` drift
  gate.
- `scripts/design-notes-gate.sh origin/main` — **RC=0**, `1 new entry
  heading(s), separator and marker present`. (A first run passed VACUOUSLY —
  `nothing to check` — because the entry was written but not yet committed;
  the gate compares committed branch state. The second run is the one that
  counts.)
- Rebase verification: `git diff --numstat` pinned to a file before and
  re-compared after — additions unchanged AND deletions unchanged. Boundary
  shape read on the file for BOTH this entry and its neighbour `#1302`, since
  `merge=union` can damage the neighbour rather than you.

### TDD, bought with mutants

The five new tests were committed failing first: all five got
`FunctionClauseError` where `ArgumentError` was expected, naming
`Grappa.Subject.subject_where/2` (3) and `Grappa.ReadCursor.subject_filter/2`
(2).

- **M1** — `"unknown subject: #{inspect(other)}"` -> a static string: kills
  **only** the 5 new assertions. The two `scrollback_test.exs` pins survive,
  because they match the prefix while these match the inspected value.
- **M2** — catch-all clause deleted: kills **7**, the 5 new plus both existing
  Scrollback pins. This is the "the promotion is load-bearing" mutant.
- A third mutant (restoring `ReadCursor`'s private) was not run: that is
  exactly the pre-implementation state, and the initial red already measured
  it.

## Gates NOT run, with the reason

- **cic (`bun run check`, `tsc`)** — this branch adds **zero** `cicchetto/`
  lines (`git diff --name-only origin/main...HEAD | grep -c '^cicchetto/'` ->
  0), and the wire drift gate inside `check.sh` is green, so the wire has not
  moved. Running it would measure `main`, not this branch.
- **`scripts/integration.sh` and e2e** — not run. This is a core-context
  refactor with no wire, controller, or client surface; the full suites are the
  ship gate and belong to whoever merges.
- **`mix boundary.find_violations` standalone** — not run separately. Boundary
  is a compiler (`compilers: [:boundary]` in `mix.exs`) with
  `check: [in: true, out: true]`, so the two new deps were enforced by the
  clean compile inside `check.sh`. The no-cycle argument was also derived by
  hand: the transitive closure of `Grappa.Subject` is 10 modules and contains
  neither `Scrollback` nor `ReadCursor`.