### PR TITLE
persistence(#1420): measure the write-lock holder, not only its victims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Top-level supervision tree:
 ```
 Grappa.Application
 ├── Grappa.Vault                       (Cloak — encrypts at-rest creds; before Repo)
+├── Grappa.Repo.LockWatch              (#1420 write-lock holder/waiter observer; before Repo — owns the ETS table the BEGIN IMMEDIATE seam writes to)
 ├── Grappa.Repo                        (Ecto + sqlite)
 ├── Phoenix.PubSub                     (name: Grappa.PubSub)
 ├── Registry                           (name: Grappa.SessionRegistry)
@@ -52,6 +53,9 @@ Grappa.Application
 
 Child order is load-bearing — see `lib/grappa/application.ex` for the
 why-comment per child. Vault before Repo (Cloak schema callbacks);
+LockWatch before Repo (#1420: it owns the ETS table
+`Repo.immediate_transaction/1` writes on every write transaction, and the
+seam self-disables while the table is absent);
 Backoff/WSPresence/NetworkCircuit before SessionSupervisor (ETS
 tables read directly from `Session.Server`'s start path); Bootstrap
 LAST (depends on Registry + SessionSupervisor existing). `Grappa.SpawnOrchestrator`

--- a/config/config.exs
+++ b/config/config.exs
@@ -121,6 +121,26 @@ config :grappa, :session, connection_stable_ms: 60_000
 #   * backoff_ms — base per-attempt linear backoff (× attempt).
 #   * backoff_cap_ms — ceiling per sleep so late attempts don't stretch a
 #     single wait past a fifth of a second.
+# #1420 — the write-lock holder/waiter observer (`Grappa.Repo.LockWatch`).
+# Every DB signal that predates it is completion-driven and therefore measures
+# the VICTIM: Ecto's per-query event fires when a query FINISHES, so a process
+# holding `RESERVED` while it sits idle emits nothing, and only the 30.1s
+# `busy_timeout` of everybody queued behind it reaches the log. This observer
+# takes the reading at the `BEGIN IMMEDIATE` seam instead, which separates the
+# HOLDER from the WAITERS, and samples the holder's live stack when it stalls.
+#
+#   * enabled — arms both the watchdog timer and the write-path seam. OFF
+#     costs one :persistent_term read per write transaction and nothing more.
+#   * stall_threshold_ms — how long a holder must hold, WITH a queue behind
+#     it, before it is reported. Well under the 30_000 busy_timeout so the
+#     report lands while the stall is happening, not after the victims have
+#     already timed out.
+#   * tick_ms — watchdog scan cadence.
+config :grappa, :lock_watch,
+  enabled: true,
+  stall_threshold_ms: 2_000,
+  tick_ms: 1_000
+
 config :grappa, :busy_retry,
   budget_ms: 1_500,
   backoff_ms: 25,

--- a/config/config.exs
+++ b/config/config.exs
@@ -403,6 +403,12 @@ config :logger, :console,
     # key the operator cannot tell a NickServ IDENTIFY that never went out
     # from a lost CTCP reply, which are not the same incident.
     :origin,
+    # #1420 — LockWatch tags how long the write-lock holder has held and how
+    # many writers are queued behind it. Without these two keys the backend
+    # drops the structured half of a stall report, leaving only the prose —
+    # and the log line IS the door that reaches CI container logs.
+    :held_ms,
+    :waiters,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/config/test.exs
+++ b/config/test.exs
@@ -157,6 +157,17 @@ config :grappa, :attach_session_log_telemetry, false
 # would make snapshot assertions flaky. Aggregation tests attach the
 # handler explicitly + drain via `reset/0` (test/grappa/db_latency_test.exs).
 config :grappa, :attach_db_latency_telemetry, false
+# #1420 — LockWatch DISARMED in test env. The suite runs pool_size: 1 under
+# the Sandbox, where every write transaction shares one connection: each of
+# them would register as a holder, and any test slow enough to cross the
+# threshold would emit a warning into whatever test is capturing the Logger
+# stream. `lock_watch_test.exs` arms it explicitly (put_test_enabled/1) and
+# disarms on_exit. The table is still created, so arming needs no restart.
+config :grappa, :lock_watch,
+  enabled: false,
+  stall_threshold_ms: 2_000,
+  tick_ms: 1_000
+
 # #1321 — VendorLog singleton attach OFF in test env. The handler only
 # logs, so a global attach would write a push rejection into whatever
 # test happens to be capturing the Logger stream. Its own tests attach

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45717,3 +45717,64 @@ test; that witness had to withhold the 001 welcome, because the shared
 fixture's welcome runs `run_perform_and_identify/1`, whose own capture site
 re-stages the same secret and would have left the witness green with the
 sniff removed from the door.
+<!-- entry #1420 -->
+
+---
+
+## 2026-08-17 — #1420: the write-lock observer, and why every earlier DB signal measured the victim
+
+Six CI runs stalled for exactly 30.1 s each — `busy_timeout: 30_000`, never
+12 s, never 47 s — and the census could name the victims every time and the
+cause not once. That asymmetry is not bad luck, it is a property of the
+instruments we had.
+
+**Every DB signal grappa emitted before this was completion-driven.** Ecto's
+`[:grappa, :repo, :query]` fires when a query FINISHES, so a process that
+opens `BEGIN IMMEDIATE` and then sits still emits nothing at all while it
+sits; the only rows reaching the log are the 30-second `begin`s and
+`SELECT`s of everybody queued behind it. `BusyRetry`'s `:on_contention` hook
+lives inside a `rescue`, so by construction it counts whoever caught the
+exception. The #1429 census greps container logs after the fact and sees the
+silence, not its author. Three instruments, one blind spot, and it is the
+same blind spot every time: **the holder is the one process in the system
+that is not finishing anything, and all we measured were finishes.**
+
+`Grappa.Repo.LockWatch` reads at the seam instead of at the completion.
+`Grappa.Repo.immediate_transaction/1` is the only producer of `BEGIN
+IMMEDIATE` in the tree, and ecto_sqlite3 executes that statement BEFORE
+invoking the transaction fun — so the fun's first statement is an exact,
+free "the lock is mine now" edge. Before it, the caller is a WAITER; after
+it, the HOLDER. The watchdog reports only a holder past a threshold WITH a
+queue behind it, and samples that holder's live `current_stacktrace` — the
+datum the issue records as missing ("separating the two needs a running
+stack"). A waiter is captured the same way whether it is blocked on SQLite's
+`busy_timeout` or queued on a DBConnection checkout, so the two candidate
+topologies stay distinguishable by their stacks rather than by argument.
+
+Decisions worth keeping:
+
+- **No caller label is stored, and `immediate_transaction/1` grew no label
+  argument.** When the watchdog fires, the holder is still inside the
+  transaction, so its stack already carries every caller frame. The identity
+  is derived at report time and the write path pays nothing for it.
+- **The seam self-disables when its ETS table is absent.** The watchdog owns
+  that table, so a restart briefly removes it — and without the check,
+  `acquired` would raise INSIDE a caller's transaction. An observer that
+  aborts the write it is watching is worse than no observer.
+- **Dead rows are reaped on the scan, never on the write path.** A process
+  killed mid-transaction never releases; an unreaped row would have the
+  instrument accusing a corpse forever while the real contention went
+  unnamed.
+- **No new noun.** Episodes fold into `Grappa.DbLatency`'s bounded ring, so
+  `GET /admin/db_latency` and `bin/grappa db-latency` inherit them with no
+  new controller and no new verb. The `Logger.warning` is the door that
+  matters for CI, where the evidence is container logs.
+- **Off in test.** Under the Sandbox's `pool_size: 1` every write
+  transaction is a holder; the observer's own tests arm it explicitly and
+  disarm on exit.
+
+What this deliberately does NOT do: it does not choose between the two
+causes #1420 names — a `Logger` call inside the transaction, or a
+pool-checkout deadlock. It turns that choice from a guess into a reading.
+Narrowing `BEGIN IMMEDIATE` is a separate decision about what we accept
+losing, and it is not this change's to make.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45778,3 +45778,58 @@ causes #1420 names — a `Logger` call inside the transaction, or a
 pool-checkout deadlock. It turns that choice from a guess into a reading.
 Narrowing `BEGIN IMMEDIATE` is a separate decision about what we accept
 losing, and it is not this change's to make.
+
+### Cost, measured — and one number deliberately withheld
+
+Two measurements, because they answer different questions.
+
+**The seam itself is resolvable and clean.** `observe/1` around a no-op,
+200_000 calls per block, five blocks per regime, alternating:
+
+| regime | ns/call | block range |
+|---|---|---|
+| armed | 355.8 | 69598–72395 us |
+| disarmed | 95.5 | 18837–19696 us |
+| delta | **260.3 ns** | ranges do not overlap |
+
+Note the disarmed cost is not zero: **~95 ns/call is the price of the
+off-switch itself** — a `:persistent_term` read, an `:ets.whereis/1`, and the
+two process-dictionary operations that are deliberately unconditional so the
+nesting counter cannot leak when the watchdog restarts. That was paid on
+purpose, and now it is quantified.
+
+**The end-to-end cost is NOT RESOLVABLE by this method.** Real
+`BEGIN IMMEDIATE` + INSERT against a WAL temp file, 2_000 transactions per
+block, four blocks per regime, alternating. The observed delta was **2.124 %**,
+but the spread WITHIN a single regime was **3.8 %** — larger than the signal,
+with the blocks overlapping (armed `[95907, 97075, 96699, 93451]` against
+disarmed `[96943, 93367, 94226, 94374]`: the armed minimum sits below the
+disarmed maximum).
+
+The clause was fixed before the numbers were seen and is not being adjusted
+now that they have been: **2.124 % is not a measurement, it is noise, and it
+is above the 1 % threshold that was declared in advance.** It may not be
+reported as "under threshold" and it may not be reported as "2 %".
+
+Composing the two measured quantities — 260.3 ns of seam on a 47.15 us
+transaction — gives roughly **0.55 %**, under the threshold. That figure is
+**DERIVED, not measured end-to-end**, and it is host-specific: where a
+transaction costs more (ZFS, `page_size 65536`) the share falls, where it
+costs less it rises. So the threshold is satisfied by derivation, and the
+difference between the two statuses is the point, not a quibble.
+
+### Armed is not observed
+
+The observer defaults ON (`config/config.exs`) and is OFF only under
+`:test`, where the Sandbox's `pool_size: 1` makes every write transaction a
+holder and the output would be noise rather than signal. CI is covered: the
+integration stack runs `MIX_ENV: dev` (`cicchetto/e2e/compose.yaml`, service
+`grappa-test`), so it inherits the armed default and will write its warning.
+
+**It will not necessarily be read.** `scripts/integration.sh` discards
+container logs on a GREEN run (#1429), so a stall report from a passing run
+is produced and then thrown away. The open question in #1420 — whether the
+stall also hits runs that pass — therefore stays open until #1429 changes,
+and it stays open for a reason this change cannot fix from here. Arming the
+instrument and observing it are two different things, and only the first is
+done.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4592,7 +4592,7 @@ hand-attach — read it through either door (both drive the same
   (`204`). `:admin_authn`-gated (admin bearer + `is_admin`); reached
   through the dumb proxy, no allowlist to maintain (#485).
 
-The handler folds **two** signal families:
+The handler folds **three** signal families:
 
 - **`[:grappa, :repo, :query]`** (Ecto's per-query telemetry) into a
   `{source, op}` table — `SELECT count(...)` split from plain `SELECT`. This is
@@ -4602,6 +4602,42 @@ The handler folds **two** signal families:
   against the baseline.
 - **the D1 write-path spans** into `send_privmsg` / `persist` / `contention`
   rows.
+- **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) into the
+  bounded `lock stalls` ring — the WRITE-LOCK HOLDER.
+
+### Reading a write-lock stall (#1420)
+
+The two families above are **completion-driven**: they fire when a query
+finishes. A process that opens `BEGIN IMMEDIATE` and then sits still emits
+nothing at all while it sits, so the only thing that ever reached the log was
+its victims — the 30.1 s `busy_timeout` rows of everybody queued behind it.
+`Grappa.Repo.LockWatch` reads at the `BEGIN IMMEDIATE` seam instead, which
+separates the **holder** from the **waiters**.
+
+A stall is reported only when a holder has held past
+`:lock_watch, :stall_threshold_ms` **with at least one waiter queued behind
+it** — a slow uncontended write is not a stall. Each episode appears twice: a
+`detected` row carrying the holder's sampled **stacktrace** plus the queue, and
+a `resolved` row carrying the total hold.
+
+Two doors, and for an incident they answer different questions:
+
+- **`Logger.warning`** — fires the moment the stall is detected, so it lands in
+  container logs and CI artefacts. This is the door that matters when the
+  evidence is a log after the fact.
+- **`bin/grappa db-latency` / `GET /admin/db_latency`** — the last 20 episodes,
+  newest first, for a node you can still reach.
+
+**What the stack tells you.** The holder's frames are the answer to "why is it
+not proceeding": a `Logger` frame means the transaction is blocked on logging;
+a `DBConnection` checkout frame means a pool-topology deadlock; anything else
+is a third answer nobody has predicted yet. That distinction is the whole
+reason the instrument exists — before it, both looked identical from the logs.
+
+**Off-switch:** `config :grappa, :lock_watch, enabled: false`. Disabled, the
+write path pays one `:persistent_term` read per write transaction and does no
+ETS work. It is **off in `:test`** (under the Sandbox's `pool_size: 1` every
+write transaction is a holder).
 
 **Taking a 25s under-load sample:** `bin/grappa db-latency-reset` → wait 25s
 **under genuine daytime load** → `bin/grappa db-latency`. Counters are

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -188,6 +188,15 @@ defmodule Grappa.Application do
         # up, the type callback would crash with `:noproc`.
         Grappa.Vault,
 
+        # LockWatch before Repo (#1420): it owns the ETS table that
+        # `Repo.immediate_transaction/1` writes to on every write
+        # transaction, so the table must exist before the first one can
+        # run. Placing it after Repo would leave a boot window in which
+        # the seam self-disables — and the seam checks for the table
+        # precisely so a watchdog restart can never abort a caller's
+        # transaction. Depends on nothing itself (ETS + a timer).
+        {Grappa.Repo.LockWatch, lock_watch_opts()},
+
         # Must come first (after Vault): every context that touches the
         # DB depends on Repo being up. Sessions write Scrollback rows;
         # Phase 2 schemas (network_credentials) carry encrypted columns
@@ -609,6 +618,18 @@ defmodule Grappa.Application do
   @spec attach_db_latency_telemetry?() :: boolean()
   defp attach_db_latency_telemetry?,
     do: Application.get_env(:grappa, :attach_db_latency_telemetry, true)
+
+  # #1420 — the write-lock holder/waiter observer. Read at boot, injected
+  # via start_link opts (never a runtime Application.get_env in a
+  # callback). `enabled` is the off-switch: it gates BOTH the watchdog
+  # timer and the write-path seam, so switching it off costs one
+  # :persistent_term read per write transaction and nothing else.
+  # `fetch_env!` and not a defaulted `get_env`: the three keys are declared
+  # together in config/config.exs, and a half-configured observer that
+  # silently falls back to invented thresholds is worse than a loud boot
+  # failure naming the missing key.
+  @spec lock_watch_opts() :: keyword()
+  defp lock_watch_opts, do: Application.fetch_env!(:grappa, :lock_watch)
 
   # #1321 — same test-env opt-out shape. The reason is neither sandbox
   # ownership nor determinism: the handler only logs, and a globally

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -18,7 +18,7 @@ defmodule Grappa.DbLatency do
   measurements into small in-memory running counters. No Repo, no
   PubSub, no schema.
 
-  ## Two signal families, one handler
+  ## Three signal families, one handler
 
   The handler consumes both the D1 write-path spans AND Ecto's built-in
   per-query telemetry, because the two answer two different open
@@ -46,6 +46,15 @@ defmodule Grappa.DbLatency do
           (budget-exhausted rows lost).
         - **mechanism 3 (pure insert / index write-amplification):** the
           `persist` row `mean_ms` on its own, watched as the table grows.
+
+    * **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) —
+      the write-lock HOLDER, which neither family above can see. Both of
+      them are completion-driven, so a process sitting idle inside
+      `BEGIN IMMEDIATE` emits nothing while it sits and only its victims
+      show up (as 30.1s `busy_timeout` rows). `Grappa.Repo.LockWatch`
+      reads at the seam instead and hands over the holder's sampled stack
+      plus the queue behind it; here they are kept as a bounded ring, so
+      the existing CLI and admin doors surface them with no new noun.
 
   ## Reading a window
 
@@ -83,8 +92,16 @@ defmodule Grappa.DbLatency do
     [:grappa, :repo, :query],
     [:grappa, :scrollback, :persist, :stop],
     [:grappa, :session, :send_privmsg, :stop],
-    [:grappa, :scrollback, :persist, :contention]
+    [:grappa, :scrollback, :persist, :contention],
+    [:grappa, :repo, :lock_stall, :detected],
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
+
+  # #1420 — the lock-stall ring is bounded: these rows carry sampled
+  # stacktraces, so an unbounded list would grow the singleton's heap for as
+  # long as the node stays up. Twenty episodes is far more than any single
+  # incident produces and still fits in one admin response.
+  @lock_stall_ring 20
 
   @type op :: :select | :insert | :update | :delete | :count | :other
 
@@ -111,11 +128,27 @@ defmodule Grappa.DbLatency do
           dropped: non_neg_integer()
         }
 
+  @typedoc """
+  One write-lock stall episode (#1420). `:detected` carries the holder's
+  sampled stack and the queue behind it; `:resolved` brackets the same
+  episode with the TOTAL hold and no samples (by then there is nothing left
+  to sample). Newest first.
+  """
+  @type lock_stall_row :: %{
+          phase: :detected | :resolved,
+          holder_pid: String.t(),
+          held_ms: non_neg_integer(),
+          waiter_count: non_neg_integer(),
+          holder: map() | nil,
+          waiters: [map()]
+        }
+
   @type snapshot :: %{
           queries: [query_row()],
           send_privmsg: span_row(),
           persist: span_row(),
-          contention: contention_row()
+          contention: contention_row(),
+          lock_stalls: [lock_stall_row()]
         }
 
   # Internal accumulators carry NATIVE time units (integer sums); the
@@ -123,13 +156,15 @@ defmodule Grappa.DbLatency do
   defstruct queries: %{},
             send_privmsg: %{n: 0, total: 0, outcomes: %{}},
             persist: %{n: 0, total: 0, outcomes: %{}},
-            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, dropped: 0}
+            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, dropped: 0},
+            lock_stalls: []
 
   @type t :: %__MODULE__{
           queries: %{{String.t() | nil, op()} => %{n: non_neg_integer(), total: integer(), queue: integer()}},
           send_privmsg: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
           persist: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
-          contention: contention_row()
+          contention: contention_row(),
+          lock_stalls: [lock_stall_row()]
         }
 
   ## ----- Public API ---------------------------------------------------
@@ -229,6 +264,33 @@ defmodule Grappa.DbLatency do
     end
   end
 
+  defp fold([:grappa, :repo, :lock_stall, :detected], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :detected,
+      holder_pid: metadata.holder.pid,
+      held_ms: measurements.held_ms,
+      waiter_count: measurements.waiter_count,
+      holder: metadata.holder,
+      waiters: metadata.waiters
+    })
+  end
+
+  defp fold([:grappa, :repo, :lock_stall, :resolved], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :resolved,
+      holder_pid: metadata.holder_pid,
+      held_ms: measurements.held_ms,
+      waiter_count: 0,
+      holder: nil,
+      waiters: []
+    })
+  end
+
+  @spec push_stall(t(), lock_stall_row()) :: t()
+  defp push_stall(state, row) do
+    %{state | lock_stalls: Enum.take([row | state.lock_stalls], @lock_stall_ring)}
+  end
+
   # Accumulate one span's duration + outcome tally.
   @spec add_span(map(), map(), map()) :: map()
   defp add_span(acc, measurements, metadata) do
@@ -293,7 +355,8 @@ defmodule Grappa.DbLatency do
       queries: queries,
       send_privmsg: span_snapshot(state.send_privmsg),
       persist: span_snapshot(state.persist),
-      contention: state.contention
+      contention: state.contention,
+      lock_stalls: state.lock_stalls
     }
   end
 

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -102,6 +102,9 @@ defmodule Grappa.HotReload.LongLivedModules do
   # would silently false-COLD when typespec union lines matched the
   # shape — review C4 / CP28 incident class).
   @modules [
+    # #1420 — first, because it is the one child that boots BEFORE Repo
+    # (it owns the ETS table the BEGIN IMMEDIATE seam writes to).
+    Grappa.Repo.LockWatch,
     Grappa.Session.Backoff,
     Grappa.WSPresence,
     Grappa.Admission.NetworkCircuit,
@@ -143,7 +146,8 @@ defmodule Grappa.HotReload.LongLivedModules do
   `:underspecs` (a divergence shows up as `contract_supertype`).
   """
   @type long_lived ::
-          Grappa.Session.Backoff
+          Grappa.Repo.LockWatch
+          | Grappa.Session.Backoff
           | Grappa.WSPresence
           | Grappa.Admission.NetworkCircuit
           | Grappa.AdminEvents

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1018,7 +1018,32 @@ defmodule Grappa.Operator do
       )
     )
 
+    # #1420 — the holder side. Printed LAST and one block per episode rather
+    # than as a table row: the payload that answers "why did the holder
+    # pause" is a stacktrace, and a stacktrace does not fit a column.
+    IO.puts("# lock stalls (write-lock holder vs waiters) — newest first")
+
+    Enum.each(snapshot.lock_stalls, fn stall ->
+      IO.puts(
+        "#{stall.phase}\tholder=#{stall.holder_pid}\theld_ms=#{stall.held_ms}" <>
+          "\twaiters=#{stall.waiter_count}"
+      )
+
+      Enum.each(lock_stall_detail_lines(stall), &IO.puts/1)
+    end)
+
     :ok
+  end
+
+  # A `:resolved` row carries no samples (the episode is over and there is
+  # nothing left to inspect), so it renders as its header line alone.
+  @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
+  defp lock_stall_detail_lines(%{holder: nil}), do: []
+
+  defp lock_stall_detail_lines(%{holder: holder, waiters: waiters}) do
+    ["  holder at #{holder.current_function} (#{holder.status}, mailbox #{holder.message_queue_len})"] ++
+      Enum.map(holder.stacktrace, &"    #{&1}") ++
+      Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}")
   end
 
   @doc """

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -9,11 +9,13 @@ defmodule Grappa.Repo do
   the full reasoning. Resist the urge to introduce dynamic Repos.
   """
 
-  use Boundary, top_level?: true, deps: [], exports: [BusyRetry]
+  use Boundary, top_level?: true, deps: [], exports: [BusyRetry, LockWatch]
 
   use Ecto.Repo,
     otp_app: :grappa,
     adapter: Ecto.Adapters.SQLite3
+
+  alias Grappa.Repo.LockWatch
 
   # #506 — pre-switch the database to WAL on a SINGLE connection before the pool
   # (or `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) open.
