### PR TITLE
packaging(#1447) slice A: shottino gets its own package, built but not published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,51 @@ jobs:
             echo "::error::shottino --help produced no usage output"; cat /tmp/shottino-help.txt; exit 1; }
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
+      # #1447 slice A — the STANDALONE client package. Inspected, NOT
+      # installed: the bouncer package above still owns /usr/bin/shottino, so
+      # `apt-get install` of this one would conflict on the path. That is
+      # exactly what the Breaks: asserted below is for, and exactly why this
+      # package is not published yet.
+      #
+      # The bats suite pins the CONFIG; only this step can prove nfpm accepted
+      # it and rendered what the config asked for.
+      - name: Prove the standalone shottino package is thin and takes the path over
+        run: |
+          deb="$(find dist-shottino -name 'shottino_*.deb' -print -quit)"
+          [ -n "$deb" ] || { echo "::error::no standalone shottino .deb in dist-shottino/"; exit 1; }
+          echo "package: $deb"
+          dpkg-deb -I "$deb"
+
+          # Exactly one regular file, and it is the client. A package that
+          # grew a second payload has stopped being the thin client package.
+          files="$(dpkg-deb -c "$deb" | awk '$1 !~ /^d/ { print $NF }')"
+          echo "contents: $files"
+          [ "$files" = "./usr/bin/shottino" ] || {
+            echo "::error::expected exactly ./usr/bin/shottino, got: $files"; exit 1; }
+
+          # The takeover metadata reached the control file intact — an
+          # unexpanded ${VAR} would show up here verbatim (nfpm does not
+          # expand deb.breaks).
+          dpkg-deb -f "$deb" Breaks | grep -qF 'grappa (<< 1.3.0)' || {
+            echo "::error::Breaks: is not the literal grappa (<< 1.3.0)"
+            dpkg-deb -f "$deb" Breaks; exit 1; }
+          dpkg-deb -f "$deb" Replaces | grep -qF 'grappa (<< 1.3.0)' || {
+            echo "::error::Replaces: is not the literal grappa (<< 1.3.0)"
+            dpkg-deb -f "$deb" Replaces; exit 1; }
+
+          # Its own version line, not the bouncer's.
+          want="$(infra/packaging/version.sh shottino)"
+          got="$(dpkg-deb -f "$deb" Version)"
+          echo "client version: '$got' (want '$want')"
+          [ "$got" = "$want" ] || {
+            echo "::error::client package is stamped '$got', expected '$want'"; exit 1; }
+
+      # NOTE (#1447 slice A): dist-shottino/ is deliberately NOT uploaded.
+      # This glob is path-scoped, which is the only thing keeping the client
+      # package off the release: `publish` attaches by NAME at any depth
+      # (infra/packaging/release_assets.sh), so anything that reaches the
+      # artifact bundle IS attached. Slice B drops /usr/bin/shottino from the
+      # bouncer package and turns publishing on in the same change.
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -512,6 +557,37 @@ jobs:
             echo "::error::shottino --help produced no usage output"; cat /tmp/shottino-help.txt; exit 1; }
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
+      # #1447 slice A — the STANDALONE client package, inspected not installed
+      # (the bouncer package above still owns /usr/bin/shottino). The deb job
+      # runs the same three proofs through dpkg-deb; here they go through rpm,
+      # where nfpm renders `replaces:` as Obsoletes: and drops deb-only Breaks.
+      - name: Prove the standalone shottino package is thin and takes the path over
+        run: |
+          pkg="$(find dist-shottino -name 'shottino-*.rpm' -print -quit)"
+          [ -n "$pkg" ] || { echo "::error::no standalone shottino .rpm in dist-shottino/"; exit 1; }
+          echo "package: $pkg"
+          rpm -qpi "$pkg"
+
+          files="$(rpm -qpl "$pkg")"
+          echo "contents: $files"
+          [ "$files" = "/usr/bin/shottino" ] || {
+            echo "::error::expected exactly /usr/bin/shottino, got: $files"; exit 1; }
+
+          # nfpm maps `replaces:` to Obsoletes: on rpm (rpm/rpm.go), so this is
+          # the same declaration the .deb spells as Replaces:.
+          rpm -qp --obsoletes "$pkg" | grep -qF 'grappa < 1.3.0' || {
+            echo "::error::Obsoletes: is not the literal grappa < 1.3.0"
+            rpm -qp --obsoletes "$pkg"; exit 1; }
+
+          want="$(infra/packaging/version.sh shottino)"
+          got="$(rpm -qp --queryformat '%{VERSION}' "$pkg")"
+          echo "client version: '$got' (want '$want')"
+          [ "$got" = "$want" ] || {
+            echo "::error::client package is stamped '$got', expected '$want'"; exit 1; }
+
+      # NOTE (#1447 slice A): dist-shottino/ is deliberately NOT uploaded —
+      # see the sibling note in the `deb` job for why the path-scoped glob is
+      # the gate.
       - name: Upload .rpm artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46877,3 +46877,111 @@ because reaching it means fabricating a state the FSM cannot emit. And the
 claim that no OTHER consumer names the moved functions was scoped to `lib` and
 `test` — a comment in `cicchetto/src/RecoverModal.tsx` named one, and was
 found only after the move._
