### PR TITLE
recover(#1468): reconcile every started step at a terminal, and prove it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46877,3 +46877,61 @@ because reaching it means fabricating a state the FSM cannot emit. And the
 claim that no OTHER consumer names the moved functions was scoped to `lib` and
 `test` — a comment in `cicchetto/src/RecoverModal.tsx` named one, and was
 found only after the move._
+<!-- entry #1468 -->
+
+---
+
+## 2026-08-17 — #1468: the terminal rule is now proven, not exemplified
+
+#623 pt3 set a rule — no progress step may be left `:running` when the recovery
+reaches a terminal state — and two of the five terminal clauses did not honour
+it. A deadline out of `:awaiting_verb_settle` or `:awaiting_nick` reported one
+step, while every path into those phases had passed through
+`:idle -> :awaiting_r`, which sets `identify: :running`. The client upserts one
+row per step name and never touches a row nobody updates, so the modal closed
+reporting a failed recovery with the identify step spinning forever.
+
+The in-code comment that justified leg (a) claimed the identify step "never
+started". That was false — `:awaiting_nick` is reachable only through
+`:awaiting_r` — and it is deleted rather than softened, in the commit that
+cures the clause it was defending.
+
+### What the red buys, and what it deliberately does not
+
+The cure is two clauses. The interesting part is why the gap survived a rule, a
+test for the rule on the sibling leg, and a review: **each leg was pinned by its
+own example, so a clause nobody wrote an example for answered to nothing.**
+
+The replacement is an **exhaustive walk**, not a StreamData property — a
+breadth-first search to fixpoint over the reachable `{phase, verb, rows}` space,
+asserting the invariant at every terminal. The space is finite and small (seven
+phases, one status per step name), so the search is a PROOF over every reachable
+path, retry loops included, where a generator would be a sample with a seed that
+can get lucky. It carries its own vacuity floors: a minimum state count, a
+minimum terminal count, and the assertion that a terminal is reached out of all
+four phases that can fail. `rows` mirrors the CLIENT's rule (`recoverProgress.ts`
+upserts by step name, last write wins) rather than a convenient one — the
+question being asked is what the modal is showing when the modal closes.
+
+### The other three clauses: two by the rule, one vacuously
+
+The issue left it unestablished whether the remaining clauses were correct for
+the same reason or by accident. Established here:
+
+- `:awaiting_r` and `:awaiting_final_r` are correct **by the rule** — the steps
+  that can still be `:running` at those terminals are exactly the ones they
+  reconcile.
+- The catch-all `terminal_steps(_, _, reason)` is correct **only vacuously**:
+  no reachable path reaches it, because `:failed` is only ever entered from the
+  four named phases. It reconciles `nick` alone and would strand rows the day a
+  new phase could fail. It is left as found — a cure nothing can exercise is a
+  claim, not a fix — and the walk is what makes that safe, since the terminal
+  becomes reachable and checked the moment such a phase exists.
+
+One inaccuracy is knowingly left in place: on the bounded-retry path the settle
+marked the reclaim verb `:ok` and the terminal marks it `:failed` again. It
+predates this issue and strands nothing, so curing it would widen past what the
+red buys.
+
+_Not established: how often leg (a) is reached in production. No frequency was
+measured, here or in the issue._

--- a/lib/grappa/session/recover_progress.ex
+++ b/lib/grappa/session/recover_progress.ex
@@ -28,18 +28,26 @@ defmodule Grappa.Session.RecoverProgress do
   and it can only stay that way while the projection stays pure. Nothing in
   it may reach for session state.
 
-  ## Known defect carried over: #1468
+  ## The terminal rule (#623 pt3, repaired by #1468)
 
-  A terminal out of `:awaiting_verb_settle` or `:awaiting_nick` reports only
-  one step, but EVERY path into those phases ran through
-  `:idle -> :awaiting_r`, which already set `identify: :running`. The client
-  never reconciles a row nobody updates, so the modal ends with `identify`
-  spinning next to a failed outcome — the very thing #623 pt3 set out to
-  prevent ("RECONCILE every in-flight step on terminal `:failed`").
+  No step may be left `:running` when the recovery reaches a terminal state.
+  The client upserts one row per step name and never touches a row nobody
+  updates, so a step the modal was told was `:running` spins forever unless
+  some later event gives it a final status.
 
