### PR TITLE
union(#1465 #1471 #1472): the guard, the census that measures it, and the scroll-rest barrier

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -62,7 +62,7 @@
 
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
-import { type ScrollGestureResult, scrollByGesture } from "./scrollGesture";
+import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
 const MOBILE_BREAKPOINT_PX = 768;
@@ -1425,4 +1425,27 @@ export async function pageScrollbackUp(
   timeoutMs: number,
 ): Promise<ScrollGestureResult> {
   return await pageScrollbackBy(page, -pixels, timeoutMs);
+}
+
+// #1336 S2 — the same wait with no gesture in front of it: hold until the
+// pane STOPS being written to, and report where it stopped.
+//
+// For a spec that parks on the unread marker through a PROGRAMMATIC
+// activation rather than a wheel. Recorded in-page, such a switch writes
+// `scrollTop` three times — the rows recreation resetting to the top, the
+// marker jump in flight, the marker — and a "distance from the bottom is
+// large" barrier is satisfied by the FIRST of the three, which is the pane on
+// its way somewhere rather than the pane where the test means it to be.
+//
+// Sampling every 50 ms, matching `pageScrollbackBy`: two agreeing samples mean
+// the pane held still for 50 ms.
+export async function pageScrollbackRest(page: Page, timeoutMs: number): Promise<number> {
+  const pane = page.locator('[data-testid="scrollback"]');
+  return await waitForScrollRest(
+    { scrollTop: () => pane.evaluate((el) => el.scrollTop) },
+    {
+      timeoutMs,
+      pollMs: 50,
+    },
+  );
 }

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -12,7 +12,7 @@
 // inside the next step.
 
 import { describe, expect, it } from "vitest";
-import { type ScrollPane, scrollByGesture } from "./scrollGesture";
+import { type ScrollPane, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 
 type Recorded = { calls: string[]; pane: ScrollPane };
 
@@ -93,5 +93,82 @@ describe("#1336 — scrollByGesture", () => {
     expect(
       await failureOf(scrollByGesture(pane, { deltaY: -4000, timeoutMs: 20, pollMs: 1 })),
     ).toContain("never settled");
+  });
+});
+
+// The scrollTop writes a SWITCH into #bofh performs, recorded in-page on the
+// dev host (2026-08-17, #1336 S2 probe, four iterations at CPU throttle 1x/6x/
+// 12x/20x — the shape was identical in all four, only the timings stretched):
+//
+//     t=0ms   354   the $server pane we switch away from
+//     t=45ms    7   the rows recreation resets scrollTop to the top
+//     t=59ms 1055   the marker jump, in flight
+//     t=78ms 1078   the marker, at rest
+//
+// and the pane's own geometry at that moment: scrollHeight 1627, clientHeight
+// 212, so maxScroll = 1415. These are DATA, not an example — every assertion
+// below is arithmetic on them.
+// Only the three POST-CLICK writes: 354 is where the $server pane we switch
+// away from was sitting, and the barrier cannot sample it — the spec gates on
+// the row count and the marker existing first, which the switch must complete
+// to satisfy. Replaying it would overstate the defect.
+const MEASURED_SWITCH_WRITES = [7, 1055, 1078] as const;
+const MEASURED_MAX_SCROLL = 1415;
+const MARKER_SCROLL_TOP = 1078;
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
+  // The defect, executed rather than argued. The pre-send barrier in
+  // scroll-on-window-switch.spec.ts is `distance-to-bottom > 50`, and
+  // `expect.poll` returns on the FIRST evaluation that satisfies it. Replayed
+  // against the writes actually recorded, that first satisfying sample is the
+  // RESET (scrollTop 7, distance 1408) — the moment the rows were recreated
+  // and the marker jump had not happened yet. The barrier cannot tell "the
+  // switch landed on the marker" from "the pane is at the top on its way
+  // there", because both are far from the bottom.
+  it("the OLD distance-only predicate is satisfied by the reset, not by the marker", () => {
+    const distances = MEASURED_SWITCH_WRITES.map((st) => MEASURED_MAX_SCROLL - st);
+    const firstAccepted = distances.findIndex((d) => d > SCROLL_BOTTOM_THRESHOLD_PX);
+
+    expect(MEASURED_SWITCH_WRITES[firstAccepted]).toBe(7);
+    expect(distances[firstAccepted]).toBe(1408);
+    // …and the position it was supposed to be waiting for is 337 away from the
+    // bottom — the number #1079 reported, twice, on two trees.
+    expect(MEASURED_MAX_SCROLL - MARKER_SCROLL_TOP).toBe(337);
+  });
+
+  it("waits past the reset and the in-flight sample, and reports the MARKER", async () => {
+    const { pane } = fakePane([...MEASURED_SWITCH_WRITES, MARKER_SCROLL_TOP]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(MARKER_SCROLL_TOP);
+  });
+
+  it("does not mistake two equal samples STRADDLING a move for rest", async () => {
+    // A pane that returns to a value it already held is not the same as a pane
+    // that never left it: only ADJACENT agreement is rest. Without that, the
+    // 1078 here would be read as rest while the pane is still travelling.
+    const { pane } = fakePane([1078, 7, 1078, 400, 400]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(400);
+  });
+
+  it("REJECTS a pane that never comes to rest, naming the last position", async () => {
+    let value = 1078;
+    const pane: ScrollPane = {
+      hover: async () => {},
+      wheel: async () => {},
+      scrollTop: async () => {
+        value -= 10;
+        return value;
+      },
+    };
+    const message = await failureOf(waitForScrollRest(pane, { timeoutMs: 20, pollMs: 1 }));
+    expect(message).toContain("never came to rest");
+    expect(message).toMatch(/last \d+/);
+  });
+
+  it("resolves at the position the pane was ALREADY holding", async () => {
+    // A settled pane is settled; the barrier is about rest, not about movement
+    // (that is `scrollByGesture`'s job, and it rejects a pane that never moved).
+    const { pane } = fakePane([1078, 1078]);
+    expect(await waitForScrollRest(pane, { timeoutMs: 1_000, pollMs: 1 })).toBe(1078);
   });
 });

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -180,9 +180,9 @@ describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
     const movingPane: Pick<ScrollPane, "scrollTop"> = {
       scrollTop: async () => 1078 - Math.floor((Date.now() - start) / 20),
     };