+<!-- entry #1447 slice A -->
+
+---
+
+## 2026-08-17 — #1447 slice A: shottino gets a package, and the README stops arguing against it
+
+A client-only host had no way to install the terminal client without also
+installing a bouncer: one binary package carried the mix release, the built
+SPA and `shottino` together — 37.0 MB of `.deb` at v1.2.0 — and its
+`postinstall.sh` enabled a systemd unit. `nfpm-shottino.yaml` renders the
+client on its own. This slice is the ADDITIVE half: the bouncer package is
+untouched and still ships `/usr/bin/shottino`.
+
+### The cut, and why it is where it is
+
+The whole change is 11-12 files, past the point where one commit is
+reviewable, so it is two slices — cut on the BOUNDARY rather than on cost.
+Slice A only adds; slice B takes the file out of the bouncer package. That
+placement is load-bearing twice over:
+
+* Every decision that presupposes the drop lands in B. `Replaces:` /
+  `Breaks:` exist because a file changed owner, so while `grappa` still
+  ships it there is nothing to declare and nothing to guess. A could
+  therefore start before that question was answered.
+* Neither slice can ship a broken pair. Both packages own
+  `/usr/bin/shottino` until B lands; publishing them together would put two
+  mutually uninstallable artifacts on the same release.
+
+### The only thing keeping this off the release page is a directory
+
+The first reading blamed `release_assets.sh`, whose `found()` matches
+release assets by NAME AT ANY DEPTH (`find "$dir" -type f -name '*.deb'`).
+That is the wrong suspect: it only ever sees what the `publish` job already
+DOWNLOADED. The real gate is one step earlier and is PATH-scoped — the
+upload steps say `path: dist/*.deb` and `path: dist/*.rpm` — so a package
+written to `dist-shottino/` is never uploaded, never downloaded, never
+attached.
+
+Both halves matter and they point the same way: the directory split is
+sufficient, and it is also the ONLY thing there, because once a file enters
+the artifact bundle the name-matching audit will attach it. So the pin
+derives the forbidden directories from the workflow's own upload globs
+rather than naming `dist`.
+
+### Two versions, two cadences
+
+The package is stamped from `frontends/shottino/version.h` (today `0.3.0`),
+not the grappa tag — vjt's ruling, 2026-08-16. `shottino --version` and the
+package version then agree, which they could not if the client inherited a
+bouncer release number it has no relationship to. `version.sh` grew a
+component argument instead of gaining a sibling script: the question it
+answers is "which file carries which version line", and that has one home.
+The no-argument form still means `grappa`, because the FreeBSD jail build
+calls it bare.
+
+### The takeover boundary is a constant, and three reasons say so
+
+`Replaces:` / `Breaks: grappa (<< 1.3.0)` — the number is vjt's, 2026-08-17.
+Deriving it from `${GRAPPA_VERSION}` was considered and rejected on
+SEMANTICS: the field asserts "every grappa older than this shipped the
+file", which is a HISTORICAL fact about one release, so at 1.4.0 the
+interpolation would claim 1.3.0 shipped a file it did not — a false
+statement in package metadata, which is worse than an inconvenient one.
+
+Two further reasons turned up in nfpm v2.43.0's source (the version
+`build.sh` pins) rather than in reasoning about it:
+
+* **`deb.breaks` is not env-expanded at all.** nfpm expands `${VARS}` in
+  depends / replaces / recommends / provides / suggests / conflicts
+  (`nfpm.go:214-227`); `Breaks` lives on the `Deb` struct (`nfpm.go:438`)
+  and is absent from that list, so an interpolation would land in the
+  control file verbatim. The option was never available.
+* **`replaces` already covers both formats.** nfpm emits Debian's
+  `Replaces:` and maps the same list to RPM's `Obsoletes:`
+  (`rpm/rpm.go`: `Obsoletes: replaces`), so the takeover needs one field,
+  not a per-format pair.
+
+A guard was drafted asserting the literal is `<=` the current `VERSION` and
+then discarded before it was written: `VERSION` stays at the PREVIOUS
+release until the cut commit, so that assertion would have read
+`1.3.0 <= 1.2.0` and been red on the day it was authored — the
+interpolation's own defect, wearing a test's clothes. What is pinned
+instead is that the two fields hold no `$`, which has a real failure mode
+behind it and is killed by a mutant that adds a third, interpolated entry.
+
+### The README paragraph was a defect, not a leftover
+
+`infra/packaging/README.md` justified the single package with "splitting it
+into its own package would add a second thing to maintain and buy nothing:
+it is a client for the server you just installed." The client-only host is
+precisely the counterexample, and it is the ordinary case. A document that
+argues against what the repo does misleads the next reader with the
+authority of prose, so it is rewritten in this slice rather than left to be
+tidied later.
+
+The same paragraph claimed "one ~180 KB binary". #1447 records the size as
+NOT measured and nobody measured it since; it could not be measured from
+the host this slice was written on, which produces a Mach-O binary rather
+than the Linux artifact the claim is about. So the number leaves the
+document and the build prints the real one instead — a figure in prose goes
+stale in silence, one in the build log is always that build's, on that host.
+
+_Not established: nothing here was built. No `.deb` or `.rpm` was produced,
+no `dpkg -i` was run, and the size line has never printed. The suite pins
+the CONFIGURATION — that the package is thin, that its version comes from
+the header, that its output directory is outside every upload glob — which
+is what can be held still without a Linux toolchain. Whether nfpm accepts
+these two files is proven by the first CI run, not here._

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -33,21 +33,62 @@ the package.
 
 ### The terminal client
 