-  Slice 4 moved this table AT PARITY and deliberately did NOT cure it:
-  a behaviour change buried in a refactor is invisible to a reviewer reading
-  the diff for a move. The fix is #1468, bought by its own red.
+  Two clauses used to break that rule: a terminal out of
+  `:awaiting_verb_settle` or `:awaiting_nick` reported ONE step, while every
+  path into those phases had gone through `:idle -> :awaiting_r`, which sets
+  `identify: :running`. #1468 reconciles them.
+
+  The clause-by-clause fix is the small half. The reason the gap survived a
+  rule, a test for the rule, and a review is that each leg was pinned by its
+  OWN example, so a clause nobody wrote an example for answered to nothing.
+  What holds the rule now is the exhaustive walk in
+  `recover_progress_test.exs`: a breadth-first search over the reachable
+  `{phase, verb, rows}` space that asserts the invariant at every terminal it
+  can reach. A new phase or a new terminal clause is covered the moment it
+  becomes reachable, without anyone remembering to write its example.
 
   Boundary: inherits the parent `Grappa.Session` boundary — same pattern as
   sibling submodules `Server`, `EventRouter`, `RecoverIdentity`. No
@@ -88,8 +96,7 @@ defmodule Grappa.Session.RecoverProgress do
 
   # #623 pt3 — RECONCILE every in-flight step on terminal :failed (not just one)
   # so the modal never strands a step at :running (the trace "hang"), keyed on
-  # the phase we failed OUT of. Two of the five clauses below do not honour
-  # that rule — see the #1468 note in the moduledoc.
+  # the phase we failed OUT of.
   def steps(old, %{phase: :failed, reason: reason, verb: verb}),
     do: terminal_steps(old, verb, reason)
 
@@ -98,19 +105,31 @@ defmodule Grappa.Session.RecoverProgress do
   def steps(_, _), do: []
 
   # #623 pt3 — the reconciled terminal step list, keyed on the phase we failed
-  # OUT of, with the two reclaim legs kept DISTINCT + trace-diagnosable:
+  # OUT of. Each clause names the steps that can still be `:running` on ANY
+  # path into that phase, plus the one that actually failed, with the two
+  # reclaim legs kept DISTINCT + trace-diagnosable:
   #   * `:awaiting_r` — a clean NICK but `+r` never came → the IDENTIFY failed
   #     (`:wrong_password`); the nick itself landed clean (`:ok`).
-  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered → the verb
-  #     failed (`:services_declined`). **#1468: `identify` — running since the
-  #     start transition — is not reconciled here, nor is `nick` after a retry.**
+  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered
+  #     (`:services_declined`). `identify` has been running since the start
+  #     transition, and `nick` is either already `:failed` (first pass) or
+  #     `:running` again (the bounded retry re-entered this phase after the
+  #     settle set it running). A phase-keyed projection cannot tell those two
+  #     paths apart, and it does not need to: `:failed` is true on both.
   #   * `:awaiting_nick` — leg (a): the re-NICK never landed → the nick failed
-  #     (`:nick_unavailable`). **#1468: `identify` is not reconciled here
-  #     either; the comment this clause used to carry claimed the identify step
-  #     never started, which no reachable path makes true.**
+  #     (`:nick_unavailable`), and `identify` — running since the start — is
+  #     reconciled with it. The comment this clause used to carry said the
+  #     identify step "never started"; that was FALSE, since `:awaiting_nick`
+  #     is only reachable through `:awaiting_r`, which starts it. Deleted
+  #     rather than softened.
   #   * `:awaiting_final_r` — leg (b): the re-NICK landed but `+r` never
   #     confirmed → the identify failed (`:identify_unconfirmed`); the nick is
