### PR TITLE
test(#1396): net the 59-arm dispatch switch before proposing to move it

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -4889,7 +4889,7 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: string; draft: string }> = [
   { kind: "ctcp", draft: "/ctcp bob VERSION" },
   { kind: "ping", draft: "/ping bob" },
   { kind: "join", draft: "/join #b" },
-  { kind: "part", draft: "/part #a" },
+  { kind: "part", draft: "/part #other" },
   { kind: "invite", draft: "/invite bob #a" },
   { kind: "kick", draft: "/kick bob" },
   { kind: "kb", draft: "/kb bob" },
@@ -4900,8 +4900,8 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: string; draft: string }> = [
   { kind: "deop", draft: "/deop bob" },
   { kind: "voice", draft: "/voice bob" },
   { kind: "devoice", draft: "/devoice bob" },
-  { kind: "mode", draft: "/mode #a +m" },
-  { kind: "mode-view", draft: "/mode #a" },
+  { kind: "mode", draft: "/mode #other +m" },
+  { kind: "mode-view", draft: "/mode #other" },
   { kind: "mode-apply-current", draft: "/mode +s" },
   { kind: "umode", draft: "/umode +i" },
   { kind: "umode-view", draft: "/umode" },
@@ -4915,7 +4915,7 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: string; draft: string }> = [
   { kind: "watchlist", draft: "/hilight badger" },
   { kind: "whois", draft: "/whois bob" },
   { kind: "whowas", draft: "/whowas bob" },
-  { kind: "who", draft: "/who #a" },
+  { kind: "who", draft: "/who #other" },
   { kind: "names", draft: "/names" },
   { kind: "list", draft: "/list" },
   { kind: "links", draft: "/links" },
@@ -5296,7 +5296,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "effects": [
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "socket.pushChannelMode(1, "#a", "+m", [])",
+            "socket.pushChannelMode(1, "#other", "+m", [])",
           ],
           "result": {
             "ok": true,
@@ -5316,7 +5316,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
         },
         "mode-view": {
           "effects": [
-            "modeModal.openModeModal("freenode", "#a")",
+            "modeModal.openModeModal("freenode", "#other")",
             "networks.networkIdBySlug("freenode")",
           ],
           "result": {
@@ -5417,7 +5417,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
         },
         "part": {
           "effects": [
-            "api.postPart("tok", "freenode", "#a", null)",
+            "api.postPart("tok", "freenode", "#other", null)",
             "networks.networkIdBySlug("freenode")",
           ],
           "result": {
@@ -5634,7 +5634,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "effects": [
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "socket.pushWho(1, "#a")",
+            "socket.pushWho(1, "#other")",
           ],
           "result": {
             "ok": true,

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
+import type { SlashCommand } from "../lib/slashCommands";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
 import { BLANK_BODY_ERROR, serverAcceptsBody } from "./serverBodyPredicate";
 
@@ -4878,7 +4879,7 @@ const DISPATCH_CASE_LABELS = [
 // One draft per arm. The `kind` column is a CLAIM the first test checks
 // against the parser — a draft whose syntax drifts stops naming its arm
 // loudly instead of silently exercising a neighbour.
-const DISPATCH_DRAFTS: ReadonlyArray<{ kind: string; draft: string }> = [
+const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string }> = [
   { kind: "privmsg", draft: "hello" },
   { kind: "me", draft: "/me waves" },
   { kind: "msg", draft: "/msg bob hi" },
@@ -4972,11 +4973,13 @@ const renderArg = (a: unknown): string => {
     // the clock pins nothing else. The SHAPE is what matters here (an arm
     // that stops passing a timestamp still shows up), so it collapses to a
     // token. Caught by a mutant run, not by review.
-    return (JSON.stringify(a) ?? String(a))
-      .replace(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g, "<iso-instant>")
-      // The CTCP PING correlation token is epoch millis inside the body, so
-      // it moves for the same reason and is collapsed the same way.
-      .replace(/\d{13}/g, "<epoch-ms>");
+    return (
+      (JSON.stringify(a) ?? String(a))
+        .replace(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g, "<iso-instant>")
+        // The CTCP PING correlation token is epoch millis inside the body, so
+        // it moves for the same reason and is collapsed the same way.
+        .replace(/\d{13}/g, "<epoch-ms>")
+    );
   } catch {
     return "unserialisable";
   }
@@ -5007,7 +5010,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
   // exists is a stale row.
   it("the draft table covers every arm of the switch, and only real arms", async () => {
     const { parseSlash } = await import("../lib/slashCommands");
-    const labels = new Set<string>(DISPATCH_CASE_LABELS);
+    const labels = new Set<SlashCommand["kind"]>(DISPATCH_CASE_LABELS);
     // Coverage is computed from the kind the parser ACTUALLY returns, never
     // from the `kind` column: a row is only protection for the arm it really
     // reaches, so a mislabelled draft must not be able to report an arm as
@@ -5695,12 +5698,14 @@ describe("#1396 — dispatch characterization over every arm", () => {
     }
 
     const all = Object.values(sig);
-    const ambient = all[0].filter((e) => all.every((s) => s.includes(e)));
+    // Every arm ran, so `all` is non-empty; the fallback keeps tsc honest
+    // without inventing a branch the loop above cannot reach.
+    const ambient = (all[0] ?? []).filter((e) => all.every((s) => s.includes(e)));
     const own = Object.fromEntries(
       Object.entries(sig).map(([k, v]) => [k, v.filter((e) => !ambient.includes(e))]),
     );
 
-    const unprotected = Object.keys(own).filter((k) => own[k].length === 0);
+    const unprotected = Object.keys(own).filter((k) => (own[k] ?? []).length === 0);
     const bySignature = new Map<string, string[]>();
     for (const [k, v] of Object.entries(own)) {
       if (v.length === 0) continue;

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -4794,3 +4794,946 @@ describe("compose /ame + /amsg confirmation above ten channels (#431)", () => {
     expect(vi.mocked(sb.sendMessage)).not.toHaveBeenCalled();
   });
 });
+
+// #1396 — the characterization net for the 59-arm `dispatchDraft` switch.
+//
+// Bucket G proposes moving that switch out of `compose.ts`. A pure move has
+// no red: behaviour is identical by construction, so no mutant can buy it.
+// What buys a move is a net fixed BEFORE it, and this is that net.
+//
+// The net asserts the OBSERVABLE OUTCOME of a dispatch — which seam the verb
+// reaches and with what arguments, plus what `submit` returns — not a
+// sequence of calls. The return value alone cannot do it: 51 of the arms
+// answer `{ok: true}`, so a table asserting that would be a mirror. The
+// discriminating observable is what LEAVES the module, so each row records
+// every mocked seam the submission touched, serialised and sorted.
+//
+// Two tests, because they fail for different reasons and a single one would
+// let a gap hide: the first reconciles the table against the switch (a draft
+// that stops parsing to its kind, or an arm nobody drives, is a hole in the
+// net rather than a red somewhere else), the second pins the effects.
+
+const DISPATCH_CASE_LABELS = [
+  "admin",
+  "alias-define",
+  "ame",
+  "amsg",
+  "away",
+  "ban",
+  "banlist",
+  "connect",
+  "ctcp",
+  "deop",
+  "devoice",
+  "disconnect",
+  "error",
+  "info",
+  "invite",
+  "join",
+  "kb",
+  "kick",
+  "kill",
+  "links",
+  "list",
+  "lusers",
+  "me",
+  "mode",
+  "mode-apply-current",
+  "mode-view",
+  "motd",
+  "msg",
+  "names",
+  "nick",
+  "notice",
+  "notify",
+  "op",
+  "open-settings",
+  "oper",
+  "part",
+  "ping",
+  "privmsg",
+  "query",
+  "quit",
+  "quote",
+  "recover",
+  "rehash",
+  "service-modal",
+  "stats",
+  "topic-clear",
+  "topic-set",
+  "topic-show",
+  "umode",
+  "umode-target-view",
+  "umode-view",
+  "unalias",
+  "unban",
+  "version",
+  "voice",
+  "watchlist",
+  "who",
+  "whois",
+  "whowas",
+] as const;
+
+// One draft per arm. The `kind` column is a CLAIM the first test checks
+// against the parser — a draft whose syntax drifts stops naming its arm
+// loudly instead of silently exercising a neighbour.
+const DISPATCH_DRAFTS: ReadonlyArray<{ kind: string; draft: string }> = [
+  { kind: "privmsg", draft: "hello" },
+  { kind: "me", draft: "/me waves" },
+  { kind: "msg", draft: "/msg bob hi" },
+  { kind: "notice", draft: "/notice bob hi" },
+  { kind: "query", draft: "/query bob" },
+  { kind: "ame", draft: "/ame waves" },
+  { kind: "amsg", draft: "/amsg hi" },
+  { kind: "ctcp", draft: "/ctcp bob VERSION" },
+  { kind: "ping", draft: "/ping bob" },
+  { kind: "join", draft: "/join #b" },
+  { kind: "part", draft: "/part #a" },
+  { kind: "invite", draft: "/invite bob #a" },
+  { kind: "kick", draft: "/kick bob" },
+  { kind: "kb", draft: "/kb bob" },
+  { kind: "ban", draft: "/ban bob" },
+  { kind: "unban", draft: "/unban bob" },
+  { kind: "banlist", draft: "/banlist" },
+  { kind: "op", draft: "/op bob" },
+  { kind: "deop", draft: "/deop bob" },
+  { kind: "voice", draft: "/voice bob" },
+  { kind: "devoice", draft: "/devoice bob" },
+  { kind: "mode", draft: "/mode #a +m" },
+  { kind: "mode-view", draft: "/mode #a" },
+  { kind: "mode-apply-current", draft: "/mode +s" },
+  { kind: "umode", draft: "/umode +i" },
+  { kind: "umode-view", draft: "/umode" },
+  { kind: "umode-target-view", draft: "/mode bob" },
+  { kind: "topic-set", draft: "/topic new topic" },
+  { kind: "topic-show", draft: "/topic" },
+  { kind: "topic-clear", draft: "/topic -delete" },
+  { kind: "nick", draft: "/nick bob" },
+  { kind: "away", draft: "/away brb" },
+  { kind: "notify", draft: "/notify bob" },
+  { kind: "watchlist", draft: "/hilight badger" },
+  { kind: "whois", draft: "/whois bob" },
+  { kind: "whowas", draft: "/whowas bob" },
+  { kind: "who", draft: "/who #a" },
+  { kind: "names", draft: "/names" },
+  { kind: "list", draft: "/list" },
+  { kind: "links", draft: "/links" },
+  { kind: "lusers", draft: "/lusers" },
+  { kind: "motd", draft: "/motd" },
+  { kind: "info", draft: "/info" },
+  { kind: "version", draft: "/version" },
+  { kind: "stats", draft: "/stats m" },
+  { kind: "admin", draft: "/admin" },
+  { kind: "oper", draft: "/oper root secret" },
+  { kind: "kill", draft: "/kill bob spam" },
+  { kind: "rehash", draft: "/rehash" },
+  { kind: "quote", draft: "/quote PING :x" },
+  { kind: "connect", draft: "/connect freenode" },
+  { kind: "disconnect", draft: "/disconnect" },
+  { kind: "quit", draft: "/quit bye" },
+  { kind: "recover", draft: "/recover" },
+  { kind: "alias-define", draft: "/alias hi /msg bob $*" },
+  { kind: "unalias", draft: "/unalias hi" },
+  { kind: "open-settings", draft: "/watch" },
+  { kind: "service-modal", draft: "/ns" },
+  { kind: "error", draft: "/nosuchverb" },
+];
+
+// Every module the harness above replaces. The effect signature is built by
+// walking these for mock functions that recorded a call, so a new seam added
+// to an arm shows up as a new line rather than as silence.
+const MOCKED_SEAM_MODULES = [
+  "../lib/api",
+  "../lib/banlistModal",
+  "../lib/channelDirectory",
+  "../lib/members",
+  "../lib/mentionsWindow",
+  "../lib/modeModal",
+  "../lib/networks",
+  "../lib/queryWindows",
+  "../lib/scrollback",
+  "../lib/selection",
+  "../lib/serviceModal",
+  "../lib/socket",
+  "../lib/umodeModal",
+  "../lib/windowState",
+] as const;
+
+// Reader-visible, and stable across runs: functions and undefined are
+// rendered by shape rather than identity so a signature never depends on a
+// mock's address.
+const renderArg = (a: unknown): string => {
+  if (typeof a === "function") return "fn";
+  if (a === undefined) return "undefined";
+  try {
+    // An ISO instant is wall-clock, so leaving it in would make this net red
+    // on every run and green only when re-recorded — a snapshot that pins
+    // the clock pins nothing else. The SHAPE is what matters here (an arm
+    // that stops passing a timestamp still shows up), so it collapses to a
+    // token. Caught by a mutant run, not by review.
+    return (JSON.stringify(a) ?? String(a))
+      .replace(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g, "<iso-instant>")
+      // The CTCP PING correlation token is epoch millis inside the body, so
+      // it moves for the same reason and is collapsed the same way.
+      .replace(/\d{13}/g, "<epoch-ms>");
+  } catch {
+    return "unserialisable";
+  }
+};
+
+async function effectSignature(): Promise<string[]> {
+  const out: string[] = [];
+  for (const path of MOCKED_SEAM_MODULES) {
+    const mod: Record<string, unknown> = await import(path);
+    const short = path.replace("../lib/", "");
+    for (const [name, value] of Object.entries(mod)) {
+      if (!vi.isMockFunction(value)) continue;
+      for (const call of value.mock.calls) {
+        out.push(`${short}.${name}(${call.map(renderArg).join(", ")})`);
+      }
+    }
+  }
+  // Sorted: the net pins WHAT left the module, not the order it left in.
+  // Ordering between independent seams is an implementation detail, and
+  // pinning it would make the net fail on a harmless reordering.
+  return out.sort();
+}
+
+describe("#1396 — dispatch characterization over every arm", () => {
+  // The reference is the `case` labels transcribed from the switch, which is
+  // outside the table being checked. Reconciled BOTH ways: an arm no draft
+  // reaches is an unprotected arm, and a draft naming an arm that no longer
+  // exists is a stale row.
+  it("the draft table covers every arm of the switch, and only real arms", async () => {
+    const { parseSlash } = await import("../lib/slashCommands");
+    const labels = new Set<string>(DISPATCH_CASE_LABELS);
+    // Coverage is computed from the kind the parser ACTUALLY returns, never
+    // from the `kind` column: a row is only protection for the arm it really
+    // reaches, so a mislabelled draft must not be able to report an arm as
+    // covered while exercising its neighbour.
+    const reached = DISPATCH_DRAFTS.map((r) => parseSlash(r.draft).kind);
+
+    const misparsed = DISPATCH_DRAFTS.filter((r) => parseSlash(r.draft).kind !== r.kind).map(
+      (r) => `${r.draft} => ${parseSlash(r.draft).kind} (claimed ${r.kind})`,
+    );
+
+    expect({
+      arms: labels.size,
+      rows: reached.length,
+      duplicated: reached.filter((k, i) => reached.indexOf(k) !== i),
+      armsWithNoDraft: [...labels].filter((k) => !reached.includes(k)),
+      draftsNamingNoArm: reached.filter((k) => !labels.has(k)),
+      misparsed,
+    }).toMatchInlineSnapshot(`
+      {
+        "arms": 59,
+        "armsWithNoDraft": [],
+        "draftsNamingNoArm": [],
+        "duplicated": [],
+        "misparsed": [],
+        "rows": 59,
+      }
+    `);
+  });
+
+  it("each arm's observable effects are pinned", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const table: Record<string, { result: unknown; effects: string[] }> = {};
+    for (const row of DISPATCH_DRAFTS) {
+      vi.clearAllMocks();
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, row.draft);
+      let result: unknown;
+      try {
+        result = await compose.submit(k, "freenode", "#a");
+      } catch (e) {
+        result = `THREW ${String(e)}`;
+      }
+      table[row.kind] = { result, effects: await effectSignature() };
+    }
+    // Read the next test before trusting a row here. Six of them record a
+    // LIMIT OF THIS HARNESS rather than the arm's behaviour, and that test
+    // names them; a `{"error": "send failed"}` in this snapshot is very
+    // likely one of those, not a pin worth defending.
+    expect(table).toMatchInlineSnapshot(`
+      {
+        "admin": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "send failed",
+          },
+        },
+        "alias-define": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "send failed",
+          },
+        },
+        "ame": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "windowState.windowStateByChannel()",
+          ],
+          "result": {
+            "ok": "/ame: 11 channels — confirm to send",
+          },
+        },
+        "amsg": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "windowState.windowStateByChannel()",
+          ],
+          "result": {
+            "ok": "/amsg: 11 channels — confirm to send",
+          },
+        },
+        "away": {
+          "effects": [
+            "mentionsWindow.clearMentionsBundle("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushAwaySet("freenode", "brb")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "ban": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelBan(1, "#a", "bob")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "banlist": {
+          "effects": [
+            "banlistModal.openBanlistModal("freenode", "#a", "b")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelBanlist(1, "#a", "b")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "connect": {
+          "effects": [
+            "api.patchNetwork("tok", "freenode", {"connection_state":"connected"})",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "You're already at the session limit for this network from this device. Disconnect first or open from a different device.",
+          },
+        },
+        "ctcp": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "#a", "\\u0001VERSION\\u0001", {"kind":"ctcp","target":"bob"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "deop": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelDeop(1, "#a", ["bob"])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "devoice": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelDevoice(1, "#a", ["bob"])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "disconnect": {
+          "effects": [
+            "api.patchNetwork("tok", "freenode", {"connection_state":"parked"})",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "You're already at the session limit for this network from this device. Disconnect first or open from a different device.",
+          },
+        },
+        "error": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "unknown command: /nosuchverb",
+          },
+        },
+        "info": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushInfo(1)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "invite": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushChannelInvite(1, "#a", "bob")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "join": {
+          "effects": [
+            "api.postJoin("tok", "freenode", "#b", null)",
+            "networks.networkIdBySlug("freenode")",
+            "selection.setSelectedChannel({"networkSlug":"freenode","channelName":"#b","kind":"channel"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "kb": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelKick(1, "#a", "bob", "")",
+            "socket.resolveUserhost(1, "bob")",
+          ],
+          "result": {
+            "error": "/kb: host unknown for bob — ban not set (run /whois bob first); kicking anyway",
+          },
+        },
+        "kick": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelKick(1, "#a", "bob", "")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "kill": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushRaw(1, "KILL bob :spam")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "links": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushLinks(1, null)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "list": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "selection.setSelectedChannel({"networkSlug":"freenode","channelName":"$list","kind":"list"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "lusers": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushLusers(1, null, null)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "me": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "#a", "\\u0001ACTION waves\\u0001")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "mode": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushChannelMode(1, "#a", "+m", [])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "mode-apply-current": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelMode(1, "#a", "+s", [])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "mode-view": {
+          "effects": [
+            "modeModal.openModeModal("freenode", "#a")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "motd": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushMotd(1, null)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "msg": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "queryWindows.canonicalQueryNick(1, "bob")",
+            "queryWindows.openQueryWindowState(1, "bob", "<iso-instant>")",
+            "scrollback.sendMessage("freenode", "bob", "hi")",
+            "selection.setSelectedChannel({"networkSlug":"freenode","channelName":"bob","kind":"query"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "names": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushNames(1, "#a")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "nick": {
+          "effects": [
+            "api.postNick("tok", "freenode", "bob")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "notice": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "#a", "hi", {"kind":"notice","target":"bob"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "notify": {
+          "effects": [
+            "api.postNotifyAdd("tok", "freenode", ["bob"])",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": "notify: watching bob",
+          },
+        },
+        "op": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelOp(1, "#a", ["bob"])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "open-settings": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "oper": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "send failed",
+          },
+        },
+        "part": {
+          "effects": [
+            "api.postPart("tok", "freenode", "#a", null)",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "ping": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "#a", "\\u0001PING <epoch-ms>\\u0001", {"kind":"ctcp","target":"bob"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "privmsg": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "#a", "hello")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "query": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "queryWindows.canonicalQueryNick(1, "bob")",
+            "queryWindows.openQueryWindowState(1, "bob", "<iso-instant>")",
+            "selection.setSelectedChannel({"networkSlug":"freenode","channelName":"bob","kind":"query"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "quit": {
+          "effects": [
+            "api.patchNetwork("tok", "freenode", {"connection_state":"parked","reason":"bye"})",
+            "api.patchNetwork("tok", "libera", {"connection_state":"parked","reason":"bye"})",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networks()",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "quote": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushRaw(1, "PING :x")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "recover": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushRecover(1)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "rehash": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushRaw(1, "REHASH")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "service-modal": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "scrollback.sendMessage("freenode", "NickServ", "help")",
+            "serviceModal.openServiceModal("freenode", "NickServ")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "stats": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushRaw(1, "STATS m")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "topic-clear": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelTopicClear(1, "#a")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "topic-set": {
+          "effects": [
+            "api.postTopic("tok", "freenode", "#a", "new topic")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "topic-show": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+          ],
+          "result": {
+            "error": "/topic #a (bare) — inline render wired in C3 (TopicBar)",
+          },
+        },
+        "umode": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushChannelUmode(1, "+i")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "umode-target-view": {
+          "effects": [
+            "api.ownNickForNetwork({"kind":"user","id":1,"slug":"freenode","inserted_at":"","updated_at":""}, {"kind":"user","name":"vjt"})",
+            "networks.networkBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.user()",
+          ],
+          "result": {
+            "error": "/mode bob: viewing another user's modes isn't supported — use /mode <#channel> for a channel, or /mode mynick for your own user modes",
+          },
+        },
+        "umode-view": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "umodeModal.openUmodeModal("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "unalias": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "send failed",
+          },
+        },
+        "unban": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelUnban(1, "#a", "bob")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "version": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushVersion(1)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "voice": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.selectedChannel()",
+            "socket.pushChannelVoice(1, "#a", ["bob"])",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "watchlist": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushWatchlistAdd("badger")",
+          ],
+          "result": {
+            "ok": "highlight (1): myname",
+          },
+        },
+        "who": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushWho(1, "#a")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "whois": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushWhois(1, "bob", null)",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "whowas": {
+          "effects": [
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "socket.pushWhowas(1, "bob")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+      }
+    `);
+  });
+
+  // The net's own honesty check, and the reason the table above is not
+  // simply declared "59 arms covered".
+  //
+  // Every submission calls `networkIdBySlug`, so a non-empty effect list
+  // proves nothing on its own. What protects an arm is an effect no other
+  // arm produces — subtract the AMBIENT set (the calls common to all 59)
+  // and see what is left. An arm with nothing left is an arm this net would
+  // not notice losing, and a pair with the SAME remainder is a pair a move
+  // could swap without the net objecting.
+  //
+  // Both lists are pinned rather than described, so the day a mock is added
+  // and an arm starts being protected, this test fails and the gain is
+  // recorded instead of passing unnoticed.
+  it("names the arms this net does NOT protect", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sig: Record<string, string[]> = {};
+    for (const row of DISPATCH_DRAFTS) {
+      vi.clearAllMocks();
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, row.draft);
+      try {
+        await compose.submit(k, "freenode", "#a");
+      } catch {
+        // A throw is itself an outcome; the effects recorded up to it are
+        // what the net can see, and the row above keeps the thrown value.
+      }
+      sig[row.kind] = await effectSignature();
+    }
+
+    const all = Object.values(sig);
+    const ambient = all[0].filter((e) => all.every((s) => s.includes(e)));
+    const own = Object.fromEntries(
+      Object.entries(sig).map(([k, v]) => [k, v.filter((e) => !ambient.includes(e))]),
+    );
+
+    const unprotected = Object.keys(own).filter((k) => own[k].length === 0);
+    const bySignature = new Map<string, string[]>();
+    for (const [k, v] of Object.entries(own)) {
+      if (v.length === 0) continue;
+      const key = JSON.stringify(v);
+      bySignature.set(key, [...(bySignature.get(key) ?? []), k]);
+    }
+
+    expect({
+      arms: Object.keys(sig).length,
+      ambient,
+      unprotected,
+      indistinguishablePairs: [...bySignature.values()].filter((g) => g.length > 1),
+    }).toMatchInlineSnapshot(`
+      {
+        "ambient": [
+          "networks.networkIdBySlug("freenode")",
+        ],
+        "arms": 59,
+        "indistinguishablePairs": [
+          [
+            "ame",
+            "amsg",
+          ],
+        ],
+        "unprotected": [
+          "admin",
+          "oper",
+          "alias-define",
+          "unalias",
+          "open-settings",
+          "error",
+        ],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## What this is

The characterization net for the 59-arm `dispatchDraft` switch, added **before** anything is moved. **1 file** (`cicchetto/src/__tests__/compose.test.ts`), declared before starting with a cap of 2; it stayed at 1. Zero production change.

Bucket G (#1396) proposes lifting the switch out of `compose.ts`. A pure move has **no red** — behaviour is identical by construction — so no mutant can buy it. What buys a move is a net fixed first, and the net has to be built while the switch is still where it was measured.

## The counts, re-measured on `1bdc624a`

The issue measured at `e974baed`; the line numbers all moved, the counts did not.

| | issue | measured |
|---|---|---|
| arms in the switch | 59 | **59 — confirmed** |
| `switch` statements in `compose.ts` | (implicit 1) | **1**, at `:931` |
| `SlashCommand` union arms | 61 | **61 arms / 60 distinct `kind`s** (`error` and `away` each have two shapes) |
| verbs in the parser's `DISPATCH` | — | **58** |

Three different numbers for three different things, and the reconciliation between them is load-bearing: **60 kinds − 59 arms = 1, and that one is `empty`**, narrowed out at `compose.ts:841` **before** the switch. The `never` exhaustiveness check at `:2047` holds *because of* that pre-filter. Anyone moving the switch must carry that line with it, or the move does not fail a test — it fails to compile, or worse, gets "fixed" by adding a 60th arm, which silences the only thing that makes a new verb a compile error today.

⚠️ Counting the arms with an unanchored `grep -oE 'case "…"'` returns **61**, with `quote` and `oper` apparently doubled. They are not duplicate arms — two are mentions inside comments. Counted by exact indentation there are 59.

## How the net asserts, and why not the obvious way

**Not the return value.** 51 of the 59 arms assign `{ok: true}`; a table asserting the result would be a mirror.

**Not a call sequence** either. What discriminates an arm is what LEAVES the module, so each row records every mocked seam the submission touched, **with its arguments**, serialised and sorted. Ordering between independent seams is deliberately not pinned — a harmless reordering should not break the net.

Three tests, because they fail for different reasons:

1. **Reconciliation** against the `case` labels transcribed from the switch — a reference outside the table. Two-sided: an arm no draft reaches, and a draft naming no arm. Coverage is computed from the kind the parser **actually returns**, never from the `kind` column, so a mislabelled draft cannot report an arm as covered while exercising its neighbour. Six drafts were mislabelled on the first run and this is what caught them.
2. **The effects table** — the net proper.
3. **The honesty check** — see below.

## 🔴 The result: six arms this net does NOT protect, named

Every submission calls `networkIdBySlug`, so a non-empty effect list proves nothing. Subtract that ambient call and six arms have **nothing left**:

| arm | why | verdict |
|---|---|---|
| `error` | returns `{error: "unknown command: …"}` and touches nothing | correct — the result IS the observable |
| `open-settings` | returns `{ok: true}`; its seam is not in the harness, so the modal-open is invisible | **unprotected** |
| `admin`, `oper`, `alias-define`, `unalias` | return `{error: "send failed"}` — they **throw before reaching their seam** | **unprotected, and the row records a harness limit, not behaviour** |

Plus one indistinguishable pair: **`ame`/`amsg`**, which both stop at the >10-channel confirm gate and never fan out.

Those four are exactly the verbs a by-name grep already suggested were undriven (`admin`, `alias`, `oper`, `unalias`), now established by measurement rather than by grep. **This is filed as a result, not smoothed over:** a snapshot that records `{"error": "send failed"}` as though it were the arm's behaviour would be asserting an artefact. The list is pinned, so the day a mock is added and an arm starts being protected, the test fails and the gain is recorded instead of passing unnoticed.

## The mutant sample — two, surgical, declared

Not 59 runs. Two mutants chosen for being the kind of mistake a MOVE makes, not the first arms in the list.

**Mutant A — `notice` relabels its message kind as `privmsg`.** Killed: the net's `notice` row flips `{"kind":"notice"}` → `{"kind":"privmsg"}`. Two older tests also died, so `notice` was already protected; the net agrees with them rather than replacing them.

**Mutant B — `mode-view` opens the modal on the source window, ignoring an explicit `/mode #chan`.** First run: **the net stayed GREEN.** Only an older test caught it.

That is the most useful thing measured here, and it was a defect in the net, not in the arm: the `mode-view` row was aimed at `#a`, the same window it was submitted from, so `cmd.channel ?? getActiveChannel()` and `channelName` were the same value and the row could not tell them apart. Four rows had that degeneracy (`mode`, `mode-view`, `who`, `part`); they now name a channel other than the one they are sent from, so the argument has somewhere to be wrong. Re-injected, mutant B now kills the net too.

**What the sample proves, and what it does not:** `notice` and `mode-view` are non-vacuous. **The other 57 arms are NOT proved non-vacuous** — they are pinned, which is not the same as demonstrated-killable. No claim is made that a mutant in any of them would be caught.

## Two determinism bugs the mutant runs exposed

The snapshot embedded an **ISO instant** (`openQueryWindowState(…, "2026-08-17T10:15:15Z")`) and an **epoch-millis CTCP PING token**. Both are wall-clock: the net would have been red on every run and green only when re-recorded, which is a snapshot that pins the clock and nothing else. Both collapse to shape tokens now — an arm that stops passing a timestamp still shows up. Proven by record + **two clean replays**, all rc 0.

Neither was visible in review; a mutant run surfaced them.

## Gates

- `bun run check` **rc 0** — `biome && tsc && tsc`. This chain earned its keep here: a formatter error in the new block short-circuited it, so an earlier "green" was a statement about formatting only and neither `tsc` had run. With biome passing, `tsc` named three real problems in the new code (a bare `string` where the parser returns a closed union, two unguarded index reads). Typing the column against `SlashCommand["kind"]` means a row naming an arm that no longer exists is now a **compile** error — the same protection the `never` check gives the switch, applied to the net that guards it.
- `bun run test` **rc 0** — 289 files / 5586 tests.

## What this does NOT claim

- **Not that all 59 arms are covered.** Six are named as unprotected; that list is the deliverable, not a caveat.
- **Not that the 57 unmutated arms would catch a defect.** Pinned ≠ proved killable. Only `notice` and `mode-view` were bought.
- **Not that the net sees everything an arm does.** It sees the 14 mocked seam modules; an arm reaching a module the harness does not replace is invisible, which is exactly why four arms show up as unprotected.
- **No move is proposed here.** The measured shape that argues for one — `dispatchDraft` is 1273 of 2384 lines and references **two** closure locals (`sendPacedBody`, `nothingToPrepare`), touching **zero** store state — is recorded for the follow-up, not acted on.