-    expect(await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 }))).toContain(
-      "never came to rest",
-    );
+    expect(
+      await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 })),
+    ).toContain("never came to rest");
   });
 
   it("resolves at the position the pane was ALREADY holding", async () => {

--- a/cicchetto/e2e/fixtures/scrollGesture.test.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.test.ts
@@ -165,6 +165,26 @@ describe("#1336 S2 — waitForScrollRest, and the barrier it replaces", () => {
     expect(message).toMatch(/last \d+/);
   });
 
+  it("does not call a pane written every 20ms 'at rest', however fast it is read", async () => {
+    // The fakes above answer from a script, so two reads taken in the same
+    // millisecond look exactly like two reads a poll apart — a barrier that
+    // compares samples with no gap between them passes every one of those
+    // tests while being worthless. This pane answers from a CLOCK instead,
+    // which is the only way the omission becomes visible.
+    //
+    // Not hypothetical: the first version of this barrier resolved instantly
+    // in situ against a pane an injected `setInterval` was moving 1px every
+    // 20ms, and the spec then failed downstream on an anonymous number
+    // instead of here, by name.
+    const start = Date.now();
+    const movingPane: Pick<ScrollPane, "scrollTop"> = {
+      scrollTop: async () => 1078 - Math.floor((Date.now() - start) / 20),
+    };
+    expect(await failureOf(waitForScrollRest(movingPane, { timeoutMs: 300, pollMs: 50 }))).toContain(
+      "never came to rest",
+    );
+  });
+
   it("resolves at the position the pane was ALREADY holding", async () => {
     // A settled pane is settled; the barrier is about rest, not about movement
     // (that is `scrollByGesture`'s job, and it rejects a pane that never moved).

--- a/cicchetto/e2e/fixtures/scrollGesture.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.ts
@@ -60,7 +60,95 @@ export type ScrollGestureResult = {
   readonly to: number;
 };
 
+export type ScrollRestOptions = {
+  // Budget for the pane to stop moving.
+  readonly timeoutMs: number;
+  // Gap between scrollTop samples.
+  readonly pollMs: number;
+};
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Wait for the pane to STOP, and report where it stopped. Rejects rather than
+// resolving when it never held still, for the same reason `scrollByGesture`
+// rejects: a caller about to assert on a position must not be handed one the
+// pane is still leaving.
+//
+// This is the half of the gesture contract that has nothing to do with a
+// wheel, and #1336 S2 is why it exists separately. `scroll-on-window-switch`
+// parks on the unread marker through a PROGRAMMATIC activation and then sends,
+// and its pre-send barrier was `distance-to-bottom > 50`. Recorded in-page,
+// the switch writes scrollTop three times — `7` (the rows recreation resetting
+// to the top), `1055` (the marker jump in flight), `1078` (the marker) — and
+// the FIRST of those already satisfies `> 50` by a wide margin (distance 1408
+// against a maxScroll of 1415). So the barrier could clear on the reset, with
+// the marker jump still to come; the jump is a scrollTop DECREASE, `onScroll`
+// reads a decrease as the operator leaving the tail, and a decrease landing
+// after a send freezes the pane at the marker — 337 from the bottom, which is
+// the number #1079 reported twice.
+//
+// A gate satisfied by a state that is not the one it names is not a gate. The
+// distance test says "not at the bottom" while meaning "the switch has
+// finished"; rest is the missing half, and unlike the distance it cannot be
+// true of a pane mid-jump.
+export async function waitForScrollRest(
+  pane: Pick<ScrollPane, "scrollTop">,
+  opts: ScrollRestOptions,
+): Promise<number> {
+  const { timeoutMs, pollMs } = opts;
+  const read = (): Promise<number> => pane.scrollTop();
+  const rest = await sampleUntilRest(read, await read(), false, timeoutMs, pollMs);
+
+  if (rest.settled === null) {
+    throw new Error(
+      `waitForScrollRest: the pane never came to rest within ${timeoutMs}ms ` +
+        `(last ${rest.last}) — it is still being written to`,
+    );
+  }
+  return rest.settled;
+}
+
+type RestProbe = {
+  readonly settled: number | null;
+  readonly last: number;
+  readonly moved: boolean;
+};
+
+// The one sampling loop both public waits are built from: read `scrollTop`
+// until two ADJACENT reads agree.
+//
+// Adjacency is load-bearing. A pane that returns to a position it held a
+// moment ago has not stopped — it has passed through twice — so comparing
+// against anything other than the immediately preceding sample would call a
+// round trip "rest".
+//
+// `requireMove` is the 20% the two callers do not share. A GESTURE has to
+// displace the pane, so resting back on the baseline is a failure (the wheel
+// was never delivered); a BARRIER only has to establish that nothing is being
+// written any more, and a pane that was already still satisfies it.
+async function sampleUntilRest(
+  read: () => Promise<number>,
+  baseline: number,
+  requireMove: boolean,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<RestProbe> {
+  const deadline = Date.now() + timeoutMs;
+  let previous = baseline;
+  let moved = false;
+
+  while (Date.now() < deadline) {
+    const current = await read();
+    if (current !== baseline) moved = true;
+    if (current === previous && (!requireMove || moved)) {
+      return { settled: current, last: current, moved };
+    }
+    previous = current;
+    await sleep(pollMs);
+  }
+
+  return { settled: null, last: previous, moved };
+}
 
 // Perform the gesture and resolve only once the pane has moved AND come to
 // rest. Rejects rather than resolving on either failure, because "it did not
@@ -85,24 +173,13 @@ export async function scrollByGesture(
   await pane.hover();
   await pane.wheel(deltaY);
 
-  const deadline = Date.now() + timeoutMs;
-  let moved = false;
-  let previous = from;
-
-  while (Date.now() < deadline) {
-    const current = await pane.scrollTop();
-    if (current !== from) {
-      if (moved && current === previous) return { from, to: current };
-      moved = true;
-    }
-    previous = current;
-    await sleep(pollMs);
-  }
+  const rest = await sampleUntilRest(() => pane.scrollTop(), from, true, timeoutMs, pollMs);
+  if (rest.settled !== null) return { from, to: rest.settled };
 
   throw new Error(
-    moved
+    rest.moved
       ? `scrollByGesture: wheel(${deltaY}) never settled within ${timeoutMs}ms ` +
-          `(from ${from}, last ${previous}) — the pane was still moving when the budget ran out`
+          `(from ${from}, last ${rest.last}) — the pane was still moving when the budget ran out`
       : `scrollByGesture: wheel(${deltaY}) never moved the pane within ${timeoutMs}ms ` +
           `(scrollTop stayed ${from}) — the gesture was not delivered, or the pane is already clamped`,
   );

--- a/cicchetto/e2e/fixtures/scrollGesture.ts
+++ b/cicchetto/e2e/fixtures/scrollGesture.ts
@@ -138,13 +138,22 @@ async function sampleUntilRest(
   let moved = false;
 
   while (Date.now() < deadline) {
+    // The gap comes FIRST, so every pair being compared is `pollMs` apart.
+    // Sleeping at the end of the body instead leaves the very first
+    // comparison — baseline against the first sample — separated by nothing
+    // but a round trip, and a pane read twice in the same millisecond reads
+    // equal whatever it is doing. Measured: with the sleep at the end, this
+    // barrier resolved instantly against a pane being written every 20ms,
+    // which is precisely the "satisfied without the thing it claims" defect
+    // the barrier exists to refuse. The unit fakes cannot see it — they have
+    // no clock — so `movingPane` below supplies one.
+    await sleep(pollMs);
     const current = await read();
     if (current !== baseline) moved = true;
     if (current === previous && (!requireMove || moved)) {
       return { settled: current, last: current, moved };
     }
     previous = current;
-    await sleep(pollMs);
   }
 
   return { settled: null, last: previous, moved };

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -82,6 +82,7 @@ import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
+  pageScrollbackRest,
   scrollbackLines,
   selectChannel,
   sidebarWindow,
@@ -280,6 +281,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
 
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
+
     // Sanity: scrollback overflows (else "not at the tail" is vacuous).
     const g = await scrollbackGeometry(page);
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
@@ -365,6 +374,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
 
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
+
     const g = await scrollbackGeometry(page);
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
 
@@ -442,6 +459,14 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
 
     const marker = page.locator('[data-testid="unread-marker"]');
     await expect(marker).toHaveCount(1);
+
+    // #1336 S2 — settle BEFORE measuring. The activation writes scrollTop
+    // three times (rows recreation to the top, marker jump in flight, marker),
+    // and every assertion below reads a position, so each one must be taken of
+    // a pane that has stopped. The distance test alone cannot do this: it is
+    // satisfied by the reset too, which is the same pane 1071px from where
+    // this test means it to be. Rejects by name if the pane never holds still.
+    await pageScrollbackRest(page, 10_000);
 
     // Sanity: the pane overflows (else "not at the tail" is vacuous).
     const g = await scrollbackGeometry(page);

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1575,6 +1575,40 @@ describe("userTopic", () => {
       });
       expect(bc.setBanlistBundle).not.toHaveBeenCalled();
     });
+
+    // #1393 — the #1251 tolerance is for a server that predates `mode`, and
+    // that server sends no key at all. A key that IS there carrying something
+    // other than a letter is mangling, and coercing it to "b" renders whatever
+    // list arrived under the "Bans" heading — the exact mis-attribution #1251
+    // added the field to end. `Grappa.Session.Wire.banlist_bundle_payload/0`
+    // declares `mode` a plain required string, so neither of these two shapes
+    // can come from any grappa.
+    it("drops payload with a non-string `mode` (mangled, not an older server)", async () => {
+      const bc = await import("../lib/banlistCard");
+      channelMock.fireEvent({
+        kind: "banlist_bundle",
+        network: "azzurra",
+        channel: "#test",
+        mode: 42,
+        entries: [],
+      });
+      expect(bc.setBanlistBundle).not.toHaveBeenCalled();
+    });
+
+    // Unlike `links_bundle.mask`, which IS `string | null` in the typespec and
+    // so tolerates an explicit null, `mode` is non-nullable: a null is as
+    // impossible on the wire as a number.
+    it("drops payload with a null `mode`", async () => {
+      const bc = await import("../lib/banlistCard");
+      channelMock.fireEvent({
+        kind: "banlist_bundle",
+        network: "azzurra",
+        channel: "#test",
+        mode: null,
+        entries: [],
+      });
+      expect(bc.setBanlistBundle).not.toHaveBeenCalled();
+    });
   });
 
   describe("invite_ack arm (P-0e + P-0f)", () => {

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -13,9 +13,18 @@ import { validate } from "../lib/wireValidate";
 // list. For each arm it synthesises a valid payload from the GENERATED
 // schema, mutates it field by field, and records what the hand narrower and
 // the schema each do with it. Arms where the two agree are a proved dead end
-// — nothing to gain by swapping them. Arms where the hand narrower ACCEPTS
-// what the schema rejects are permissiveness holes, and they are the only
-// place a migration buys safety rather than line count.
+// — nothing to gain by swapping them.
+//
+// A disagreement is measured in BOTH directions, because they cost opposite
+// things and one alone cannot settle whether an arm is worth migrating:
+//
+//   * the hand narrower ACCEPTS what the schema rejects — a permissiveness
+//     hole, the only place a migration buys safety rather than line count;
+//   * the schema ACCEPTS what the hand narrower rejects — strictness the
+//     migration would silently LOSE, since the typespec is the looser of the
+//     two and swapping in the generated check drops the hand-written guard.
+//
+// Measuring one direction only would report an asymmetry as a parity.
 //
 // Arms are matched to schemas by their `kind` LITERAL, not by a camelised
 // name: the name heuristic missed three arms whose schema lives under a
@@ -97,6 +106,7 @@ type ArmReport = {
   schema: string;
   fields: number;
   handAcceptsSchemaRejects: string;
+  schemaAcceptsHandRejects: string;
   schemaRejectsValid: boolean;
 };
 
@@ -106,15 +116,17 @@ function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport 
   const fields = Object.keys(valid).filter((f) => f !== "kind");
 
   const holes: string[] = [];
+  const losses: string[] = [];
   for (const f of fields) {
     for (const [label, mutated] of [
       ["drop", without(valid, f)],
       ["null", { ...valid, [f]: null }],
       ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
     ] as const) {
-      if (verdict(hand, mutated) === "accept" && verdict(generated, mutated) === "reject") {
-        holes.push(`${f}/${label}`);
-      }
+      const byHand = verdict(hand, mutated);
+      const bySchema = verdict(generated, mutated);
+      if (byHand === "accept" && bySchema === "reject") holes.push(`${f}/${label}`);
+      if (bySchema === "accept" && byHand === "reject") losses.push(`${f}/${label}`);
     }
   }
 
@@ -123,6 +135,7 @@ function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport 
     schema: schemaName,
     fields: fields.length,
     handAcceptsSchemaRejects: holes.length === 0 ? "-" : holes.join(", "),
+    schemaAcceptsHandRejects: losses.length === 0 ? "-" : losses.join(", "),
     // The oracle's own sanity check: a schema that rejects its OWN sample
     // means the sampler and the schema disagree, and every verdict on that
     // arm is noise rather than a measurement.
@@ -160,6 +173,17 @@ const weakened: Narrower = (raw) => {
   if (typeof raw !== "object" || raw === null) return null;
   const r = raw as Record<string, unknown>;
   return typeof r.network === "string" ? { kind: "away_confirmed", ...r } : null;
+};
+
+// The control for the OTHER direction, which needs its own mutant: an arm
+// agreeing in one direction says nothing about the other. `whowas_bundle`'s
+// `user` is `string | null` in the typespec, so the schema accepts a null the
+// hand narrower here refuses ON PURPOSE — and `user/null` has to show up as a
+// loss.
+const strengthened: Narrower = (raw) => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  return typeof r.user === "string" ? { kind: "whowas_bundle", ...r } : null;
 };
 
 // The 42 `case` labels of `narrowUserEvent`, transcribed from the switch so
@@ -228,6 +252,24 @@ describe("#1393 — user-topic boundary census", () => {
     `);
   });
 
+  it("detects a strengthened boundary (control for the second direction)", () => {
+    const node = candidatesFor("whowas_bundle")[0].node;
+    const valid = sample(node) as Record<string, unknown>;
+    const generated: Narrower = (raw) => validate(node, raw);
+    const losses = Object.keys(valid)
+      .filter((f) => f !== "kind")
+      .filter(
+        (f) =>
+          verdict(generated, { ...valid, [f]: null }) === "accept" &&
+          verdict(strengthened, { ...valid, [f]: null }) === "reject",
+      );
+    expect(losses).toMatchInlineSnapshot(`
+      [
+        "user",
+      ]
+    `);
+  });
+
   // Reconciliation. The census walks SCHEMAS (indexed by kind literal), while
   // the thing under test is the hand `switch` in `userTopic.ts`. Those two
   // sets are not the same by construction, so the difference is reported
@@ -257,23 +299,33 @@ describe("#1393 — user-topic boundary census", () => {
     const reports = handArms.flatMap((k) =>
       candidatesFor(k).map(({ name, node }) => censusArm(k, name, node)),
     );
-    const holes = reports.filter((r) => r.handAcceptsSchemaRejects !== "-");
+    const divergent = reports.filter(
+      (r) => r.handAcceptsSchemaRejects !== "-" || r.schemaAcceptsHandRejects !== "-",
+    );
+    // Counted over distinct ARMS, not over reports: an ambiguous `kind`
+    // literal is censused once per candidate schema, so `reports.length`
+    // overcounts the boundary by however many duplicates the wire happens to
+    // carry. The parity figure the verdict rests on is an arm count.
+    const divergentArms = new Set(divergent.map((r) => r.arm));
     expect({
       armsWithSchema: handArms.length,
       armsCensused: reports.length,
+      armsAtParity: handArms.length - divergentArms.size,
       brokenOracles: reports.filter((r) => r.schemaRejectsValid).map((r) => r.arm),
-      holes,
+      divergent,
     }).toMatchInlineSnapshot(`
       {
+        "armsAtParity": 34,
         "armsCensused": 43,
         "armsWithSchema": 42,
         "brokenOracles": [],
-        "holes": [
+        "divergent": [
           {
             "arm": "bundle_hash",
             "fields": 2,
             "handAcceptsSchemaRejects": "version/null, version/wrong-type",
             "schema": "S_CicWireBundleHashPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -281,6 +333,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 2,
             "handAcceptsSchemaRejects": "http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type",
             "schema": "S_ServerSettingsWireChangedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -288,6 +341,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 4,
             "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
             "schema": "S_SessionWireBanlistBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -295,6 +349,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 15,
             "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
             "schema": "S_SessionWireIsupportChangedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -302,6 +357,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 3,
             "handAcceptsSchemaRejects": "mask/drop",
             "schema": "S_SessionWireLinksBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -309,6 +365,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 13,
             "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
             "schema": "S_SessionWireLusersBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -316,6 +373,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 30,
             "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
             "schema": "S_SessionWireWhoisBundlePayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
@@ -323,6 +381,7 @@ describe("#1393 — user-topic boundary census", () => {
             "fields": 4,
             "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
             "schema": "S_SessionWireWindowInvitedPayload",
+            "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
         ],

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import { narrowUserEvent } from "../lib/userTopic";
+import * as schemas from "../lib/wireSchema";
+import type { WireNode } from "../lib/wireValidate";
+import { validate } from "../lib/wireValidate";
+
+// #1393 — the mutate-every-field MEASUREMENT `wireAdminBoundary` applies to
+// the admin channel, pointed at the WHOLE user topic.
+//
+// `userTopic.ts` hand-narrows 42 arms and uses zero generated schemas, while
+// a schema for every one of those arms is already emitted next to it. The
+// review calls that an arrested migration; this file turns the claim into a
+// list. For each arm it synthesises a valid payload from the GENERATED
+// schema, mutates it field by field, and records what the hand narrower and
+// the schema each do with it. Arms where the two agree are a proved dead end
+// — nothing to gain by swapping them. Arms where the hand narrower ACCEPTS
+// what the schema rejects are permissiveness holes, and they are the only
+// place a migration buys safety rather than line count.
+//
+// Arms are matched to schemas by their `kind` LITERAL, not by a camelised
+// name: the name heuristic missed three arms whose schema lives under a
+// differently-named Wire module.
+//
+// `kind` is excluded from the mutation matrix on purpose. Mutating the
+// discriminator tests DISPATCH, not field validation: the hand narrower
+// falls through its switch while the schema rejects a literal mismatch —
+// same verdict, different mechanism, no information about the boundary.
+
+type Narrower = (raw: unknown) => unknown;
+
+const hand: Narrower = (raw) => narrowUserEvent(raw);
+
+function sample(node: WireNode): unknown {
+  if (typeof node === "string") {
+    switch (node) {
+      case "s":
+        return "sample";
+      case "i":
+        return 1;
+      case "b":
+        return true;
+      case "z":
+        return null;
+      case "x":
+        return { opaque: true };
+    }
+  }
+  if ("l" in node) return node.l;
+  if ("e" in node) return node.e[0];
+  if ("a" in node) return [sample(node.a)];
+  if ("r" in node) return { key: sample(node.r) };
+  if ("p" in node) return node.p.map(sample);
+  if ("u" in node) return sample(node.u[0] as WireNode);
+  return Object.fromEntries(Object.entries(node.o).map(([k, v]) => [k, sample(v)]));
+}
+
+function wrongType(value: unknown): unknown {
+  if (typeof value === "string") return 12345;
+  if (typeof value === "number") return "12345";
+  if (typeof value === "boolean") return "true";
+  if (Array.isArray(value)) return "not-an-array";
+  return "not-an-object";
+}
+
+function without(obj: Record<string, unknown>, field: string): Record<string, unknown> {
+  const copy = { ...obj };
+  delete copy[field];
+  return copy;
+}
+
+function verdict(narrow: Narrower, payload: unknown): "accept" | "reject" {
+  return narrow(payload) === null ? "reject" : "accept";
+}
+
+function isObjectNode(node: WireNode): node is { o: Record<string, WireNode> } {
+  return typeof node !== "string" && "o" in node;
+}
+
+// Every generated schema that carries a `kind` literal, indexed by it.
+function schemasByKind(): Map<string, Candidate[]> {
+  const out = new Map<string, Candidate[]>();
+  for (const [name, node] of Object.entries(schemas) as [string, WireNode][]) {
+    if (!name.startsWith("S_") || !isObjectNode(node)) continue;
+    const k = node.o.kind;
+    if (k === undefined || typeof k === "string" || !("l" in k)) continue;
+    const list = out.get(k.l as string) ?? [];
+    list.push({ name, node });
+    out.set(k.l as string, list);
+  }
+  return out;
+}
+
+type Candidate = { name: string; node: WireNode };
+
+type ArmReport = {
+  arm: string;
+  schema: string;
+  fields: number;
+  handAcceptsSchemaRejects: string;
+  schemaRejectsValid: boolean;
+};
+
+function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport {
+  const generated: Narrower = (raw) => validate(node, raw);
+  const valid = sample(node) as Record<string, unknown>;
+  const fields = Object.keys(valid).filter((f) => f !== "kind");
+
+  const holes: string[] = [];
+  for (const f of fields) {
+    for (const [label, mutated] of [
+      ["drop", without(valid, f)],
+      ["null", { ...valid, [f]: null }],
+      ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
+    ] as const) {
+      if (verdict(hand, mutated) === "accept" && verdict(generated, mutated) === "reject") {
+        holes.push(`${f}/${label}`);
+      }
+    }
+  }
+
+  return {
+    arm: kind,
+    schema: schemaName,
+    fields: fields.length,
+    handAcceptsSchemaRejects: holes.length === 0 ? "-" : holes.join(", "),
+    // The oracle's own sanity check: a schema that rejects its OWN sample
+    // means the sampler and the schema disagree, and every verdict on that
+    // arm is noise rather than a measurement.
+    schemaRejectsValid: verdict(generated, valid) === "reject",
+  };
+}
+
+const BY_KIND = schemasByKind();
+// An ambiguous kind literal (`web_session_severed` is emitted by two Wire
+// modules) is kept if ANY of its candidate schemas produces a sample the hand
+// narrower accepts — and every candidate is then censused, so the arm cannot
+// fall out of the list because the first candidate happened to be the wrong
+// module's.
+const accepts = (k: string): boolean =>
+  candidatesFor(k).some(({ node }) => verdict(hand, sample(node)) === "accept");
+
+const ARMS = [...BY_KIND.keys()];
+
+// Every schema whose `kind` literal is this one. Throws rather than returning
+// empty: `ARMS` is derived from the same map, so a miss here would mean the
+// map changed under the walk, and a census that silently skipped an arm is
+// worse than one that stops.
+function candidatesFor(kind: string): [Candidate, ...Candidate[]] {
+  const found = BY_KIND.get(kind);
+  if (found === undefined || found.length === 0) {
+    throw new Error(`no generated schema carries the kind literal "${kind}"`);
+  }
+  return found as [Candidate, ...Candidate[]];
+}
+
+// The control. Two boundaries agreeing means nothing unless the matrix can
+// tell them apart, so this one is weakened ON PURPOSE — it skips the `state`
+// check — and `state` has to show up as a hole.
+const weakened: Narrower = (raw) => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  return typeof r.network === "string" ? { kind: "away_confirmed", ...r } : null;
+};
+
+// The 42 `case` labels of `narrowUserEvent`, transcribed from the switch so
+// the reconciliation below has a reference OUTSIDE the schema walk.
+const HAND_SWITCH_ARMS = [
+  "archive_changed",
+  "archive_purged",
+  "auto_away_debounce_changed",
+  "away_confirmed",
+  "banlist_bundle",
+  "bundle_hash",
+  "channels_changed",
+  "connection_progress",
+  "connection_state_changed",
+  "directory_complete",
+  "directory_failed",
+  "directory_progress",
+  "invite_ack",
+  "isupport_changed",
+  "join_failed",
+  "joined",
+  "kicked",
+  "links_bundle",
+  "lusers_bundle",
+  "mentions_bundle",
+  "names_reply",
+  "notify_list",
+  "own_nick_changed",
+  "peer_away",
+  "presence_changed",
+  "presence_error",
+  "presence_snapshot",
+  "query_windows_list",
+  "recover_progress",
+  "recover_result",
+  "server_reply",
+  "server_settings_changed",
+  "session_identity_changed",
+  "supported_umodes_changed",
+  "umode_changed",
+  "web_session_severed",
+  "who_reply",
+  "whois_bundle",
+  "whowas_bundle",
+  "window_invite_declined",
+  "window_invited",
+  "window_pending",
+] as const;
+
+describe("#1393 — user-topic boundary census", () => {
+  it("detects a weakened boundary (control for the matrix itself)", () => {
+    const node = candidatesFor("away_confirmed")[0].node;
+    const valid = sample(node) as Record<string, unknown>;
+    const generated: Narrower = (raw) => validate(node, raw);
+    const holes = Object.keys(valid)
+      .filter((f) => f !== "kind")
+      .filter(
+        (f) =>
+          verdict(weakened, { ...valid, [f]: null }) === "accept" &&
+          verdict(generated, { ...valid, [f]: null }) === "reject",
+      );
+    expect(holes).toMatchInlineSnapshot(`
+      [
+        "state",
+      ]
+    `);
+  });
+
+  // Reconciliation. The census walks SCHEMAS (indexed by kind literal), while
+  // the thing under test is the hand `switch` in `userTopic.ts`. Those two
+  // sets are not the same by construction, so the difference is reported
+  // rather than assumed away: a hand arm missing from the census is an arm
+  // nobody measured, and a censused kind absent from the switch belongs to a
+  // different topic and its verdict says nothing about this one.
+  it("reconciles the censused set against the hand switch", () => {
+    const censused = new Set(ARMS.filter(accepts));
+    const handSwitch = new Set<string>(HAND_SWITCH_ARMS);
+    expect({
+      handArms: handSwitch.size,
+      censused: censused.size,
+      inSwitchNotCensused: [...handSwitch].filter((k) => !censused.has(k)),
+      censusedNotInSwitch: [...censused].filter((k) => !handSwitch.has(k)),
+    }).toMatchInlineSnapshot(`
+      {
+        "censused": 42,
+        "censusedNotInSwitch": [],
+        "handArms": 42,
+        "inSwitchNotCensused": [],
+      }
+    `);
+  });
+
+  it("censuses every hand-narrowed arm against its generated schema", () => {
+    const handArms = ARMS.filter(accepts);
+    const reports = handArms.flatMap((k) =>
+      candidatesFor(k).map(({ name, node }) => censusArm(k, name, node)),
+    );
+    const holes = reports.filter((r) => r.handAcceptsSchemaRejects !== "-");
+    expect({
+      armsWithSchema: handArms.length,
+      armsCensused: reports.length,
+      brokenOracles: reports.filter((r) => r.schemaRejectsValid).map((r) => r.arm),
+      holes,
+    }).toMatchInlineSnapshot(`
+      {
+        "armsCensused": 43,
+        "armsWithSchema": 42,
+        "brokenOracles": [],
+        "holes": [
+          {
+            "arm": "bundle_hash",
+            "fields": 2,
+            "handAcceptsSchemaRejects": "version/null, version/wrong-type",
+            "schema": "S_CicWireBundleHashPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "server_settings_changed",
+            "fields": 2,
+            "handAcceptsSchemaRejects": "http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type",
+            "schema": "S_ServerSettingsWireChangedPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "banlist_bundle",
+            "fields": 4,
+            "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
+            "schema": "S_SessionWireBanlistBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "isupport_changed",
+            "fields": 15,
+            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
+            "schema": "S_SessionWireIsupportChangedPayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "links_bundle",
+            "fields": 3,
+            "handAcceptsSchemaRejects": "mask/drop",
+            "schema": "S_SessionWireLinksBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "lusers_bundle",
+            "fields": 13,
+            "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
+            "schema": "S_SessionWireLusersBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "whois_bundle",
+            "fields": 30,
+            "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
+            "schema": "S_SessionWireWhoisBundlePayload",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "window_invited",
+            "fields": 4,
+            "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
+            "schema": "S_SessionWireWindowInvitedPayload",
+            "schemaRejectsValid": false,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -339,7 +339,7 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "banlist_bundle",
             "fields": 4,
-            "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
+            "handAcceptsSchemaRejects": "mode/drop",
             "schema": "S_SessionWireBanlistBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -881,6 +881,16 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         !Array.isArray(r.entries)
       )
         return null;
+      // #1251 — WHICH list this is, and the tolerance is for ABSENCE only: a
+      // grappa predating the field omits the key entirely and could only ever
+      // have sent the ban list, so absent means `b` (unknown-is-never-fatal,
+      // #447). #1393 — a key that IS present carrying a non-string is
+      // mangling, not an older peer, and coercing it to `b` would render
+      // whatever list arrived under the "Bans" heading: the mis-attribution
+      // #1251 exists to end. Stricter than `links_bundle`'s `mask`, which this
+      // arm used to claim to mirror, only because the typespecs differ —
+      // `mask` is `string | null`, `mode` is a plain required string.
+      if (r.mode !== undefined && typeof r.mode !== "string") return null;
       const entries: BanlistEntry[] = [];
       for (const raw of r.entries) {
         const entry = narrowBanlistEntry(raw);
@@ -891,9 +901,6 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         kind: "banlist_bundle",
         network: r.network,
         channel: r.channel,
-        // #1251 — WHICH list this is. Additive-tolerant like links_bundle's
-        // `mask`: a grappa that predates the field could only ever have sent
-        // the ban list, so absent means `b` (unknown-is-never-fatal, #447).
         mode: typeof r.mode === "string" ? r.mode : "b",
         entries,
       };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46683,3 +46683,113 @@ and the question of what #1393 does next is not settled here.
 _Not claimed: that a wrong-typed `mode` was ever observed in production.
 The finding is an inconsistency between two sibling arms, measured in the
 source, not an incident. Nothing here changes what the server emits._
+<!-- entry #1336 S2 -->
+
+---
+
+## 2026-08-17 — #1336 S2: the barrier said "not at the bottom" and meant "the switch has finished"
+
+#1079 reports `scroll-on-window-switch` settling 337px from the bottom against
+an expected 50 — the same number twice, on two trees. The shared cause with
+#1080 was established a slice ago: a scrollTop DECREASE landing after a send
+makes `onScroll` disarm the follow intent, `tailFollowWhenSettled` yields, and
+the pane freezes wherever the decrease left it. But that spec has no wheel, so
+its TRIGGER stayed inference, and the previous slice refused to cure an
+inference on the grounds that a barrier silencing an unmeasured write is the
+paper-over this epic exists to refuse. This slice measured it.
+
+### What the switch actually does
+
+An in-page scroll recorder, installed before the sidebar click, four
+iterations at CPU throttle 1x/6x/12x/20x. The shape was identical in all four;
+only the timings stretched:
+
+| t (1x) | scrollTop | what it is |
+|---|---|---|
+| 0ms | 354 | the `$server` pane we switch away from |
+| 45ms | **7** | the rows recreation resetting to the top |
+| 59ms | 1055 | the marker jump, in flight |
+| 78ms | **1078** | the marker, at rest |
+
+Geometry at that moment: `scrollHeight` 1627, `clientHeight` 212, so
+`maxScroll` is 1415. Two arithmetic consequences, both from those measured
+numbers alone. `1415 - 1078 = 337` — the reported failure is the pane sitting
+exactly on the marker, which independently reproduces what the previous slice
+derived. And `1415 - 7 = 1408`.
+
+That second number is the finding. The barrier guarding the send is
+`distance-to-bottom > 50`, and 1408 satisfies it as comfortably as 337 does.
+**The barrier cannot tell "the switch landed on the marker" from "the pane is
+at the top with the marker jump still to come."** It says "not at the bottom"
+while meaning "the activation has finished" — the #1080 shape again, a gate
+satisfied by a state that is not the one it names, except that here the state
+is TRANSIENT rather than pre-existing, which is why reading the spec never
+revealed it.
+
+`waitForScrollRest` is the missing half: the gesture core with the wheel taken
+off, holding until two ADJACENT samples agree and rejecting if the pane never
+stops. Unlike distance, rest cannot be true of a pane mid-jump. Both waits now
+share one sampling loop, and `requireMove` is the only thing they disagree
+about — a gesture resting back on its baseline was never delivered, while a
+barrier is satisfied by a pane that was already still.
+
+### The instrument had the disease it was built to cure
+
+Worth recording because it was caught by measurement and would have survived
+any amount of reading. The first version put the `pollMs` sleep at the END of
+the loop body, so the FIRST comparison — baseline against the first sample —
+was separated by one round trip instead of by a poll. A pane read twice in the
+same millisecond reads equal whatever it is doing, so the barrier resolved
+INSTANTLY against a pane an injected `setInterval` was moving 1px every 20ms,
+and the spec then died downstream on an anonymous number.
+
+The unit fakes could not have caught it: they answer from a script, one value
+per read, so "no gap" and "a poll apart" are the same sequence to them. The
+regression test therefore answers from a CLOCK
+(`1078 - floor(elapsed / 20)`), which is the only shape in which the omission
+is observable — and it is the only one of the eleven cases that the
+sleep-position mutant kills.
+
+### The attribution, both sides
+
+The displacement is an injected `setInterval` writing the pane every 20ms, run
+on both sides of the change, on the same test:
+
+| | what the red says |
+|---|---|
+| barrier removed | `expect(received).toBeLessThanOrEqual(expected)` — it accuses the product |
+| barrier present | `waitForScrollRest: the pane never came to rest within 10000ms (last 576)` — it accuses the barrier's subject, by name |
+
+`576` is itself attributable: `1078 - 10000/20 = 578`, the jitter's own
+position when the budget ran out.
+
+An earlier attempt at that displacement was silently INERT — injected at the
+first of the three call sites while the run was scoped to the third, so it
+never executed and both sides passed identically. That is the same
+inert-injection the gesture helper's "never moved" reject was built for after
+it happened to the previous slice, and it happened again here to the person
+who had just read about it.
+
+### What this does NOT establish
+
+**The natural failure is still not reproduced.** Nobody in this epic has
+reproduced it, and this slice does not either: in eight recorded samples the
+barrier exited at the marker (1078) every single time, never at the reset. So
+the vacuity is proven — the predicate demonstrably admits a state that is not
+the one it names, and that state demonstrably occurs, 45ms into every switch —
+while its EXPLOITATION remains unobserved. What is fixed is a barrier that
+could not distinguish two panes; whether that is the mechanism behind #1079's
+337 is not shown here.
+
+**CPU throttling cannot arbitrate it, measured.** The obvious way to widen the
+window fails, and fails for a structural reason: the barrier polls through the
+page too, so throttling slows the clock and the thing being clocked together.
+The margin between the marker landing and the barrier clearing GREW with the
+rate — 105ms at 1x, 167ms at 20x — instead of closing. Whatever inverts those
+two clocks is not CPU speed, and a late network-timed rows recreation (the
+catch-up refresh the spec's own comments call the "307 race") remains the
+candidate nobody has instrumented.
+
+**The post-send decrease seen at throttled rates is not the freeze.** It is
+`1431 → 1415`, the tail-follow overshooting and clamping to `maxScroll`. It
+would have made a tidy story and it is the wrong one.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46607,3 +46607,79 @@ _Not measured here: whether an ircd in the wild repeats `MODES=` within one
 line or sends `-MODES`. The slice is justified by the internal divergence,
 not by a field frequency nobody has counted; the three changes state what
 happens in those cases, not how often they occur._
+<!-- entry #1393 -->
+
+---
+
+## 2026-08-17 — #1393: a tolerance may only be as wide as the typespec it excuses
+
+`banlist_bundle`'s narrower in `userTopic.ts` coerced any non-string `mode`
+— a number, an explicit `null` — into `"b"`. It now drops such a payload.
+Absent `mode` still means `b`. The change is small; the reason it is
+recorded here is that the arm's own comment argued for the old behaviour,
+so the code alone reads as a regression against a written policy.
+
+### The comment named a model stricter than itself
+
+The fallback justified itself as "additive-tolerant like `links_bundle`'s
+`mask`". The two arms did not implement the same policy. `links_bundle`
+guards its field —
+
+```ts
+if (r.mask !== undefined && r.mask !== null && typeof r.mask !== "string") return null;
+```
+
+— and drops a wrong-typed `mask`. `banlist_bundle` had no guard, so
+`typeof r.mode === "string" ? r.mode : "b"` swallowed everything. An arm
+claiming parity with a sibling that is strictly stricter is the kind of
+divergence a reader cannot see without opening both files, which is why it
+survived from #1251 to here.
+
+### Why the fix is STRICTER than the model it imitates
+
+Not zeal — the typespecs differ, and that difference is the whole ruling:
+
+| wire typespec | field | so an explicit `null` is |
+|---|---|---|
+| `Grappa.Session.Wire.links_bundle_payload/0` | `mask: string \| null` | a shape the server really sends → tolerated |
+| `Grappa.Session.Wire.banlist_bundle_payload/0` | `mode: string`, required | impossible from any grappa → dropped |
+
+So the correct port of the `mask` posture onto `mode` tolerates **absence
+only**. Absence is an older server, which is exactly and only what #1251
+excused when it added the field; **that tolerance survives, and the test
+pinning it is unchanged**. A key that is PRESENT carrying a non-string
+cannot have come from a grappa of any vintage — it is mangling.
+
+The general rule this is an instance of: **a cross-vintage tolerance is
+sized by what an older peer can actually emit, not by what the current
+narrower happens not to reject.** Read the typespec of the field before
+widening or narrowing a fallback; two fields that look alike at the call
+site can have different nullability, and the looser one is not the
+template.
+
+### Why dropping beats coercing here
+
+Two rulings point the same way. #1400 settled that the client boundary
+FAILS LOUD: a required field arriving with the wrong type is not invented.
+And #1251 added `mode` precisely so a list-mode bundle is not mislabelled —
+without it "the modal would render solanum's quiet list under a Bans
+heading". Answering a mangled value with `"b"` reinstates exactly the
+mis-attribution the field exists to prevent, which on this surface is the
+largest available surprise: the modal would assert, in its heading, a fact
+about the payload that the payload denies. An empty modal is a smaller
+lie than a confidently mislabelled one.
+
+### Provenance, and what stays unmeasured
+
+The divergence was not spotted by reading; it came out of the #1393 census
+(`cicchetto/src/__tests__/wireUserBoundary.test.ts`), which mutates every
+field of every user-topic arm against its generated schema. That census
+also settles the bucket it was built for: of 42 arms, 34 agree with their
+schema in both directions, and all 8 that diverge carry a written,
+issue-numbered rationale for diverging — `banlist_bundle` was the only one
+whose rationale falsified itself. The census measures; it migrates nothing,
+and the question of what #1393 does next is not settled here.
+
+_Not claimed: that a wrong-typed `mode` was ever observed in production.
+The finding is an inconsistency between two sibling arms, measured in the
+source, not an incident. Nothing here changes what the server emits._


### PR DESCRIPTION
## What this is

One branch replaying three PRs, replacing them: **#1472**, **#1471**, **#1465**. All three were based on `0330053c` and went stale together when #1470 landed. Replayed onto `1bdc624a` in that order — the guard before the bench that measures it.

8 files, 9 commits. No `Closes` keyword: the replay rewrote the shas, so GitHub cannot close the sources on its own and they are closed by hand, by content.

## Why one branch and not three merges

The cheap reason is the obvious one: three rebases and three ~40-minute `integration` runs collapse into one gate and one merge.

**The honest reason is better, and it is what this PR is really about.** #1471 is a census that MEASURES the boundary #1472 changes. Merged separately, each would have been green on its own, and *neither would ever have asked whether the bench still told the truth after the guard moved*. Together, that question is unavoidable — and it is answered in commit `5bb8c68f` rather than discovered later as drift.

## What each source brings

### #1472 — `banlist_bundle.mode`: stop coercing mangled input into the ban list

The arm justified its fallback as "additive-tolerant like `links_bundle`'s `mask`", but `links_bundle` guards the field and drops a wrong-typed value while `banlist_bundle` coerced *anything* non-string to `"b"`. It claimed parity with a sibling strictly stricter than itself.

The guard is now **stricter** than the model it imitates, and only because the typespecs differ:

| wire typespec | field | an explicit `null` is |
|---|---|---|
| `links_bundle_payload/0` | `mask: string \| null` | a shape the server really sends → tolerated |
| `banlist_bundle_payload/0` | `mode: string`, required | impossible from any grappa → dropped |

**BEHAVIOUR CHANGE**: a `mode` that is present but not a string used to reach the modal and now drops. The #1251 absent-tolerance is untouched — an older server omits the key entirely and still lands as `b`; its pinning test is unchanged and green.

Carries a DESIGN_NOTES entry, because the code alone now reads as a regression against a comment that argued the other way.

### #1471 — the user-topic boundary census, measured in both directions

`wireUserBoundary.test.ts` points the existing mutate-every-field harness at all 42 user-topic arms and records, per arm, where the hand narrower and the generated schema disagree — in **both** directions, because they cost opposite things:

* hand ACCEPTS what the schema REJECTS — a permissiveness hole, the only place migrating buys safety rather than line count;
* schema ACCEPTS what the hand REJECTS — strictness a migration would silently LOSE.

Measured: 8 arms diverge in the first direction, **zero** in the second, `armsAtParity: 34`. Every one of the 8 carries a written, issue-numbered rationale for diverging — which is why the census closes the sizing question with "nothing to migrate" rather than a slice list. Each direction has its own positive control; a zero in a column with no mutant would mean "blind", not "measured".

### #1465 — `waitForScrollRest`: settle the pane before measuring it

The e2e barrier for #1079 moved the pane off the tail but did not wait for it to come to rest, so the measurement could run mid-scroll. Also carries a DESIGN_NOTES entry recording the vacuity that was proved and the exploitation that was not.

## The reconciliation this union forced

The census had recorded `banlist_bundle` as accepting three mutations the schema rejects:

```
- "handAcceptsSchemaRejects": "mode/drop, mode/null, mode/wrong-type",
+ "handAcceptsSchemaRejects": "mode/drop",
```

Exactly one line moved, and no arm changed unexpectedly — the bench was run against the new guard and the red was read before the snapshot was rewritten. The residue is **named, not leftover**: `mode/drop` stays because #1251's absent-means-`b` allowance stays. `armsAtParity` is unchanged at 34 — the arm still diverges, just by less, so it does not join the parity set.

## DESIGN_NOTES: two branches append, so every eater mode applies

The cherry-picks pass through the `merge=union` driver and both #1465 and #1472 add an entry, so the separator-eater was measured rather than assumed:

| check | result |
|---|---|
| numstat, two-sided | `186  0  docs/DESIGN_NOTES.md` — **additions = 76 (#1472) + 110 (#1465), deletions ZERO** |
| file line delta | 46609 → 46795 = **+186**, equal to additions |
| marker uniqueness | `grep -Fxc` = 1 for each; a whole-file `uniq -d` over every marker returns nothing |
| boundary shape, read ON the file | both entries: previous entry's last line / marker / blank / `---` / blank / `## …`, with **no blank line before the marker** |
| tail mode (previous entry's last line) | intact for both — the `#1390 slice 3` entry above `#1393`, and the `#1393` entry above `#1336 S2` |
| `_Deploy:` count | **66 on `origin/main`, 66 here** |
| `scripts/design-notes-gate.sh` | **RC 0** — "2 new entry heading(s), separator and marker present" |

## Gates

- `bun run check` **rc 0** — `biome && tsc && tsc`. A biome failure short-circuits that chain, so a green recorded before the last edit is not a green and the type checks it "passed" never ran (#1469); this rc 0 is the whole chain.
- `bun run test` **rc 0** — 290 files / 5595 tests.
- The e2e specs #1465 touches are left to CI, which is the real gate for them.

## What this does NOT claim

- **Not that the 34 at parity are correct** — they agree with their schemas in both directions, which is not the same as being right. If schema and hand arm are wrong the same way, the census reads parity. `wireAdminBoundary`'s recorded SHAPES are the anchor against that and are not replicated here.
- **Not that the seven preserved tolerances are the right calls** — only that they are deliberate and written down. Whether each premise still holds (a server of that vintage still in the field) is unmeasured.
- **Not that a wrong-typed `banlist_bundle.mode` was ever observed in production.** The finding is an inconsistency between two sibling arms, measured in the source, not an incident.
- **Nothing about the server side**: `mode` was already required in the typespec, and nothing here changes what grappa emits.
- Census mutations are three (drop / null / wrong-type) and first-level fields only; a nested hole would not show. Agreement between the schemas and the SERVER contract is unmeasured — this compares two client-side boundaries against each other.
- **No verdict on #1393 itself.** The census measures the bucket; whether the issue closes on it belongs to its owner.
