### PR TITLE
arch(#1390) slice 3: one parse for the 005, one merge rule for MODES/LINELEN

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46526,3 +46526,84 @@ how pins disappear one at a time.
 
 _Not measured here: nothing in this entry claims a verdict for the full
 suite or the type gates; those are a separate run._
+<!-- entry #1390 slice 3 -->
+
+---
+
+## 2026-08-17 — #1390 slice 3: the last two 005 tokens come home, and the three choices that forced
+
+`MODES=` and `LINELEN=` were the only ISUPPORT tokens with a SECOND parser.
+`Session.Server` scanned them out of a 005 with a pair of `reduce_while`
+helpers into two loose integers on state, while `ISupport.merge_isupport/2`
+folded the other fifteen. They were also being parsed a second time by that
+very module: `archive_token/2` writes EVERY advertised token into `raw`, so
+`"MODES=4"` produced both a scanner result and a `raw` entry. The `raw`
+typedoc's promise — "one 005, two readers, no second parse" — described a
+state of affairs the file 3,400 lines away contradicted.
+
+They are typed fields now, on the `put_limit/3` the #1255 length limits
+already share, with `@negatable` entries and accessors that default through
+`Map.get/3`. Two loose keys leave the state map; the parse becomes one.
+
+### Unlike the length limits, these two seed a number
+
+`nicklen`/`channellen`/`topiclen` default to `nil` because nothing enforces
+them and seeding a number would start rejecting input the ircd accepts.
+`MODES`/`LINELEN` cannot do that: `ModeChunker` must pick a chunk size and
+`LineSplit` a frame budget on the first outbound line, long before a 005
+arrives. 3 (IRCv3 / RFC 2812 §3.2.3) and 512 (RFC 2812) are the same values
+`Session.Server` seeded, moved rather than invented.
+
+### Three behaviour changes, because there was no single behaviour to keep
+
+The tiebreak was least surprise. Each is bought by its own named red rather
+than riding along on "the parse is unified", and each is recorded here so a
+later reader finds the choice instead of deducing it from a diff:
+
+1. **A token repeated within ONE 005 line now honours the LAST occurrence.**
+   The scanners `:halt`ed on the first parseable hit. A repeated token is
+   draft-brocklesby-irc-isupport-03 §2's way to CORRECT a value, so ignoring
+   the correction is the worse surprise — and `raw`, the archive the Phase 6
+   facade will read, already honoured the last one. Across LINES both rules
+   already agreed, which is why this went unnoticed.
+2. **A malformed `MODES=` no longer resets to 3.** `parse_modes_token/2`
+   answered `{:cont, 3}` on a failed parse: it discarded an advertised value
+   and substituted the hardcoded default, tightening the limit. Its LINELEN
+   twin answered `{:cont, current}` on the same input. Two twins diverging on
+   one input is a slip, not a contract; an unreadable token must not produce
+   an arbitrary narrower limit.
+3. **`-MODES` / `-LINELEN` revoke.** `"-MODES"` never matched
+   `"MODES=" <> rest`, so a §2 negation was silently dropped and the value
+   survived until reconnect. `@negatable` already documents that a parsed
+   token missing from it is a visible omission rather than a silent one.
+
+### What deliberately did not move
+
+`Session.Wire.isupport_changed/3` keeps its arity and its payload — which
+publishes neither number, only the derived `frame_budget_base` — and the
+`:session_snapshot` reply keeps its own `linelen:` key. Both are client
+contract, and collapsing them would be a wire change for no behavioural
+gain. `LineSplit` and `ModeChunker` keep taking the value as a parameter:
+they were already pure and already outside the session. The other tokens
+sitting in `raw` (`NETWORK`, `TARGMAX`, …) stay untyped — the rule for this
+slice is that a token comes home when it has a second parser, not when it
+could be enriched, and those have no consumer.
+
+`Session.Server.default_modes_per_chunk/0` was deleted: public, zero callers,
+and a second home for a constant `ISupport.default/0` now holds.
+
+### The #1108 disjunct, and why removing it is not a leap
+
+The broadcast gate read `isupport != prev_isupport or linelen != state.linelen`
+because a 005 advertising ONLY `LINELEN` had to reach cic, which sizes its
+"this will split" warning off it. The second disjunct is gone — not merely
+because the field moved inside the table it is compared against, but because
+`archive_token/2` had already made it redundant: any 005 that changes a
+LINELEN or a MODES has moved `raw`, and therefore the table. That reasoning
+is in the code comment rather than left to be re-derived, since #1108 exists
+because this gate was got wrong once.
+
+_Not measured here: whether an ircd in the wild repeats `MODES=` within one
+line or sends `-MODES`. The slice is justified by the internal divergence,
+not by a field frequency nobody has counted; the three changes state what
+happens in those cases, not how often they occur._

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -57,7 +57,7 @@ defmodule Grappa.Protocol do
   # `:: 1` (not `pos_integer()`) so the spec matches the success typing of
   # the literal constant under Dialyzer `:underspecs` — the codebase idiom
   # for a constant-returning function (`Grappa.Notify.max_entries/0 :: 64`,
-  # `Session.Server.default_modes_per_chunk/0 :: 3`). A bump edits the spec
+  # `Grappa.IRC.Identifier.max_nick_length/0 :: 30`). A bump edits the spec
   # alongside `@protocol_version`, which is a deliberate, reviewed event
   # per the additive-only rule — the spec doubles as the bump tripwire.
   @spec version() :: 1

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -2,8 +2,10 @@ defmodule Grappa.Session.ISupport do
   @moduledoc """
   Per-network capability table, parsed from the upstream's 005
   RPL_ISUPPORT tokens: `CHANMODES=`, `PREFIX=`, `STATUSMSG=`,
-  `CASEMAPPING=`, `MONITOR=`/`WATCH=`, and — since #1255 — `CHANTYPES=`,
-  `MAXLIST=`, `NICKLEN=`, `CHANNELLEN=` and `TOPICLEN=`.
+  `CASEMAPPING=`, `MONITOR=`/`WATCH=`, since #1255 `CHANTYPES=`,
+  `MAXLIST=`, `NICKLEN=`, `CHANNELLEN=` and `TOPICLEN=`, and — since
+  #1390 — `MODES=` and `LINELEN=`, the last two that `Session.Server`
+  still scanned for itself under a merge rule of their own.
 
   ## Why this exists
 
@@ -134,6 +136,8 @@ defmodule Grappa.Session.ISupport do
           nicklen: pos_integer() | nil,
           channellen: pos_integer() | nil,
           topiclen: pos_integer() | nil,
+          modes: pos_integer(),
+          linelen: pos_integer(),
           raw: raw()
         }
 
@@ -199,6 +203,16 @@ defmodule Grappa.Session.ISupport do
   # #1108 took for the frame budget.
   @default_maxlist %{}
 
+  # #1390 — unlike the length limits above, these two seed a NUMBER rather
+  # than "unadvertised". `ModeChunker` has to pick a chunk size and
+  # `LineSplit` a frame budget on the very first outbound line, long before
+  # any 005 arrives, so "do not enforce" is not a value either can be handed.
+  # 3 is the IRCv3 / RFC 2812 §3.2.3 de-facto minimum every major ircd meets;
+  # 512 is RFC 2812's line limit. Both were the `Session.Server` state
+  # defaults this module took over.
+  @default_modes 3
+  @default_linelen 512
+
   @doc """
   The pre-005 default capability table (bahamut/Azzurra values). Used as
   the initial `Session.Server` state field and as the fallback whenever a
@@ -223,6 +237,8 @@ defmodule Grappa.Session.ISupport do
       nicklen: nil,
       channellen: nil,
       topiclen: nil,
+      modes: @default_modes,
+      linelen: @default_linelen,
       raw: %{}
     }
   end
