### PR TITLE
refactor(#1390): move the channel-directory ETL out of the session GenServer

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46441,3 +46441,88 @@ _Not measured here: whether the slice is behaviour-free beyond the two test
 files it touches. The 847 tests in `server_test.exs` and `event_router_test.exs`
 are green; the rest of the suite and the type gates are a separate run, and
 this entry does not claim their verdict._
+<!-- entry #1390 slice 2 -->
+
+---
+
+## 2026-08-17 — #1390 slice 2: the channel-directory ETL leaves the session
+
+Slice 1 bundled ten injected callbacks into `Session.Deps` — a co-mutation
+group, valuable by key count. This slice is chosen on a different axis, and
+the axis is the point: of the four clusters the issue's proposed direction
+lists, only this one crosses a DOMAIN boundary. Away, identity/recovery and
+auth-handshake all regroup session-domain fields inside the module that
+already owns them; they shrink the state map without moving anything. The
+channel directory is a foreign domain — `Grappa.ChannelDirectory` has been
+its own context all along — running a full ETL inside the hottest process in
+the tree.
+
+The measured footprint outside `server.ex` decided it. `pending_auth` alone
+appears 86 times across `event_router.ex` and `ns_interceptor.ex`, so the
+auth cluster is not the cheap bundle it reads as; `away_state` already has
+its own module. The four directory keys are named outside `server.ex` only
+in comments, in `numeric_router.ex` and `wire.ex` — nothing reads them.
+
+### What moved, and what the shape buys
+
+Four state keys collapse into one `directory` holding a
+`Session.DirectoryIngest`: the three config tunables plus the in-flight
+tracker, with `run == nil` carrying exactly the guard `directory_refresh ==
+nil` used to. Unlike its `*Accum` siblings, which are pure data drained by
+`EventRouter`, this struct also owns the row parse, the batch boundary and
+the throttle window — because that is what the extraction is FOR.
+
+A struct rather than a declared map type, and that choice is measured rather
+than reasoned: #1391's mutant pair established that a struct-field typo is a
+compile error while a bare-map key typo compiles clean, and that declaring a
+map's shape buys neither. The tracker was an anonymous map with
+`buffer: [map()]`.
+
+### The red that buys it
+
+`directory_ingest_test.exs` runs `async: true` on plain `ExUnit.Case`: no
+`DataCase`, no Repo, no `Session.Server`, no fake ircd, 14 cases in 0.09s.
+Its sibling `directory_test.exs` needs all four — 240 lines, `async: false`,
+25 references to `start_server`/`IRCServer` — because before this the parse,
+batch and throttle decisions were reachable only by booting a GenServer.
+
+That is a falsifiable boundary rather than a metric: if a later change
+re-entangles the decisions with the process, the file stops being writable
+that way. The two `server_test.exs` pins were each killed by exactly one
+surgical mutant (a plain map in place of the struct kills the first; one
+re-added legacy key kills the second), so neither is vacuous.
+
+### Two behaviours preserved deliberately, not tidied
+
+Both were named as risks before any code was written, and both look like
+untidiness:
+
+  * the `directory_complete` total is re-read from the DB snapshot with
+    `ttl_ms: 0`, NOT taken from the accumulator's running `count`. The two
+    diverge the moment `ChannelDirectory.ingest/3` dedupes or upserts, so
+    collapsing them would change the number cic renders.
+  * the watchdog calls `abort/1`, which DROPS the buffered rows and never
+    finalises. A truncated refresh therefore leaves the prior snapshot
+    intact and loses everything buffered since the last batch. Flushing on
+    timeout would change the DB on every stalled refresh.
+
+`flush_directory_buffer/2` carried a `:batch | :final` discriminator in its
+`@spec` that BOTH clauses ignored. It is not carried into the new module —
+dead in, dead out — and it is recorded here rather than left to be
+rediscovered as an omission.
+
+### A retraction, because it is a result
+
+The slice's own commitment was that `directory_test.exs` would stay green
+untouched, and that having to edit it would BE the behaviour change. It
+needed one line, and the commitment's dichotomy was wrong: line 105 was
+`assert :sys.get_state(pid).directory_refresh == nil`, a structural pin on
+the NAME of a private field, not an assertion of behaviour. Its behavioural
+twin three lines above — the `assert_receive` of the `directory_failed`
+broadcast — passed throughout. The pin was re-pointed at `.directory.run`,
+in its own commit so a reviewer can tell a moved pin from a softened assert,
+and deliberately not deleted: "the behavioural test already covers it" is
+how pins disappear one at a time.
+
+_Not measured here: nothing in this entry claims a verdict for the full
+suite or the type gates; those are a separate run._

--- a/lib/grappa/session/directory_ingest.ex
+++ b/lib/grappa/session/directory_ingest.ex
@@ -107,15 +107,21 @@ defmodule Grappa.Session.DirectoryIngest do
             run: nil
 
   @doc """
-  Build the idle ingest. Tunables are explicit: `Session.Server` resolves
-  config-default-or-opts-override once, at `do_init/1`.
+  Build the idle ingest from `t:Grappa.Session.start_opts/0`, taking the
+  struct's config defaults for anything the caller does not pin.
+
+  Same shape and same opt-key spelling as before the extraction, so a test
+  that pinned `:directory_ingest_batch` keeps working. Mirrors its slice-1
+  sibling `Deps.from_opts/1`.
   """
-  @spec new(keyword()) :: t()
-  def new(opts) do
+  @spec from_opts(map()) :: t()
+  def from_opts(opts) when is_map(opts) do
+    defaults = %__MODULE__{}
+
     %__MODULE__{
-      timeout_ms: Keyword.fetch!(opts, :timeout_ms),
-      throttle_ms: Keyword.fetch!(opts, :throttle_ms),
-      batch: Keyword.fetch!(opts, :batch)
+      timeout_ms: Map.get(opts, :directory_refresh_timeout_ms, defaults.timeout_ms),
+      throttle_ms: Map.get(opts, :directory_progress_throttle_ms, defaults.throttle_ms),
+      batch: Map.get(opts, :directory_ingest_batch, defaults.batch)
     }
   end
 
@@ -187,7 +193,7 @@ defmodule Grappa.Session.DirectoryIngest do
   def finish(%__MODULE__{run: nil} = ingest), do: {ingest, [], nil}
 
   def finish(%__MODULE__{run: %Run{} = run} = ingest) do
-    {rows, _drained} = drain(run)
+    {rows, _} = drain(run)
     {%{ingest | run: nil}, rows, run.timer}
   end
 

--- a/lib/grappa/session/directory_ingest.ex
+++ b/lib/grappa/session/directory_ingest.ex
@@ -1,0 +1,225 @@
+defmodule Grappa.Session.DirectoryIngest do
+  @moduledoc """
+  #1390 slice 2 — the channel-directory (#84) `LIST` ingest, as a struct
+  that owns its own decisions.
+
+  ## What this is
+
+  `Session.Server` used to carry the whole ETL: four state fields
+  (`directory_refresh_timeout_ms`, `directory_progress_throttle_ms`,
+  `directory_ingest_batch`, `directory_refresh`), three compile-env
+  constants, a watchdog, and seven private functions parsing RPL_LIST rows,
+  batching them, throttling progress pings and flushing the tail. The
+  channel directory is a domain of its own — `Grappa.ChannelDirectory` — so
+  none of that belonged on the hottest process in the tree.
+
+  The four fields collapse to one `directory` key holding this struct.
+  `run == nil` IS the "no refresh in flight" guard, exactly as
+  `directory_refresh == nil` was.
+
+  ## Why this one carries logic, unlike its `*Accum` siblings
+
+  `WhoisAccum`, `LinksAccum` and friends are pure data drained by
+  `EventRouter`. This module also owns the batch boundary, the throttle
+  window and the row parse, because that is the whole point of the
+  extraction: before it, those decisions were reachable only by booting a
+  `Session.Server`, a fake ircd and the Repo (`directory_test.exs` is
+  `async: false` on `DataCase` for exactly that reason).
+  `directory_ingest_test.exs` drives them on plain `ExUnit.Case`,
+  `async: true`, with no process and no database — and it can only stay
+  that way while the decisions stay pure.
+
+  ## Struct, not a declared map type
+
+  The tracker used to be an anonymous map with declared keys and a
+  `buffer: [map()]`. #1391 measured the difference with a mutant pair: a
+  struct-field typo is a *compile* error, a bare-map key typo compiles
+  clean, and declaring the map's shape changes neither. So the fix that
+  buys anything here is the struct.
+
+  ## IO stays at the call site, on purpose
+
+  `absorb/3` and `finish/1` hand back what to do, never do it. Two pieces
+  of observable behaviour depend on that split and are preserved
+  deliberately rather than tidied:
+
+    * the `directory_complete` total is re-read from the DB snapshot by
+      `Session.Server`, NOT taken from `run.count` — the two can differ
+      the moment `ChannelDirectory.ingest/3` dedupes or upserts;
+    * `abort/1` (the watchdog) DROPS the buffered rows and hands back
+      nothing to write, so a truncated refresh never calls
+      `ChannelDirectory.finalize/2`. Flushing on timeout would change the
+      DB on every stalled refresh.
+  """
+
+  alias Grappa.ChannelDirectory
+
+  @cfg Application.compile_env(:grappa, Grappa.ChannelDirectory, [])
+  @default_timeout_ms Keyword.get(@cfg, :refresh_timeout_ms, 60_000)
+  @default_throttle_ms Keyword.get(@cfg, :progress_throttle_ms, 1_000)
+  @default_batch Keyword.get(@cfg, :ingest_batch, 200)
+
+  defmodule Run do
+    @moduledoc """
+    The in-flight half of a `LIST` refresh: present from the moment the
+    `LIST` hits the wire until 323 RPL_LISTEND or the watchdog.
+
+    `buffer` holds parsed rows newest-first for an O(1) prepend and is
+    reversed at flush so the ingest preserves wire order. `count` is the
+    running total across flushes, not the buffer depth. `last_emit_ms` is a
+    `System.monotonic_time(:millisecond)` stamp seeded when the refresh is
+    armed, and `timer` is the watchdog ref the caller must cancel on a
+    clean finish.
+    """
+
+    @type t :: %__MODULE__{
+            buffer: [Grappa.ChannelDirectory.ingest_row()],
+            count: non_neg_integer(),
+            last_emit_ms: integer(),
+            timer: reference() | nil
+          }
+
+    defstruct buffer: [], count: 0, last_emit_ms: 0, timer: nil
+  end
+
+  @typedoc """
+  What `Session.Server` must perform, in the order handed back.
+
+  `{:ingest, rows}` is a bulk write of wire-ordered rows; `{:progress, n}`
+  is a throttled `directory_progress` ping carrying the running total.
+  """
+  @type action :: {:ingest, [ChannelDirectory.ingest_row()]} | {:progress, non_neg_integer()}
+
+  @type t :: %__MODULE__{
+          timeout_ms: pos_integer(),
+          throttle_ms: non_neg_integer(),
+          batch: pos_integer(),
+          run: Run.t() | nil
+        }
+
+  # The defaults ARE the production config, which is what makes
+  # `Map.get(state, :directory, %DirectoryIngest{})` an exact equivalent for a
+  # process hot-reloaded across the field's introduction — the same contract
+  # the #1390 slice-1 `Deps` bundle relies on.
+  defstruct timeout_ms: @default_timeout_ms,
+            throttle_ms: @default_throttle_ms,
+            batch: @default_batch,
+            run: nil
+
+  @doc """
+  Build the idle ingest. Tunables are explicit: `Session.Server` resolves
+  config-default-or-opts-override once, at `do_init/1`.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    %__MODULE__{
+      timeout_ms: Keyword.fetch!(opts, :timeout_ms),
+      throttle_ms: Keyword.fetch!(opts, :throttle_ms),
+      batch: Keyword.fetch!(opts, :batch)
+    }
+  end
+
+  @doc "True while a `LIST` refresh is streaming. The in-flight guard."
+  @spec in_flight?(t()) :: boolean()
+  def in_flight?(%__MODULE__{run: nil}), do: false
+  def in_flight?(%__MODULE__{}), do: true
+
+  @doc """
+  Arm a refresh. `now_ms` seeds the throttle window, so the first row is
+  inside it and emits no ping — the pre-extraction behaviour.
+  """
+  @spec start(t(), integer(), reference() | nil) :: t()
+  def start(%__MODULE__{} = ingest, now_ms, timer) do
+    %{ingest | run: %Run{last_emit_ms: now_ms, timer: timer}}
+  end
+
+  @doc """
+  Parse one 322 RPL_LIST row.
+
+  Params carry the client-nick echo first:
+  `:server 322 <nick> <#channel> <#users> :<topic>`. The three-element
+  clause covers a stripped upstream that omits the trailing topic. A
+  non-binary count coerces to 0 — never crash an ingest on a malformed
+  numeric — and an unrecognised shape is dropped.
+  """
+  @spec parse_row([String.t()]) :: {:ok, ChannelDirectory.ingest_row()} | :error
+  def parse_row([_, channel, count_str, topic]) when is_binary(channel) do
+    {:ok, %{name: channel, topic: topic, user_count: user_count(count_str)}}
+  end
+
+  def parse_row([_, channel, count_str]) when is_binary(channel) do
+    {:ok, %{name: channel, topic: nil, user_count: user_count(count_str)}}
+  end
+
+  def parse_row(_), do: :error
+
+  @doc """
+  Absorb one parsed row, returning the ingest and what to perform.
+
+  The batch flush is ordered BEFORE the progress ping, so a ping never
+  reports a count the DB has not been offered yet.
+  """
+  @spec absorb(t(), ChannelDirectory.ingest_row(), integer()) :: {t(), [action()]}
+  def absorb(%__MODULE__{run: %Run{} = run} = ingest, row, now_ms) do
+    appended = %{run | buffer: [row | run.buffer], count: run.count + 1}
+
+    {flushed, flush_actions} =
+      if length(appended.buffer) >= ingest.batch do
+        {rows, drained} = drain(appended)
+        {drained, [{:ingest, rows}]}
+      else
+        {appended, []}
+      end
+
+    {emitted, progress_actions} = throttle(flushed, ingest.throttle_ms, now_ms)
+
+    {%{ingest | run: emitted}, flush_actions ++ progress_actions}
+  end
+
+  @doc """
+  Finish a refresh: hand back the tail rows (wire order, empty when there
+  is nothing buffered) and the watchdog ref to cancel, and clear the run.
+
+  Safe on an already-cleared ingest — `abort/1` leaves it in exactly that
+  shape — where it yields no rows and no timer.
+  """
+  @spec finish(t()) :: {t(), [ChannelDirectory.ingest_row()], reference() | nil}
+  def finish(%__MODULE__{run: nil} = ingest), do: {ingest, [], nil}
+
+  def finish(%__MODULE__{run: %Run{} = run} = ingest) do
+    {rows, _drained} = drain(run)
+    {%{ingest | run: nil}, rows, run.timer}
+  end
+
+  @doc """
+  Abandon a refresh without flushing — the `:directory_refresh_timeout`
+  watchdog. Buffered rows since the last batch are DROPPED and no
+  finalisation is offered; see the moduledoc for why that is preserved.
+  """
+  @spec abort(t()) :: t()
+  def abort(%__MODULE__{} = ingest), do: %{ingest | run: nil}
+
+  # Buffer is newest-first; hand back wire order and leave the run empty.
+  @spec drain(Run.t()) :: {[ChannelDirectory.ingest_row()], Run.t()}
+  defp drain(%Run{buffer: []} = run), do: {[], run}
+  defp drain(%Run{buffer: buffer} = run), do: {Enum.reverse(buffer), %{run | buffer: []}}
+
+  @spec throttle(Run.t(), non_neg_integer(), integer()) :: {Run.t(), [action()]}
+  defp throttle(%Run{} = run, throttle_ms, now_ms) do
+    if now_ms - run.last_emit_ms >= throttle_ms do
+      {%{run | last_emit_ms: now_ms}, [{:progress, run.count}]}
+    else
+      {run, []}
+    end
+  end
+
+  @spec user_count(term()) :: non_neg_integer()
+  defp user_count(count_str) when is_binary(count_str) do
+    case Integer.parse(count_str) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  defp user_count(_), do: 0
+end

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -296,7 +296,7 @@ defmodule Grappa.Session.NumericRouter do
   #     an assertion on its true wire shape.
   #
   # Reachable because these are normally consumed by `Session.Server`'s
-  # `%{directory_refresh: %{}}` clause, whose tracker the `#84` watchdog
+  # `%DirectoryIngest{run: %Run{}}` clause, whose run the `#84` watchdog
   # NILS on `:directory_refresh_timeout` — every late frame then falls
   # through to the generic numeric path. `/quote LIST` never arms the
   # tracker at all.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1917,7 +1917,7 @@ defmodule Grappa.Session.Server do
   #      isn't connected yet (pre-001, parked, or mid-reconnect). Reject
   #      with `{:error, :not_connected}` BEFORE touching the DB or arming a
   #      timer; there's nothing to send `LIST` to.
-  #   2. `directory_refresh: nil` (client present) — the happy path. Put
+  #   2. `run: nil` (client present) — the happy path. Put
   #      `LIST` on the wire FIRST (so a transport error short-circuits with
   #      no DB churn), then nuke the prior snapshot, arm the watchdog, and
   #      record the in-flight tracker. The streamed 321/322/323 capture is
@@ -3217,9 +3217,9 @@ defmodule Grappa.Session.Server do
 
   # Channel directory (#84) refresh watchdog (merged C4). Armed by
   # `handle_call(:refresh_directory, ...)`; fires if 323 RPL_LISTEND never
-  # arrives within `directory_refresh_timeout_ms`. Two clauses:
+  # arrives within the ingest's `timeout_ms`. Two clauses:
   #
-  #   * `directory_refresh: nil` — the refresh already finalised (323
+  #   * `run: nil` — the refresh already finalised (323
   #     cleared the tracker in C3) and `cancel_and_drain/2` either didn't
   #     run or this is a stale duplicate. No-op; never crash on a benign
   #     late timer. Mirrors the `:ghost_timeout` fallback above.
@@ -3440,11 +3440,11 @@ defmodule Grappa.Session.Server do
   # refresh is in-flight. 321 RPL_LISTSTART (header, ignored), 322 RPL_LIST
   # (one channel row → batched ingest + throttled progress ping), 323
   # RPL_LISTEND (finalise the snapshot, cancel the watchdog, emit
-  # `directory_complete`). The `%{directory_refresh: %{}}` head is
-  # load-bearing: it matches ONLY when a refresh is in flight (the tracker
-  # is a map). A `nil` tracker fails the map pattern, so the numerics fall
+  # `directory_complete`). The `%DirectoryIngest{run: %Run{}}` head is
+  # load-bearing: it matches ONLY when a refresh is in flight. A `nil` run
+  # fails the struct pattern, so the numerics fall
   # through to the generic handler below — same shape-match discrimination
-  # the C4 watchdog uses (`%{directory_refresh: nil}` vs catch-all),
+  # the C4 watchdog uses (`run: nil` vs catch-all),
   # sidestepping a `not is_nil/1` guard. While in-flight the dedicated
   # handler CONSUMES them — they are NOT persisted (the snapshot is the
   # durable record, the pings are the live signal).

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -6630,7 +6630,6 @@ defmodule Grappa.Session.Server do
     :ok = ChannelDirectory.ingest(state.subject, state.network_id, rows)
   end
 
-
   # mIRC sort: ops (@) → voiced (+) → plain (no prefix). Within tier,
   # alphabetical by nick (caller `Enum.sort_by` does the secondary).
   defp member_sort_tier(modes) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1141,7 +1141,7 @@ defmodule Grappa.Session.Server do
       # `config :grappa, Grappa.ChannelDirectory` (the `DirectoryIngest`
       # struct defaults), opts-overridable so tests can pin a short timeout
       # or a small batch. No refresh in flight at boot.
-      directory: directory_ingest(opts),
+      directory: DirectoryIngest.from_opts(opts),
       # #100 sustained-reconnect reset gate — config default, opts-overridable
       # for tests. Timer armed on 001, nil until then.
       connection_stable_ms: Map.get(opts, :connection_stable_ms, @connection_stable_ms),
@@ -6624,24 +6624,12 @@ defmodule Grappa.Session.Server do
 
   # Empty is a no-op — never round-trip an empty insert.
   @spec ingest_directory_rows(t(), [ChannelDirectory.ingest_row()]) :: :ok
-  defp ingest_directory_rows(_state, []), do: :ok
+  defp ingest_directory_rows(_, []), do: :ok
 
   defp ingest_directory_rows(state, rows) do
     :ok = ChannelDirectory.ingest(state.subject, state.network_id, rows)
   end
 
-  # Config default (the struct's) or the test-pinned opt, under the SAME opt
-  # keys the four former state fields used.
-  @spec directory_ingest(map()) :: DirectoryIngest.t()
-  defp directory_ingest(opts) do
-    defaults = %DirectoryIngest{}
-
-    DirectoryIngest.new(
-      timeout_ms: Map.get(opts, :directory_refresh_timeout_ms, defaults.timeout_ms),
-      throttle_ms: Map.get(opts, :directory_progress_throttle_ms, defaults.throttle_ms),
-      batch: Map.get(opts, :directory_ingest_batch, defaults.batch)
-    )
-  end
 
   # mIRC sort: ops (@) → voiced (+) → plain (no prefix). Within tier,
   # alphabetical by nick (caller `Enum.sort_by` does the secondary).

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -103,6 +103,7 @@ defmodule Grappa.Session.Server do
     Backoff,
     Broadcaster,
     Deps,
+    DirectoryIngest,
     EventRouter,
     FloodAllowance,
     GhostRecovery,
@@ -208,19 +209,6 @@ defmodule Grappa.Session.Server do
   # Opts-overridable (`:autojoin_defer_ms`) as a test seam; production inherits
   # this default.
   @autojoin_defer_ms 500
-
-  # Channel directory (#84) refresh tunables — compile-time defaults
-  # sourced from `config :grappa, Grappa.ChannelDirectory`. Injected into
-  # state in `do_init/1` so later tasks (refresh trigger, streamed-322
-  # capture, timeout watchdog) read them from state and tests can override
-  # via start opts. `refresh_timeout_ms` bounds a single LIST refresh
-  # before it's declared failed; `progress_throttle_ms` rate-limits the
-  # `directory_progress` pings; `ingest_batch` is the streamed-322 flush
-  # size.
-  @directory_cfg Application.compile_env(:grappa, Grappa.ChannelDirectory, [])
-  @directory_refresh_timeout_ms Keyword.get(@directory_cfg, :refresh_timeout_ms, 60_000)
-  @directory_progress_throttle_ms Keyword.get(@directory_cfg, :progress_throttle_ms, 1_000)
-  @directory_ingest_batch Keyword.get(@directory_cfg, :ingest_batch, 200)
 
   # #100 — sustained-reconnect reset gate. On 001 RPL_WELCOME we arm a
   # `:connection_stable` timer instead of resetting the Backoff ladder
@@ -756,34 +744,12 @@ defmodule Grappa.Session.Server do
           # ircd answers a non-op `MODE #chan e` with — can't strand the
           # entry). NOT persisted across crashes.
           list_mode_pending: %{{String.t(), ListModes.mode()} => ListModeAccum.t()},
-          # Channel directory (#84) refresh tunables — config-derived at
-          # boot (`config :grappa, Grappa.ChannelDirectory`), opts-overridable
-          # in `do_init/1` so tests can pin them. Read by later tasks: the
-          # refresh trigger / send_list guard (`refresh_timeout_ms` watchdog),
-          # the streamed-322 ingest (`ingest_batch` flush size), and the
-          # `directory_progress` ping emitter (`progress_throttle_ms` rate
-          # limit). Static for the GenServer lifetime; not persisted.
-          directory_refresh_timeout_ms: pos_integer(),
-          directory_progress_throttle_ms: non_neg_integer(),
-          directory_ingest_batch: pos_integer(),
-          # Channel directory (#84) in-flight refresh tracker. `nil` when no
-          # `LIST` is streaming. Set by `handle_call(:refresh_directory, ...)`
-          # the instant the upstream `LIST` is on the wire; cleared on 323
-          # RPL_LISTEND (C3) or the `:directory_refresh_timeout` watchdog (C4).
-          # The presence of this map IS the in-flight guard — a second
-          # `:refresh_directory` while non-nil replies `{:error,
-          # :already_refreshing}`. `buffer` accumulates parsed 322 rows pending
-          # a batch flush (`directory_ingest_batch`); `count` is the running
-          # ingested tally; `last_emit_ms` gates `directory_progress` throttling
-          # (`directory_progress_throttle_ms`); `timer` is the watchdog ref.
-          directory_refresh:
-            nil
-            | %{
-                buffer: [map()],
-                count: non_neg_integer(),
-                last_emit_ms: integer(),
-                timer: reference() | nil
-              },
+          # #1390 slice 2 — the channel directory (#84) `LIST` ingest: the
+          # three config tunables plus the in-flight tracker, in one struct
+          # that owns the parse / batch / throttle decisions. Always present;
+          # `run == nil` IS the in-flight guard the four former fields
+          # expressed with `directory_refresh == nil`. See `DirectoryIngest`.
+          directory: DirectoryIngest.t(),
           # #100 sustained-reconnect reset gate. `connection_stable_ms` is
           # static config for the process lifetime; `connection_stable_timer`
           # is the armed-on-001 ref (nil until 001, nil again once it fires
@@ -1171,15 +1137,11 @@ defmodule Grappa.Session.Server do
       # appends entries; the end numeric emits :list_mode_bundle and clears.
       # Bounded by in-flight queries. NOT persisted across crashes.
       list_mode_pending: %{},
-      # Channel directory (#84) refresh tunables — config default
-      # (`@directory_*` from `config :grappa, Grappa.ChannelDirectory`),
-      # opts-overridable so tests can pin a short timeout / small batch.
-      directory_refresh_timeout_ms: Map.get(opts, :directory_refresh_timeout_ms, @directory_refresh_timeout_ms),
-      directory_progress_throttle_ms: Map.get(opts, :directory_progress_throttle_ms, @directory_progress_throttle_ms),
-      directory_ingest_batch: Map.get(opts, :directory_ingest_batch, @directory_ingest_batch),
-      # Channel directory (#84) — no refresh in flight at boot. Set when the
-      # operator triggers a `LIST` refresh; cleared on 323 / timeout.
-      directory_refresh: nil,
+      # Channel directory (#84) ingest — config defaults from
+      # `config :grappa, Grappa.ChannelDirectory` (the `DirectoryIngest`
+      # struct defaults), opts-overridable so tests can pin a short timeout
+      # or a small batch. No refresh in flight at boot.
+      directory: directory_ingest(opts),
       # #100 sustained-reconnect reset gate — config default, opts-overridable
       # for tests. Timer armed on 001, nil until then.
       connection_stable_ms: Map.get(opts, :connection_stable_ms, @connection_stable_ms),
@@ -1963,18 +1925,18 @@ defmodule Grappa.Session.Server do
   #   3. catch-all (`directory_refresh` non-nil) — a refresh is already
   #      streaming. The tracker's presence IS the guard; reply
   #      `{:error, :already_refreshing}` and leave the in-flight run untouched.
-  def handle_call(:refresh_directory, _, %{directory_refresh: nil, client: nil} = state) do
+  def handle_call(:refresh_directory, _, %{directory: %DirectoryIngest{run: nil}, client: nil} = state) do
     {:reply, {:error, :not_connected}, state}
   end
 
-  def handle_call(:refresh_directory, _, %{directory_refresh: nil} = state) do
+  def handle_call(:refresh_directory, _, %{directory: %DirectoryIngest{run: nil} = ingest} = state) do
     case Client.send_line(state.client, "LIST\r\n") do
       :ok ->
         ChannelDirectory.replace_start(state.subject, state.network_id)
-        timer = Process.send_after(self(), :directory_refresh_timeout, state.directory_refresh_timeout_ms)
+        timer = Process.send_after(self(), :directory_refresh_timeout, ingest.timeout_ms)
         now = System.monotonic_time(:millisecond)
 
-        {:reply, :ok, %{state | directory_refresh: %{buffer: [], count: 0, last_emit_ms: now, timer: timer}}}
+        {:reply, :ok, %{state | directory: DirectoryIngest.start(ingest, now, timer)}}
 
       {:error, _} = err ->
         {:reply, err, state}
@@ -3266,13 +3228,15 @@ defmodule Grappa.Session.Server do
   #     affordance. The prior DB snapshot (if any) stays intact — only the
   #     in-flight state is wiped. `network` is on the Logger allowlist and
   #     already threaded by `Log.set_session_context/2`.
-  def handle_info(:directory_refresh_timeout, %{directory_refresh: nil} = state),
+  def handle_info(:directory_refresh_timeout, %{directory: %DirectoryIngest{run: nil}} = state),
     do: {:noreply, state}
 
-  def handle_info(:directory_refresh_timeout, state) do
+  def handle_info(:directory_refresh_timeout, %{directory: %DirectoryIngest{} = ingest} = state) do
     Logger.warning("directory refresh timed out before RPL_LISTEND", network: state.network_slug)
     broadcast_window_state(state, SessionWire.directory_failed(state.network_slug, "timeout"))
-    {:noreply, %{state | directory_refresh: nil}}
+    # `abort/1`, not `finish/1`: the buffered rows are DROPPED and no
+    # finalisation runs. Preserved deliberately — see `DirectoryIngest`.
+    {:noreply, %{state | directory: DirectoryIngest.abort(ingest)}}
   end
 
   # 465 ERR_YOUREBANNEDCREEP — k-line / g-line. Hard, terminal,
@@ -3497,7 +3461,7 @@ defmodule Grappa.Session.Server do
   # true; do not re-derive it from this clause's fall-through.
   def handle_info(
         {:irc, %Message{command: {:numeric, code}} = msg},
-        %{directory_refresh: %{}} = state
+        %{directory: %DirectoryIngest{run: %DirectoryIngest.Run{}}} = state
       )
       when code in [321, 322, 323] do
     {:noreply, handle_directory_numeric(code, msg, state)}
@@ -6610,99 +6574,73 @@ defmodule Grappa.Session.Server do
   defp handle_directory_numeric(321, _, state), do: state
 
   defp handle_directory_numeric(322, %Message{params: params}, state) do
-    case parse_list_entry(params) do
-      {:ok, row} -> accumulate_directory_row(state, row)
-      :error -> state
+    case DirectoryIngest.parse_row(params) do
+      {:ok, row} ->
+        {ingest, actions} =
+          DirectoryIngest.absorb(state.directory, row, System.monotonic_time(:millisecond))
+
+        Enum.reduce(actions, %{state | directory: ingest}, &perform_directory_action/2)
+
+      :error ->
+        state
     end
   end
 
   defp handle_directory_numeric(323, _, state) do
-    flushed = flush_directory_buffer(state, :final)
-    :ok = ChannelDirectory.finalize(flushed.subject, flushed.network_id)
-    :ok = cancel_and_drain(flushed.directory_refresh.timer, :directory_refresh_timeout)
+    {ingest, tail, timer} = DirectoryIngest.finish(state.directory)
+    finished = %{state | directory: ingest}
 
+    :ok = ingest_directory_rows(finished, tail)
+    :ok = ChannelDirectory.finalize(finished.subject, finished.network_id)
+    :ok = cancel_and_drain(timer, :directory_refresh_timeout)
+
+    # The total is re-read from the snapshot the ingest just wrote, NOT taken
+    # from the accumulator's running count: the two diverge the moment
+    # `ChannelDirectory.ingest/3` dedupes or upserts. Not a tidy-up target.
     broadcast_window_state(
-      flushed,
-      SessionWire.directory_complete(flushed.network_slug, total_directory_rows(flushed))
+      finished,
+      SessionWire.directory_complete(
+        finished.network_slug,
+        ChannelDirectory.list(finished.subject, finished.network_id, ttl_ms: 0).total
+      )
     )
 
-    %{flushed | directory_refresh: nil}
+    finished
   end
 
-  # RPL_LIST params carry the client-nick echo as params[0]:
-  #   `:server 322 <nick> <#channel> <#users> :<topic>` → 4-element list.
-  # The 3-element clause covers a stripped upstream that omits the trailing
-  # topic. A non-binary count is coerced to 0 (defensive — never crash the
-  # ingest on a malformed numeric); a shape we don't recognise is dropped.
-  @spec parse_list_entry([String.t()]) :: {:ok, ChannelDirectory.ingest_row()} | :error
-  defp parse_list_entry([_, channel, count_str, topic]) when is_binary(channel) do
-    {:ok, %{name: channel, topic: topic, user_count: parse_user_count(count_str)}}
+  # `DirectoryIngest` decides; the session performs. Order is the order the
+  # accumulator handed back — the batch write precedes the progress ping it
+  # reports, so a ping never names a count the DB has not been offered.
+  @spec perform_directory_action(DirectoryIngest.action(), t()) :: t()
+  defp perform_directory_action({:ingest, rows}, state) do
+    :ok = ingest_directory_rows(state, rows)
+    state
   end
 
-  defp parse_list_entry([_, channel, count_str]) when is_binary(channel) do
-    {:ok, %{name: channel, topic: nil, user_count: parse_user_count(count_str)}}
+  defp perform_directory_action({:progress, count}, state) do
+    broadcast_window_state(state, SessionWire.directory_progress(state.network_slug, count))
+    state
   end
 
-  defp parse_list_entry(_), do: :error
+  # Empty is a no-op — never round-trip an empty insert.
+  @spec ingest_directory_rows(t(), [ChannelDirectory.ingest_row()]) :: :ok
+  defp ingest_directory_rows(_state, []), do: :ok
 
-  @spec parse_user_count(term()) :: non_neg_integer()
-  defp parse_user_count(count_str) when is_binary(count_str) do
-    case Integer.parse(count_str) do
-      {n, _} -> n
-      :error -> 0
-    end
+  defp ingest_directory_rows(state, rows) do
+    :ok = ChannelDirectory.ingest(state.subject, state.network_id, rows)
   end
 
-  defp parse_user_count(_), do: 0
+  # Config default (the struct's) or the test-pinned opt, under the SAME opt
+  # keys the four former state fields used.
+  @spec directory_ingest(map()) :: DirectoryIngest.t()
+  defp directory_ingest(opts) do
+    defaults = %DirectoryIngest{}
 
-  # Push one parsed row onto the in-flight buffer (newest-first; reversed at
-  # flush time so ingest preserves wire order). Flush on the batch boundary
-  # so the DB write cadence is bounded regardless of LIST size.
-  @spec accumulate_directory_row(t(), ChannelDirectory.ingest_row()) :: t()
-  defp accumulate_directory_row(%{directory_refresh: ref} = state, row) do
-    appended = %{ref | buffer: [row | ref.buffer], count: ref.count + 1}
-    buffered = %{state | directory_refresh: appended}
-
-    flushed =
-      if length(appended.buffer) >= state.directory_ingest_batch do
-        flush_directory_buffer(buffered, :batch)
-      else
-        buffered
-      end
-
-    maybe_emit_progress(flushed)
-  end
-
-  # Bulk-ingest the buffered rows (wire order) and clear the buffer. Empty
-  # buffer is a no-op — never round-trip an empty insert.
-  @spec flush_directory_buffer(t(), :batch | :final) :: t()
-  defp flush_directory_buffer(%{directory_refresh: %{buffer: []}} = state, _), do: state
-
-  defp flush_directory_buffer(%{directory_refresh: ref} = state, _) do
-    :ok = ChannelDirectory.ingest(state.subject, state.network_id, Enum.reverse(ref.buffer))
-    %{state | directory_refresh: %{ref | buffer: []}}
-  end
-
-  # Emit a `directory_progress` ping at most once per
-  # `directory_progress_throttle_ms` (monotonic clock, same source as the
-  # `last_emit_ms` seed in `handle_call(:refresh_directory, ...)`).
-  @spec maybe_emit_progress(t()) :: t()
-  defp maybe_emit_progress(%{directory_refresh: ref} = state) do
-    now = System.monotonic_time(:millisecond)
-
-    if now - ref.last_emit_ms >= state.directory_progress_throttle_ms do
-      broadcast_window_state(state, SessionWire.directory_progress(state.network_slug, ref.count))
-      %{state | directory_refresh: %{ref | last_emit_ms: now}}
-    else
-      state
-    end
-  end
-
-  # Authoritative finalised row count — read back from the snapshot the
-  # ingest just wrote (TTL irrelevant; we only want `.total`).
-  @spec total_directory_rows(t()) :: non_neg_integer()
-  defp total_directory_rows(state) do
-    ChannelDirectory.list(state.subject, state.network_id, ttl_ms: 0).total
+    DirectoryIngest.new(
+      timeout_ms: Map.get(opts, :directory_refresh_timeout_ms, defaults.timeout_ms),
+      throttle_ms: Map.get(opts, :directory_progress_throttle_ms, defaults.throttle_ms),
+      batch: Map.get(opts, :directory_ingest_batch, defaults.batch)
+    )
   end
 
   # mIRC sort: ops (@) → voiced (+) → plain (no prefix). Within tier,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1922,8 +1922,8 @@ defmodule Grappa.Session.Server do
   #      no DB churn), then nuke the prior snapshot, arm the watchdog, and
   #      record the in-flight tracker. The streamed 321/322/323 capture is
   #      Task C3; the watchdog handler is `:directory_refresh_timeout` below.
-  #   3. catch-all (`directory_refresh` non-nil) — a refresh is already
-  #      streaming. The tracker's presence IS the guard; reply
+  #   3. catch-all (`run` non-nil) — a refresh is already
+  #      streaming. The run's presence IS the guard; reply
   #      `{:error, :already_refreshing}` and leave the in-flight run untouched.
   def handle_call(:refresh_directory, _, %{directory: %DirectoryIngest{run: nil}, client: nil} = state) do
     {:reply, {:error, :not_connected}, state}

--- a/test/grappa/session/directory_ingest_test.exs
+++ b/test/grappa/session/directory_ingest_test.exs
@@ -14,6 +14,9 @@ defmodule Grappa.Session.DirectoryIngestTest do
   point of it. It is not a mirror of the implementation: it asserts the
   decisions, and two of them are behaviour that a tidy-up would silently
   change (see the `abort/1` test).
+
+  Steps are bound to numbered names (`r0`, `r1`, …) rather than rebound:
+  each assertion then names the exact step it is about.
   """
 
   use ExUnit.Case, async: true
@@ -24,26 +27,26 @@ defmodule Grappa.Session.DirectoryIngestTest do
   # decision boundary, and a config-derived batch size would make the
   # assertions read as coincidence.
   defp ingest(opts) do
-    DirectoryIngest.new(
-      timeout_ms: Keyword.get(opts, :timeout_ms, 60_000),
-      throttle_ms: Keyword.get(opts, :throttle_ms, 1_000),
-      batch: Keyword.get(opts, :batch, 200)
-    )
+    DirectoryIngest.from_opts(%{
+      directory_refresh_timeout_ms: Keyword.get(opts, :timeout_ms, 60_000),
+      directory_progress_throttle_ms: Keyword.get(opts, :throttle_ms, 1_000),
+      directory_ingest_batch: Keyword.get(opts, :batch, 200)
+    })
   end
 
-  defp armed(opts, now) do
-    opts |> ingest() |> DirectoryIngest.start(now, make_ref())
-  end
+  defp armed(opts, now), do: DirectoryIngest.start(ingest(opts), now, make_ref())
+
+  defp row(name), do: %{name: name, topic: nil, user_count: 1}
 
   describe "parse_row/1" do
     test "a full RPL_LIST row yields name, topic and count" do
-      assert {:ok, row} = DirectoryIngest.parse_row(["mynick", "#elixir", "42", "The topic"])
-      assert row == %{name: "#elixir", topic: "The topic", user_count: 42}
+      assert {:ok, parsed} = DirectoryIngest.parse_row(["mynick", "#elixir", "42", "The topic"])
+      assert parsed == %{name: "#elixir", topic: "The topic", user_count: 42}
     end
 
     test "a stripped upstream that omits the trailing topic yields a nil topic" do
-      assert {:ok, row} = DirectoryIngest.parse_row(["mynick", "#elixir", "7"])
-      assert row == %{name: "#elixir", topic: nil, user_count: 7}
+      assert {:ok, parsed} = DirectoryIngest.parse_row(["mynick", "#elixir", "7"])
+      assert parsed == %{name: "#elixir", topic: nil, user_count: 7}
     end
 
     test "a non-numeric user count coerces to 0 rather than crashing the ingest" do
@@ -61,68 +64,68 @@ defmodule Grappa.Session.DirectoryIngestTest do
       idle = ingest([])
       refute DirectoryIngest.in_flight?(idle)
 
-      running = DirectoryIngest.start(idle, 0, make_ref())
-      assert DirectoryIngest.in_flight?(running)
+      assert DirectoryIngest.in_flight?(DirectoryIngest.start(idle, 0, make_ref()))
     end
   end
 
   describe "absorb/3 — the batch boundary" do
     test "rows below the batch size buffer without an ingest action" do
-      run = armed([batch: 3], 0)
+      r0 = armed([batch: 3], 0)
 
-      {run, actions} = DirectoryIngest.absorb(run, row("#a"), 0)
-      assert actions == []
-      {_run, actions} = DirectoryIngest.absorb(run, row("#b"), 0)
-      assert actions == []
+      {r1, first} = DirectoryIngest.absorb(r0, row("#a"), 0)
+      assert first == []
+
+      {_, second} = DirectoryIngest.absorb(r1, row("#b"), 0)
+      assert second == []
     end
 
     test "reaching the batch size emits ONE ingest action carrying wire order" do
-      run = armed([batch: 3], 0)
+      r0 = armed([batch: 3], 0)
 
-      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
-      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
-      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 0)
+      {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
+      {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)
+      {_, third} = DirectoryIngest.absorb(r2, row("#c"), 0)
 
-      assert [{:ingest, rows}] = actions
+      assert [{:ingest, rows}] = third
       assert Enum.map(rows, & &1.name) == ["#a", "#b", "#c"]
     end
 
     test "the running tally survives a flush — count is total, not buffer depth" do
-      run = armed([batch: 2, throttle_ms: 0], 0)
+      r0 = armed([batch: 2, throttle_ms: 0], 0)
 
-      {run, _} = DirectoryIngest.absorb(run, row("#a"), 0)
-      {run, _} = DirectoryIngest.absorb(run, row("#b"), 0)
-      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 0)
+      {r1, _} = DirectoryIngest.absorb(r0, row("#a"), 0)
+      {r2, _} = DirectoryIngest.absorb(r1, row("#b"), 0)
+      {_, third} = DirectoryIngest.absorb(r2, row("#c"), 0)
 
