### PR TITLE
union: replay #1457 + #1458 + #1459 + #1460 onto current main, gated as one tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Top-level supervision tree:
 ```
 Grappa.Application
 ├── Grappa.Vault                       (Cloak — encrypts at-rest creds; before Repo)
+├── Grappa.Repo.LockWatch              (#1420 write-lock holder/waiter observer; before Repo — owns the ETS table the BEGIN IMMEDIATE seam writes to)
 ├── Grappa.Repo                        (Ecto + sqlite)
 ├── Phoenix.PubSub                     (name: Grappa.PubSub)
 ├── Registry                           (name: Grappa.SessionRegistry)
@@ -52,6 +53,9 @@ Grappa.Application
 
 Child order is load-bearing — see `lib/grappa/application.ex` for the
 why-comment per child. Vault before Repo (Cloak schema callbacks);
+LockWatch before Repo (#1420: it owns the ETS table
+`Repo.immediate_transaction/1` writes on every write transaction, and the
+seam self-disables while the table is absent);
 Backoff/WSPresence/NetworkCircuit before SessionSupervisor (ETS
 tables read directly from `Session.Server`'s start path); Bootstrap
 LAST (depends on Registry + SessionSupervisor existing). `Grappa.SpawnOrchestrator`

--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1386,7 +1386,7 @@ export async function inlineNickColorVar(locator: Locator): Promise<string> {
   return match[0];
 }
 
-// #1336 — page the scrollback UP with a wheel gesture that has demonstrably
+// #1336 — move the scrollback with a wheel gesture that has demonstrably
 // LANDED before the caller moves on.
 //
 // `page.mouse.wheel()` resolves before the scroll is applied (measured: the
@@ -1397,23 +1397,32 @@ export async function inlineNickColorVar(locator: Locator): Promise<string> {
 // testnet) owns the hover → wheel → moved-and-held wait and REJECTS both a
 // gesture that never landed and one still in flight.
 //
-// `pixels` is the distance to travel UP, positive; the DOM's negative-is-up
-// sign convention is applied here so callers read as the operator's intent.
+// `deltaY` carries the DOM's own sign convention: NEGATIVE scrolls up.
 // Sampling every 50 ms: two agreeing samples then mean the pane has held
 // still for 50 ms, which chromium's wheel animation (hundreds of ms of
 // continuous travel, measured) does not do mid-flight.
-export async function pageScrollbackUp(
+export async function pageScrollbackBy(
   page: Page,
-  pixels: number,
+  deltaY: number,
   timeoutMs: number,
 ): Promise<ScrollGestureResult> {
   const pane = page.locator('[data-testid="scrollback"]');
   return await scrollByGesture(
     {
       hover: () => pane.hover(),
-      wheel: async (deltaY: number) => await page.mouse.wheel(0, deltaY),
+      wheel: async (delta: number) => await page.mouse.wheel(0, delta),
       scrollTop: () => pane.evaluate((el) => el.scrollTop),
     },
-    { deltaY: -pixels, timeoutMs, pollMs: 50 },
+    { deltaY, timeoutMs, pollMs: 50 },
   );
+}
+
+// `pixels` is the distance to travel UP, positive, so the call site reads as
+// the operator's intent rather than as a DOM sign.
+export async function pageScrollbackUp(
+  page: Page,
+  pixels: number,
+  timeoutMs: number,
+): Promise<ScrollGestureResult> {
+  return await pageScrollbackBy(page, -pixels, timeoutMs);
 }

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -35,7 +35,12 @@
 // a fully-read channel.
 
 import type { Page } from "@playwright/test";
-import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  pageScrollbackBy,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -129,14 +134,23 @@ async function visibleRowIds(page: Page): Promise<number[]> {
   });
 }
 
+// #1336 — every gesture in this file goes through the shared door, which
+// waits for the pane to MOVE and then HOLD and REJECTS when it did neither.
+//
+// Measured before the conversion, on a quiet host: delete the gesture below
+// outright and FOUR of the six tests stay green (`--grep "forward-only
+// contract"`, 4 passed / 2 failed). Only the two strict-inequality assertions
+// notice, and even they blame the product — the red reads
+// `expect(701).toBeLessThan(701)`, never "the wheel was not delivered". The
+// budget is a condition-wait ceiling, not a sleep: it resolves the instant the
+// pane settles.
+const GESTURE_TIMEOUT_MS = 5_000;
+
 async function scrollByPx(page: Page, deltaY: number): Promise<void> {
   // BUGHUNT-2: real WheelEvent so the input-event gate in
   // ScrollbackPane's onScroll passes. Synthetic dispatchEvent(scroll)
   // was gated out post-BUGHUNT-2.
-  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
-  if (!box) throw new Error("scrollback bounding box null");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.wheel(0, deltaY);
+  await pageScrollbackBy(page, deltaY, GESTURE_TIMEOUT_MS);
 }
 
 async function scrollToBottom(page: Page): Promise<void> {
@@ -147,10 +161,11 @@ async function scrollToBottom(page: Page): Promise<void> {
   // ALSO advances the cursor, but via a DIFFERENT path — a direct
   // reached-bottom advance in `scrollToBottomGesture`, not the settle — so
   // the wheel is what pins the settle contract these tests assert.)
-  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
-  if (!box) throw new Error("scrollback bounding box null");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.wheel(0, 5000);
+  //
+  // #1336: this one was watched by NOBODY — deleting it left all six tests
+  // green. Through the shared door a wheel that moves nothing is a named
+  // failure instead of a silent pass.
+  await pageScrollbackBy(page, 5000, GESTURE_TIMEOUT_MS);
 }
 
 async function focusChannelAndWaitForRows(page: Page): Promise<void> {

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -47,6 +47,7 @@ import {
   uploadState,
 } from "./lib/uploadOrchestrator";
 import { windowStateByChannel } from "./lib/windowState";
+import { NOT_JOINED_STATES } from "./lib/windowStateSets";
 
 // Sticky-bottom compose surface. Reads + writes compose.ts state;
 // dispatches submit on Enter; arrow keys walk per-channel history.
@@ -109,7 +110,6 @@ export type Props = {
 // it is not on screen while composing normally.
 const COUNTDOWN_FROM = 10;
 
-const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #356 — how long a green success/notice stays up before self-clearing.

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   SERVER_WINDOW_NAME,
 } from "./lib/windowKinds";
 import { windowStateByChannel } from "./lib/windowState";
+import { NOT_JOINED_STATES } from "./lib/windowStateSets";
 import NickText from "./NickText";
 import WindowBadges from "./WindowBadges";
 
@@ -87,10 +88,6 @@ import WindowBadges from "./WindowBadges";
 //   per-window `:parked` events from `Session.Server.terminate/2`; cic
 //   derives the cascade from the network-level state.
 
-// #902 — `invited` left this set with the pseudo-row itself: an unanswered
-// invite is announced by the top banner now, so no sidebar row carries that
-// state to grey out.
-const NOT_JOINED_STATES = new Set(["failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #96 — a row's state, spoken. Every non-live sidebar row is rendered muted +

--- a/cicchetto/src/lib/pseudoChannels.ts
+++ b/cicchetto/src/lib/pseudoChannels.ts
@@ -2,7 +2,7 @@ import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { channelsBySlug } from "./networks";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { isMobile } from "./theme";
-import { windowStateByChannel } from "./windowState";
+import { type WindowState, windowStateByChannel } from "./windowState";
 
 // Synthetic window rows: keys with windowState != "joined" whose
 // (slug, name) is NOT yet in channelsBySlug AND not a known query
@@ -60,7 +60,7 @@ import { windowStateByChannel } from "./windowState";
 
 export type PseudoRow = {
   name: string;
-  state: "pending" | "failed" | "kicked" | "parked";
+  state: Exclude<WindowState, "invited" | "joined">;
 };
 
 export function pseudoChannelsForNetwork(slug: string, networkId: number): PseudoRow[] {
@@ -83,7 +83,7 @@ export function pseudoChannelsForNetwork(slug: string, networkId: number): Pseud
     const name = decoded.name;
     if (live.has(name)) continue;
     if (queries.has(name)) continue;
-    out.push({ name, state: state as PseudoRow["state"] });
+    out.push({ name, state });
   }
   return out;
 }

--- a/cicchetto/src/lib/windowStateSets.ts
+++ b/cicchetto/src/lib/windowStateSets.ts
@@ -1,0 +1,27 @@
+import type { WindowState } from "./windowState";
+
+// #1402 A3 — the window-state VOCABULARY, split from the live store.
+//
+// `ComposeBox` and `Sidebar` each carried a byte-identical
+// `new Set(["failed", "kicked", "parked"])` typed `Set<string>`, which accepts
+// any string and ties neither copy to the server's set. One definition, typed
+// against `WindowState`, makes a member that stops being a server state a tsc
+// error here.
+//
+// It does NOT live in `windowState.ts` with the type it constrains, and the
+// reason is measured rather than aesthetic: that module builds a Solid module
+// root at import time (via `selection.ts`), so three suites — Sidebar,
+// ComposeBox, Shell — replace it wholesale with `vi.mock`. Importing a real
+// constant from it forces every one of those mocks to either restate the set
+// (the copy this deletes, reborn in test land) or call `importOriginal`, which
+// drags the real module's import-time side effects through their other partial
+// mocks. This module imports `WindowState` as a TYPE, which is erased, so it
+// has no runtime edge to the store and nothing needs to mock it.
+//
+// `invited` is absent by #902: an unanswered invite is announced by the top
+// banner, so no sidebar row carries that state to grey out.
+export const NOT_JOINED_STATES: ReadonlySet<WindowState> = new Set<WindowState>([
+  "failed",
+  "kicked",
+  "parked",
+]);

--- a/config/config.exs
+++ b/config/config.exs
@@ -121,6 +121,26 @@ config :grappa, :session, connection_stable_ms: 60_000
 #   * backoff_ms — base per-attempt linear backoff (× attempt).
 #   * backoff_cap_ms — ceiling per sleep so late attempts don't stretch a
 #     single wait past a fifth of a second.
+# #1420 — the write-lock holder/waiter observer (`Grappa.Repo.LockWatch`).
+# Every DB signal that predates it is completion-driven and therefore measures
+# the VICTIM: Ecto's per-query event fires when a query FINISHES, so a process
+# holding `RESERVED` while it sits idle emits nothing, and only the 30.1s
+# `busy_timeout` of everybody queued behind it reaches the log. This observer
+# takes the reading at the `BEGIN IMMEDIATE` seam instead, which separates the
+# HOLDER from the WAITERS, and samples the holder's live stack when it stalls.
+#
+#   * enabled — arms both the watchdog timer and the write-path seam. OFF
+#     costs one :persistent_term read per write transaction and nothing more.
+#   * stall_threshold_ms — how long a holder must hold, WITH a queue behind
+#     it, before it is reported. Well under the 30_000 busy_timeout so the
+#     report lands while the stall is happening, not after the victims have
+#     already timed out.
+#   * tick_ms — watchdog scan cadence.
+config :grappa, :lock_watch,
+  enabled: true,
+  stall_threshold_ms: 2_000,
+  tick_ms: 1_000
+
 config :grappa, :busy_retry,
   budget_ms: 1_500,
   backoff_ms: 25,

--- a/config/config.exs
+++ b/config/config.exs
@@ -403,6 +403,12 @@ config :logger, :console,
     # key the operator cannot tell a NickServ IDENTIFY that never went out
     # from a lost CTCP reply, which are not the same incident.
     :origin,
+    # #1420 — LockWatch tags how long the write-lock holder has held and how
+    # many writers are queued behind it. Without these two keys the backend
+    # drops the structured half of a stall report, leaving only the prose —
+    # and the log line IS the door that reaches CI container logs.
+    :held_ms,
+    :waiters,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/config/test.exs
+++ b/config/test.exs
@@ -157,6 +157,17 @@ config :grappa, :attach_session_log_telemetry, false
 # would make snapshot assertions flaky. Aggregation tests attach the
 # handler explicitly + drain via `reset/0` (test/grappa/db_latency_test.exs).
 config :grappa, :attach_db_latency_telemetry, false
+# #1420 — LockWatch DISARMED in test env. The suite runs pool_size: 1 under
+# the Sandbox, where every write transaction shares one connection: each of
+# them would register as a holder, and any test slow enough to cross the
+# threshold would emit a warning into whatever test is capturing the Logger
+# stream. `lock_watch_test.exs` arms it explicitly (put_test_enabled/1) and
+# disarms on_exit. The table is still created, so arming needs no restart.
+config :grappa, :lock_watch,
+  enabled: false,
+  stall_threshold_ms: 2_000,
+  tick_ms: 1_000
+
 # #1321 — VendorLog singleton attach OFF in test env. The handler only
 # logs, so a global attach would write a push rejection into whatever
 # test happens to be capturing the Logger stream. Its own tests attach

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46203,3 +46203,71 @@ stall also hits runs that pass — therefore stays open until #1429 changes,
 and it stays open for a reason this change cannot fix from here. Arming the
 instrument and observing it are two different things, and only the first is
 done.
+<!-- entry #1402 -->
+
+---
+
+## 2026-08-17 — #1402 (bucket M, A3 first slice): the window-state copies are gone, and the detection they were assumed to give was never there
+
+Two of the six restatements of the window-state set were byte-identical
+`new Set(["failed", "kicked", "parked"])` declarations in `ComposeBox.tsx` and
+`Sidebar.tsx`, and a third was `PseudoRow["state"]`, a hand-written four-token
+subset. This slice removes all three: one `NOT_JOINED_STATES` typed
+`ReadonlySet<WindowState>`, and `Exclude<WindowState, "invited" | "joined">`
+for the row type. The `state as PseudoRow["state"]` cast at the push site goes
+too — the two `continue` guards above it already narrow the union, so the cast
+was not carrying the assignment, only silencing the compiler.
+
+### What this does NOT buy, measured rather than assumed
+
+The issue, this entry's own predecessor at `windowState.ts`, and the recon that
+opened the slice all say the same thing: that once the type derives from the
+server set, a seventh window state makes `tsc` report every site that does not
+handle it. **It does not, and the claim is now measured false.**
+
+A seventh state (`"locked"`) was injected into the emitted
+`SESSION_WINDOW_STATE_WINDOW_STATE` const and `tsc --noEmit` was run against
+both the unfixed and the fixed tree: **rc=0 with zero errors on both.** The
+instrument was proved able to fail first — a deliberate required field on
+`PseudoRow` produced `TS2741` at rc=1 — so the green is a real negative and not
+a broken harness. The reason is structural, not a gap to plug: `Exclude<T, …>`
+is defined relative to `T` and therefore GROWS with it, and a `Set` is under no
+obligation to be exhaustive. Both are "cannot drift" constructs. Neither is a
+"must be handled" construct, and no amount of removing casts turns one into the
+other.
+
+What the typing does buy was measured with the opposite mutant. Removing
+`"parked"` from the emitted const produces `TS2769` at
+`windowStateSets.ts:26`, naming the site — and produced **nothing at all** on
+the unfixed tree, where the `Set<string>` accepted the orphaned member without
+comment. So the slice detects a state being REMOVED or RENAMED upstream, and is
+blind to one being ADDED.
+
+### Why the blind half is being left blind
+
+Making an added state red would contradict a live invariant. CLAUDE.md's
+window-state section closes with "New states automatically inherit
+synthetic-row + greyed-class treatment as long as they land in
+`windowStateByChannel`" — silence on a seventh state is the DOCUMENTED
+behaviour, not an oversight, and the shape shipped here delivers exactly it.
+An exhaustiveness assertion against the emitted const would catch the addition,
+and it is deliberately NOT in this slice: it is a change to what the invariant
+promises, which is vjt's call and not a slice's. The sentence at
+`windowState.ts:37-39` that asserts the opposite is knowingly left standing for
+the same reason — correcting it presumes the ruling.
+
+### Where the constant lives, and why not where it belongs
+
+`NOT_JOINED_STATES` sits in a new `lib/windowStateSets.ts` rather than beside
+`WindowState` in `windowState.ts`. Putting it in the natural home failed 24
+tests: `windowState.ts` builds a Solid module root at import time through
+`selection.ts`, and Sidebar, ComposeBox and Shell each replace the whole module
+with `vi.mock`. Restating the set inside three mocks would rebuild, in test
+land, the duplication this slice deletes; `importOriginal` pulls the real
+module's import-time side effects through those suites' other partial mocks and
+fails on an unrelated `../lib/networks` stub. The new module imports
+`WindowState` as a type, which is erased, so it carries no runtime edge to the
+store and no suite needs to know it exists.
+
+_Shipping note: bundle-only, and nothing about the server or the wire moves —
+the emitted const is read, never rewritten._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46148,3 +46148,58 @@ causes #1420 names — a `Logger` call inside the transaction, or a
 pool-checkout deadlock. It turns that choice from a guess into a reading.
 Narrowing `BEGIN IMMEDIATE` is a separate decision about what we accept
 losing, and it is not this change's to make.
+
+### Cost, measured — and one number deliberately withheld
+
+Two measurements, because they answer different questions.
+
+**The seam itself is resolvable and clean.** `observe/1` around a no-op,
+200_000 calls per block, five blocks per regime, alternating:
+
+| regime | ns/call | block range |
+|---|---|---|
+| armed | 355.8 | 69598–72395 us |
+| disarmed | 95.5 | 18837–19696 us |
+| delta | **260.3 ns** | ranges do not overlap |
+
+Note the disarmed cost is not zero: **~95 ns/call is the price of the
+off-switch itself** — a `:persistent_term` read, an `:ets.whereis/1`, and the
+two process-dictionary operations that are deliberately unconditional so the
+nesting counter cannot leak when the watchdog restarts. That was paid on
+purpose, and now it is quantified.
+
+**The end-to-end cost is NOT RESOLVABLE by this method.** Real
+`BEGIN IMMEDIATE` + INSERT against a WAL temp file, 2_000 transactions per
+block, four blocks per regime, alternating. The observed delta was **2.124 %**,
+but the spread WITHIN a single regime was **3.8 %** — larger than the signal,
+with the blocks overlapping (armed `[95907, 97075, 96699, 93451]` against
+disarmed `[96943, 93367, 94226, 94374]`: the armed minimum sits below the
+disarmed maximum).
+
+The clause was fixed before the numbers were seen and is not being adjusted
+now that they have been: **2.124 % is not a measurement, it is noise, and it
+is above the 1 % threshold that was declared in advance.** It may not be
+reported as "under threshold" and it may not be reported as "2 %".
+
+Composing the two measured quantities — 260.3 ns of seam on a 47.15 us
+transaction — gives roughly **0.55 %**, under the threshold. That figure is
+**DERIVED, not measured end-to-end**, and it is host-specific: where a
+transaction costs more (ZFS, `page_size 65536`) the share falls, where it
+costs less it rises. So the threshold is satisfied by derivation, and the
+difference between the two statuses is the point, not a quibble.
+
+### Armed is not observed
+
+The observer defaults ON (`config/config.exs`) and is OFF only under
+`:test`, where the Sandbox's `pool_size: 1` makes every write transaction a
+holder and the output would be noise rather than signal. CI is covered: the
+integration stack runs `MIX_ENV: dev` (`cicchetto/e2e/compose.yaml`, service
+`grappa-test`), so it inherits the armed default and will write its warning.
+
+**It will not necessarily be read.** `scripts/integration.sh` discards
+container logs on a GREEN run (#1429), so a stall report from a passing run
+is produced and then thrown away. The open question in #1420 — whether the
+stall also hits runs that pass — therefore stays open until #1429 changes,
+and it stays open for a reason this change cannot fix from here. Arming the
+instrument and observing it are two different things, and only the first is
+done.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46036,3 +46036,54 @@ the caveat would have forbidden a fold that is exactly equivalent.
 stale — the type has lived in `Grappa.Subject`, not `Grappa.Session`, since the
 V1 promotion. It is left alone anyway, because its `String.t()` is the wider
 type and narrowing it is a separate judgement with its own risk.
+<!-- entry #1336 -->
+
+---
+
+## 2026-08-17 — #1336: a gesture nobody watched, and the two ways to be green about one
+
+`cursor-forward-only.spec.ts` drove nine wheel gestures through two
+hand-rolled `mouse.move` + `mouse.wheel` helpers. Every caller then slept a
+fixed `SETTLE_WAIT_MS` — 500 ms of product debounce plus 500 ms of slack —
+and read the cursor ONCE, with no assertion that retries. `page.mouse.wheel()`
+resolves before the scroll is applied (~250 ms, measured on #1080), so half
+that slack was already owed to a dispatch nobody waited for.
+
+Measured BEFORE touching it, deleting one gesture at a time, chromium,
+`--grep "forward-only contract"`, on a host whose #1429 census was clean
+(`db30=0`, `gaps_ge_10=0` on every service):
+
+| mutant | kills | what survived, and why |
+|---|---|---|
+| `scrollByPx` deleted | 2 of 6 | only the two STRICT inequalities notice. The equality test, the no-retreat test and the audit-"strengthened" disjunction all accept "nothing moved" |
+| `scrollToBottom` deleted | 0 of 6 | nobody was watching it at all |
+
+The sharpest of those: *"scroll back to bottom advances cursor to tail"*
+passes with the scroll-back-to-bottom removed, because the cursor is
+forward-only and the preceding scroll-up cannot retreat it off the tail it
+is already sitting on. **The contract under test is what makes its own
+verification vacuous** — not load, not timing.
+
+Both helpers now go through `pageScrollbackBy`, the signed sibling of
+#1080's `pageScrollbackUp` over the same unit-tested `scrollGesture` core,
+which waits for the pane to MOVE and then HOLD and rejects when it did
+neither. The attribution is one displacement — remove the hover, so the
+wheel is dispatched away from the pane — run on both sides of the change:
+
+| | reds | what the red says |
+|---|---|---|
+| before | 2 of 6 | `expect(701).toBeLessThan(701)` — it accuses the product |
+| after | 6 of 6 | `never moved the pane (scrollTop stayed 4029)` — it accuses the gesture, by name |
+
+Converted spec green at 6/6 in 29.1 s, against 32.4 s for the baseline: a
+condition-wait that resolves on arrival costs nothing when the gesture lands.
+
+**What this does NOT do, stated because the epic exists to refuse exactly
+this kind of overclaim.** It does not repair those four assertions: the
+disjunction still accepts "nothing moved", and `scrollToBottom`'s effect is
+still asserted by no one. It closes one of the two holes — being green about
+a gesture that never happened — and leaves the other open. And a prediction
+of mine died here: I expected the converted `scrollToBottom` to REJECT as
+"already clamped" and thereby prove itself a no-op. It did not reject. The
+pane does move; the gesture is real and merely unobserved, which is a
+narrower and different claim than the one I set out to make.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46087,3 +46087,64 @@ of mine died here: I expected the converted `scrollToBottom` to REJECT as
 "already clamped" and thereby prove itself a no-op. It did not reject. The
 pane does move; the gesture is real and merely unobserved, which is a
 narrower and different claim than the one I set out to make.
+<!-- entry #1420 -->
+
+---
+
+## 2026-08-17 — #1420: the write-lock observer, and why every earlier DB signal measured the victim
+
+Six CI runs stalled for exactly 30.1 s each — `busy_timeout: 30_000`, never
+12 s, never 47 s — and the census could name the victims every time and the
+cause not once. That asymmetry is not bad luck, it is a property of the
+instruments we had.
+
+**Every DB signal grappa emitted before this was completion-driven.** Ecto's
+`[:grappa, :repo, :query]` fires when a query FINISHES, so a process that
+opens `BEGIN IMMEDIATE` and then sits still emits nothing at all while it
+sits; the only rows reaching the log are the 30-second `begin`s and
+`SELECT`s of everybody queued behind it. `BusyRetry`'s `:on_contention` hook
+lives inside a `rescue`, so by construction it counts whoever caught the
+exception. The #1429 census greps container logs after the fact and sees the
+silence, not its author. Three instruments, one blind spot, and it is the
+same blind spot every time: **the holder is the one process in the system
+that is not finishing anything, and all we measured were finishes.**
+
+`Grappa.Repo.LockWatch` reads at the seam instead of at the completion.
+`Grappa.Repo.immediate_transaction/1` is the only producer of `BEGIN
+IMMEDIATE` in the tree, and ecto_sqlite3 executes that statement BEFORE
+invoking the transaction fun — so the fun's first statement is an exact,
+free "the lock is mine now" edge. Before it, the caller is a WAITER; after
+it, the HOLDER. The watchdog reports only a holder past a threshold WITH a
+queue behind it, and samples that holder's live `current_stacktrace` — the
+datum the issue records as missing ("separating the two needs a running
+stack"). A waiter is captured the same way whether it is blocked on SQLite's
+`busy_timeout` or queued on a DBConnection checkout, so the two candidate
+topologies stay distinguishable by their stacks rather than by argument.
+
+Decisions worth keeping:
+
+- **No caller label is stored, and `immediate_transaction/1` grew no label
+  argument.** When the watchdog fires, the holder is still inside the
+  transaction, so its stack already carries every caller frame. The identity
+  is derived at report time and the write path pays nothing for it.
+- **The seam self-disables when its ETS table is absent.** The watchdog owns
+  that table, so a restart briefly removes it — and without the check,
+  `acquired` would raise INSIDE a caller's transaction. An observer that
+  aborts the write it is watching is worse than no observer.
+- **Dead rows are reaped on the scan, never on the write path.** A process
+  killed mid-transaction never releases; an unreaped row would have the
+  instrument accusing a corpse forever while the real contention went
+  unnamed.
+- **No new noun.** Episodes fold into `Grappa.DbLatency`'s bounded ring, so
+  `GET /admin/db_latency` and `bin/grappa db-latency` inherit them with no
+  new controller and no new verb. The `Logger.warning` is the door that
+  matters for CI, where the evidence is container logs.
+- **Off in test.** Under the Sandbox's `pool_size: 1` every write
+  transaction is a holder; the observer's own tests arm it explicitly and
+  disarm on exit.
+
+What this deliberately does NOT do: it does not choose between the two
+causes #1420 names — a `Logger` call inside the transaction, or a
+pool-checkout deadlock. It turns that choice from a guess into a reading.
+Narrowing `BEGIN IMMEDIATE` is a separate decision about what we accept
+losing, and it is not this change's to make.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45917,3 +45917,122 @@ the channel list are folded upstream), so what is measured is the
 boundary, not a user-visible regression.
 
 _Deploy: **--cic HOT, client-only.** No server, schema or wire change._
+<!-- entry #1392 -->
+
+---
+
+## 2026-08-17 — #1392: three spellings of one subject predicate, and the claims measurement retired
+
+Bucket C of the 2026-08-15 architecture review. `Grappa.Subject`'s moduledoc
+has declared it the single source of truth for the
+`{:user, uuid} | {:visitor, uuid}` discriminator since the V1 visitor-parity
+promotion, and named `Grappa.Scrollback` and `Grappa.ReadCursor` as the
+contexts it was promoted OUT of. Neither of them referenced `Grappa.Subject`
+at all. The promotion reached nine modules and stopped one short of the two it
+was named after.
+
+Counted at `f59b0c7e`: `Subject.subject_where/2` served 19 call sites across
+seven modules, `Scrollback.subject_where/2` (private) 12, and
+`ReadCursor.subject_filter/2` (private) 7. A fourth spelling sat on the write
+side — `ReadCursor.subject_attrs/1`, one call site, duplicating
+`Subject.put_subject_id/2`.
+
+### The predicate did not diverge; the diagnostic did
+
+All three built the same clause: the same `is_binary/1` guards on both
+branches, the same equality against the same FK column, and the same
+**positional** binding — `[m]` in one, `[row]` in the other two, both index 0.
+That last detail is what makes the fold a substitution rather than a rewrite:
+no call site's query shape can change the result, because the binding is
+resolved by position and the position is identical. No value in the valid
+domain makes any two of them build a different query.
+
+They differed OFF the domain, and there the difference is real.
+`Scrollback` carried an explicit fall-through raising `ArgumentError` with the
+inspected subject, added by B5.4 L-pers-2 precisely because a
+`FunctionClauseError` hides both the offending value and the function name.
+`Subject` and `ReadCursor` had no such clause.
+
+So the fold could not be a deletion. Dropping the two privates and letting
+`Subject.subject_where/2` answer would have removed that diagnostic from 12
+call sites; the clause was promoted **with** the function instead. That is a
+behaviour change and the commit says so rather than claiming none: 19 existing
+`Subject.subject_where/2` call sites and 7 former `subject_filter/2` ones move
+from `FunctionClauseError` to `ArgumentError`. Nothing in `test/` asserted
+`FunctionClauseError` on these functions, and the two pins that already
+existed (`scrollback_test.exs`, `~r/unknown subject:/`) stay green untouched —
+which is the evidence the fold is transparent at the Scrollback boundary.
+
+### What the issue text claimed and the code did not
+
+Two figures in the issue body do not reproduce, and the code wins:
+
+`subject_filter/2` has **7** call sites, not 8. Classifying all twelve
+occurrences of the token in `read_cursor.ex`: seven calls, two clauses, one
+`@spec`, and two mentions in prose. The likeliest source of the eighth is the
+`@spec` or the cross-reference comment, but no base was constructed that
+yields 8, so that stays a guess.
+
+"Seven modules re-declare the type literal" merges three different types. Only
+**four** declarations are verbatim clones of `Subject.t()` (`accounts.ex`,
+`read_cursor.ex`, `scrollback.ex`, `session.ex`). Two more —
+`accounts/revocations.ex`, `rate_limit/request_budget.ex` — spell the id as
+`String.t()`, which is strictly WIDER than `Ecto.UUID.t() :: <<_::288>>`;
+substituting `Subject.t()` there narrows a type rather than deduplicating one.
+Three others (`account_deletion.ex`, `themes.ex`, `grappa_web/subject.ex`) are
+the rich-struct shape. The issue excluded `account_deletion.ex` for exactly
+that reason but did not name `themes.ex`, which is the same animal and equally
+uncollapsible: a core context cannot depend on `GrappaWeb`.
+
+Three of the four true clones collapse here. `accounts.ex:103` does not:
+`Grappa.Accounts` is a DEP of `Grappa.Subject`, so referencing `Subject.t()`
+from inside it would close `Subject → Accounts → Subject` if Boundary tracks
+remote type references. Whether it does was not established — the repo
+contains no discriminating case, since every remote `Grappa.X.t()` in a core
+`@spec` sits in a boundary that already declares `X`. The declaration is worth
+two `@spec` sites, so the cheap move is to leave it and say why.
+
+### The write-side asymmetry is real and unreachable
+
+`Subject.put_subject_id/2` guards `is_map(attrs) and is_binary(uid)`.
+`ReadCursor.subject_attrs/1` had no guard at all, so `{:user, nil}` returned
+`%{user_id: nil}` — a value where every sibling raises, flowing into
+`Cursor.changeset/2` and failing late at the XOR CHECK instead of early at the
+call site.
+
+Tracing it settled the question the other way, and that is worth recording:
+both paths into `upsert_cursor/5` (`do_set/4` and `force_write/4`) call
+`get/3` first, and every public entry passes through `message_belongs?/4` as
+well — all of them subject-guarded. A malformed subject raises before
+`subject_attrs/1` is ever reached. The asymmetry was measured; the exploit path
+does not exist. Folding it into `put_subject_id/2` is therefore deduplication,
+not a fix, and it is recorded as such rather than dressed up as one.
+
+`put_subject_id/2` keeps its `FunctionClauseError` posture deliberately. Giving
+it the same `ArgumentError` fall-through would be a second behaviour change
+across 24 call sites that nothing here asks for; a hard failure on a malformed
+shape is already the right answer, and uniformity for its own sake can be its
+own change.
+
+### Two sentences in the moduledoc that were not true
+
+`subject_where/2`'s `@doc` promised a
+`WHERE user_id = ? AND visitor_id IS NULL`-shaped clause. None of the three
+spellings ever emitted the second conjunct — all three emit the single
+equality, and the DB-level XOR CHECK is what makes it redundant. Harmless at
+runtime, but it is the sentence a reader would use to reason about subject
+isolation, so it stated a guarantee the code did not provide.
+
+The same `@doc` told multi-join callers to write the where-clause themselves.
+`ReadCursor.bulk_for_subject/1` has always been a multi-join caller and has
+always been correct, because the real precondition is narrower than "no
+joins": binding 0 must be the table carrying the subject FK. Stated as written,
+the caveat would have forbidden a fold that is exactly equivalent.
+
+### Left out, and named so nobody has to re-derive it
+
+`request_budget.ex:58-63` justifies its local declaration as keeping "the
+`Grappa.RateLimit` boundary free of a `Grappa.Session` dep". That reason is
+stale — the type has lived in `Grappa.Subject`, not `Grappa.Session`, since the
+V1 promotion. It is left alone anyway, because its `String.t()` is the wider
+type and narrowing it is a separate judgement with its own risk.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4592,7 +4592,7 @@ hand-attach — read it through either door (both drive the same
   (`204`). `:admin_authn`-gated (admin bearer + `is_admin`); reached
   through the dumb proxy, no allowlist to maintain (#485).
 
-The handler folds **two** signal families:
+The handler folds **three** signal families:
 
 - **`[:grappa, :repo, :query]`** (Ecto's per-query telemetry) into a
   `{source, op}` table — `SELECT count(...)` split from plain `SELECT`. This is
@@ -4602,6 +4602,42 @@ The handler folds **two** signal families:
   against the baseline.
 - **the D1 write-path spans** into `send_privmsg` / `persist` / `contention`
   rows.
+- **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) into the
+  bounded `lock stalls` ring — the WRITE-LOCK HOLDER.
+
+### Reading a write-lock stall (#1420)
+
+The two families above are **completion-driven**: they fire when a query
+finishes. A process that opens `BEGIN IMMEDIATE` and then sits still emits
+nothing at all while it sits, so the only thing that ever reached the log was
+its victims — the 30.1 s `busy_timeout` rows of everybody queued behind it.
+`Grappa.Repo.LockWatch` reads at the `BEGIN IMMEDIATE` seam instead, which
+separates the **holder** from the **waiters**.
+
+A stall is reported only when a holder has held past
+`:lock_watch, :stall_threshold_ms` **with at least one waiter queued behind
+it** — a slow uncontended write is not a stall. Each episode appears twice: a
+`detected` row carrying the holder's sampled **stacktrace** plus the queue, and
+a `resolved` row carrying the total hold.
+
+Two doors, and for an incident they answer different questions:
+
+- **`Logger.warning`** — fires the moment the stall is detected, so it lands in
+  container logs and CI artefacts. This is the door that matters when the
+  evidence is a log after the fact.
+- **`bin/grappa db-latency` / `GET /admin/db_latency`** — the last 20 episodes,
+  newest first, for a node you can still reach.
+
+**What the stack tells you.** The holder's frames are the answer to "why is it
+not proceeding": a `Logger` frame means the transaction is blocked on logging;
+a `DBConnection` checkout frame means a pool-topology deadlock; anything else
+is a third answer nobody has predicted yet. That distinction is the whole
+reason the instrument exists — before it, both looked identical from the logs.
+
+**Off-switch:** `config :grappa, :lock_watch, enabled: false`. Disabled, the
+write path pays one `:persistent_term` read per write transaction and does no
+ETS work. It is **off in `:test`** (under the Sandbox's `pool_size: 1` every
+write transaction is a holder).
 
 **Taking a 25s under-load sample:** `bin/grappa db-latency-reset` → wait 25s
 **under genuine daytime load** → `bin/grappa db-latency`. Counters are

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -188,6 +188,15 @@ defmodule Grappa.Application do
         # up, the type callback would crash with `:noproc`.
         Grappa.Vault,
 
+        # LockWatch before Repo (#1420): it owns the ETS table that
+        # `Repo.immediate_transaction/1` writes to on every write
+        # transaction, so the table must exist before the first one can
+        # run. Placing it after Repo would leave a boot window in which
+        # the seam self-disables — and the seam checks for the table
+        # precisely so a watchdog restart can never abort a caller's
+        # transaction. Depends on nothing itself (ETS + a timer).
+        {Grappa.Repo.LockWatch, lock_watch_opts()},
+
         # Must come first (after Vault): every context that touches the
         # DB depends on Repo being up. Sessions write Scrollback rows;
         # Phase 2 schemas (network_credentials) carry encrypted columns
@@ -609,6 +618,18 @@ defmodule Grappa.Application do
   @spec attach_db_latency_telemetry?() :: boolean()
   defp attach_db_latency_telemetry?,
     do: Application.get_env(:grappa, :attach_db_latency_telemetry, true)
+
+  # #1420 — the write-lock holder/waiter observer. Read at boot, injected
+  # via start_link opts (never a runtime Application.get_env in a
+  # callback). `enabled` is the off-switch: it gates BOTH the watchdog
+  # timer and the write-path seam, so switching it off costs one
+  # :persistent_term read per write transaction and nothing else.
+  # `fetch_env!` and not a defaulted `get_env`: the three keys are declared
+  # together in config/config.exs, and a half-configured observer that
+  # silently falls back to invented thresholds is worse than a loud boot
+  # failure naming the missing key.
+  @spec lock_watch_opts() :: keyword()
+  defp lock_watch_opts, do: Application.fetch_env!(:grappa, :lock_watch)
 
   # #1321 — same test-env opt-out shape. The reason is neither sandbox
   # ownership nor determinism: the handler only logs, and a globally

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -18,7 +18,7 @@ defmodule Grappa.DbLatency do
   measurements into small in-memory running counters. No Repo, no
   PubSub, no schema.
 
-  ## Two signal families, one handler
+  ## Three signal families, one handler
 
   The handler consumes both the D1 write-path spans AND Ecto's built-in
   per-query telemetry, because the two answer two different open
@@ -46,6 +46,15 @@ defmodule Grappa.DbLatency do
           (budget-exhausted rows lost).
         - **mechanism 3 (pure insert / index write-amplification):** the
           `persist` row `mean_ms` on its own, watched as the table grows.
+
+    * **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) —
+      the write-lock HOLDER, which neither family above can see. Both of
+      them are completion-driven, so a process sitting idle inside
+      `BEGIN IMMEDIATE` emits nothing while it sits and only its victims
+      show up (as 30.1s `busy_timeout` rows). `Grappa.Repo.LockWatch`
+      reads at the seam instead and hands over the holder's sampled stack
+      plus the queue behind it; here they are kept as a bounded ring, so
+      the existing CLI and admin doors surface them with no new noun.
 
   ## Reading a window
 
@@ -83,8 +92,16 @@ defmodule Grappa.DbLatency do
     [:grappa, :repo, :query],
     [:grappa, :scrollback, :persist, :stop],
     [:grappa, :session, :send_privmsg, :stop],
-    [:grappa, :scrollback, :persist, :contention]
+    [:grappa, :scrollback, :persist, :contention],
+    [:grappa, :repo, :lock_stall, :detected],
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
+
+  # #1420 — the lock-stall ring is bounded: these rows carry sampled
+  # stacktraces, so an unbounded list would grow the singleton's heap for as
+  # long as the node stays up. Twenty episodes is far more than any single
+  # incident produces and still fits in one admin response.
+  @lock_stall_ring 20
 
   @type op :: :select | :insert | :update | :delete | :count | :other
 
@@ -111,11 +128,27 @@ defmodule Grappa.DbLatency do
           dropped: non_neg_integer()
         }
 
+  @typedoc """
+  One write-lock stall episode (#1420). `:detected` carries the holder's
+  sampled stack and the queue behind it; `:resolved` brackets the same
+  episode with the TOTAL hold and no samples (by then there is nothing left
+  to sample). Newest first.
+  """
+  @type lock_stall_row :: %{
+          phase: :detected | :resolved,
+          holder_pid: String.t(),
+          held_ms: non_neg_integer(),
+          waiter_count: non_neg_integer(),
+          holder: map() | nil,
+          waiters: [map()]
+        }
+
   @type snapshot :: %{
           queries: [query_row()],
           send_privmsg: span_row(),
           persist: span_row(),
-          contention: contention_row()
+          contention: contention_row(),
+          lock_stalls: [lock_stall_row()]
         }
 
   # Internal accumulators carry NATIVE time units (integer sums); the
@@ -123,13 +156,15 @@ defmodule Grappa.DbLatency do
   defstruct queries: %{},
             send_privmsg: %{n: 0, total: 0, outcomes: %{}},
             persist: %{n: 0, total: 0, outcomes: %{}},
-            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, dropped: 0}
+            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, dropped: 0},
+            lock_stalls: []
 
   @type t :: %__MODULE__{
           queries: %{{String.t() | nil, op()} => %{n: non_neg_integer(), total: integer(), queue: integer()}},
           send_privmsg: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
           persist: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
-          contention: contention_row()
+          contention: contention_row(),
+          lock_stalls: [lock_stall_row()]
         }
 
   ## ----- Public API ---------------------------------------------------
@@ -229,6 +264,33 @@ defmodule Grappa.DbLatency do
     end
   end
 
+  defp fold([:grappa, :repo, :lock_stall, :detected], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :detected,
+      holder_pid: metadata.holder.pid,
+      held_ms: measurements.held_ms,
+      waiter_count: measurements.waiter_count,
+      holder: metadata.holder,
+      waiters: metadata.waiters
+    })
+  end
+
+  defp fold([:grappa, :repo, :lock_stall, :resolved], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :resolved,
+      holder_pid: metadata.holder_pid,
+      held_ms: measurements.held_ms,
+      waiter_count: 0,
+      holder: nil,
+      waiters: []
+    })
+  end
+
+  @spec push_stall(t(), lock_stall_row()) :: t()
+  defp push_stall(state, row) do
+    %{state | lock_stalls: Enum.take([row | state.lock_stalls], @lock_stall_ring)}
+  end
+
   # Accumulate one span's duration + outcome tally.
   @spec add_span(map(), map(), map()) :: map()
   defp add_span(acc, measurements, metadata) do
@@ -293,7 +355,8 @@ defmodule Grappa.DbLatency do
       queries: queries,
       send_privmsg: span_snapshot(state.send_privmsg),
       persist: span_snapshot(state.persist),
-      contention: state.contention
+      contention: state.contention,
+      lock_stalls: state.lock_stalls
     }
   end
 

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -102,6 +102,9 @@ defmodule Grappa.HotReload.LongLivedModules do
   # would silently false-COLD when typespec union lines matched the
   # shape — review C4 / CP28 incident class).
   @modules [
+    # #1420 — first, because it is the one child that boots BEFORE Repo
+    # (it owns the ETS table the BEGIN IMMEDIATE seam writes to).
+    Grappa.Repo.LockWatch,
     Grappa.Session.Backoff,
     Grappa.WSPresence,
     Grappa.Admission.NetworkCircuit,
@@ -143,7 +146,8 @@ defmodule Grappa.HotReload.LongLivedModules do
   `:underspecs` (a divergence shows up as `contract_supertype`).
   """
   @type long_lived ::
-          Grappa.Session.Backoff
+          Grappa.Repo.LockWatch
+          | Grappa.Session.Backoff
           | Grappa.WSPresence
           | Grappa.Admission.NetworkCircuit
           | Grappa.AdminEvents

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1018,7 +1018,32 @@ defmodule Grappa.Operator do
       )
     )
 
+    # #1420 — the holder side. Printed LAST and one block per episode rather
+    # than as a table row: the payload that answers "why did the holder
+    # pause" is a stacktrace, and a stacktrace does not fit a column.
+    IO.puts("# lock stalls (write-lock holder vs waiters) — newest first")
+
+    Enum.each(snapshot.lock_stalls, fn stall ->
+      IO.puts(
+        "#{stall.phase}\tholder=#{stall.holder_pid}\theld_ms=#{stall.held_ms}" <>
+          "\twaiters=#{stall.waiter_count}"
+      )
+
+      Enum.each(lock_stall_detail_lines(stall), &IO.puts/1)
+    end)
+
     :ok
+  end
+
+  # A `:resolved` row carries no samples (the episode is over and there is
+  # nothing left to inspect), so it renders as its header line alone.
+  @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
+  defp lock_stall_detail_lines(%{holder: nil}), do: []
+
+  defp lock_stall_detail_lines(%{holder: holder, waiters: waiters}) do
+    ["  holder at #{holder.current_function} (#{holder.status}, mailbox #{holder.message_queue_len})"] ++
+      Enum.map(holder.stacktrace, &"    #{&1}") ++
+      Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}")
   end
 
   @doc """

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -96,9 +96,8 @@ defmodule Grappa.ReadCursor do
   alias Grappa.Networks.Network
   alias Grappa.PubSub.Topic
   alias Grappa.ReadCursor.{Cursor, Wire}
-  alias Grappa.Repo
   alias Grappa.Scrollback.Message
-  alias Grappa.Subject
+  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -830,5 +830,4 @@ defmodule Grappa.ReadCursor do
     |> Grappa.Scrollback.channel_or_dm_where(channel, nil)
     |> Repo.exists?()
   end
-
 end

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -40,9 +40,11 @@ defmodule Grappa.ReadCursor do
 
   Mirrors `Grappa.Scrollback.Message`'s convention. The subject
   discriminated union (`{:user, uuid}` | `{:visitor, uuid}`) is the
-  same tagged-tuple shape Scrollback's `fetch/6` accepts. Same predicate
-  helpers (`subject_filter/1`, `subject_attrs/1`) keep the per-subject
-  iso boundary uniform across contexts.
+  same tagged-tuple shape Scrollback's `fetch/6` accepts, and since
+  #1392 it is the same CODE: the private `subject_filter/2` and
+  `subject_attrs/1` this module used to carry were synonyms of
+  `Grappa.Subject.subject_where/2` and `Grappa.Subject.put_subject_id/2`,
+  and now call them.
 
   ## Boundary
 
@@ -58,6 +60,9 @@ defmodule Grappa.ReadCursor do
       `messages` table by id.
     * `Grappa.PubSub` — `Topic.channel/3` for the `read_cursor_set`
       cross-device broadcast.
+    * `Grappa.Subject` — the subject discriminator itself: `t/0`,
+      `subject_where/2` for every read, `put_subject_id/2` for the
+      insert (#1392).
 
   The `Cursor` schema module is internal; callers receive `%Cursor{}`
   structs by type but MUST NOT alias or import the schema module
@@ -66,7 +71,15 @@ defmodule Grappa.ReadCursor do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Scrollback, Grappa.Visitors.Visitor],
+    deps: [
+      Grappa.Accounts,
+      Grappa.IRC,
+      Grappa.PubSub,
+      Grappa.Repo,
+      Grappa.Scrollback,
+      Grappa.Subject,
+      Grappa.Visitors.Visitor
+    ],
     # `Networks.Network` is referenced ONLY as a schema — the
     # `belongs_to :network` FK association + the `join: n in Network`
     # slug lookup in `bulk_for_subject/1` (field access, no Networks
@@ -85,6 +98,7 @@ defmodule Grappa.ReadCursor do
   alias Grappa.ReadCursor.{Cursor, Wire}
   alias Grappa.Repo
   alias Grappa.Scrollback.Message
+  alias Grappa.Subject
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.
@@ -99,7 +113,7 @@ defmodule Grappa.ReadCursor do
   tagged-tuple shape across both contexts so callers don't need to
   re-encode the principal at every boundary.
   """
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Subject.t()
 
   @typedoc """
   Bulk envelope shape: nested `%{network_slug => %{channel => message_id}}`.
@@ -131,7 +145,7 @@ defmodule Grappa.ReadCursor do
     channel = Identifier.canonical_target(channel)
 
     Cursor
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([c], c.network_id == ^network_id and c.channel == ^channel)
     |> Repo.one()
   end
@@ -209,7 +223,7 @@ defmodule Grappa.ReadCursor do
       )
 
     base
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> Repo.all()
     |> Enum.reduce(%{}, fn {slug, channel, id}, acc ->
       Map.update(acc, slug, %{channel => id}, &Map.put(&1, channel, id))
@@ -346,7 +360,7 @@ defmodule Grappa.ReadCursor do
       )
 
     query
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> Repo.all()
     |> Enum.reduce(%{}, fn {slug, channel, bucket, n}, acc ->
       key = if bucket == 1, do: :messages, else: :events
@@ -408,12 +422,12 @@ defmodule Grappa.ReadCursor do
       )
 
     # Scope the DRIVING `read_cursors` to the subject via the shared
-    # `subject_filter/2` (binding 0 == `rc`), identical to
+    # `Subject.subject_where/2` (binding 0 == `rc`), identical to
     # `bulk_unread_split/3` + `bulk_for_subject/1` — one way to express
     # "these cursors are mine". `subject_pair/1` is still needed for the
     # `on:`-clause match on `messages` (a join-side filter belongs in `on:`,
     # not `where`, so the JOIN keeps its driving row).
-    scoped = subject_filter(ranked, subject)
+    scoped = Subject.subject_where(ranked, subject)
 
     capped =
       from(r in subquery(scoped),
@@ -662,7 +676,7 @@ defmodule Grappa.ReadCursor do
     else
       old_query =
         Cursor
-        |> subject_filter(subject)
+        |> Subject.subject_where(subject)
         |> where(
           [c],
           c.network_id == ^network_id and Identifier.nick_fold(c.channel) == ^folded_old
@@ -701,7 +715,7 @@ defmodule Grappa.ReadCursor do
   @spec cursor_folds_to?(subject(), integer(), String.t()) :: boolean()
   defp cursor_folds_to?(subject, network_id, folded) do
     Cursor
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([c], c.network_id == ^network_id and Identifier.nick_fold(c.channel) == ^folded)
     |> Repo.exists?()
   end
@@ -776,11 +790,14 @@ defmodule Grappa.ReadCursor do
 
   defp upsert_cursor(nil, subject, network_id, channel, message_id) do
     attrs =
-      Map.merge(subject_attrs(subject), %{
-        network_id: network_id,
-        channel: channel,
-        last_read_message_id: message_id
-      })
+      Subject.put_subject_id(
+        %{
+          network_id: network_id,
+          channel: channel,
+          last_read_message_id: message_id
+        },
+        subject
+      )
 
     %Cursor{}
     |> Cursor.changeset(attrs)
@@ -808,27 +825,10 @@ defmodule Grappa.ReadCursor do
     # narrowing is a read-time concern (scrollback display), not a
     # write-time concern (cursor validity).
     Message
-    |> subject_filter(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.id == ^message_id and m.network_id == ^network_id)
     |> Grappa.Scrollback.channel_or_dm_where(channel, nil)
     |> Repo.exists?()
   end
 
-  # Mirrors `Grappa.Scrollback.subject_where/2` — same tagged-tuple
-  # discriminator, same `m.user_id` / `m.visitor_id` partition. Reused
-  # across `Cursor` queries (binding name `c`) and `Message` existence
-  # queries (binding name `m`); Ecto's binding-by-position lookup
-  # works on both since each query has a single from-binding.
-  @spec subject_filter(Ecto.Queryable.t(), subject()) :: Ecto.Query.t()
-  defp subject_filter(queryable, {:user, user_id}) when is_binary(user_id) do
-    where(queryable, [row], row.user_id == ^user_id)
-  end
-
-  defp subject_filter(queryable, {:visitor, visitor_id}) when is_binary(visitor_id) do
-    where(queryable, [row], row.visitor_id == ^visitor_id)
-  end
-
-  @spec subject_attrs(subject()) :: %{atom() => Ecto.UUID.t()}
-  defp subject_attrs({:user, user_id}), do: %{user_id: user_id}
-  defp subject_attrs({:visitor, visitor_id}), do: %{visitor_id: visitor_id}
 end

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -96,8 +96,8 @@ defmodule Grappa.ReadCursor do
   alias Grappa.Networks.Network
   alias Grappa.PubSub.Topic
   alias Grappa.ReadCursor.{Cursor, Wire}
-  alias Grappa.Scrollback.Message
   alias Grappa.{Repo, Subject}
+  alias Grappa.Scrollback.Message
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment) used by
   # rename_dm_peer/4 to match a DM cursor by the fold of the peer nick.

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -9,11 +9,13 @@ defmodule Grappa.Repo do
   the full reasoning. Resist the urge to introduce dynamic Repos.
   """
 
-  use Boundary, top_level?: true, deps: [], exports: [BusyRetry]
+  use Boundary, top_level?: true, deps: [], exports: [BusyRetry, LockWatch]
 
   use Ecto.Repo,
     otp_app: :grappa,
     adapter: Ecto.Adapters.SQLite3
+
+  alias Grappa.Repo.LockWatch
 
   # #506 — pre-switch the database to WAL on a SINGLE connection before the pool
   # (or `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) open.
@@ -178,9 +180,30 @@ defmodule Grappa.Repo do
   together when a caller first needs it. Advertising the `Multi` failure
   4-tuple now (with no caller that can produce it) forces every caller's
   `@spec` to carry an impossible return — Dialyzer flags exactly that.
+
+  ## Observability
+
+  This is the ONLY producer of `BEGIN IMMEDIATE` in the tree, which makes it
+  the one seam where the holder of SQLite's write lock can be told apart
+  from the processes queued behind it. `Grappa.Repo.LockWatch.observe/1`
+  wraps the call and is handed back the `acquired` callback, which fires as
+  the FIRST statement inside the transaction body — i.e. once
+  `BEGIN IMMEDIATE` has actually granted the lock, which is what makes a
+  holder distinguishable from a waiter. Nothing else changes: `observe/1`
+  passes `transaction/2`'s return value and any raise or `rollback/1` throw
+  through untouched, so the transaction's semantics are exactly what they
+  were before (#1420).
   """
   @spec immediate_transaction(fun()) :: {:ok, any()} | {:error, any()}
   def immediate_transaction(fun) do
-    transaction(fun, mode: :immediate)
+    LockWatch.observe(fn acquired ->
+      transaction(
+        fn ->
+          acquired.()
+          fun.()
+        end,
+        mode: :immediate
+      )
+    end)
   end
 end

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -141,7 +141,11 @@ defmodule Grappa.Repo.LockWatch do
   defstruct [:stall_threshold_ms, :tick_ms, :enabled]
 
   @type t :: %__MODULE__{
-          stall_threshold_ms: pos_integer(),
+          # non_neg, not pos: a threshold of 0 means "report every contended
+          # holder at once" — noisy, but a coherent operator choice, and the
+          # setting the tests use to take a reading without waiting on a
+          # clock. `tick_ms` stays pos: a zero tick is a busy loop.
+          stall_threshold_ms: non_neg_integer(),
           tick_ms: pos_integer(),
           enabled: boolean()
         }
@@ -243,7 +247,7 @@ defmodule Grappa.Repo.LockWatch do
   end
 
   @spec close_episode([row()]) :: :ok
-  defp close_episode([{_pid, :holding, since, true}]) do
+  defp close_episode([{_, :holding, since, true}]) do
     held_ms = now_ms() - since
 
     Logger.warning(
@@ -307,7 +311,7 @@ defmodule Grappa.Repo.LockWatch do
     _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
     :persistent_term.put(@enabled_key, state.enabled)
 
-    if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
+    _ = if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
 
     {:ok, state}
   end
@@ -330,7 +334,7 @@ defmodule Grappa.Repo.LockWatch do
   # A stall is a holder past the threshold WITH a queue behind it. Neither
   # half alone qualifies: a lone slow transaction blocks nobody, and waiters
   # with no holder are the pool's business, not the write lock's.
-  @spec detect(integer(), pos_integer()) :: :ok
+  @spec detect(integer(), non_neg_integer()) :: :ok
   defp detect(now, threshold_ms) do
     {holders, waiters} = partition(rows(), now)
 
@@ -385,7 +389,7 @@ defmodule Grappa.Repo.LockWatch do
   end
 
   @spec alive?(row()) :: boolean()
-  defp alive?({pid, _role, _since, _reported?}) do
+  defp alive?({pid, _, _, _}) do
     if Process.alive?(pid) do
       true
     else
@@ -396,7 +400,7 @@ defmodule Grappa.Repo.LockWatch do
 
   @spec partition([row()], integer()) :: {[{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]}
   defp partition(rows, now) do
-    {holding, waiting} = Enum.split_with(rows, fn {_pid, role, _since, _} -> role == :holding end)
+    {holding, waiting} = Enum.split_with(rows, fn {_, role, _, _} -> role == :holding end)
 
     {Enum.map(holding, fn {pid, _, since, _} -> {pid, now - since} end),
      Enum.map(waiting, fn {pid, _, since, _} -> {pid, now - since} end)}
@@ -405,7 +409,7 @@ defmodule Grappa.Repo.LockWatch do
   @spec unreported?(pid()) :: boolean()
   defp unreported?(pid) do
     case :ets.lookup(@table, pid) do
-      [{_pid, _role, _since, reported?}] -> not reported?
+      [{_, _, _, reported?}] -> not reported?
       [] -> false
     end
   end

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -1,0 +1,472 @@
+defmodule Grappa.Repo.LockWatch do
+  @moduledoc """
+  Holder-vs-waiter observer for SQLite's single write lock (#1420).
+
+  ## Why a new signal, and not another handler on the old ones
+
+  Every DB signal grappa already emits is **completion-driven**, so all of
+  them measure the VICTIM by construction:
+
+    * `[:grappa, :repo, :query]` fires when a query FINISHES. A process that
+      opens `BEGIN IMMEDIATE` and then sits still emits nothing at all while
+      it sits; the only rows that reach the log are the 30-second `begin`s
+      and `SELECT`s of everybody stuck BEHIND it.
+    * `Grappa.Repo.BusyRetry`'s `:on_contention` hook fires inside a
+      `rescue` — it counts, by definition, whoever caught the exception.
+    * The #1429 CI census greps container logs after the fact: it sees the
+      silence, never who caused it.
+
+  The #1420 census hit that wall six times: `db30=4`, `dropped=2`,
+  `saturated=2`, every gap exactly 30.1 s (the `busy_timeout: 30_000` of the
+  WAITERS), and the issue's own "Not established" section names the missing
+  datum — *"why the holder itself pauses [...] separating the two needs a
+  running stack."*
+
+  This module produces that running stack.
+
+  ## The state machine
+
+  `Grappa.Repo.immediate_transaction/1` is the ONLY producer of
+  `BEGIN IMMEDIATE` in the tree, so there is exactly one seam to instrument.
+
+  The split is free because of an ordering READ IN THE DEPENDENCIES, not
+  assumed: `DBConnection.transaction/3` evaluates `begin/3` and only enters
+  `run_transaction/5` on `{:ok, _}` (`db_connection.ex:1103-1107`), and
+  `Exqlite.Connection.handle_begin/2` emits `"BEGIN IMMEDIATE TRANSACTION"`
+  for `mode: :immediate` on an idle connection (`connection.ex:307`). So by
+  the time the transaction fun runs, SQLite has already granted `RESERVED`:
+
+      waiting()   -->  inside the `begin`, lock NOT yet held  ==> WAITER
+      acquired()  -->  first statement of the fun, RESERVED held  ==> HOLDER
+      released()  -->  transaction over
+
+  The same reading gives the failure case for free: when `begin` raises
+  (busy past `busy_timeout`) the fun never runs, so `acquired/0` never
+  fires and a writer that timed out is never mislabelled a holder — the
+  `after` simply drops its waiter row.
+
+  It also gives the nesting case: on a connection already in a transaction,
+  `handle_begin/2` emits `SAVEPOINT` instead (`connection.ex:310-315`),
+  which is why the depth counter below exists — an inner release must not
+  erase an outer holder.
+
+  A waiter is a waiter whether it is blocked on SQLite's `busy_timeout` or
+  queued on a DBConnection checkout — the two candidate topologies #1420
+  names. Its sampled stack says which, so the instrument does not have to
+  guess between them.
+
+  ## What it reports, and when
+
+  A watchdog tick scans the table and reports only when a holder has held
+  for at least `stall_threshold_ms` **AND at least one waiter is queued
+  behind it**. A slow-but-uncontended transaction is not a stall, and
+  reporting one would bury the signal it exists to find.
+
+  One report per episode (the row's `reported?` flag arms on the first and
+  disarms on release) — otherwise a 30 s stall prints 30 times. Release
+  emits a second, `:resolved` event carrying the TOTAL hold, so an episode
+  has both an opening and a closing bracket.
+
+  ## Deriving the holder's identity instead of storing it
+
+  No caller label is stored, and `immediate_transaction/1` grows no label
+  argument. When the watchdog fires, the holder is still INSIDE the
+  transaction, so its `:current_stacktrace` already contains the
+  `immediate_transaction` frame and every caller frame above it. The
+  identity is derived at report time and costs the hot path nothing.
+
+  ## Doors
+
+  `Logger.warning` (the door that reaches CI container logs, which is where
+  #1420's evidence lives) plus a `:telemetry` event that `Grappa.DbLatency`
+  folds into a bounded ring — so `GET /admin/db_latency` and
+  `bin/grappa db-latency` both inherit the data with no new noun.
+
+  ## Cost and off-switch
+
+  On the write path: one `:persistent_term` read, one `:ets.whereis/1`, and
+  three ETS row operations per write transaction — against a WAL write
+  transaction costing milliseconds. `Process.info/2` (which briefly
+  suspends its target) runs ONLY once a stall has already been detected,
+  on a process that is by definition already stopped.
+
+  Off by default; `config :grappa, :lock_watch, enabled: true` arms it.
+  `config/test.exs` leaves it OFF — its own tests arm it explicitly.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @table :grappa_repo_lock_watch
+  @enabled_key {__MODULE__, :enabled}
+  @depth_key {__MODULE__, :depth}
+  @stack_frames 12
+
+  @typedoc "Role of a row in the watch table."
+  @type role :: :waiting | :holding
+
+  @typedoc "One watch-table row: who, in which role, since when, already reported?"
+  @type row :: {pid(), role(), integer(), boolean()}
+
+  @typedoc """
+  Handed to the transactor by `observe/1`, to be invoked as the FIRST
+  statement inside the transaction body — the moment `BEGIN IMMEDIATE`
+  has returned and `RESERVED` is held.
+  """
+  @type acquired_fun :: (-> :ok)
+
+  @typedoc """
+  One sampled process. `pid` is `inspect/1`-formatted and the stacktrace is
+  pre-formatted because this rides telemetry into a JSON admin response —
+  every field must be JSON-encodable at the point it is built, not later.
+  """
+  @type sample :: %{
+          pid: String.t(),
+          elapsed_ms: non_neg_integer(),
+          current_function: String.t(),
+          status: atom() | nil,
+          message_queue_len: non_neg_integer() | nil,
+          initial_call: String.t(),
+          stacktrace: [String.t()]
+        }
+
+  @typedoc "A detected stall: one holder, the queue behind it."
+  @type stall :: %{
+          holder: sample(),
+          waiters: [sample()],
+          waiter_count: non_neg_integer()
+        }
+
+  defstruct [:stall_threshold_ms, :tick_ms, :enabled]
+
+  @type t :: %__MODULE__{
+          stall_threshold_ms: pos_integer(),
+          tick_ms: pos_integer(),
+          enabled: boolean()
+        }
+
+  ## ----- Write-path seam ----------------------------------------------
+
+  @doc """
+  Runs `transactor` under observation, handing it the callback to invoke at
+  the exact moment the write lock is held.
+
+  This is the whole seam, in one function, with ONE caller in production
+  (`Grappa.Repo.immediate_transaction/1`) — the three edges are private
+  because their ORDER is the measurement. Calling `acquired` anywhere other
+  than the first statement inside the transaction body would classify
+  waiters as holders, which is precisely the confusion the instrument
+  exists to resolve, so the ordering is not left to call sites.
+
+  `try/after` guarantees the episode closes on a raise or a
+  `Repo.rollback/1` throw, and the transactor's return value passes through
+  untouched: observing a transaction must not change it.
+  """
+  @spec observe((acquired_fun() -> result)) :: result when result: var
+  def observe(transactor) when is_function(transactor, 1) do
+    waiting()
+
+    try do
+      transactor.(&acquired/0)
+    after
+      released()
+    end
+  end
+
+  @doc """
+  One detection pass at the given threshold. The watchdog's tick calls this;
+  it is public so an operator (or a test) can take the reading on demand
+  instead of waiting for a tick.
+  """
+  @spec scan(non_neg_integer()) :: :ok
+  def scan(stall_threshold_ms) when is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
+    detect(now_ms(), stall_threshold_ms)
+  end
+
+  # Entering `BEGIN IMMEDIATE`. The caller is a WAITER until `acquired/0`.
+  #
+  # The depth bookkeeping is deliberately NOT gated on `enabled?/0`, while
+  # the ETS work is. Gating both would let the counter leak: if the flag (or
+  # the table) goes away between this call and `released/0` — a watchdog
+  # restart is enough — the decrement is skipped and a long-lived process
+  # such as a `Session.Server` keeps a non-zero depth for the rest of its
+  # life, permanently invisible to the instrument. A process-dictionary read
+  # and write cost nanoseconds; a silently blinded observer costs the whole
+  # investigation.
+  @spec waiting() :: :ok
+  defp waiting do
+    depth = depth()
+    Process.put(@depth_key, depth + 1)
+
+    # Only the OUTERMOST transaction owns the row. A nested
+    # `immediate_transaction/1` collapses to a SAVEPOINT on the same
+    # connection, so an inner `released/0` deleting the row would erase a
+    # holder that is still holding — an instrument lying about the very
+    # thing it measures.
+    if depth == 0 and enabled?() do
+      :ets.insert(@table, {self(), :waiting, now_ms(), false})
+    end
+
+    :ok
+  end
+
+  # `BEGIN IMMEDIATE` returned: the caller now HOLDS `RESERVED`.
+  #
+  # Runs as the first statement inside the transaction fun, so it must never
+  # raise — a raise here would abort a caller's write transaction, which is
+  # precisely the semantic change this instrument is forbidden to make.
+  # `enabled?/0` proves the table exists and `:ets.update_element/3` answers
+  # `false` (never raises) for an absent key.
+  @spec acquired() :: :ok
+  defp acquired do
+    if depth() == 1 and enabled?() do
+      :ets.update_element(@table, self(), [{2, :holding}, {3, now_ms()}])
+    end
+
+    :ok
+  end
+
+  # Transaction over. Closes the episode, and brackets it if it was reported.
+  @spec released() :: :ok
+  defp released do
+    case depth() do
+      depth when depth > 1 ->
+        Process.put(@depth_key, depth - 1)
+
+      _ ->
+        Process.delete(@depth_key)
+        if enabled?(), do: close_episode(:ets.take(@table, self()))
+    end
+
+    :ok
+  end
+
+  @spec close_episode([row()]) :: :ok
+  defp close_episode([{_pid, :holding, since, true}]) do
+    held_ms = now_ms() - since
+
+    Logger.warning(
+      "db lock stall RESOLVED: holder #{inspect(self())} released RESERVED after #{held_ms}ms",
+      held_ms: held_ms
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :resolved],
+      %{held_ms: held_ms},
+      %{holder_pid: inspect(self())}
+    )
+  end
+
+  defp close_episode(_), do: :ok
+
+  ## ----- Public API ---------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc """
+  Current holder + waiters, sampled now. The live read behind the watchdog,
+  exposed so an operator can ask the question mid-incident rather than
+  waiting for a tick.
+  """
+  @spec inspect_lock() :: %{holders: [sample()], waiters: [sample()]}
+  def inspect_lock do
+    now = now_ms()
+    {holders, waiters} = partition(rows(), now)
+
+    %{
+      holders: Enum.map(holders, fn {pid, elapsed} -> sample(pid, elapsed) end),
+      waiters: Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
+    }
+  end
+
+  if Mix.env() == :test do
+    @doc false
+    # Test seam: arm/disarm the write-path instrumentation. Gated to :test so
+    # no other build carries a runtime toggle. Tests MUST disarm on_exit — a
+    # flag left armed is failure-at-a-distance for every later test.
+    @spec put_test_enabled(boolean()) :: :ok
+    def put_test_enabled(enabled?) when is_boolean(enabled?) do
+      :persistent_term.put(@enabled_key, enabled?)
+    end
+  end
+
+  ## ----- GenServer callbacks ------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      stall_threshold_ms: Keyword.fetch!(opts, :stall_threshold_ms),
+      tick_ms: Keyword.fetch!(opts, :tick_ms),
+      enabled: Keyword.fetch!(opts, :enabled)
+    }
+
+    # `:public` because the seam writes from every caller's own process; the
+    # table is owned here so a supervisor restart rebuilds it clean.
+    _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
+    :persistent_term.put(@enabled_key, state.enabled)
+
+    if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:tick, state) do
+    scan(state.stall_threshold_ms)
+    Process.send_after(self(), :tick, state.tick_ms)
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_, _) do
+    :persistent_term.put(@enabled_key, false)
+    :ok
+  end
+
+  ## ----- Detection -----------------------------------------------------
+
+  # A stall is a holder past the threshold WITH a queue behind it. Neither
+  # half alone qualifies: a lone slow transaction blocks nobody, and waiters
+  # with no holder are the pool's business, not the write lock's.
+  @spec detect(integer(), pos_integer()) :: :ok
+  defp detect(now, threshold_ms) do
+    {holders, waiters} = partition(rows(), now)
+
+    stalled = Enum.filter(holders, fn {pid, elapsed} -> elapsed >= threshold_ms and unreported?(pid) end)
+
+    if stalled != [] and waiters != [] do
+      waiter_samples = Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
+      Enum.each(stalled, &report(&1, waiter_samples))
+    end
+
+    :ok
+  end
+
+  @spec report({pid(), non_neg_integer()}, [sample()]) :: :ok
+  defp report({pid, elapsed}, waiter_samples) do
+    # Arm the flag BEFORE emitting: an emit that raced the next tick would
+    # double-report the same episode.
+    _ = :ets.update_element(@table, pid, [{4, true}])
+
+    holder = sample(pid, elapsed)
+
+    stall = %{holder: holder, waiters: waiter_samples, waiter_count: length(waiter_samples)}
+
+    Logger.warning(
+      "db lock stall: holder #{holder.pid} has held RESERVED for #{holder.elapsed_ms}ms " <>
+        "with #{stall.waiter_count} waiter(s) queued — holder at #{holder.current_function}, " <>
+        "stack: #{Enum.join(holder.stacktrace, " <- ")}",
+      held_ms: holder.elapsed_ms,
+      waiters: stall.waiter_count
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :detected],
+      %{held_ms: holder.elapsed_ms, waiter_count: stall.waiter_count},
+      stall
+    )
+  end
+
+  ## ----- Sampling -------------------------------------------------------
+
+  # Reaps dead rows as it reads. A process killed mid-transaction never runs
+  # `released/0`, so its row would otherwise sit in the table forever and be
+  # re-reported as an eternal holder — the instrument accusing a corpse while
+  # the real contention goes unnamed. Reaping happens here, off the write
+  # path, because only the scan side cares.
+  @spec rows() :: [row()]
+  defp rows do
+    case :ets.whereis(@table) do
+      :undefined -> []
+      _ -> Enum.filter(:ets.tab2list(@table), &alive?/1)
+    end
+  end
+
+  @spec alive?(row()) :: boolean()
+  defp alive?({pid, _role, _since, _reported?}) do
+    if Process.alive?(pid) do
+      true
+    else
+      :ets.delete(@table, pid)
+      false
+    end
+  end
+
+  @spec partition([row()], integer()) :: {[{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]}
+  defp partition(rows, now) do
+    {holding, waiting} = Enum.split_with(rows, fn {_pid, role, _since, _} -> role == :holding end)
+
+    {Enum.map(holding, fn {pid, _, since, _} -> {pid, now - since} end),
+     Enum.map(waiting, fn {pid, _, since, _} -> {pid, now - since} end)}
+  end
+
+  @spec unreported?(pid()) :: boolean()
+  defp unreported?(pid) do
+    case :ets.lookup(@table, pid) do
+      [{_pid, _role, _since, reported?}] -> not reported?
+      [] -> false
+    end
+  end
+
+  # The whole point of the instrument: WHERE is this process, right now.
+  # `Process.info/2` returns nil for a dead pid, which is a real outcome
+  # here (the holder can die between the scan and the sample), so it folds
+  # to an explicit empty sample rather than crashing the watchdog.
+  @spec sample(pid(), non_neg_integer()) :: sample()
+  defp sample(pid, elapsed_ms) do
+    info = Process.info(pid, [:current_function, :status, :message_queue_len, :dictionary])
+
+    %{
+      pid: inspect(pid),
+      elapsed_ms: elapsed_ms,
+      current_function: format_mfa(info && Keyword.get(info, :current_function)),
+      status: info && Keyword.get(info, :status),
+      message_queue_len: info && Keyword.get(info, :message_queue_len),
+      initial_call: format_mfa(initial_call(info)),
+      stacktrace: stacktrace(pid)
+    }
+  end
+
+  @spec initial_call(keyword() | nil) :: mfa() | nil
+  defp initial_call(nil), do: nil
+
+  defp initial_call(info) do
+    info |> Keyword.get(:dictionary, []) |> Keyword.get(:"$initial_call")
+  end
+
+  @spec stacktrace(pid()) :: [String.t()]
+  defp stacktrace(pid) do
+    case Process.info(pid, :current_stacktrace) do
+      {:current_stacktrace, frames} ->
+        frames
+        |> Enum.take(@stack_frames)
+        |> Enum.map(&(&1 |> Exception.format_stacktrace_entry() |> String.trim()))
+
+      nil ->
+        []
+    end
+  end
+
+  @spec format_mfa(mfa() | nil) :: String.t()
+  defp format_mfa({module, function, arity}), do: Exception.format_mfa(module, function, arity)
+  defp format_mfa(_), do: "unknown"
+
+  ## ----- Helpers --------------------------------------------------------
+
+  # The table check is not defensive noise: the watchdog owns the table, so a
+  # supervisor restart briefly removes it. Without this, `acquired/0` would
+  # raise INSIDE a caller's transaction and abort a write that had nothing to
+  # do with the instrument.
+  @spec enabled?() :: boolean()
+  defp enabled? do
+    :persistent_term.get(@enabled_key, false) and :ets.whereis(@table) != :undefined
+  end
+
+  @spec depth() :: non_neg_integer()
+  defp depth, do: Process.get(@depth_key, 0)
+
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -50,10 +50,9 @@ defmodule Grappa.Scrollback do
   import Ecto.Query
 
   alias Grappa.IRC.Identifier
-  alias Grappa.Repo
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
-  alias Grappa.Subject
+  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,7 +33,7 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Visitors.Visitor],
+    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # `Networks.Network` is referenced by `Scrollback.Message` (the
     # `belongs_to :network` association) and `Scrollback.Wire` (the
     # `%Network{slug: _}` pattern that A1+A26 made the wire-shape
@@ -53,6 +53,7 @@ defmodule Grappa.Scrollback do
   alias Grappa.Repo
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
+  alias Grappa.Subject
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier
@@ -334,7 +335,7 @@ defmodule Grappa.Scrollback do
   defp nick_shaped?("$server"), do: false
   defp nick_shaped?(name) when is_binary(name), do: target_kind(name) == :query
 
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Subject.t()
 
   @doc """
   Fetches up to `limit` messages for `(subject, network_id, channel)`,
@@ -421,7 +422,7 @@ defmodule Grappa.Scrollback do
     capped = min(limit, @max_limit)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -499,7 +500,7 @@ defmodule Grappa.Scrollback do
     capped = min(limit, @max_limit)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -565,7 +566,7 @@ defmodule Grappa.Scrollback do
       when is_integer(network_id) and is_integer(after_id) and
              (is_binary(own_nick) or is_nil(own_nick)) and is_boolean(hide_presence) do
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> maybe_exclude_presence(hide_presence)
@@ -643,7 +644,7 @@ defmodule Grappa.Scrollback do
 
     query =
       Message
-      |> subject_where(subject)
+      |> Subject.subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
       |> maybe_exclude_presence(hide_presence)
@@ -783,7 +784,7 @@ defmodule Grappa.Scrollback do
              (is_binary(own_nick) or is_nil(own_nick)) and
              is_integer(limit) and limit > 0 do
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
     |> where([m], m.id > ^after_id)
@@ -851,7 +852,7 @@ defmodule Grappa.Scrollback do
 
     base =
       Message
-      |> subject_where(subject)
+      |> Subject.subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
       |> maybe_exclude_presence(hide_presence)
@@ -939,7 +940,7 @@ defmodule Grappa.Scrollback do
     folded_active = MapSet.new(active_keyset, &Identifier.canonical_target/1)
 
     Message
-    |> subject_where(subject)
+    |> Subject.subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> group_by([m], Identifier.nick_fold(fragment("COALESCE(?, ?)", m.dm_with, m.channel)))
     |> select([m], %{
@@ -1132,22 +1133,6 @@ defmodule Grappa.Scrollback do
     )
   end
 
-  defp subject_where(query, {:user, user_id}) when is_binary(user_id),
-    do: where(query, [m], m.user_id == ^user_id)
-
-  defp subject_where(query, {:visitor, visitor_id}) when is_binary(visitor_id),
-    do: where(query, [m], m.visitor_id == ^visitor_id)
-
-  # B5.4 L-pers-2: explicit fall-through replaces an implicit
-  # FunctionClauseError (Erlang-level message hides both the
-  # offending value and the function name). ArgumentError carries
-  # the inspected subject so caller bugs (typo `:users` for `:user`,
-  # `nil` from a stale ref, leftover atom from a refactor) surface
-  # with actionable diagnostics. Same fail-loud behaviour, better
-  # post-mortem.
-  defp subject_where(_, other),
-    do: raise(ArgumentError, "unknown subject: #{inspect(other)}")
-
   defp maybe_before(query, nil), do: query
 
   # Cursor key is monotonic id post-CP29 R-2 — was server_time, but
@@ -1225,7 +1210,7 @@ defmodule Grappa.Scrollback do
     case BusyRetry.run(fn ->
            {:ok,
             Message
-            |> subject_where(subject)
+            |> Subject.subject_where(subject)
             |> where([m], m.network_id == ^network_id)
             |> where_dm_peer(folded_peer)
             |> Repo.delete_all()}
@@ -1278,7 +1263,7 @@ defmodule Grappa.Scrollback do
     else
       base =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
 
       # DISTINCT migrated-row count via the shared DM-peer predicate — the
@@ -1400,7 +1385,7 @@ defmodule Grappa.Scrollback do
     else
       {count, _} =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
         |> where(
           [m],
@@ -1510,7 +1495,7 @@ defmodule Grappa.Scrollback do
     else
       {count, _} =
         Message
-        |> subject_where(subject)
+        |> Subject.subject_where(subject)
         |> where([m], m.network_id == ^network_id)
         |> where(
           [m],
@@ -1565,7 +1550,7 @@ defmodule Grappa.Scrollback do
     case BusyRetry.run(fn ->
            {:ok,
             Message
-            |> subject_where(subject)
+            |> Subject.subject_where(subject)
             |> where([m], m.network_id == ^network_id)
             |> where([m], m.channel == ^canonical)
             |> Repo.delete_all()}

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -50,9 +50,9 @@ defmodule Grappa.Scrollback do
   import Ecto.Query
 
   alias Grappa.IRC.Identifier
+  alias Grappa.{Repo, Subject}
   alias Grappa.Repo.BusyRetry
   alias Grappa.Scrollback.{Message, Meta, Telemetry}
-  alias Grappa.{Repo, Subject}
 
   # Identifier.nick_fold/1 is a query macro (ASCII fold fragment, #121/#525).
   require Identifier

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -117,7 +117,7 @@ defmodule Grappa.Session do
   `(visitor, network_id)` for the same `network_id` and even the
   same UUID never collide.
   """
-  @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
+  @type subject :: Grappa.Subject.t()
 
   @typedoc """
   #1088 — the connection an informational reply is addressed to: the

--- a/lib/grappa/subject.ex
+++ b/lib/grappa/subject.ex
@@ -73,18 +73,27 @@ defmodule Grappa.Subject do
     do: Map.put(attrs, :visitor_id, vid)
 
   @doc """
-  Adds a `WHERE user_id = ? AND visitor_id IS NULL`-shaped clause
-  (or its visitor mirror) to `queryable`.
+  Adds a `WHERE user_id = ?` clause (or its visitor mirror) to
+  `queryable`.
 
-  Mirror of the per-context private `subject_where/2` helpers in
-  `Grappa.Scrollback` and `Grappa.ReadCursor` — promoted to the
-  shared boundary so new contexts (V1: query_windows, push,
-  user_settings) don't each grow their own copy.
+  Only the one equality — NOT the `AND visitor_id IS NULL` this
+  docstring used to promise, which no spelling of the helper has ever
+  emitted. The second conjunct is redundant under the DB-level XOR
+  CHECK, so the omission is correct; the sentence was not, and it is
+  the sentence a reader reaches for when reasoning about subject
+  isolation (#1392).
 
-  Uses positional binding `[row]` — the queryable must have a
-  single from-binding (the common case for context-internal
-  filters). Multi-join callers should write the where-clause
-  directly.
+  The only spelling of this predicate. `Grappa.Scrollback` and
+  `Grappa.ReadCursor` kept private synonyms until #1392 folded them
+  here, which is what the V1 promotion had claimed since it landed.
+
+  Uses positional binding `[row]`, so the precondition is that
+  **binding 0 carries the subject FK** — not that the query has a
+  single from-binding, as this docstring used to say.
+  `ReadCursor.bulk_for_subject/1` joins `networks` and has always been
+  a correct caller: the join is at position 1, the cursor at 0. A
+  caller whose subject-scoped table is NOT the from-binding must write
+  the where-clause directly.
   """
   @spec subject_where(Ecto.Queryable.t(), t()) :: Ecto.Query.t()
   def subject_where(queryable, {:user, user_id}) when is_binary(user_id),
@@ -92,6 +101,26 @@ defmodule Grappa.Subject do
 
   def subject_where(queryable, {:visitor, visitor_id}) when is_binary(visitor_id),
     do: where(queryable, [row], row.visitor_id == ^visitor_id)
+
+  # B5.4 L-pers-2, promoted from `Grappa.Scrollback` by #1392: explicit
+  # fall-through replaces an implicit FunctionClauseError (Erlang-level
+  # message hides both the offending value and the function name).
+  # ArgumentError carries the inspected subject so caller bugs (typo
+  # `:users` for `:user`, `nil` from a stale ref, leftover atom from a
+  # refactor) surface with actionable diagnostics.
+  #
+  # This clause is why the fold is not a deletion. Retiring the two
+  # private spellings without it would have stripped the diagnostic
+  # from Scrollback's 12 call sites; carrying it along instead moves
+  # the other 26 UP to it, which is a behaviour change in the fail-loud
+  # direction and is named as one.
+  #
+  # `put_subject_id/2` deliberately keeps the bare FunctionClauseError:
+  # giving it this clause too is a second behaviour change across its
+  # own call sites that nothing has asked for, and a hard failure on a
+  # malformed shape is already the right answer.
+  def subject_where(_, other),
+    do: raise(ArgumentError, "unknown subject: #{inspect(other)}")
 
   @doc """
   Resolves the bare-id subject from `Plug.Conn.assigns`.

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -22,7 +22,9 @@ defmodule Grappa.DbLatencyTest do
     [:grappa, :repo, :query],
     [:grappa, :scrollback, :persist, :stop],
     [:grappa, :session, :send_privmsg, :stop],
-    [:grappa, :scrollback, :persist, :contention]
+    [:grappa, :scrollback, :persist, :contention],
+    [:grappa, :repo, :lock_stall, :detected],
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
 
   # Native-unit duration for a whole number of milliseconds, via the
@@ -46,6 +48,7 @@ defmodule Grappa.DbLatencyTest do
       assert snapshot.send_privmsg.n == 0
       assert snapshot.persist.n == 0
       assert snapshot.contention.n == 0
+      assert snapshot.lock_stalls == []
     end
   end
 
@@ -185,6 +188,54 @@ defmodule Grappa.DbLatencyTest do
       assert contention.busy_locked == 1
       assert contention.queue_timeout == 1
       assert contention.dropped == 1
+    end
+
+    test "[:grappa, :repo, :lock_stall, :*] folds both brackets of an episode, newest first" do
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :detected],
+        %{held_ms: 2_400, waiter_count: 2},
+        %{
+          holder: %{pid: "#PID<0.111.0>", stacktrace: ["Foo.bar/1"]},
+          waiters: [%{pid: "#PID<0.222.0>"}, %{pid: "#PID<0.333.0>"}]
+        }
+      )
+
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :resolved],
+        %{held_ms: 30_120},
+        %{holder_pid: "#PID<0.111.0>"}
+      )
+
+      assert [resolved, detected] = DbLatency.snapshot().lock_stalls
+
+      # Newest first: an operator reading a live incident wants the last
+      # thing that happened at the top, not to scroll a boot-long history.
+      assert resolved.phase == :resolved
+      assert resolved.held_ms == 30_120
+      assert resolved.holder == nil
+
+      assert detected.phase == :detected
+      assert detected.waiter_count == 2
+      assert detected.holder.stacktrace == ["Foo.bar/1"]
+      assert length(detected.waiters) == 2
+    end
+
+    test "the lock-stall ring is bounded, keeping the newest episodes" do
+      for n <- 1..25 do
+        :telemetry.execute(
+          [:grappa, :repo, :lock_stall, :resolved],
+          %{held_ms: n},
+          %{holder_pid: "#PID<0.#{n}.0>"}
+        )
+      end
+
+      stalls = DbLatency.snapshot().lock_stalls
+
+      # These rows carry sampled stacktraces; unbounded, they would grow the
+      # singleton's heap for as long as the node lives.
+      assert length(stalls) == 20
+      assert hd(stalls).held_ms == 25
+      assert List.last(stalls).held_ms == 6
     end
 
     test "reset/0 zeroes accumulated state" do

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -113,6 +113,30 @@ defmodule Grappa.ReadCursorTest do
     end
   end
 
+  # #1392 — `ReadCursor` kept a private `subject_filter/2`, the third
+  # spelling of one predicate. Its two clauses were exact synonyms of
+  # `Grappa.Subject.subject_where/2` on the whole valid domain; they
+  # differed only OFF it, where this module fell through to a
+  # `FunctionClauseError` while `Grappa.Scrollback` raised an
+  # `ArgumentError` naming the value. Folding the spelling away carries
+  # the better diagnostic here too, so these pin a real behaviour
+  # change, not the fold's transparency.
+  describe "malformed subject — fail-loud (#1392)" do
+    test "get/3 raises ArgumentError naming the subject" do
+      net = network_fixture()
+
+      assert_raise ArgumentError, ~r/unknown subject: \{:typo, "x"\}/, fn ->
+        ReadCursor.get({:typo, "x"}, net.id, "#sniffo")
+      end
+    end
+
+    test "bulk_for_subject/1 raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: nil/, fn ->
+        ReadCursor.bulk_for_subject(nil)
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # DM-window nick fold — one window ⇒ one cursor row (#532 D)
   # ---------------------------------------------------------------------------

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -1,0 +1,255 @@
+defmodule Grappa.Repo.LockWatchTest do
+  @moduledoc """
+  #1420 — the write-lock observer, bought with a REAL `SQLITE_BUSY` wait.
+
+  ## Why a private repo and not the Sandbox
+
+  The suite runs `pool_size: 1` under `Ecto.Adapters.SQL.Sandbox`, where
+  every process shares one connection: two writers cannot contend, they
+  queue. That is exactly why `Grappa.Repo.BusyRetry` carries a fault
+  injection seam at all. But an INJECTED busy would prove nothing here —
+  the claim under test is that `acquired` fires only once SQLite has
+  actually granted `RESERVED`, and a hand-raised exception never grants
+  anything. So this file follows `Grappa.Repo.BusyRetryFidelityTest`: a
+  private `TmpRepo` on a temp file with `pool_size: 2`, one process parked
+  inside a write transaction and a second genuinely blocked in its
+  `BEGIN IMMEDIATE`.
+
+  ## Why the detection pass is driven, not awaited
+
+  `LockWatch.scan/1` is called directly instead of waiting for the
+  watchdog's tick. A test that sleeps past a tick interval measures the
+  scheduler as much as the code; driving the pass makes the assertions
+  deterministic under `--repeat-each`. The barrier before each scan is a
+  polled CONDITION (both processes visible in their expected roles), never
+  a fixed sleep.
+
+  Both processes are `spawn_monitor`'d rather than linked, so a writer that
+  dies takes down an assertion with a readable reason instead of the test
+  process.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.Repo.LockWatch
+
+  defmodule TmpRepo do
+    @moduledoc false
+    use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+  end
+
+  @detected [:grappa, :repo, :lock_stall, :detected]
+
+  setup do
+    LockWatch.put_test_enabled(true)
+    on_exit(fn -> LockWatch.put_test_enabled(false) end)
+
+    handler = "lock-watch-test-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        @detected,
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:stall, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    :ok
+  end
+
+  describe "holder vs waiter under a real BEGIN IMMEDIATE contention" do
+    test "names the HOLDER, lists the blocked writer as a waiter, and samples the holder's live stack" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(holder, [waiter])
+
+      LockWatch.scan(0)
+
+      assert_receive {:stall, measurements, stall}, 1_000
+
+      # M1 — a mutant that reports the longest-queued WAITER as the holder
+      # (the two roles are symmetric in the table; only the tag separates
+      # them) has to survive both of these to live.
+      assert stall.holder.pid == inspect(holder)
+      assert [waiter_sample] = stall.waiters
+      assert waiter_sample.pid == inspect(waiter)
+
+      # M2 — a mutant that never promotes `:waiting` to `:holding` leaves no
+      # holder at all, so there is nothing to report and this never arrives;
+      # a mutant that promotes TOO EARLY (before the transaction opens)
+      # promotes the blocked writer too, and the waiter count goes to zero.
+      assert stall.waiter_count == 1
+      assert measurements.waiter_count == 1
+      assert is_integer(measurements.held_ms)
+
+      # M4 — a mutant sampling `self()` (the scanning process) instead of
+      # the holder's pid still produces a well-formed record, and only the
+      # CONTENT of the stack tells the two apart. This frame is the reason
+      # the holder is stuck, which is the datum #1420 says is missing.
+      assert Enum.any?(stall.holder.stacktrace, &(&1 =~ "park_until_released"))
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a holder that has not crossed the threshold is not reported, queue or no queue" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(holder, [waiter])
+
+      # M5 — a mutant that drops the `elapsed >= threshold` comparison
+      # reports immediately and dies here. The holder has been holding for
+      # milliseconds, not the ten seconds demanded.
+      LockWatch.scan(10_000)
+
+      refute_receive {:stall, _, _}, 300
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a slow but UNCONTENDED holder is not a stall" do
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      await_roles(holder, [])
+
+      # M3 — a mutant that emits on a slow holder without checking for a
+      # queue behind it fires here. Nobody is blocked: this transaction is
+      # slow, and slow is not a stall. Reporting it would bury the signal
+      # the instrument exists to find under every long write in the system.
+      LockWatch.scan(0)
+
+      refute_receive {:stall, _, _}, 300
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+
+      Supervisor.stop(repo)
+    end
+  end
+
+  describe "the production seam" do
+    test "Grappa.Repo.immediate_transaction/1 registers its caller as the holder, and clears on exit" do
+      me = inspect(self())
+
+      # Pins that the observer is actually WIRED to the production function,
+      # in the right place. The tests above drive `LockWatch.observe/1`
+      # themselves, so on their own they would still pass if
+      # `immediate_transaction/1` had never been instrumented at all.
+      #
+      # Honest limit: the DataCase sandbox already holds a transaction on
+      # this connection, and `Exqlite.Connection.handle_begin/2` emits
+      # SAVEPOINT rather than BEGIN IMMEDIATE in that state
+      # (deps/exqlite/lib/exqlite/connection.ex:310-315). So this pins the
+      # WIRING and the edge ORDER; the real `RESERVED` acquisition is what
+      # the TmpRepo tests above measure.
+      assert {:ok, %{holders: holders}} =
+               Grappa.Repo.immediate_transaction(fn -> LockWatch.inspect_lock() end)
+
+      assert Enum.any?(holders, &(&1.pid == me))
+
+      assert %{holders: [], waiters: []} = LockWatch.inspect_lock()
+    end
+  end
+
+  ## ----- helpers --------------------------------------------------------
+
+  defp start_tmp_repo do
+    path = Path.join(System.tmp_dir!(), "lock_watch_#{System.unique_integer([:positive])}.db")
+    on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
+
+    # busy_timeout is generous on purpose: the waiter must still be WAITING
+    # when the scan runs. A short timeout would turn it into an error path
+    # and measure `BusyRetry` instead of this module.
+    {:ok, repo} =
+      TmpRepo.start_link(database: path, pool_size: 2, busy_timeout: 30_000, journal_mode: :wal)
+
+    TmpRepo.query!("CREATE TABLE t(id integer)")
+
+    repo
+  end
+
+  # A writer that goes through the SAME `LockWatch.observe/1` production
+  # uses — re-implementing the edge sequence here would test a copy of the
+  # mechanism rather than the mechanism.
+  defp start_writer(id, after_insert) do
+    test_pid = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        LockWatch.observe(fn acquired ->
+          TmpRepo.transaction(
+            fn ->
+              acquired.()
+              TmpRepo.query!("INSERT INTO t VALUES (#{id})")
+              send(test_pid, {:holding, self()})
+              if after_insert == :park, do: park_until_released()
+            end,
+            mode: :immediate
+          )
+        end)
+      end)
+
+    # A failing assertion would otherwise leave this process parked inside
+    # its transaction, holding both the file lock and a watch-table row, and
+    # poison every test that follows.
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    {pid, ref}
+  end
+
+  # Named, and named distinctively, because its frame IS the oracle for the
+  # holder-stack assertion.
+  defp park_until_released do
+    receive do
+      :release -> :ok
+    end
+  end
+
+  defp await_roles(holder, waiters) do
+    await_until(
+      fn ->
+        %{holders: held, waiters: queued} = LockWatch.inspect_lock()
+
+        pids(held) == [inspect(holder)] and Enum.sort(pids(queued)) == Enum.sort(Enum.map(waiters, &inspect/1))
+      end,
+      300
+    )
+  end
+
+  defp pids(samples), do: Enum.map(samples, & &1.pid)
+
+  defp await_until(_fun, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
+
+  defp await_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      await_until(fun, attempts - 1)
+    end
+  end
+end

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -50,7 +50,7 @@ defmodule Grappa.Repo.LockWatchTest do
       :telemetry.attach(
         handler,
         @detected,
-        fn _event, measurements, metadata, _ ->
+        fn _, measurements, metadata, _ ->
           send(test_pid, {:stall, measurements, metadata})
         end,
         nil
@@ -198,20 +198,7 @@ defmodule Grappa.Repo.LockWatchTest do
   defp start_writer(id, after_insert) do
     test_pid = self()
 
-    {pid, ref} =
-      spawn_monitor(fn ->
-        LockWatch.observe(fn acquired ->
-          TmpRepo.transaction(
-            fn ->
-              acquired.()
-              TmpRepo.query!("INSERT INTO t VALUES (#{id})")
-              send(test_pid, {:holding, self()})
-              if after_insert == :park, do: park_until_released()
-            end,
-            mode: :immediate
-          )
-        end)
-      end)
+    {pid, ref} = spawn_monitor(fn -> observed_write(id, after_insert, test_pid) end)
 
     # A failing assertion would otherwise leave this process parked inside
     # its transaction, holding both the file lock and a watch-table row, and
@@ -219,6 +206,24 @@ defmodule Grappa.Repo.LockWatchTest do
     on_exit(fn -> Process.exit(pid, :kill) end)
 
     {pid, ref}
+  end
+
+  # Split out of `start_writer/2` so no body nests deeper than two levels.
+  # `observe/1` is production's own wrapper — the point is that the test
+  # drives the real edge sequence rather than a hand-written copy of it.
+  defp observed_write(id, after_insert, test_pid) do
+    LockWatch.observe(fn acquired ->
+      TmpRepo.transaction(fn -> insert_then(id, after_insert, test_pid, acquired) end,
+        mode: :immediate
+      )
+    end)
+  end
+
+  defp insert_then(id, after_insert, test_pid, acquired) do
+    acquired.()
+    TmpRepo.query!("INSERT INTO t VALUES (?)", [id])
+    send(test_pid, {:holding, self()})
+    if after_insert == :park, do: park_until_released()
   end
 
   # Named, and named distinctively, because its frame IS the oracle for the
@@ -242,7 +247,7 @@ defmodule Grappa.Repo.LockWatchTest do
 
   defp pids(samples), do: Enum.map(samples, & &1.pid)
 
-  defp await_until(_fun, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
+  defp await_until(_, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
 
   defp await_until(fun, attempts) do
     if fun.() do

--- a/test/grappa/subject_test.exs
+++ b/test/grappa/subject_test.exs
@@ -1,6 +1,7 @@
 defmodule Grappa.SubjectTest do
   @moduledoc """
-  Tests for the subject-label codec (#413).
+  Tests for the subject-label codec (#413) and the fail-loud posture of
+  `subject_where/2` (#1392).
 
   `label/1` + `from_label/1` are the single source of truth for the
   user-rooted topic-label encoding — `user.name` for users,
@@ -9,10 +10,17 @@ defmodule Grappa.SubjectTest do
   silent dead-drop on drift: a subject that no longer round-trips
   does not raise, it just stops matching, far from the cause. The
   property test is exactly the shape an encode/decode pair calls for.
+
+  `subject_where/2`'s happy path is not restated here: it is exercised
+  by the 38 call sites across nine contexts, whose own context tests
+  run real queries and would go red on a swapped FK column. What those
+  call sites do NOT pin is the off-domain clause, which is the one
+  `Grappa.Scrollback` used to own alone.
   """
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  alias Grappa.ReadCursor.Cursor
   alias Grappa.Subject
 
   describe "label/1" do
@@ -45,6 +53,39 @@ defmodule Grappa.SubjectTest do
     property "visitor ids survive label |> from_label" do
       check all(id <- visitor_id()) do
         assert Subject.from_label(Subject.label({:visitor, id})) == {:visitor, id}
+      end
+    end
+  end
+
+  # #1392 — the fall-through promoted here from
+  # `Grappa.Scrollback.subject_where/2` (added by B5.4 L-pers-2). It is
+  # the ONE clause the three former spellings disagreed on: `Scrollback`
+  # raised `ArgumentError` naming the offending value, `Grappa.Subject`
+  # and `Grappa.ReadCursor` fell through to a `FunctionClauseError`
+  # whose Erlang-level message hides both the value and the function.
+  # Folding the two privates into this module without the fall-through
+  # would have been a diagnostic regression at 12 call sites, so the
+  # clause travels WITH the function.
+  #
+  # These assert the inspected value is IN the message, not merely that
+  # something raised: naming the subject is the entire reason the clause
+  # exists over a bare pattern-match failure.
+  describe "subject_where/2 — fail-loud off the valid domain (#1392)" do
+    test "an unknown discriminator raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: \{:typo, "x"\}/, fn ->
+        Subject.subject_where(Cursor, {:typo, "x"})
+      end
+    end
+
+    test "a nil subject raises ArgumentError naming the subject" do
+      assert_raise ArgumentError, ~r/unknown subject: nil/, fn ->
+        Subject.subject_where(Cursor, nil)
+      end
+    end
+
+    test "a well-tagged subject with a non-binary id raises ArgumentError naming it" do
+      assert_raise ArgumentError, ~r/unknown subject: \{:user, nil\}/, fn ->
+        Subject.subject_where(Cursor, {:user, nil})
       end
     end
   end


### PR DESCRIPTION
## What this is

A single branch that replays four already-reviewed PRs onto the current `main`
(`3b8461a6`), so they are gated **together, once**, instead of four times against
four stale bases. Each of the four was cut against a different, older base; merging
them in sequence would have invalidated the next one's base every time.

The stronger reason is not cost. **Textual non-overlap is not semantic
independence** — these four had never been compiled, tested or run as one tree.
This branch is that tree.

Contained, in replay order:

| source PR | issue | branch | commits | its own base |
|---|---|---|---|---|
| #1457 | #1392 — fold the two private subject predicates | `w2-1392-subject-ssot` | 6 | `60657249` |
| #1458 | #1336 — prove the nine cursor gestures landed | `w1-1336-cursor-gesture` | 3 | `f3c37191` |
| #1459 | #1420 — measure the SQLite write-lock holder | `w2-1420-lockwatch` | 4 | `e1892e80` |
| #1460 | #1402 — one typed window-state set | `w1-1402-window-state-fold` | 2 | `2617474b` |

The replay rewrites the SHAs, so GitHub cannot close the four source PRs on merge.
They are closed by hand, by content, after this lands. Nothing here is linked to an
issue in the Development panel, and there is no closing keyword in this body: the
four entries in `docs/DESIGN_NOTES.md` carry the record, and the issues are the
source PRs' business, not this branch's.

## Completeness proof

Every cherry-pick ran clean (rc=0, no conflicts). Completeness is the claim that
nothing was silently dropped in the replay, and it is measured, not asserted: the
union's contribution against `origin/main` must equal the sum of the four
per-PR contributions, each measured against **its own** merge-base.

```
PR #1457 (60657249..b10bb29d)   7 files   +277   -82
PR #1458 (f3c37191..ba0e2616)   3 files    +91   -16
PR #1459 (e1892e80..f223ccf2)  13 files  +1127   -11
PR #1460 (2617474b..e5b1411e)   5 files   +100    -8
                                        ------  -----
sum                                      +1595   -117

union  (3b8461a6..0a5c32b0)    25 files  +1595   -117   <- exact match
```

File count is 25, not 28: `docs/DESIGN_NOTES.md` is the one file all four touch,
so the naive sum counts it four times. Everything else is disjoint.

The contribution was also checked incrementally, after each of the four picks, so a
loss would have been attributable to the exact pick that caused it. None occurred.

### The `merge=union` tail-fusion check

`docs/DESIGN_NOTES.md` is a `merge=union` file. Its known failure mode is not at the
head — the `<!-- entry #NNNN -->` marker guards that — but at the **tail**: when a
new entry's closing line is byte-identical to the previous entry's, union merge
emits one copy and the *previous* entry silently loses its closing. The tell is a
numstat that quietly drops.

- `docs/DESIGN_NOTES.md`: **+354**, exactly `119 + 51 + 116 + 68`. Nothing dropped.
- Total file length `45919 → 46273` = +354, consistent.
- `^_Deploy:` lines: **66 → 66**. None of the four entries adds one, and none of the
  existing ones lost theirs.
- `^## ` headings: **713 → 717** (+4, one per entry).
- `^<!-- entry #` markers: **68 → 72** (+4). All four verified **absent** on the base
  before the replay.
- Boundary form re-read on the file at all four markers
  (45920 `#1392`, 46039 `#1336`, 46090 `#1420`, 46206 `#1402`):
  text / marker / blank / `---` / blank / heading, with no blank line before the marker.
- **Pure-suffix property**: the base version of the file survives byte-for-byte as a
  prefix of the union's version. `sha256` of `3b8461a6:docs/DESIGN_NOTES.md` equals
  `sha256` of the first 45919 lines of the union's file —
  `3083d2aa3a0c79a39adc2831d89ff6aad53de1c4cbc794493861355bd6699adf` both sides.
  This is the strongest available statement that no earlier line was rewritten or
  eaten, and it is worth stating because a line swallowed by union merge never lands
  in any commit, so `git log -S` and pickaxe cannot find it after the fact. All the
  detection weight sits before the commit.

## Gates run here

| gate | result |
|---|---|
| `scripts/design-notes-gate.sh` | rc=0 — "4 new entry heading(s), separator and marker present" |
| `scripts/bun.sh run check` | rc=0, 59 warnings + 6 infos — the measured baseline for this base, unchanged |
| `scripts/bun.sh run test` | rc=0, 289 files, 5583 tests passed — the baseline for `3b8461a6`, unchanged (this branch adds no vitest test) |

## Gates deliberately NOT run here — CI is the first place these meet

Stated so nobody reads the three green boxes above as coverage they are not:

- **No Elixir compile, no `scripts/check.sh`, no `scripts/test.sh`.** #1457 and #1459
  are almost entirely server-side (`lib/grappa/subject.ex`, `read_cursor.ex`,
  `scrollback.ex`, `repo.ex`, the new `repo/lock_watch.ex`, `application.ex`) and this
  branch is the **first tree in which those two coexist**. Dialyzer, Credo and Sobelow
  are likewise unrun. Another worker holds the compile lane while investigating an
  unrelated red on `main`; taking it would have cost them their measurement.
- **No local testnet, no e2e, no `scripts/integration.sh`.** #1458 changes
  `cicchetto/e2e/fixtures/cicchettoPage.ts`, a shared fixture, and #1459 adds a
  supervised child that starts in every boot. Their interaction is exactly what a full
  run would answer, and this PR's CI is where it gets answered — once, rather than four
  times.
- **The four source PRs' own evidence was not re-measured against this base.** Mutants,
  red-first runs and per-slice attributions in those PRs attest their original bases.
  A gate whose base has moved is no longer a gate; those are named here as unmeasured
  rather than quietly inherited.
- Nothing about the substance of the four changes was re-reviewed. This branch is a
  replay, not a rewrite: no line was edited during the cherry-picks, and the only
  merge resolution anywhere was `merge=union` appending in `docs/DESIGN_NOTES.md`.
