### PR TITLE
fix(#1393): stop coercing a mangled banlist `mode` into the ban list

### DIFF
--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1575,6 +1575,40 @@ describe("userTopic", () => {
       });
       expect(bc.setBanlistBundle).not.toHaveBeenCalled();
     });
+
+    // #1393 — the #1251 tolerance is for a server that predates `mode`, and
+    // that server sends no key at all. A key that IS there carrying something
+    // other than a letter is mangling, and coercing it to "b" renders whatever
+    // list arrived under the "Bans" heading — the exact mis-attribution #1251
+    // added the field to end. `Grappa.Session.Wire.banlist_bundle_payload/0`
+    // declares `mode` a plain required string, so neither of these two shapes
+    // can come from any grappa.
+    it("drops payload with a non-string `mode` (mangled, not an older server)", async () => {
+      const bc = await import("../lib/banlistCard");
+      channelMock.fireEvent({
+        kind: "banlist_bundle",
+        network: "azzurra",
+        channel: "#test",
+        mode: 42,
+        entries: [],
+      });
+      expect(bc.setBanlistBundle).not.toHaveBeenCalled();
+    });
+
+    // Unlike `links_bundle.mask`, which IS `string | null` in the typespec and
+    // so tolerates an explicit null, `mode` is non-nullable: a null is as
+    // impossible on the wire as a number.
+    it("drops payload with a null `mode`", async () => {
+      const bc = await import("../lib/banlistCard");
+      channelMock.fireEvent({
+        kind: "banlist_bundle",
+        network: "azzurra",
+        channel: "#test",
+        mode: null,
+        entries: [],
+      });
+      expect(bc.setBanlistBundle).not.toHaveBeenCalled();
+    });
   });
 
   describe("invite_ack arm (P-0e + P-0f)", () => {

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -881,6 +881,16 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         !Array.isArray(r.entries)
       )
         return null;
+      // #1251 — WHICH list this is, and the tolerance is for ABSENCE only: a
+      // grappa predating the field omits the key entirely and could only ever
+      // have sent the ban list, so absent means `b` (unknown-is-never-fatal,
+      // #447). #1393 — a key that IS present carrying a non-string is
+      // mangling, not an older peer, and coercing it to `b` would render
+      // whatever list arrived under the "Bans" heading: the mis-attribution
+      // #1251 exists to end. Stricter than `links_bundle`'s `mask`, which this
+      // arm used to claim to mirror, only because the typespecs differ —
+      // `mask` is `string | null`, `mode` is a plain required string.
+      if (r.mode !== undefined && typeof r.mode !== "string") return null;
       const entries: BanlistEntry[] = [];
       for (const raw of r.entries) {
         const entry = narrowBanlistEntry(raw);
@@ -891,9 +901,6 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         kind: "banlist_bundle",
         network: r.network,
         channel: r.channel,
-        // #1251 — WHICH list this is. Additive-tolerant like links_bundle's
-        // `mask`: a grappa that predates the field could only ever have sent
-        // the ban list, so absent means `b` (unknown-is-never-fatal, #447).
         mode: typeof r.mode === "string" ? r.mode : "b",
         entries,
       };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46526,3 +46526,79 @@ how pins disappear one at a time.
 
 _Not measured here: nothing in this entry claims a verdict for the full
 suite or the type gates; those are a separate run._
+<!-- entry #1393 -->
+
+---
+
+## 2026-08-17 — #1393: a tolerance may only be as wide as the typespec it excuses
+
+`banlist_bundle`'s narrower in `userTopic.ts` coerced any non-string `mode`
+— a number, an explicit `null` — into `"b"`. It now drops such a payload.
+Absent `mode` still means `b`. The change is small; the reason it is
+recorded here is that the arm's own comment argued for the old behaviour,
+so the code alone reads as a regression against a written policy.
+
+### The comment named a model stricter than itself
+
+The fallback justified itself as "additive-tolerant like `links_bundle`'s
+`mask`". The two arms did not implement the same policy. `links_bundle`
+guards its field —
+
+```ts
+if (r.mask !== undefined && r.mask !== null && typeof r.mask !== "string") return null;
+```
+
+— and drops a wrong-typed `mask`. `banlist_bundle` had no guard, so
+`typeof r.mode === "string" ? r.mode : "b"` swallowed everything. An arm
+claiming parity with a sibling that is strictly stricter is the kind of
+divergence a reader cannot see without opening both files, which is why it
+survived from #1251 to here.
+
+### Why the fix is STRICTER than the model it imitates
+
+Not zeal — the typespecs differ, and that difference is the whole ruling:
+
+| wire typespec | field | so an explicit `null` is |
+|---|---|---|
+| `Grappa.Session.Wire.links_bundle_payload/0` | `mask: string \| null` | a shape the server really sends → tolerated |
+| `Grappa.Session.Wire.banlist_bundle_payload/0` | `mode: string`, required | impossible from any grappa → dropped |
+
+So the correct port of the `mask` posture onto `mode` tolerates **absence
+only**. Absence is an older server, which is exactly and only what #1251
+excused when it added the field; **that tolerance survives, and the test
+pinning it is unchanged**. A key that is PRESENT carrying a non-string
+cannot have come from a grappa of any vintage — it is mangling.
+
+The general rule this is an instance of: **a cross-vintage tolerance is
+sized by what an older peer can actually emit, not by what the current
+narrower happens not to reject.** Read the typespec of the field before
+widening or narrowing a fallback; two fields that look alike at the call
+site can have different nullability, and the looser one is not the
+template.
+
+### Why dropping beats coercing here
+
+Two rulings point the same way. #1400 settled that the client boundary
+FAILS LOUD: a required field arriving with the wrong type is not invented.
+And #1251 added `mode` precisely so a list-mode bundle is not mislabelled —
+without it "the modal would render solanum's quiet list under a Bans
+heading". Answering a mangled value with `"b"` reinstates exactly the
+mis-attribution the field exists to prevent, which on this surface is the
+largest available surprise: the modal would assert, in its heading, a fact
+about the payload that the payload denies. An empty modal is a smaller
+lie than a confidently mislabelled one.
+
+### Provenance, and what stays unmeasured
+
+The divergence was not spotted by reading; it came out of the #1393 census
+(`cicchetto/src/__tests__/wireUserBoundary.test.ts`), which mutates every
+field of every user-topic arm against its generated schema. That census
+also settles the bucket it was built for: of 42 arms, 34 agree with their
+schema in both directions, and all 8 that diverge carry a written,
+issue-numbered rationale for diverging — `banlist_bundle` was the only one
+whose rationale falsified itself. The census measures; it migrates nothing,
+and the question of what #1393 does next is not settled here.
+
+_Not claimed: that a wrong-typed `mode` was ever observed in production.
+The finding is an inconsistency between two sibling arms, measured in the
+source, not an incident. Nothing here changes what the server emits._


### PR DESCRIPTION
## What this is

A **behaviour change**, not a cleanup. `banlist_bundle` used to coerce any non-string `mode` — a number, an explicit `null` — into `"b"`. It now drops such a payload. The absent-`mode` tolerance is untouched.

2 files, 1 production line added plus its comment, 2 tests.

## Why

The arm justified its fallback in its own comment:

> `mode`: […] Additive-tolerant **like `links_bundle`'s `mask`**: a grappa that predates the field could only ever have sent the ban list, so absent means `b` (unknown-is-never-fatal, #447).

But the two arms did not implement the same policy. `links_bundle` guards the field and drops a wrong-typed `mask`:

```ts
if (r.mask !== undefined && r.mask !== null && typeof r.mask !== "string") return null;
```

`banlist_bundle` had no such guard, so `typeof r.mode === "string" ? r.mode : "b"` swallowed everything. The arm claimed parity with a sibling that is strictly stricter than it.

**Why that matters beyond tidiness.** #1251 added `mode` precisely so a list-mode bundle is not mislabelled: without it, "the modal would render solanum's quiet list under a 'Bans' heading" (its own test says so). Coercing a mangled value to `"b"` reinstates exactly that mis-attribution — the failure mode the field exists to prevent, and about the worst possible surprise on this surface. Dropping the bundle is the least-surprising answer; the modal renders nothing rather than something false.

## Why the guard is STRICTER than the `mask` one it is modelled on

Because the typespecs differ, not because the posture does. Measured in `wireSchema.ts`:

| | typespec | so an explicit `null` is |
|---|---|---|
| `Grappa.Session.Wire.links_bundle_payload/0` → `mask` | `{ u: ["s", "z"] }` — `string \| null` | a shape the server really sends → tolerated |
| `Grappa.Session.Wire.banlist_bundle_payload/0` → `mode` | `"s"` — a plain **required** string | impossible from any grappa → dropped |

So `mode` tolerates **absence only**. A key that is absent is an older server (#1251). A key that is present carrying a non-string cannot have come from a grappa of any vintage — it is mangling, and #1400's ruling is that the client boundary fails loud rather than inventing a value for a required field.

## What still works — the #1251 tolerance survives, named

An older server sending no `mode` still lands as `b`. The test that pins it (`"calls setBanlistBundle with the bundle (kind stripped) on success path"`, which sends no `mode` and expects `mode: "b"`) is **unchanged and still passes**. So does `"carries the mode letter through to the store"`.

## The red that bought it

Written before the guard. On `origin/main` both new tests fail, and they fail by naming the defect rather than a count — the payload reaches the store with a fabricated letter:

```
FAIL  banlist_bundle arm (#376) > drops payload with a non-string `mode` (mangled, not an older server)
Received:  "mode": "b",
FAIL  banlist_bundle arm (#376) > drops payload with a null `mode`
Received:  "mode": "b",

Tests  2 failed | 157 passed (159)
```

Exactly two failures, both new; no cascade. After the guard: `159 passed (159)`.

**One mutant, one assertion.** The two tests are not redundant: replacing the guard with the *literal* `links_bundle` port (`r.mode !== undefined && r.mode !== null && typeof r.mode !== "string"`) — the version that tolerates null — kills the null test **only**:

```
FAIL  banlist_bundle arm (#376) > drops payload with a null `mode`
Tests  1 failed | 158 passed (159)
```

The mutant was injected after the commit and reverted after the reading.

## Ordering with #1471

#1471 adds `wireUserBoundary.test.ts`, whose snapshot records `banlist_bundle` as `mode/drop, mode/null, mode/wrong-type`. This PR reduces that arm to `mode/drop` alone. The two do not conflict textually — they touch different files — but **whichever lands second needs that inline snapshot refreshed**, and the residue is a NAMED one: `mode/drop` stays, because the #1251 tolerance stays.

## Gates

- `bun run check` rc 0 — biome plus **both** `tsc` invocations. A biome failure short-circuits that chain, so a green recorded before the last edit is not a green.
- `bun run test` rc 0 — 289 files / 5585 tests.

## What this does NOT claim

- **Not that a wrong-typed `mode` was ever observed in production.** The finding is an inconsistency between two sibling arms, measured in the source, not an incident report.
- **Not that the other seven arms diverging from their generated schema are defects** — they carry written, numbered rationales, and `banlist_bundle` is the only one whose rationale falsifies itself by naming a model stricter than its own implementation. The full arm-by-arm measurement is in #1471.
- **No claim about the server side.** Nothing here changes what grappa emits; `mode` was already required in the typespec.
