### PR TITLE
cic(#1402): fold the duplicated window-state sets, and measure what that does not buy

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -47,6 +47,7 @@ import {
   uploadState,
 } from "./lib/uploadOrchestrator";
 import { windowStateByChannel } from "./lib/windowState";
+import { NOT_JOINED_STATES } from "./lib/windowStateSets";
 
 // Sticky-bottom compose surface. Reads + writes compose.ts state;
 // dispatches submit on Enter; arrow keys walk per-channel history.
@@ -109,7 +110,6 @@ export type Props = {
 // it is not on screen while composing normally.
 const COUNTDOWN_FROM = 10;
 
-const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #356 — how long a green success/notice stays up before self-clearing.

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   SERVER_WINDOW_NAME,
 } from "./lib/windowKinds";
 import { windowStateByChannel } from "./lib/windowState";
+import { NOT_JOINED_STATES } from "./lib/windowStateSets";
 import NickText from "./NickText";
 import WindowBadges from "./WindowBadges";
 
@@ -87,10 +88,6 @@ import WindowBadges from "./WindowBadges";
 //   per-window `:parked` events from `Session.Server.terminate/2`; cic
 //   derives the cascade from the network-level state.
 
-// #902 — `invited` left this set with the pseudo-row itself: an unanswered
-// invite is announced by the top banner now, so no sidebar row carries that
-// state to grey out.
-const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #96 — a row's state, spoken. Every non-live sidebar row is rendered muted +

--- a/cicchetto/src/lib/pseudoChannels.ts
+++ b/cicchetto/src/lib/pseudoChannels.ts
@@ -2,7 +2,7 @@ import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { channelsBySlug } from "./networks";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { isMobile } from "./theme";
-import { windowStateByChannel } from "./windowState";
+import { type WindowState, windowStateByChannel } from "./windowState";
 
 // Synthetic window rows: keys with windowState != "joined" whose
 // (slug, name) is NOT yet in channelsBySlug AND not a known query
@@ -60,7 +60,7 @@ import { windowStateByChannel } from "./windowState";
 
 export type PseudoRow = {
   name: string;
-  state: "pending" | "failed" | "kicked" | "parked";
+  state: Exclude<WindowState, "invited" | "joined">;
 };
 
 export function pseudoChannelsForNetwork(slug: string, networkId: number): PseudoRow[] {
@@ -83,7 +83,7 @@ export function pseudoChannelsForNetwork(slug: string, networkId: number): Pseud
     const name = decoded.name;
     if (live.has(name)) continue;
     if (queries.has(name)) continue;
-    out.push({ name, state: state as PseudoRow["state"] });
+    out.push({ name, state });
   }
   return out;
 }

--- a/cicchetto/src/lib/windowStateSets.ts
+++ b/cicchetto/src/lib/windowStateSets.ts
@@ -1,0 +1,27 @@
+import type { WindowState } from "./windowState";
+
+// #1402 A3 — the window-state VOCABULARY, split from the live store.
+//
+// `ComposeBox` and `Sidebar` each carried a byte-identical
+// `new Set(["failed", "kicked", "parked"])` typed `Set<string>`, which accepts
+// any string and ties neither copy to the server's set. One definition, typed
+// against `WindowState`, makes a member that stops being a server state a tsc
+// error here.
+//
+// It does NOT live in `windowState.ts` with the type it constrains, and the
+// reason is measured rather than aesthetic: that module builds a Solid module
+// root at import time (via `selection.ts`), so three suites — Sidebar,
+// ComposeBox, Shell — replace it wholesale with `vi.mock`. Importing a real
+// constant from it forces every one of those mocks to either restate the set
+// (the copy this deletes, reborn in test land) or call `importOriginal`, which
+// drags the real module's import-time side effects through their other partial
+// mocks. This module imports `WindowState` as a TYPE, which is erased, so it
+// has no runtime edge to the store and nothing needs to mock it.
+//
+// `invited` is absent by #902: an unanswered invite is announced by the top
+// banner, so no sidebar row carries that state to grey out.
+export const NOT_JOINED_STATES: ReadonlySet<WindowState> = new Set<WindowState>([
+  "failed",
+  "kicked",
+  "parked",
+]);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45810,3 +45810,71 @@ matters. It is gone as a side effect of the fix, and no test asserts
 it — `default.css` was not touched.
 
 _Deploy: **--cic HOT, client-only.** No server, schema or wire change._