-      assert {:progress, 3} in actions
+      assert {:progress, 3} in third
     end
   end
 
   describe "absorb/3 — the progress throttle" do
     test "no progress ping inside the throttle window" do
-      run = armed([throttle_ms: 1_000], 0)
+      r0 = armed([throttle_ms: 1_000], 0)
 
-      {_run, actions} = DirectoryIngest.absorb(run, row("#a"), 999)
+      {_, actions} = DirectoryIngest.absorb(r0, row("#a"), 999)
       refute Enum.any?(actions, &match?({:progress, _}, &1))
     end
 
     test "a ping once the window elapses, and the window then restarts" do
-      run = armed([throttle_ms: 1_000], 0)
+      r0 = armed([throttle_ms: 1_000], 0)
 
-      {run, actions} = DirectoryIngest.absorb(run, row("#a"), 1_000)
-      assert {:progress, 1} in actions
+      {r1, at_1000} = DirectoryIngest.absorb(r0, row("#a"), 1_000)
+      assert {:progress, 1} in at_1000
 
-      {run, actions} = DirectoryIngest.absorb(run, row("#b"), 1_500)
-      refute Enum.any?(actions, &match?({:progress, _}, &1))
+      {r2, at_1500} = DirectoryIngest.absorb(r1, row("#b"), 1_500)
+      refute Enum.any?(at_1500, &match?({:progress, _}, &1))
 
