### PR TITLE
e2e(#1336 S2): settle the pane before measuring it, not just move it off the tail

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -62,7 +62,7 @@
 
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
-import { type ScrollGestureResult, scrollByGesture } from "./scrollGesture";
+import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
 const MOBILE_BREAKPOINT_PX = 768;
@@ -1425,4 +1425,27 @@ export async function pageScrollbackUp(
   timeoutMs: number,
 ): Promise<ScrollGestureResult> {
   return await pageScrollbackBy(page, -pixels, timeoutMs);
+}
+
+// #1336 S2 — the same wait with no gesture in front of it: hold until the
+// pane STOPS being written to, and report where it stopped.
+//
+// For a spec that parks on the unread marker through a PROGRAMMATIC
+// activation rather than a wheel. Recorded in-page, such a switch writes
+// `scrollTop` three times — the rows recreation resetting to the top, the
+// marker jump in flight, the marker — and a "distance from the bottom is
+// large" barrier is satisfied by the FIRST of the three, which is the pane on
+// its way somewhere rather than the pane where the test means it to be.
+//
+// Sampling every 50 ms, matching `pageScrollbackBy`: two agreeing samples mean
+// the pane held still for 50 ms.
+export async function pageScrollbackRest(page: Page, timeoutMs: number): Promise<number> {
+  const pane = page.locator('[data-testid="scrollback"]');
+  return await waitForScrollRest(
+    { scrollTop: () => pane.evaluate((el) => el.scrollTop) },
+    {
+      timeoutMs,
+      pollMs: 50,
+    },
+  );
 }

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -12,7 +12,7 @@
 // inside the next step.
 
 import { describe, expect, it } from "vitest";
-import { type ScrollPane, scrollByGesture } from "./scrollGesture";
+import { type ScrollPane, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 
 type Recorded = { calls: string[]; pane: ScrollPane };
 
@@ -93,5 +93,82 @@ describe("#1336 — scrollByGesture", () => {
     expect(
       await failureOf(scrollByGesture(pane, { deltaY: -4000, timeoutMs: 20, pollMs: 1 })),
     ).toContain("never settled");
+  });
+});
+
+// The scrollTop writes a SWITCH into #bofh performs, recorded in-page on the
+// dev host (2026-08-17, #1336 S2 probe, four iterations at CPU throttle 1x/6x/
+// 12x/20x — the shape was identical in all four, only the timings stretched):
+//
+//     t=0ms   354   the $server pane we switch away from
+//     t=45ms    7   the rows recreation resets scrollTop to the top
+//     t=59ms 1055   the marker jump, in flight
+//     t=78ms 1078   the marker, at rest
+//
+// and the pane's own geometry at that moment: scrollHeight 1627, clientHeight
+// 212, so maxScroll = 1415. These are DATA, not an example — every assertion
+// below is arithmetic on them.
+// Only the three POST-CLICK writes: 354 is where the $server pane we switch
+// away from was sitting, and the barrier cannot sample it — the spec gates on
+// the row count and the marker existing first, which the switch must complete
+// to satisfy. Replaying it would overstate the defect.
+const MEASURED_SWITCH_WRITES = [7, 1055, 1078] as const;
+const MEASURED_MAX_SCROLL = 1415;
+const MARKER_SCROLL_TOP = 1078;
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
+  // The defect, executed rather than argued. The pre-send barrier in
+  // scroll-on-window-switch.spec.ts is `distance-to-bottom > 50`, and
+  // `expect.poll` returns on the FIRST evaluation that satisfies it. Replayed
+  // against the writes actually recorded, that first satisfying sample is the
+  // RESET (scrollTop 7, distance 1408) — the moment the rows were recreated
+  // and the marker jump had not happened yet. The barrier cannot tell "the
+  // switch landed on the marker" from "the pane is at the top on its way
+  // there", because both are far from the bottom.
+  it("the OLD distance-only predicate is satisfied by the reset, not by the marker", () => {
+    const distances = MEASURED_SWITCH_WRITES.map((st) => MEASURED_MAX_SCROLL - st);
+    const firstAccepted = distances.findIndex((d) => d > SCROLL_BOTTOM_THRESHOLD_PX);
+
+    expect(MEASURED_SWITCH_WRITES[firstAccepted]).toBe(7);
+    expect(distances[firstAccepted]).toBe(1408);
+    // …and the position it was supposed to be waiting for is 337 away from the
+    // bottom — the number #1079 reported, twice, on two trees.
+    expect(MEASURED_MAX_SCROLL - MARKER_SCROLL_TOP).toBe(337);
+  });
+
+  it("waits past the reset and the in-flight sample, and reports the MARKER", async () => {
+    const { pane } = fakePane([...MEASURED_SWITCH_WRITES, MARKER_SCROLL_TOP]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(MARKER_SCROLL_TOP);
+  });
+
+  it("does not mistake two equal samples STRADDLING a move for rest", async () => {
+    // A pane that returns to a value it already held is not the same as a pane
+    // that never left it: only ADJACENT agreement is rest. Without that, the
+    // 1078 here would be read as rest while the pane is still travelling.
+    const { pane } = fakePane([1078, 7, 1078, 400, 400]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(400);
+  });
+
+  it("REJECTS a pane that never comes to rest, naming the last position", async () => {
+    let value = 1078;
+    const pane: ScrollPane = {
+      hover: async () => {},
+      wheel: async () => {},
+      scrollTop: async () => {
+        value -= 10;
+        return value;
+      },
+    };
+    const message = await failureOf(waitForScrollRest(pane, { timeoutMs: 20, pollMs: 1 }));
+    expect(message).toContain("never came to rest");
+    expect(message).toMatch(/last \d+/);
+  });
+
+  it("resolves at the position the pane was ALREADY holding", async () => {
+    // A settled pane is settled; the barrier is about rest, not about movement
+    // (that is `scrollByGesture`'s job, and it rejects a pane that never moved).
+    const { pane } = fakePane([1078, 1078]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(1078);
   });
 });

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -180,9 +180,9 @@ describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
     const movingPane: Pick<ScrollPane, "scrollTop"> = {
       scrollTop: async () => 1078 - Math.floor((Date.now() - start) / 20),
     };
-    expect(await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 }))).toContain(
-      "never came to rest",
-    );
+    expect(
+      await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 })),
+    ).toContain("never came to rest");
   });
 
   it("resolves at the position the pane was ALREADY holding", async () => {

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -165,6 +165,26 @@ describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
     expect(message).toMatch(/last \d+/);
   });
 
