### PR TITLE
refactor(#1390): move the recover progress projection out of the session

### DIFF
--- a/cicchetto/src/RecoverModal.tsx
+++ b/cicchetto/src/RecoverModal.tsx
@@ -28,8 +28,9 @@ import { dismissRecover, recoverState } from "./lib/recoverProgress";
 const STEP_LABEL: Record<RecoverStep, string> = {
   identify: "Identifying to services",
   // review-#4: on the recover (re-identify) path the server emits `register`
-  // as the FINAL "+r confirmed" step (recover_progress_steps/:succeeded), NOT
-  // a fresh registration — so "Identity confirmed", not "Registering your nick".
+  // as the FINAL "+r confirmed" step (RecoverProgress.steps/2, the :succeeded
+  // clause), NOT a fresh registration — so "Identity confirmed", not
+  // "Registering your nick".
   register: "Identity confirmed",
   nick: "Reclaiming your nick",
   recover: "Recovering your nick",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46793,3 +46793,87 @@ candidate nobody has instrumented.
 **The post-send decrease seen at throttled rates is not the freeze.** It is
 `1431 → 1415`, the tail-follow overshooting and clamping to `maxScroll`. It
 would have made a tidy story and it is the wrong one.
+<!-- entry #1390 slice 4 -->
+
+---
+
+## 2026-08-17 — #1390 slice 4: the recover projection leaves the session, defect and all
+
+`recover_progress_steps/2` + `recover_terminal_steps/3` were twelve clauses
+of a pure function — FSM transition in, modal step list out — sitting as
+private clauses of a 7,136-line GenServer with a single caller. They are a
+TRANSLATION between two vocabularies that must not learn each other:
+`RecoverIdentity` owns the phases and knows nothing about a modal,
+`Session.Wire` owns the wire types and builds payloads without choosing which
+ones to send. Choosing is now `Grappa.Session.RecoverProgress`.
+
+### Two continuations the issue proposed, and why neither was bought
+
+Measured before proposing, and recorded so the next reader does not repeat
+the search:
+
+* **The parameterised `Session.SubMachine` runner.** The two sub-machines
+  share `{verdict, next, lines}` and little else: `advance_ghost/2` returns
+  `{:noreply, state}` and releases a parked advisory at its terminal;
+  `advance_recover/2` returns state, carries TWO timers, re-arms one on entry
+  to a specific phase, and broadcasts progress on every transition. The 20%
+  that does not fit IS the terminal — the part that matters — so a runner
+  parameterised on `{fsm_module, state_field, timer_fields}` would hand each
+  machine back its own terminal callback. A mechanism heavier than the
+  problem it replaces.
+* **"One FSM, one interpreter."** The divergence is real: `GhostRecovery` is
+  driven by `advance_ghost/2` AND by a hand-rolled `:ghost_timeout` arm that
+  redoes step + flush + release + clear, while its sibling routes all six of
+  its inputs through one function. **But the bug was looked for and is not
+  there.** The hand-rolled arm discards `next` and never reads the phase, and
+  is correct only because `:timeout` on a non-terminal phase is `:failed` by
+  construction and the FSM field is nil at every terminal; the `/recover`
+  entry likewise re-implements start and arms `:recover_timeout` without a
+  cancel, and is safe only because a second `/recover` in flight is refused
+  and the terminal nils FSM and timers together. Four hand-rolled sites, four
+  invariants held elsewhere, zero consequences: a pure refactor, and nothing
+  red buys it.
+
+### The defect this slice MOVES without curing: #1468
+
+#623 pt3 states the rule in its own comment — "RECONCILE every in-flight step
+on terminal `:failed` (not just one) so the modal never strands a step at
+`:running`" — and the leg (b) integration test asserts it in those words.
+Two of the five terminal clauses do not honour it:
+
+```
+:idle --start--> :awaiting_r                    nick:running, identify:running
+      --{:nick_error,433}--> :awaiting_verb_settle   nick:failed, recover:running
+      --settle--> :awaiting_nick                recover:ok,  nick:running
+      --timeout--> :failed                      ONLY nick:failed  ← identify still :running
+```
+
+The `:awaiting_nick` clause carried a comment claiming "the identify step
+never started". No reachable path makes that true: `:awaiting_nick` comes
+only from `:awaiting_verb_settle`, which comes only from `:awaiting_r`, whose
+entry transition starts identify. The `:awaiting_verb_settle` terminal strands
+identify always, and `nick` too on the retry path. Verified on the client, not
+inferred: `recoverProgress.ts` upserts rows by step name and leaves untouched
+rows alone, and `RecoverModal.tsx` keeps the `is-running` class whatever the
+outcome — so the modal ends with identify spinning beside a failed result.
+
+It is carried over UNCURED on purpose. A behaviour change buried inside a move
+is invisible to a reviewer reading the diff as a refactor, and this project
+has decided twice already that the two must not travel together. The two
+characterisation tests assert what the code does today and carry #1468 in
+their names, so the fix cannot land without turning them red — which is the
+point of writing them that way rather than omitting the awkward cases.
+
+### What the extraction buys immediately
+
+The #1468 fix needs an oracle: "no step is left `:running` at a terminal",
+over every reachable transition. As a session test that is a fake ircd, a
+socket and fifteen broadcast round-trips per path. Against a pure function it
+is a property on plain `ExUnit.Case`, `async: true`. The extraction is what
+makes the fix cheap to buy, which is why it went first.
+
+_Not measured here: the projection's unreachable catch-all clause has no test,
+because reaching it means fabricating a state the FSM cannot emit. And the
+claim that no OTHER consumer names the moved functions was scoped to `lib` and
+`test` — a comment in `cicchetto/src/RecoverModal.tsx` named one, and was
+found only after the move._

--- a/lib/grappa/session/recover_progress.ex
+++ b/lib/grappa/session/recover_progress.ex
@@ -54,8 +54,7 @@ defmodule Grappa.Session.RecoverProgress do
   failure token when it failed.
   """
   @type step_entry ::
-          {SessionWire.recover_step(), SessionWire.recover_status(),
-           SessionWire.recover_reason() | nil}
+          {SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}
 
   @doc """
   Maps an FSM transition (old phase → next state) to the progress step(s) the

--- a/lib/grappa/session/recover_progress.ex
+++ b/lib/grappa/session/recover_progress.ex
@@ -1,0 +1,134 @@
+defmodule Grappa.Session.RecoverProgress do
+  @moduledoc """
+  #1390 slice 4 — the projection from a `Grappa.Session.RecoverIdentity`
+  transition to the progress steps the cic recover modal renders (#581).
+
+  ## What this is
+
+  One pure function: `(previous phase, next FSM state) -> [{step, status,
+  reason}]`. `Session.Server` broadcasts each returned triple as a
+  `recover_progress` event on the user topic; the client upserts one row per
+  step name and flips it as later events arrive.
+
+  It is a TRANSLATION between two vocabularies that must not learn each
+  other. `RecoverIdentity` owns the phases (`:awaiting_r`,
+  `:awaiting_verb_settle`, …) and knows nothing about a modal;
+  `Grappa.Session.Wire` owns the wire types (`recover_step/0`,
+  `recover_status/0`, `recover_reason/0`) and builds payloads without
+  deciding which ones to send. Choosing which steps a transition implies is
+  neither of those jobs, so it is this module's.
+
+  ## Why it left `Session.Server`
+
+  Twelve clauses of a hand-maintained table sat as two `defp` functions with
+  a single caller inside a 7,136-line GenServer, so the only way to exercise
+  them was to boot a session, a fake ircd and the Repo and read the
+  broadcasts back. Out here `recover_progress_test.exs` drives the real FSM
+  on plain `ExUnit.Case`, `async: true`, with no process and no database —
+  and it can only stay that way while the projection stays pure. Nothing in
+  it may reach for session state.
+
+  ## Known defect carried over: #1468
+
+  A terminal out of `:awaiting_verb_settle` or `:awaiting_nick` reports only
+  one step, but EVERY path into those phases ran through
+  `:idle -> :awaiting_r`, which already set `identify: :running`. The client
+  never reconciles a row nobody updates, so the modal ends with `identify`
+  spinning next to a failed outcome — the very thing #623 pt3 set out to
+  prevent ("RECONCILE every in-flight step on terminal `:failed`").
+
+  Slice 4 moved this table AT PARITY and deliberately did NOT cure it:
+  a behaviour change buried in a refactor is invisible to a reviewer reading
+  the diff for a move. The fix is #1468, bought by its own red.
+
+  Boundary: inherits the parent `Grappa.Session` boundary — same pattern as
+  sibling submodules `Server`, `EventRouter`, `RecoverIdentity`. No
+  `use Boundary` here.
+  """
+
+  alias Grappa.Session.RecoverIdentity
+  alias Grappa.Session.Wire, as: SessionWire
+
+  @typedoc """
+  One progress row for the modal: which step, what it is doing now, and the
+  failure token when it failed.
+  """
+  @type step_entry ::
+          {SessionWire.recover_step(), SessionWire.recover_status(),
+           SessionWire.recover_reason() | nil}
+
+  @doc """
+  Maps an FSM transition (old phase → next state) to the progress step(s) the
+  modal renders. Order mirrors the source-verified sequence: NICK + IDENTIFY
+  go out together, `+r` is the success (`:register`), and a held nick detours
+  through the reclaim verb. `verb` (`:recover | :release`) doubles as its own
+  step atom.
+
+  Transitions with nothing to show — the bounded retry above all — return
+  `[]`: a retry must not flicker in the modal.
+  """
+  @spec steps(RecoverIdentity.phase(), RecoverIdentity.t()) :: [step_entry()]
+  def steps(:idle, %{phase: :awaiting_r}),
+    do: [{:nick, :running, nil}, {:identify, :running, nil}]
+
+  def steps(:awaiting_r, %{phase: :awaiting_verb_settle, verb: verb}),
+    do: [{:nick, :failed, nil}, {verb, :running, nil}]
+
+  # #623 — the verb settled; the re-NICK goes out ALONE. Only the nick step
+  # runs now — the identify step waits for `:nick_observed` (the sequencing
+  # barrier), so the modal never shows identify running before the nick lands.
+  def steps(:awaiting_verb_settle, %{phase: :awaiting_nick, verb: verb}),
+    do: [{verb, :ok, nil}, {:nick, :running, nil}]
+
+  # #623 — the re-NICK landed AND was observed → the sameNick IDENTIFY goes out.
+  def steps(:awaiting_nick, %{phase: :awaiting_final_r}),
+    do: [{:nick, :ok, nil}, {:identify, :running, nil}]
+
+  def steps(_, %{phase: :succeeded}),
+    do: [{:nick, :ok, nil}, {:identify, :ok, nil}, {:register, :ok, nil}]
+
+  # #623 pt3 — RECONCILE every in-flight step on terminal :failed (not just one)
+  # so the modal never strands a step at :running (the trace "hang"), keyed on
+  # the phase we failed OUT of. Two of the five clauses below do not honour
+  # that rule — see the #1468 note in the moduledoc.
+  def steps(old, %{phase: :failed, reason: reason, verb: verb}),
+    do: terminal_steps(old, verb, reason)
+
+  # #623 — the retry (`:awaiting_nick` → `:awaiting_verb_settle`) and every
+  # other transition are SILENT: no visible retry churn.
+  def steps(_, _), do: []
+
+  # #623 pt3 — the reconciled terminal step list, keyed on the phase we failed
+  # OUT of, with the two reclaim legs kept DISTINCT + trace-diagnosable:
+  #   * `:awaiting_r` — a clean NICK but `+r` never came → the IDENTIFY failed
+  #     (`:wrong_password`); the nick itself landed clean (`:ok`).
+  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered → the verb
+  #     failed (`:services_declined`). **#1468: `identify` — running since the
+  #     start transition — is not reconciled here, nor is `nick` after a retry.**
+  #   * `:awaiting_nick` — leg (a): the re-NICK never landed → the nick failed
+  #     (`:nick_unavailable`). **#1468: `identify` is not reconciled here
+  #     either; the comment this clause used to carry claimed the identify step
+  #     never started, which no reachable path makes true.**
+  #   * `:awaiting_final_r` — leg (b): the re-NICK landed but `+r` never
+  #     confirmed → the identify failed (`:identify_unconfirmed`); the nick is
+  #     already `:ok`.
+  @spec terminal_steps(
+          RecoverIdentity.phase(),
+          RecoverIdentity.verb(),
+          RecoverIdentity.reason()
+        ) :: [step_entry()]
+  defp terminal_steps(:awaiting_r, _, reason),
+    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
+
+  defp terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
+    do: [{verb, :failed, reason}]
+
+  defp terminal_steps(:awaiting_nick, _, reason),
+    do: [{:nick, :failed, reason}]
+
+  defp terminal_steps(:awaiting_final_r, _, reason),
+    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
+
+  defp terminal_steps(_, _, reason),
+    do: [{:nick, :failed, reason}]
+end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -121,6 +121,7 @@ defmodule Grappa.Session.Server do
     Persistor,
     Presence,
     RecoverIdentity,
+    RecoverProgress,
     WhoisAccum,
     WhowasAccum,
     WindowState
@@ -4591,7 +4592,7 @@ defmodule Grappa.Session.Server do
   # consumer must never fail the recovery. Returns state unchanged.
   @spec broadcast_recover_events(t(), RecoverIdentity.phase(), RecoverIdentity.t()) :: t()
   defp broadcast_recover_events(state, old_phase, next) do
-    Enum.each(recover_progress_steps(old_phase, next), fn {step, status, reason} ->
+    Enum.each(RecoverProgress.steps(old_phase, next), fn {step, status, reason} ->
       _ =
         Broadcaster.to_user(
           state,
@@ -4618,74 +4619,6 @@ defmodule Grappa.Session.Server do
 
     state
   end
-
-  # #581 — map an FSM transition (old phase → next state) to the progress
-  # step(s) the modal renders. Order mirrors the source-verified sequence:
-  # NICK + IDENTIFY go out together, `+r` is the success (`:register`),
-  # and a held nick detours through the reclaim verb. `verb` (`:recover |
-  # :release`) doubles as its own step atom.
-  @spec recover_progress_steps(RecoverIdentity.phase(), RecoverIdentity.t()) ::
-          [{SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}]
-  defp recover_progress_steps(:idle, %{phase: :awaiting_r}),
-    do: [{:nick, :running, nil}, {:identify, :running, nil}]
-
-  defp recover_progress_steps(:awaiting_r, %{phase: :awaiting_verb_settle, verb: verb}),
-    do: [{:nick, :failed, nil}, {verb, :running, nil}]
-
-  # #623 — the verb settled; the re-NICK goes out ALONE. Only the nick step
-  # runs now — the identify step waits for `:nick_observed` (the sequencing
-  # barrier), so the modal never shows identify running before the nick lands.
-  defp recover_progress_steps(:awaiting_verb_settle, %{phase: :awaiting_nick, verb: verb}),
-    do: [{verb, :ok, nil}, {:nick, :running, nil}]
-
-  # #623 — the re-NICK was observed on-nick; the sameNick IDENTIFY goes out now.
-  defp recover_progress_steps(:awaiting_nick, %{phase: :awaiting_final_r}),
-    do: [{:nick, :ok, nil}, {:identify, :running, nil}]
-
-  defp recover_progress_steps(_, %{phase: :succeeded}),
-    do: [{:nick, :ok, nil}, {:identify, :ok, nil}, {:register, :ok, nil}]
-
-  # #623 pt3 — RECONCILE every in-flight step on terminal :failed (not just one)
-  # so the modal never strands a step at :running (the trace "hang"), keyed on
-  # the phase we failed OUT of.
-  defp recover_progress_steps(old, %{phase: :failed, reason: reason, verb: verb}),
-    do: recover_terminal_steps(old, verb, reason)
-
-  # #623 — the retry (`:awaiting_nick` → `:awaiting_verb_settle`) and every
-  # other transition are SILENT: no visible retry churn.
-  defp recover_progress_steps(_, _), do: []
-
-  # #623 pt3 — the reconciled terminal step list, keyed on the phase we failed
-  # OUT of. Every step still :running at that phase is flipped to its terminal
-  # status, and the two reclaim legs stay DISTINCT + trace-diagnosable:
-  #   * `:awaiting_r` — a clean NICK but `+r` never came → the IDENTIFY failed
-  #     (`:wrong_password`); the nick itself landed clean (`:ok`).
-  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered → the verb
-  #     failed (`:services_declined`).
-  #   * `:awaiting_nick` — leg (a): the re-NICK never landed → the nick failed
-  #     (`:nick_unavailable`); the identify step never started.
-  #   * `:awaiting_final_r` — leg (b): the re-NICK landed but `+r` never
-  #     confirmed → the identify failed (`:identify_unconfirmed`); the nick is
-  #     already `:ok`.
-  @spec recover_terminal_steps(
-          RecoverIdentity.phase(),
-          RecoverIdentity.verb(),
-          RecoverIdentity.reason()
-        ) :: [{SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}]
-  defp recover_terminal_steps(:awaiting_r, _, reason),
-    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
-
-  defp recover_terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
-    do: [{verb, :failed, reason}]
-
-  defp recover_terminal_steps(:awaiting_nick, _, reason),
-    do: [{:nick, :failed, reason}]
-
-  defp recover_terminal_steps(:awaiting_final_r, _, reason),
-    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
-
-  defp recover_terminal_steps(_, _, reason),
-    do: [{:nick, :failed, reason}]
 
   # Build the IRC.Client opts map from the pre-resolved primitive
   # plan. Nick-fallback + Cloak password decryption already happened

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -33,8 +33,10 @@ defmodule Grappa.Session.RecoverProgressTest do
 
   # One FSM hop: returns the state reached and what the modal is told about
   # the transition into it.
+  # The verdict and the outbound lines are the host's business, not this
+  # projection's — hence the bare `_`, the naming strategy Credo infers here.
   defp hop(fsm, input) do
-    {_verdict, next, _lines} = RecoverIdentity.step(fsm, input)
+    {_, next, _} = RecoverIdentity.step(fsm, input)
     {next, RecoverProgress.steps(fsm.phase, next)}
   end
 

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -1,0 +1,144 @@
+defmodule Grappa.Session.RecoverProgressTest do
+  @moduledoc """
+  #1390 slice 4 — the FSM-transition → modal-step projection, driven without
+  a session.
+
+  Every case here walks the REAL `RecoverIdentity` FSM from `:idle` with
+  `step/2` and asks the projection what the modal should be told. Nothing is
+  hand-built: a state the FSM cannot produce is not a state worth asserting,
+  and driving it this way makes each assertion also a proof that the
+  transition is reachable.
+
+  Before this slice the projection was two `defp` clauses inside
+  `Session.Server`, so the only way to exercise it was to boot a
+  `Session.Server`, a fake ircd and the Repo and read the broadcasts back —
+  which is what the 15 tests of `server_test.exs`'s
+  `recover_identity (#581) — server integration` describe do, `async: false`,
+  for a handful of paths. These run on plain `ExUnit.Case`, `async: true`,
+  with no process, no socket and no database.
+
+  Two cases carry the **#1468** defect: a terminal out of
+  `:awaiting_verb_settle` or `:awaiting_nick` leaves a step the modal already
+  showed as `:running` without a terminal status, so cic renders it spinning
+  forever beside a failed outcome. This slice MOVES the projection at parity
+  and does not cure it — the two tests below assert what the code does today
+  and say so in their names, so the #1468 fix cannot land without turning
+  them red.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.{RecoverIdentity, RecoverProgress}
+
+  defp start_fsm, do: RecoverIdentity.init("vjt", "s3cret")
+
+  # One FSM hop: returns the state reached and what the modal is told about
+  # the transition into it.
+  defp hop(fsm, input) do
+    {_verdict, next, _lines} = RecoverIdentity.step(fsm, input)
+    {next, RecoverProgress.steps(fsm.phase, next)}
+  end
+
+  defp advance(fsm, inputs), do: Enum.reduce(inputs, fsm, fn i, acc -> elem(hop(acc, i), 0) end)
+
+  describe "the happy path" do
+    test "the start transition sets BOTH the nick and the identify step running" do
+      # NICK and IDENTIFY go out together, so both steps start together.
+      assert {_, [{:nick, :running, nil}, {:identify, :running, nil}]} =
+               hop(start_fsm(), :start)
+    end
+
+    test "+r observed on the first attempt reports the whole sequence ok" do
+      fsm = advance(start_fsm(), [:start])
+
+      assert {_, [{:nick, :ok, nil}, {:identify, :ok, nil}, {:register, :ok, nil}]} =
+               hop(fsm, :r_observed)
+    end
+  end
+
+  describe "the reclaim detour" do
+    test "a 433 fails the nick step and starts the RECOVER verb" do
+      fsm = advance(start_fsm(), [:start])
+
+      assert {_, [{:nick, :failed, nil}, {:recover, :running, nil}]} =
+               hop(fsm, {:nick_error, 433})
+    end
+
+    test "a 437 starts the RELEASE verb instead — the verb doubles as its step" do
+      fsm = advance(start_fsm(), [:start])
+
+      assert {_, [{:nick, :failed, nil}, {:release, :running, nil}]} =
+               hop(fsm, {:nick_error, 437})
+    end
+
+    test "the settle tick completes the verb and re-runs the nick step ALONE" do
+      # #623 — the identify step deliberately does NOT restart here: it waits
+      # for the nick to be observed, so the modal never shows identify running
+      # before the nick has landed.
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}])
+
+      assert {_, [{:recover, :ok, nil}, {:nick, :running, nil}]} = hop(fsm, :settle)
+    end
+
+    test "the observed re-NICK completes the nick step and starts identify" do
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle])
+
+      assert {_, [{:nick, :ok, nil}, {:identify, :running, nil}]} = hop(fsm, :nick_observed)
+    end
+
+    test "the bounded RETRY is silent — no visible churn in the modal" do
+      # #623 — a 433/437 on the re-NICK sends the FSM back to await the verb.
+      # The modal is told nothing, which is the point: a retry must not flicker.
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle])
+
+      assert {_, []} = hop(fsm, {:nick_error, 433})
+    end
+  end
+
+  describe "terminals that reconcile every started step" do
+    test "a deadline in :awaiting_r blames the identify step, not the nick" do
+      # The NICK landed clean (no 433/437 ever came), so `+r` missing means the
+      # IDENTIFY was refused.
+      fsm = advance(start_fsm(), [:start])
+
+      assert {_, [{:nick, :ok, nil}, {:identify, :failed, :wrong_password}]} =
+               hop(fsm, :timeout)
+    end
+
+    test "a deadline in :awaiting_final_r blames identify with the reclaim reason" do
+      # The nick WAS reclaimed, so this is not a wrong password: the sameNick
+      # IDENTIFY simply went unconfirmed.
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle, :nick_observed])
+
+      assert {_, [{:nick, :ok, nil}, {:identify, :failed, :identify_unconfirmed}]} =
+               hop(fsm, :timeout)
+    end
+  end
+
+  # #1468 — the two terminals that do NOT reconcile every started step. Both
+  # paths ran through `:idle -> :awaiting_r`, which set `identify: :running`,
+  # and neither terminal ever gives that step a final status. cic upserts step
+  # rows by name (`recoverProgress.ts`) and `RecoverModal` keeps rendering
+  # `is-running` regardless of the outcome, so the modal ends with identify
+  # spinning next to a failed result.
+  #
+  # This slice moves the projection AT PARITY: curing the defect here would be
+  # a behaviour change hidden inside a refactor. The assertions below pin what
+  # the code does today, and their names say it is a defect — the #1468 fix
+  # turns them red, which is exactly what should happen.
+  describe "terminals that strand a step (#1468 — moved here unchanged, not cured)" do
+    test "#1468 — a deadline in :awaiting_verb_settle reports ONLY the verb" do
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}])
+
+      # Neither `identify` (running since the start) nor `nick` (running again
+      # after a retry) is reconciled.
+      assert {_, [{:recover, :failed, :services_declined}]} = hop(fsm, :timeout)
+    end
+
+    test "#1468 — a deadline in :awaiting_nick reports ONLY the nick" do
+      fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle])
+
+      # `identify` has been :running since the start transition and stays there.
+      assert {_, [{:nick, :failed, :nick_unavailable}]} = hop(fsm, :timeout)
+    end
+  end
+end


### PR DESCRIPTION
Fourth slice of #1390. `recover_progress_steps/2` + `recover_terminal_steps/3` —
twelve clauses, 68 lines, one caller — leave `Session.Server` for
`Grappa.Session.RecoverProgress`. **Extraction at parity: no behaviour changes.**

They are a translation between two vocabularies that must not learn each other:
`RecoverIdentity` owns the phases and knows nothing about a modal, `Session.Wire`
owns the wire types and builds payloads without choosing which ones to send.
Choosing is now its own module, and testable without standing up a session — the
new test file drives all twelve clauses directly.

## The defect this slice MOVES without curing: #1468

On two of the five terminal phases the `/recover` modal leaves `identify`
spinning forever next to a failed outcome. Every path through
`:awaiting_verb_settle` and `:awaiting_nick` passes through
`:idle -> :awaiting_r`, whose entry transition sets `identify: running`, and
neither terminal clause reconciles it. #623 pt3 states the rule in its own
comment — reconcile *every* in-flight step on a terminal, not just one — and its
integration test asserts it in those words; two clauses do not honour it.
Verified client-side too: `recoverProgress.ts` upserts by name and never touches
a row nobody updates, and `RecoverModal.tsx:125` keeps `is-running` regardless of
outcome.

**This PR does not fix it, deliberately.** Two tests characterise the current
behaviour with `#1468` in their names, so the fix cannot land without turning
them red. Both were proven to fail against a mutant of the clause they pin. The
fix is a separate PR, bought by an `async: true` property that drives
`RecoverIdentity.step/2` over every reachable transition, accumulates steps under
the client's upsert rule, and asserts that no step remains `:running` at a
terminal phase — red today. This extraction is what makes that property cheap to
write.

## Two continuations #1390 proposes, measured and not bought

Both are recorded in DESIGN_NOTES so the next reader does not repeat the search.

- **The parameterised `Session.SubMachine` runner.** The two sub-machines share
  `{verdict, next, lines}` and little else. The 20% that does not fit *is* the
  terminal, so the runner would hand each machine back its own terminal callback:
  a mechanism heavier than the problem it replaces.
- **"One FSM, one interpreter."** The divergence is real — four hand-rolled sites
  around `GhostRecovery` — but the bug was looked for and is not there. Each site
  is correct by an invariant held elsewhere. A pure refactor with nothing red to
  buy it.

## Notes

- Sits directly on `main` (`1bdc624a`); `merge-base == origin/main`, no rebase.
- **Five files, not the four declared.** `cicchetto/src/RecoverModal.tsx` carries a
  comment naming the moved function. Declared overrun: a `git grep` of the moved
  symbols over `lib` + `test` does not reach `cicchetto/src`.
- `P6` was falsified in the useful direction: the 15 recover integration tests do
  **not** notice if the `:succeeded` clause goes mute, so the extraction adds
  coverage the session suite did not have.

## Gates

`scripts/check.sh` RC=0 on `5fc28a61`: Credo `6116 mods/funs, no issues`;
`6518 tests, 0 failures` (6507 + the 11 new); Dialyzer `Total errors: 0`;
wireTypes + wireSchema in sync; bats green. `design-notes-gate.sh` reports
`1 new entry heading(s), separator and marker present`.