-`shottino` (`frontends/shottino`, C + ncurses) ships in the SAME package
-as the bouncer rather than a separate `grappa-shottino`. It is one
-~180 KB binary, and its runtime libraries are already package
-dependencies for the bundled ERTS — the only addition is `libncursesw6`,
-which is NOT the same Debian package as the `libncurses6` ERTS wants
-(shottino links the WIDE build because it is UTF-8 end to end). Splitting
-it into its own package would add a second thing to maintain and buy
-nothing: it is a client for the server you just installed.
+`shottino` (`frontends/shottino`, C + ncurses) has **its own package**,
+built from `nfpm-shottino.yaml` (GH #1447).
 
-Both packages build it from source so it links the build host's
+It used to ship only inside the bouncer package, and the reason written
+here was that splitting it "would add a second thing to maintain and buy
+nothing: it is a client for the server you just installed." **That premise
+was wrong, and the host it is wrong about is the ordinary one:** a machine
+that wants to *talk to* a grappa somewhere else is not the machine running
+it. Today that user has to take a self-contained ERTS and a built SPA —
+37.0 MB of `.deb` at v1.2.0, essentially none of which the client uses —
+and `postinstall.sh` enables a systemd unit they never asked for. The
+client is one C binary against ncursesw and OpenSSL. A second yaml is a
+smaller price than that.
+
+The standalone package is deliberately thin: **one file**, no maintainer
+scripts, no system user, no unit, and none of the bouncer's ERTS-side
+dependencies. It carries the WIDE `libncursesw6` (NOT the `libncurses6`
+ERTS wants — Debian ships them separately; Fedora folds both SONAMEs into
+`ncurses-libs`), OpenSSL, and `ca-certificates`, because the client calls
+`SSL_CTX_set_default_verify_paths()` and verifies with `SSL_VERIFY_PEER`.
+
+It keeps **its own version line** — `frontends/shottino/version.h`, read by
+`version.sh shottino` — rather than the grappa tag. Two artifacts, two
+cadences: `shottino --version` and the package version agree, which they
+could not if the package were stamped with a bouncer release number.
+
+Its metadata takes `/usr/bin/shottino` over from the bouncer with
+`Replaces:` / `Breaks: grappa (<< 1.3.0)` (nfpm maps `replaces` to RPM's
+`Obsoletes`). That boundary is historical — the first release that stops
+shipping the file — so it is written as a constant and must not become
+`${GRAPPA_VERSION}`: at 1.4.0 that would assert grappa 1.3.0 shipped a file
+it did not. `deb.breaks` is also absent from nfpm's env-expansion list, so
+an interpolation there reaches the control file verbatim.
+
+**Where the split stands.** The bouncer package **still ships the client**;
+dropping it from `nfpm.yaml` and from the AUR `PKGBUILD` is the next step.
+Until then both packages own `/usr/bin/shottino` and cannot be
+co-installed, so the standalone one is **built and proven on every
+packaging job but not published**: it is written to `dist-shottino/`, and
+the release workflow's upload steps are path-scoped globs (`path:
+dist/*.deb`), so nothing outside `dist/` reaches the release. That
+directory split is the only gate — `release_assets.sh found` matches by
+name at ANY depth, so a file that reaches the artifact bundle WILL be
+attached — and it is pinned by `test/infra/packaging_shottino_pkg_test.bats`.
+
+Every package builds the client from source so it links the build host's
 ncurses/openssl, the same constraint that governs the ERTS payload.
-`SKIP_SHOTTINO=1` opts the `.deb` build out; without that opt-out a
-failed client build FAILS the package build, because a package that
-silently ships without a binary it advertises is worse than one that
-refuses to build.
+`SKIP_SHOTTINO=1` opts both the build and the client package out; without
+that opt-out a failed client build FAILS the package build, because a
+package that silently ships without a binary it advertises is worse than
+one that refuses to build.
+
+The build **prints the binary's size** (`==> shottino binary: N bytes`)
+instead of recording it here. This paragraph carried "one ~180 KB binary"
+for a long time with nothing behind it; a number in prose goes stale in
+silence, while one in the build log is always that build's, on that host.
 
 `build.sh` snapshots and restores `config.mk` around `./configure`:
 that file is tracked, and leaving it modified makes the tree dirty, which

--- a/infra/packaging/build.sh
+++ b/infra/packaging/build.sh
@@ -16,11 +16,14 @@
 #   GRAPPA_PKG_FORMAT deb | rpm — the nfpm output format (default: deb).
 #                     Build each format on its OWN distro: the bundled ERTS
 #                     + shottino link the build host's glibc/libssl.
-#   OUT_DIR           where the package lands (default: <repo>/dist)
+#   OUT_DIR           where the BOUNCER package lands (default: <repo>/dist)
+#   SHOTTINO_OUT_DIR  where the STANDALONE CLIENT package lands
+#                     (default: <repo>/dist-shottino). Deliberately NOT
+#                     OUT_DIR — see the client-package section below.
 #   NFPM_BIN          path to nfpm (default: on PATH, else downloaded pinned)
 #   SKIP_RELEASE=1    reuse an existing _build/prod/rel/grappa
 #   SKIP_CIC=1        reuse an existing staged cicchetto-dist
-#   SKIP_SHOTTINO=1   skip the terminal-client build
+#   SKIP_SHOTTINO=1   skip the terminal-client build AND its package
 
 set -euo pipefail
 
@@ -30,7 +33,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 PKG_DIR="${SCRIPT_DIR}"
 STAGING="${PKG_DIR}/staging"
+SHOTTINO_STAGING="${PKG_DIR}/staging-shottino"
 OUT_DIR="${OUT_DIR:-${REPO_ROOT}/dist}"
+# The standalone client package lands OUTSIDE OUT_DIR, and that is the whole
+# mechanism keeping #1447 slice A unpublished. The release workflow's upload
+# steps are PATH-scoped globs (`path: dist/*.deb`, `path: dist/*.rpm`), so a
+# package written elsewhere is never uploaded, never downloaded by `publish`,
+# and never attached. `release_assets.sh found` matches by NAME AT ANY DEPTH,
+# so once a file reaches the artifact bundle it WILL be attached — the
+# directory split is the only gate, and it lives here.
+#
+# It matters because slice A leaves the bouncer package shipping
+# /usr/bin/shottino: until slice B drops it, both packages own that path and
+# publishing the pair would ship two artifacts that cannot be co-installed.
+SHOTTINO_OUT_DIR="${SHOTTINO_OUT_DIR:-${REPO_ROOT}/dist-shottino}"
 
 say() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
@@ -42,6 +58,14 @@ if [ -z "${GRAPPA_VERSION:-}" ]; then
 	GRAPPA_VERSION="$("${SCRIPT_DIR}/version.sh")" || die "could not read the VERSION file — set GRAPPA_VERSION"
 fi
 export GRAPPA_VERSION
+
+# The client keeps its OWN version line (frontends/shottino/version.h) — two
+# artifacts, two cadences (#1447). Same script, different component, so the
+# "which file carries which number" answer stays in one place.
+if [ -z "${SHOTTINO_VERSION:-}" ]; then
+	SHOTTINO_VERSION="$("${SCRIPT_DIR}/version.sh" shottino)" || die "could not read frontends/shottino/version.h — set SHOTTINO_VERSION"
+fi
+export SHOTTINO_VERSION
 
 # ── Architecture ───────────────────────────────────────────────────────────
 if [ -z "${GRAPPA_PKG_ARCH:-}" ]; then
@@ -138,10 +162,21 @@ if [ "${SKIP_SHOTTINO:-}" != "1" ]; then
 	)
 	mkdir -p "${STAGING}/usr/bin"
 	install -m 0755 "${REPO_ROOT}/frontends/shottino/shottino" "${SHOTTINO_BIN}"
+	# The SAME binary also stages for the standalone package. Two staging trees
+	# rather than one shared with the bouncer, so slice B can drop the bouncer's
+	# copy by deleting its `contents:` entry and this line, and nothing else.
+	mkdir -p "${SHOTTINO_STAGING}/usr/bin"
+	install -m 0755 "${REPO_ROOT}/frontends/shottino/shottino" "${SHOTTINO_STAGING}/usr/bin/shottino"
 	# Prove the staged artifact RUNS before packaging it. `--help` needs no
 	# server, terminal or config, so it exercises the dynamic links for real.
 	"${SHOTTINO_BIN}" --help >/dev/null 2>&1 || die "staged shottino does not run (link error?)"
 	[ -x "${SHOTTINO_BIN}" ] || die "shottino missing at ${SHOTTINO_BIN}"
+	# The measured size of the shipped binary, on the build host that produced
+	# it. `wc -c` because BSD stat and GNU stat disagree on flags and this
+	# script runs on both. Printed rather than written down anywhere: a number
+	# in prose goes stale silently, a number in the build log is always the one
+	# from that build.
+	say "shottino binary: $(wc -c <"${SHOTTINO_BIN}" | tr -d ' ') bytes ($(uname -s) $(uname -m))"
 	# Put config.mk back now that the compile is done, and drop the trap so
 	# it cannot fire twice.
 	restore_config_mk
@@ -177,3 +212,18 @@ say "nfpm package (${GRAPPA_PKG_FORMAT}) → ${OUT_DIR}"
 
 say "done — package(s) in ${OUT_DIR}:"
 ls -la "${OUT_DIR}"/*."${GRAPPA_PKG_FORMAT}"
+
+# ── nfpm, the standalone client ────────────────────────────────────────────
+# Second config, same binary, same format flag — a second package is a second
+# yaml, not a new toolchain. Skipped in lockstep with the client BUILD: without
+# a staged binary there is nothing to package.
+if [ "${SKIP_SHOTTINO:-}" != "1" ]; then
+	mkdir -p "${SHOTTINO_OUT_DIR}"
+	say "nfpm package shottino ${SHOTTINO_VERSION} (${GRAPPA_PKG_FORMAT}) → ${SHOTTINO_OUT_DIR}"
+	(
+		cd "${PKG_DIR}"
+		"${nfpm_bin}" package -f nfpm-shottino.yaml -p "${GRAPPA_PKG_FORMAT}" -t "${SHOTTINO_OUT_DIR}"
+	)
+	say "done — client package(s) in ${SHOTTINO_OUT_DIR}:"
+	ls -la "${SHOTTINO_OUT_DIR}"/*."${GRAPPA_PKG_FORMAT}"
+fi

--- a/infra/packaging/nfpm-shottino.yaml
+++ b/infra/packaging/nfpm-shottino.yaml
@@ -53,14 +53,19 @@ description: |
 #     replaces / recommends / provides / suggests / conflicts (nfpm.go:214-227)
 #     and the Deb struct's `breaks` (nfpm.go:438) is absent from that list — an
 #     interpolation would land in the control file verbatim.
-#   * `replaces` covers BOTH formats: nfpm emits Debian's `Replaces:` and maps
-#     the same list to RPM's `Obsoletes:` (rpm/rpm.go: `Obsoletes: replaces`).
+#   * `breaks` is deb-only, hence the top-level `deb:` block below.
 #
-# `breaks` is deb-only, hence the top-level `deb:` block rather than an entry
-# under `overrides:`.
-replaces:
-  - grappa (<< 1.3.0)
-
+# 🔴 `replaces` reaches BOTH formats but the two SPELL a relation differently,
+# so it is written per-format and must NOT be hoisted to a shared top-level
+# list. nfpm maps `replaces` to RPM's `Obsoletes:` (rpm/rpm.go:289) via
+# rpmpack, whose parser is
+# `([^=<>\s]*)\s*((?:=|>|<)*)\s*(.*)?` (rpmpack/sense.go:24). Feed the Debian
+# spelling `grappa (<< 1.3.0)` to that and group 2 matches EMPTY — `(` is not
+# an operator — so it parses as name `grappa`, version `(<< 1.3.0)`, sense
+# `""`. And `""` is a legal key mapping to SenseAny (sense.go `stringToSense`),
+# so nothing errors: the build stays green and ships an Obsoletes: with a
+# garbage version and no comparison at all. Measured in the two sources, not
+# inferred from the syntax.
 deb:
   breaks:
     - grappa (<< 1.3.0)
@@ -91,11 +96,19 @@ overrides:
       - libncursesw6
       - libssl3t64 | libssl3
       - ca-certificates
+    # Debian relation syntax: parenthesised, `<<` for strictly-less.
+    replaces:
+      - grappa (<< 1.3.0)
   rpm:
     depends:
       - ncurses-libs
       - openssl-libs
       - ca-certificates
+    # RPM relation syntax for the SAME statement: bare, single `<`. Emitted as
+    # `Obsoletes:`. See the comment above the `deb:` block for what happens if
+    # the Debian spelling reaches this list instead.
+    replaces:
+      - grappa < 1.3.0
 
 contents:
   - src: ./staging-shottino/usr/bin/shottino

--- a/infra/packaging/nfpm-shottino.yaml
+++ b/infra/packaging/nfpm-shottino.yaml
@@ -1,0 +1,109 @@
+# nfpm config — builds the STANDALONE shottino .deb / .rpm from the staging
+# tree assembled by build.sh. Sibling of nfpm.yaml (the bouncer), rendered by
+# the same single nfpm binary into either format.
+#
+# WHY A SECOND PACKAGE (GH #1447). The bouncer package carries a self-contained
+# ERTS and the built SPA: 37.0 MB of .deb at v1.2.0, essentially all of it
+# runtime the terminal client does not use. It also enables a systemd unit. A
+# machine that wants only the client should take neither. The client is one C
+# binary against ncursesw + OpenSSL, so the split costs a second yaml and buys
+# a client-only host its whole disk back.
+#
+# The FORMAT is a flag, the PAYLOAD is not: the binary links the BUILD host's
+# glibc/ncursesw/libssl, so the .deb and the .rpm are still two builds on two
+# distros — the same constraint that governs the ERTS payload next door.
+#
+# ${SHOTTINO_VERSION} / ${GRAPPA_PKG_ARCH} are expanded from the environment
+# build.sh exports.
+
+name: shottino
+arch: ${GRAPPA_PKG_ARCH}
+platform: linux
+# The CLIENT's own version line (frontends/shottino/version.h), NOT the grappa
+# tag — vjt's ruling, 2026-08-16. Two artifacts, two cadences: `shottino
+# --version` and the package version agree, which they could not if the package
+# were stamped with the bouncer's release number. Derived by
+# `version.sh shottino`, so the header stays the single source.
+version: ${SHOTTINO_VERSION}
+section: net
+priority: optional
+maintainer: "Marcello Barnaba <vjt@users.noreply.github.com>"
+vendor: "Marcello Barnaba"
+homepage: "https://github.com/vjt/grappa-irc"
+license: "MIT"
+description: |
+  Terminal client for a grappa IRC bouncer — an irssi-shaped ncurses UI over
+  the same REST + Phoenix Channels API the web frontend uses. Talks to a
+  grappa server over the network; it does NOT need one installed locally.
+  Install the `grappa` package if you want to run the bouncer itself.
+
+# Takes /usr/bin/shottino over from the bouncer package, which shipped it up
+# to (but not including) 1.3.0 — vjt's ruling, 2026-08-17. Without this, dpkg
+# refuses the install against any grappa that still owns the path:
+# "trying to overwrite '/usr/bin/shottino', which is also in package grappa".
+#
+# The boundary is HISTORICAL and FIXED — the first release that stops shipping
+# the file — so it is written as a constant. It must NOT become
+# `${GRAPPA_VERSION}`: at 1.4.0 that would claim every grappa older than 1.4.0
+# shipped the file, which is false for 1.3.0, and a false statement in package
+# metadata is worse than an inconvenient one. Two further reasons, measured in
+# nfpm v2.43.0 (the version build.sh pins) rather than assumed:
+#
+#   * `deb.breaks` is NOT env-expanded. nfpm expands ${VARS} in depends /
+#     replaces / recommends / provides / suggests / conflicts (nfpm.go:214-227)
+#     and the Deb struct's `breaks` (nfpm.go:438) is absent from that list — an
+#     interpolation would land in the control file verbatim.
+#   * `replaces` covers BOTH formats: nfpm emits Debian's `Replaces:` and maps
+#     the same list to RPM's `Obsoletes:` (rpm/rpm.go: `Obsoletes: replaces`).
+#
+# `breaks` is deb-only, hence the top-level `deb:` block rather than an entry
+# under `overrides:`.
+replaces:
+  - grappa (<< 1.3.0)
+
+deb:
+  breaks:
+    - grappa (<< 1.3.0)
+
+# Runtime deps are per-format (disjoint package names across distro families).
+# NOT the bouncer's list: no ERTS here, so libncurses6 (the NARROW build ERTS
+# wants), libstdc++6, libgcc-s1 and the maintainer-script tools (passwd /
+# shadow-utils / util-linux / the openssl CLI) all stay out.
+#
+# The set is what `configure` probes and what the binary actually calls:
+#   ncursesw  — `check_pkg ncursesw`; the WIDE build, because the client is
+#               UTF-8 end to end. On Debian that is libncursesw6, a DIFFERENT
+#               package from libncurses6; Fedora folds both SONAMEs into
+#               ncurses-libs.
+#   openssl   — `check_pkg openssl`; libssl.so.3 + libcrypto.so.3.
+#   CA store  — shottino.c calls SSL_CTX_set_default_verify_paths() then
+#               SSL_CTX_set_verify(SSL_VERIFY_PEER), so it reads the system
+#               trust store. ca-certificates is a real dependency here, not one
+#               copied over from the server package.
+#
+# libssl3t64 | libssl3: Debian's 64-bit time_t transition renamed the OpenSSL
+# runtime package on Ubuntu 24.04 (noble) and forward WITHOUT a
+# `Provides: libssl3`, so a hard-coded `libssl3` is UNINSTALLABLE there. Same
+# libssl.so.3 SONAME either way. Kept byte-identical to the bouncer's entry.
+overrides:
+  deb:
+    depends:
+      - libncursesw6
+      - libssl3t64 | libssl3
+      - ca-certificates
+  rpm:
+    depends:
+      - ncurses-libs
+      - openssl-libs
+      - ca-certificates
+
+contents:
+  - src: ./staging-shottino/usr/bin/shottino
+    dst: /usr/bin/shottino
+    file_info:
+      mode: 0755
+
+# NO `scripts:` block, deliberately. The bouncer's postinstall creates a system
+# user, generates secrets and `systemctl enable`s a unit; a terminal client
+# must do none of that. Installing this package puts one binary on PATH and
+# changes nothing else about the machine — which is the whole point of #1447.

--- a/infra/packaging/version.sh
+++ b/infra/packaging/version.sh
@@ -1,10 +1,27 @@
 #!/bin/sh
-# version.sh — echo grappa's single canonical version to stdout.
+# version.sh — echo a component's single canonical version to stdout.
 #
-# THE single source of truth is the repo-root `VERSION` file; every other
-# carrier DERIVES from it, most of them through this script. Bump the
-# version by editing that file — nothing else.
+#   version.sh            grappa   (default — every pre-#1447 caller)
+#   version.sh grappa     grappa
+#   version.sh shottino   the terminal client
+#
+# This script is where "which file carries which version line" is answered,
+# ONCE. It does not hold a version of its own: each component's number stays in
+# its own carrier and is read from there.
+#
+#   grappa    the repo-root `VERSION` file. THE single source of truth for the
+#             bouncer; every other carrier DERIVES from it, most of them
+#             through this script. Bump by editing that file — nothing else.
+#   shottino  `frontends/shottino/version.h`. A SEPARATE line on a separate
+#             cadence (#1447, vjt's ruling 2026-08-16): the standalone client
+#             package is stamped with it, not with the grappa tag, so
+#             `shottino --version` and the package version agree.
+#
 # Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+#
+# The no-argument form is load-bearing and must keep meaning `grappa`: the
+# FreeBSD jail build calls this bare (see the POSIX note below), as do
+# build.sh and the AUR recipe generator.
 #
 # POSIX sh, NOT bash: the FreeBSD jail build (infra/freebsd/jail_cic_build.sh)
 # runs /bin/sh with no bash/bun port and calls this to derive the version.
@@ -22,11 +39,30 @@ SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1007
 REPO_ROOT="$(CDPATH= cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# `head -1` + `tr -d` strips any trailing newline / CR so the echoed value is
-# a bare `X.Y.Z`.
-version="$(head -1 "${REPO_ROOT}/VERSION" 2>/dev/null | tr -d '\r\n')"
+component="${1:-grappa}"
+
+case "${component}" in
+grappa)
+	# `head -1` + `tr -d` strips any trailing newline / CR so the echoed value
+	# is a bare `X.Y.Z`.
+	source_file="${REPO_ROOT}/VERSION"
+	version="$(head -1 "${source_file}" 2>/dev/null | tr -d '\r\n')"
+	;;
+shottino)
+	# The one `#define SHOTTINO_VERSION "X.Y.Z"` in the header. Anchored on the
+	# define so the `#ifndef` guard above it cannot match, and quote-delimited
+	# so a trailing comment cannot leak into the value.
+	source_file="${REPO_ROOT}/frontends/shottino/version.h"
+	version="$(sed -n 's/^#define SHOTTINO_VERSION "\(.*\)"$/\1/p' "${source_file}" 2>/dev/null | head -1 | tr -d '\r\n')"
+	;;
+*)
+	printf 'version.sh: unknown component %s (want: grappa | shottino)\n' "${component}" >&2
+	exit 2
+	;;
+esac
+
 if [ -z "${version}" ]; then
-	printf 'version.sh: could not read version from %s/VERSION\n' "${REPO_ROOT}" >&2
+	printf 'version.sh: could not read the %s version from %s\n' "${component}" "${source_file}" >&2
 	exit 1
 fi
 printf '%s\n' "${version}"

--- a/test/infra/integration_path_filter_test.bats
+++ b/test/infra/integration_path_filter_test.bats
@@ -185,20 +185,24 @@ assert_listed() {
     # Limit, stated rather than papered over: a trace observes the branch
     # this host takes. A producer that reads a different file per platform
     # would need every platform traced, and this sees one.
+    # The invocation as a human reads it, with no space dangling when the
+    # orchestration passes no argument — an empty one would misreport WHAT ran.
+    local shown="$producer${args:+ $args}"
+
     local trace rc=0
     # shellcheck disable=SC2086  # $args is the argument LIST — splitting is the point
     trace="$(cd "$REPO_ROOT" && sh -x "$REPO_ROOT/$producer" $args 2>&1 >/dev/null)" || rc=$?
     [ "$rc" -eq 0 ] || {
-        printf 'the e2e invocation `%s %s` failed (rc=%s) — cannot derive its reads:\n%s\n' \
-            "$producer" "$args" "$rc" "$trace" >&2
+        printf 'the e2e invocation `%s` failed (rc=%s) — cannot derive its reads:\n%s\n' \
+            "$shown" "$rc" "$trace" >&2
         return 1
     }
 
     local sources
     sources="$(printf '%s\n' "$trace" | files_named_in_trace)"
     [ -n "$sources" ] || {
-        printf 'tracing `%s %s` named no file under %s — the derivation is broken:\n%s\n' \
-            "$producer" "$args" "$REPO_ROOT" "$trace" >&2
+        printf 'tracing `%s` named no file under %s — the derivation is broken:\n%s\n' \
+            "$shown" "$REPO_ROOT" "$trace" >&2
         return 1
     }
 
@@ -206,6 +210,6 @@ assert_listed() {
     while IFS= read -r source_file; do
         [ -n "$source_file" ] || continue
         assert_listed "$paths" "$source_file" \
-            "the e2e stack's own \`$producer $args\` run reads it to produce GRAPPA_VERSION"
+            "the e2e stack's own \`$shown\` run reads it to produce GRAPPA_VERSION"
     done <<<"$sources"
 }

--- a/test/infra/integration_path_filter_test.bats
+++ b/test/infra/integration_path_filter_test.bats
@@ -16,6 +16,17 @@
 # would be a second copy of the filter, drifting the same way the filter
 # drifts from itself.
 #
+# The rule the version check enforces, stated once: A FILE BELONGS IN THE
+# FILTER WHEN THE E2E STACK READS IT. Read is meant literally and is measured
+# literally — the invocation `scripts/integration.sh` makes is re-run under a
+# shell trace and the files it names are the requirement. That phrasing is
+# load-bearing since #1447 gave the producer a second component: a file the
+# producer can read for SOME argument is not a suite input, only the files it
+# reads for the argument the suite passes are. The rule is never softened into
+# an exclusion list — an exception named after a file is the drift this suite
+# was written to catch, so the ONLY way a path leaves the requirement is by
+# ceasing to be read.
+#
 # NOT derived from `Grappa.Deploy.Preflight.docker_image?/1`, though it
 # reads like the same list: preflight answers "does the deployed container
 # need a COLD restart", this filter answers "can this change break the e2e
@@ -47,6 +58,25 @@ paths_for() {
         }
         inpaths { inpaths = 0 }
     ' "$WORKFLOW"
+}
+
+# The repo-rooted regular files named anywhere in a `sh -x` trace, read from
+# stdin. Deliberately an OVER-approximation of "reads": a path the run merely
+# names, but never opens, still earns a filter entry. The failure this gate
+# exists to prevent is a MISSING entry, so erring towards more is the safe
+# direction — an over-wide filter runs a suite that did not need to run, an
+# under-wide one lets a breaking change through without running it at all.
+files_named_in_trace() {
+    local token
+    tr ' ' '\n' | while IFS= read -r token; do
+        token="${token%\'}"
+        token="${token#\'}"
+        case "$token" in
+        "$REPO_ROOT"/*)
+            if [ -f "$token" ]; then printf '%s\n' "${token#"$REPO_ROOT"/}"; fi
+            ;;
+        esac
+    done | sort -u
 }
 
 # Fail unless `$2` is an exact entry of the filter list in `$1`.
@@ -120,30 +150,55 @@ assert_listed() {
         return 1
     }
 
-    local producer
-    producer="$(grep -oE '\$SRC_ROOT/[A-Za-z0-9._/-]+/version\.sh' \
-                    "$REPO_ROOT/scripts/integration.sh" \
-                | sed -E 's|^\$SRC_ROOT/||' | sort -u)"
-    [ "$(printf '%s\n' "$producer" | grep -c .)" -eq 1 ] || {
-        printf 'expected exactly one version producer in scripts/integration.sh, got:\n%s\n' \
-            "$producer" >&2
+    # The producer AND the arguments the orchestration hands it, captured as
+    # ONE invocation: since #1447 the producer answers a different component
+    # per argument, so its path alone no longer says which files get read.
+    local invocation
+    invocation="$(grep -oE '"\$SRC_ROOT/[A-Za-z0-9._/-]+/version\.sh"[^)]*' \
+                      "$REPO_ROOT/scripts/integration.sh" | sort -u)"
+    [ "$(printf '%s\n' "$invocation" | grep -c .)" -eq 1 ] || {
+        printf 'expected exactly one version invocation in scripts/integration.sh, got:\n%s\n' \
+            "$invocation" >&2
         return 1
     }
+
+    local producer args
+    producer="$(printf '%s' "$invocation" | sed -E 's|^"\$SRC_ROOT/||; s|".*$||')"
+    args="$(printf '%s' "$invocation" | sed -E 's|^"[^"]*"||; s|^ +||' | tr -d '"')"
 
     local paths
     paths="$(paths_for push)"
     assert_listed "$paths" "$producer" \
         "scripts/integration.sh runs it to export GRAPPA_VERSION"
 
-    # ...and whatever THAT script reads, which is the version's single source
-    # of truth. Derived, not transcribed: if the producer ever grows a second
-    # input, the second input is required here too.
+    # ...and whatever THAT INVOCATION reads. The rule is a property, never a
+    # list and never an exclusion: a file belongs in the filter when the e2e
+    # stack's own run of the producer touches it — the same reason `VERSION`
+    # is in there. So the read set is OBSERVED rather than parsed out of the
+    # producer's source: the very invocation above is re-run under a shell
+    # trace, with the same argument, and the repo-rooted files it names are
+    # required. A producer that grows a second input for THIS component grows
+    # the requirement with it; one that reads a file only for some OTHER
+    # component the e2e stack never asks for was never a suite input, and
+    # naming it here would assert a dependency that does not exist.
+    #
+    # Limit, stated rather than papered over: a trace observes the branch
+    # this host takes. A producer that reads a different file per platform
+    # would need every platform traced, and this sees one.
+    local trace rc=0
+    # shellcheck disable=SC2086  # $args is the argument LIST — splitting is the point
+    trace="$(cd "$REPO_ROOT" && sh -x "$REPO_ROOT/$producer" $args 2>&1 >/dev/null)" || rc=$?
+    [ "$rc" -eq 0 ] || {
+        printf 'the e2e invocation `%s %s` failed (rc=%s) — cannot derive its reads:\n%s\n' \
+            "$producer" "$args" "$rc" "$trace" >&2
+        return 1
+    }
+
     local sources
-    sources="$(grep -oE '\$\{REPO_ROOT\}/[A-Za-z0-9._/-]+' "$REPO_ROOT/$producer" \
-               | sed -E 's|^\$\{REPO_ROOT\}/||' | sort -u)"
+    sources="$(printf '%s\n' "$trace" | files_named_in_trace)"
     [ -n "$sources" ] || {
-        printf '%s reads no ${REPO_ROOT}-rooted file — the derivation is broken\n' \
-            "$producer" >&2
+        printf 'tracing `%s %s` named no file under %s — the derivation is broken:\n%s\n' \
+            "$producer" "$args" "$REPO_ROOT" "$trace" >&2
         return 1
     }
 
@@ -151,6 +206,6 @@ assert_listed() {
     while IFS= read -r source_file; do
         [ -n "$source_file" ] || continue
         assert_listed "$paths" "$source_file" \
-            "$producer reads it to produce GRAPPA_VERSION"
+            "the e2e stack's own \`$producer $args\` run reads it to produce GRAPPA_VERSION"
     done <<<"$sources"
 }

--- a/test/infra/packaging_shottino_pkg_test.bats
+++ b/test/infra/packaging_shottino_pkg_test.bats
@@ -160,31 +160,41 @@ upload_dirs() {
 
 # ── The path takeover, written literally ───────────────────────────────────
 
-@test "#1447 the takeover fields name grappa (<< 1.3.0)" {
+@test "#1447 the takeover names grappa 1.3.0 in each format's own relation syntax" {
     # vjt's ruling, 2026-08-17: the boundary is the first release that stops
     # shipping the file. A historical constant, written as a constant.
-    # `replaces` covers both formats — nfpm maps it to Debian's Replaces: and
-    # to RPM's Obsoletes: (rpm/rpm.go: `Obsoletes: replaces`).
-    grep -qF -- '- grappa (<< 1.3.0)' "$NFPM_CLIENT"
+    #
+    # Deb and RPM SPELL a relation differently and `replaces` reaches both, so
+    # it is written per-format. The Debian spelling is what deb.breaks and
+    # overrides.deb.replaces carry; overrides.rpm.replaces carries the rpm one.
     [ "$(grep -cF -- '- grappa (<< 1.3.0)' "$NFPM_CLIENT")" -eq 2 ]
-    grep -q '^replaces:$' "$NFPM_CLIENT"
+    [ "$(grep -cF -- '- grappa < 1.3.0' "$NFPM_CLIENT")" -eq 1 ]
     grep -q '^  breaks:$' "$NFPM_CLIENT"
 }
 
-@test "#1447 the takeover fields are literal, never interpolated" {
-    # Not a restatement of the constant above — this has its own failure mode.
-    # nfpm v2.43.0 expands ${VARS} in depends/replaces/recommends/provides/
-    # suggests/conflicts (nfpm.go:214-227) and NOT in deb.breaks (the Deb
-    # struct, nfpm.go:438). An interpolation there is written verbatim into the
-    # control file, producing a malformed relationship that nothing else
-    # catches. So: these two fields hold no `$`, ever.
-    takeover="$(awk '
-        /^replaces:/ { f = 1; next }
-        /^  breaks:/ { f = 1; next }
-        f && /^[[:space:]]*-/ { print; next }
-        f { f = 0 }
-    ' "$NFPM_CLIENT")"
+@test "#1447 no Debian-spelled relation is offered to the rpm renderer" {
+    # This is the one that would have shipped silently. nfpm maps `replaces` to
+    # RPM's Obsoletes: (rpm/rpm.go:289) through rpmpack, whose parser is
+    # `([^=<>\s]*)\s*((?:=|>|<)*)\s*(.*)?` (rpmpack/sense.go:24). Given
+    # `grappa (<< 1.3.0)` the operator group matches EMPTY — `(` is not an
+    # operator — so it yields name `grappa`, version `(<< 1.3.0)`, sense `""`;
+    # and `""` is a legal key for SenseAny, so NOTHING errors. Green build,
+    # garbage metadata. Hence: no parenthesised relation under overrides.rpm.
+    rpm_block="$(awk '/^  rpm:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$NFPM_CLIENT")"
+    [ -n "$rpm_block" ]
+    grep -q 'grappa' <<<"$rpm_block"
+    refute grep -q '((<<|>>))' <<<"$rpm_block"
+    refute grep -qF '(<<' <<<"$rpm_block"
+}
+
+@test "#1447 the takeover relations are literal, never interpolated" {
+    # Not a restatement of the constants above — its own failure mode. nfpm
+    # v2.43.0 expands ${VARS} in depends/replaces/recommends/provides/suggests/
+    # conflicts (nfpm.go:214-227) and NOT in deb.breaks (the Deb struct,
+    # nfpm.go:438), so an interpolation there is written into the control file
+    # verbatim. Every relation naming grappa holds no `$`, ever.
+    takeover="$(grep -E '^[[:space:]]*- grappa[ (]' "$NFPM_CLIENT")"
     [ -n "$takeover" ]
-    [ "$(printf '%s\n' "$takeover" | wc -l)" -eq 2 ]
+    [ "$(printf '%s\n' "$takeover" | wc -l)" -eq 3 ]
     refute grep -q '\$' <<<"$takeover"
 }

--- a/test/infra/packaging_shottino_pkg_test.bats
+++ b/test/infra/packaging_shottino_pkg_test.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1447 slice A — shottino gets its OWN nfpm config, built
+# and proven on every packaging job but NOT published yet.
+#
+# Slice A is deliberately additive: `grappa` still ships /usr/bin/shottino, so
+# the two packages both own that path and CANNOT be co-installed. That makes
+# "the standalone package does not reach the release" the load-bearing property
+# of this slice, and it is the first thing pinned below.
+#
+# THE HAZARD, MEASURED — and not where the first reading put it.
+#
+# `infra/packaging/release_assets.sh` matches release assets by NAME AT ANY
+# DEPTH (`found()`: `find "$dir" -type f -name '*.deb'`), so it was the obvious
+# suspect. It is not the gatekeeper: it only ever sees what the `publish` job
+# DOWNLOADED. The real gate is one step earlier — the upload globs are
+# PATH-scoped (`path: dist/*.deb`, `path: dist/*.rpm`), so a package written
+# outside `dist/` is never uploaded, never downloaded, and never attached.
+# That is why a separate output directory is the cure, and why this suite
+# derives the forbidden directories FROM the workflow instead of naming `dist`.
+#
+# The other three properties are the ones that make the package a CLIENT
+# package rather than a second copy of the bouncer: its own version line, one
+# file, no maintainer scripts, no ERTS deps.
+#
+# Every derivation carries a floor — a derivation that matched nothing would
+# make its assertion pass vacuously.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    PKG_DIR="$REPO_ROOT/infra/packaging"
+    NFPM_SERVER="$PKG_DIR/nfpm.yaml"
+    NFPM_CLIENT="$PKG_DIR/nfpm-shottino.yaml"
+    VERSION_SH="$PKG_DIR/version.sh"
+    BUILD_SH="$PKG_DIR/build.sh"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+    VERSION_H="$REPO_ROOT/frontends/shottino/version.h"
+}
+
+# The `contents:` block of an nfpm config: from `contents:` to the next
+# top-level key. Top-level keys sit at column 0, everything inside is deeper.
+contents_block() {
+    awk '/^contents:/ { f = 1; next } f && /^[a-z]/ { exit } f' "$1"
+}
+
+# Every `dst:` a config installs, one per line.
+installed_paths() {
+    contents_block "$1" | sed -n 's/^[[:space:]]*dst:[[:space:]]*//p'
+}
+
+# The directories the release workflow UPLOADS from — the dirname of every
+# `path:` under an upload-artifact step. These are the directories a build
+# output must stay out of to remain unpublished.
+upload_dirs() {
+    awk '
+        /uses: actions\/upload-artifact/ { hit = 1 }
+        hit && /^[[:space:]]+path:[[:space:]]/ {
+            sub(/^[[:space:]]+path:[[:space:]]*/, "")
+            sub(/\/[^\/]*$/, "")
+            print
+            hit = 0
+        }
+    ' "$WORKFLOW" | sort -u
+}
+
+# ── The slice's load-bearing property ──────────────────────────────────────
+
+@test "#1447 the workflow's upload globs are path-scoped, so a directory can hide from the release" {
+    # The floor for the test below: if this derivation found nothing, "the
+    # client package is built outside every upload dir" would hold vacuously.
+    run upload_dirs
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [ "$(printf '%s\n' "$output" | wc -l)" -ge 2 ]
+}
+
+@test "#1447 the client package is written outside every directory the release uploads" {
+    grep -q 'SHOTTINO_OUT_DIR' "$BUILD_SH"
+
+    client_out="$(sed -n 's/^SHOTTINO_OUT_DIR="\${SHOTTINO_OUT_DIR:-\${REPO_ROOT}\/\(.*\)}"$/\1/p' "$BUILD_SH")"
+    [ -n "$client_out" ]
+
+    while IFS= read -r dir; do
+        [ "$dir" != "$client_out" ]
+    done < <(upload_dirs)
+}
+
+# ── Its own version line, derived from the header ──────────────────────────
+
+@test "#1447 version.sh with no argument still prints the repo VERSION" {
+    # The FreeBSD jail build calls this bare (infra/freebsd/jail_cic_build.sh).
+    # Making the new mode the default would break it silently.
+    run "$VERSION_SH"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(head -1 "$REPO_ROOT/VERSION" | tr -d '\r')" ]
+}
+
+@test "#1447 version.sh shottino prints the version line from version.h" {
+    # DERIVED from the header, never re-typed here: a suite that hard-coded
+    # 0.3.0 would need editing on every client release and would pin nothing.
+    from_header="$(sed -n 's/^#define SHOTTINO_VERSION "\(.*\)"$/\1/p' "$VERSION_H")"
+    [ -n "$from_header" ]
+
+    run "$VERSION_SH" shottino
+    [ "$status" -eq 0 ]
+    [ "$output" = "$from_header" ]
+}
+
+@test "#1447 the client package does not take the bouncer's version" {
+    # Two artifacts, two cadences (vjt, 2026-08-16). The config must reach for
+    # the shottino line, not GRAPPA_VERSION.
+    grep -q '^version: \${SHOTTINO_VERSION}$' "$NFPM_CLIENT"
+    refute grep -q '^version: \${GRAPPA_VERSION}$' "$NFPM_CLIENT"
+}
+
+# ── A client package, not a second bouncer ─────────────────────────────────
+
+@test "#1447 the client package is named shottino, not grappa" {
+    grep -q '^name: shottino$' "$NFPM_CLIENT"
+}
+
+@test "#1447 the client package ships exactly one file, the client binary" {
+    run installed_paths "$NFPM_CLIENT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "/usr/bin/shottino" ]
+}
+
+@test "#1447 the client package runs no maintainer scripts" {
+    # The server package's postinstall creates a system user, generates
+    # secrets and enables a unit. A terminal client must do none of that —
+    # installing it must not enable a service the user did not ask for.
+    grep -q '^scripts:' "$NFPM_SERVER"
+    refute grep -q '^scripts:' "$NFPM_CLIENT"
+}
+
+@test "#1447 the client package carries none of the bouncer-only dependencies" {
+    # Derived from the server config, not re-typed: these are the entries that
+    # exist for ERTS or for the maintainer scripts. If the client config grows
+    # one, it has stopped being a client package.
+    server_only=(libncurses6 libstdc++6 libgcc-s1 passwd shadow-utils util-linux)
+    for dep in "${server_only[@]}"; do
+        grep -qF -- "- $dep" "$NFPM_SERVER"
+        refute grep -qF -- "- $dep" "$NFPM_CLIENT"
+    done
+}
+
+@test "#1447 the client package depends on the wide ncurses and on OpenSSL" {
+    # configure probes exactly these two (`check_pkg ncursesw`,
+    # `check_pkg openssl`), and shottino.c calls
+    # SSL_CTX_set_default_verify_paths + SSL_VERIFY_PEER, so the system CA
+    # store is a runtime dependency and not a copied one.
+    grep -qF -- '- libncursesw6' "$NFPM_CLIENT"
+    grep -qF -- '- ca-certificates' "$NFPM_CLIENT"
+    grep -qE '^\s+- libssl3t64 \| libssl3$' "$NFPM_CLIENT"
+    grep -qF -- '- ncurses-libs' "$NFPM_CLIENT"
+    grep -qF -- '- openssl-libs' "$NFPM_CLIENT"
+}
+
+# ── The path takeover, written literally ───────────────────────────────────
+
+@test "#1447 the takeover fields name grappa (<< 1.3.0)" {
+    # vjt's ruling, 2026-08-17: the boundary is the first release that stops
+    # shipping the file. A historical constant, written as a constant.
+    # `replaces` covers both formats — nfpm maps it to Debian's Replaces: and
+    # to RPM's Obsoletes: (rpm/rpm.go: `Obsoletes: replaces`).
+    grep -qF -- '- grappa (<< 1.3.0)' "$NFPM_CLIENT"
+    [ "$(grep -cF -- '- grappa (<< 1.3.0)' "$NFPM_CLIENT")" -eq 2 ]
+    grep -q '^replaces:$' "$NFPM_CLIENT"
+    grep -q '^  breaks:$' "$NFPM_CLIENT"
+}
+
+@test "#1447 the takeover fields are literal, never interpolated" {
+    # Not a restatement of the constant above — this has its own failure mode.
+    # nfpm v2.43.0 expands ${VARS} in depends/replaces/recommends/provides/
+    # suggests/conflicts (nfpm.go:214-227) and NOT in deb.breaks (the Deb
+    # struct, nfpm.go:438). An interpolation there is written verbatim into the
+    # control file, producing a malformed relationship that nothing else
+    # catches. So: these two fields hold no `$`, ever.
+    takeover="$(awk '
+        /^replaces:/ { f = 1; next }
+        /^  breaks:/ { f = 1; next }
+        f && /^[[:space:]]*-/ { print; next }
+        f { f = 0 }
+    ' "$NFPM_CLIENT")"
+    [ -n "$takeover" ]
+    [ "$(printf '%s\n' "$takeover" | wc -l)" -eq 2 ]
+    refute grep -q '\$' <<<"$takeover"
+}