@@ -447,6 +463,27 @@ defmodule Grappa.Session.ISupport do
   def topiclen(isupport) when is_map(isupport), do: Map.get(isupport, :topiclen)
 
   @doc """
+  The advertised `MODES=` (#1390): how many mode changes one MODE line may
+  carry, which is what `Grappa.Session.ModeChunker` chunks against. Always
+  a number — see `@default_modes` for why this one cannot be `nil`.
+
+  The `Map.get/3` default is the hot-reload contract: a live session's
+  table predates this field, and a plain hot reload does not rewrite
+  process state.
+  """
+  @spec modes(t()) :: pos_integer()
+  def modes(isupport) when is_map(isupport), do: Map.get(isupport, :modes, @default_modes)
+
+  @doc """
+  The advertised `LINELEN=` (#1390), the upstream's max wire-frame size —
+  the number `Grappa.IRC.LineSplit` subtracts the relayed source prefix
+  from to get the body budget. Always a number; see `modes/1` for the
+  hot-reload fallback.
+  """
+  @spec linelen(t()) :: pos_integer()
+  def linelen(isupport) when is_map(isupport), do: Map.get(isupport, :linelen, @default_linelen)
+
+  @doc """
   Every token the upstream advertised, verbatim — see `t:raw/0` for what
   this is for and the two boundaries it must respect. Empty before the
   first 005.
@@ -473,7 +510,9 @@ defmodule Grappa.Session.ISupport do
     "MAXLIST" => :maxlist,
     "NICKLEN" => :nicklen,
     "CHANNELLEN" => :channellen,
-    "TOPICLEN" => :topiclen
+    "TOPICLEN" => :topiclen,
+    "MODES" => :modes,
+    "LINELEN" => :linelen
   }
 
   # #1255 — draft-brocklesby-irc-isupport-03 §2: a token advertised with a
@@ -573,6 +612,14 @@ defmodule Grappa.Session.ISupport do
   defp merge_token("CHANNELLEN=" <> rest, acc), do: put_limit(acc, :channellen, rest)
   defp merge_token("TOPICLEN=" <> rest, acc), do: put_limit(acc, :topiclen, rest)
 
+  # #1390 — the two tokens `Session.Server` used to scan for itself, on the
+  # same `put_limit/3` as the limits above. That shared arm is the point of
+  # the move: a malformed value keeps the prior one instead of substituting a
+  # narrower default, and the write is unconditional, so a token repeated
+  # within one line lands last-wins like every other token here.
+  defp merge_token("MODES=" <> rest, acc), do: put_limit(acc, :modes, rest)
+  defp merge_token("LINELEN=" <> rest, acc), do: put_limit(acc, :linelen, rest)
+
   defp merge_token(_, acc), do: acc
 
   # #1255 — the verbatim archive, written for EVERY advertised token
@@ -614,7 +661,7 @@ defmodule Grappa.Session.ISupport do
   @spec token_name?(String.t()) :: boolean()
   defp token_name?(name), do: Regex.match?(@token_name, name)
 
-  @spec put_limit(t(), :nicklen | :channellen | :topiclen, String.t()) :: t()
+  @spec put_limit(t(), :nicklen | :channellen | :topiclen | :modes | :linelen, String.t()) :: t()
   defp put_limit(acc, key, rest) do
     case Integer.parse(rest) do
       {n, ""} when n > 0 -> Map.put(acc, key, n)

--- a/lib/grappa/session/mode_chunker.ex
+++ b/lib/grappa/session/mode_chunker.ex
@@ -29,9 +29,10 @@ defmodule Grappa.Session.ModeChunker do
 
   ## Default max_per_chunk
 
-  IRCv3 spec says 3 when `MODES=` is absent. Session.Server stores the
-  advertised value (or the default) in `state.modes_per_chunk` and passes it
-  to every `chunk/3` call.
+  IRCv3 spec says 3 when `MODES=` is absent. Since #1390 the advertised
+  value (or that default) is a field of the per-network capability table:
+  `Session.Server` reads it with `Grappa.Session.ISupport.modes/1` and
+  passes it to every `chunk/3` call.
 
   ## Round-trip contract
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -546,33 +546,17 @@ defmodule Grappa.Session.Server do
           # is unavailable and param-derived routing returns {:active, nil}.
           # `nil` until the user issues the first command in this session.
           last_command_window: window_ref() | nil,
-          # S5.1: ISUPPORT MODES=N advertised by the upstream server. Bounds
-          # how many mode changes a single MODE line may carry. Defaults to 3
-          # per IRCv3 spec when the upstream omits MODES= from 005. Updated
-          # when 005 RPL_ISUPPORT arrives with a MODES= token. Kept as a
-          # bounded integer on state (not a generic ISUPPORT map) to stay
-          # minimal — only MODES= is consumed server-side for now.
-          modes_per_chunk: pos_integer(),
-          # BUGHUNT-1 A — max wire-frame size for outbound PRIVMSG auto-
-          # split. Defaults to 512 per RFC 2812 when upstream omits
-          # LINELEN= from 005 RPL_ISUPPORT (Bahamut/InspIRCd/UnrealIRCd
-          # commonly do). Used by `Grappa.IRC.LineSplit` to compute the
-          # body budget = `linelen - LineSplit.relay_frame_overhead(target)`,
-          # which reserves the worst-case relayed `:nick!user@host ` source
-          # prefix the server prepends (#246), not just the client-side
-          # `PRIVMSG <target> :\r\n` framing. Sibling shape to
-          # `modes_per_chunk` — bounded integer on state, not a generic
-          # ISUPPORT map.
-          linelen: pos_integer(),
-          # #216: per-network channel-mode capability table parsed from
-          # 005 RPL_ISUPPORT `CHANMODES=` + `PREFIX=`. Unlike modes_per_chunk
-          # / linelen (bounded ints consumed only server-side), this one is
-          # ALSO broadcast to cic (the `/mode` modal drives its available
-          # toggles from it) AND read by EventRouter's MODE-string walkers
-          # (single source of truth for per-user vs channel modes + param
-          # arity — replaces the former hardcoded event_router constants).
-          # Defaults to `ISupport.default/0` (bahamut/Azzurra values) until
-          # a 005 with the tokens arrives. See `Grappa.Session.ISupport`.
+          # #216: per-network capability table parsed from 005 RPL_ISUPPORT.
+          # Broadcast to cic (the `/mode` modal drives its available toggles
+          # from it) AND read by EventRouter's MODE-string walkers (single
+          # source of truth for per-user vs channel modes + param arity —
+          # replaces the former hardcoded event_router constants). Since
+          # #1390 it also carries `MODES=` and `LINELEN=`, which used to sit
+          # here as two loose integers with a scanner of their own: one 005,
+          # one parse, one merge rule. `ModeChunker` and `LineSplit` read
+          # them through `ISupport.modes/1` / `ISupport.linelen/1`. Defaults
+          # to `ISupport.default/0` (bahamut/Azzurra values) until a 005
+          # arrives. See `Grappa.Session.ISupport`.
           isupport: ISupport.t(),
           # #247: authoritative /notify presence map for this session,
           # keyed by ASCII-folded nick (#121/#525) — `:unknown` until the first
@@ -1071,9 +1055,8 @@ defmodule Grappa.Session.Server do
       # S10 — sibling prime-stamp map for the labels_pending lazy TTL sweep.
       labels_pending_at: %{},
       last_command_window: nil,
-      modes_per_chunk: 3,
-      linelen: 512,
-      # #216: default channel-mode capability table until 005 arrives.
+      # #216: default capability table until 005 arrives — MODES/LINELEN
+      # included since #1390.
       isupport: ISupport.default(),
       # #247: /notify presence map — seeded at the end-of-MOTD arm.
       presence: %{},
@@ -1775,7 +1758,7 @@ defmodule Grappa.Session.Server do
   # S5.2 — Channel-ops verb handlers
   # ---------------------------------------------------------------------------
   # All chunked verbs (/op /deop /voice /devoice /ban /unban) delegate to
-  # ModeChunker.chunk/3 with state.modes_per_chunk (ISUPPORT MODES= value,
+  # ModeChunker.chunk/3 with `ISupport.modes/1` (the ISUPPORT MODES= value,
   # default 3). The chunker splits the param list into N-mode slices and
   # returns one {mode_str, params_slice} per chunk; we send each as a
   # separate MODE line. The mode letter is repeated once per param by the
@@ -2450,8 +2433,10 @@ defmodule Grappa.Session.Server do
   # #1108: the live LINELEN, for the cold WS after-join snapshot — whose
   # sibling `:get_isupport` covers the rest of the same payload. Raw, not a
   # budget: the wire builder owns that projection, so there is exactly one.
+  # Since #1390 the value comes out of the same table `:get_isupport`
+  # returns; the two replies cannot drift because there is one field.
   def handle_call(:get_linelen, _, state) do
-    {:reply, {:ok, state.linelen}, state}
+    {:reply, {:ok, ISupport.linelen(Map.get(state, :isupport, ISupport.default()))}, state}
   end
 
   # #229: returns the per-session umode set. Always succeeds ([] before the
@@ -2530,6 +2515,8 @@ defmodule Grappa.Session.Server do
   # deploy. The COLD restart is what guarantees no pre-#902 struct is left
   # in a live proc for `invited_windows/2` to pattern-match against.
   def handle_call(:session_snapshot, _, state) do
+    isupport = Map.get(state, :isupport, ISupport.default())
+
     {:reply,
      {:ok,
       %{
@@ -2555,8 +2542,13 @@ defmodule Grappa.Session.Server do
         # pair: this is the login hot path, and #482 already measured what a
         # third serial blocking call per network does to user-topic
         # broadcast latency.
-        isupport: Map.get(state, :isupport, ISupport.default()),
-        linelen: state.linelen
+        #
+        # #1390 — `linelen` keeps its own snapshot key even though it now
+        # lives inside the table beside it: the key is the client contract
+        # `GrappaChannel` and `Session.Wire` read, and collapsing it would
+        # be a wire change for zero behavioural gain.
+        isupport: isupport,
+        linelen: ISupport.linelen(isupport)
       }}, state}
   end
 
@@ -3376,42 +3368,31 @@ defmodule Grappa.Session.Server do
     {:noreply, %{state | caps_active: caps_active}}
   end
 
-  # S5.1 — 005 RPL_ISUPPORT: extract MODES=N + LINELEN=N if advertised.
-  # Params are space-separated ISUPPORT tokens (e.g. ["grappa-test",
-  # "MODES=4", "LINELEN=512", "CHANTYPES=#", "are supported ..."]).  We
-  # scan every param for the known prefixes. Defaults (3 modes,
-  # 512-byte linelen) are preserved when the token is absent.
+  # S5.1 / #216 — 005 RPL_ISUPPORT: fold the advertised tokens into the
+  # per-network `isupport` capability table. Params are space-separated
+  # ISUPPORT tokens (e.g. ["grappa-test", "MODES=4", "LINELEN=512",
+  # "CHANTYPES=#", "are supported ..."]).
   #
-  # #1255 — the two scanners below and the ISUPPORT table do NOT share a
-  # merge rule, and this comment used to claim the wrong one for both:
+  # #1390 — there is now ONE parse. `MODES=` and `LINELEN=` used to be
+  # scanned here into two loose integer state fields by a pair of
+  # `reduce_while` scanners that `:halt`ed on the first parseable hit,
+  # while `ISupport.merge_isupport/2` folded every other token
+  # last-wins — two merge rules over one line, held apart by nothing but
+  # a comment (and the same two tokens were ALSO being archived verbatim
+  # in `ISupport.raw/1`, so they were parsed twice). They are typed
+  # fields of the table now, and the three behaviour differences that
+  # unification forced are recorded in DESIGN_NOTES 2026-08-17.
   #
-  #   * `extract_modes_isupport/2` + `extract_linelen_isupport/2` are
-  #     `reduce_while` scanners that `:halt` on the first parseable hit,
-  #     so the FIRST occurrence wins WITHIN one line. Across lines they
-  #     are last-wins like everything else: each call re-scans a fresh
-  #     param list seeded from the current value, so a later line
-  #     carrying the token overwrites what an earlier one set.
-  #   * `ISupport.merge_isupport/2` is a plain reduce whose clauses write
-  #     unconditionally — LAST advertisement wins, which is what
-  #     draft-brocklesby-irc-isupport-03 §2 requires of a re-advertised
-  #     parameter. The "first advertised, ignore later ones to avoid a
-  #     misbehaving server downgrading us mid-session" protection this
-  #     comment used to describe has never existed in either place.
-  #
-  # #216: ALSO fold CHANMODES= + PREFIX= into the per-network
-  # `isupport` capability table. When it changes, broadcast the typed
-  # `isupport_changed` payload on `Topic.user/1` so the cic `/mode`
-  # modal can drive its available toggles from the network's real
-  # capability set (and the EventRouter MODE walkers read the same
-  # table off state). A 005 arrives in several lines during registration;
-  # broadcasting only on an actual change keeps the fan-out minimal.
+  # When the table changes, broadcast the typed `isupport_changed`
+  # payload on `Topic.user/1` so the cic `/mode` modal can drive its
+  # available toggles from the network's real capability set (and the
+  # EventRouter MODE walkers read the same table off state). A 005
+  # arrives in several lines during registration; broadcasting only on an
+  # actual change keeps the fan-out minimal.
   def handle_info(
         {:irc, %Message{command: {:numeric, 5}} = msg},
         state
       ) do
-    modes_per_chunk = extract_modes_isupport(msg.params, state.modes_per_chunk)
-    linelen = extract_linelen_isupport(msg.params, state.linelen)
-
     # `Map.get` default (not `state.isupport`) + `Map.put` write (not a
     # `%{state | isupport: ...}` update, which KeyErrors when the key is
     # absent) so a live proc whose state predates the :isupport field —
@@ -3421,18 +3402,21 @@ defmodule Grappa.Session.Server do
     prev_isupport = Map.get(state, :isupport, ISupport.default())
     isupport = ISupport.merge_isupport(msg.params, prev_isupport)
 
-    # #1108 — LINELEN is in the same broadcast, so a 005 line that advertises
-    # ONLY LINELEN (no CHANMODES/PREFIX) must still reach the client: gating
-    # on the capability table alone would leave every connected cic sizing
-    # its "this will split" warning against the previous frame all session.
-    if isupport != prev_isupport or linelen != state.linelen do
+    # #1108 — a 005 line that advertises ONLY LINELEN (no CHANMODES/PREFIX)
+    # must still reach the client, or every connected cic sizes its "this
+    # will split" warning against the previous frame all session. That case
+    # needed its own disjunct while LINELEN lived outside the table; it does
+    # not now, and not merely because the field moved: `archive_token/2`
+    # writes EVERY advertised token into `ISupport.raw/1`, so any 005 that
+    # changes a LINELEN or a MODES has already moved the table it is
+    # compared against.
+    if isupport != prev_isupport do
       broadcast_window_state(
         state,
-        SessionWire.isupport_changed(state.network_id, isupport, linelen)
+        SessionWire.isupport_changed(state.network_id, isupport, ISupport.linelen(isupport))
       )
     end
 
-    state = %{state | modes_per_chunk: modes_per_chunk, linelen: linelen}
     {:noreply, Map.put(state, :isupport, isupport)}
   end
 
@@ -3732,7 +3716,13 @@ defmodule Grappa.Session.Server do
     # HERE (the facade now passes `target` RAW); the wire + `dm_with`
     # display keep the raw casing. Fold once and thread both forms.
     key = fold_key(state, target)
-    fragments = LineSplit.split_privmsg_body(body, target, state.linelen)
+
+    fragments =
+      LineSplit.split_privmsg_body(
+        body,
+        target,
+        ISupport.linelen(Map.get(state, :isupport, ISupport.default()))
+      )
 
     case persist_and_send_fragments(target, key, fragments, state, nil) do
       {:ok, last_message} ->
@@ -3818,7 +3808,12 @@ defmodule Grappa.Session.Server do
     # long. Reusing the sized-for-PRIVMSG splitter keeps ONE copy of the #246
     # worst-case relay ceilings (and of the fragment-count table `cic`'s
     # preview is pinned to) rather than forking it for a byte.
-    fragments = LineSplit.split_privmsg_body(body, target, state.linelen)
+    fragments =
+      LineSplit.split_privmsg_body(
+        body,
+        target,
+        ISupport.linelen(Map.get(state, :isupport, ISupport.default()))
+      )
 
     case persist_and_send_notice_fragments(key, target, fragments, state, nil) do
       {:ok, last_message} -> {:reply, {:ok, last_message}, state}
@@ -6723,18 +6718,6 @@ defmodule Grappa.Session.Server do
   end
 
   # ---------------------------------------------------------------------------
-  # S5.1 — ISUPPORT MODES= extraction
-  # ---------------------------------------------------------------------------
-
-  @doc """
-  The default max-modes-per-chunk when upstream omits MODES= from ISUPPORT.
-  IRCv3 spec and RFC 2812 §3.2.3 both cite 3 as the de-facto minimum; all
-  major IRCds (bahamut, ircd-seven, UnrealIRCd) default to at least 3.
-  """
-  @spec default_modes_per_chunk() :: 3
-  def default_modes_per_chunk, do: 3
-
-  # ---------------------------------------------------------------------------
   # S5.2 — ops verb private helpers
   # ---------------------------------------------------------------------------
 
@@ -6756,7 +6739,8 @@ defmodule Grappa.Session.Server do
   @spec send_chunked_mode(t(), String.t(), String.t(), [String.t()]) ::
           {:reply, :ok | {:error, atom()}, t()}
   defp send_chunked_mode(state, channel, mode_str, params) do
-    chunks = ModeChunker.chunk(mode_str, params, state.modes_per_chunk)
+    modes = ISupport.modes(Map.get(state, :isupport, ISupport.default()))
+    chunks = ModeChunker.chunk(mode_str, params, modes)
     {:reply, flush_mode_chunks(state.client, channel, chunks), state}
   end
 
@@ -6801,47 +6785,6 @@ defmodule Grappa.Session.Server do
       end
     end
   end
-
-  # Scans 005 RPL_ISUPPORT params for a "MODES=N" token and returns N as
-  # an integer. Returns the current value unchanged when no MODES= is found.
-  # Silently ignores malformed tokens (e.g. "MODES=" with no number) — the
-  # default is always a safe fallback.
-  @spec extract_modes_isupport([String.t()], pos_integer()) :: pos_integer()
-  defp extract_modes_isupport(params, current) when is_list(params) do
-    Enum.reduce_while(params, current, &parse_modes_token/2)
-  end
-
-  @spec parse_modes_token(String.t(), pos_integer()) ::
-          {:cont, pos_integer()} | {:halt, pos_integer()}
-  defp parse_modes_token("MODES=" <> rest, _) do
-    case Integer.parse(rest) do
-      {n, ""} when n > 0 -> {:halt, n}
-      _ -> {:cont, 3}
-    end
-  end
-
-  defp parse_modes_token(_, acc), do: {:cont, acc}
-
-  # BUGHUNT-1 A — Scans 005 RPL_ISUPPORT params for a "LINELEN=N" token
-  # and returns N as an integer. Returns the current value unchanged
-  # when no LINELEN= is found (default 512 per RFC 2812). Silently
-  # ignores malformed tokens (e.g. "LINELEN=0" or "LINELEN=" with no
-  # number) — the prior value is always a safe fallback.
-  @spec extract_linelen_isupport([String.t()], pos_integer()) :: pos_integer()
-  defp extract_linelen_isupport(params, current) when is_list(params) do
-    Enum.reduce_while(params, current, &parse_linelen_token/2)
-  end
-
-  @spec parse_linelen_token(String.t(), pos_integer()) ::
-          {:cont, pos_integer()} | {:halt, pos_integer()}
-  defp parse_linelen_token("LINELEN=" <> rest, current) do
-    case Integer.parse(rest) do
-      {n, ""} when n > 0 -> {:halt, n}
-      _ -> {:cont, current}
-    end
-  end
-
-  defp parse_linelen_token(_, acc), do: {:cont, acc}
 
   # ---------------------------------------------------------------------------
   # S3.2 — away state internal helpers

--- a/test/grappa/session/isupport_test.exs
+++ b/test/grappa/session/isupport_test.exs
@@ -519,6 +519,114 @@ defmodule Grappa.Session.ISupportTest do
     end
   end
 
+  # #1390 — MODES= and LINELEN= were the last two 005 tokens carrying a
+  # SECOND parser: `Session.Server` scanned them into two bare integer state
+  # fields while this module archived the very same tokens in `raw`. One 005,
+  # two parses, two merge rules. They come home here, so the typed value is a
+  # fact of the ISUPPORT table rather than a field of the session process.
+  #
+  # Unlike the #1255 length limits they carry a protocol DEFAULT (3 / 512)
+  # instead of `nil`: `ModeChunker` and `LineSplit` need a usable number
+  # before 005 ever arrives, and "advertised as absent" is not a number.
+  describe "MODES + LINELEN (#1390)" do
+    test "default/0 seeds the values every consumer needs pre-005" do
+      d = ISupport.default()
+      assert ISupport.modes(d) == 3
+      assert ISupport.linelen(d) == 512
+    end
+
+    test "merge_isupport/2 parses MODES and LINELEN off a 005 param list" do
+      params = [
+        "grappa-test",
+        "MODES=6",
+        "LINELEN=480",
+        "are supported by this server"
+      ]
+
+      isupport = ISupport.merge_isupport(params, ISupport.default())
+      assert ISupport.modes(isupport) == 6
+      assert ISupport.linelen(isupport) == 480
+    end
+
+    test "the accessors fall back to the seed on a table predating the fields" do
+      # A session hot-reloaded across this change holds an `isupport` map
+      # built before the two keys existed — a plain hot reload does not
+      # rewrite process state. The accessor must answer the protocol default
+      # rather than KeyError. Same contract as the #1255 limits above.
+      pre_1390 = Map.drop(ISupport.default(), [:modes, :linelen])
+      assert ISupport.modes(pre_1390) == 3
+      assert ISupport.linelen(pre_1390) == 512
+    end
+
+    test "merge_isupport/2 ignores a non-positive or non-numeric LINELEN" do
+      # INVARIANCE, not one of the three changes below: the scanner this
+      # replaces already kept the prior value on a malformed LINELEN. The two
+      # cases exercise different guards — `LINELEN=0` the positivity one,
+      # `LINELEN=abc` the parse one — so they fail independently.
+      seeded = ISupport.merge_isupport(["grappa-test", "LINELEN=480"], ISupport.default())
+
+      assert ISupport.linelen(ISupport.merge_isupport(["grappa-test", "LINELEN=0"], seeded)) == 480
+      assert ISupport.linelen(ISupport.merge_isupport(["grappa-test", "LINELEN=x"], seeded)) == 480
+    end
+  end
+
+  # #1390 — three BEHAVIOUR CHANGES, deliberate, not a tidy-up. Unifying the
+  # parse FORCED a choice: the scanner and this module did not agree on the
+  # same input, so there was no single "current behaviour" to preserve. The
+  # tiebreak was least surprise. Each change is bought by its own assertion
+  # here, and each reason is recorded in DESIGN_NOTES rather than left to be
+  # deduced from the diff.
+  describe "MODES + LINELEN — the three behaviour changes (#1390)" do
+    test "a MODES repeated within ONE 005 line honours the LAST occurrence" do
+      # WAS: `extract_modes_isupport/2` was a `reduce_while` that `:halt`ed on
+      # the first parseable hit, so this line yielded 4. A repeated token is
+      # draft-brocklesby §2's way to CORRECT a value; ignoring the correction
+      # is the worse surprise, and `raw` — the archive the Phase 6 facade
+      # reads — already honoured the last one.
+      merged = ISupport.merge_isupport(["grappa-test", "MODES=4", "MODES=6"], ISupport.default())
+      assert ISupport.modes(merged) == 6
+    end
+
+    test "a LINELEN repeated within ONE 005 line honours the LAST occurrence" do
+      # Same change on the twin token, asserted separately: the two clauses
+      # can regress on their own, and the failure should say which.
+      merged =
+        ISupport.merge_isupport(["grappa-test", "LINELEN=512", "LINELEN=480"], ISupport.default())
+
+      assert ISupport.linelen(merged) == 480
+    end
+
+    test "a malformed MODES leaves the advertised value standing" do
+      # WAS: `parse_modes_token/2` answered `{:cont, 3}` on a failed parse —
+      # it dropped the advertised value and substituted the hardcoded default,
+      # tightening the limit. Its LINELEN twin kept the prior value on the
+      # very same input (see the invariance test above): the divergence is the
+      # evidence this was a slip, not a contract. An unreadable token must not
+      # produce an arbitrary narrower limit.
+      seeded = ISupport.merge_isupport(["grappa-test", "MODES=6"], ISupport.default())
+      assert ISupport.modes(ISupport.merge_isupport(["grappa-test", "MODES=x"], seeded)) == 6
+    end
+
+    test "-MODES reverts to the seed instead of being ignored" do
+      # WAS: `"-MODES"` never matched `"MODES=" <> rest`, so a revocation was
+      # silently dropped and the advertised value survived until reconnect.
+      # §2 negation reverts to the behaviour-if-unspecified, which is
+      # `default/0`; `@negatable` records that a parsed token without an entry
+      # there is a visible omission rather than a silent one.
+      advertised = ISupport.merge_isupport(["grappa-test", "MODES=6"], ISupport.default())
+      assert ISupport.modes(advertised) == 6
+      assert ISupport.modes(ISupport.merge_isupport(["grappa-test", "-MODES"], advertised)) == 3
+    end
+
+    test "-LINELEN reverts to the seed instead of being ignored" do
+      advertised = ISupport.merge_isupport(["grappa-test", "LINELEN=480"], ISupport.default())
+      assert ISupport.linelen(advertised) == 480
+
+      assert ISupport.linelen(ISupport.merge_isupport(["grappa-test", "-LINELEN"], advertised)) ==
+               512
+    end
+  end
+
   # #1255 — draft-brocklesby-irc-isupport-03 §2: "-PARAMETER" is "used to
   # negate a previously specified parameter; that is, revert to the
   # behaviour that would occur if the parameter had not been specified".

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3426,7 +3426,10 @@ defmodule Grappa.Session.ServerTest do
       # is safe here: the session is idle between handshake and the next
       # send_privmsg call.
       linelen = 512
-      :sys.replace_state(pid, fn state -> %{state | linelen: linelen} end)
+
+      :sys.replace_state(pid, fn state ->
+        %{state | isupport: Map.put(state.isupport, :linelen, linelen)}
+      end)
 
       budget = linelen - Grappa.IRC.LineSplit.relay_frame_overhead("#sniffo")
       # A body spanning three full budgets → a deterministic ≥ 3 fragments.

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -308,6 +308,45 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #1390 slice 3 — MODES= and LINELEN= were the last two 005 tokens parsed
+  # outside `ISupport`, into two bare integers on state. They now live in the
+  # capability table the same 005 already fills. Same two-pin split as the
+  # bundles above: forgetting to ADD them to the table and forgetting to
+  # REMOVE the two loose keys are different mistakes.
+  @isupport_scanner_keys ~w[modes_per_chunk linelen]a
+
+  describe "ISUPPORT MODES/LINELEN bundle (#1390)" do
+    test "a live session carries both limits inside the capability table" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      isupport = :sys.get_state(pid).isupport
+      # The RAW keys, not the accessors: an accessor answers the seed even
+      # when the key is missing (that fallback is its hot-reload contract, and
+      # `isupport_test.exs` pins it), so reading through it would pass on a
+      # table that never learned the fields.
+      assert Map.fetch!(isupport, :modes) == 3
+      assert Map.fetch!(isupport, :linelen) == 512
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "the two scanner names are gone from the top level of state" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      state = :sys.get_state(pid)
+      # Same pre-state guard as the bundles above: an empty map must not pass.
+      assert is_map(state) and map_size(state) > 10
+
+      assert Enum.filter(@isupport_scanner_keys, &Map.has_key?(state, &1)) == []
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "DB-driven init (sub-task 2g)" do
     test "threads credential password + auth_method to IRC.Client (server_pass branch)" do
       {server, port} = start_server()
@@ -11031,7 +11070,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "/op — multi-nick with modes_per_chunk=3 produces chunked MODE lines", %{
+    test "/op — multi-nick with ISUPPORT MODES=2 produces chunked MODE lines", %{
       server: server,
       user: user,
       network: network,
@@ -11048,6 +11087,38 @@ defmodule Grappa.Session.ServerTest do
 
       assert {:ok, "MODE #test +o carol\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE #test +o carol\r\n"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1390 slice 3 — the observable half of the last-wins change. The unit
+    # test in `isupport_test.exs` buys the RULE and the state pins buy the
+    # WIRING; neither shows a user-visible difference. This one does: under
+    # the `reduce_while` scanner this slice deletes, the line below yielded 4
+    # and grappa emitted ONE `+oooo` line. It is the same repeated-token input
+    # asserted where the operator actually sees it.
+    test "/op — a 005 line repeating MODES chunks by the LAST value (#1390)", %{
+      server: server,
+      user: user,
+      network: network,
+      pid: pid
+    } do
+      IRCServer.feed(server, ":irc.test.org 005 grappa-test MODES=4 MODES=2 :are supported\r\n")
+      flush_server(server)
+
+      assert :ok =
+               Session.send_op({:user, user.id}, network.id, "#test", [
+                 "alice",
+                 "bob",
+                 "carol",
+                 "dave"
+               ])
+
+      assert {:ok, "MODE #test +oo alice bob\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "MODE #test +oo alice bob\r\n"), 1_000)
+
+      assert {:ok, "MODE #test +oo carol dave\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "MODE #test +oo carol dave\r\n"), 1_000)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Third slice of the bucket-A session decomposition. `MODES=` and `LINELEN=`
were the last two ISUPPORT tokens parsed outside `Grappa.Session.ISupport`:
`Session.Server` scanned them with a pair of `reduce_while` helpers into two
loose integers on state, while `merge_isupport/2` folded the other fifteen —
and archived those same two tokens verbatim in `raw`, so one 005 line was
being parsed twice under two merge rules. The module's own `raw` typedoc has
been promising *"one 005, two readers, no second parse"* while the second
parse sat 3,400 lines away.

They are typed fields of the capability table now, on the same `put_limit/3`
the #1255 length limits use, with `@negatable` entries and accessors whose
`Map.get/3` default carries the hot-reload contract. Two keys leave the
session state map (76 → 74); ~40 lines of scanner and one dead public
function go with them.

## Three behaviour changes, decided deliberately

The two parsers did not agree on the same input, so there was no single
"current behaviour" to preserve — unifying **forced** a choice. Each is bought
by its own named test and recorded in DESIGN_NOTES rather than left to be
deduced from the diff:

1. **A token repeated within ONE 005 line now honours the LAST occurrence.**
   The scanners halted on the first parseable hit. A repeat is
   draft-brocklesby §2's way to CORRECT a value, and `raw` already honoured
   the last one.
2. **A malformed `MODES=` no longer resets to the hardcoded 3.** Its LINELEN
   twin kept the prior value on that same input; two twins diverging on one
   input is a slip, not a contract.
3. **`-MODES` / `-LINELEN` revoke.** `"-MODES"` never matched
   `"MODES=" <> rest`, so a §2 negation was silently dropped. `@negatable`
   already documents that a parsed token missing from it is a visible
   omission.

## What deliberately did not move

`Session.Wire.isupport_changed/3` keeps its arity and payload, and the
`:session_snapshot` reply keeps its own `linelen:` key — both are client
contract. `LineSplit` and `ModeChunker` keep taking the number as a
parameter: already pure, already outside. Tokens in `raw` with no second
parser stay untyped.

The #1108 disjunct on the broadcast gate is gone, and not merely because the
field moved inside the table it was compared against: `archive_token/2`
writes EVERY advertised token into `raw`, so any 005 changing LINELEN or
MODES had already moved that table. The reasoning is in the comment, since
#1108 exists because this gate was got wrong once.

## Evidence

- `scripts/check.sh` **RC=0**, whole chain: Credo `6111 mods/funs, found no
  issues`; `8 doctests, 61 properties, 6507 tests, 0 failures`; Dialyzer
  `Total errors: 0`; Sobelow, wireTypes drift gate and bats past it. The test
  delta is **+12 exactly** against slice 2's 6495 — the 9 new unit tests plus
  the 3 session ones.
- **The red was read before the green**, by displacement (lib at the parent
  commit, tests at HEAD): 9 failures in `isupport_test.exs`, 3 in
  `server_test.exs` — the two structural pins and the observable one — and no
  other test in either file.
- **Eight mutants executed**, not predicted. The three behaviour changes are
  exclusive: a first-wins guard kills the repeated-token test in the unit file
  *and* its session twin (one assertion each, no third); reinstating the
  reset-to-3 kills only the malformed-token test; dropping one `@negatable`
  entry at a time kills only its own negation test.

## Two predictions the measurement corrected

Reported rather than quietly dropped:

- I predicted that moving the seed in `default/0` would kill the
  `default/0` test and nothing else. It also kills the `-MODES` test: the
  seed `3` is pinned by three assertions, because a negation restores
  `default/0` and that test asserts the literal. The exclusivity was an
  armchair claim.
- I predicted that removing both seeds from `default/0` would kill only the
  state pin. The interesting half held — the accessor-based assertion stays
  green while the raw-key pin dies, which is exactly why one is written with
  the accessor and the other with `Map.fetch!` — but it also kills both
  negation tests, because `@negatable` restores through
  `Map.fetch!(default(), key)` and raises without the key. `default/0` and
  `@negatable` are coupled by construction.

## Not established

No `scripts/integration.sh` run: that lane was not mine. The exclusivity of
two boundary-group mutants was not executed, only predicted. Whether an ircd
in the wild repeats `MODES=` within one line or sends `-MODES` is not
established and is not load-bearing — the slice is justified by the internal
divergence.