### PR TITLE
test(#1393): census the user-topic wire boundary arm by arm

### DIFF
--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -13,9 +13,18 @@ import { validate } from "../lib/wireValidate";
 // list. For each arm it synthesises a valid payload from the GENERATED
 // schema, mutates it field by field, and records what the hand narrower and
 // the schema each do with it. Arms where the two agree are a proved dead end
-// — nothing to gain by swapping them. Arms where the hand narrower ACCEPTS
-// what the schema rejects are permissiveness holes, and they are the only
-// place a migration buys safety rather than line count.
+// — nothing to gain by swapping them.
+//
+// A disagreement is measured in BOTH directions, because they cost opposite
+// things and one alone cannot settle whether an arm is worth migrating:
+//
+//   * the hand narrower ACCEPTS what the schema rejects — a permissiveness
+//     hole, the only place a migration buys safety rather than line count;
+//   * the schema ACCEPTS what the hand narrower rejects — strictness the
+//     migration would silently LOSE, since the typespec is the looser of the
+//     two and swapping in the generated check drops the hand-written guard.
+//
+// Measuring one direction only would report an asymmetry as a parity.
 //
 // Arms are matched to schemas by their `kind` LITERAL, not by a camelised
 // name: the name heuristic missed three arms whose schema lives under a
@@ -97,6 +106,7 @@ type ArmReport = {
   schema: string;
   fields: number;
   handAcceptsSchemaRejects: string;
+  schemaAcceptsHandRejects: string;
   schemaRejectsValid: boolean;
 };
 
@@ -106,15 +116,17 @@ function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport 
   const fields = Object.keys(valid).filter((f) => f !== "kind");
 
   const holes: string[] = [];
+  const losses: string[] = [];
   for (const f of fields) {
     for (const [label, mutated] of [
       ["drop", without(valid, f)],
       ["null", { ...valid, [f]: null }],
       ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
     ] as const) {
-      if (verdict(hand, mutated) === "accept" && verdict(generated, mutated) === "reject") {
-        holes.push(`${f}/${label}`);
-      }
+      const byHand = verdict(hand, mutated);
+      const bySchema = verdict(generated, mutated);
+      if (byHand === "accept" && bySchema === "reject") holes.push(`${f}/${label}`);
+      if (bySchema === "accept" && byHand === "reject") losses.push(`${f}/${label}`);
     }
   }
 
@@ -123,6 +135,7 @@ function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport 
     schema: schemaName,
     fields: fields.length,
     handAcceptsSchemaRejects: holes.length === 0 ? "-" : holes.join(", "),
+    schemaAcceptsHandRejects: losses.length === 0 ? "-" : losses.join(", "),
     // The oracle's own sanity check: a schema that rejects its OWN sample
     // means the sampler and the schema disagree, and every verdict on that
     // arm is noise rather than a measurement.
@@ -160,6 +173,17 @@ const weakened: Narrower = (raw) => {
   if (typeof raw !== "object" || raw === null) return null;
   const r = raw as Record<string, unknown>;
   return typeof r.network === "string" ? { kind: "away_confirmed", ...r } : null;
+};
+
+// The control for the OTHER direction, which needs its own mutant: an arm
+// agreeing in one direction says nothing about the other. `whowas_bundle`'s
+// `user` is `string | null` in the typespec, so the schema accepts a null the
+// hand narrower here refuses ON PURPOSE — and `user/null` has to show up as a
+// loss.
+const strengthened: Narrower = (raw) => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  return typeof r.user === "string" ? { kind: "whowas_bundle", ...r } : null;
 };
 
 // The 42 `case` labels of `narrowUserEvent`, transcribed from the switch so