### PR DESCRIPTION
## What this is

Slice A of #1447: **shottino gets its own package, built and proven but not
published**, and `grappa` is left **completely intact**.

The cut is on the **boundary, not on the cost**. Slice A only ADDS; slice B is
the one that removes `/usr/bin/shottino` from the bouncer package. That split
is forced by co-installability: while both packages own that path they cannot
be installed side by side, so **neither slice may ship a broken pair**. Hence
the standalone package is built and inspected in CI but **no upload is added**,
and every decision that presupposes the drop — the version cut included —
falls into slice B.

## The rulings this slice implements (not re-arbitrated here)

- **`Replaces:` / `Breaks: grappa (<< 1.3.0)` is LITERAL, and the number was
  decided by vjt** — it is not derived from anything in the tree, and this
  slice does not compute it.
- **`VERSION` is NOT touched.** It stays `1.2.0` until the cut commit
  (`release: cut 1.3.0`). Writing `1.3.0-dev` here would have been a packaging
  decision of its own, so it was not taken.
- The bats clause "the literal is `<=` the current VERSION" was **dropped**: it
  would assert `1.3.0 <= 1.2.0` and be red the day it was written. What remains
  here is the pin on the literal; the assertion *"`grappa` no longer ships
  `/usr/bin/shottino`"* belongs to slice B, where it becomes true.