+<!-- entry #1402 -->
+
+---
+
+## 2026-08-17 — #1402 (bucket M, A3 first slice): the window-state copies are gone, and the detection they were assumed to give was never there
+
+Two of the six restatements of the window-state set were byte-identical
+`new Set(["failed", "kicked", "parked"])` declarations in `ComposeBox.tsx` and
+`Sidebar.tsx`, and a third was `PseudoRow["state"]`, a hand-written four-token
+subset. This slice removes all three: one `NOT_JOINED_STATES` typed
+`ReadonlySet<WindowState>`, and `Exclude<WindowState, "invited" | "joined">`
+for the row type. The `state as PseudoRow["state"]` cast at the push site goes
+too — the two `continue` guards above it already narrow the union, so the cast
+was not carrying the assignment, only silencing the compiler.
+
+### What this does NOT buy, measured rather than assumed
+
+The issue, this entry's own predecessor at `windowState.ts`, and the recon that
+opened the slice all say the same thing: that once the type derives from the
+server set, a seventh window state makes `tsc` report every site that does not
+handle it. **It does not, and the claim is now measured false.**
+
+A seventh state (`"locked"`) was injected into the emitted
+`SESSION_WINDOW_STATE_WINDOW_STATE` const and `tsc --noEmit` was run against
+both the unfixed and the fixed tree: **rc=0 with zero errors on both.** The
+instrument was proved able to fail first — a deliberate required field on
+`PseudoRow` produced `TS2741` at rc=1 — so the green is a real negative and not
+a broken harness. The reason is structural, not a gap to plug: `Exclude<T, …>`
+is defined relative to `T` and therefore GROWS with it, and a `Set` is under no
+obligation to be exhaustive. Both are "cannot drift" constructs. Neither is a
+"must be handled" construct, and no amount of removing casts turns one into the
+other.
+
+What the typing does buy was measured with the opposite mutant. Removing
+`"parked"` from the emitted const produces `TS2769` at
+`windowStateSets.ts:26`, naming the site — and produced **nothing at all** on
+the unfixed tree, where the `Set<string>` accepted the orphaned member without
+comment. So the slice detects a state being REMOVED or RENAMED upstream, and is
+blind to one being ADDED.
+
+### Why the blind half is being left blind
+
+Making an added state red would contradict a live invariant. CLAUDE.md's
+window-state section closes with "New states automatically inherit
+synthetic-row + greyed-class treatment as long as they land in
+`windowStateByChannel`" — silence on a seventh state is the DOCUMENTED
+behaviour, not an oversight, and the shape shipped here delivers exactly it.
+An exhaustiveness assertion against the emitted const would catch the addition,
+and it is deliberately NOT in this slice: it is a change to what the invariant
+promises, which is vjt's call and not a slice's. The sentence at
+`windowState.ts:37-39` that asserts the opposite is knowingly left standing for
+the same reason — correcting it presumes the ruling.
+
+### Where the constant lives, and why not where it belongs
+
+`NOT_JOINED_STATES` sits in a new `lib/windowStateSets.ts` rather than beside
+`WindowState` in `windowState.ts`. Putting it in the natural home failed 24
+tests: `windowState.ts` builds a Solid module root at import time through
+`selection.ts`, and Sidebar, ComposeBox and Shell each replace the whole module
+with `vi.mock`. Restating the set inside three mocks would rebuild, in test
+land, the duplication this slice deletes; `importOriginal` pulls the real
+module's import-time side effects through those suites' other partial mocks and
+fails on an unrelated `../lib/networks` stub. The new module imports
+`WindowState` as a type, which is erased, so it carries no runtime edge to the
+store and no suite needs to know it exists.
+
+_Shipping note: bundle-only, and nothing about the server or the wire moves —
+the emitted const is read, never rewritten._


### PR DESCRIPTION
First slice of bucket M / A3. It deletes the window-state copies the finding
names, and it does NOT deliver the detection everyone — the issue, the code
comment, and my own recon — assumed those copies were costing us. That second
half is measured, not conceded, and is the reason to read this body before the
diff.

## What the slice removes

| site on `2617474b` | before | after |
|---|---|---|
| `ComposeBox.tsx:112` | `const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"])` | imports the one definition |
| `Sidebar.tsx:93` | byte-identical to the above | imports the one definition |
| `pseudoChannels.ts:63` | `state: "pending" \| "failed" \| "kicked" \| "parked"` | `Exclude<WindowState, "invited" \| "joined">` |
| `pseudoChannels.ts:86` | `state: state as PseudoRow["state"]` | `state` |