-  #     already `:ok`.
+  #     already `:ok`, and so is the verb.
+  #
+  # The `verb` row on the retry path is the one thing this list does not get
+  # exactly right, and it predates #1468: the settle marked it `:ok`, and the
+  # terminal marks it `:failed` again. It strands nothing, so #1468 leaves it
+  # as found rather than widening past what its red buys.
   @spec terminal_steps(
           RecoverIdentity.phase(),
           RecoverIdentity.verb(),
@@ -120,14 +139,22 @@ defmodule Grappa.Session.RecoverProgress do
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
-    do: [{verb, :failed, reason}]
+    do: [{:nick, :failed, reason}, {verb, :failed, reason}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_nick, _, reason),
-    do: [{:nick, :failed, reason}]
+    do: [{:nick, :failed, reason}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_final_r, _, reason),
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
+  # No reachable path lands here: `:failed` is only ever entered from the four
+  # phases above (`RecoverIdentity.step/2` has no other clause that stops with
+  # `phase: :failed`), so this default satisfies the rule VACUOUSLY rather than
+  # by honouring it — it reconciles `nick` alone. Left as found, since the
+  # exhaustive walk cannot reach it and a cure nothing can exercise is a claim,
+  # not a fix. The walk is what makes that safe: the day a new phase can fail,
+  # the terminal it produces becomes reachable and the invariant is checked
+  # there, on this clause, without anyone remembering it exists.
   defp terminal_steps(_, _, reason),
     do: [{:nick, :failed, reason}]
 end

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -62,8 +62,11 @@ defmodule Grappa.Session.RecoverProgressTest do
   defp explore([], seen, terminals), do: %{states: seen, terminals: terminals}
 
   defp explore([{fsm, rows, path} | queue], seen, terminals) do
-    {next_queue, next_seen, next_terminals} =
-      Enum.reduce(@inputs, {queue, seen, terminals}, fn input, {q, s, t} ->
+    # The frontier this node opens is built by PREPENDING and reversed once at
+    # the end, then appended to the queue as a whole — breadth-first order kept
+    # without growing the queue one `++ [item]` at a time.
+    {frontier, next_seen, next_terminals} =
+      Enum.reduce(@inputs, {[], seen, terminals}, fn input, {f, s, t} ->
         {next_fsm, steps} = hop(fsm, input)
         next_rows = upsert(rows, steps)
         next_path = [input | path]
@@ -71,24 +74,24 @@ defmodule Grappa.Session.RecoverProgressTest do
 
         cond do
           Map.has_key?(s, key) ->
-            {q, s, t}
+            {f, s, t}
 
           next_fsm.phase in [:succeeded, :failed] ->
             terminal = %{phase: next_fsm.phase, from: fsm.phase, rows: next_rows, path: next_path}
-            {q, Map.put(s, key, true), [terminal | t]}
+            {f, Map.put(s, key, true), [terminal | t]}
 
           true ->
-            {q ++ [{next_fsm, next_rows, next_path}], Map.put(s, key, true), t}
+            {[{next_fsm, next_rows, next_path} | f], Map.put(s, key, true), t}
         end
       end)
 
-    explore(next_queue, next_seen, next_terminals)
+    explore(queue ++ Enum.reverse(frontier), next_seen, next_terminals)
   end
 
   # The client's rule: one row per step name, last write wins, rows nobody
   # updates are left exactly as they were.
   defp upsert(rows, steps) do
-    Enum.reduce(steps, rows, fn {step, status, _reason}, acc -> Map.put(acc, step, status) end)
+    Enum.reduce(steps, rows, fn {step, status, _}, acc -> Map.put(acc, step, status) end)
   end
 
   describe "the happy path" do

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -17,13 +17,12 @@ defmodule Grappa.Session.RecoverProgressTest do
   for a handful of paths. These run on plain `ExUnit.Case`, `async: true`,
   with no process, no socket and no database.
 
-  Two cases carry the **#1468** defect: a terminal out of
-  `:awaiting_verb_settle` or `:awaiting_nick` leaves a step the modal already
-  showed as `:running` without a terminal status, so cic renders it spinning
-  forever beside a failed outcome. This slice MOVES the projection at parity
-  and does not cure it — the two tests below assert what the code does today
-  and say so in their names, so the #1468 fix cannot land without turning
-  them red.
+  **#1468 cured here.** Two terminals used to leave a step the modal already
+  showed as `:running` without a terminal status, so cic rendered it spinning
+  forever beside a failed outcome. The examples below pin each cured terminal,
+  but the assertion that actually holds the rule is the exhaustive walk at the
+  bottom: one example per leg is how the gap survived a rule, a test for the
+  rule, and a review.
   """
   use ExUnit.Case, async: true
 
@@ -41,6 +40,56 @@ defmodule Grappa.Session.RecoverProgressTest do
   end
 
   defp advance(fsm, inputs), do: Enum.reduce(inputs, fsm, fn i, acc -> elem(hop(acc, i), 0) end)
+
+  @inputs [
+    :start,
+    :r_observed,
+    {:nick_error, 433},
+    {:nick_error, 437},
+    :settle,
+    :nick_observed,
+    :timeout
+  ]
+
+  # Breadth-first to fixpoint over {phase, verb, rows}. Terminals are
+  # recorded and NOT expanded: what happens after the FSM stops is the
+  # host's business, and a self-loop there would only re-emit the same
+  # terminal projection forever.
+  defp walk do
+    explore([{start_fsm(), %{}, []}], %{}, [])
+  end
+
+  defp explore([], seen, terminals), do: %{states: seen, terminals: terminals}
+
+  defp explore([{fsm, rows, path} | queue], seen, terminals) do
+    {next_queue, next_seen, next_terminals} =
+      Enum.reduce(@inputs, {queue, seen, terminals}, fn input, {q, s, t} ->
+        {next_fsm, steps} = hop(fsm, input)
+        next_rows = upsert(rows, steps)
+        next_path = [input | path]
+        key = {next_fsm.phase, next_fsm.verb, next_rows}
+
+        cond do
+          Map.has_key?(s, key) ->
+            {q, s, t}
+
+          next_fsm.phase in [:succeeded, :failed] ->
+            terminal = %{phase: next_fsm.phase, from: fsm.phase, rows: next_rows, path: next_path}
+            {q, Map.put(s, key, true), [terminal | t]}
+
+          true ->
+            {q ++ [{next_fsm, next_rows, next_path}], Map.put(s, key, true), t}
+        end
+      end)
+
+    explore(next_queue, next_seen, next_terminals)
+  end
+
+  # The client's rule: one row per step name, last write wins, rows nobody
+  # updates are left exactly as they were.
+  defp upsert(rows, steps) do
+    Enum.reduce(steps, rows, fn {step, status, _reason}, acc -> Map.put(acc, step, status) end)
+  end
 
   describe "the happy path" do
     test "the start transition sets BOTH the nick and the identify step running" do
@@ -116,31 +165,85 @@ defmodule Grappa.Session.RecoverProgressTest do
     end
   end
 
-  # #1468 — the two terminals that do NOT reconcile every started step. Both
-  # paths ran through `:idle -> :awaiting_r`, which set `identify: :running`,
-  # and neither terminal ever gives that step a final status. cic upserts step
-  # rows by name (`recoverProgress.ts`) and `RecoverModal` keeps rendering
-  # `is-running` regardless of the outcome, so the modal ends with identify
-  # spinning next to a failed result.
-  #
-  # This slice moves the projection AT PARITY: curing the defect here would be
-  # a behaviour change hidden inside a refactor. The assertions below pin what
-  # the code does today, and their names say it is a defect — the #1468 fix
-  # turns them red, which is exactly what should happen.
-  describe "terminals that strand a step (#1468 — moved here unchanged, not cured)" do
-    test "#1468 — a deadline in :awaiting_verb_settle reports ONLY the verb" do
+  # #1468 — the two terminals that used to strand a step. Both paths ran
+  # through `:idle -> :awaiting_r`, which sets `identify: :running`, and
+  # neither terminal gave that step a final status. cic upserts step rows by
+  # name (`recoverProgress.ts`) and `RecoverModal` keeps rendering `is-running`
+  # regardless of the outcome, so the modal ended with identify spinning beside
+  # a failed result.
+  describe "terminals that used to strand a step (#1468)" do
+    test "#1468 — a deadline in :awaiting_verb_settle reconciles identify and nick too" do
       fsm = advance(start_fsm(), [:start, {:nick_error, 433}])
 
-      # Neither `identify` (running since the start) nor `nick` (running again
-      # after a retry) is reconciled.
-      assert {_, [{:recover, :failed, :services_declined}]} = hop(fsm, :timeout)
+      # `identify` has been running since the start transition; `nick` is
+      # either already :failed (first pass) or :running again (after a retry),
+      # and this projection cannot tell those apart — so it reconciles both.
+      assert {_, steps} = hop(fsm, :timeout)
+      assert {:identify, :failed, :services_declined} in steps
+      assert {:nick, :failed, :services_declined} in steps
+      assert {:recover, :failed, :services_declined} in steps
     end
 
-    test "#1468 — a deadline in :awaiting_nick reports ONLY the nick" do
+    test "#1468 — a deadline in :awaiting_nick reconciles the identify step too" do
       fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle])
 
-      # `identify` has been :running since the start transition and stays there.
-      assert {_, [{:nick, :failed, :nick_unavailable}]} = hop(fsm, :timeout)
+      assert {_, steps} = hop(fsm, :timeout)
+      assert {:nick, :failed, :nick_unavailable} in steps
+      assert {:identify, :failed, :nick_unavailable} in steps
+    end
+  end
+
+  # ── The rule itself, over the whole reachable graph ────────────────────────
+  #
+  # #623 pt3's rule is "no step may be left :running when the recovery reaches
+  # a terminal state". One example per leg is exactly how #1468 survived: the
+  # rule existed, a test for the rule existed on the sibling leg, and the
+  # clause next door did not honour it.
+  #
+  # This is an EXHAUSTIVE WALK rather than a StreamData property, and the
+  # difference matters. The reachable space is finite and small — a phase, a
+  # verb, and one status per step name — so a breadth-first search to fixpoint
+  # is a PROOF over every reachable path, retry loops included, instead of a
+  # sample of them. A generator would rediscover the same handful of states
+  # with a seed that can be lucky; this cannot be lucky, and cannot flake.
+  #
+  # The accumulated rows mirror the CLIENT's rule, not a convenient one:
+  # `recoverProgress.ts` upserts by step name, last write wins, and never
+  # touches a row nobody updated. That is why a Map keyed by step name is the
+  # faithful model of "what the modal is showing when the modal closes".
+  describe "#623 pt3, proven over every reachable transition (#1468)" do
+    test "no reachable terminal leaves a step :running" do
+      %{terminals: terminals, states: states} = walk()
+
+      # Vacuity floors. A walk that explored nothing, or never reached a
+      # terminal, would satisfy the assertion below by having nothing to check.
+      assert map_size(states) > 10,
+             "the walk explored only #{map_size(states)} states — the search is broken"
+
+      assert length(terminals) >= 4,
+             "the walk reached only #{length(terminals)} terminals"
+
+      # ...and it must reach a terminal out of EVERY phase that can fail, or a
+      # future clause could strand rows on a leg this never visits.
+      failed_from =
+        terminals
+        |> Enum.filter(fn %{phase: phase} -> phase == :failed end)
+        |> Enum.map(& &1.from)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert failed_from == [:awaiting_final_r, :awaiting_nick, :awaiting_r, :awaiting_verb_settle]
+
+      for %{rows: rows, path: path, phase: phase, from: from} <- terminals do
+        running = for {step, status} <- rows, status == :running, do: step
+
+        assert running == [],
+               """
+               terminal #{inspect(phase)} out of #{inspect(from)} left #{inspect(running)} at :running.
+               path:  #{inspect(Enum.reverse(path))}
+               rows:  #{inspect(rows)}
+               """
+      end
     end
   end
 end


### PR DESCRIPTION
## The defect

#623 pt3 set a rule — **no progress step may be left `:running` when the
recovery reaches a terminal state** — and two of the five terminal clauses did
not honour it. A deadline out of `:awaiting_verb_settle` or `:awaiting_nick`
reported a single step, while every path into those phases had gone through
`:idle -> :awaiting_r`, which sets `identify: :running`.

It is user-visible, not theoretical: `recoverProgress.ts` upserts one row per
step name and never touches a row nobody updates, and `RecoverModal` keeps the
`is-running` treatment regardless of the outcome. The modal closed reporting a
failed recovery with the identify step spinning forever.

**The comment that justified leg (a) claimed the identify step "never
started".** That is false — `:awaiting_nick` is reachable only through
`:awaiting_r` — and it is **deleted**, in the same commit as the clause it was
defending, rather than softened into something vaguer.

## The shape of the fix, and why not a property

Curing the two clauses is the small half. The interesting question is why the
gap survived a rule, a test for the rule on the sibling leg, and a review: each
leg was pinned by its **own example**, so a clause nobody wrote an example for
answered to nothing.

The issue suggested a StreamData property. **I used an exhaustive walk
instead** — a breadth-first search to fixpoint over the reachable
`{phase, verb, rows}` space, asserting the invariant at every terminal:

- the space is **finite and small** (seven phases, one status per step name),
  so the search is a **proof** over every reachable path, retry loops included,
  where a generator is a sample whose seed can get lucky;
- it cannot flake, and it cannot pass by luck;
- `rows` mirrors the **client's** rule (upsert by step name, last write wins),
  because the question being asked is what the modal shows when the modal
  closes;
- it carries its own vacuity floors — a minimum state count, a minimum terminal
  count, and the assertion that a terminal is reached out of **each** of the
  four phases that can fail. A walk that explored nothing would otherwise
  satisfy the invariant by having nothing to check.

**The walk immediately paid for itself.** With the cure reverted it reported a
path no example covered — `[:start, {:nick_error, 437}, :settle,
{:nick_error, 433}, :timeout]`, the RELEASE leg with a bounded retry — leaving
**two** rows stranded (`nick` and `identify`), where the issue described only
the RECOVER legs and only `identify`.

## The other three clauses: two by the rule, one vacuously

The issue left this unestablished. Established here:

- `:awaiting_r` and `:awaiting_final_r` are correct **by the rule** — the steps
  that can still be `:running` at those terminals are exactly the ones they
  reconcile.
- The catch-all `terminal_steps(_, _, reason)` is correct **only vacuously**:
  no reachable path reaches it, since `:failed` is only ever entered from the
  four named phases. It reconciles `nick` alone and would strand rows the day a
  new phase can fail. **Named as a second, latent defect and left as found** —
  a cure nothing can exercise is a claim, not a fix — and the walk is what
  makes leaving it safe: the terminal becomes reachable and checked the moment
  such a phase exists.

One inaccuracy is knowingly left in place: on the bounded-retry path the settle
marked the reclaim verb `:ok` and the terminal marks it `:failed` again. It
predates this issue and strands nothing, so curing it would widen the change
past what the red buys.

## Evidence

- **Red before green, by reverting the cure**: 3 failures — both cured examples
  and the walk. Restored: **12 tests, 0 failures**.
- **`scripts/check.sh` RC=0**, read from a file. The first run was **RED**, on
  two Credo findings of mine in the new walk (a single-item `++` append and a
  `_reason` discard where the file's inferred strategy is a bare `_`); both
  fixed in their own commit and the gate re-run **from the top**, since
  `check.sh` halts at the first red phase and a downstream green from the
  earlier run would not have existed.
- That clean run covers Credo, Sobelow, doctor, **Dialyzer (`Total errors: 0`,
  `done (passed successfully)`)**, ExUnit **6519 tests + 8 doctests + 61
  properties, 0 failures**, and **540 bats**.
- 3 files: the projection, its test, and the decision-log entry.

## What this PR does not claim

- **No production frequency was measured.** How often leg (a) is reached in
  practice is unknown, here as in the issue.
- **The catch-all's unreachability is a reading of today's `step/2`**, not a
  theorem about future clauses — which is precisely why the walk, and not the
  reading, is what guards it.
- **Nothing was exercised against a live session.** This projection is pure and
  the walk drives the real FSM in-process; that the server broadcasts these
  triples unchanged is covered by the existing `server_test.exs` integration
  describe, not by anything added here.