- The `README.md` § "The terminal client" paragraph is **rewritten inside this
  slice**, by vjt's order, rather than softened.

## The eight files

1. **`infra/packaging/nfpm-shottino.yaml`** (new) — `name: shottino`, exactly
   one file (`/usr/bin/shottino`), **no `scripts:`**, dependencies limited to
   ncursesw + OpenSSL + `ca-certificates`.
2. **`infra/packaging/version.sh`** — now `version.sh [grappa|shottino]`. The
   **no-argument form still means `grappa`**, which is load-bearing: the
   FreeBSD jail build, `build.sh` and the AUR recipe generator all call it bare.
3. **`infra/packaging/build.sh`** — `SHOTTINO_OUT_DIR` (default
   `dist-shottino/`), a second staging tree, a second nfpm invocation, and it
   now **prints the binary's size** (`wc -c`).
4. **`.github/workflows/release.yml`** — two steps (jobs `deb` and `rpm`) that
   **INSPECT without installing** (`dpkg-deb` / `rpm -qp`): one file, the
   takeover fields verbatim, its own version. Installing is impossible in
   slice A because `grappa` still owns the path. **No upload step is added.**
5. **`test/infra/packaging_shottino_pkg_test.bats`** (new) — 13 tests.
6. **`infra/packaging/README.md`** — the rewritten paragraph.
7. **`docs/DESIGN_NOTES.md`** — one entry, marker `<!-- entry #1447 slice A -->`.
8. **`test/infra/integration_path_filter_test.bats`** — the path-filter gate,
   restricted (see below).