@@ -228,6 +252,24 @@ describe("#1393 — user-topic boundary census", () => {
     `);
   });
 
+  it("detects a strengthened boundary (control for the second direction)", () => {
+    const node = candidatesFor("whowas_bundle")[0].node;
+    const valid = sample(node) as Record<string, unknown>;
+    const generated: Narrower = (raw) => validate(node, raw);
+    const losses = Object.keys(valid)
+      .filter((f) => f !== "kind")
+      .filter(
+        (f) =>
+          verdict(generated, { ...valid, [f]: null }) === "accept" &&
+          verdict(strengthened, { ...valid, [f]: null }) === "reject",
+      );
+    expect(losses).toMatchInlineSnapshot(`
+      [
+        "user",
+      ]
+    `);
+  });
+
   // Reconciliation. The census walks SCHEMAS (indexed by kind literal), while
   // the thing under test is the hand `switch` in `userTopic.ts`. Those two
   // sets are not the same by construction, so the difference is reported
@@ -257,23 +299,33 @@ describe("#1393 — user-topic boundary census", () => {
     const reports = handArms.flatMap((k) =>
       candidatesFor(k).map(({ name, node }) => censusArm(k, name, node)),
     );
-    const holes = reports.filter((r) => r.handAcceptsSchemaRejects !== "-");
+    const divergent = reports.filter(
+      (r) => r.handAcceptsSchemaRejects !== "-" || r.schemaAcceptsHandRejects !== "-",
+    );
+    // Counted over distinct ARMS, not over reports: an ambiguous `kind`
+    // literal is censused once per candidate schema, so `reports.length`
+    // overcounts the boundary by however many duplicates the wire happens to
+    // carry. The parity figure the verdict rests on is an arm count.
+    const divergentArms = new Set(divergent.map((r) => r.arm));
     expect({
       armsWithSchema: handArms.length,
       armsCensused: reports.length,
+      armsAtParity: handArms.length - divergentArms.size,
       brokenOracles: reports.filter((r) => r.schemaRejectsValid).map((r) => r.arm),
-      holes,
+      divergent,
     }).toMatchInlineSnapshot(`
       {
+        "armsAtParity": 34,
         "armsCensused": 43,
         "armsWithSchema": 42,
         "brokenOracles": [],
-        "holes": [
+        "divergent": [
           {
             "arm": "bundle_hash",
             "fields": 2,
             "handAcceptsSchemaRejects": "version/null, version/wrong-type",
             "schema": "S_CicWireBundleHashPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -281,6 +333,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 2,
             "handAcceptsSchemaRejects": "http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type",
             "schema": "S_ServerSettingsWireChangedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -288,6 +341,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 4,
             "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
             "schema": "S_SessionWireBanlistBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -295,6 +349,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 15,
             "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
             "schema": "S_SessionWireIsupportChangedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -302,6 +357,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 3,
             "handAcceptsSchemaRejects": "mask/drop",
             "schema": "S_SessionWireLinksBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -309,6 +365,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 13,
             "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
             "schema": "S_SessionWireLusersBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -316,6 +373,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 30,
             "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
             "schema": "S_SessionWireWhoisBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -323,6 +381,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 4,
             "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
             "schema": "S_SessionWireWindowInvitedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
         ],

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import { narrowUserEvent } from "../lib/userTopic";
+import * as schemas from "../lib/wireSchema";
+import type { WireNode } from "../lib/wireValidate";
+import { validate } from "../lib/wireValidate";
+
+// #1393 — the mutate-every-field MEASUREMENT `wireAdminBoundary` applies to
+// the admin channel, pointed at the WHOLE user topic.
+//
+// `userTopic.ts` hand-narrows 42 arms and uses zero generated schemas, while
+// a schema for every one of those arms is already emitted next to it. The
+// review calls that an arrested migration; this file turns the claim into a
+// list. For each arm it synthesises a valid payload from the GENERATED
+// schema, mutates it field by field, and records what the hand narrower and
+// the schema each do with it. Arms where the two agree are a proved dead end
+// — nothing to gain by swapping them. Arms where the hand narrower ACCEPTS
+// what the schema rejects are permissiveness holes, and they are the only
+// place a migration buys safety rather than line count.
+//
+// Arms are matched to schemas by their `kind` LITERAL, not by a camelised
+// name: the name heuristic missed three arms whose schema lives under a
+// differently-named Wire module.
+//
+// `kind` is excluded from the mutation matrix on purpose. Mutating the
+// discriminator tests DISPATCH, not field validation: the hand narrower
+// falls through its switch while the schema rejects a literal mismatch —
+// same verdict, different mechanism, no information about the boundary.
+
+type Narrower = (raw: unknown) => unknown;
+
+const hand: Narrower = (raw) => narrowUserEvent(raw);
+
+function sample(node: WireNode): unknown {
+  if (typeof node === "string") {
+    switch (node) {
+      case "s":
+        return "sample";
+      case "i":
+        return 1;
+      case "b":
+        return true;
+      case "z":
+        return null;
+      case "x":
+        return { opaque: true };
+    }
+  }
+  if ("l" in node) return node.l;
+  if ("e" in node) return node.e[0];
+  if ("a" in node) return [sample(node.a)];
+  if ("r" in node) return { key: sample(node.r) };
+  if ("p" in node) return node.p.map(sample);
+  if ("u" in node) return sample(node.u[0] as WireNode);
+  return Object.fromEntries(Object.entries(node.o).map(([k, v]) => [k, sample(v)]));
+}
+
+function wrongType(value: unknown): unknown {
+  if (typeof value === "string") return 12345;
+  if (typeof value === "number") return "12345";
+  if (typeof value === "boolean") return "true";
+  if (Array.isArray(value)) return "not-an-array";
+  return "not-an-object";
+}
+
+function without(obj: Record<string, unknown>, field: string): Record<string, unknown> {
+  const copy = { ...obj };
+  delete copy[field];
+  return copy;
+}
+
+function verdict(narrow: Narrower, payload: unknown): "accept" | "reject" {
+  return narrow(payload) === null ? "reject" : "accept";
+}
+
+function isObjectNode(node: WireNode): node is { o: Record<string, WireNode> } {
+  return typeof node !== "string" && "o" in node;
+}
+
+// Every generated schema that carries a `kind` literal, indexed by it.
+function schemasByKind(): Map<string, Candidate[]> {
+  const out = new Map<string, Candidate[]>();
+  for (const [name, node] of Object.entries(schemas) as [string, WireNode][]) {
+    if (!name.startsWith("S_") || !isObjectNode(node)) continue;
+    const k = node.o.kind;
+    if (k === undefined || typeof k === "string" || !("l" in k)) continue;
+    const list = out.get(k.l as string) ?? [];
+    list.push({ name, node });
+    out.set(k.l as string, list);
+  }
+  return out;
+}
+
+type Candidate = { name: string; node: WireNode };
+
+type ArmReport = {
+  arm: string;
+  schema: string;
+  fields: number;
+  handAcceptsSchemaRejects: string;
+  schemaRejectsValid: boolean;
+};
+
+function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport {
+  const generated: Narrower = (raw) => validate(node, raw);
+  const valid = sample(node) as Record<string, unknown>;
+  const fields = Object.keys(valid).filter((f) => f !== "kind");
+
+  const holes: string[] = [];
+  for (const f of fields) {
+    for (const [label, mutated] of [
+      ["drop", without(valid, f)],
+      ["null", { ...valid, [f]: null }],
+      ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
+    ] as const) {
+      if (verdict(hand, mutated) === "accept" && verdict(generated, mutated) === "reject") {
+        holes.push(`${f}/${label}`);
+      }
+    }
+  }
+
+  return {
+    arm: kind,
+    schema: schemaName,
+    fields: fields.length,
+    handAcceptsSchemaRejects: holes.length === 0 ? "-" : holes.join(", "),
+    // The oracle's own sanity check: a schema that rejects its OWN sample
+    // means the sampler and the schema disagree, and every verdict on that
+    // arm is noise rather than a measurement.
+    schemaRejectsValid: verdict(generated, valid) === "reject",
+  };
+}
+
+const BY_KIND = schemasByKind();
+// An ambiguous kind literal (`web_session_severed` is emitted by two Wire
+// modules) is kept if ANY of its candidate schemas produces a sample the hand
+// narrower accepts — and every candidate is then censused, so the arm cannot
+// fall out of the list because the first candidate happened to be the wrong
+// module's.
+const accepts = (k: string): boolean =>
+  candidatesFor(k).some(({ node }) => verdict(hand, sample(node)) === "accept");
+
+const ARMS = [...BY_KIND.keys()];
+
+// Every schema whose `kind` literal is this one. Throws rather than returning
+// empty: `ARMS` is derived from the same map, so a miss here would mean the
+// map changed under the walk, and a census that silently skipped an arm is
+// worse than one that stops.
+function candidatesFor(kind: string): [Candidate, ...Candidate[]] {
+  const found = BY_KIND.get(kind);
+  if (found === undefined || found.length === 0) {
+    throw new Error(`no generated schema carries the kind literal "${kind}"`);
+  }
+  return found as [Candidate, ...Candidate[]];
+}
+
+// The control. Two boundaries agreeing means nothing unless the matrix can
+// tell them apart, so this one is weakened ON PURPOSE — it skips the `state`
+// check — and `state` has to show up as a hole.
+const weakened: Narrower = (raw) => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  return typeof r.network === "string" ? { kind: "away_confirmed", ...r } : null;
+};
+
+// The 42 `case` labels of `narrowUserEvent`, transcribed from the switch so
+// the reconciliation below has a reference OUTSIDE the schema walk.
+const HAND_SWITCH_ARMS = [
+  "archive_changed",
+  "archive_purged",
+  "auto_away_debounce_changed",
+  "away_confirmed",
+  "banlist_bundle",
+  "bundle_hash",
+  "channels_changed",
+  "connection_progress",
+  "connection_state_changed",
+  "directory_complete",
+  "directory_failed",
+  "directory_progress",
+  "invite_ack",
+  "isupport_changed",
+  "join_failed",
+  "joined",
+  "kicked",
+  "links_bundle",
+  "lusers_bundle",
+  "mentions_bundle",
+  "names_reply",
+  "notify_list",
+  "own_nick_changed",
+  "peer_away",
+  "presence_changed",
+  "presence_error",
+  "presence_snapshot",
+  "query_windows_list",
+  "recover_progress",
+  "recover_result",
+  "server_reply",
+  "server_settings_changed",
+  "session_identity_changed",
+  "supported_umodes_changed",
+  "umode_changed",
+  "web_session_severed",
+  "who_reply",
+  "whois_bundle",
+  "whowas_bundle",
+  "window_invite_declined",
+  "window_invited",
+  "window_pending",
+] as const;
+
+describe("#1393 — user-topic boundary census", () => {
+  it("detects a weakened boundary (control for the matrix itself)", () => {
+    const node = candidatesFor("away_confirmed")[0].node;
+    const valid = sample(node) as Record<string, unknown>;
+    const generated: Narrower = (raw) => validate(node, raw);
+    const holes = Object.keys(valid)
+      .filter((f) => f !== "kind")
+      .filter(
+        (f) =>
+          verdict(weakened, { ...valid, [f]: null }) === "accept" &&
+          verdict(generated, { ...valid, [f]: null }) === "reject",
+      );
+    expect(holes).toMatchInlineSnapshot(`
+      [
+        "state",
+      ]
+    `);
+  });
+
+  // Reconciliation. The census walks SCHEMAS (indexed by kind literal), while
+  // the thing under test is the hand `switch` in `userTopic.ts`. Those two
+  // sets are not the same by construction, so the difference is reported
+  // rather than assumed away: a hand arm missing from the census is an arm
+  // nobody measured, and a censused kind absent from the switch belongs to a
+  // different topic and its verdict says nothing about this one.
+  it("reconciles the censused set against the hand switch", () => {
+    const censused = new Set(ARMS.filter(accepts));
+    const handSwitch = new Set<string>(HAND_SWITCH_ARMS);
+    expect({
+      handArms: handSwitch.size,
+      censused: censused.size,
+      inSwitchNotCensused: [...handSwitch].filter((k) => !censused.has(k)),
+      censusedNotInSwitch: [...censused].filter((k) => !handSwitch.has(k)),
+    }).toMatchInlineSnapshot(`
+      {
+        "censused": 42,
+        "censusedNotInSwitch": [],
+        "handArms": 42,
+        "inSwitchNotCensused": [],
+      }
+    `);
+  });
+
+  it("censuses every hand-narrowed arm against its generated schema", () => {
+    const handArms = ARMS.filter(accepts);
+    const reports = handArms.flatMap((k) =>
+      candidatesFor(k).map(({ name, node }) => censusArm(k, name, node)),
+    );
+    const holes = reports.filter((r) => r.handAcceptsSchemaRejects !== "-");
+    expect({
+      armsWithSchema: handArms.length,
+      armsCensused: reports.length,
+      brokenOracles: reports.filter((r) => r.schemaRejectsValid).map((r) => r.arm),
+      holes,
+    }).toMatchInlineSnapshot(`
+      {
+        "armsCensused": 43,
+        "armsWithSchema": 42,
+        "brokenOracles": [],
+        "holes": [
+          {
+            "arm": "bundle_hash",
+            "fields": 2,
+            "handAcceptsSchemaRejects": "version/null, version/wrong-type",
+            "schema": "S_CicWireBundleHashPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "server_settings_changed",
+            "fields": 2,
+            "handAcceptsSchemaRejects": "http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type",
+            "schema": "S_ServerSettingsWireChangedPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "banlist_bundle",
+            "fields": 4,
+            "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
+            "schema": "S_SessionWireBanlistBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "isupport_changed",
+            "fields": 15,
+            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
+            "schema": "S_SessionWireIsupportChangedPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "links_bundle",
+            "fields": 3,
+            "handAcceptsSchemaRejects": "mask/drop",
+            "schema": "S_SessionWireLinksBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "lusers_bundle",
+            "fields": 13,
+            "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
+            "schema": "S_SessionWireLusersBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "whois_bundle",
+            "fields": 30,
+            "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
+            "schema": "S_SessionWireWhoisBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "window_invited",
+            "fields": 4,
+            "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
+            "schema": "S_SessionWireWindowInvitedPayload",
+            "schemaRejectsValid": false,
+          },
+        ],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## What this is

A **measurement** of the user-topic wire boundary, not a migration. `cicchetto/src/__tests__/wireUserBoundary.test.ts` points the existing `wireAdminBoundary` mutate-every-field harness at `narrowUserEvent`, so that bucket D of the architecture review (#1393) can be sized from a list instead of by eye.

**No arm is converted here.** `userTopic.ts` is untouched; this is one test file, zero production change.

## Why

`userTopic.ts` hand-narrows 42 arms and uses zero generated schemas, while a schema for every one of those arms is already emitted next to it. #1393 proposes continuing the migration arm by arm — but a swap that changes no verdict buys line count, and a swap that closes a real permissiveness hole buys safety. Nothing said which arms were which, so every slice was sized by guess.

## The census

Reconciled both ways rather than asserted — the walk goes over schemas indexed by `kind` literal, and is checked against the hand `switch`:

| | |
|---|---|
| arms in the hand `switch` | **42** |
| arms censused | **42** |
| in switch, not censused | none |
| censused, not in switch | none |
| census runs | 43 (one arm against two candidate schemas) |
| schemas rejecting their own sample | none |

Matching by `kind` literal rather than a camelised name is load-bearing: three arms (`connection_state_changed`, `query_windows_list`, `server_settings_changed`) have schemas under differently-named Wire modules, and the name heuristic reports them as missing. `web_session_severed` has two candidates (`S_AdminEventsWire…`, `S_RateLimitWire…`) and is censused against both.

### Both directions, because they cost opposite things

A disagreement is measured twice, and one direction alone cannot settle whether an arm is worth migrating:

* **hand ACCEPTS what the schema REJECTS** — a permissiveness hole, the only place a migration buys safety rather than line count;
* **schema ACCEPTS what the hand REJECTS** — strictness the migration would silently LOSE, since the typespec is the looser of the two and swapping in the generated check drops the hand-written guard.

Measured on `origin/main`: **8 arms diverge in the first direction, ZERO in the second.** The parity figure `armsAtParity: 34` is derived in the snapshot, over distinct arms rather than reports (an ambiguous `kind` literal is censused once per candidate and would otherwise overcount the boundary).

⚠️ **An earlier revision of this PR measured only the first direction and reported the 34 as "full parity".** That was a stronger claim than the measurement supported: with one direction, an asymmetry reads as a parity. The second direction is now measured, and it came back empty — so the parity holds, but it holds as a result rather than as an assumption.

### 34 arms at parity — a proved dead end

Neither direction disagrees. Migrating these buys line count, not safety:

`archive_changed`, `archive_purged`, `auto_away_debounce_changed`, `away_confirmed`, `channels_changed`, `connection_progress`, `connection_state_changed`, `directory_complete`, `directory_failed`, `directory_progress`, `invite_ack`, `join_failed`, `joined`, `kicked`, `mentions_bundle`, `names_reply`, `notify_list`, `own_nick_changed`, `peer_away`, `presence_changed`, `presence_error`, `presence_snapshot`, `query_windows_list`, `recover_progress`, `recover_result`, `server_reply`, `session_identity_changed`, `supported_umodes_changed`, `umode_changed`, `web_session_severed`, `who_reply`, `whowas_bundle`, `window_invite_declined`, `window_pending`.

### 8 arms where the hand narrower ACCEPTS what the schema REJECTS

| arm | fields | divergence (field/mutation) |
|---|---|---|
| `isupport_changed` | 15 | `list_modes_queryable`, `prefix_order`, `chantypes`, `casemapping`, `maxlist` (drop/null/wrong-type); `nicklen`, `channellen`, `topiclen` (drop/wrong-type); `frame_budget_base` (drop/null/wrong-type) |
| `lusers_bundle` | 13 | twelve numeric fields, drop + wrong-type each |
| `whois_bundle` | 30 | `source` (drop/null/wrong-type), `extra_lines` (drop) |
| `banlist_bundle` | 4 | `mode` (drop/null/wrong-type) |
| `window_invited` | 4 | `inviter` (drop/null/wrong-type) |
| `server_settings_changed` | 2 | `http_host_aliases` (drop/null/wrong-type) |
| `bundle_hash` | 2 | `version` (null/wrong-type) |
| `links_bundle` | 3 | `mask` (drop) |

## The verdict: every one of the 8 is divergent BY POLICY

A divergence has two readings — a deliberate tolerance to preserve, or unintended permissiveness to close — and `wireValidate.ts:18-31` states which side of that line the generated interpreter deliberately does not cross:

> A narrower is not just types — it is the defence at the boundary, and part of that defence is a judgement call the typespec cannot express: a DEFAULT that rescues an event instead of dropping it; a TOLERANCE toward a payload minted by a peer of a different vintage (cic deploys independently of the server) […] Those stay hand-written at the call site, named as policy.

Read arm by arm against the source, **all eight already carry that ruling in writing, with the issue number that made it**:

| arm | written rationale | issue |
|---|---|---|
| `isupport_changed` | five named fallbacks — `list_modes_queryable`→`["b"]`, `prefix_order`→`[]`, `chantypes`→the RFC 2812 sigil class, `casemapping`→`ascii`, `maxlist`→`{}` — plus `frame_budget_base`→`null` | #1251, #1302, #1255, #1108 |
| `lusers_bundle` | "per-field null-coercion of a non-number is RETAINED deliberately": a display-only card, one garbled optional count must not blow away the eleven good ones | codebase review S44, 2026-07-08 |
| `whois_bundle` | `source`: "Tolerant, NOT a drop condition (old servers omit it)"; `extra_lines`: optional, `undefined` tolerated | #606, #221 |
| `server_settings_changed` | `http_host_aliases`: "a malformed / absent value degrades to []" — dropping instead would strand the byte caps too | #324 |
| `bundle_hash` | `version`: "Normalise absent / malformed → null" | #292 |
| `links_bundle` | `mask`: absent → `null`, and a wrong type is **explicitly rejected** by a dedicated guard | #513a |
| `window_invited` | `inviter`: absent → the `"*"` sentinel, "so the banner has one nameless shape, not two" | #902 |
| `banlist_bundle` | `mode`: absent → `"b"`, "additive-tolerant like `links_bundle`'s `mask`" | #1251 |

So the count that matters is not 8 divergences but **zero arms worth migrating**: the 34 buy line count, and each of the 8 would reverse a decision that is written down, numbered, and load-bearing for cross-vintage deploys. `frame_budget_base` (#1108) is not the exception in that list — it is the typical case.

**Whether #1393 closes on this is not decided here** — the issue stays open, and the ruling belongs to its owner. This PR supplies the measurement it would rest on.

**One follow-up is arbitrated and ships separately.** `banlist_bundle.mode` is the only arm whose rationale falsifies itself: it claims parity with `links_bundle`'s `mask`, but `links_bundle` writes a guard rejecting a wrong-typed value and `banlist_bundle` coerces one to `"b"` — rendering a bundle as the ban list when it is not. That is a behaviour change and gets its own PR; the #1251 absent-tolerance survives, named.

## A correction to the issue's unused-type count, by method

#1393 states "165 generated types, 73 with no consumer". Re-measured at `a60082eb`: **187 generated**, **87 named outside** the generated files, but **153 reached structurally** inside a consumed aggregate — leaving **34 genuinely inert**. A name-based count reports 100, i.e. **66 false positives**.

This bears directly on the issue's fourth proposed direction: a gate failing on "a generated type with no importer", implemented the obvious way, would be wrong about two thirds of what it flags. It has to walk reachability, not names.

## Why the numbers are trustworthy

- **A positive control per direction.** A deliberately weakened narrower (the `state` check removed) is caught as a hole, reporting `["state"]`. A deliberately strengthened one (refusing a `whowas_bundle.user` null the typespec allows) is caught as a loss, reporting `["user"]`. An arm agreeing in one direction says nothing about the other, so a zero in the second column needs its own mutant or it means "blind", not "measured".
- **The second column was probed inside the census itself**, not only in its control: making `hand` reject `whowas_bundle.user === null` surfaces `whowas_bundle → user/null` and drops `armsAtParity` from 34 to 33. One mutant, exactly those two assertions, reverted after the reading.
- **Oracle checked from outside**: every arm asserts the schema accepts its own sample. None failed — had one failed, that arm's verdicts would be noise rather than measurement.
- **Two-way reconciliation** against the 42 `case` labels transcribed from the switch, a reference outside the schema walk.
- `kind` is excluded from the matrix on purpose: mutating the discriminator exercises dispatch, not field validation. Both sides reject it by different mechanisms (switch fallthrough vs literal mismatch) — an identical verdict carrying no information.

## What this does NOT establish

- **Not that the 34 are correct.** They are *the same as each other in both directions*, not *right*. If the schema is wrong and the hand arm is wrong the same way, this reads as parity. `wireAdminBoundary`'s recorded SHAPES are the anchor against exactly that, and they are **not** replicated here.
- **Not that the seven preserved tolerances are the right calls** — only that they are deliberate and written down. Whether each premise still holds (a BEAM of that vintage still in the field) is unmeasured.
- **Mutations are three** (drop / null / wrong-type) and **first-level fields only**: no nested mutation, no empty arrays, no out-of-enum strings. A deeper hole would not show.
- **Field-by-field agreement between the 42 schemas and the SERVER contract is unmeasured.** This compares two client-side boundaries against each other, not the client against the server.
- **No claim that a wrong-typed `banlist_bundle.mode` was ever observed in production.** The follow-up rests on an inconsistency between two sibling arms, measured in the source, not on an incident.

## Gates

- `bun run check` rc 0 — biome plus **both** `tsc` invocations. Worth stating: a biome failure short-circuits that chain, so a green recorded before the last edit is not a green, and the type checks it "passed" never ran.
- `bun run test` rc 0 — 290 files / 5587 tests.

#1393 stays open: this measures the bucket, it does not migrate it.
