### PR TITLE
e2e(#1336): make the cursor spec's gestures prove they landed

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1386,7 +1386,7 @@ export async function inlineNickColorVar(locator: Locator): Promise<string> {
   return match[0];
 }
 
-// #1336 — page the scrollback UP with a wheel gesture that has demonstrably
+// #1336 — move the scrollback with a wheel gesture that has demonstrably
 // LANDED before the caller moves on.
 //
 // `page.mouse.wheel()` resolves before the scroll is applied (measured: the
@@ -1397,23 +1397,32 @@ export async function inlineNickColorVar(locator: Locator): Promise<string> {
 // testnet) owns the hover → wheel → moved-and-held wait and REJECTS both a
 // gesture that never landed and one still in flight.
 //
-// `pixels` is the distance to travel UP, positive; the DOM's negative-is-up
-// sign convention is applied here so callers read as the operator's intent.
+// `deltaY` carries the DOM's own sign convention: NEGATIVE scrolls up.
 // Sampling every 50 ms: two agreeing samples then mean the pane has held
 // still for 50 ms, which chromium's wheel animation (hundreds of ms of
 // continuous travel, measured) does not do mid-flight.
-export async function pageScrollbackUp(
+export async function pageScrollbackBy(
   page: Page,
-  pixels: number,
+  deltaY: number,
   timeoutMs: number,
 ): Promise<ScrollGestureResult> {
   const pane = page.locator('[data-testid="scrollback"]');
   return await scrollByGesture(
     {
       hover: () => pane.hover(),
-      wheel: async (deltaY: number) => await page.mouse.wheel(0, deltaY),
+      wheel: async (delta: number) => await page.mouse.wheel(0, delta),
       scrollTop: () => pane.evaluate((el) => el.scrollTop),
     },
-    { deltaY: -pixels, timeoutMs, pollMs: 50 },
+    { deltaY, timeoutMs, pollMs: 50 },
   );
+}
+
+// `pixels` is the distance to travel UP, positive, so the call site reads as
+// the operator's intent rather than as a DOM sign.
+export async function pageScrollbackUp(
+  page: Page,
+  pixels: number,
+  timeoutMs: number,
+): Promise<ScrollGestureResult> {
+  return await pageScrollbackBy(page, -pixels, timeoutMs);
 }

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -35,7 +35,12 @@
 // a fully-read channel.
 
 import type { Page } from "@playwright/test";
-import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  pageScrollbackBy,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -129,14 +134,23 @@ async function visibleRowIds(page: Page): Promise<number[]> {
   });
 }
 
+// #1336 — every gesture in this file goes through the shared door, which
+// waits for the pane to MOVE and then HOLD and REJECTS when it did neither.
+//
+// Measured before the conversion, on a quiet host: delete the gesture below
+// outright and FOUR of the six tests stay green (`--grep "forward-only
+// contract"`, 4 passed / 2 failed). Only the two strict-inequality assertions
+// notice, and even they blame the product — the red reads
+// `expect(701).toBeLessThan(701)`, never "the wheel was not delivered". The
+// budget is a condition-wait ceiling, not a sleep: it resolves the instant the
+// pane settles.
+const GESTURE_TIMEOUT_MS = 5_000;
+
 async function scrollByPx(page: Page, deltaY: number): Promise<void> {
   // BUGHUNT-2: real WheelEvent so the input-event gate in
   // ScrollbackPane's onScroll passes. Synthetic dispatchEvent(scroll)
   // was gated out post-BUGHUNT-2.
-  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
-  if (!box) throw new Error("scrollback bounding box null");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.wheel(0, deltaY);
+  await pageScrollbackBy(page, deltaY, GESTURE_TIMEOUT_MS);
 }
 
 async function scrollToBottom(page: Page): Promise<void> {
@@ -147,10 +161,11 @@ async function scrollToBottom(page: Page): Promise<void> {
   // ALSO advances the cursor, but via a DIFFERENT path — a direct
   // reached-bottom advance in `scrollToBottomGesture`, not the settle — so
   // the wheel is what pins the settle contract these tests assert.)
-  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
-  if (!box) throw new Error("scrollback bounding box null");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.wheel(0, 5000);
+  //
+  // #1336: this one was watched by NOBODY — deleting it left all six tests
+  // green. Through the shared door a wheel that moves nothing is a named
+  // failure instead of a silent pass.
+  await pageScrollbackBy(page, 5000, GESTURE_TIMEOUT_MS);
 }
 
 async function focusChannelAndWaitForRows(page: Page): Promise<void> {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45645,3 +45645,54 @@ GENERATED artefact looks like someone else's red precisely because no hand
 edited it.** The cheap discriminator that would have caught it in one step:
 biome names the failing file, and `src/lib/wireTypes.ts` was in this
 branch's diff.
+<!-- entry #1336 -->
+
+---
+
+## 2026-08-17 — #1336: a gesture nobody watched, and the two ways to be green about one
+
+`cursor-forward-only.spec.ts` drove nine wheel gestures through two
+hand-rolled `mouse.move` + `mouse.wheel` helpers. Every caller then slept a
+fixed `SETTLE_WAIT_MS` — 500 ms of product debounce plus 500 ms of slack —
+and read the cursor ONCE, with no assertion that retries. `page.mouse.wheel()`
+resolves before the scroll is applied (~250 ms, measured on #1080), so half
+that slack was already owed to a dispatch nobody waited for.
+
+Measured BEFORE touching it, deleting one gesture at a time, chromium,
+`--grep "forward-only contract"`, on a host whose #1429 census was clean
+(`db30=0`, `gaps_ge_10=0` on every service):
+
+| mutant | kills | what survived, and why |
+|---|---|---|
+| `scrollByPx` deleted | 2 of 6 | only the two STRICT inequalities notice. The equality test, the no-retreat test and the audit-"strengthened" disjunction all accept "nothing moved" |
+| `scrollToBottom` deleted | 0 of 6 | nobody was watching it at all |
+
+The sharpest of those: *"scroll back to bottom advances cursor to tail"*
+passes with the scroll-back-to-bottom removed, because the cursor is
+forward-only and the preceding scroll-up cannot retreat it off the tail it
+is already sitting on. **The contract under test is what makes its own
+verification vacuous** — not load, not timing.
+
+Both helpers now go through `pageScrollbackBy`, the signed sibling of
+#1080's `pageScrollbackUp` over the same unit-tested `scrollGesture` core,
+which waits for the pane to MOVE and then HOLD and rejects when it did
+neither. The attribution is one displacement — remove the hover, so the
+wheel is dispatched away from the pane — run on both sides of the change:
+
+| | reds | what the red says |
+|---|---|---|
+| before | 2 of 6 | `expect(701).toBeLessThan(701)` — it accuses the product |
+| after | 6 of 6 | `never moved the pane (scrollTop stayed 4029)` — it accuses the gesture, by name |
+
+Converted spec green at 6/6 in 29.1 s, against 32.4 s for the baseline: a
+condition-wait that resolves on arrival costs nothing when the gesture lands.
+
+**What this does NOT do, stated because the epic exists to refuse exactly
+this kind of overclaim.** It does not repair those four assertions: the
+disjunction still accepts "nothing moved", and `scrollToBottom`'s effect is
+still asserted by no one. It closes one of the two holes — being green about
+a gesture that never happened — and leaves the other open. And a prediction
+of mine died here: I expected the converted `scrollToBottom` to REJECT as
+"already clamped" and thereby prove itself a no-op. It did not reject. The
+pane does move; the gesture is real and merely unobserved, which is a
+narrower and different claim than the one I set out to make.


### PR DESCRIPTION
Slice of #1336 (*the e2e suite's own instruments are not deterministic*),
sub-shape 1: **a gate satisfied by the pre-existing state is not a gate.**

`cursor-forward-only.spec.ts` drove nine wheel gestures through two
hand-rolled `mouse.move` + `mouse.wheel` helpers, each caller then sleeping a
fixed `SETTLE_WAIT_MS` (500 ms of product debounce + 500 ms of slack) and
reading the cursor ONCE, with no assertion that retries. `page.mouse.wheel()`
resolves before the scroll is applied — ~250 ms, measured on #1080 — so half
that slack was already owed to a dispatch nobody waited for.

## What was measured, and against which base

Everything below ran on this branch, chromium, `--grep "forward-only
contract"`, 6 tests, and was **re-verified after the rebase onto
`f3c37191`**. Every run's #1429 log census was clean on all 12 services
(`db30=0`, `idle30=0`, `dropped=0`, `saturated=0`); the only non-zero signal
is a build gap on the `cicchetto-build-test` oneshot, which is a build and
not a service stall.

**Before touching anything — delete one gesture at a time:**

| mutant | kills | what survived |
|---|---|---|
| `scrollByPx` deleted outright | **2 of 6** | only the two STRICT inequalities notice |
| `scrollToBottom` deleted outright | **0 of 6** | nobody was watching it |

The three survivors of the first mutant are an equality assertion, a
no-retreat assertion, and the audit-"strengthened" disjunction
`inVisibleBand || stayedAtOrBelowPrior` — all three accept "nothing moved".
And *"scroll back to bottom advances cursor to tail"* passes with the
scroll-back-to-bottom deleted, because the cursor is forward-only and the
preceding scroll-up cannot retreat it off the tail it already occupies: the
contract under test is what makes its own verification vacuous.

**The attribution — one displacement (remove the hover, so the wheel is
dispatched away from the pane), run on both sides of the change:**

| | reds | what the red says |
|---|---|---|
| before | **2 of 6** | `expect(701).toBeLessThan(701)` — accuses the product |
| after | **6 of 6** | `never moved the pane (scrollTop stayed 4029)` — accuses the gesture, by name |

**Gates:** converted spec **6/6 green in 29.1 s** (baseline was 32.4 s — a
condition-wait that resolves on arrival costs nothing when the gesture
lands). `scripts/bun.sh run check` **RC=0, 59 warnings + 6 infos**, re-run
after the rebase and identical to main's baseline.
`scripts/design-notes-gate.sh` **RC=0**, also re-run after the rebase.

## What this does NOT do

- It does **not** repair those four assertions. The disjunction still accepts
  "nothing moved", and `scrollToBottom`'s effect is still asserted by no one.
  One of the two holes is closed — being green about a gesture that never
  happened — and the other is left open, named rather than papered over.
- A prediction of mine died here: I expected the converted `scrollToBottom`
  to reject as "already clamped" and thereby prove itself a no-op. It did
  not reject. The pane does move; the gesture is **real and merely
  unobserved**, which is a narrower claim than the one I set out to make.
- No claim that this fixes a CI red. The natural failure was never
  reproduced, and the full `scripts/integration.sh` has not been run on this
  branch — the scoped `--grep` above is an iso-rerun, not a ship gate.
- The five other spec files still driving a bare `mouse.wheel` are untouched.
  One of them, `issue230-wheel-underfill-loadmore`, is not named in any
  report filed under the epic.