## Why the client package writes to its own directory — measured, plus a retraction

The guard that keeps an unpublished package unpublished is **the upload step's
path scoping**, not the release audit:

- `release.yml:288` uploads `path: dist/*.deb` and `:595` uploads
  `path: dist/*.rpm`. Those globs are **directory-scoped**, so a package
  written to `dist-shottino/` is never collected.
- `infra/packaging/release_assets.sh` is a **later** step and is NOT the guard.
  Its `expected_kinds` table (line 32, `'*.deb  Debian package (.deb)'`) feeds
  `found()`, which is `find "$dir" -type f -name "$pat"` — it matches **by name
  at ANY depth**, so it would happily see a nested second `.deb`. What saves it
  is that it only ever looks at what `publish` has already **downloaded**.

The first pass of this work attributed the protection to that glob. That
attribution was **wrong and is retracted**: the mechanism is the upload
scoping, one step earlier. The conclusion (`dist-shottino/` is safe) is
unchanged; the reason is not.

## The README paragraph, and the premise that died

The old § "The terminal client" argued *against* a separate package on the
grounds that the client is *"a client for the server you just installed"*.
That premise is refuted by the **client-only host** — the machine that wants
shottino and will never run the bouncer — which is exactly the case #1447 is
about. The paragraph is rewritten rather than softened.