@@ -178,9 +180,30 @@ defmodule Grappa.Repo do
   together when a caller first needs it. Advertising the `Multi` failure
   4-tuple now (with no caller that can produce it) forces every caller's
   `@spec` to carry an impossible return — Dialyzer flags exactly that.
+
+  ## Observability
+
+  This is the ONLY producer of `BEGIN IMMEDIATE` in the tree, which makes it
+  the one seam where the holder of SQLite's write lock can be told apart
+  from the processes queued behind it. `Grappa.Repo.LockWatch.observe/1`
+  wraps the call and is handed back the `acquired` callback, which fires as
+  the FIRST statement inside the transaction body — i.e. once
+  `BEGIN IMMEDIATE` has actually granted the lock, which is what makes a
+  holder distinguishable from a waiter. Nothing else changes: `observe/1`
+  passes `transaction/2`'s return value and any raise or `rollback/1` throw
+  through untouched, so the transaction's semantics are exactly what they
+  were before (#1420).
   """
   @spec immediate_transaction(fun()) :: {:ok, any()} | {:error, any()}
   def immediate_transaction(fun) do
-    transaction(fun, mode: :immediate)
+    LockWatch.observe(fn acquired ->
+      transaction(
+        fn ->
+          acquired.()
+          fun.()
+        end,
+        mode: :immediate
+      )
+    end)
   end
 end

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -141,7 +141,11 @@ defmodule Grappa.Repo.LockWatch do
   defstruct [:stall_threshold_ms, :tick_ms, :enabled]
 
   @type t :: %__MODULE__{
-          stall_threshold_ms: pos_integer(),
+          # non_neg, not pos: a threshold of 0 means "report every contended
+          # holder at once" — noisy, but a coherent operator choice, and the
+          # setting the tests use to take a reading without waiting on a
+          # clock. `tick_ms` stays pos: a zero tick is a busy loop.
+          stall_threshold_ms: non_neg_integer(),
           tick_ms: pos_integer(),
           enabled: boolean()
         }
@@ -243,7 +247,7 @@ defmodule Grappa.Repo.LockWatch do
   end
 
   @spec close_episode([row()]) :: :ok
-  defp close_episode([{_pid, :holding, since, true}]) do
+  defp close_episode([{_, :holding, since, true}]) do
     held_ms = now_ms() - since
 
     Logger.warning(
@@ -307,7 +311,7 @@ defmodule Grappa.Repo.LockWatch do
     _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
     :persistent_term.put(@enabled_key, state.enabled)
 
-    if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
+    _ = if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
 
     {:ok, state}
   end
@@ -330,7 +334,7 @@ defmodule Grappa.Repo.LockWatch do
   # A stall is a holder past the threshold WITH a queue behind it. Neither
   # half alone qualifies: a lone slow transaction blocks nobody, and waiters
   # with no holder are the pool's business, not the write lock's.
-  @spec detect(integer(), pos_integer()) :: :ok
+  @spec detect(integer(), non_neg_integer()) :: :ok
   defp detect(now, threshold_ms) do
     {holders, waiters} = partition(rows(), now)
 
@@ -385,7 +389,7 @@ defmodule Grappa.Repo.LockWatch do
   end
 
   @spec alive?(row()) :: boolean()
-  defp alive?({pid, _role, _since, _reported?}) do
+  defp alive?({pid, _, _, _}) do
     if Process.alive?(pid) do
       true
     else
@@ -396,7 +400,7 @@ defmodule Grappa.Repo.LockWatch do
 
   @spec partition([row()], integer()) :: {[{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]}
   defp partition(rows, now) do
-    {holding, waiting} = Enum.split_with(rows, fn {_pid, role, _since, _} -> role == :holding end)
+    {holding, waiting} = Enum.split_with(rows, fn {_, role, _, _} -> role == :holding end)
 
     {Enum.map(holding, fn {pid, _, since, _} -> {pid, now - since} end),
      Enum.map(waiting, fn {pid, _, since, _} -> {pid, now - since} end)}
@@ -405,7 +409,7 @@ defmodule Grappa.Repo.LockWatch do
   @spec unreported?(pid()) :: boolean()
   defp unreported?(pid) do
     case :ets.lookup(@table, pid) do
-      [{_pid, _role, _since, reported?}] -> not reported?
+      [{_, _, _, reported?}] -> not reported?
       [] -> false
     end
   end

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -1,0 +1,472 @@
+defmodule Grappa.Repo.LockWatch do
+  @moduledoc """
+  Holder-vs-waiter observer for SQLite's single write lock (#1420).
+
+  ## Why a new signal, and not another handler on the old ones
+
+  Every DB signal grappa already emits is **completion-driven**, so all of
+  them measure the VICTIM by construction:
+
+    * `[:grappa, :repo, :query]` fires when a query FINISHES. A process that
+      opens `BEGIN IMMEDIATE` and then sits still emits nothing at all while
+      it sits; the only rows that reach the log are the 30-second `begin`s
+      and `SELECT`s of everybody stuck BEHIND it.
+    * `Grappa.Repo.BusyRetry`'s `:on_contention` hook fires inside a
+      `rescue` — it counts, by definition, whoever caught the exception.
+    * The #1429 CI census greps container logs after the fact: it sees the
+      silence, never who caused it.
+
+  The #1420 census hit that wall six times: `db30=4`, `dropped=2`,
+  `saturated=2`, every gap exactly 30.1 s (the `busy_timeout: 30_000` of the
+  WAITERS), and the issue's own "Not established" section names the missing
+  datum — *"why the holder itself pauses [...] separating the two needs a
+  running stack."*
+
+  This module produces that running stack.
+
+  ## The state machine
+
+  `Grappa.Repo.immediate_transaction/1` is the ONLY producer of
+  `BEGIN IMMEDIATE` in the tree, so there is exactly one seam to instrument.
+
+  The split is free because of an ordering READ IN THE DEPENDENCIES, not
+  assumed: `DBConnection.transaction/3` evaluates `begin/3` and only enters
+  `run_transaction/5` on `{:ok, _}` (`db_connection.ex:1103-1107`), and
+  `Exqlite.Connection.handle_begin/2` emits `"BEGIN IMMEDIATE TRANSACTION"`
+  for `mode: :immediate` on an idle connection (`connection.ex:307`). So by
+  the time the transaction fun runs, SQLite has already granted `RESERVED`:
+
+      waiting()   -->  inside the `begin`, lock NOT yet held  ==> WAITER
+      acquired()  -->  first statement of the fun, RESERVED held  ==> HOLDER
+      released()  -->  transaction over
+
+  The same reading gives the failure case for free: when `begin` raises
+  (busy past `busy_timeout`) the fun never runs, so `acquired/0` never
+  fires and a writer that timed out is never mislabelled a holder — the
+  `after` simply drops its waiter row.
+
+  It also gives the nesting case: on a connection already in a transaction,
+  `handle_begin/2` emits `SAVEPOINT` instead (`connection.ex:310-315`),
+  which is why the depth counter below exists — an inner release must not
+  erase an outer holder.
+
+  A waiter is a waiter whether it is blocked on SQLite's `busy_timeout` or
+  queued on a DBConnection checkout — the two candidate topologies #1420
+  names. Its sampled stack says which, so the instrument does not have to
+  guess between them.
+
+  ## What it reports, and when
+
+  A watchdog tick scans the table and reports only when a holder has held
+  for at least `stall_threshold_ms` **AND at least one waiter is queued
+  behind it**. A slow-but-uncontended transaction is not a stall, and
+  reporting one would bury the signal it exists to find.
+
+  One report per episode (the row's `reported?` flag arms on the first and
+  disarms on release) — otherwise a 30 s stall prints 30 times. Release
+  emits a second, `:resolved` event carrying the TOTAL hold, so an episode
+  has both an opening and a closing bracket.
+
+  ## Deriving the holder's identity instead of storing it
+
+  No caller label is stored, and `immediate_transaction/1` grows no label
+  argument. When the watchdog fires, the holder is still INSIDE the
+  transaction, so its `:current_stacktrace` already contains the
+  `immediate_transaction` frame and every caller frame above it. The
+  identity is derived at report time and costs the hot path nothing.
+
+  ## Doors
+
+  `Logger.warning` (the door that reaches CI container logs, which is where
+  #1420's evidence lives) plus a `:telemetry` event that `Grappa.DbLatency`
+  folds into a bounded ring — so `GET /admin/db_latency` and
+  `bin/grappa db-latency` both inherit the data with no new noun.
+
+  ## Cost and off-switch
+
+  On the write path: one `:persistent_term` read, one `:ets.whereis/1`, and
+  three ETS row operations per write transaction — against a WAL write
+  transaction costing milliseconds. `Process.info/2` (which briefly
+  suspends its target) runs ONLY once a stall has already been detected,
+  on a process that is by definition already stopped.
+
+  Off by default; `config :grappa, :lock_watch, enabled: true` arms it.
+  `config/test.exs` leaves it OFF — its own tests arm it explicitly.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @table :grappa_repo_lock_watch
+  @enabled_key {__MODULE__, :enabled}
+  @depth_key {__MODULE__, :depth}
+  @stack_frames 12
+
+  @typedoc "Role of a row in the watch table."
+  @type role :: :waiting | :holding
+
+  @typedoc "One watch-table row: who, in which role, since when, already reported?"
+  @type row :: {pid(), role(), integer(), boolean()}
+
+  @typedoc """
+  Handed to the transactor by `observe/1`, to be invoked as the FIRST
+  statement inside the transaction body — the moment `BEGIN IMMEDIATE`
+  has returned and `RESERVED` is held.
+  """
+  @type acquired_fun :: (-> :ok)
+
+  @typedoc """
+  One sampled process. `pid` is `inspect/1`-formatted and the stacktrace is
+  pre-formatted because this rides telemetry into a JSON admin response —
+  every field must be JSON-encodable at the point it is built, not later.
+  """
+  @type sample :: %{
+          pid: String.t(),
+          elapsed_ms: non_neg_integer(),
+          current_function: String.t(),
+          status: atom() | nil,
+          message_queue_len: non_neg_integer() | nil,
+          initial_call: String.t(),
+          stacktrace: [String.t()]
+        }
+
+  @typedoc "A detected stall: one holder, the queue behind it."
+  @type stall :: %{
+          holder: sample(),
+          waiters: [sample()],
+          waiter_count: non_neg_integer()
+        }
+
+  defstruct [:stall_threshold_ms, :tick_ms, :enabled]
+
+  @type t :: %__MODULE__{
+          stall_threshold_ms: pos_integer(),
+          tick_ms: pos_integer(),
+          enabled: boolean()
+        }
+
+  ## ----- Write-path seam ----------------------------------------------
+
+  @doc """
+  Runs `transactor` under observation, handing it the callback to invoke at
+  the exact moment the write lock is held.
+
+  This is the whole seam, in one function, with ONE caller in production
+  (`Grappa.Repo.immediate_transaction/1`) — the three edges are private
+  because their ORDER is the measurement. Calling `acquired` anywhere other
+  than the first statement inside the transaction body would classify
+  waiters as holders, which is precisely the confusion the instrument
+  exists to resolve, so the ordering is not left to call sites.
+
+  `try/after` guarantees the episode closes on a raise or a
+  `Repo.rollback/1` throw, and the transactor's return value passes through
+  untouched: observing a transaction must not change it.
+  """
+  @spec observe((acquired_fun() -> result)) :: result when result: var
+  def observe(transactor) when is_function(transactor, 1) do
+    waiting()
+
+    try do
+      transactor.(&acquired/0)
+    after
+      released()
+    end
+  end
+
+  @doc """
+  One detection pass at the given threshold. The watchdog's tick calls this;
+  it is public so an operator (or a test) can take the reading on demand
+  instead of waiting for a tick.
+  """
+  @spec scan(non_neg_integer()) :: :ok
+  def scan(stall_threshold_ms) when is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
+    detect(now_ms(), stall_threshold_ms)
+  end
+
+  # Entering `BEGIN IMMEDIATE`. The caller is a WAITER until `acquired/0`.
+  #
+  # The depth bookkeeping is deliberately NOT gated on `enabled?/0`, while
+  # the ETS work is. Gating both would let the counter leak: if the flag (or
+  # the table) goes away between this call and `released/0` — a watchdog
+  # restart is enough — the decrement is skipped and a long-lived process
+  # such as a `Session.Server` keeps a non-zero depth for the rest of its
+  # life, permanently invisible to the instrument. A process-dictionary read
+  # and write cost nanoseconds; a silently blinded observer costs the whole
+  # investigation.
+  @spec waiting() :: :ok
+  defp waiting do
+    depth = depth()
+    Process.put(@depth_key, depth + 1)
+
+    # Only the OUTERMOST transaction owns the row. A nested
+    # `immediate_transaction/1` collapses to a SAVEPOINT on the same
+    # connection, so an inner `released/0` deleting the row would erase a
+    # holder that is still holding — an instrument lying about the very
+    # thing it measures.
+    if depth == 0 and enabled?() do
+      :ets.insert(@table, {self(), :waiting, now_ms(), false})
+    end
+
+    :ok
+  end
+
+  # `BEGIN IMMEDIATE` returned: the caller now HOLDS `RESERVED`.
+  #
+  # Runs as the first statement inside the transaction fun, so it must never
+  # raise — a raise here would abort a caller's write transaction, which is
+  # precisely the semantic change this instrument is forbidden to make.
+  # `enabled?/0` proves the table exists and `:ets.update_element/3` answers
+  # `false` (never raises) for an absent key.
+  @spec acquired() :: :ok
+  defp acquired do
+    if depth() == 1 and enabled?() do
+      :ets.update_element(@table, self(), [{2, :holding}, {3, now_ms()}])
+    end
+
+    :ok
+  end
+
+  # Transaction over. Closes the episode, and brackets it if it was reported.
+  @spec released() :: :ok
+  defp released do
+    case depth() do
+      depth when depth > 1 ->
+        Process.put(@depth_key, depth - 1)
+
+      _ ->
+        Process.delete(@depth_key)
+        if enabled?(), do: close_episode(:ets.take(@table, self()))
+    end
+
+    :ok
+  end
+
+  @spec close_episode([row()]) :: :ok
+  defp close_episode([{_pid, :holding, since, true}]) do
+    held_ms = now_ms() - since
+
+    Logger.warning(
+      "db lock stall RESOLVED: holder #{inspect(self())} released RESERVED after #{held_ms}ms",
+      held_ms: held_ms
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :resolved],
+      %{held_ms: held_ms},
+      %{holder_pid: inspect(self())}
+    )
+  end
+
+  defp close_episode(_), do: :ok
+
+  ## ----- Public API ---------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  Current holder + waiters, sampled now. The live read behind the watchdog,
+  exposed so an operator can ask the question mid-incident rather than
+  waiting for a tick.
+  """
+  @spec inspect_lock() :: %{holders: [sample()], waiters: [sample()]}
+  def inspect_lock do
+    now = now_ms()
+    {holders, waiters} = partition(rows(), now)
+
+    %{
+      holders: Enum.map(holders, fn {pid, elapsed} -> sample(pid, elapsed) end),
+      waiters: Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
+    }
+  end
+
+  if Mix.env() == :test do
+    @doc false
+    # Test seam: arm/disarm the write-path instrumentation. Gated to :test so
+    # no other build carries a runtime toggle. Tests MUST disarm on_exit — a
+    # flag left armed is failure-at-a-distance for every later test.
+    @spec put_test_enabled(boolean()) :: :ok
+    def put_test_enabled(enabled?) when is_boolean(enabled?) do
+      :persistent_term.put(@enabled_key, enabled?)
+    end
+  end
+
+  ## ----- GenServer callbacks ------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      stall_threshold_ms: Keyword.fetch!(opts, :stall_threshold_ms),
+      tick_ms: Keyword.fetch!(opts, :tick_ms),
+      enabled: Keyword.fetch!(opts, :enabled)
+    }
+
+    # `:public` because the seam writes from every caller's own process; the
+    # table is owned here so a supervisor restart rebuilds it clean.
+    _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
+    :persistent_term.put(@enabled_key, state.enabled)
+
+    if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:tick, state) do
+    scan(state.stall_threshold_ms)
+    Process.send_after(self(), :tick, state.tick_ms)
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_, _) do
+    :persistent_term.put(@enabled_key, false)
+    :ok
+  end
+
+  ## ----- Detection -----------------------------------------------------
+
+  # A stall is a holder past the threshold WITH a queue behind it. Neither
+  # half alone qualifies: a lone slow transaction blocks nobody, and waiters
+  # with no holder are the pool's business, not the write lock's.
+  @spec detect(integer(), pos_integer()) :: :ok
+  defp detect(now, threshold_ms) do
+    {holders, waiters} = partition(rows(), now)
+
+    stalled = Enum.filter(holders, fn {pid, elapsed} -> elapsed >= threshold_ms and unreported?(pid) end)
+
+    if stalled != [] and waiters != [] do
+      waiter_samples = Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
+      Enum.each(stalled, &report(&1, waiter_samples))
+    end
+
+    :ok
+  end
+
+  @spec report({pid(), non_neg_integer()}, [sample()]) :: :ok
+  defp report({pid, elapsed}, waiter_samples) do
+    # Arm the flag BEFORE emitting: an emit that raced the next tick would
+    # double-report the same episode.
+    _ = :ets.update_element(@table, pid, [{4, true}])
+
+    holder = sample(pid, elapsed)
+
+    stall = %{holder: holder, waiters: waiter_samples, waiter_count: length(waiter_samples)}
+
+    Logger.warning(
+      "db lock stall: holder #{holder.pid} has held RESERVED for #{holder.elapsed_ms}ms " <>
+        "with #{stall.waiter_count} waiter(s) queued — holder at #{holder.current_function}, " <>
+        "stack: #{Enum.join(holder.stacktrace, " <- ")}",
+      held_ms: holder.elapsed_ms,
+      waiters: stall.waiter_count
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :detected],
+      %{held_ms: holder.elapsed_ms, waiter_count: stall.waiter_count},
+      stall
+    )
+  end
+
+  ## ----- Sampling -------------------------------------------------------
+
+  # Reaps dead rows as it reads. A process killed mid-transaction never runs
+  # `released/0`, so its row would otherwise sit in the table forever and be
+  # re-reported as an eternal holder — the instrument accusing a corpse while
+  # the real contention goes unnamed. Reaping happens here, off the write
+  # path, because only the scan side cares.
+  @spec rows() :: [row()]
+  defp rows do
+    case :ets.whereis(@table) do
+      :undefined -> []
+      _ -> Enum.filter(:ets.tab2list(@table), &alive?/1)
+    end
+  end
+
+  @spec alive?(row()) :: boolean()
+  defp alive?({pid, _role, _since, _reported?}) do
+    if Process.alive?(pid) do
+      true
+    else
+      :ets.delete(@table, pid)
+      false
+    end
+  end
+
+  @spec partition([row()], integer()) :: {[{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]}
+  defp partition(rows, now) do
+    {holding, waiting} = Enum.split_with(rows, fn {_pid, role, _since, _} -> role == :holding end)
+
+    {Enum.map(holding, fn {pid, _, since, _} -> {pid, now - since} end),
+     Enum.map(waiting, fn {pid, _, since, _} -> {pid, now - since} end)}
+  end
+
+  @spec unreported?(pid()) :: boolean()
+  defp unreported?(pid) do
+    case :ets.lookup(@table, pid) do
+      [{_pid, _role, _since, reported?}] -> not reported?
+      [] -> false
+    end
+  end
+
+  # The whole point of the instrument: WHERE is this process, right now.
+  # `Process.info/2` returns nil for a dead pid, which is a real outcome
+  # here (the holder can die between the scan and the sample), so it folds
+  # to an explicit empty sample rather than crashing the watchdog.
+  @spec sample(pid(), non_neg_integer()) :: sample()
+  defp sample(pid, elapsed_ms) do
+    info = Process.info(pid, [:current_function, :status, :message_queue_len, :dictionary])
+
+    %{
+      pid: inspect(pid),
+      elapsed_ms: elapsed_ms,
+      current_function: format_mfa(info && Keyword.get(info, :current_function)),
+      status: info && Keyword.get(info, :status),
+      message_queue_len: info && Keyword.get(info, :message_queue_len),
+      initial_call: format_mfa(initial_call(info)),
+      stacktrace: stacktrace(pid)
+    }
+  end
+
+  @spec initial_call(keyword() | nil) :: mfa() | nil
+  defp initial_call(nil), do: nil
+
+  defp initial_call(info) do
+    info |> Keyword.get(:dictionary, []) |> Keyword.get(:"$initial_call")
+  end
+
+  @spec stacktrace(pid()) :: [String.t()]
+  defp stacktrace(pid) do
+    case Process.info(pid, :current_stacktrace) do
+      {:current_stacktrace, frames} ->
+        frames
+        |> Enum.take(@stack_frames)
+        |> Enum.map(&(&1 |> Exception.format_stacktrace_entry() |> String.trim()))
+
+      nil ->
+        []
+    end
+  end
+
+  @spec format_mfa(mfa() | nil) :: String.t()
+  defp format_mfa({module, function, arity}), do: Exception.format_mfa(module, function, arity)
+  defp format_mfa(_), do: "unknown"
+
+  ## ----- Helpers --------------------------------------------------------
+
+  # The table check is not defensive noise: the watchdog owns the table, so a
+  # supervisor restart briefly removes it. Without this, `acquired/0` would
+  # raise INSIDE a caller's transaction and abort a write that had nothing to
+  # do with the instrument.
+  @spec enabled?() :: boolean()
+  defp enabled? do
+    :persistent_term.get(@enabled_key, false) and :ets.whereis(@table) != :undefined
+  end
+
+  @spec depth() :: non_neg_integer()
+  defp depth, do: Process.get(@depth_key, 0)
+
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -22,7 +22,9 @@ defmodule Grappa.DbLatencyTest do
     [:grappa, :repo, :query],
     [:grappa, :scrollback, :persist, :stop],
     [:grappa, :session, :send_privmsg, :stop],
-    [:grappa, :scrollback, :persist, :contention]
+    [:grappa, :scrollback, :persist, :contention],
+    [:grappa, :repo, :lock_stall, :detected],
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
 
   # Native-unit duration for a whole number of milliseconds, via the
@@ -46,6 +48,7 @@ defmodule Grappa.DbLatencyTest do
       assert snapshot.send_privmsg.n == 0
       assert snapshot.persist.n == 0
       assert snapshot.contention.n == 0
+      assert snapshot.lock_stalls == []
     end
   end
 
@@ -185,6 +188,54 @@ defmodule Grappa.DbLatencyTest do
       assert contention.busy_locked == 1
       assert contention.queue_timeout == 1
       assert contention.dropped == 1
+    end
+
+    test "[:grappa, :repo, :lock_stall, :*] folds both brackets of an episode, newest first" do
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :detected],
+        %{held_ms: 2_400, waiter_count: 2},
+        %{
+          holder: %{pid: "#PID<0.111.0>", stacktrace: ["Foo.bar/1"]},
+          waiters: [%{pid: "#PID<0.222.0>"}, %{pid: "#PID<0.333.0>"}]
+        }
+      )
+
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :resolved],
+        %{held_ms: 30_120},
+        %{holder_pid: "#PID<0.111.0>"}
+      )
+
+      assert [resolved, detected] = DbLatency.snapshot().lock_stalls
+
+      # Newest first: an operator reading a live incident wants the last
+      # thing that happened at the top, not to scroll a boot-long history.
+      assert resolved.phase == :resolved
+      assert resolved.held_ms == 30_120
+      assert resolved.holder == nil
+
+      assert detected.phase == :detected
+      assert detected.waiter_count == 2
+      assert detected.holder.stacktrace == ["Foo.bar/1"]
+      assert length(detected.waiters) == 2
+    end
+
+    test "the lock-stall ring is bounded, keeping the newest episodes" do
+      for n <- 1..25 do
+        :telemetry.execute(
+          [:grappa, :repo, :lock_stall, :resolved],
+          %{held_ms: n},
+          %{holder_pid: "#PID<0.#{n}.0>"}
+        )
+      end
+
+      stalls = DbLatency.snapshot().lock_stalls
+
+      # These rows carry sampled stacktraces; unbounded, they would grow the
+      # singleton's heap for as long as the node lives.
+      assert length(stalls) == 20
+      assert hd(stalls).held_ms == 25
+      assert List.last(stalls).held_ms == 6
     end
 
     test "reset/0 zeroes accumulated state" do

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -1,0 +1,255 @@
+defmodule Grappa.Repo.LockWatchTest do
+  @moduledoc """
+  #1420 — the write-lock observer, bought with a REAL `SQLITE_BUSY` wait.
+
+  ## Why a private repo and not the Sandbox
+
+  The suite runs `pool_size: 1` under `Ecto.Adapters.SQL.Sandbox`, where
+  every process shares one connection: two writers cannot contend, they
+  queue. That is exactly why `Grappa.Repo.BusyRetry` carries a fault
+  injection seam at all. But an INJECTED busy would prove nothing here —
+  the claim under test is that `acquired` fires only once SQLite has
+  actually granted `RESERVED`, and a hand-raised exception never grants
+  anything. So this file follows `Grappa.Repo.BusyRetryFidelityTest`: a
+  private `TmpRepo` on a temp file with `pool_size: 2`, one process parked
+  inside a write transaction and a second genuinely blocked in its
+  `BEGIN IMMEDIATE`.
+
+  ## Why the detection pass is driven, not awaited
+
+  `LockWatch.scan/1` is called directly instead of waiting for the
+  watchdog's tick. A test that sleeps past a tick interval measures the
+  scheduler as much as the code; driving the pass makes the assertions
+  deterministic under `--repeat-each`. The barrier before each scan is a
+  polled CONDITION (both processes visible in their expected roles), never
+  a fixed sleep.
+
+  Both processes are `spawn_monitor`'d rather than linked, so a writer that
+  dies takes down an assertion with a readable reason instead of the test
+  process.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.Repo.LockWatch
+
+  defmodule TmpRepo do
+    @moduledoc false
+    use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+  end
+
+  @detected [:grappa, :repo, :lock_stall, :detected]
+
+  setup do
+    LockWatch.put_test_enabled(true)
+    on_exit(fn -> LockWatch.put_test_enabled(false) end)
+
+    handler = "lock-watch-test-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        @detected,
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:stall, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    :ok
+  end
+
+  describe "holder vs waiter under a real BEGIN IMMEDIATE contention" do
+    test "names the HOLDER, lists the blocked writer as a waiter, and samples the holder's live stack" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(holder, [waiter])
+
+      LockWatch.scan(0)
+
+      assert_receive {:stall, measurements, stall}, 1_000
+
+      # M1 — a mutant that reports the longest-queued WAITER as the holder
+      # (the two roles are symmetric in the table; only the tag separates
+      # them) has to survive both of these to live.
+      assert stall.holder.pid == inspect(holder)
+      assert [waiter_sample] = stall.waiters
+      assert waiter_sample.pid == inspect(waiter)
+
+      # M2 — a mutant that never promotes `:waiting` to `:holding` leaves no
+      # holder at all, so there is nothing to report and this never arrives;
+      # a mutant that promotes TOO EARLY (before the transaction opens)
+      # promotes the blocked writer too, and the waiter count goes to zero.
+      assert stall.waiter_count == 1
+      assert measurements.waiter_count == 1
+      assert is_integer(measurements.held_ms)
+
+      # M4 — a mutant sampling `self()` (the scanning process) instead of
+      # the holder's pid still produces a well-formed record, and only the
+      # CONTENT of the stack tells the two apart. This frame is the reason
+      # the holder is stuck, which is the datum #1420 says is missing.
+      assert Enum.any?(stall.holder.stacktrace, &(&1 =~ "park_until_released"))
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a holder that has not crossed the threshold is not reported, queue or no queue" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(holder, [waiter])
+
+      # M5 — a mutant that drops the `elapsed >= threshold` comparison
+      # reports immediately and dies here. The holder has been holding for
+      # milliseconds, not the ten seconds demanded.
+      LockWatch.scan(10_000)
+
+      refute_receive {:stall, _, _}, 300
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a slow but UNCONTENDED holder is not a stall" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      await_roles(holder, [])
+
+      # M3 — a mutant that emits on a slow holder without checking for a
+      # queue behind it fires here. Nobody is blocked: this transaction is
+      # slow, and slow is not a stall. Reporting it would bury the signal
+      # the instrument exists to find under every long write in the system.
+      LockWatch.scan(0)
+
+      refute_receive {:stall, _, _}, 300
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+
+      Supervisor.stop(repo)
+    end
+  end
+
+  describe "the production seam" do
+    test "Grappa.Repo.immediate_transaction/1 registers its caller as the holder, and clears on exit" do
+      me = inspect(self())
+
+      # Pins that the observer is actually WIRED to the production function,
+      # in the right place. The tests above drive `LockWatch.observe/1`
+      # themselves, so on their own they would still pass if
+      # `immediate_transaction/1` had never been instrumented at all.
+      #
+      # Honest limit: the DataCase sandbox already holds a transaction on
+      # this connection, and `Exqlite.Connection.handle_begin/2` emits
+      # SAVEPOINT rather than BEGIN IMMEDIATE in that state
+      # (deps/exqlite/lib/exqlite/connection.ex:310-315). So this pins the
+      # WIRING and the edge ORDER; the real `RESERVED` acquisition is what
+      # the TmpRepo tests above measure.
+      assert {:ok, %{holders: holders}} =
+               Grappa.Repo.immediate_transaction(fn -> LockWatch.inspect_lock() end)
+
+      assert Enum.any?(holders, &(&1.pid == me))
+
+      assert %{holders: [], waiters: []} = LockWatch.inspect_lock()
+    end
+  end
+
+  ## ----- helpers --------------------------------------------------------
+
+  defp start_tmp_repo do
+    path = Path.join(System.tmp_dir!(), "lock_watch_#{System.unique_integer([:positive])}.db")
+    on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
+
+    # busy_timeout is generous on purpose: the waiter must still be WAITING
+    # when the scan runs. A short timeout would turn it into an error path
+    # and measure `BusyRetry` instead of this module.
+    {:ok, repo} =
+      TmpRepo.start_link(database: path, pool_size: 2, busy_timeout: 30_000, journal_mode: :wal)
+
+    TmpRepo.query!("CREATE TABLE t(id integer)")
+
+    repo
+  end
+
+  # A writer that goes through the SAME `LockWatch.observe/1` production
+  # uses — re-implementing the edge sequence here would test a copy of the
+  # mechanism rather than the mechanism.
+  defp start_writer(id, after_insert) do
+    test_pid = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        LockWatch.observe(fn acquired ->
+          TmpRepo.transaction(
+            fn ->
+              acquired.()
+              TmpRepo.query!("INSERT INTO t VALUES (#{id})")
+              send(test_pid, {:holding, self()})
+              if after_insert == :park, do: park_until_released()
+            end,
+            mode: :immediate
+          )
+        end)
+      end)
+
+    # A failing assertion would otherwise leave this process parked inside
+    # its transaction, holding both the file lock and a watch-table row, and
+    # poison every test that follows.
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    {pid, ref}
+  end
+
+  # Named, and named distinctively, because its frame IS the oracle for the
+  # holder-stack assertion.
+  defp park_until_released do
+    receive do
+      :release -> :ok
+    end
+  end
+
+  defp await_roles(holder, waiters) do
+    await_until(
+      fn ->
+        %{holders: held, waiters: queued} = LockWatch.inspect_lock()
+
+        pids(held) == [inspect(holder)] and Enum.sort(pids(queued)) == Enum.sort(Enum.map(waiters, &inspect/1))
+      end,
+      300
+    )
+  end
+
+  defp pids(samples), do: Enum.map(samples, & &1.pid)
+
+  defp await_until(_fun, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
+
+  defp await_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      await_until(fun, attempts - 1)
+    end
+  end
+end

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -50,7 +50,7 @@ defmodule Grappa.Repo.LockWatchTest do
       :telemetry.attach(
         handler,
         @detected,
-        fn _event, measurements, metadata, _ ->
+        fn _, measurements, metadata, _ ->
           send(test_pid, {:stall, measurements, metadata})
         end,
         nil
@@ -198,20 +198,7 @@ defmodule Grappa.Repo.LockWatchTest do
   defp start_writer(id, after_insert) do
     test_pid = self()
 
-    {pid, ref} =
-      spawn_monitor(fn ->
-        LockWatch.observe(fn acquired ->
-          TmpRepo.transaction(
-            fn ->
-              acquired.()
-              TmpRepo.query!("INSERT INTO t VALUES (#{id})")
-              send(test_pid, {:holding, self()})
-              if after_insert == :park, do: park_until_released()
-            end,
-            mode: :immediate
-          )
-        end)
-      end)
+    {pid, ref} = spawn_monitor(fn -> observed_write(id, after_insert, test_pid) end)
 
     # A failing assertion would otherwise leave this process parked inside
     # its transaction, holding both the file lock and a watch-table row, and
@@ -219,6 +206,24 @@ defmodule Grappa.Repo.LockWatchTest do
     on_exit(fn -> Process.exit(pid, :kill) end)
 
     {pid, ref}
+  end
+
+  # Split out of `start_writer/2` so no body nests deeper than two levels.
+  # `observe/1` is production's own wrapper — the point is that the test
+  # drives the real edge sequence rather than a hand-written copy of it.
+  defp observed_write(id, after_insert, test_pid) do
+    LockWatch.observe(fn acquired ->
+      TmpRepo.transaction(fn -> insert_then(id, after_insert, test_pid, acquired) end,
+        mode: :immediate
+      )
+    end)
+  end
+
+  defp insert_then(id, after_insert, test_pid, acquired) do
+    acquired.()
+    TmpRepo.query!("INSERT INTO t VALUES (?)", [id])
+    send(test_pid, {:holding, self()})
+    if after_insert == :park, do: park_until_released()
   end
 
   # Named, and named distinctively, because its frame IS the oracle for the
@@ -242,7 +247,7 @@ defmodule Grappa.Repo.LockWatchTest do
 
   defp pids(samples), do: Enum.map(samples, & &1.pid)
 
-  defp await_until(_fun, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
+  defp await_until(_, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
 
   defp await_until(fun, attempts) do
     if fun.() do


### PR DESCRIPTION
## Why

Six CI runs stalled for exactly 30.1 s each. The census could name the
victims every time and the cause not once — and that is not bad luck, it is a
property of the instruments.

**Every DB signal grappa had was completion-driven, so all of them measured
the victim by construction:**

- `[:grappa, :repo, :query]` fires when a query FINISHES. A process that opens
  `BEGIN IMMEDIATE` and then sits still emits nothing at all while it sits;
  the only rows reaching the log are the 30-second `begin`s and `SELECT`s of
  everybody queued behind it.
- `BusyRetry`'s `:on_contention` hook lives inside a `rescue`, so it counts
  whoever caught the exception.
- The #1429 log census greps for the silence after the fact.

One blind spot, three times: **the holder is the only process in the system
that is not finishing anything, and finishes were all we measured.**

## What this is

`Grappa.Repo.LockWatch` reads at the seam instead of at the completion.
`Repo.immediate_transaction/1` is the sole producer of `BEGIN IMMEDIATE`, and
the ordering is **read in the dependencies, not assumed**: DBConnection enters
`run_transaction/5` only on `{:ok, _}` from `begin/3`
(`db_connection.ex:1103-1107`) and Exqlite emits `BEGIN IMMEDIATE TRANSACTION`
for `mode: :immediate` on an idle connection (`connection.ex:307`). So the
transaction fun's first statement is the exact acquisition edge: before it a
WAITER, after it the HOLDER.

A stall is reported only when a holder is past the threshold **with a queue
behind it** — a slow uncontended write is not a stall. The holder's live
`current_stacktrace` is sampled: a `Logger` frame means blocked on logging, a
`DBConnection` frame means a pool-topology deadlock, anything else is a third
answer nobody predicted. That distinction is the datum #1420 records as
missing ("separating the two needs a running stack").

Transaction semantics are untouched: `observe/1` is `try/after` around
`transaction/2`, passing the return value and any raise or `rollback/1` throw
through unchanged. The seam self-disables when its ETS table is absent, so a
watchdog restart can never abort a caller's write.

## What this is NOT

**Not the cure.** Narrowing `BEGIN IMMEDIATE` trades away what #1374/#1375
were written to buy. This turns that decision from a guess into a reading and
leaves the decision where it belongs.

## Cost

**Seam, resolvable:** 355.8 ns/call armed vs 95.5 ns/call disarmed, block
ranges non-overlapping — **260.3 ns per write transaction**. The disarmed
**micro-cost is ~95 ns**: the `persistent_term` read, the `ets.whereis`, and
the unconditional depth bookkeeping that stops the nesting counter leaking
across a watchdog restart.

**End-to-end: NOT RESOLVABLE BY THIS METHOD.** Observed delta **2.124 %**
against a **within-regime spread of 3.8 %** — the spread is larger than the
signal and the blocks overlap. The clause was fixed before the numbers were
seen and is not adjusted after: 2.124 % is **not a measurement**, and it is
above the 1 % threshold declared in advance. Composing the two resolvable
quantities (260.3 ns on a 47.15 us transaction) gives ~0.55 %, under
threshold — but that is **DERIVED, not measured end-to-end**, and it is
host-specific.

## Switch

Default ON (`config/config.exs`); OFF only under `:test`, where the Sandbox's
`pool_size: 1` makes every write transaction a holder and the output would be
noise. CI is covered — the integration stack runs `MIX_ENV: dev`
(`cicchetto/e2e/compose.yaml`, service `grappa-test`).

**Armed is not observed:** `integration.sh` discards container logs on a GREEN
run (#1429), so a stall in a passing run is written and then thrown away. The
#1420 question about green runs stays open, and this change cannot close it.

## The red that buys it

Real `SQLITE_BUSY` contention, not injected: a private `TmpRepo`
(`pool_size: 2`) with one process parked inside a write transaction and a
second genuinely blocked in its `BEGIN IMMEDIATE`. Six mutants, all confirmed
as ARRIVED (`Compiling 2 files` in each log), all killed:

| mutant | predicted | measured |
|---|---|---|
| roles swapped in `detect/2` | test 1 | test 1 |
| `acquired` made a no-op | all 4 | all 4 |
| `acquired` called outside the transaction body | test 1 + barriers | tests 1, 2 |
| emit without checking for a queue | test 3 | test 3 |
| stack sampled from `self()` | test 1 | test 1 |
| threshold comparison dropped | test 2 | test 2 |

The third is the one that matters: it validates that **the edge order IS the
measurement**. Only the per-test attribution was recorded, not which
assertion fired.

## Gates

`scripts/check.sh` **RC=0** (read from a file, not from a wrapper's exit
code): Credo `found no issues`, Dialyzer `Total errors: 0`, Sobelow, doctor
passed, **8 doctests / 61 properties / 6462 tests / 0 failures**,
`deps.audit` `No vulnerabilities found`, bats **540 ok / 0 not ok**.

Four rounds were needed because `check.sh` short-circuits; every red was
mine, cross-checked against the diff (Credo, an architecture test refusing an
unregistered long-lived GenServer, and two Dialyzer errors where my own
`scan/1` and `detect/2` specs contradicted each other).

## What I do NOT claim

- `scripts/integration.sh` and e2e: **never run** on this branch.
- The end-to-end cost: **not measured** (see above).
- `check.sh` went green on base `60657249`; `origin/main` has since moved to
  `e1892e80`, so **this branch is not fast-forwardable** and the gate predates
  the current head.