+  it("does not call a pane written every 20ms 'at rest', however fast it is read", async () => {
+    // The fakes above answer from a script, so two reads taken in the same
+    // millisecond look exactly like two reads a poll apart — a barrier that
+    // compares samples with no gap between them passes every one of those
+    // tests while being worthless. This pane answers from a CLOCK instead,
+    // which is the only way the omission becomes visible.
+    //
+    // Not hypothetical: the first version of this barrier resolved instantly
+    // in situ against a pane an injected `setInterval` was moving 1px every
+    // 20ms, and the spec then failed downstream on an anonymous number
+    // instead of here, by name.
+    const start = Date.now();
+    const movingPane: Pick<ScrollPane, "scrollTop"> = {
+      scrollTop: async () => 1078 - Math.floor((Date.now() - start) / 20),
+    };
+    expect(await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 }))).toContain(
+      "never came to rest",
+    );
+  });
+
   it("resolves at the position the pane was ALREADY holding", async () => {
     // A settled pane is settled; the barrier is about rest, not about movement
     // (that is `scrollByGesture`'s job, and it rejects a pane that never moved).

--- a/cicchetto/e2e/fixtures/scrollGesture.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.ts
@@ -60,7 +60,95 @@ export type ScrollGestureResult = {
   readonly to: number;
 };
 
+export type ScrollRestOptions = {
+  // Budget for the pane to stop moving.
+  readonly timeoutMs: number;
+  // Gap between scrollTop samples.
+  readonly pollMs: number;
+};
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Wait for the pane to STOP, and report where it stopped. Rejects rather than
+// resolving when it never held still, for the same reason `scrollByGesture`
+// rejects: a caller about to assert on a position must not be handed one the
+// pane is still leaving.
+//
+// This is the half of the gesture contract that has nothing to do with a
+// wheel, and #1336 S2 is why it exists separately. `scroll-on-window-switch`
+// parks on the unread marker through a PROGRAMMATIC activation and then sends,
+// and its pre-send barrier was `distance-to-bottom > 50`. Recorded in-page,
+// the switch writes scrollTop three times — `7` (the rows recreation resetting
+// to the top), `1055` (the marker jump in flight), `1078` (the marker) — and
+// the FIRST of those already satisfies `> 50` by a wide margin (distance 1408
+// against a maxScroll of 1415). So the barrier could clear on the reset, with
+// the marker jump still to come; the jump is a scrollTop DECREASE, `onScroll`
+// reads a decrease as the operator leaving the tail, and a decrease landing
+// after a send freezes the pane at the marker — 337 from the bottom, which is
+// the number #1079 reported twice.
+//
+// A gate satisfied by a state that is not the one it names is not a gate. The
+// distance test says "not at the bottom" while meaning "the switch has
+// finished"; rest is the missing half, and unlike the distance it cannot be
+// true of a pane mid-jump.
+export async function waitForScrollRest(
+  pane: Pick<ScrollPane, "scrollTop">,
+  opts: ScrollRestOptions,
+): Promise<number> {
+  const { timeoutMs, pollMs } = opts;
+  const read = (): Promise<number> => pane.scrollTop();
+  const rest = await sampleUntilRest(read, await read(), false, timeoutMs, pollMs);
+
+  if (rest.settled === null) {
+    throw new Error(
+      `waitForScrollRest: the pane never came to rest within ${timeoutMs}ms ` +
+        `(last ${rest.last}) — it is still being written to`,
+    );
+  }
+  return rest.settled;
+}
+
+type RestProbe = {
+  readonly settled: number | null;
+  readonly last: number;
+  readonly moved: boolean;
+};
+
+// The one sampling loop both public waits are built from: read `scrollTop`
+// until two ADJACENT reads agree.
+//
+// Adjacency is load-bearing. A pane that returns to a position it held a
+// moment ago has not stopped — it has passed through twice — so comparing
+// against anything other than the immediately preceding sample would call a
+// round trip "rest".
+//
+// `requireMove` is the 20% the two callers do not share. A GESTURE has to
+// displace the pane, so resting back on the baseline is a failure (the wheel
+// was never delivered); a BARRIER only has to establish that nothing is being
+// written any more, and a pane that was already still satisfies it.
+async function sampleUntilRest(
+  read: () => Promise<number>,
+  baseline: number,
+  requireMove: boolean,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<RestProbe> {
+  const deadline = Date.now() + timeoutMs;
+  let previous = baseline;
+  let moved = false;
+
+  while (Date.now() < deadline) {
+    const current = await read();
+    if (current !== baseline) moved = true;
+    if (current === previous && (!requireMove || moved)) {
+      return { settled: current, last: current, moved };
+    }
+    previous = current;
+    await sleep(pollMs);
+  }
+
+  return { settled: null, last: previous, moved };
+}
 
 // Perform the gesture and resolve only once the pane has moved AND come to
 // rest. Rejects rather than resolving on either failure, because "it did not
@@ -85,24 +173,13 @@ export async function scrollByGesture(
   await pane.hover();
   await pane.wheel(deltaY);
 
-  const deadline = Date.now() + timeoutMs;
-  let moved = false;
-  let previous = from;
-
-  while (Date.now() < deadline) {
-    const current = await pane.scrollTop();
-    if (current !== from) {
-      if (moved && current === previous) return { from, to: current };
-      moved = true;
-    }
-    previous = current;
-    await sleep(pollMs);
-  }
+  const rest = await sampleUntilRest(() => pane.scrollTop(), from, true, timeoutMs, pollMs);
+  if (rest.settled !== null) return { from, to: rest.settled };
 
   throw new Error(
-    moved
+    rest.moved
       ? `scrollByGesture: wheel(${deltaY}) never settled within ${timeoutMs}ms ` +
-          `(from ${from}, last ${previous}) — the pane was still moving when the budget ran out`
+          `(from ${from}, last ${rest.last}) — the pane was still moving when the budget ran out`
       : `scrollByGesture: wheel(${deltaY}) never moved the pane within ${timeoutMs}ms ` +
           `(scrollTop stayed ${from}) — the gesture was not delivered, or the pane is already clamped`,
   );

--- a/cicchetto/e2e/fixtures/scrollGesture.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.ts
@@ -138,13 +138,22 @@ async function sampleUntilRest(
   let moved = false;
 
   while (Date.now() < deadline) {
+    // The gap comes FIRST, so every pair being compared is `pollMs` apart.
+    // Sleeping at the end of the body instead leaves the very first
+    // comparison — baseline against the first sample — separated by nothing
+    // but a round trip, and a pane read twice in the same millisecond reads
+    // equal whatever it is doing. Measured: with the sleep at the end, this
+    // barrier resolved instantly against a pane being written every 20ms,
+    // which is precisely the "satisfied without the thing it claims" defect
+    // the barrier exists to refuse. The unit fakes cannot see it — they have
+    // no clock — so `movingPane` below supplies one.
+    await sleep(pollMs);
     const current = await read();
     if (current !== baseline) moved = true;
     if (current === previous && (!requireMove || moved)) {
       return { settled: current, last: current, moved };
     }
     previous = current;
-    await sleep(pollMs);
   }
 
   return { settled: null, last: previous, moved };

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -82,6 +82,7 @@ import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
+  pageScrollbackRest,
   scrollbackLines,
   selectChannel,
   sidebarWindow,
@@ -280,6 +281,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
 
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
+
     // Sanity: scrollback overflows (else "not at the tail" is vacuous).
     const g = await scrollbackGeometry(page);
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
@@ -365,6 +374,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
 
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
+
     const g = await scrollbackGeometry(page);
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
 
@@ -442,6 +459,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
 
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
+
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
 
     // Sanity: the pane overflows (else "not at the tail" is vacuous).
     const g = await scrollbackGeometry(page);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46526,3 +46526,113 @@ how pins disappear one at a time.
 
 _Not measured here: nothing in this entry claims a verdict for the full
 suite or the type gates; those are a separate run._
+<!-- entry #1336 S2 -->
+
+---
+
+## 2026-08-17 — #1336 S2: the barrier said "not at the bottom" and meant "the switch has finished"
+
+#1079 reports `scroll-on-window-switch` settling 337px from the bottom against
+an expected 50 — the same number twice, on two trees. The shared cause with
+#1080 was established a slice ago: a scrollTop DECREASE landing after a send
+makes `onScroll` disarm the follow intent, `tailFollowWhenSettled` yields, and
+the pane freezes wherever the decrease left it. But that spec has no wheel, so
+its TRIGGER stayed inference, and the previous slice refused to cure an
+inference on the grounds that a barrier silencing an unmeasured write is the
+paper-over this epic exists to refuse. This slice measured it.
+
+### What the switch actually does
+
+An in-page scroll recorder, installed before the sidebar click, four
+iterations at CPU throttle 1x/6x/12x/20x. The shape was identical in all four;
+only the timings stretched:
+
+| t (1x) | scrollTop | what it is |
+|---|---|---|
+| 0ms | 354 | the `$server` pane we switch away from |
+| 45ms | **7** | the rows recreation resetting to the top |
+| 59ms | 1055 | the marker jump, in flight |
+| 78ms | **1078** | the marker, at rest |
+
+Geometry at that moment: `scrollHeight` 1627, `clientHeight` 212, so
+`maxScroll` is 1415. Two arithmetic consequences, both from those measured
+numbers alone. `1415 - 1078 = 337` — the reported failure is the pane sitting
+exactly on the marker, which independently reproduces what the previous slice
+derived. And `1415 - 7 = 1408`.
+
+That second number is the finding. The barrier guarding the send is
+`distance-to-bottom > 50`, and 1408 satisfies it as comfortably as 337 does.
+**The barrier cannot tell "the switch landed on the marker" from "the pane is
+at the top with the marker jump still to come."** It says "not at the bottom"
+while meaning "the activation has finished" — the #1080 shape again, a gate
+satisfied by a state that is not the one it names, except that here the state
+is TRANSIENT rather than pre-existing, which is why reading the spec never
+revealed it.
+
+`waitForScrollRest` is the missing half: the gesture core with the wheel taken
+off, holding until two ADJACENT samples agree and rejecting if the pane never
+stops. Unlike distance, rest cannot be true of a pane mid-jump. Both waits now
+share one sampling loop, and `requireMove` is the only thing they disagree
+about — a gesture resting back on its baseline was never delivered, while a
+barrier is satisfied by a pane that was already still.
+
+### The instrument had the disease it was built to cure
+
+Worth recording because it was caught by measurement and would have survived
+any amount of reading. The first version put the `pollMs` sleep at the END of
+the loop body, so the FIRST comparison — baseline against the first sample —
+was separated by one round trip instead of by a poll. A pane read twice in the
+same millisecond reads equal whatever it is doing, so the barrier resolved
+INSTANTLY against a pane an injected `setInterval` was moving 1px every 20ms,
+and the spec then died downstream on an anonymous number.
+
+The unit fakes could not have caught it: they answer from a script, one value
+per read, so "no gap" and "a poll apart" are the same sequence to them. The
+regression test therefore answers from a CLOCK
+(`1078 - floor(elapsed / 20)`), which is the only shape in which the omission
+is observable — and it is the only one of the eleven cases that the
+sleep-position mutant kills.
+
+### The attribution, both sides
+
+The displacement is an injected `setInterval` writing the pane every 20ms, run
+on both sides of the change, on the same test:
+
+| | what the red says |
+|---|---|
+| barrier removed | `expect(received).toBeLessThanOrEqual(expected)` — it accuses the product |
+| barrier present | `waitForScrollRest: the pane never came to rest within 10000ms (last 576)` — it accuses the barrier's subject, by name |
+
+`576` is itself attributable: `1078 - 10000/20 = 578`, the jitter's own
+position when the budget ran out.
+
+An earlier attempt at that displacement was silently INERT — injected at the
+first of the three call sites while the run was scoped to the third, so it
+never executed and both sides passed identically. That is the same
+inert-injection the gesture helper's "never moved" reject was built for after
+it happened to the previous slice, and it happened again here to the person
+who had just read about it.
+
+### What this does NOT establish
+
+**The natural failure is still not reproduced.** Nobody in this epic has
+reproduced it, and this slice does not either: in eight recorded samples the
+barrier exited at the marker (1078) every single time, never at the reset. So
+the vacuity is proven — the predicate demonstrably admits a state that is not
+the one it names, and that state demonstrably occurs, 45ms into every switch —
+while its EXPLOITATION remains unobserved. What is fixed is a barrier that
+could not distinguish two panes; whether that is the mechanism behind #1079's
+337 is not shown here.
+
+**CPU throttling cannot arbitrate it, measured.** The obvious way to widen the
+window fails, and fails for a structural reason: the barrier polls through the
+page too, so throttling slows the clock and the thing being clocked together.
+The margin between the marker landing and the barrier clearing GREW with the
+rate — 105ms at 1x, 167ms at 20x — instead of closing. Whatever inverts those
+two clocks is not CPU speed, and a late network-timed rows recreation (the
+catch-up refresh the spec's own comments call the "307 race") remains the
+candidate nobody has instrumented.
+
+**The post-send decrease seen at throttled rates is not the freeze.** It is
+`1431 → 1415`, the tail-follow overshooting and clamping to `maxScroll`. It
+would have made a tidy story and it is the wrong one.


### PR DESCRIPTION
## What #1079 is, measured

#1079 reports `scroll-on-window-switch` settling **337 px** from the bottom
against an expected 50 — the same number twice, on two trees. The shared cause
with #1080 was established a slice ago (a scrollTop DECREASE after a send
disarms `followMode`, the pane freezes), but that spec has no wheel, so its
**trigger** stayed inference and the previous slice deliberately refused to
cure an inference.

An in-page scroll recorder, four iterations at CPU throttle 1x/6x/12x/20x —
identical shape in all four, only the timings stretch:

| t (1x) | scrollTop | what it is |
|---|---|---|
| 0 ms | 354 | the `$server` pane we switch away from |
| 45 ms | **7** | the rows recreation resetting to the top |
| 59 ms | 1055 | the marker jump, in flight |
| 78 ms | **1078** | the marker, at rest |

Geometry there: `scrollHeight` 1627, `clientHeight` 212, so `maxScroll` 1415.
Two things follow by arithmetic on those measured numbers:

* `1415 − 1078 = **337**` — the reported failure is the pane sitting exactly
  on the marker. Reproduces independently what the previous slice derived.
* `1415 − 7 = **1408**` — and the barrier guarding the send is
  `distance-to-bottom > 50`.

**So the barrier is satisfied by the reset just as readily as by the marker.**
It cannot tell "the switch landed on the marker" from "the pane is at the top
with the marker jump still to come": it says *not at the bottom* while meaning
*the activation has finished*. That is the #1080 shape — a gate satisfied by a
state that is not the one it names — except the state here is **transient**
rather than pre-existing, which is why reading the spec never surfaced it.

## The fix

`waitForScrollRest` — the gesture core with the wheel taken off: hold until
two **adjacent** samples agree, reject if the pane never stops. Unlike
distance, rest cannot be true of a pane mid-jump. Both waits now share one
sampling loop; `requireMove` is the only thing they disagree about, because a
gesture resting back on its baseline was never delivered while a barrier is
satisfied by a pane that was already still.

Applied at all three sites in the spec where an activation is followed by
reads of a position — including the app-startup test, which has no send and so
no freeze to suffer, because its marker-offset assertions are measurements of
a position just the same.

## The instrument had the disease it was built to cure

The first version put the `pollMs` sleep at the **end** of the loop body, so
the first comparison — baseline against first sample — was separated by one
round trip instead of a poll. A pane read twice in the same millisecond reads
equal whatever it is doing, so the barrier resolved *instantly* against a pane
an injected `setInterval` was moving 1 px every 20 ms.

The unit fakes could not catch it — they answer from a script, so "no gap" and
"a poll apart" are the same sequence. The regression test answers from a
**clock** instead, and it is the only one of the eleven cases the
sleep-position mutant kills.

## Evidence

Two-sided displacement (`setInterval` writing the pane every 20 ms), same test:

| | what the red says |
|---|---|
| barrier removed | `expect(received).toBeLessThanOrEqual(expected)` — accuses the **product** |
| barrier present | `waitForScrollRest: the pane never came to rest within 10000ms (last 576)` — accuses the barrier's subject, **by name** |

`576` is itself attributable: `1078 − 10000/20 = 578`.

An earlier attempt at that displacement was silently **inert** — injected at
the first of three call sites while the run was scoped to the third — and both
sides passed identically. Recorded because it is the same inert injection the
gesture helper's "never moved" reject exists for.

**Mutants: five declared, five killed, none survived.**

| mutant | killed |
|---|---|
| gap moved back to the end of the body | **1** — only the clock case, which is the proof it is the only test that can see it |
| rest compared against baseline, not previous | 5 (incl. 3 `scrollByGesture` — the sampler really is shared) |
| adjacency dropped | 7 |
| move requirement ignored | 1 |
| never-rest resolves instead of rejecting | 2 |

Gates: `bun run test` 289 files / 5589 tests RC=0 — the five pre-existing
`scrollByGesture` cases stayed green **through** the re-expression on the
shared sampler, which is the regression oracle for the refactor.
`bun run check` RC=0. Target spec on the stack: 12 passed (4 tests ×
`--repeat-each 3`). `design-notes-gate.sh` RC=0.

## What this does NOT establish

* **The natural failure is still not reproduced.** In eight recorded samples
  the barrier exited at the marker (1078) every time, never at the reset. The
  vacuity is proven — the predicate demonstrably admits a state that is not
  the one it names, and that state demonstrably occurs 45 ms into every switch
  — but its **exploitation** is unobserved. This does not claim to be the
  mechanism behind #1079's 337.
* **CPU throttling cannot arbitrate it, measured.** The margin between the
  marker landing and the barrier clearing *grows* with the rate (105 ms at 1x,
  167 ms at 20x) because the barrier polls through the page too. A late
  network-timed rows recreation (the "307 race" the spec's own comments name)
  remains the uninstrumented candidate.
* **The post-send decrease at throttled rates is not the freeze** — it is
  `1431 → 1415`, the tail-follow overshooting and clamping to `maxScroll`.
* **The five specs with a raw `mouse.wheel`** (`cp14-b2`, `issue230`,
  `issue535`, `issue887`, `login-advanced-scroll-reachability`) are untouched
  and unmeasured — candidates by shape only.

## Full-suite note, stated rather than buried

A local full `scripts/integration.sh` on this tree came back **755 passed / 3
failed** (`freshness-on-activation`, `issue1229-unread-retention-bound`,
`issue269-visitor-reconnect-toggle`). All three pass in isolation locally
(3/3, 16.3 s), none references any instrument this PR touches, and CI's own
integration was green at this branch's original base. Those are different
hosts, so they do **not** attribute: I have not established the three are
pre-existing, only that they are not reproducible in isolation here and have
no overlap with the changed surface.

### Update — the three reds, measured rather than argued

The full-suite note above is now settled by measurement. Three complete
`scripts/integration.sh` runs on the **same host**, alternating sides:

| run | side | reds |
|---|---|---|
| 1 | this branch (`bad57ae1`) | 3 — `freshness-on-activation:81`, `issue1229:134`, `issue269:54` |
| 2 | clean `main` (`d3f40354`) | 4 — `error-banners:121`, `issue498:208`, `issue947:71`, `nick-follow-query:49` |
| 3 | this branch, rebased (`91c9faad`) | 1 — `issue1041-left-edge-sidebar:167` |

**Eight distinct names across three runs, pairwise overlap zero.** The run that
matters is the third: same side, same regime, **none of the original three
reproduced**. A deterministic breakage caused by this change would have come
back.

Containment is closed by construction, not by argument. Of the 53 exports in
`cicchettoPage.ts` exactly **two** reach the changed code (`pageScrollbackBy`,
plus the new `pageScrollbackRest`). Walking the transitive import closure of
all eight red specs (7–10 modules each) finds **no caller** of any changed
function; the same walker does find the callers in the three specs that do use
them (`scroll-on-window-switch`, `cursor-forward-only`, `issue168-scroll-authority`),
so the negative result discriminates. Those three consumers were green in run 3.

**What this does not establish.** Not that the three reds are pre-existing —
they were never reproduced anywhere, so they are simply **unattributed**. Three
runs exclude a *deterministic* fault in this change; they have essentially no
power against a small probabilistic shift. The mechanism behind the host's
run-to-run randomisation is not identified (fixture leak #1137 and load are
unmeasured candidates), and `issue1041` is unattributed in its own right. A red
count of 1 here against 4 on `main` is **not** evidence this side is better.

Also in this branch: `91c9faad` reformats the clock case the way biome wants it.
That job was red because `check` is `biome && tsc && tsc`, so a formatting error
short-circuited the type checks — meaning tsc had never actually run on the file.
Both `tsc` invocations were therefore re-run **standalone** (rc 0 each), plus
`check` (rc 0) and `test` (289 files / 5589 tests, rc 0).