The old "~180 KB" figure is **gone rather than restated**: it could not be
measured on the authoring host (which produces Mach-O, not the target ELF).
The build now prints the real size. Better silent than stale.

## The path-filter gate: restricted by a property, and bought

Teaching `version.sh` a second component made
`test/infra/integration_path_filter_test.bats` demand
`frontends/shottino/version.h` in `integration.yml`'s path filter, because it
derived the requirement by grepping the producer's SOURCE for every
`${REPO_ROOT}`-rooted path. **Listing it would have been false** — the e2e
stack does not read the client's version, so the entry would assert a
dependency that does not exist and a shottino bump would boot the whole
integration suite for nothing.

The fix is the rule, not an exception:

> **A file belongs in the filter when the e2e stack READS it.**

And "reads" is now measured literally: the gate extracts the **whole
invocation** `scripts/integration.sh` makes — path **and** argument, since the
argument is what selects a component — re-runs that same invocation under
`sh -x`, and requires every repo-rooted file the trace names. `version.h` drops
out of the requirement because **it is not read**, not because it is excused.

### Three mutants, each killing exactly the one assertion

| mutant | gesture | result |
|---|---|---|
| **A** | the producer's `grappa` branch grows a **second real read** (`README.md`, not in the filter) | red: *MISSING: README.md* — the restricted derivation is not defanged |
| **B** | **`VERSION` removed** from the filter, in both the `push` and `pull_request` blocks | red: *MISSING: VERSION* |
| **C** | `scripts/integration.sh` passes `shottino` to the producer | red: *MISSING: frontends/shottino/version.h* — no named exception; the argument decides |

