### PR TITLE
test(#1397): hoist passthrough_handler onto Grappa.IRCServer (19 copies, one body)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47065,3 +47065,59 @@ asserts is proven by the first CI run, not here. The committed
 `shottino/.SRCINFO` is hand-written and agrees with its `PKGBUILD` on the
 sentinels; nothing compares the two field by field, and the real regeneration
 is the arch job's `makepkg --printsrcinfo`._
+<!-- entry #1397 -->
+
+---
+
+## 2026-08-17 — #1397: a shared test helper arrives as a qualified call, not as a case-template import
+
+#1397 counts 152 duplicated helper definitions over 102 files and proposes, for
+the server half, to `import Grappa.AuthFixtures` in `DataCase` **and** in
+`ConnCase` and then delete the copies. The first slice took the opposite route —
+hoist onto the module that already owns the domain, call it qualified, touch no
+case template — and the reason is not taste.
+
+**The import is a compile-time collision, and it is unsliceable.** In Elixir a
+local `defp` that collides with an imported function of the same name and arity
+is a compile error, not a shadow. An import in a case template lands in the
+namespace of every file that uses it: `Grappa.DataCase` has 115 users and
+`GrappaWeb.ConnCase` has 61. The files that would break are exactly the ones the
+issue wants to clean — the 14 local `user_fixture`, 7 `network_fixture` and 4
+`visitor_fixture`. So the import and all 25 deletions would have to land in one
+commit, which is precisely the "big-bang" the issue's own slicing plan rules out.
+The issue's proposed "first slice of one file with zero deletions" cannot be the
+import step; that sentence died with its premise.
+
+**The suite already routes around this, measurably.** Of the 123 files importing
+`AuthFixtures`, 110 import it wholesale and **none of those 110 defines a
+colliding local**. The only two files that define a fixture of their own —
+`user_settings_test.exs` and `user_settings_display_prefs_test.exs` — both import
+with a narrowed `only: [visitor_fixture: 0]`, spelled exactly around their local
+`defp user_fixture`. Zero counter-examples in 110 is not proof of the language
+rule, but it is the shape the codebase has already settled into.
+
+**A qualified call has none of that coupling.** `passthrough_handler/0` is an
+argument to `IRCServer.start_link/1`, so every caller already has the module in
+scope; the helper moves with no import anywhere, and a test that still wants a
+handler of its own keeps it without a word. Each family of #1397 then becomes an
+independent, separately reviewable slice — which is the property that makes the
+remaining fifteen helpers tractable at all.
+
+**Corollary for the rest of the bucket:** prefer the module that consumes the
+helper over the case template, every time. `AuthFixtures` is already a module;
+its fixtures can be reached as `AuthFixtures.user_fixture(...)` without the
+template gaining anything. The template import buys keystrokes and costs the
+ability to slice.
+
+**Not established here.** Nothing was compiled or run for this entry. The
+collision is the documented Elixir rule plus the 110-to-0 evidence above, not a
+build we watched fail. The claim that consolidation is behaviour-preserving rests,
+for this slice only, on the nineteen bodies being byte-identical — one sha1 over
+the definition line, nineteen occurrences — and not on a suite run.
+
+**`await_handshake` is explicitly out of this reasoning.** Its 13 copies differ on
+three axes (timeout `1_000` ×11 vs `5_000` ×2, prefix `"USER"` ×12 vs `"USER "`
+×1, alias `IRCServer` ×12 vs `Grappa.IRCServer` ×1), and the timeout is a live
+decision: two files have already found one second insufficient. Consolidating it
+is choosing a barrier value, not removing a duplicate, and it must be bought with
+its own reason.

--- a/test/grappa/account_deletion_test.exs
+++ b/test/grappa/account_deletion_test.exs
@@ -33,10 +33,8 @@ defmodule Grappa.AccountDeletionTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa/bootstrap_test.exs
+++ b/test/grappa/bootstrap_test.exs
@@ -42,10 +42,8 @@ defmodule Grappa.BootstrapTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -23,11 +23,7 @@ defmodule Grappa.IRC.ClientTest do
   alias Grappa.IRC.{AuthFSM, Client, FakeLag, Message}
   alias Grappa.IRCServer
 
-  # Default handler: ignore everything; tests that need scripted replies
-  # supply their own.
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
-  defp start_server(handler \\ passthrough_handler()) do
+  defp start_server(handler \\ IRCServer.passthrough_handler()) do
     {:ok, server} = IRCServer.start_link(handler)
     {server, IRCServer.port(server)}
   end
@@ -2097,7 +2093,7 @@ defmodule Grappa.IRC.ClientTest do
     test "start_link/1 still works (no-state delegate to start_link/2)" do
       # The /1 arity is the existing legacy contract — every existing
       # caller in the test suite uses it. S11 must not break it.
-      {:ok, server} = IRCServer.start_link(passthrough_handler())
+      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(server)
       _ = start_client(port)
 
@@ -2115,7 +2111,7 @@ defmodule Grappa.IRC.ClientTest do
     # upstream close from a deadline miss.
 
     test "tcp_closed drains pending waiters with {:error, :tcp_closed}" do
-      {:ok, server} = IRCServer.start_link(passthrough_handler())
+      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(server)
       client = start_client(port)
 

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -25,10 +25,8 @@ defmodule Grappa.LiveIntrospectionTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -23,10 +23,8 @@ defmodule Grappa.Networks.ConnectionStateTest do
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -28,10 +28,8 @@ defmodule Grappa.OperatorTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -19,10 +19,8 @@ defmodule Grappa.Session.DirectoryTest do
   alias Grappa.{ChannelDirectory, IRCServer, PubSub.Topic, Scrollback, Session}
   alias Grappa.Networks.{Credentials, SessionPlan}
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -74,9 +74,7 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
-  defp start_server(handler \\ passthrough_handler()) do
+  defp start_server(handler \\ IRCServer.passthrough_handler()) do
     {:ok, server} = IRCServer.start_link(handler)
     {server, IRCServer.port(server)}
   end

--- a/test/grappa/spawn_orchestrator_test.exs
+++ b/test/grappa/spawn_orchestrator_test.exs
@@ -40,10 +40,8 @@ defmodule Grappa.SpawnOrchestratorTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -38,9 +38,7 @@ defmodule Grappa.Visitors.LoginTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
-  defp start_server(handler \\ passthrough_handler()) do
+  defp start_server(handler \\ IRCServer.passthrough_handler()) do
     {:ok, server} = IRCServer.start_link(handler)
     {server, IRCServer.port(server)}
   end

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -25,10 +25,8 @@ defmodule Grappa.Visitors.ReaperTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -131,10 +131,8 @@ defmodule GrappaWeb.GrappaChannelTest do
 
   # Shared IRC-fake helpers for after-join snapshot tests.
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -44,10 +44,8 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -43,10 +43,8 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(passthrough_handler())
+    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
     {server, Grappa.IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -43,9 +43,7 @@ defmodule GrappaWeb.AuthControllerTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
-  defp start_server(handler \\ passthrough_handler()) do
+  defp start_server(handler \\ IRCServer.passthrough_handler()) do
     {:ok, server} = IRCServer.start_link(handler)
     {server, IRCServer.port(server)}
   end

--- a/test/grappa_web/controllers/channels_controller_test.exs
+++ b/test/grappa_web/controllers/channels_controller_test.exs
@@ -41,10 +41,8 @@ defmodule GrappaWeb.ChannelsControllerTest do
     setup_network(vjt, 1024 + rem(System.unique_integer([:positive]), 60_000), "azzurra")
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -36,10 +36,8 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     {:ok, conn: put_bearer(conn, session.id), vjt: vjt}
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -20,8 +20,6 @@ defmodule GrappaWeb.NickControllerTest do
   alias Grappa.{IRCServer, Scrollback, Visitors}
   alias Grappa.Networks.Credentials
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   # Completes registration (001) so the session is welcomed and inbound
   # numerics traverse the post-registration path (NumericRouter) instead
   # of AuthFSM's registration clauses.
@@ -35,7 +33,7 @@ defmodule GrappaWeb.NickControllerTest do
     end
   end
 
-  defp start_server, do: start_server(passthrough_handler())
+  defp start_server, do: start_server(IRCServer.passthrough_handler())
 
   defp start_server(handler) do
     {:ok, server} = IRCServer.start_link(handler)

--- a/test/grappa_web/controllers/session_controller_test.exs
+++ b/test/grappa_web/controllers/session_controller_test.exs
@@ -37,10 +37,8 @@ defmodule GrappaWeb.SessionControllerTest do
     :ok
   end
 
-  defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
-
   defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -54,6 +54,22 @@ defmodule Grappa.IRCServer do
   ## API
 
   @doc """
+  The do-nothing handler: buffers every inbound line, replies to none,
+  keeps handler state untouched. The right `start_link/1` argument for
+  a test that cares about what the CLIENT sent, not what the server
+  answers.
+
+  Lifted here from nineteen byte-identical `defp` copies across the
+  suite (#1397). It belongs on this module rather than in a case
+  template because it is an argument to `start_link/1`, so the caller
+  already has `IRCServer` in scope and reaches it as a qualified call —
+  no `import`, and therefore no collision with a test that still keeps
+  a local handler of its own.
+  """
+  @spec passthrough_handler() :: handler()
+  def passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
+
+  @doc """
   Spawns the fake IRC server with `handler` driving inbound-line
   reactions. Initial handler state is `%{}` — equivalent to
   `start_link/2` with `initial_state` of `%{}`. Use `start_link/2`


### PR DESCRIPTION
## What this is

Bucket **H test-harness** of the 2026-08-15 architecture review, first slice.
`passthrough_handler` — the do-nothing handler every session test hands to
`IRCServer.start_link/1` — was defined **19 times, once per test file**. All 19 are
**byte-identical**: one sha1 over the definition line, 19 occurrences, no whitespace
normalisation needed.

    defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end

It moves onto `Grappa.IRCServer`, the module that consumes it. **20 files, one logical
change, one commit** (a second commit carries the decision record).

- 19 `defp` deleted; on `client_test.exs` the two comment lines documenting the deleted
  function go with it (the only file that had them).
- **21** call sites qualified — not 19: `client_test.exs` has three.
- Each site takes the prefix its own file already uses for the module: bare `IRCServer.`
  in the 13 files holding an alias, `Grappa.IRCServer.` in the 6 that spell it out. No
  file gains a second style for the same module.

## 🔴 Why the helper is a qualified call and NOT an import in the case template

The issue proposes importing `AuthFixtures` in `DataCase` **and** `ConnCase`. This slice
takes the opposite route deliberately, and the reason is structural rather than stylistic.

In Elixir a local `defp` colliding with an imported function of the same name and arity is
a **compile error**, not a shadow. An import in a case template lands in the namespace of
every file using it: **115 `DataCase` users + 61 `ConnCase` users = 176 files**. The files
it would break are exactly the ones the issue wants cleaned — the **25** local fixture
copies (14 `user_fixture`, 7 `network_fixture`, 4 `visitor_fixture`).

The suite has already settled around this, measurably:

- **123** files import `AuthFixtures`; **110** import it wholesale.
- **None of those 110** defines a colliding local.
- The only **2** files that define a fixture of their own — `user_settings_test.exs` and
  `user_settings_display_prefs_test.exs` — both import with a narrowed
  `only: [visitor_fixture: 0]`, spelled exactly around their local `defp user_fixture`.

So the import route forces the hoist and all 25 deletions into **one commit**, which is
the big-bang the issue's own slicing plan rules out. **The issue's proposed "first slice of
one file with zero deletions" is dead with its premise** — stating that plainly rather than
quietly routing around it. A qualified call has none of that coupling: the caller already
has `IRCServer` in scope, nothing is imported anywhere, and a test that still wants its own
handler keeps it without a word. That is what keeps the remaining fifteen helper families
independently sliceable.

The reasoning is recorded in `docs/DESIGN_NOTES.md` (entry `#1397`) rather than only here,
because it sets the boundary for those fifteen.

## What is deliberately NOT in this slice

**`await_handshake`.** Its 13 copies differ on three axes — timeout `1_000` ×11 vs `5_000`
×2, prefix `"USER"` ×12 vs `"USER "` ×1, alias `IRCServer` ×12 vs `Grappa.IRCServer` ×1.
Consolidating it means **choosing a timeout**, and two files have already found one second
insufficient. That is a barrier decision to be bought with its own reason, not a
deduplication, and it does not belong in a mechanical slice.

**The `\\` defaults in the `start_server/1` heads.** This change edits their default
*expression*, so the "remove defaults when you touch them" rule is arguably in scope. They
are left alone on purpose: they belong to `start_server`, a separate family in this same
issue (21 clauses, 6 distinct bodies) with its own slice, and removing them here would
change every caller and blow the declared file count. Flagging the call rather than
omitting it.

## Verification

`scripts/check.sh` — **RC=0**, every phase run:

| phase | result |
|---|---|
| Credo (strict) | `6093 mods/funs, found no issues.` |
| Sobelow v0.14.1 | one **Low**-confidence finding, `lib/grappa/cic/bundle.ex:170` — outside this diff |
| Doctor | 353 modules passed, 0 failed, 100% spec coverage |
| ExUnit | **8 doctests, 61 properties, 6507 tests, 0 failures** |
| Dialyzer | `done (passed successfully)` |
| bats | **540 ok, 0 not ok** |

### Positive control

A refactor that centralises something should be provable by breaking the centre. The
helper was mutated to return a value that is not a 2-arity function
(`def passthrough_handler, do: :mutant`), which fails the `is_function(handler, 2)` guard
on `start_link/1`. Deliberately not a compile error — that would redden the whole suite
and measure nothing.

Result: **610 failures across exactly 19 distinct files. 0 missing, 0 unexpected.** The
per-file failure counts sum to 610, i.e. every reported failure is attributed, which is
what validates the count rather than eyeballing it. Before this slice, breaking one copy
reddened one file.

## What this PR does not claim

- 🔴 **The positive control proves the 19 files DEPEND on the single definition. It does
  NOT prove their assertions are sensitive to the passthrough's SEMANTICS.** The mutant
  breaks `start_link/1`'s guard, not the handler's behaviour; a mutant that *replies*
  instead of staying silent could well leave some of those 19 green. That was not measured,
  and it is the honest limit of this evidence.
- The green is on a **shared `_build`** (the caches are shared across worktrees by design).
  No forced rebuild was done. Nothing suggests contamination — there were no failures at
  all — but the result is "green on a shared build tree", not "green on one rebuilt from
  scratch".
- **No suite-time and no Argon2 number.** The issue leaves both explicitly unestablished
  and this slice does not touch either; nothing here should be read as a speedup claim.
- The remaining fifteen families are untouched. The DESIGN_NOTES entry fixes the principle
  (prefer the consuming module over the case template); it does not prove the next slice.