The two `Set`s were `Set<string>`, which accepts any string: two copies was the
A3 finding, but the missing TYPE is what made them worth touching. The cast
removal is not cosmetic either — the two `continue` guards above the push
already narrow the union, so the cast was not carrying the assignment, only
silencing the compiler.

## The detection half is NOT bought, and that is deliberate

A seventh state (`"locked"`) was injected into the emitted
`SESSION_WINDOW_STATE_WINDOW_STATE` const, and `tsc --noEmit` run on both
sides:

| mutant | pre-fix | post-fix |
|---|---|---|
| **7th state ADDED** | rc=0, 0 errors | **rc=0, 0 errors** — unchanged, not bought |
| **`"parked"` REMOVED** | rc=0, 0 errors | **rc=1, `TS2769` at `windowStateSets.ts:26`** — bought, by name |
| control (deliberate required field on `PseudoRow`) | — | rc=1, `TS2741` — instrument proved able to fail |

So the slice detects a state REMOVED or RENAMED upstream and is blind to one
ADDED. The reason is structural: `Exclude<T, …>` is defined relative to `T` and
grows with it, and a `Set` need not be exhaustive. Both are "cannot drift"
constructs; neither is a "must be handled" construct.

**Blind is the documented behaviour, not a gap left open by laziness.**
CLAUDE.md's window-state invariant closes with "New states automatically
inherit synthetic-row + greyed-class treatment as long as they land in
`windowStateByChannel`". An exhaustiveness assertion against the emitted const
would catch the addition and would also change what that invariant promises,
which is a ruling rather than a slice. It is deliberately absent here.

For the same reason the sentence at `windowState.ts:37-39` — "a seventh state
arrives here … and tsc reports every site that does not handle it", written by
#1406 X-S8 — is knowingly left standing even though this PR measures it false.
Correcting it presumes the ruling it depends on.

## Where the constant lives, and why not where it belongs

`NOT_JOINED_STATES` is in a new `lib/windowStateSets.ts`, not beside
`WindowState` in `windowState.ts`. The natural home was tried first and failed
24 tests: `windowState.ts` builds a Solid module root at import time via
`selection.ts`, and Sidebar, ComposeBox and Shell each replace the whole module
with `vi.mock`. Restating the set in three mocks rebuilds the duplication in
test land; `importOriginal` drags the real module's import-time side effects
through those suites' other partial mocks and dies on an unrelated
`../lib/networks` stub. The new module imports `WindowState` as a type, which
is erased, so it has no runtime edge to the store and no suite needs to mock
it. No test file is touched by this PR.

## Gates

| gate | result |
|---|---|
| `scripts/bun.sh run test` | **rc=0 — 289 files, 5579 tests, 0 failures** (unchanged count: pure refactor, existing tests are the characterization) |
| `scripts/bun.sh run check` | **rc=0 — 59 warnings + 6 infos**, identical to the declared baseline (biome green, so tsc ran) |
| `scripts/design-notes-gate.sh` | **rc=0** — marker `<!-- entry #1402 -->` verified absent on the base first, unique after |

Branched from `origin/main` = `2617474b`, re-fetched before pushing and
unmoved, so every gate above ran on the live base. Contribution: 5 files,
100 additions, 8 deletions.

## Not run, and not claimed

- **No new test.** The behaviour is unchanged by construction — a cast and a
  duplicate definition are both erased or inert at runtime — and the 289 files
  already passing are the characterization. A test that pinned the set's
  membership would assert the copy rather than the derivation.
- **No e2e, no `scripts/integration.sh`, no Elixir gate.** Cic-only branch, no
  `lib/grappa/**`, no lane taken.
- **The other three restatements in the A3 list are untouched**: `CLAUDE.md`'s
  prose, the server type (which is the SSOT), and `windowState.ts` itself
  (already derived by #1406). The four gating MEDIUMs of bucket M are untouched.
- **`NETWORK_GREYED_STATES` is left alone deliberately.** It is a second
  byte-identical `Set` duplicated across the same two files, which the issue
  does not name — but it is keyed on `net.connection_state`, a DIFFERENT closed
  set with its own SSOT, so folding it here would have been the boundary
  violation and not the fix.
- **No claim that a seventh state is handled correctly at runtime.** What is
  measured is that nothing reports it. Whether inheriting the greyed treatment
  is right for an unknown future state is the invariant's claim, not this PR's.

Refs #1402.