**Mutant B is the #715 class, fabricated on purpose.** #715 is the path-filter
gap: a change that breaks the e2e stack landing without `integration` ever
running. To show the restriction does not reopen it, the hole was **built** —
`VERSION`, a file the stack genuinely reads, was deleted from the filter — and
the gate went red naming it, with the reason derived from the real run.
Restoring the filter returns it to green. The restriction removes from the
requirement **only** what stopped being read.

Two limits are written into the file rather than papered over: the derivation
is an **over-approximation** (a path the run merely names counts), which is the
safe direction; and a trace observes **the branch this host takes**.

## Verification

- Full `bats` suite: **553 ok / 0 not ok** (before this work: 552 ok / **1 not
  ok**, and that red was this branch's — it is closed, not declared
  pre-existing).
- `scripts/shellcheck.sh`: clean.
- `scripts/design-notes-gate.sh`: *1 new entry heading(s), separator and marker
  present*.
- Rebased onto `7b3329b1`; the branch's `--numstat` contribution is byte-identical
  before and after the rebase, and the entry's boundary shape was re-read on the
  file.

## What this PR does NOT claim

1. **That nfpm accepts these two files.** Nothing was built here: no `.deb`, no
   `.rpm`, no `dpkg -i`, and the new size line **has never printed**. The bats
   suite pins the CONFIGURATION; that nfpm accepts it is proven by the first CI
   run, not by the author.
2. **That the README's `config.mk` paragraph is correct.** Out of scope, not
   measured, left untouched.
3. **That shottino compiles cleanly on Fedora.** #1447 records this as not
   established. The `rpm` job installs the `*-devel` packages and today's
   package does contain shottino — strong indirect evidence, not a measurement.
4. **That the restricted gate covers the multi-platform case.** It traces the
   branch **this host** takes. A producer reading different carriers per
   platform would need every platform traced; this sees one. Stated in the file
   as a limit, not solved.