-      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 2_000)
-      assert {:progress, 3} in actions
+      {_, at_2000} = DirectoryIngest.absorb(r2, row("#c"), 2_000)
+      assert {:progress, 3} in at_2000
     end
 
     test "the flush is ordered BEFORE the progress ping it reports" do
-      run = armed([batch: 1, throttle_ms: 0], 0)
+      r0 = armed([batch: 1, throttle_ms: 0], 0)
 
-      {_run, actions} = DirectoryIngest.absorb(run, row("#a"), 0)
+      {_, actions} = DirectoryIngest.absorb(r0, row("#a"), 0)
 
       assert [{:ingest, _}, {:progress, 1}] = actions
     end
@@ -131,20 +134,18 @@ defmodule Grappa.Session.DirectoryIngestTest do
   describe "finish/1" do
     test "flushes the tail in wire order, hands back the watchdog ref, and clears the run" do
       timer = make_ref()
-      run = DirectoryIngest.start(ingest(batch: 100), 0, timer)
+      r0 = DirectoryIngest.start(ingest(batch: 100), 0, timer)
 
-      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
-      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
+      {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
+      {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)
 
-      assert {cleared, rows, ^timer} = DirectoryIngest.finish(run)
+      assert {cleared, rows, ^timer} = DirectoryIngest.finish(r2)
       assert Enum.map(rows, & &1.name) == ["#a", "#b"]
       refute DirectoryIngest.in_flight?(cleared)
     end
 
     test "an empty buffer flushes nothing — never round-trip an empty insert" do
-      run = armed([], 0)
-
-      assert {cleared, [], _timer} = DirectoryIngest.finish(run)
+      assert {cleared, [], _} = DirectoryIngest.finish(armed([], 0))
       refute DirectoryIngest.in_flight?(cleared)
     end
   end
@@ -156,17 +157,15 @@ defmodule Grappa.Session.DirectoryIngestTest do
       # last batch are lost and `ChannelDirectory.finalize/2` never runs for
       # that refresh. A version that flushed on timeout would change the DB
       # on every truncated refresh. #1390 slice 2 preserves it deliberately.
-      run = armed([batch: 100], 0)
+      r0 = armed([batch: 100], 0)
 
-      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
-      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
+      {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
+      {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)
 
-      cleared = DirectoryIngest.abort(run)
+      cleared = DirectoryIngest.abort(r2)
 
       refute DirectoryIngest.in_flight?(cleared)
       assert {^cleared, [], nil} = DirectoryIngest.finish(cleared)
     end
   end
-
-  defp row(name), do: %{name: name, topic: nil, user_count: 1}
 end

--- a/test/grappa/session/directory_ingest_test.exs
+++ b/test/grappa/session/directory_ingest_test.exs
@@ -1,0 +1,172 @@
+defmodule Grappa.Session.DirectoryIngestTest do
+  @moduledoc """
+  #1390 slice 2 — the channel-directory ETL, exercised WITHOUT a session.
+
+  This file is the boundary claim made falsifiable. It runs `async: true`
+  on plain `ExUnit.Case`: no `DataCase`, no Repo, no `Session.Server`, no
+  fake ircd. Its sibling `directory_test.exs` needs all four (240 lines,
+  `async: false`, 25 references to `start_server`/`IRCServer`) because
+  before this extraction the parse / batch / throttle decisions were only
+  reachable by booting a GenServer.
+
+  If a later change re-entangles those decisions with the session process,
+  this file stops compiling or stops being `async: true` — that is the
+  point of it. It is not a mirror of the implementation: it asserts the
+  decisions, and two of them are behaviour that a tidy-up would silently
+  change (see the `abort/1` test).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.DirectoryIngest
+
+  # Tunables pinned per-test rather than taken from config: the point is the
+  # decision boundary, and a config-derived batch size would make the
+  # assertions read as coincidence.
+  defp ingest(opts) do
+    DirectoryIngest.new(
+      timeout_ms: Keyword.get(opts, :timeout_ms, 60_000),
+      throttle_ms: Keyword.get(opts, :throttle_ms, 1_000),
+      batch: Keyword.get(opts, :batch, 200)
+    )
+  end
+
+  defp armed(opts, now) do
+    opts |> ingest() |> DirectoryIngest.start(now, make_ref())
+  end
+
+  describe "parse_row/1" do
+    test "a full RPL_LIST row yields name, topic and count" do
+      assert {:ok, row} = DirectoryIngest.parse_row(["mynick", "#elixir", "42", "The topic"])
+      assert row == %{name: "#elixir", topic: "The topic", user_count: 42}
+    end
+
+    test "a stripped upstream that omits the trailing topic yields a nil topic" do
+      assert {:ok, row} = DirectoryIngest.parse_row(["mynick", "#elixir", "7"])
+      assert row == %{name: "#elixir", topic: nil, user_count: 7}
+    end
+
+    test "a non-numeric user count coerces to 0 rather than crashing the ingest" do
+      assert {:ok, %{user_count: 0}} = DirectoryIngest.parse_row(["mynick", "#x", "lots", "t"])
+    end
+
+    test "a shape we do not recognise is dropped" do
+      assert :error = DirectoryIngest.parse_row(["mynick"])
+      assert :error = DirectoryIngest.parse_row([])
+    end
+  end
+
+  describe "start/3 and in_flight?/1" do
+    test "a fresh ingest is not in flight, and starting arms it" do
+      idle = ingest([])
+      refute DirectoryIngest.in_flight?(idle)
+
+      running = DirectoryIngest.start(idle, 0, make_ref())
+      assert DirectoryIngest.in_flight?(running)
+    end
+  end
+
+  describe "absorb/3 — the batch boundary" do
+    test "rows below the batch size buffer without an ingest action" do
+      run = armed([batch: 3], 0)
+
+      {run, actions} = DirectoryIngest.absorb(run, row("#a"), 0)
+      assert actions == []
+      {_run, actions} = DirectoryIngest.absorb(run, row("#b"), 0)
+      assert actions == []
+    end
+
+    test "reaching the batch size emits ONE ingest action carrying wire order" do
+      run = armed([batch: 3], 0)
+
+      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
+      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
+      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 0)
+
+      assert [{:ingest, rows}] = actions
+      assert Enum.map(rows, & &1.name) == ["#a", "#b", "#c"]
+    end
+
+    test "the running tally survives a flush — count is total, not buffer depth" do
+      run = armed([batch: 2, throttle_ms: 0], 0)
+
+      {run, _} = DirectoryIngest.absorb(run, row("#a"), 0)
+      {run, _} = DirectoryIngest.absorb(run, row("#b"), 0)
+      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 0)
+
+      assert {:progress, 3} in actions
+    end
+  end
+
+  describe "absorb/3 — the progress throttle" do
+    test "no progress ping inside the throttle window" do
+      run = armed([throttle_ms: 1_000], 0)
+
+      {_run, actions} = DirectoryIngest.absorb(run, row("#a"), 999)
+      refute Enum.any?(actions, &match?({:progress, _}, &1))
+    end
+
+    test "a ping once the window elapses, and the window then restarts" do
+      run = armed([throttle_ms: 1_000], 0)
+
+      {run, actions} = DirectoryIngest.absorb(run, row("#a"), 1_000)
+      assert {:progress, 1} in actions
+
+      {run, actions} = DirectoryIngest.absorb(run, row("#b"), 1_500)
+      refute Enum.any?(actions, &match?({:progress, _}, &1))
+
+      {_run, actions} = DirectoryIngest.absorb(run, row("#c"), 2_000)
+      assert {:progress, 3} in actions
+    end
+
+    test "the flush is ordered BEFORE the progress ping it reports" do
+      run = armed([batch: 1, throttle_ms: 0], 0)
+
+      {_run, actions} = DirectoryIngest.absorb(run, row("#a"), 0)
+
+      assert [{:ingest, _}, {:progress, 1}] = actions
+    end
+  end
+
+  describe "finish/1" do
+    test "flushes the tail in wire order, hands back the watchdog ref, and clears the run" do
+      timer = make_ref()
+      run = DirectoryIngest.start(ingest(batch: 100), 0, timer)
+
+      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
+      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
+
+      assert {cleared, rows, ^timer} = DirectoryIngest.finish(run)
+      assert Enum.map(rows, & &1.name) == ["#a", "#b"]
+      refute DirectoryIngest.in_flight?(cleared)
+    end
+
+    test "an empty buffer flushes nothing — never round-trip an empty insert" do
+      run = armed([], 0)
+
+      assert {cleared, [], _timer} = DirectoryIngest.finish(run)
+      refute DirectoryIngest.in_flight?(cleared)
+    end
+  end
+
+  describe "abort/1 — the watchdog" do
+    test "DROPS the buffered rows and hands back nothing to write" do
+      # Behaviour pin, not tidiness. `handle_info(:directory_refresh_timeout,
+      # ...)` wipes the tracker without flushing, so rows buffered since the
+      # last batch are lost and `ChannelDirectory.finalize/2` never runs for
+      # that refresh. A version that flushed on timeout would change the DB
+      # on every truncated refresh. #1390 slice 2 preserves it deliberately.
+      run = armed([batch: 100], 0)
+
+      {run, []} = DirectoryIngest.absorb(run, row("#a"), 0)
+      {run, []} = DirectoryIngest.absorb(run, row("#b"), 0)
+
+      cleared = DirectoryIngest.abort(run)
+
+      refute DirectoryIngest.in_flight?(cleared)
+      assert {^cleared, [], nil} = DirectoryIngest.finish(cleared)
+    end
+  end
+
+  defp row(name), do: %{name: name, topic: nil, user_count: 1}
+end

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -102,7 +102,7 @@ defmodule Grappa.Session.DirectoryTest do
     assert network_slug == network.slug
     # `:sys.get_state` serializes AFTER the timeout handler returns, so the
     # in-flight tracker is guaranteed cleared by the time we read it.
-    assert :sys.get_state(pid).directory_refresh == nil
+    assert :sys.get_state(pid).directory.run == nil
   end
 
   # #910 — the timeout above is exactly what makes the LIST family's routing

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -38,6 +38,7 @@ defmodule Grappa.Session.ServerTest do
     AwayState,
     Backoff,
     Deps,
+    DirectoryIngest,
     GhostRecovery,
     ISupport,
     RecoverIdentity,
@@ -268,6 +269,40 @@ defmodule Grappa.Session.ServerTest do
       assert is_map(state) and map_size(state) > 10
 
       assert Enum.filter(@di_keys, &Map.has_key?(state, &1)) == []
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
+  # #1390 slice 2 — the channel-directory ETL left the session, so its three
+  # config tunables and its in-flight tracker left the top level of state with
+  # it. Same two-pin split as the `Deps` bundle above, for the same reason:
+  # forgetting to ADD the struct and forgetting to REMOVE the four loose keys
+  # are different mistakes.
+  @directory_keys ~w[directory_refresh_timeout_ms directory_progress_throttle_ms
+                     directory_ingest_batch directory_refresh]a
+
+  describe "channel-directory ingest bundle (#1390)" do
+    test "a live session carries the directory ingest in one struct, idle" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      assert %DirectoryIngest{run: nil} = :sys.get_state(pid).directory
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the four directory names are gone from the top level of state" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      state = :sys.get_state(pid)
+      # Same pre-state guard as the bundle above: an empty map must not pass.
+      assert is_map(state) and map_size(state) > 10
+
+      assert Enum.filter(@directory_keys, &Map.has_key?(state, &1)) == []
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Second slice of #1390. The channel directory is a domain of its own —
`Grappa.ChannelDirectory` has been its own context all along — yet its
whole ETL lived inside the session GenServer: three compile-env constants,
four state fields, a watchdog, and seven private functions parsing
RPL_LIST rows, batching them, throttling progress pings and flushing the
tail.

The four state keys collapse into one `directory` holding a
`Session.DirectoryIngest`. `run == nil` IS the in-flight guard, exactly as
`directory_refresh == nil` was.

## Why this cluster and not the three the issue suggests

The issue's proposed direction lists identity/recovery, away and
auth-handshake as the continuation. Measured footprints decided otherwise:

| cluster | fields | outside `server.ex` |
|---|---|---|
| away | 3 | already has its own `away_state.ex` |
| identity/recovery | 6 | reaches `session.ex`, `deps.ex`, `grappa_channel.ex` |
| auth-handshake | 4 | `pending_auth` alone: **86** occurrences, 2 modules |
| **directory** | **4** | **comments only**, in `numeric_router.ex` + `wire.ex` |

Those three regroup session-domain fields inside the module that already
owns them: they shrink the state map without moving anything across a
boundary. Only the directory does, and the receiving context already
exists.

## The red that buys it

`directory_ingest_test.exs` runs `async: true` on plain `ExUnit.Case` — no
DataCase, no Repo, no `Session.Server`, no fake ircd — 14 cases in 0.09s.
Its sibling `directory_test.exs` needs all four: 240 lines, `async: false`,
25 references to `start_server`/`IRCServer`, because before this the parse,
batch and throttle decisions were reachable only by booting a GenServer.

That is a falsifiable boundary rather than a metric. If a later change
re-entangles the decisions with the process, the file stops being writable
that way.

## The structural pins are not vacuous, and that was measured

The two `server_test.exs` pins were written AFTER the implementation, so
they had never been seen red. Two surgical mutants fixed that, and they are
disjoint — **one mutant, one assertion**:

- a plain map in place of the struct kills only *"a live session carries the
  directory ingest in one struct, idle"*;
- one re-added legacy key kills only *"the four directory names are gone
  from the top level of state"*.

## A pin was re-pointed, not deleted

`directory_test.exs:105` was `assert :sys.get_state(pid).directory_refresh
== nil` — a `:sys.get_state` pin on the NAME of a private field, not an
assertion of behaviour. Its behavioural twin three lines above (the
`assert_receive` of the `directory_failed` broadcast with `reason:
"timeout"`) passed throughout, so the observable never moved.

It now reads `.directory.run`, in its own commit (`60215800`) so a reviewer
can tell a moved pin from a softened assert. Deleting it on the grounds that
the behavioural test covers the same case was the tempting move; that
reasoning is how pins disappear one at a time.

This also retracts a commitment made when the slice was proposed — that
having to touch `directory_test.exs` would BE the behaviour change. The
dichotomy had no room for a structural pin, which is neither an assert nor a
behaviour.

## Two behaviours preserved on purpose

Both were named as risks before any code was written, and both look like
untidiness:

- the `directory_complete` total is re-read from the DB snapshot with
  `ttl_ms: 0`, **not** taken from the accumulator's running `count`. The two
  diverge the moment `ChannelDirectory.ingest/3` dedupes or upserts, so
  collapsing them would change the number cic renders.
- the watchdog calls `abort/1`, which **drops** the buffered rows and never
  finalises. A truncated refresh leaves the prior snapshot intact and loses
  everything buffered since the last batch. Flushing on timeout would change
  the DB on every stalled refresh.

`flush_directory_buffer/2` carried a `:batch | :final` discriminator in its
`@spec` that BOTH clauses ignored. It is not carried into the new module —
dead in, dead out — and it is recorded rather than left to be rediscovered
as an omission.

## Struct, not a declared map type

Measured rather than assumed: #1391's mutant pair established that a
struct-field typo is a *compile* error while a bare-map key typo compiles
clean, and that declaring a map's shape buys neither. The tracker was an
anonymous map with `buffer: [map()]`.

## Scope: 8 commits, 7 files — one file over the declared count

The declared perimeter was **5 files (+1 conditional)**. It came in at
**7**, and both extras are stated as an overrun rather than as foresight:

- `numeric_router.ex` — the conditional became real: its comment described
  the dispatch head by a field that no longer exists, so it read as false
  rather than dated. `wire.ex` was left alone on purpose: it names
  `directory_progress_throttle_ms`, and that spelling survives as the
  start-opt key, so it is still true.
- `directory_test.exs` — the one line of the re-pointed pin.

A sixth stale comment was missed by the first sweep, because that grep
searched `directory_refresh:` **with** the colon and the comment wrote the
identifier bare. Fixed in its own commit rather than amended away.

## Gate

`scripts/check.sh` → **RC=0, full chain**:

- `compile --warnings-as-errors`, `format --check-formatted`
- Credo `--strict`: `6114 mods/funs, found no issues`
- suite: `8 doctests, 61 properties, 6495 tests, 0 failures`
- Dialyzer: `Total errors: 0`
- Sobelow and the bats set: through

Two self-inflicted gate reds on the way, both in code this slice
introduced: 17 Credo issues (variable rebinding in the new test, and
`_name` where the local strategy is a bare `_`), and one
`contract_supertype`. The latter was a correct design signal — it pushed the
construction out of a private `server.ex` helper and into
`DirectoryIngest.from_opts/1`, the exact shape of its slice-1 sibling
`Deps.from_opts/1`.

## What is NOT measured

- **Behaviour-freedom is not proven, only evidenced.** The suite is green
  and `directory_test.exs` needed one line, which is a pin — that is
  evidence, not an equivalence proof.
- **The key count is not the win here**: 4 → 1, against slice 1's 10 → 1.
  The claim is the boundary and the testability, not the arithmetic.
- Whether `ChannelDirectory.ingest/3` actually dedupes was not checked. The
  first preserved risk says `count` and `.total` **can** diverge, not that
  they do today.
- No mutants beyond the two that pinned the structural assertions.
- **No rebase was performed and no union-driver check is claimed.**
  `origin/main` is `a60082eb`, which is this branch's merge-base — slice 1
  landed fast-forward, so a rebase would be a no-op and the `merge=union`
  driver would never run. What was measured is the file state: both
  `<!-- entry #1390 -->` and `<!-- entry #1390 slice 2 -->` appear exactly
  once by `grep -Fxc`, no duplicate markers anywhere, and the entry adds 85
  lines with zero deletions.
