### PR TITLE
refactor(#1390): fold the ten injected session callbacks into one Deps struct

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46365,3 +46365,79 @@ error naming the arm instead of silence. Deriving the entry needs the topic
 axis in the codegen, which stays open. Nor does it touch a narrower: no
 runtime behaviour moves, and the 1.150-odd lines of hand narrowing that the
 rest of #1406 is about are untouched here.
+<!-- entry #1390 -->
+
+---
+
+## 2026-08-17 — #1390 slice 1: the ten injected callbacks become one `Deps` struct
+
+Bucket A of the 2026-08-15 architecture review wants `Session.Server`
+decomposed. This is the first slice, and it was picked first because it is the
+only one whose value does not rest on a theory about types: it is
+behaviour-free, the ten fields are contiguous in the typedef, and it takes a
+closure off the `EventRouter` state contract that had no business being read as
+if it were state.
+
+The ten are dependencies, not state. Nothing in a session's lifetime writes
+them — `init/1` reads them out of the resolved plan and every later touch is a
+call. They now live in `Grappa.Session.Deps`, and `Session.Server`'s top-level
+state goes from **85 keys to 76**.
+
+### What did not change, deliberately
+
+`start_link/1`'s keyword API. All ten option keys are spelled exactly as
+before, so no producer of a session plan moved: `Networks.SessionPlan`,
+`Visitors.SessionPlan`, `Bootstrap` and the rest write into `opts`, and
+`Deps.from_opts/1` is the only thing that had to learn the new shape. That is
+what keeps this slice at six files instead of fifteen.
+
+### Why `EventRouter` matches a plain map and not `%Deps{}`
+
+`Deps` already names `EventRouter.query_window_open?()` for one of its field
+types. Pattern-matching `%Deps{}` inside `EventRouter` would put a compile
+dependency back the other way and close a cycle, so the read there is a plain
+`%{query_window_open?: fun}` map pattern — a struct is a map, so the production
+`%Deps{}` matches it.
+
+The absent-`deps` arm keeps its `false` default and specifically does NOT fall
+back to `%Deps{}`. The struct's own default for that field is
+`&QueryWindows.open?/3`, a real DB read; handing that to `EventRouter` would
+cost the module its "No Repo" purity in every test that builds a state without
+`deps`.
+
+### The tolerant reads are load-bearing, and a test proved it
+
+Two of the twelve read sites were `Map.get(state, key, default)` rather than
+dot-access, tolerating a live process that predates the field across a hot
+reload. Bundling them silently hardened both, and
+`recover_identity (#581) — hot-reload safety` caught it. They are now
+`Map.get(state, :deps, %Deps{})`, which is exactly equivalent: the struct's
+defaults for those two fields (`nil` and `&QueryWindows.open?/3`) are the
+values the two `Map.get` calls were already defaulting to. The other ten sites
+were dot-access or pattern matches before and after, so their failure profile
+is unchanged.
+
+That test needed one update, and it is worth recording why it is not a
+weakening. It simulated the stale process with
+`Map.delete(state, :recover_source)`. After the bundle that top-level key does
+not exist, so the delete became a no-op and the test would have passed while
+exercising nothing at all — the failure mode where a green test is worse than
+no test. It now deletes `:deps`. The assertion is untouched; only the key that
+stands in for the stale shape moved.
+
+### Measurement notes
+
+The state-key count is **85**, not the 84 the review recon reported — and 85 on
+both the recon's commit and this branch's base, so it is a difference of
+counting method, not drift. A first pass said 89 by including the four nested
+keys of `directory_refresh`; the typedef has 85 at top level.
+
+The nine callback `@type` declarations moved into `deps.ex` with their
+typedocs, transplanted mechanically rather than retyped so the prose that
+records which Boundary cycle each closure dodges travels with them.
+`restored_away` is not one of the ten and stays where it was.
+
+_Not measured here: whether the slice is behaviour-free beyond the two test
+files it touches. The 847 tests in `server_test.exs` and `event_router_test.exs`
+are green; the rest of the suite and the type gates are a separate run, and
+this entry does not claim their verdict._

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -84,7 +84,7 @@ defmodule Grappa.Session do
     exports: [Backoff, NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
-  alias Grappa.Session.{FloodAllowance, ISupport, Server}
+  alias Grappa.Session.{Deps, FloodAllowance, ISupport, Server}
 
   require Logger
 
@@ -213,23 +213,23 @@ defmodule Grappa.Session do
           optional(:managed_source_alias) => String.t() | nil,
           optional(:notify_pid) => pid(),
           optional(:notify_ref) => reference(),
-          optional(:visitor_committer) => Server.visitor_committer(),
-          optional(:visitor_password_rotator) => Server.visitor_password_rotator(),
-          optional(:visitor_nick_persister) => Server.visitor_nick_persister(),
-          optional(:credential_failer) => Server.credential_failer(),
-          optional(:credential_committer) => Server.credential_committer(),
-          optional(:registration_committer) => Server.registration_committer(),
-          optional(:last_joined_persister) => Server.last_joined_persister(),
+          optional(:visitor_committer) => Deps.visitor_committer(),
+          optional(:visitor_password_rotator) => Deps.visitor_password_rotator(),
+          optional(:visitor_nick_persister) => Deps.visitor_nick_persister(),
+          optional(:credential_failer) => Deps.credential_failer(),
+          optional(:credential_committer) => Deps.credential_committer(),
+          optional(:registration_committer) => Deps.registration_committer(),
+          optional(:last_joined_persister) => Deps.last_joined_persister(),
           # #581 — visitor-only /recover secret reader (the visitor plan injects
           # it; user plans omit it). Twin of the `init_opts` entry in
           # `Grappa.Session.Server` — MUST stay in sync (a build_plan map with a
           # key absent here fails `resolve/2`'s `{:ok, start_opts()}` spec →
           # dialyzer `missing_range` cascade across every resolve consumer).
-          optional(:recover_source) => Server.recover_source(),
+          optional(:recover_source) => Deps.recover_source(),
           # GH #417 — persist/restore the EXPLICIT away across crash/reconnect
           # (user-only; the visitor plan omits both). Kept in sync with the
           # `Grappa.Session.Server.start_opts/0` twin.
-          optional(:away_persister) => Server.away_persister(),
+          optional(:away_persister) => Deps.away_persister(),
           optional(:restored_away) => Server.restored_away(),
           optional(:refresh_plan) => Server.refresh_plan_check(),
           # GH #189 — on-connect perform list + its `$oper_pass` secret,

--- a/lib/grappa/session/deps.ex
+++ b/lib/grappa/session/deps.ex
@@ -1,0 +1,245 @@
+defmodule Grappa.Session.Deps do
+  @moduledoc """
+  The callbacks a session is BUILT with, in one struct.
+
+  These ten are dependencies, not state. Nothing in a session's lifetime
+  writes them: `init/1` reads them out of the resolved plan and every later
+  read is a call. Carried as opaque function references rather than module
+  aliases because the producing contexts (Networks, Visitors, QueryWindows)
+  already depend on `Grappa.Session`, so a literal alias would close a
+  Boundary cycle — the per-type notes below record which cycle each one
+  dodges.
+
+  Grouping them costs no behaviour and buys two things. `Session.Server`'s
+  state drops from 85 top-level keys to 76, and the `EventRouter` state
+  contract stops carrying a bare closure among fields that are genuinely
+  state: what it sees now is one typed field it can project as a whole.
+
+  The struct is built by `from_opts/1` from the SAME `start_link/1` keyword
+  API as before — the ten option keys are unchanged, so no producer of a
+  session plan had to move.
+  """
+
+  alias Grappa.QueryWindows
+  alias Grappa.Session.EventRouter
+
+  @typedoc """
+  Optional opaque callback the visitor-side `SessionPlan` injects into
+  every visitor plan. Invoked by `apply_effects/2` when EventRouter emits
+  `:identity_secret_confirmed` so the confirmed NickServ password AND the nick held
+  at the identify instant land on the credential (#561). The function shape
+  mirrors `Grappa.Visitors.commit_identity/4` (the closure captures
+  `network_id`, so the args are `(visitor_id, password, nick)`). Carried as
+  an opaque function reference (not a module name) to avoid a static
+  `Session → Visitors` boundary alias — Visitors already deps Session
+  via `Visitors.Login`, so a literal alias would close a cycle.
+  """
+  @type visitor_committer ::
+          (Ecto.UUID.t(), String.t(), String.t() ->
+             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
+
+  @typedoc """
+  #131 — visitor-side SET PASSWD committer the visitor `SessionPlan`
+  injects. The visitor counterpart of `credential_committer`. Invoked from
+  the outbound NickServ-secret capture choke point (NOT the `+r` path) when
+  a well-formed in-session `SET PASSWD` leaves the wire.
+
+  Deliberately NOT `visitor_committer` (`commit_identity/4`): that one
+  promotes anon→permanent (+ binds the identified nick), which is only safe
+  behind the `+r` identity proof. This shape maps to
+  `Grappa.Visitors.rotate_password/2`, which is
+  identity-gated (`{:error, :not_identified}` for an anon row) so an
+  optimistic commit can't pin an unidentified visitor permanent. Same
+  Boundary-cycle-avoiding function-reference indirection as
+  `visitor_committer`.
+  """
+  @type visitor_password_rotator ::
+          (Ecto.UUID.t(), String.t() ->
+             {:ok, struct()} | {:error, :not_found | :not_identified | Ecto.Changeset.t()})
+
+  @typedoc """
+  V9 (visitor-parity cluster, 2026-05-15) — opaque callback the
+  visitor-side `SessionPlan` injects so `apply_effects/2` can rotate
+  `visitors.nick` after EventRouter observes the upstream NICK
+  self-echo. Same Boundary-cycle reasoning as `visitor_committer`:
+  Visitors deps Session via Login, so a static
+  `Session → Grappa.Visitors` alias would close the cycle. The
+  function shape mirrors `Grappa.Visitors.update_nick/3` exactly —
+  including #561's `{:ok, :held_identified}` (the echo persist is a no-op
+  when the credential is identified; its nick is bound at `+r` instead).
+  """
+  @type visitor_nick_persister ::
+          (Ecto.UUID.t(), String.t() ->
+             {:ok, struct() | :held_identified} | {:error, :not_found | Ecto.Changeset.t()})
+
+  @typedoc """
+  Optional opaque callback injected by `Networks.SessionPlan.resolve/1`
+  into every user-session plan. Called from `handle_terminal_failure/2`
+  when a hard upstream error (k-line / permanent SASL) means the session
+  should never be restarted without operator action.
+
+  The closure captures `user_id` + `network_id` and calls
+  `Networks.mark_failed_by_ids/3` — a static Networks alias is avoided
+  here for the same Boundary reason as `visitor_committer` (Networks
+  already deps Session; closing the cycle is banned by `use Boundary`).
+
+  Calling convention: fire inside a supervised `Task.Supervisor.start_child/2`
+  (S37) BEFORE `{:stop, :normal}` so the Server's GenServer exit is truly
+  `:normal` and the `:transient` supervisor doesn't restart. The Task's
+  async execution means `mark_failed_by_ids` runs after the process has
+  exited — `stop_session` inside `mark_failed` finds `whereis → nil` and is
+  a no-op.
+  """
+  @type credential_failer :: (String.t() -> :ok)
+
+  @typedoc """
+  #131 — opaque callback injected by `Networks.SessionPlan.resolve/1`
+  into every USER-session plan. Invoked from the outbound NickServ-secret
+  capture choke point when a well-formed in-session `SET PASSWD` leaves
+  the wire, so the new upstream NickServ password is committed to the
+  bound credential OPTIMISTICALLY (no `+r` rendezvous fires for a password
+  change from an already-identified session).
+
+  User-side mirror of `visitor_committer`: the closure captures
+  `(user_id, network_id)` and forwards to
+  `Grappa.Networks.Credentials.commit_password/3`. The function-reference
+  indirection avoids a static `Session → Grappa.Networks` alias (Networks
+  already deps Session for `stop_session`, so the reverse closes a
+  Boundary cycle). Visitor plans don't carry it (nil); the visitor home
+  is reached via `visitor_committer` instead.
+  """
+  @type credential_committer ::
+          (String.t() ->
+             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
+
+  @typedoc """
+  #349 — opaque callback injected by `Networks.SessionPlan.resolve/1` into
+  every USER-session plan. Invoked from the `+r` observer (`apply_effects/2`)
+  when a wizard-driven REGISTER is confirmed (a staged
+  `pending_registration_secret` + the services-set `+r`), so the REGISTER
+  password is committed to the bound credential AND its `auth_method` flips to
+  `:nickserv_identify` (the registered nick must auto-identify on every future
+  reconnect, else services enforce it).
+
+  Distinct from `credential_committer` (#131, SET PASSWD — password only, no
+  auth_method change): registration promotes a `--auth none` binding to
+  auto-identify, so it forwards to
+  `Grappa.Networks.Credentials.commit_registration_password/3`. Same
+  function-reference indirection (Networks deps Session; the reverse would
+  close a Boundary cycle) and `(user_id, network_id)` capture as
+  `credential_committer`. Visitor plans don't carry it (nil); the visitor `+r`
+  promotion runs via `visitor_committer` instead.
+  """
+  @type registration_committer ::
+          (String.t() ->
+             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
+
+  @typedoc """
+  CP22 cluster B (channel-client-polish #14, B-restart) — opaque
+  callback that persists a channels-list CHANGE so a graceful or crash
+  restart can rehydrate the channel list at boot. First argument is the
+  current `Map.keys(state.members)` keyset, second the channels THIS
+  change removed from it.
+
+  Boundary-clean: Session.Server cannot reference `Grappa.Networks`
+  directly (the cycle is banned — Networks already deps Session for
+  stop_session calls on /disconnect). The callback wraps a closure
+  that knows the (user_id, network_id) pair and forwards to
+  `Grappa.Networks.Credentials.merge_last_joined_channels/4`.
+  Returns `:ok` on success or `{:error, reason}`; Session.Server logs
+  failures but does not retry — the next channels-list mutation unions
+  the live keyset back in, and a missing snapshot only forces the next
+  restart to fall back to operator autojoin.
+
+  #1385 — the two arguments exist because the keyset ALONE cannot tell
+  "not restored yet" from "left": both read as absent. The departures
+  therefore travel separately, sourced from the event that caused them.
+  """
+  @type last_joined_persister :: ([String.t()], [String.t()] -> :ok | {:error, term()})
+
+  @typedoc """
+  GH #581 — opaque reader the visitor `SessionPlan` injects so
+  `handle_call(:recover_identity, ...)` can resolve the PERSISTENT recover
+  target (the registered nick + NickServ secret) without a static
+  `Session → Networks/Visitors` alias (Boundary cycle — Visitors deps
+  Session via Login). Reads the LIVE credential each call
+  (`Credentials.get_visitor_credential` + `Credential.recover_secret/1`),
+  NOT `state.pending_password` (one-shot cleared at 001) — so it resolves the
+  SAME source as the `recoverable` button gate
+  (`Credential.has_nickserv_secret?/1`), the review-#1 fix. `nil` on state =
+  no reader injected (user sessions — recover is visitor-only).
+  """
+  @type recover_source ::
+          (-> {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover})
+
+  @typedoc """
+  GH #417 — opaque closure that persists the EXPLICIT away snapshot to the
+  producing context (Networks), forwarding `(reason, since)` to
+  `Grappa.Networks.Credentials.update_away/4`. `(nil, nil)` clears it on
+  `/back`. Boundary-clean for the same reason as `last_joined_persister`:
+  Networks already deps Session, so the reverse edge cannot be expressed
+  without closing a cycle. Called fire-and-forget from
+  `set_explicit_away_internal/3` + the explicit `unset_explicit_away`
+  handle_call arms; a `{:error, _}` is logged, not retried (the next away
+  transition overwrites). `nil` on state = no persister injected (visitor
+  sessions — away is not persisted for the ephemeral subject).
+  """
+  @type away_persister :: (String.t() | nil, DateTime.t() | nil -> :ok | {:error, term()})
+
+  @typedoc """
+  The ten injected callbacks. Nine default to `nil` — a plan that does not
+  supply one is declaring the session cannot do that thing (a user session
+  has no `recover_source`; a visitor session has no `away_persister`).
+
+  `query_window_open?` is the exception and does NOT default to `nil`: it
+  has a real production default, `&QueryWindows.open?/3`. A session always
+  has an answer to "is a query window open" — the injection point exists so
+  tests can supply a fake and keep `EventRouter` a sandbox-free classifier,
+  not because the capability is optional.
+  """
+  @type t :: %__MODULE__{
+          visitor_committer: visitor_committer() | nil,
+          visitor_password_rotator: visitor_password_rotator() | nil,
+          visitor_nick_persister: visitor_nick_persister() | nil,
+          credential_failer: credential_failer() | nil,
+          credential_committer: credential_committer() | nil,
+          registration_committer: registration_committer() | nil,
+          last_joined_persister: last_joined_persister() | nil,
+          recover_source: recover_source() | nil,
+          away_persister: away_persister() | nil,
+          query_window_open?: EventRouter.query_window_open?()
+        }
+
+  defstruct visitor_committer: nil,
+            visitor_password_rotator: nil,
+            visitor_nick_persister: nil,
+            credential_failer: nil,
+            credential_committer: nil,
+            registration_committer: nil,
+            last_joined_persister: nil,
+            recover_source: nil,
+            away_persister: nil,
+            query_window_open?: &QueryWindows.open?/3
+
+  @doc """
+  Reads the ten callbacks out of a resolved `Grappa.Session.start_opts/0`.
+
+  Absent keys take the struct defaults, which is the same rule `init/1`
+  applied when these lived as ten separate `Map.get(opts, :key)` lines.
+  """
+  @spec from_opts(map()) :: t()
+  def from_opts(opts) when is_map(opts) do
+    %__MODULE__{
+      visitor_committer: Map.get(opts, :visitor_committer),
+      visitor_password_rotator: Map.get(opts, :visitor_password_rotator),
+      visitor_nick_persister: Map.get(opts, :visitor_nick_persister),
+      credential_failer: Map.get(opts, :credential_failer),
+      credential_committer: Map.get(opts, :credential_committer),
+      registration_committer: Map.get(opts, :registration_committer),
+      last_joined_persister: Map.get(opts, :last_joined_persister),
+      recover_source: Map.get(opts, :recover_source),
+      away_persister: Map.get(opts, :away_persister),
+      query_window_open?: Map.get(opts, :query_window_open?, &QueryWindows.open?/3)
+    }
+  end
+end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -125,9 +125,11 @@ defmodule Grappa.Session.EventRouter do
 
   @typedoc """
   #400 — injected open-query-window predicate `(subject, network_id, nick)
-  -> bool`. Read from `state.query_window_open?` (an `optional(any())`
-  key on the state map above) to decide whether a services-sender arrival
-  re-keys to the service's own query window or the synthetic `$server`.
+  -> bool`. Read from `state.deps.query_window_open?` (#1390 bundled the
+  host's ten injected callbacks into one `Grappa.Session.Deps` struct; before
+  it, this sat loose on the state map) to decide whether a services-sender
+  arrival re-keys to the service's own query window or the synthetic
+  `$server`.
 
   EventRouter is a pure classifier ("No Repo, no Logger"); the fact it
   needs is a DB read (`Grappa.QueryWindows.open?/3`). Rather than alias
@@ -2919,7 +2921,7 @@ defmodule Grappa.Session.EventRouter do
   #
   # The open-window fact is a per-(subject, network) DB read. EventRouter
   # is a pure classifier ("No Repo"), so the lookup is injected as the
-  # opaque `state.query_window_open?` callback (see the type's docstring).
+  # opaque `state.deps.query_window_open?` callback (see the type's docstring).
   # Absent → false → `$server`, which post-#546 is also the correct default
   # for a peer, so the sandbox-free classifier suite needs no DI seam to
   # observe production routing.
@@ -2933,7 +2935,17 @@ defmodule Grappa.Session.EventRouter do
   # discipline 1) and could only ever disagree with itself.
   @spec open_query_or_server(String.t(), state()) :: String.t()
   defp open_query_or_server(sender, state) do
-    open? = Map.get(state, :query_window_open?, fn _, _, _ -> false end)
+    # Deliberately a PLAIN map pattern, not `%Deps{}`: `Deps` already
+    # references this module for the `query_window_open?()` type, and matching
+    # its struct here would close a compile/export cycle. A struct IS a map, so
+    # the production `%Deps{}` matches. The absent arm keeps its `false`
+    # default — NOT the `Deps` default, which is the real DB read and would
+    # cost this module its "No Repo" purity in any test that omits `deps`.
+    open? =
+      case Map.get(state, :deps) do
+        %{query_window_open?: fun} when is_function(fun, 3) -> fun
+        _ -> fn _, _, _ -> false end
+      end
 
     if open?.(state.subject, state.network_id, sender),
       do: sender,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -102,6 +102,7 @@ defmodule Grappa.Session.Server do
     AwayState,
     Backoff,
     Broadcaster,
+    Deps,
     EventRouter,
     FloodAllowance,
     GhostRecovery,
@@ -237,169 +238,6 @@ defmodule Grappa.Session.Server do
                         )
 
   @typedoc """
-  Optional opaque callback the visitor-side `SessionPlan` injects into
-  every visitor plan. Invoked by `apply_effects/2` when EventRouter emits
-  `:identity_secret_confirmed` so the confirmed NickServ password AND the nick held
-  at the identify instant land on the credential (#561). The function shape
-  mirrors `Grappa.Visitors.commit_identity/4` (the closure captures
-  `network_id`, so the args are `(visitor_id, password, nick)`). Carried as
-  an opaque function reference (not a module name) to avoid a static
-  `Session → Visitors` boundary alias — Visitors already deps Session
-  via `Visitors.Login`, so a literal alias would close a cycle.
-  """
-  @type visitor_committer ::
-          (Ecto.UUID.t(), String.t(), String.t() ->
-             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
-
-  @typedoc """
-  #131 — visitor-side SET PASSWD committer the visitor `SessionPlan`
-  injects. The visitor counterpart of `credential_committer`. Invoked from
-  the outbound NickServ-secret capture choke point (NOT the `+r` path) when
-  a well-formed in-session `SET PASSWD` leaves the wire.
-
-  Deliberately NOT `visitor_committer` (`commit_identity/4`): that one
-  promotes anon→permanent (+ binds the identified nick), which is only safe
-  behind the `+r` identity proof. This shape maps to
-  `Grappa.Visitors.rotate_password/2`, which is
-  identity-gated (`{:error, :not_identified}` for an anon row) so an
-  optimistic commit can't pin an unidentified visitor permanent. Same
-  Boundary-cycle-avoiding function-reference indirection as
-  `visitor_committer`.
-  """
-  @type visitor_password_rotator ::
-          (Ecto.UUID.t(), String.t() ->
-             {:ok, struct()} | {:error, :not_found | :not_identified | Ecto.Changeset.t()})
-
-  @typedoc """
-  V9 (visitor-parity cluster, 2026-05-15) — opaque callback the
-  visitor-side `SessionPlan` injects so `apply_effects/2` can rotate
-  `visitors.nick` after EventRouter observes the upstream NICK
-  self-echo. Same Boundary-cycle reasoning as `visitor_committer`:
-  Visitors deps Session via Login, so a static
-  `Session → Grappa.Visitors` alias would close the cycle. The
-  function shape mirrors `Grappa.Visitors.update_nick/3` exactly —
-  including #561's `{:ok, :held_identified}` (the echo persist is a no-op
-  when the credential is identified; its nick is bound at `+r` instead).
-  """
-  @type visitor_nick_persister ::
-          (Ecto.UUID.t(), String.t() ->
-             {:ok, struct() | :held_identified} | {:error, :not_found | Ecto.Changeset.t()})
-
-  @typedoc """
-  Optional opaque callback injected by `Networks.SessionPlan.resolve/1`
-  into every user-session plan. Called from `handle_terminal_failure/2`
-  when a hard upstream error (k-line / permanent SASL) means the session
-  should never be restarted without operator action.
-
-  The closure captures `user_id` + `network_id` and calls
-  `Networks.mark_failed_by_ids/3` — a static Networks alias is avoided
-  here for the same Boundary reason as `visitor_committer` (Networks
-  already deps Session; closing the cycle is banned by `use Boundary`).
-
-  Calling convention: fire inside a supervised `Task.Supervisor.start_child/2`
-  (S37) BEFORE `{:stop, :normal}` so the Server's GenServer exit is truly
-  `:normal` and the `:transient` supervisor doesn't restart. The Task's
-  async execution means `mark_failed_by_ids` runs after the process has
-  exited — `stop_session` inside `mark_failed` finds `whereis → nil` and is
-  a no-op.
-  """
-  @type credential_failer :: (String.t() -> :ok)
-
-  @typedoc """
-  #131 — opaque callback injected by `Networks.SessionPlan.resolve/1`
-  into every USER-session plan. Invoked from the outbound NickServ-secret
-  capture choke point when a well-formed in-session `SET PASSWD` leaves
-  the wire, so the new upstream NickServ password is committed to the
-  bound credential OPTIMISTICALLY (no `+r` rendezvous fires for a password
-  change from an already-identified session).
-
-  User-side mirror of `visitor_committer`: the closure captures
-  `(user_id, network_id)` and forwards to
-  `Grappa.Networks.Credentials.commit_password/3`. The function-reference
-  indirection avoids a static `Session → Grappa.Networks` alias (Networks
-  already deps Session for `stop_session`, so the reverse closes a
-  Boundary cycle). Visitor plans don't carry it (nil); the visitor home
-  is reached via `visitor_committer` instead.
-  """
-  @type credential_committer ::
-          (String.t() ->
-             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
-
-  @typedoc """
-  #349 — opaque callback injected by `Networks.SessionPlan.resolve/1` into
-  every USER-session plan. Invoked from the `+r` observer (`apply_effects/2`)
-  when a wizard-driven REGISTER is confirmed (a staged
-  `pending_registration_secret` + the services-set `+r`), so the REGISTER
-  password is committed to the bound credential AND its `auth_method` flips to
-  `:nickserv_identify` (the registered nick must auto-identify on every future
-  reconnect, else services enforce it).
-
-  Distinct from `credential_committer` (#131, SET PASSWD — password only, no
-  auth_method change): registration promotes a `--auth none` binding to
-  auto-identify, so it forwards to
-  `Grappa.Networks.Credentials.commit_registration_password/3`. Same
-  function-reference indirection (Networks deps Session; the reverse would
-  close a Boundary cycle) and `(user_id, network_id)` capture as
-  `credential_committer`. Visitor plans don't carry it (nil); the visitor `+r`
-  promotion runs via `visitor_committer` instead.
-  """
-  @type registration_committer ::
-          (String.t() ->
-             {:ok, struct()} | {:error, :not_found | Ecto.Changeset.t()})
-
-  @typedoc """
-  CP22 cluster B (channel-client-polish #14, B-restart) — opaque
-  callback that persists a channels-list CHANGE so a graceful or crash
-  restart can rehydrate the channel list at boot. First argument is the
-  current `Map.keys(state.members)` keyset, second the channels THIS
-  change removed from it.
-
-  Boundary-clean: Session.Server cannot reference `Grappa.Networks`
-  directly (the cycle is banned — Networks already deps Session for
-  stop_session calls on /disconnect). The callback wraps a closure
-  that knows the (user_id, network_id) pair and forwards to
-  `Grappa.Networks.Credentials.merge_last_joined_channels/4`.
-  Returns `:ok` on success or `{:error, reason}`; Session.Server logs
-  failures but does not retry — the next channels-list mutation unions
-  the live keyset back in, and a missing snapshot only forces the next
-  restart to fall back to operator autojoin.
-
-  #1385 — the two arguments exist because the keyset ALONE cannot tell
-  "not restored yet" from "left": both read as absent. The departures
-  therefore travel separately, sourced from the event that caused them.
-  """
-  @type last_joined_persister :: ([String.t()], [String.t()] -> :ok | {:error, term()})
-
-  @typedoc """
-  GH #581 — opaque reader the visitor `SessionPlan` injects so
-  `handle_call(:recover_identity, ...)` can resolve the PERSISTENT recover
-  target (the registered nick + NickServ secret) without a static
-  `Session → Networks/Visitors` alias (Boundary cycle — Visitors deps
-  Session via Login). Reads the LIVE credential each call
-  (`Credentials.get_visitor_credential` + `Credential.recover_secret/1`),
-  NOT `state.pending_password` (one-shot cleared at 001) — so it resolves the
-  SAME source as the `recoverable` button gate
-  (`Credential.has_nickserv_secret?/1`), the review-#1 fix. `nil` on state =
-  no reader injected (user sessions — recover is visitor-only).
-  """
-  @type recover_source ::
-          (-> {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover})
-
-  @typedoc """
-  GH #417 — opaque closure that persists the EXPLICIT away snapshot to the
-  producing context (Networks), forwarding `(reason, since)` to
-  `Grappa.Networks.Credentials.update_away/4`. `(nil, nil)` clears it on
-  `/back`. Boundary-clean for the same reason as `last_joined_persister`:
-  Networks already deps Session, so the reverse edge cannot be expressed
-  without closing a cycle. Called fire-and-forget from
-  `set_explicit_away_internal/3` + the explicit `unset_explicit_away`
-  handle_call arms; a `{:error, _}` is logged, not retried (the next away
-  transition overwrites). `nil` on state = no persister injected (visitor
-  sessions — away is not persisted for the ephemeral subject).
-  """
-  @type away_persister :: (String.t() | nil, DateTime.t() | nil -> :ok | {:error, term()})
-
-  @typedoc """
   GH #417 — the away snapshot `SessionPlan.resolve/1` read back from the
   credential's `away_reason` / `away_since` columns, threaded into
   `init/1` opts. `{reason, since}` seeds `:away_explicit` (via
@@ -533,19 +371,19 @@ defmodule Grappa.Session.Server do
           optional(:managed_source_alias) => String.t() | nil,
           optional(:notify_pid) => pid(),
           optional(:notify_ref) => reference(),
-          optional(:visitor_committer) => visitor_committer(),
-          optional(:visitor_password_rotator) => visitor_password_rotator(),
-          optional(:visitor_nick_persister) => visitor_nick_persister(),
-          optional(:credential_failer) => credential_failer(),
-          optional(:credential_committer) => credential_committer(),
-          optional(:registration_committer) => registration_committer(),
-          optional(:last_joined_persister) => last_joined_persister(),
+          optional(:visitor_committer) => Deps.visitor_committer(),
+          optional(:visitor_password_rotator) => Deps.visitor_password_rotator(),
+          optional(:visitor_nick_persister) => Deps.visitor_nick_persister(),
+          optional(:credential_failer) => Deps.credential_failer(),
+          optional(:credential_committer) => Deps.credential_committer(),
+          optional(:registration_committer) => Deps.registration_committer(),
+          optional(:last_joined_persister) => Deps.last_joined_persister(),
           # #581 — visitor-only reader for the /recover secret source (user
           # plans omit it; recover is visitor-only).
-          optional(:recover_source) => recover_source(),
+          optional(:recover_source) => Deps.recover_source(),
           # GH #417 — persist/restore the EXPLICIT away across crash/reconnect.
           # User-only (visitor plans omit both).
-          optional(:away_persister) => away_persister(),
+          optional(:away_persister) => Deps.away_persister(),
           optional(:restored_away) => restored_away(),
           optional(:query_window_open?) => EventRouter.query_window_open?(),
           optional(:refresh_plan) => refresh_plan_check(),
@@ -667,19 +505,8 @@ defmodule Grappa.Session.Server do
           # Read at 001 by `run_perform_and_identify/1`. nil when unset.
           perform_list: String.t() | nil,
           oper_pass: String.t() | nil,
-          visitor_committer: visitor_committer() | nil,
-          visitor_password_rotator: visitor_password_rotator() | nil,
-          visitor_nick_persister: visitor_nick_persister() | nil,
-          credential_failer: credential_failer() | nil,
-          credential_committer: credential_committer() | nil,
-          registration_committer: registration_committer() | nil,
-          last_joined_persister: last_joined_persister() | nil,
-          # #581 — visitor-only /recover secret reader (nil for user sessions).
-          recover_source: recover_source() | nil,
-          # GH #417 — persister for the EXPLICIT away snapshot; nil for
-          # visitor sessions (away not persisted for the ephemeral subject).
-          away_persister: away_persister() | nil,
-          query_window_open?: EventRouter.query_window_open?(),
+          # #1390 — the ten injected callbacks, bundled. See `Deps`.
+          deps: Deps.t(),
           ghost_recovery: GhostRecovery.t() | nil,
           ghost_timer: reference() | nil,
           # #676 h14 — the `nick_fallback` advisory built at 001 but held
@@ -1148,7 +975,7 @@ defmodule Grappa.Session.Server do
   # fixtures / a bare Bootstrap plan) → just `:ignore`.
   @spec hold_session(
           :no_client_source | :no_static_prefix | :mode2_disarmed,
-          credential_failer() | nil
+          Deps.credential_failer() | nil
         ) :: :ignore
   defp hold_session(reason, credential_failer) do
     text = "static-mapping: #{hold_reason_text(reason)}"
@@ -1254,25 +1081,7 @@ defmodule Grappa.Session.Server do
       pending_password: pending_password_from_opts(opts),
       perform_list: Map.get(opts, :perform_list),
       oper_pass: Map.get(opts, :oper_pass),
-      visitor_committer: Map.get(opts, :visitor_committer),
-      visitor_password_rotator: Map.get(opts, :visitor_password_rotator),
-      visitor_nick_persister: Map.get(opts, :visitor_nick_persister),
-      credential_failer: Map.get(opts, :credential_failer),
-      credential_committer: Map.get(opts, :credential_committer),
-      registration_committer: Map.get(opts, :registration_committer),
-      last_joined_persister: Map.get(opts, :last_joined_persister),
-      # #581 — visitor-only /recover secret reader (nil for user sessions).
-      recover_source: Map.get(opts, :recover_source),
-      # GH #417 — persister for the EXPLICIT away snapshot (nil for visitors).
-      away_persister: Map.get(opts, :away_persister),
-      # #400 — open-query-window predicate EventRouter consults to re-key a
-      # services-sender NOTICE/PRIVMSG onto the service's own query window
-      # when the operator has one open (else `$server`, today's behaviour).
-      # Production default is the real DB read; Server already deps
-      # QueryWindows (#373 `rename/4`), so injecting the fn reference adds
-      # no new Boundary edge. Tests override via opts with a fake closure —
-      # EventRouter stays a pure, sandbox-free classifier ("No Repo").
-      query_window_open?: Map.get(opts, :query_window_open?, &QueryWindows.open?/3),
+      deps: Deps.from_opts(opts),
       ghost_recovery: nil,
       ghost_timer: nil,
       parked_nick_fallback: nil,
@@ -3860,8 +3669,8 @@ defmodule Grappa.Session.Server do
   @spec handle_terminal_failure(String.t(), t()) :: {:stop, :normal, t()}
   defp handle_terminal_failure(reason, state) when is_binary(reason) do
     _ =
-      if is_function(state.credential_failer, 1) do
-        failer = state.credential_failer
+      if is_function(state.deps.credential_failer, 1) do
+        failer = state.deps.credential_failer
         Task.Supervisor.start_child(Grappa.TaskSupervisor, fn -> failer.(reason) end)
       end
 
@@ -4597,11 +4406,17 @@ defmodule Grappa.Session.Server do
   # the now-stale stored password is repaired by retyping it into
   # the per-network password field (#124, Settings -> General). A cold restart re-inits with the committer wired.
   @spec rotate_stored_password(t(), String.t()) :: {{:ok, term()} | {:error, term()}, keyword()}
-  defp rotate_stored_password(%{subject: {:visitor, visitor_id}, visitor_password_rotator: rotator}, new_password)
+  defp rotate_stored_password(
+         %{subject: {:visitor, visitor_id}, deps: %Deps{visitor_password_rotator: rotator}},
+         new_password
+       )
        when is_function(rotator, 2),
        do: {rotator.(visitor_id, new_password), [visitor_id: visitor_id]}
 
-  defp rotate_stored_password(%{subject: {:user, user_id}, credential_committer: committer}, new_password)
+  defp rotate_stored_password(
+         %{subject: {:user, user_id}, deps: %Deps{credential_committer: committer}},
+         new_password
+       )
        when is_function(committer, 1),
        do: {committer.(new_password), [user: user_id]}
 
@@ -4768,7 +4583,7 @@ defmodule Grappa.Session.Server do
   # practice the reader is always present — the nil clause is pure defense.
   @spec recover_source(t()) :: {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover}
   defp recover_source(state) do
-    case Map.get(state, :recover_source) do
+    case Map.get(state, :deps, %Deps{}).recover_source do
       fun when is_function(fun, 0) -> fun.()
       _ -> {:error, :nothing_to_recover}
     end
@@ -5102,7 +4917,7 @@ defmodule Grappa.Session.Server do
           t()
         ) :: {:channel, String.t()} | {:query, String.t()} | {:server, nil}
   defp resolve_numeric_query_window({:query, target}, state) when is_binary(target) do
-    open? = Map.get(state, :query_window_open?, &QueryWindows.open?/3)
+    open? = Map.get(state, :deps, %Deps{}).query_window_open?
 
     if open?.(state.subject, state.network_id, target),
       do: {:query, target},
@@ -5208,7 +5023,7 @@ defmodule Grappa.Session.Server do
           prev.network_id,
           next_keys,
           departed,
-          prev.last_joined_persister
+          prev.deps.last_joined_persister
         )
     end
 
@@ -5254,7 +5069,7 @@ defmodule Grappa.Session.Server do
           pos_integer(),
           [String.t()],
           [String.t()],
-          last_joined_persister() | nil
+          Deps.last_joined_persister() | nil
         ) :: :ok
   defp persist_last_joined(_, _, _, _, nil), do: :ok
 
@@ -6183,7 +5998,7 @@ defmodule Grappa.Session.Server do
         _ -> state.nick
       end
 
-    case {state.subject, state.visitor_committer} do
+    case {state.subject, state.deps.visitor_committer} do
       {{:visitor, visitor_id}, committer} when is_function(committer, 3) ->
         case committer.(visitor_id, password, bind_nick) do
           {:ok, _} ->
@@ -6239,7 +6054,7 @@ defmodule Grappa.Session.Server do
   # which is operator-driven and rotated via the user-side path
   # documented in `nick_controller.ex`.
   defp apply_effects([{:visitor_nick_changed, new_nick} | rest], state) do
-    case {state.subject, state.visitor_nick_persister} do
+    case {state.subject, state.deps.visitor_nick_persister} do
       {{:visitor, visitor_id}, persister} when is_function(persister, 2) ->
         case persister.(visitor_id, new_nick) do
           {:ok, :held_identified} ->
@@ -6476,7 +6291,7 @@ defmodule Grappa.Session.Server do
   # apply_effects +r arm stays flat.
   defp commit_user_registration(user_id, password, %{
          pending_registration_secret: secret,
-         registration_committer: committer
+         deps: %Deps{registration_committer: committer}
        })
        when is_binary(secret) and is_function(committer, 1) do
     case committer.(password) do
@@ -7164,9 +6979,9 @@ defmodule Grappa.Session.Server do
   defp persist_away_clear(state), do: call_away_persister(state, nil, nil)
 
   @spec call_away_persister(t(), String.t() | nil, DateTime.t() | nil) :: :ok
-  defp call_away_persister(%{away_persister: nil}, _, _), do: :ok
+  defp call_away_persister(%{deps: %Deps{away_persister: nil}}, _, _), do: :ok
 
-  defp call_away_persister(%{away_persister: fun}, reason, since)
+  defp call_away_persister(%{deps: %Deps{away_persister: fun}}, reason, since)
        when is_function(fun, 2) do
     case fun.(reason, since) do
       :ok ->

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -14,6 +14,7 @@ defmodule Grappa.Session.EventRouterTest do
   alias Grappa.IRC.{JoinFailure, Message, Parser}
 
   alias Grappa.Session.{
+    Deps,
     EventRouter,
     GhostRecovery,
     ISupport,
@@ -28,6 +29,12 @@ defmodule Grappa.Session.EventRouterTest do
   @user_id "00000000-0000-0000-0000-000000000001"
   @subject {:user, @user_id}
   @network_id 42
+
+  # #1390 — the host injects its ten callbacks as ONE `Deps` struct now, so a
+  # state that wants a fake predicate carries a REAL `%Deps{}`. Building a bare
+  # map here would let these tests keep passing against a shape production no
+  # longer has, which is the whole thing the bundle is supposed to make visible.
+  defp deps(open?), do: %Deps{query_window_open?: open?}
 
   defp base_state(overrides \\ %{}) do
     Map.merge(
@@ -604,7 +611,7 @@ defmodule Grappa.Session.EventRouterTest do
       # The contrast with the CTCP test above is what this test is for, and
       # #546 sharpened it: give BOTH an open window and they still diverge —
       # framing goes to `$server`, conversation goes to the peer.
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m = msg(:notice, ["vjt", "just a notice"], {:nick, "alice", "u", "h"})
 
@@ -1002,7 +1009,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a nick-prefixed NOTICE carries sender_kind = user and its user@host" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
       m = msg(:notice, ["vjt", "hey"], {:nick, "bob", "u", "h"})
 
       assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
@@ -1015,7 +1022,7 @@ defmodule Grappa.Session.EventRouterTest do
     # refuses to report a partial one; the KIND is still known, so it is
     # still reported — the two facts are independent.
     test "a partial prefix still reports the kind, without a half mask" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
       m = msg(:notice, ["vjt", "hey"], {:nick, "bob", nil, "h"})
 
       assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
@@ -1025,7 +1032,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "plain peer NOTICE gets no ctcp meta (additive)" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m = msg(:notice, ["vjt", "hey are you around?"], {:nick, "bob", "u", "h"})
 
@@ -1048,7 +1055,7 @@ defmodule Grappa.Session.EventRouterTest do
     # WITHOUT this, generalising the nick branch would start dumping raw
     # \x01 rows into open conversations.
     test "#546 CTCP-framed peer NOTICE stays on $server EVEN with an open query window" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m = msg(:notice, ["vjt", "\x01PING 1706743200000\x01"], {:nick, "bob", "u", "h"})
 
@@ -1106,7 +1113,7 @@ defmodule Grappa.Session.EventRouterTest do
     # Sonic settled on exactly that on #it-opers (2026-07-30). This reverses
     # UX-6-L / #422 Option B's "peer NOTICE opens the window" arm.
     test "#546 peer NOTICE with NO open query window routes to $server" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> false end})
+      state = base_state(%{deps: deps(fn _, _, _ -> false end)})
 
       m =
         msg(
@@ -1137,7 +1144,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "#546 peer NOTICE WITH an open query window routes to the peer's window" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m =
         msg(
@@ -1163,10 +1170,11 @@ defmodule Grappa.Session.EventRouterTest do
 
       state =
         base_state(%{
-          query_window_open?: fn subject, network_id, nick ->
-            send(parent, {:open_check, subject, network_id, nick})
-            false
-          end
+          deps:
+            deps(fn subject, network_id, nick ->
+              send(parent, {:open_check, subject, network_id, nick})
+              false
+            end)
         })
 
       m = msg(:notice, ["vjt", "yo"], {:nick, "alice", "u", "host.example.com"})
@@ -1178,7 +1186,7 @@ defmodule Grappa.Session.EventRouterTest do
     # #546 must NOT leak into the PRIVMSG door: a DM from a peer still opens
     # the conversation. Only NOTICEs became non-opening.
     test "#546 peer PRIVMSG still lands in the DM window with NO open query window" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> false end})
+      state = base_state(%{deps: deps(fn _, _, _ -> false end)})
 
       m = msg(:privmsg, ["vjt", "you around?"], {:nick, "alice", "u", "host.example.com"})
 
@@ -1207,12 +1215,12 @@ defmodule Grappa.Session.EventRouterTest do
   # by hand — the reply belongs in THAT window, not $server where they'd
   # never see it. The open-window fact is a DB read; EventRouter is a pure
   # classifier ("No Repo"), so the lookup is injected as an opaque
-  # `state.query_window_open?` callback (mirror of `visitor_nick_persister`
+  # `state.deps.query_window_open?` callback (mirror of `visitor_nick_persister`
   # — the SessionPlan.resolve/1 DI seam the Server already carries). Absent
   # (pure tests that don't inject it) → false → today's $server behaviour.
   describe "route/2 — #400 services re-key to an open query window" do
     test "NOTICE from a service with an OPEN query window routes to the service nick" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m =
         msg(
@@ -1227,7 +1235,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "NOTICE from a service with NO open query window still routes to $server (regression)" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> false end})
+      state = base_state(%{deps: deps(fn _, _, _ -> false end)})
 
       m =
         msg(
@@ -1241,7 +1249,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "PRIVMSG from a service with an OPEN query window routes to the service nick" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m =
         msg(
@@ -1260,10 +1268,11 @@ defmodule Grappa.Session.EventRouterTest do
 
       state =
         base_state(%{
-          query_window_open?: fn subject, network_id, nick ->
-            send(parent, {:open_check, subject, network_id, nick})
-            true
-          end
+          deps:
+            deps(fn subject, network_id, nick ->
+              send(parent, {:open_check, subject, network_id, nick})
+              true
+            end)
         })
 
       m = msg(:notice, ["vjt", "reply"], {:nick, "SeenServ", "service", "azzurra.chat"})
@@ -1273,7 +1282,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "ChanServ bracket-prefixed NOTICE keeps channel precedence even with an open query window (open-Q 3)" do
-      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
 
       m =
         msg(

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -247,8 +247,8 @@ defmodule Grappa.Session.ServerTest do
 
   describe "injected dependency bundle (#1390)" do
     test "a live session carries the callbacks in one Deps struct" do
-      {_server, port} = start_server()
-      {user, network, _cred} = setup_user_and_network(port)
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
       assert %Deps{} = :sys.get_state(pid).deps
@@ -257,8 +257,8 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the ten callback names are gone from the top level of state" do
-      {_server, port} = start_server()
-      {user, network, _cred} = setup_user_and_network(port)
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
       state = :sys.get_state(pid)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -37,6 +37,7 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.Session.{
     AwayState,
     Backoff,
+    Deps,
     GhostRecovery,
     ISupport,
     RecoverIdentity,
@@ -229,6 +230,47 @@ defmodule Grappa.Session.ServerTest do
     end
 
     %{server: server, pid: pid, network: network, subject: subject, label: label}
+  end
+
+  # #1390 slice 1 — the ten injected callbacks are ONE typed field, not ten
+  # top-level state keys. They are dependencies, not state: nothing in the
+  # session's lifetime writes them, and grouping them is behaviour-free, so
+  # no existing test can tell the two shapes apart. These two pins can.
+  #
+  # Split in two on purpose: forgetting to ADD the bundle and forgetting to
+  # REMOVE the ten loose keys are different mistakes, and each must kill
+  # exactly one assertion.
+  @di_keys ~w[visitor_committer visitor_password_rotator visitor_nick_persister
+              credential_failer credential_committer registration_committer
+              last_joined_persister recover_source away_persister
+              query_window_open?]a
+
+  describe "injected dependency bundle (#1390)" do
+    test "a live session carries the callbacks in one Deps struct" do
+      {_server, port} = start_server()
+      {user, network, _cred} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      assert %Deps{} = :sys.get_state(pid).deps
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the ten callback names are gone from the top level of state" do
+      {_server, port} = start_server()
+      {user, network, _cred} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      state = :sys.get_state(pid)
+      # Assert the pre-state is observable at all: if `start_session_for/2`
+      # ever stops returning a live session this test must fail loudly rather
+      # than pass on an empty map.
+      assert is_map(state) and map_size(state) > 10
+
+      assert Enum.filter(@di_keys, &Map.has_key?(state, &1)) == []
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
   end
 
   describe "DB-driven init (sub-task 2g)" do
@@ -13064,16 +13106,22 @@ defmodule Grappa.Session.ServerTest do
                      1_000
     end
 
-    test "hot-reload safety: a live proc predating the :recover_source field survives" do
+    test "hot-reload safety: a live proc predating the :deps bundle survives" do
       # #229/#581 hot-reload contract. A plain hot reload does NOT rewrite live
-      # process state, so a Session.Server spawned before the #581
-      # `:recover_source` field existed keeps its old keyless map. `handle_call`
-      # reads it via `Map.get` (never `state.recover_source`), so a /recover on
-      # a stale proc must degrade to `:nothing_to_recover`, never KeyError-crash.
+      # process state, so a Session.Server spawned before the field existed
+      # keeps its old keyless map. `handle_call` reads it via `Map.get` (never
+      # dot-access), so a /recover on a stale proc must degrade to
+      # `:nothing_to_recover`, never KeyError-crash.
+      #
+      # #1390 moved the reader into the `:deps` bundle, so the stale shape this
+      # models is now a proc with no `:deps` key at all. Deleting the OLD
+      # top-level `:recover_source` would be a no-op against today's state and
+      # the test would pass while exercising nothing — the assertion below is
+      # unchanged, only the key that simulates the stale proc moved.
       %{pid: pid, subject: subject, network: network} = start_recover_visitor("s3cret")
 
-      # Simulate the stale-proc shape: strip :recover_source from live state.
-      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :recover_source) end)
+      # Simulate the stale-proc shape: strip :deps from live state.
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :deps) end)
 
       assert {:error, :nothing_to_recover} = Session.recover_identity(subject, network.id)
 


### PR DESCRIPTION
First slice of #1390. `Grappa.Session.Server` carried ten injected
callbacks as ten top-level state keys. They become one `deps` field
holding a `Grappa.Session.Deps` struct, in a new
`lib/grappa/session/deps.ex`. Session state goes from **85 to 76** keys.

`start_link/1` does not change: the ten opt keys are byte-identical, and
that is what keeps eight other files out of this slice.

The ten: `visitor_committer`, `visitor_password_rotator`,
`visitor_nick_persister`, `credential_failer`, `credential_committer`,
`registration_committer`, `last_joined_persister`, `recover_source`,
`away_persister`, `query_window_open?`.

## Three things the diff does not explain about itself

1. **`EventRouter` matches a PLAIN map, not `%Deps{}`.** `Deps` already
   names `EventRouter.query_window_open?()` as a type, so matching the
   struct would close a compile/export cycle. A struct is a map, so the
   plain match still works.

2. **The absent branch holds `false`, NOT `%Deps{}`.** The struct's
   default for `query_window_open?` is `&QueryWindows.open?/3` — a real
   DB read. Defaulting to the struct would cost `EventRouter` its "no
   Repo" purity in every test that omits `deps`.

3. **Two of the twelve call sites were `Map.get(state, key, default)`**,
   deliberately tolerant of a process that predates the field (hot
   reload). Bundling had hardened them, and the #581 test caught it.
   They are now `Map.get(state, :deps, %Deps{})` — an exact equivalent,
   because the struct's defaults ARE what those two were passing.
   The #581 test was **re-aimed, not weakened**: it simulated staleness
   with `Map.delete(state, :recover_source)`, which after the bundle is
   a **no-op** — it would have passed while exercising nothing. It now
   deletes `:deps`; the assertion is unchanged.

## Three reds, in order

1. **TDD red 1** — the bundle pin, before `Deps` existed.
2. **TDD red 2** — the attributable red: the ten loose keys still present
   at the top level of state.
3. **Dialyzer red, and it was hidden.** `ci.check` chains its steps
   through `mix cmd`, which **halts on the first non-zero**, and
   `credo --strict` sits ahead of `dialyzer`. A Credo red in the test
   file therefore meant Dialyzer never ran at all — so its silence was
   the absence of a measure, not a pass. With Credo fixed, Dialyzer
   produced nine `unknown_type` errors.

## The slice is 7 files, not 6

The original count was six, read off the edited set. It was wrong for a
structural reason worth stating: **moving an `@type` out of a module
breaks every module that names it remotely, and the diff never opens
those.** Nine of the ten types moved from `Session.Server` to
`Session.Deps`, but `Grappa.Session`'s `start_opts/0` still spelled them
`Server.visitor_committer()` and friends — a seventh file,
`lib/grappa/session.ex`, that nothing in the six-file diff touched.

Nine and not ten: `query_window_open?` needs no rename there, because
that map never carried the key — it does not on `main` either. That
asymmetry with `Server.start_opts/0` is pre-existing and deliberately
left alone.

## Gate

`scripts/check.sh` → **RC=0, full chain**:

- `mix compile --warnings-as-errors`, `mix format --check-formatted`
- Credo `--strict`: `6098 mods/funs, found no issues`
- suite: `8 doctests, 61 properties, 6479 tests, 0 failures`
- Dialyzer: `Total errors: 0`
- Sobelow and the bats set: through

## What is NOT measured

- **The style commit was never gated on its own.** The gate ran once
  over the **union** of both fixes; the two were then split into two
  logical commits.
- Behaviour invariance beyond the suite: no mutants on this slice. It is
  behaviour-free by construction and the two pins are structural, so
  mutants were not required — but they were not run.
- **85 → 76** is arithmetic on the typedef. It was not re-read off live
  state after the change.
- Risk A1 (dropping the catch-all makes a typo go red) is **not bought**
  and does not touch this slice. It needs a mutant before slices 3-4 of
  #1390 get sized.
- SEC-28 is out of scope, on a **boundary** argument rather than a cost
  one: its call sites live in `Push` and `WindowCounts`, not `Session`.

## Base

Branched at `0a5c32b0`; `main` has since gained three #1406 commits. They
overlap only in `docs/DESIGN_NOTES.md`, and `git merge-tree` reports the
merge as clean.
