### PR TITLE
packaging(#1447) slice B: the client leaves the bouncer package, and the pair moves in one step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,8 +199,13 @@ jobs:
       - name: Build the .deb
         run: infra/packaging/build.sh
 
-      - name: Install the .deb (postinstall runs openssl secrets + migrate)
-        run: sudo apt-get install -y ./dist/grappa_*.deb
+      # BOTH packages, one transaction — which is itself the proof that #1447
+      # landed whole: while the bouncer still owned /usr/bin/shottino this
+      # command could not have succeeded (dpkg refuses two owners of one
+      # path). The Recommends: cannot be exercised here — the client is not in
+      # any apt repo — so the pair is named explicitly.
+      - name: Install both packages (postinstall runs openssl secrets + migrate)
+        run: sudo apt-get install -y ./dist/grappa_*.deb ./dist-shottino/shottino_*.deb
 
       - name: Prove the packaged migrate applied every migration
         run: |
@@ -228,22 +233,32 @@ jobs:
       # on the INSTALLED artifact, not on the build tree. `--help` exits 0
       # without a server, a terminal or config, so it exercises the real
       # dynamic links (libncursesw, libssl) that the package `depends` on.
-      - name: Prove the packaged shottino installed and runs
+      #
+      # Both directions, because #1447 is a MOVE: the file must be gone from
+      # the bouncer package AND present on the host from the client one. The
+      # first half is asserted on the artifact rather than on the filesystem —
+      # the filesystem has it either way, which is exactly how a failed move
+      # would look green.
+      - name: Prove the client moved packages — out of the bouncer, into its own
         run: |
-          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing from the .deb"; exit 1; }
+          deb="$(find dist -name 'grappa_*.deb' -print -quit)"
+          if dpkg-deb -c "$deb" | grep -q ' ./usr/bin/shottino$'; then
+            echo "::error::the bouncer .deb still ships /usr/bin/shottino"
+            dpkg-deb -c "$deb" | grep shottino; exit 1
+          fi
+          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing after installing both packages"; exit 1; }
+          dpkg -S /usr/bin/shottino | grep -q '^shottino:' || {
+            echo "::error::/usr/bin/shottino is not owned by the shottino package"
+            dpkg -S /usr/bin/shottino; exit 1; }
           /usr/bin/shottino --help > /tmp/shottino-help.txt
           grep -q '^usage: ' /tmp/shottino-help.txt || {
             echo "::error::shottino --help produced no usage output"; cat /tmp/shottino-help.txt; exit 1; }
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
-      # #1447 slice A — the STANDALONE client package. Inspected, NOT
-      # installed: the bouncer package above still owns /usr/bin/shottino, so
-      # `apt-get install` of this one would conflict on the path. That is
-      # exactly what the Breaks: asserted below is for, and exactly why this
-      # package is not published yet.
-      #
-      # The bats suite pins the CONFIG; only this step can prove nfpm accepted
-      # it and rendered what the config asked for.
+      # #1447 — the STANDALONE client package, now installed alongside the
+      # bouncer by the step above. This one still reads the ARTIFACT's
+      # metadata: the bats suite pins the CONFIG, and only here can nfpm's
+      # rendering of it be proven.
       - name: Prove the standalone shottino package is thin and takes the path over
         run: |
           deb="$(find dist-shottino -name 'shottino_*.deb' -print -quit)"
@@ -275,17 +290,24 @@ jobs:
           [ "$got" = "$want" ] || {
             echo "::error::client package is stamped '$got', expected '$want'"; exit 1; }
 
-      # NOTE (#1447 slice A): dist-shottino/ is deliberately NOT uploaded.
-      # This glob is path-scoped, which is the only thing keeping the client
-      # package off the release: `publish` attaches by NAME at any depth
-      # (infra/packaging/release_assets.sh), so anything that reaches the
-      # artifact bundle IS attached. Slice B drops /usr/bin/shottino from the
-      # bouncer package and turns publishing on in the same change.
+      # Two packages, two upload steps (#1447 slice B). One glob over a shared
+      # directory would publish whatever landed there next; a step per artifact
+      # keeps publication something a human wrote down. `publish` then attaches
+      # by NAME (infra/packaging/release_assets.sh), and its expected-kind
+      # table requires BOTH — a client package that failed to build fails the
+      # release loudly instead of vanishing from it.
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grappa-deb
           path: dist/*.deb
+          if-no-files-found: error
+
+      - name: Upload the client .deb artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shottino-deb
+          path: dist-shottino/*.deb
           if-no-files-found: error
 
   arch:
@@ -341,15 +363,16 @@ jobs:
           printf 'builder ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/builder
           chown -R builder:builder .
 
-      - name: regen.sh (derive pkgver from VERSION) + makepkg — build the package
+      - name: regen.sh (derive both pkgvers) + makepkg — build both packages
         run: |
           cd infra/packaging/aur
-          # regen.sh (#538/#652) fills the committed `pkgver=@GRAPPA_VERSION@`
-          # sentinel from the repo-root VERSION file (the single source of truth), then
-          # runs updpkgsums (fetches the now-existing tag tarball, rewrites
-          # sha256sums=('SKIP')) and regenerates .SRCINFO. It is the SAME
-          # derivation path a human uses to publish to the AUR — scripted, so
-          # the version can never be a forgotten manual step.
+          # regen.sh (#538/#652) fills the committed sentinels from their own
+          # carriers — the repo-root VERSION for the bouncer, and since #1447
+          # frontends/shottino/version.h for the client — then runs updpkgsums
+          # (fetches the now-existing tag tarball, rewrites sha256sums=('SKIP'))
+          # and regenerates each .SRCINFO. It is the SAME derivation path a
+          # human uses to publish to the AUR — scripted, so a version can never
+          # be a forgotten manual step. ONE regen.sh run covers both recipes.
           # makepkg then builds the mix release + cicchetto FROM THE TARBALL
           # (no .git → Grappa.Version reports the bare version). No
           # --warnings-as-errors: Elixir 1.20 warns from deps (see PKGBUILD).
@@ -357,20 +380,29 @@ jobs:
           # (the builder has NOPASSWD sudo) rather than aborting the hard dep
           # check — so a future `depends` entry not transitively present still
           # builds. -f overwrites an existing package file.
+          #
+          # TWO makepkg runs, because #1447 made these two pkgbases rather than
+          # one split: PKGBUILD(5) does not let a package_*() override pkgver,
+          # and the client keeps its own version line.
           sudo -u builder bash -euo pipefail -c '
             ./regen.sh
             makepkg -sf --noconfirm
+            cd shottino && makepkg -sf --noconfirm
           '
 
-      - name: namcap the built package (advisory)
+      - name: namcap the built packages (advisory)
         run: |
           cd infra/packaging/aur
-          sudo -u builder namcap ./*.pkg.tar.zst || true
+          sudo -u builder namcap ./*.pkg.tar.zst ./shottino/*.pkg.tar.zst || true
 
-      - name: Install the package (grappa.install runs secrets + migrate)
+      - name: Install both packages (grappa.install runs secrets + migrate)
         run: |
           cd infra/packaging/aur
-          pacman -U --noconfirm ./*.pkg.tar.zst
+          # One transaction, both packages — the Arch-side proof that the pair
+          # is co-installable now that only the client's recipe owns
+          # /usr/bin/shottino. pacman aborts on a file conflict, so this step
+          # could not have passed before #1447 slice B.
+          pacman -U --noconfirm ./*.pkg.tar.zst ./shottino/*.pkg.tar.zst
 
       - name: Prove the packaged migrate applied every migration
         run: |
@@ -394,22 +426,54 @@ jobs:
             exit 1
           fi
 
-      # Mirror of the .deb proof — the Arch package is a SOURCE build, so
-      # this additionally confirms shottino compiled on the Arch toolchain
-      # (a newer gcc than the Debian one) and links that host's libs.
-      - name: Prove the packaged shottino installed and runs
+      # Mirror of the .deb proof, both directions — the Arch packages are a
+      # SOURCE build, so this additionally confirms shottino compiled on the
+      # Arch toolchain (a newer gcc than the Debian one) and links that host's
+      # libs. `pacman -Qo` is the ownership question: which package put the
+      # file there. Asking the filesystem alone would pass either way, and
+      # "either way" is precisely the failure #1447 slice B could ship.
+      - name: Prove the client moved recipes — out of the bouncer, into its own
         run: |
-          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing from the Arch package"; exit 1; }
+          cd infra/packaging/aur
+          if bsdtar -tf ./*.pkg.tar.zst | grep -qx 'usr/bin/shottino'; then
+            echo "::error::the bouncer Arch package still ships usr/bin/shottino"; exit 1
+          fi
+          cd - >/dev/null
+          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing after installing both packages"; exit 1; }
+          pacman -Qo /usr/bin/shottino | grep -q 'shottino ' || {
+            echo "::error::/usr/bin/shottino is not owned by the shottino package"
+            pacman -Qo /usr/bin/shottino; exit 1; }
           /usr/bin/shottino --help | grep -q '^usage: ' || {
             echo "::error::shottino --help produced no usage output"; exit 1; }
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
-      - name: Stage Arch artifacts (package + regenerated recipe metadata)
+      # Its own version line, read off the INSTALLED package (#1447). This is
+      # the assertion a split PKGBUILD could not have satisfied: pkgver is
+      # global to a pkgbase, so a split would report the bouncer's number here.
+      - name: Prove the Arch client package carries the client's own version
+        run: |
+          want="$(infra/packaging/version.sh shottino)"
+          got="$(pacman -Q shottino | awk '{print $2}' | cut -d- -f1)"
+          echo "client package version: '$got' (want '$want')"
+          [ "$got" = "$want" ] || {
+            echo "::error::the Arch client package is stamped '$got', expected '$want'"; exit 1; }
+
+      - name: Stage Arch artifacts (packages + regenerated recipe metadata)
         run: |
           mkdir -p arch-out
           cp infra/packaging/aur/*.pkg.tar.zst arch-out/
+          cp infra/packaging/aur/shottino/*.pkg.tar.zst arch-out/
           # The regenerated recipe metadata a human copies into the AUR repo.
+          # The client's copies are RENAMED, and not for tidiness: a release
+          # asset is keyed by BASENAME, and the publish job's fallback uploads
+          # with --clobber — two files called PKGBUILD would leave the release
+          # holding one of them, silently, with no way to tell which. The
+          # expected-kinds table names these two just like the others, so a
+          # rename that drifts is a loud missing kind rather than a quiet
+          # substitution. See aur/README.md for the publish-side rename back.
           cp infra/packaging/aur/PKGBUILD infra/packaging/aur/.SRCINFO arch-out/
+          cp infra/packaging/aur/shottino/PKGBUILD arch-out/shottino.PKGBUILD
+          cp infra/packaging/aur/shottino/.SRCINFO arch-out/shottino.SRCINFO
 
       - name: Upload Arch artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -521,8 +585,13 @@ jobs:
       - name: Build the .rpm (Fedora ERTS via GRAPPA_PKG_FORMAT=rpm)
         run: GRAPPA_PKG_FORMAT=rpm infra/packaging/build.sh
 
-      - name: Install the .rpm (%post runs openssl secrets + migrate)
-        run: dnf install -y --setopt=install_weak_deps=False ./dist/*.rpm
+      # BOTH packages in one transaction — the rpm-side proof that the pair is
+      # co-installable now that only one of them owns /usr/bin/shottino.
+      # install_weak_deps stays FALSE (this asserts the hard dependency set, as
+      # it always has); the client is named explicitly rather than arriving as
+      # the Recommends:, which no repo here could satisfy anyway.
+      - name: Install both packages (%post runs openssl secrets + migrate)
+        run: dnf install -y --setopt=install_weak_deps=False ./dist/*.rpm ./dist-shottino/*.rpm
 
       - name: Prove the packaged migrate applied every migration
         run: |
@@ -546,21 +615,29 @@ jobs:
             exit 1
           fi
 
-      # Same proof discipline as the .deb — assert on the INSTALLED artifact.
+      # Same proof discipline as the .deb, both directions — the file must be
+      # ABSENT from the bouncer's payload and delivered by the client package.
       # Like the arch source build, this also confirms shottino compiled on
       # this toolchain (Fedora's gcc) and links THIS host's ncursesw/openssl.
-      - name: Prove the packaged shottino installed and runs
+      - name: Prove the client moved packages — out of the bouncer, into its own
         run: |
-          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing from the .rpm"; exit 1; }
+          pkg="$(find dist -name 'grappa-*.rpm' -print -quit)"
+          if rpm -qpl "$pkg" | grep -qx '/usr/bin/shottino'; then
+            echo "::error::the bouncer .rpm still ships /usr/bin/shottino"; exit 1
+          fi
+          test -x /usr/bin/shottino || { echo "::error::/usr/bin/shottino missing after installing both packages"; exit 1; }
+          rpm -qf /usr/bin/shottino | grep -q '^shottino-' || {
+            echo "::error::/usr/bin/shottino is not owned by the shottino package"
+            rpm -qf /usr/bin/shottino; exit 1; }
           /usr/bin/shottino --help > /tmp/shottino-help.txt
           grep -q '^usage: ' /tmp/shottino-help.txt || {
             echo "::error::shottino --help produced no usage output"; cat /tmp/shottino-help.txt; exit 1; }
           echo "shottino OK: $(/usr/bin/shottino --help | head -1)"
 
-      # #1447 slice A — the STANDALONE client package, inspected not installed
-      # (the bouncer package above still owns /usr/bin/shottino). The deb job
-      # runs the same three proofs through dpkg-deb; here they go through rpm,
-      # where nfpm renders `replaces:` as Obsoletes: and drops deb-only Breaks.
+      # #1447 — the STANDALONE client package's own metadata, read off the
+      # artifact. The deb job runs the same three proofs through dpkg-deb;
+      # here they go through rpm, where nfpm renders `replaces:` as Obsoletes:
+      # and drops the deb-only Breaks.
       - name: Prove the standalone shottino package is thin and takes the path over
         run: |
           pkg="$(find dist-shottino -name 'shottino-*.rpm' -print -quit)"
@@ -585,14 +662,19 @@ jobs:
           [ "$got" = "$want" ] || {
             echo "::error::client package is stamped '$got', expected '$want'"; exit 1; }
 
-      # NOTE (#1447 slice A): dist-shottino/ is deliberately NOT uploaded —
-      # see the sibling note in the `deb` job for why the path-scoped glob is
-      # the gate.
+      # One upload step per artifact — see the sibling note in the `deb` job.
       - name: Upload .rpm artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grappa-rpm
           path: dist/*.rpm
+          if-no-files-found: error
+
+      - name: Upload the client .rpm artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shottino-rpm
+          path: dist-shottino/*.rpm
           if-no-files-found: error
 
   docker:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46985,3 +46985,83 @@ the CONFIGURATION — that the package is thin, that its version comes from
 the header, that its output directory is outside every upload glob — which
 is what can be held still without a Linux toolchain. Whether nfpm accepts
 these two files is proven by the first CI run, not here._
+<!-- entry #1447 slice B -->
+
+---
+
+## 2026-08-17 — #1447 slice B: the client leaves the bouncer package, and the pair moves in one step
+
+Slice A gave shottino its own package and deliberately withheld it. This is
+the other half of the same decision: `grappa` stops shipping
+`/usr/bin/shottino`, the takeover relations written in slice A become true,
+and the client package is published.
+
+**Why one slice and not two.** The two halves are not shippable apart.
+Dropping the file alone deletes the client from every host that has it, with
+nothing to install in its place; publishing alone ships two packages that both
+own one path and therefore cannot be co-installed. The boundary is not
+deb-vs-Arch either — a per-channel cut was considered and rejected, because it
+would leave the invariant *"`grappa` does not ship the client"* true on
+deb/rpm and false on Arch, which is the half-migrated state that teaches the
+next reader whichever pattern they happen to open first.
+
+**`Recommends:` is the upgrade path, not a courtesy.** The file leaves the
+package in this release, so without a pointer `apt upgrade` removes
+`/usr/bin/shottino` and pulls nothing back. apt installs Recommends by
+default and dnf installs weak deps by default, so the replacement lands in the
+same transaction. **pacman has no equivalent that installs by default**, so
+the Arch bouncer recipe carries `optdepends` instead — advisory by
+construction, and that asymmetry is pacman's, not a decision taken here.
+
+### Arch needs two recipes, because `pkgver` is not overridable
+
+vjt's ruling is that the standalone package keeps shottino's own version line,
+so that `shottino --version` and the package version agree. A split PKGBUILD
+(`pkgname=('grappa' 'shottino')`) CANNOT honour it: `PKGBUILD(5)` § PACKAGE
+SPLITTING enumerates the fourteen variables a `package_*()` function may
+override — `pkgdesc arch url license groups depends optdepends provides
+conflicts replaces backup options install changelog` — and `pkgver` is not
+among them, so both halves of a split take the pkgbase's single version. The
+client would have been stamped with the bouncer's number, which is precisely
+the disagreement the separate package exists to prevent.
+
+So: a second pkgbase at `infra/packaging/aur/shottino/`. It carries TWO
+sentinels — `pkgver=@SHOTTINO_VERSION@` from `frontends/shottino/version.h`,
+and `_grappaver=@GRAPPA_VERSION@` naming the tag whose tarball holds the
+source, because one repository has only ever one tag. `aur/regen.sh` fills
+both recipes in one run; `version_single_source_test.exs` pins all three
+sentinels.
+
+_Read from the upstream man page during this work, not measured locally:
+`makepkg` does not exist on the authoring host, so the overridable-variable
+list is documentation, not an experiment._
+
+### The release audit had to grow names, or it would have gone quiet
+
+`release_assets.sh` expected kinds by EXTENSION (`*.deb`, `*.rpm`,
+`*.pkg.tar.zst`). With two packages per format that is no longer a
+completeness check: a release whose client leg died would match the bouncer's
+file, report a complete set, and publish without the client — silently, which
+is #573's failure one package later. The kinds are now scoped by package name
+(`grappa_*.deb`, `shottino_*.deb`, …), so a missing client package is a named
+gap in the release body.
+
+The client's AUR recipe ships as `shottino.PKGBUILD` / `shottino.SRCINFO`, and
+the rename is load-bearing: a GitHub release asset is keyed by BASENAME and
+the publish job's fallback uploads with `--clobber`, so two files called
+`PKGBUILD` would leave the release holding one of them with nothing to say
+which one.
+
+**Publication is per-artifact, not per-glob.** The client package keeps its
+own output directory (`dist-shottino/`) and gains its own upload step rather
+than being written into `dist/` where the existing glob would have swept it
+up. In slice A that directory was the gate; here it is the reason a future
+package cannot become published by accident when someone widens a path.
+
+_Not established: nothing was built. No `.deb`, `.rpm` or `.pkg.tar.zst` was
+produced on the authoring host, no `dpkg -i`, `dnf install` or `pacman -U` was
+run, and `makepkg` is absent — so the co-installability the workflow now
+asserts is proven by the first CI run, not here. The committed
+`shottino/.SRCINFO` is hand-written and agrees with its `PKGBUILD` on the
+sentinels; nothing compares the two field by field, and the real regeneration
+is the arch job's `makepkg --printsrcinfo`._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4041,8 +4041,9 @@ image (a musl ERTS will not run on a glibc target).
 
 **`GRAPPA_PKG_FORMAT` picks the nfpm output format; it does NOT make the
 payload portable (#438).** The staging tree is format-agnostic, but the
-release bundles ERTS + crypto NIFs — and, since it ships, `shottino` —
-linked against the BUILD host's glibc/libssl. A Debian-built payload is
+release bundles ERTS + crypto NIFs linked against the BUILD host's
+glibc/libssl — and so, separately packaged but built on the same host for
+the same reason, does `shottino`. A Debian-built payload is
 therefore a valid `.deb` and NOT a valid `.rpm`. Build each format on its
 own distro: `release.yml`'s `rpm` job runs in a `fedora:43` container with
 its own Fedora ERTS, the `deb` job on the Ubuntu runner. The Arch recipe
@@ -4061,20 +4062,43 @@ whoever reorders this next. `build.sh` snapshots `config.mk`, installs a
 compile, and restores explicitly afterwards. Deleting either half of that
 trap dance reintroduces the dirty tree.
 
-### shottino ships inside the bouncer package
+### shottino ships as its own package (#1447)
 
-**One package, not a `grappa-shottino` split — considered and rejected.**
-The terminal client is one ~180 KB binary whose runtime libs (`libssl`,
-wide `ncursesw`) are ALREADY in `nfpm.yaml`'s `depends` for the bundled
-ERTS, so shipping it costs a binary and adds no new dependency, while a
-separate package would add something to maintain and buy nothing. It is a
-client for THIS server: installing grappa and getting a way to talk to it
-is the expected shape. The AUR recipe makes the same call for the same
-reason.
+**One package per artifact — reversing the earlier call, on evidence.**
+This section used to argue for shipping the client inside the bouncer:
+its runtime libs were already in `nfpm.yaml`'s `depends`, so it cost a
+binary and no new dependency, and "it is a client for THIS server" made the
+bundle the expected shape. The premise that died is that last one. A
+**client-only host** — a laptop that talks to someone else's bouncer and
+will never run one — had to install the whole server, ERTS included, to get
+a 200-odd KB terminal client. Since 1.3.0 the client is `shottino`, its own
+package, on its own version line (`frontends/shottino/version.h`, so
+`shottino --version` and the package version agree).
 
-It is **built here rather than shipped prebuilt** because it links the
+**The pair must move together, and does.** While both packages owned
+`/usr/bin/shottino` they could not be co-installed, so the standalone one
+was built and proven but withheld from the release (#1447 slice A) until
+the bouncer dropped the file (slice B). The bouncer now carries a
+`Recommends:` (deb) / `recommends` (rpm) on the client, because otherwise
+an upgrade would remove `/usr/bin/shottino` from every host that has it
+today and pull nothing back; both apt and dnf install those by default.
+pacman has no weak dependency that installs by default, so the Arch bouncer
+recipe uses `optdepends` — advisory by construction.
+
+**Arch needs TWO recipes for one decision.** `aur/PKGBUILD` builds the
+bouncer, `aur/shottino/PKGBUILD` the client. Not a split package
+(`pkgname=(grappa shottino)`), because `PKGBUILD(5)` § PACKAGE SPLITTING
+does not list `pkgver` among the variables a `package_*()` may override:
+both halves of a split share one version, which would stamp the client with
+the bouncer's number and break the very agreement the separate package
+exists to keep. The client recipe therefore carries a second sentinel,
+`_grappaver`, naming the tag whose tarball holds the source — one
+repository, one tag, two version lines. `aur/regen.sh` derives both.
+
+The client is **built rather than shipped prebuilt** because it links the
 build host's ncurses/openssl exactly like the ERTS payload — the same
-constraint that makes a build valid for one format only. `SKIP_SHOTTINO=1`
+constraint that makes a build valid for one format only, which is why it is
+built beside the bouncer even though it now ships apart. `SKIP_SHOTTINO=1`
 opts out (mirroring `SKIP_RELEASE` / `SKIP_CIC`); without the opt-out a
 shottino build failure FAILS the whole package build, because a package
 that silently ships without a binary it advertises is worse than one that
@@ -4237,7 +4261,9 @@ crypto NIFs link the user's own Arch libs — no Debian-built payload
 pretending to be portable, and it matches AUR convention
 (rebuild-on-upgrade). Everything else is reused from the shared substrate;
 only the PKGBUILD, `grappa.install` and the sysusers/tmpfiles
-declarations are Arch-specific. It ships shottino in the same package for
+declarations are Arch-specific. Since #1447 the client has its OWN recipe
+next door (`aur/shottino/`, see above); the bouncer recipe keeps only an
+`optdepends` pointer at it. The Arch build otherwise stays a source build for
 the same reason the `.deb` does.
 
 - **`makedepends` names `erlang-headless`, not bare `elixir`.** The
@@ -4263,6 +4289,16 @@ the same reason the `.deb` does.
   with `updpkgsums` and regenerates `.SRCINFO`. Run it from a checkout ON
   the release tag — `updpkgsums` fetches the `vX.Y.Z` tarball, so the tag
   must already exist — and do NOT commit the result.
+- **The client recipe carries TWO sentinels (#1447).**
+  `aur/shottino/PKGBUILD` takes `pkgver=@SHOTTINO_VERSION@` from
+  `frontends/shottino/version.h` and `_grappaver=@GRAPPA_VERSION@` from the
+  repo-root `VERSION`, because its source is the bouncer's tag tarball —
+  the only tag that exists. One `regen.sh` run fills both recipes and
+  regenerates both `.SRCINFO`s. Its release assets are staged as
+  `shottino.PKGBUILD` / `shottino.SRCINFO`: a GitHub release asset is keyed
+  by BASENAME and the publish fallback uploads with `--clobber`, so two
+  files named `PKGBUILD` would leave the release holding one of them with
+  nothing to say which. Rename them back when pushing to the AUR.
 - **BUILD ≠ PUBLISH (#538).** No AUR credentials live in this tree; the
   push to `aur.archlinux.org` stays a human `git push`, and the
   PKGBUILD/.SRCINFO ride out as release assets. Deriving the version is

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -20,7 +20,6 @@ shipped list below.
 | `/usr/lib/grappa/`                     | the mix release (self-contained ERTS + compiled app)       |
 | `/usr/lib/grappa/bin/grappa`           | the release boot script                                    |
 | `/usr/bin/grappa`                      | operator CLI wrapper (sources env, drops to `grappa` user) |
-| `/usr/bin/shottino`                    | terminal client (`frontends/shottino`), built from source  |
 | `/usr/share/grappa/cicchetto-dist/`    | built SPA (`CIC_DIST_ROOT`), served by the BEAM            |
 | `/usr/share/grappa/grappa.env.example` | env template                                               |
 | `/usr/share/grappa/gen-secrets.sh`     | openssl secret generator                                   |
@@ -67,16 +66,39 @@ shipping the file — so it is written as a constant and must not become
 it did not. `deb.breaks` is also absent from nfpm's env-expansion list, so
 an interpolation there reaches the control file verbatim.
 
-**Where the split stands.** The bouncer package **still ships the client**;
-dropping it from `nfpm.yaml` and from the AUR `PKGBUILD` is the next step.
-Until then both packages own `/usr/bin/shottino` and cannot be
-co-installed, so the standalone one is **built and proven on every
-packaging job but not published**: it is written to `dist-shottino/`, and
-the release workflow's upload steps are path-scoped globs (`path:
-dist/*.deb`), so nothing outside `dist/` reaches the release. That
-directory split is the only gate — `release_assets.sh found` matches by
-name at ANY depth, so a file that reaches the artifact bundle WILL be
-attached — and it is pinned by `test/infra/packaging_shottino_pkg_test.bats`.
+**Where the split stands.** Done, in both halves at once. The bouncer
+package no longer ships `/usr/bin/shottino` — it is out of `nfpm.yaml`'s
+`contents:` and out of the AUR bouncer recipe — and the standalone package
+is **published** from `dist-shottino/`, through an upload step of its own
+rather than a glob over a shared directory. The two halves had to land
+together: dropping the file alone takes the client away from everyone who
+has it, and publishing alone ships a pair that cannot be co-installed.
+
+**The upgrade path is `Recommends:`, and it is not decoration.** The file
+leaves the bouncer package in 1.3.0, so without a pointer `apt upgrade`
+would delete `/usr/bin/shottino` from every host that has it today and pull
+nothing back. apt installs Recommends by default and dnf installs weak deps
+by default, so on both the replacement arrives in the same transaction.
+**pacman has no equivalent**, so the Arch recipe uses `optdepends`, which is
+advisory by construction — an Arch user is told where the client went and
+installs it deliberately. That difference is pacman's, not a choice made
+here.
+
+**Two AUR recipes, not one split package.** `aur/PKGBUILD` is the bouncer,
+`aur/shottino/PKGBUILD` the client, and the reason is a constraint rather
+than a preference: `PKGBUILD(5)` § PACKAGE SPLITTING lists the variables a
+`package_*()` function may override and `pkgver` is not among them, so a
+split would stamp the client with the bouncer's number — the exact
+disagreement the own-version-line ruling above forbids. The client recipe
+therefore carries two sentinels: `pkgver=@SHOTTINO_VERSION@` from its own
+carrier, and `_grappaver=@GRAPPA_VERSION@` naming the tag whose tarball
+holds the source. `aur/regen.sh` fills both and regenerates both
+`.SRCINFO`s; `test/grappa/version_single_source_test.exs` pins all of it.
+
+Both halves are pinned by `test/infra/packaging_shottino_pkg_test.bats`,
+and the release audit (`release_assets.sh`) now expects the client's
+packages **by name** — a release that builds the bouncer and loses the
+client fails loudly instead of publishing a set that looks complete.
 
 Every package builds the client from source so it links the build host's
 ncurses/openssl, the same constraint that governs the ERTS payload.

--- a/infra/packaging/aur/.SRCINFO
+++ b/infra/packaging/aur/.SRCINFO
@@ -13,6 +13,7 @@ pkgbase = grappa
 	depends = ncurses
 	depends = gcc-libs
 	depends = ca-certificates
+	optdepends = shottino: the terminal client, now its own package (#1447)
 	optdepends = perl-image-exiftool: strip metadata from image uploads (#39)
 	optdepends = ffmpeg: strip metadata from video uploads (#39)
 	optdepends = nginx: TLS + static reverse proxy (recommended, not required)

--- a/infra/packaging/aur/PKGBUILD
+++ b/infra/packaging/aur/PKGBUILD
@@ -25,7 +25,7 @@ pkgname=grappa
 # so an underived build fails loudly instead of shipping `grappa-@GRAPPA_VERSION@`.
 pkgver=@GRAPPA_VERSION@
 pkgrel=1
-pkgdesc="Always-on IRC bouncer with a REST + Phoenix Channels API, a bundled web PWA (cicchetto) and a terminal client (shottino)"
+pkgdesc="Always-on IRC bouncer with a REST + Phoenix Channels API and a bundled web PWA (cicchetto)"
 arch=('x86_64')
 url="https://github.com/vjt/grappa-irc"
 license=('MIT')
@@ -45,7 +45,16 @@ depends=('openssl' 'ncurses' 'gcc-libs' 'ca-certificates')
 makedepends=('elixir' 'erlang-headless' 'bun')
 # Media metadata strip shells out to these fail-closed; nginx fronts
 # TLS/static. All optional — the bouncer boots + self-serves without any.
-optdepends=('perl-image-exiftool: strip metadata from image uploads (#39)'
+#
+# shottino is the Arch stand-in for the .deb/.rpm `Recommends:` (#1447): the
+# terminal client left this package in 1.3.0 and lives in its own recipe
+# (infra/packaging/aur/shottino/) on its own version line. pacman has no weak
+# dependency that installs by default, so this pointer is advisory BY
+# CONSTRUCTION — an Arch user who upgrades and finds /usr/bin/shottino gone
+# gets told where it went, and installs it deliberately. That difference from
+# Debian/Fedora is pacman's, not a decision taken here.
+optdepends=('shottino: the terminal client, now its own package (#1447)'
+            'perl-image-exiftool: strip metadata from image uploads (#39)'
             'ffmpeg: strip metadata from video uploads (#39)'
             'nginx: TLS + static reverse proxy (recommended, not required)')
 install="${pkgname}.install"
@@ -93,16 +102,6 @@ build() {
 	bun install --frozen-lockfile
 	bun run build
 	cd ..
-
-	# shottino — the terminal client (frontends/shottino). Source-built here
-	# like everything else, so it links the user's own ncurses/openssl; its
-	# runtime libs are already in `depends`. The C toolchain and pkgconf come
-	# from base-devel, which makepkg assumes.
-	echo "==> shottino (terminal client)"
-	./configure --prefix=/usr
-	make -C frontends/shottino
-	# `make check` is NOT run here: the suites build with ASan/UBSan, a CI
-	# gate, not something to impose on a user's rebuild.
 }
 
 package() {
@@ -126,10 +125,6 @@ package() {
 	install -Dm755 infra/packaging/grappa-wrapper.sh \
 		"${pkgdir}/usr/bin/grappa"
 
-	# shottino — terminal client for this server, in the same package as
-	# the bouncer (like the .deb).
-	install -Dm755 frontends/shottino/shottino \
-		"${pkgdir}/usr/bin/shottino"
 	install -Dm644 infra/packaging/README.md \
 		"${pkgdir}/usr/share/doc/grappa/README.md"
 

--- a/infra/packaging/aur/README.md
+++ b/infra/packaging/aur/README.md
@@ -100,6 +100,22 @@ release, a maintainer:
    and pushes there. (`grappa.sysusers` / `grappa.tmpfiles` are **not**
    copied — they ship inside the source tarball and are installed from it by
    `package()`, keeping this repo their single source of truth.)
+4. Publishes the CLIENT recipe too, as a **second AUR package** (#1447):
+   `shottino/PKGBUILD` + `shottino/.SRCINFO` go into the `shottino` AUR repo,
+   not into `grappa`'s. The same `regen.sh` run in step 2 derived both.
+   Off the GitHub release they arrive as **`shottino.PKGBUILD`** and
+   **`shottino.SRCINFO`** — an asset is keyed by basename and two files
+   called `PKGBUILD` would clobber each other, so rename them back to
+   `PKGBUILD`/`.SRCINFO` in that repo.
+
+**Why two recipes and not one split package.** `PKGBUILD(5)` § PACKAGE
+SPLITTING lists what a `package_*()` function may override, and `pkgver` is
+not on that list: a split shares one version across both halves. The client
+keeps its own line (`frontends/shottino/version.h`) so that
+`shottino --version` and the package version agree, and two version lines
+need two pkgbases. Its recipe carries a second sentinel, `_grappaver`, for
+the tag whose tarball holds the source — the client's number never names a
+tag, because there is only ever one.
 
 The committed `PKGBUILD`/`.SRCINFO` are a **template**, turned into the
 concrete publishable recipe by `regen.sh`:
@@ -122,7 +138,11 @@ PKGBUILD, since `regen.sh` only runs at release: a PKGBUILD dep change must be
 copied here too to keep the committed snapshot honest (e.g. #527's
 `erlang-headless`). The guard test
 `test/grappa/version_single_source_test.exs` fails if either carrier stops
-being the `@GRAPPA_VERSION@` sentinel.
+being the `@GRAPPA_VERSION@` sentinel — and, since #1447, if the client
+recipe's `pkgver` stops being `@SHOTTINO_VERSION@` or its `_grappaver` stops
+being `@GRAPPA_VERSION@`. What that guard does NOT do is compare a `PKGBUILD`
+with its `.SRCINFO` field by field: the structural mirroring above stays a
+human discipline, and the only full regeneration is `regen.sh`'s.
 
 ## Version reporting (bare `X.Y.Z`, #419 R3)
 

--- a/infra/packaging/aur/regen.sh
+++ b/infra/packaging/aur/regen.sh
@@ -2,33 +2,59 @@
 # regen.sh — turn the committed sentinel recipe into a concrete, buildable
 # and publishable one, deriving the version from the repo-root VERSION file.
 #
-# The committed PKGBUILD/.SRCINFO carry `pkgver=@GRAPPA_VERSION@`; this is the
-# ONE path that fills it, shared by:
+# TWO recipes since #1447, because they carry TWO version lines:
+#
+#   ./PKGBUILD           the bouncer      pkgver=@GRAPPA_VERSION@
+#   ./shottino/PKGBUILD  the client       pkgver=@SHOTTINO_VERSION@
+#                                         _grappaver=@GRAPPA_VERSION@
+#
+# A split package could not express that: PKGBUILD(5) does not let a
+# `package_*()` override `pkgver`, so both halves would take the bouncer's
+# number and `shottino --version` would disagree with the package it came
+# from. The client's SOURCE is still the grappa tag tarball, which is why its
+# recipe also carries `_grappaver` — the tag that exists on GitHub.
+#
+# This is the ONE path that fills those sentinels, shared by:
 #
 #   * .github/workflows/release.yml's Arch job (before `makepkg -sf`), and
 #   * the human AUR publish (see README.md "Publishing to the AUR").
 #
-# Steps: derive pkgver from the VERSION file, refresh the checksums against the tag
-# tarball (updpkgsums), regenerate .SRCINFO. Run from a checkout on the
-# release tag — updpkgsums fetches the `vX.Y.Z` tarball, so the tag must
-# already exist.
+# Steps, per recipe: derive the version from its own carrier, refresh the
+# checksums against the tag tarball (updpkgsums), regenerate .SRCINFO. Run from
+# a checkout on the release tag — updpkgsums fetches the `vX.Y.Z` tarball, so
+# the tag must already exist.
 #
-# NB: this rewrites PKGBUILD in place (pkgver + sha256sums). The RESULT is what
-# you build/publish; do NOT commit it — the committed recipe stays the
-# @GRAPPA_VERSION@ sentinel (test/grappa/version_single_source_test.exs
-# enforces that).
+# NB: this rewrites both PKGBUILDs in place. The RESULT is what you
+# build/publish; do NOT commit it — the committed recipes stay sentinels
+# (test/grappa/version_single_source_test.exs enforces that, for both).
 # Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
 set -euo pipefail
 
 AUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 version="$("${AUR_DIR}/../version.sh")"
-echo "==> deriving pkgver=${version} from the VERSION file (#538/#652 single source)"
-sed -i -E "s/^pkgver=.*/pkgver=${version}/" "${AUR_DIR}/PKGBUILD"
+client_version="$("${AUR_DIR}/../version.sh" shottino)"
 
-cd "${AUR_DIR}"
-echo "==> updpkgsums (real sha256 of the v${version} tag tarball)"
-updpkgsums
-echo "==> regenerating .SRCINFO from PKGBUILD"
-makepkg --printsrcinfo >.SRCINFO
-echo "==> recipe ready: pkgver=${version}"
+# derive <recipe-dir> <pkgver> — fill the sentinels, checksum, regenerate.
+# One function for both recipes: the client's extra `_grappaver` is a no-op
+# sed on the bouncer's, which has no such line, so the two paths cannot drift
+# in the part that matters (updpkgsums + printsrcinfo run identically).
+derive() {
+	local dir="$1" pkgver="$2"
+	echo "==> ${dir}: deriving pkgver=${pkgver} (#538/#652 single source)"
+	sed -i -E "s/^pkgver=.*/pkgver=${pkgver}/" "${dir}/PKGBUILD"
+	# The tag that carries the source is ALWAYS the bouncer's version, even in
+	# the recipe whose pkgver is not.
+	sed -i -E "s/^_grappaver=.*/_grappaver=${version}/" "${dir}/PKGBUILD"
+	(
+		cd "${dir}"
+		echo "==> ${dir}: updpkgsums (real sha256 of the v${version} tag tarball)"
+		updpkgsums
+		echo "==> ${dir}: regenerating .SRCINFO from PKGBUILD"
+		makepkg --printsrcinfo >.SRCINFO
+	)
+}
+
+derive "${AUR_DIR}" "${version}"
+derive "${AUR_DIR}/shottino" "${client_version}"
+echo "==> recipes ready: grappa=${version}, shottino=${client_version}"

--- a/infra/packaging/aur/shottino/.SRCINFO
+++ b/infra/packaging/aur/shottino/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = shottino
+	pkgdesc = Terminal client for grappa — an irssi-shaped ncurses UI over its REST + Phoenix Channels API
+	pkgver = @SHOTTINO_VERSION@
+	pkgrel = 1
+	url = https://github.com/vjt/grappa-irc
+	arch = x86_64
+	license = MIT
+	depends = ncurses
+	depends = openssl
+	depends = ca-certificates
+	optdepends = grappa: the bouncer this client talks to, if you run one locally
+	source = shottino-@SHOTTINO_VERSION@.tar.gz::https://github.com/vjt/grappa-irc/archive/refs/tags/v@GRAPPA_VERSION@.tar.gz
+	sha256sums = SKIP
+
+pkgname = shottino

--- a/infra/packaging/aur/shottino/PKGBUILD
+++ b/infra/packaging/aur/shottino/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: Marcello Barnaba <vjt@users.noreply.github.com>
+#
+# Arch/AUR renderer for shottino, grappa's terminal client (#1447). A SECOND
+# recipe rather than a split of ../PKGBUILD, and the reason is a measured
+# constraint, not taste: PKGBUILD(5) § PACKAGE SPLITTING lists the variables a
+# `package_*()` function may override, and `pkgver` is NOT among them — it is
+# global to the pkgbase. A split would therefore stamp this package with the
+# BOUNCER's version, and vjt's ruling for #1447 is that the standalone package
+# keeps shottino's own line so that `shottino --version` and the package
+# version agree. Two version lines need two pkgbases.
+#
+# The SOURCE is still the grappa tag tarball — one repository, one tag, two
+# recipes — so this file carries TWO sentinels: `pkgver` from
+# frontends/shottino/version.h, and `_grappaver` naming the tag that actually
+# exists on GitHub. `../regen.sh` fills both; both are pinned by
+# test/grappa/version_single_source_test.exs so a hand-edited copy is caught.
+#
+# arch=(x86_64): the client is plain C and has no bun/x86-only toolchain
+# reason to be limited, unlike the bouncer recipe. It stays x86_64 because
+# that is the architecture the release job builds and proves — an arch nobody
+# tests is a claim, not a package.
+#
+# BUILD ≠ PUBLISH: like the bouncer recipe, publishing to the AUR is a human
+# step and no credentials live in this tree. See ../README.md.
+
+pkgname=shottino
+# DERIVED, never hand-edited — and from a DIFFERENT carrier than the bouncer's:
+# frontends/shottino/version.h, read via `infra/packaging/version.sh shottino`.
+# The `@SHOTTINO_VERSION@` sentinel is deliberate: makepkg's pkgver lint refuses
+# '@', so an underived build fails loudly instead of publishing the sentinel.
+pkgver=@SHOTTINO_VERSION@
+pkgrel=1
+# The grappa tag that carries this source. Distinct from pkgver ON PURPOSE:
+# the client's number moves on its own cadence, while the tarball only exists
+# under the bouncer's tag. Filled by ../regen.sh from the repo-root VERSION.
+_grappaver=@GRAPPA_VERSION@
+pkgdesc="Terminal client for grappa — an irssi-shaped ncurses UI over its REST + Phoenix Channels API"
+arch=('x86_64')
+url="https://github.com/vjt/grappa-irc"
+license=('MIT')
+# What the binary links, and nothing else. ncurses is Arch's single wide
+# build (no narrow/wide split like Debian); ca-certificates because the client
+# calls SSL_CTX_set_default_verify_paths + SSL_VERIFY_PEER, so the system CA
+# store is a RUNTIME dependency, not a copied one.
+depends=('ncurses' 'openssl' 'ca-certificates')
+# No makedepends: the C toolchain and pkgconf come from base-devel, which
+# makepkg assumes. Deliberately no elixir/erlang/bun — this package builds one
+# C binary and must not drag the bouncer's build stack onto a client-only host,
+# which is the entire point of #1447.
+optdepends=('grappa: the bouncer this client talks to, if you run one locally')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${_grappaver}.tar.gz")
+# SKIP until the vX.Y.Z tag exists: ../regen.sh replaces this with the real
+# hash via updpkgsums, exactly as it does for the bouncer recipe.
+sha256sums=('SKIP')
+
+# GitHub tag tarballs extract to <repo>-<version>/ — and the version there is
+# the GRAPPA tag, not this package's.
+_srcdir="grappa-irc-${_grappaver}"
+
+build() {
+	cd "${srcdir}/${_srcdir}"
+
+	# configure probes ncursesw + openssl through pkg-config and writes
+	# config.mk, which the Makefile reads. It fails loudly on a missing dep
+	# rather than producing a client with half its features.
+	./configure --prefix=/usr
+	make -C frontends/shottino
+	# `make check` is NOT run here: those suites build with ASan/UBSan — a CI
+	# gate, not something to impose on a user's rebuild.
+}
+
+package() {
+	cd "${srcdir}/${_srcdir}"
+
+	install -Dm755 frontends/shottino/shottino "${pkgdir}/usr/bin/shottino"
+	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/infra/packaging/build.sh
+++ b/infra/packaging/build.sh
@@ -18,8 +18,8 @@
 #                     + shottino link the build host's glibc/libssl.
 #   OUT_DIR           where the BOUNCER package lands (default: <repo>/dist)
 #   SHOTTINO_OUT_DIR  where the STANDALONE CLIENT package lands
-#                     (default: <repo>/dist-shottino). Deliberately NOT
-#                     OUT_DIR — see the client-package section below.
+#                     (default: <repo>/dist-shottino). One directory per
+#                     artifact — see the client-package section below.
 #   NFPM_BIN          path to nfpm (default: on PATH, else downloaded pinned)
 #   SKIP_RELEASE=1    reuse an existing _build/prod/rel/grappa
 #   SKIP_CIC=1        reuse an existing staged cicchetto-dist
@@ -35,17 +35,16 @@ PKG_DIR="${SCRIPT_DIR}"
 STAGING="${PKG_DIR}/staging"
 SHOTTINO_STAGING="${PKG_DIR}/staging-shottino"
 OUT_DIR="${OUT_DIR:-${REPO_ROOT}/dist}"
-# The standalone client package lands OUTSIDE OUT_DIR, and that is the whole
-# mechanism keeping #1447 slice A unpublished. The release workflow's upload
-# steps are PATH-scoped globs (`path: dist/*.deb`, `path: dist/*.rpm`), so a
-# package written elsewhere is never uploaded, never downloaded by `publish`,
-# and never attached. `release_assets.sh found` matches by NAME AT ANY DEPTH,
-# so once a file reaches the artifact bundle it WILL be attached — the
-# directory split is the only gate, and it lives here.
+# One directory per artifact. In #1447 slice A this split was a GATE — the
+# workflow's upload steps are PATH-scoped globs, so a package written outside
+# `dist/` could not reach the release while the bouncer still owned
+# /usr/bin/shottino and the two could not be co-installed.
 #
-# It matters because slice A leaves the bouncer package shipping
-# /usr/bin/shottino: until slice B drops it, both packages own that path and
-# publishing the pair would ship two artifacts that cannot be co-installed.
+# Slice B dropped the file from the bouncer, so the pair is co-installable and
+# the client package IS published — from its own upload step, reading this
+# directory. The split stays because it keeps publication EXPLICIT: a new
+# package is published when someone writes its upload step, never because a
+# glob over a shared directory quietly widened.
 SHOTTINO_OUT_DIR="${SHOTTINO_OUT_DIR:-${REPO_ROOT}/dist-shottino}"
 
 say() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
@@ -130,10 +129,13 @@ mkdir -p "${STAGING}/usr/lib/grappa"
 cp -a "${REL_DIR}/." "${STAGING}/usr/lib/grappa/"
 
 # ── shottino (terminal client) ─────────────────────────────────────────────
-# The C client ships in the same package as the bouncer, built here so it
-# links the BUILD host's ncurses/openssl like the ERTS payload does.
-# Unless SKIP_SHOTTINO=1, a build failure FAILS the package build.
-SHOTTINO_BIN="${STAGING}/usr/bin/shottino"
+# The C client ships as its OWN package (#1447), built here rather than
+# elsewhere so it links the BUILD host's ncurses/openssl exactly like the ERTS
+# payload does — same host, same glibc floor, one build per format.
+# Unless SKIP_SHOTTINO=1, a build failure FAILS the package build: a package
+# that silently ships without a binary it advertises is worse than one that
+# refuses to build.
+SHOTTINO_BIN="${SHOTTINO_STAGING}/usr/bin/shottino"
 if [ "${SKIP_SHOTTINO:-}" != "1" ]; then
 	say "building shottino → ${SHOTTINO_BIN}"
 	# ./configure rewrites ${REPO_ROOT}/config.mk, a TRACKED file. Snapshot
@@ -160,13 +162,8 @@ if [ "${SKIP_SHOTTINO:-}" != "1" ]; then
 		make -C frontends/shottino clean
 		make -C frontends/shottino
 	)
-	mkdir -p "${STAGING}/usr/bin"
-	install -m 0755 "${REPO_ROOT}/frontends/shottino/shottino" "${SHOTTINO_BIN}"
-	# The SAME binary also stages for the standalone package. Two staging trees
-	# rather than one shared with the bouncer, so slice B can drop the bouncer's
-	# copy by deleting its `contents:` entry and this line, and nothing else.
 	mkdir -p "${SHOTTINO_STAGING}/usr/bin"
-	install -m 0755 "${REPO_ROOT}/frontends/shottino/shottino" "${SHOTTINO_STAGING}/usr/bin/shottino"
+	install -m 0755 "${REPO_ROOT}/frontends/shottino/shottino" "${SHOTTINO_BIN}"
 	# Prove the staged artifact RUNS before packaging it. `--help` needs no
 	# server, terminal or config, so it exercises the dynamic links for real.
 	"${SHOTTINO_BIN}" --help >/dev/null 2>&1 || die "staged shottino does not run (link error?)"

--- a/infra/packaging/nfpm.yaml
+++ b/infra/packaging/nfpm.yaml
@@ -22,18 +22,19 @@ vendor: "Marcello Barnaba"
 homepage: "https://github.com/vjt/grappa-irc"
 license: "MIT"
 description: |
-  Always-on IRC bouncer with a REST + Phoenix Channels API, a bundled
-  irssi-shaped web PWA (cicchetto), and a terminal client (shottino).
-  One supervised OTP process per (user, network); sqlite-backed
-  scrollback. Ships a self-contained Erlang/OTP release and self-serves
-  the web frontend, so nginx is recommended for TLS but not required.
-  The terminal client installs as /usr/bin/shottino and talks to the
-  same REST + Channels API as the web frontend.
+  Always-on IRC bouncer with a REST + Phoenix Channels API and a bundled
+  irssi-shaped web PWA (cicchetto). One supervised OTP process per
+  (user, network); sqlite-backed scrollback. Ships a self-contained
+  Erlang/OTP release and self-serves the web frontend, so nginx is
+  recommended for TLS but not required.
+  The terminal client (shottino) is its OWN package since 1.3.0 — install
+  it anywhere, with or without this server (#1447).
 
 # Runtime deps are per-format (disjoint package names across distro
 # families), so they live under `overrides` — NOT top-level `depends`,
-# which nfpm would apply to BOTH formats. The bundled ERTS links these
-# system libs; shottino links the same libssl + the WIDE ncurses.
+# which nfpm would apply to BOTH formats. What they cover is the bundled
+# ERTS and the maintainer scripts; the terminal client declares its own
+# (nfpm-shottino.yaml) since it stopped riding along in 1.3.0.
 #
 # recommends: the media-metadata strip shells out to exiftool/ffmpeg
 # fail-closed (without them uploads 422), and nginx is the recommended
@@ -44,13 +45,13 @@ description: |
 overrides:
   deb:
     depends:
-      # libncursesw6 is for SHOTTINO and is NOT the same Debian package as
-      # libncurses6: the client links libncursesw.so.6 (the WIDE build,
-      # because it is UTF-8 end to end) while ERTS wants the narrow
-      # libncurses6. Debian ships them separately, so depending on only one
-      # leaves the other's consumer with "cannot open shared object file"
-      # at exec time. (Fedora folds both SONAMEs into one ncurses-libs — see
-      # the rpm override.)
+      # libncurses6 is for ERTS, and it is the NARROW build. The WIDE
+      # libncursesw6 used to sit beside it for shottino; it left with the
+      # binary in 1.3.0 (#1447) and is declared by the client's own package
+      # now. Debian ships the two separately, so a dependency kept here for a
+      # file this package no longer contains would be a claim about someone
+      # else's payload. (Fedora folds both SONAMEs into one ncurses-libs, so
+      # the rpm override below keeps its single entry for ERTS.)
       #
       # libssl3t64 | libssl3: Debian's 64-bit time_t transition renamed the
       # OpenSSL runtime package `libssl3` -> `libssl3t64` on Ubuntu 24.04
@@ -62,7 +63,6 @@ overrides:
       # libssl.so.3 SONAME either way.
       - libssl3t64 | libssl3
       - libncurses6
-      - libncursesw6
       - libstdc++6
       - libgcc-s1
       - ca-certificates
@@ -74,18 +74,25 @@ overrides:
       # present) — unlike Fedora, where it is a separate package (see rpm).
       - openssl
     recommends:
+      # shottino: THE UPGRADE PATH, not a suggestion. /usr/bin/shottino left
+      # this package in 1.3.0 (#1447); without this entry `apt upgrade` would
+      # remove the client from every host that has it today and pull nothing
+      # back, because nothing else references the replacement. apt installs
+      # Recommends by default, so the client arrives in the same transaction.
+      - shottino
       - libimage-exiftool-perl
       - ffmpeg
       - nginx
   rpm:
     depends:
       # Fedora/RHEL package names for the SAME SONAMEs the deb depends on.
-      # openssl-libs = libssl.so.3 + libcrypto.so.3; ncurses-libs is ONE
-      # package providing BOTH libncurses.so.6 (ERTS) and libncursesw.so.6
-      # (shottino) — no wide/narrow split like Debian, so a single entry
-      # covers both consumers. shadow-utils provides useradd/groupadd (the
-      # deb's `passwd`); ca-certificates is the system CA trust store the
-      # upstream-TLS verify_peer path reads.
+      # openssl-libs = libssl.so.3 + libcrypto.so.3; ncurses-libs is here for
+      # ERTS's libncurses.so.6. Fedora folds the wide and narrow SONAMEs into
+      # that one package, which is why this side needs no edit now that the
+      # client (libncursesw.so.6) has left — unlike the deb, where the wide
+      # build is a separate package and had to go. shadow-utils provides
+      # useradd/groupadd (the deb's `passwd`); ca-certificates is the system
+      # CA trust store the upstream-TLS verify_peer path reads.
       - openssl-libs
       - ncurses-libs
       - libstdc++
@@ -103,6 +110,10 @@ overrides:
       - openssl
       - util-linux
     recommends:
+      # See the deb override: the client is a weak dep so that a dnf upgrade
+      # brings it back in the same transaction the file leaves this package.
+      # dnf installs weak deps by default (install_weak_deps=True).
+      - shottino
       - perl-Image-ExifTool
       - ffmpeg
       - nginx
@@ -111,14 +122,6 @@ contents:
   # The mix release (self-contained ERTS + compiled app + boot scripts).
   - src: ./staging/usr/lib/grappa
     dst: /usr/lib/grappa
-
-  # shottino — the terminal client (frontends/shottino), compiled by
-  # build.sh into the staging tree. Ships in the SAME package as the
-  # bouncer: its runtime deps are already in `depends` above.
-  - src: ./staging/usr/bin/shottino
-    dst: /usr/bin/shottino
-    file_info:
-      mode: 0755
 
   # The built cicchetto SPA dist (CIC_DIST_ROOT points here). Read-only
   # static assets served by Plug.Static.

--- a/infra/packaging/release_assets.sh
+++ b/infra/packaging/release_assets.sh
@@ -27,13 +27,31 @@ set -euo pipefail
 # label per line, TAB-separated. This table IS the contract — a new package
 # kind is added HERE and both the attach glob and the audit follow. Keep it
 # byte-aligned with the bats suite.
+#
+# Patterns are scoped by PACKAGE NAME, not by extension alone (#1447 slice B).
+# Since the terminal client ships as its own artifact, every format produces
+# TWO packages, and a bare `*.deb` is satisfied by either of them: a release
+# whose client leg died would match on the bouncer's file, report a complete
+# set, and publish without the client SILENTLY. That is #573's failure one
+# package later, and the same posture the packaging README states one level
+# down — a package that silently ships without a binary it advertises is worse
+# than one that refuses to build.
+#
+# The names come from the builders, not from taste: nfpm writes
+# `<name>_<ver>_<arch>.deb` and `<name>-<ver>-1.<arch>.rpm`, makepkg writes
+# `<name>-<ver>-1-<arch>.pkg.tar.zst`.
 expected_kinds() {
 	printf '%s\n' \
-		'*.deb	Debian package (.deb)' \
-		'*.rpm	RPM package (.rpm)' \
-		'*.pkg.tar.zst	Arch package (.pkg.tar.zst)' \
-		'PKGBUILD	Arch PKGBUILD recipe' \
-		'.SRCINFO	Arch .SRCINFO recipe'
+		'grappa_*.deb	Debian package, bouncer (.deb)' \
+		'shottino_*.deb	Debian package, client (.deb)' \
+		'grappa-*.rpm	RPM package, bouncer (.rpm)' \
+		'shottino-*.rpm	RPM package, client (.rpm)' \
+		'grappa-*.pkg.tar.zst	Arch package, bouncer (.pkg.tar.zst)' \
+		'shottino-*.pkg.tar.zst	Arch package, client (.pkg.tar.zst)' \
+		'PKGBUILD	Arch PKGBUILD recipe, bouncer' \
+		'.SRCINFO	Arch .SRCINFO recipe, bouncer' \
+		'shottino.PKGBUILD	Arch PKGBUILD recipe, client' \
+		'shottino.SRCINFO	Arch .SRCINFO recipe, client'
 }
 
 # Sentinel markers delimiting the partial-release block inside a release

--- a/test/grappa/version_single_source_test.exs
+++ b/test/grappa/version_single_source_test.exs
@@ -16,6 +16,13 @@ defmodule Grappa.VersionSingleSourceTest do
       same `version.sh` at release time, filling the committed
       `@GRAPPA_VERSION@` sentinel (a value `makepkg` REFUSES, so an
       underived build fails loudly instead of shipping `grappa-@…@`);
+    * the Arch CLIENT recipe (#1447, `aur/shottino/`) — a SECOND pkgbase, and
+      therefore a second carrier: `pkgver=@SHOTTINO_VERSION@` derives from
+      `frontends/shottino/version.h` (the client's own line, so
+      `shottino --version` and the package agree), while `_grappaver` stays
+      `@GRAPPA_VERSION@` because the source tarball only exists under the
+      bouncer's tag. Split into two recipes rather than one split package
+      because `PKGBUILD(5)` does not let a `package_*()` override `pkgver`;
     * the cicchetto `<meta cicchetto-version>` — `vite.config.ts` reads
       the `GRAPPA_VERSION` env (cic builds mount only `./cicchetto`, so
       they cannot read the repo root; the build wrappers export it from
@@ -96,6 +103,34 @@ defmodule Grappa.VersionSingleSourceTest do
     test ".SRCINFO pkgver is the @GRAPPA_VERSION@ sentinel (regenerated with PKGBUILD)" do
       pkgver = carrier_value("infra/packaging/aur/.SRCINFO", ~r/pkgver\s*=\s*(\S+)/)
       assert pkgver == "@GRAPPA_VERSION@"
+    end
+
+    test "the Arch client PKGBUILD pkgver is the @SHOTTINO_VERSION@ sentinel (#1447)" do
+      # A DIFFERENT carrier from every other line here: the client's number
+      # lives in frontends/shottino/version.h and moves on its own cadence.
+      # Hard-coding it would be the same drift this suite exists to catch, one
+      # package over — and it would go unnoticed longer, since nothing else in
+      # the tree reads that number.
+      pkgver = carrier_value("infra/packaging/aur/shottino/PKGBUILD", ~r/^pkgver=(.+)$/m)
+      assert pkgver == "@SHOTTINO_VERSION@"
+    end
+
+    test "the Arch client recipe still names the GRAPPA tag as its source (#1447)" do
+      # Not a duplicate of the assertion above — the opposite failure. One
+      # repository, one tag: the tarball exists under the BOUNCER's version, so
+      # a recipe that derived its source from the client's line would fetch a
+      # tag that was never cut. Two sentinels, two carriers, one tarball.
+      grappaver = carrier_value("infra/packaging/aur/shottino/PKGBUILD", ~r/^_grappaver=(.+)$/m)
+      assert grappaver == "@GRAPPA_VERSION@"
+    end
+
+    test "the Arch client .SRCINFO carries both sentinels (regenerated with its PKGBUILD)" do
+      # The committed .SRCINFO is hand-written until the arch job regenerates
+      # it; nothing in this suite compares it to its PKGBUILD field by field,
+      # so this pins the two values a hand-edit gets wrong first.
+      srcinfo = "infra/packaging/aur/shottino/.SRCINFO"
+      assert carrier_value(srcinfo, ~r/pkgver\s*=\s*(\S+)/) == "@SHOTTINO_VERSION@"
+      assert carrier_value(srcinfo, ~r/source\s*=\s*\S*tags\/v(\S+)\.tar\.gz/) == "@GRAPPA_VERSION@"
     end
 
     # The cicchetto carrier — package.json's version neutralised to 0.0.0 (vite

--- a/test/infra/packaging_shottino_pkg_test.bats
+++ b/test/infra/packaging_shottino_pkg_test.bats
@@ -1,23 +1,23 @@
 #!/usr/bin/env bats
 #
-# Bats suite for GH #1447 slice A — shottino gets its OWN nfpm config, built
-# and proven on every packaging job but NOT published yet.
+# Bats suite for GH #1447 — shottino has its OWN package, and since slice B the
+# bouncer no longer ships the client binary at all.
 #
-# Slice A is deliberately additive: `grappa` still ships /usr/bin/shottino, so
-# the two packages both own that path and CANNOT be co-installed. That makes
-# "the standalone package does not reach the release" the load-bearing property
-# of this slice, and it is the first thing pinned below.
+# Slice A was deliberately additive: `grappa` still shipped /usr/bin/shottino,
+# both packages owned that path, and they could NOT be co-installed — so the
+# standalone package was built, inspected, and kept off the release. Slice B is
+# the other half of that one decision: the bouncer drops the file, the takeover
+# relations become true, and the client package is published.
 #
-# THE HAZARD, MEASURED — and not where the first reading put it.
+# THE ORDER IS THE WHOLE POINT. Dropping the file without publishing the
+# replacement would take the client away from everyone who has it today, and
+# publishing without dropping would ship a pair that cannot be installed
+# together. Neither half is shippable alone, which is why they are one slice.
 #
-# `infra/packaging/release_assets.sh` matches release assets by NAME AT ANY
-# DEPTH (`found()`: `find "$dir" -type f -name '*.deb'`), so it was the obvious
-# suspect. It is not the gatekeeper: it only ever sees what the `publish` job
-# DOWNLOADED. The real gate is one step earlier — the upload globs are
-# PATH-scoped (`path: dist/*.deb`, `path: dist/*.rpm`), so a package written
-# outside `dist/` is never uploaded, never downloaded, and never attached.
-# That is why a separate output directory is the cure, and why this suite
-# derives the forbidden directories FROM the workflow instead of naming `dist`.
+# The upload derivation below survives from slice A with its polarity flipped.
+# Then, a package's absence from every upload directory was the gate; now, the
+# client package's OWN upload step is the property — publication is explicit,
+# never a side effect of a glob widening.
 #
 # The other three properties are the ones that make the package a CLIENT
 # package rather than a second copy of the bouncer: its own version line, one
@@ -37,6 +37,10 @@ setup() {
     BUILD_SH="$PKG_DIR/build.sh"
     WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
     VERSION_H="$REPO_ROOT/frontends/shottino/version.h"
+    PKGBUILD="$PKG_DIR/aur/PKGBUILD"
+    PKGBUILD_CLIENT="$PKG_DIR/aur/shottino/PKGBUILD"
+    SRCINFO_CLIENT="$PKG_DIR/aur/shottino/.SRCINFO"
+    REGEN="$PKG_DIR/aur/regen.sh"
 }
 
 # The `contents:` block of an nfpm config: from `contents:` to the next
@@ -65,26 +69,137 @@ upload_dirs() {
     ' "$WORKFLOW" | sort -u
 }
 
-# ── The slice's load-bearing property ──────────────────────────────────────
+# ── The pair that must land together ───────────────────────────────────────
 
-@test "#1447 the workflow's upload globs are path-scoped, so a directory can hide from the release" {
+@test "#1447 the workflow's upload globs are path-scoped, so publication is per-directory" {
     # The floor for the test below: if this derivation found nothing, "the
-    # client package is built outside every upload dir" would hold vacuously.
+    # client package's directory is uploaded" would hold vacuously.
     run upload_dirs
     [ "$status" -eq 0 ]
     [ -n "$output" ]
     [ "$(printf '%s\n' "$output" | wc -l)" -ge 2 ]
 }
 
-@test "#1447 the client package is written outside every directory the release uploads" {
+@test "#1447 the bouncer package no longer ships the client binary" {
+    # THE assertion slice A could not make. Until the bouncer stops owning
+    # /usr/bin/shottino, the standalone package's Replaces:/Breaks: describe a
+    # takeover that has not happened and the two cannot be co-installed.
+    run installed_paths "$NFPM_SERVER"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    refute grep -qx '/usr/bin/shottino' <<<"$output"
+}
+
+@test "#1447 the client package IS published, from its own output directory" {
+    # The converse of slice A's gate, and deliberately not "some glob happens
+    # to reach it": the client's directory has an upload step of its own, so
+    # publishing it stays a decision someone had to write down.
     grep -q 'SHOTTINO_OUT_DIR' "$BUILD_SH"
 
     client_out="$(sed -n 's/^SHOTTINO_OUT_DIR="\${SHOTTINO_OUT_DIR:-\${REPO_ROOT}\/\(.*\)}"$/\1/p' "$BUILD_SH")"
     [ -n "$client_out" ]
 
-    while IFS= read -r dir; do
-        [ "$dir" != "$client_out" ]
-    done < <(upload_dirs)
+    upload_dirs | grep -qxF "$client_out"
+}
+
+@test "#1447 the bouncer recommends the client, per format, or an upgrade removes it" {
+    # NOT cosmetic, and the reason is the upgrade path: the file leaves the
+    # bouncer package in this release, so `apt upgrade` on a host that has
+    # shottino today would delete /usr/bin/shottino and pull nothing back.
+    # A Recommends is installed by default on Debian and by dnf's weak deps on
+    # Fedora, so the replacement arrives in the same transaction. Per format,
+    # because the two override blocks are disjoint (see nfpm.yaml).
+    deb_block="$(awk '/^  deb:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$NFPM_SERVER")"
+    rpm_block="$(awk '/^  rpm:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$NFPM_SERVER")"
+    [ -n "$deb_block" ]
+    [ -n "$rpm_block" ]
+
+    grep -qF -- '- shottino' <<<"$deb_block"
+    grep -qF -- '- shottino' <<<"$rpm_block"
+}
+
+# ── The Arch recipe, where the same decision has different mechanics ────────
+
+@test "#1447 the AUR client is a SECOND recipe, and only it installs the binary" {
+    # NOT a split package, and the reason is measured: PKGBUILD(5) § PACKAGE
+    # SPLITTING names the variables a package_*() may override and `pkgver` is
+    # not one of them, so a split would stamp the client with the bouncer's
+    # version — the exact disagreement the own-version-line ruling forbids.
+    # Two version lines, two pkgbases.
+    [ -f "$PKGBUILD_CLIENT" ]
+    grep -qx 'pkgname=shottino' "$PKGBUILD_CLIENT"
+    grep -qF 'usr/bin/shottino' "$PKGBUILD_CLIENT"
+
+    # And the bouncer recipe neither builds nor installs it any more. Read off
+    # the FUNCTION BODIES, not the file: the recipe names shottino in prose
+    # (the optdepends pointer and its why-comment), and a whole-file grep would
+    # be satisfied by that prose while the install line was still there.
+    bouncer_pkg="$(awk '/^package\(\)/ { f = 1 } f { print } f && /^}/ { exit }' "$PKGBUILD")"
+    bouncer_build="$(awk '/^build\(\)/ { f = 1 } f { print } f && /^}/ { exit }' "$PKGBUILD")"
+    [ -n "$bouncer_pkg" ]
+    [ -n "$bouncer_build" ]
+    refute grep -qF 'usr/bin/shottino' <<<"$bouncer_pkg"
+    refute grep -qF 'frontends/shottino' <<<"$bouncer_build"
+}
+
+@test "#1447 the AUR client recipe carries its OWN version sentinel, plus the tag that has the source" {
+    # THE property that forced a second pkgbase. pkgver comes from the client
+    # carrier; _grappaver names the tag that actually exists on GitHub, since
+    # one repository ships both. Sentinels, not numbers: makepkg's pkgver lint
+    # refuses '@', so an underived build fails loudly.
+    grep -qx 'pkgver=@SHOTTINO_VERSION@' "$PKGBUILD_CLIENT"
+    grep -qx '_grappaver=@GRAPPA_VERSION@' "$PKGBUILD_CLIENT"
+    refute grep -qx 'pkgver=@GRAPPA_VERSION@' "$PKGBUILD_CLIENT"
+
+    # The bouncer's own sentinel is untouched by all this.
+    grep -qx 'pkgver=@GRAPPA_VERSION@' "$PKGBUILD"
+}
+
+@test "#1447 the AUR client recipe does not drag the bouncer's build stack onto a client-only host" {
+    # The whole point of #1447: a machine that wants the terminal client must
+    # not need elixir, erlang or bun to get it. Derived from the bouncer's
+    # makedepends rather than re-typed, so a new entry there is checked here.
+    bouncer_makedeps="$(sed -n "s/^makedepends=(\(.*\))$/\1/p" "$PKGBUILD" | tr -d "'" )"
+    [ -n "$bouncer_makedeps" ]
+
+    # Compared against the client's DECLARATIONS, never its prose — the recipe
+    # says in a comment that it wants none of these, and a comment is not a
+    # dependency list. Every `depends=`/`makedepends=` line, sentinel included
+    # so an empty match cannot pass vacuously.
+    client_decls="$(grep -E '^(make)?depends=' "$PKGBUILD_CLIENT" || true)"
+    [ -n "$client_decls" ]
+    for dep in $bouncer_makedeps; do
+        refute grep -qF "$dep" <<<"$client_decls"
+    done
+}
+
+@test "#1447 the AUR bouncer recipe points at the client through optdepends" {
+    # The Arch stand-in for Recommends: pacman has no weak dep that installs by
+    # default, so the pointer is advisory BY CONSTRUCTION — but a user who
+    # upgrades and finds the client gone must be told where it went.
+    optdeps="$(awk '/^optdepends=\(/ { f = 1 } f { print } f && /\)$/ { exit }' "$PKGBUILD")"
+    [ -n "$optdeps" ]
+    grep -qF 'shottino' <<<"$optdeps"
+}
+
+@test "#1447 regen.sh derives BOTH recipes, or the second one publishes a sentinel" {
+    # regen.sh is the ONE path that fills the sentinels. A second recipe it
+    # does not know about would reach makepkg with `pkgver=@SHOTTINO_VERSION@`
+    # — caught by makepkg's lint, but at release time, in CI, on a tag.
+    grep -qF 'version.sh" shottino' "$REGEN"
+    grep -qF 'shottino' "$REGEN"
+    grep -qF '_grappaver=' "$REGEN"
+}
+
+@test "#1447 the client .SRCINFO is committed and agrees with its recipe on the sentinels" {
+    # Coherence NOT proven here beyond the version carriers: .SRCINFO is
+    # regenerated by `makepkg --printsrcinfo`, which does not run on this host.
+    # What IS checkable without makepkg is that the committed copy carries the
+    # same sentinels — the one thing a hand-edit gets wrong first.
+    [ -f "$SRCINFO_CLIENT" ]
+    grep -qE '^\s*pkgver = @SHOTTINO_VERSION@$' "$SRCINFO_CLIENT"
+    grep -qE '^\s*source = .*v@GRAPPA_VERSION@\.tar\.gz$' "$SRCINFO_CLIENT"
+    grep -qx 'pkgname = shottino' "$SRCINFO_CLIENT"
 }
 
 # ── Its own version line, derived from the header ──────────────────────────

--- a/test/infra/release_assets_test.bats
+++ b/test/infra/release_assets_test.bats
@@ -13,6 +13,12 @@
 # Scope: the SET LOGIC (expected vs arrived) + the idempotent partial-release
 # body marker — the bug-prone parts that must not live untested in YAML.
 # Pure filesystem + string logic; no docker, no network, no mix.
+#
+# #1447 slice B — the kinds are matched by the PACKAGE NAME, not by extension
+# alone. From this release the client ships as its own artifact, so a bare
+# `*.deb` would be satisfied by EITHER package: a release that built the
+# bouncer and lost the client would look complete and say nothing. That is the
+# same failure #573 was filed for, one package later.
 
 load ../bats_helpers
 
@@ -33,6 +39,17 @@ seed_complete() {
     : > "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
     : > "$ASSETS/grappa-arch/PKGBUILD"
     : > "$ASSETS/grappa-arch/.SRCINFO"
+    # The client package, on its own version line (#1447). Named as the real
+    # builders name it: nfpm writes `<name>_<ver>_<arch>.deb` and
+    # `<name>-<ver>-1.<arch>.rpm`, makepkg writes `<name>-<ver>-1-<arch>.pkg.tar.zst`.
+    : > "$ASSETS/grappa-deb/shottino_0.3.0_amd64.deb"
+    : > "$ASSETS/grappa-rpm/shottino-0.3.0-1.x86_64.rpm"
+    : > "$ASSETS/grappa-arch/shottino-0.3.0-1-x86_64.pkg.tar.zst"
+    # The client's AUR recipe, staged under a distinct BASENAME: a release
+    # asset is keyed by basename, so a second file called PKGBUILD would
+    # overwrite the first (the publish fallback uploads with --clobber).
+    : > "$ASSETS/grappa-arch/shottino.PKGBUILD"
+    : > "$ASSETS/grappa-arch/shottino.SRCINFO"
 }
 
 @test "found: a complete nested tree lists every expected asset file" {
@@ -44,7 +61,12 @@ seed_complete() {
     echo "$output" | grep -q 'grappa-0.8.0-1-x86_64.pkg.tar.zst'
     echo "$output" | grep -q '/PKGBUILD$'
     echo "$output" | grep -q '/.SRCINFO$'
-    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 5 ]
+    echo "$output" | grep -q 'shottino_0.3.0_amd64.deb'
+    echo "$output" | grep -q 'shottino-0.3.0-1.x86_64.rpm'
+    echo "$output" | grep -q 'shottino-0.3.0-1-x86_64.pkg.tar.zst'
+    echo "$output" | grep -q '/shottino.PKGBUILD$'
+    echo "$output" | grep -q '/shottino.SRCINFO$'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 10 ]
 }
 
 @test "found: matches by NAME at any depth, not by a path-coupled glob (flat layout)" {
@@ -69,7 +91,32 @@ seed_complete() {
     rm "$ASSETS/grappa-rpm/grappa-0.8.0-1.x86_64.rpm"
     run "$SCRIPT" missing "$ASSETS"
     [ "$status" -eq 0 ]
-    [ "$output" = "RPM package (.rpm)" ]
+    [ "$output" = "RPM package, bouncer (.rpm)" ]
+}
+
+@test "missing: a client package that did not build is named, not absorbed (#1447)" {
+    # The whole reason the kinds are name-scoped. The bouncer's .deb is right
+    # there, so an extension-only `*.deb` pattern would find it, call the kind
+    # satisfied, and publish a release with no client — silently. A release
+    # that loses an artifact it advertises must FAIL LOUDLY.
+    seed_complete
+    rm "$ASSETS/grappa-deb/shottino_0.3.0_amd64.deb"
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "Debian package, client (.deb)" ]
+}
+
+@test "missing: losing the client's whole leg names all three of its packages (#1447)" {
+    seed_complete
+    rm "$ASSETS/grappa-deb/shottino_0.3.0_amd64.deb"
+    rm "$ASSETS/grappa-rpm/shottino-0.3.0-1.x86_64.rpm"
+    rm "$ASSETS/grappa-arch/shottino-0.3.0-1-x86_64.pkg.tar.zst"
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'Debian package, client (.deb)'
+    echo "$output" | grep -q 'RPM package, client (.rpm)'
+    echo "$output" | grep -q 'Arch package, client (.pkg.tar.zst)'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 3 ]
 }
 
 @test "missing: a dead Arch leg names all three of its outputs" {
@@ -77,18 +124,35 @@ seed_complete() {
     rm "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
     rm "$ASSETS/grappa-arch/PKGBUILD"
     rm "$ASSETS/grappa-arch/.SRCINFO"
+    rm "$ASSETS/grappa-arch/shottino-0.3.0-1-x86_64.pkg.tar.zst"
     run "$SCRIPT" missing "$ASSETS"
     [ "$status" -eq 0 ]
-    echo "$output" | grep -q 'Arch package (.pkg.tar.zst)'
-    echo "$output" | grep -q 'Arch PKGBUILD recipe'
-    echo "$output" | grep -q 'Arch .SRCINFO recipe'
-    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 3 ]
+    echo "$output" | grep -q 'Arch package, bouncer (.pkg.tar.zst)'
+    echo "$output" | grep -q 'Arch package, client (.pkg.tar.zst)'
+    echo "$output" | grep -q 'Arch PKGBUILD recipe, bouncer'
+    echo "$output" | grep -q 'Arch .SRCINFO recipe, bouncer'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 4 ]
 }
 
 @test "missing: an empty assets tree names every expected kind" {
     run "$SCRIPT" missing "$ASSETS"
     [ "$status" -eq 0 ]
-    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 5 ]
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 10 ]
+}
+
+@test "missing: the client's recipe is its own kind, not the bouncer's (#1447)" {
+    # The two recipes are DIFFERENT files with different sentinels, staged
+    # under different basenames precisely so one cannot stand in for the
+    # other. An expected-kinds table that matched `PKGBUILD` alone would call
+    # the pair complete with the client's recipe missing.
+    seed_complete
+    rm "$ASSETS/grappa-arch/shottino.PKGBUILD"
+    rm "$ASSETS/grappa-arch/shottino.SRCINFO"
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'Arch PKGBUILD recipe, client'
+    echo "$output" | grep -q 'Arch .SRCINFO recipe, client'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
 }
 
 @test "notice: a complete set produces no marker block" {
@@ -105,7 +169,7 @@ seed_complete() {
     [ "$status" -eq 0 ]
     echo "$output" | grep -q '<!-- grappa:partial-release:start -->'
     echo "$output" | grep -q '<!-- grappa:partial-release:end -->'
-    echo "$output" | grep -q 'RPM package (.rpm)'
+    echo "$output" | grep -q 'RPM package, bouncer (.rpm)'
 }
 
 @test "apply-body: a partial set prepends the block, and is idempotent" {
@@ -119,7 +183,7 @@ seed_complete() {
     # block present exactly once, changelog preserved
     [ "$(grep -c 'grappa:partial-release:start' "$BATS_TEST_TMPDIR/body2.md")" -eq 1 ]
     grep -q 'a real changelog line' "$BATS_TEST_TMPDIR/body2.md"
-    grep -q 'RPM package (.rpm)' "$BATS_TEST_TMPDIR/body2.md"
+    grep -q 'RPM package, bouncer (.rpm)' "$BATS_TEST_TMPDIR/body2.md"
 
     # Feeding the already-marked body back in must NOT double the block.
     run bash -c "'$SCRIPT' apply-body '$ASSETS' < '$BATS_TEST_TMPDIR/body2.md'"


### PR DESCRIPTION
Slice B of #1447. Slice A (#1478, now on `main`) gave shottino its own package and
deliberately withheld it. This is the other half of the same decision: the `grappa`
package stops shipping `/usr/bin/shottino`, the takeover relations written in slice A
become true, and the client package is published.

## File count: **16**, not 12 — declared overrun

12 planned, plus 4 dragged in by the second AUR recipe:

| # | file | why |
|---|---|---|
| 1 | `.github/workflows/release.yml` | inverted assertions for the three formats, co-installation, publication |
| 2 | `infra/packaging/nfpm.yaml` | binary dropped, per-format `Recommends:`, `libncursesw6` travels with the binary |
| 3 | `infra/packaging/build.sh` | the client stages only into its own tree |
| 4 | `infra/packaging/release_assets.sh` | asset kinds keyed by package NAME (+2 kinds for the client recipe) |
| 5 | `infra/packaging/aur/PKGBUILD` | the bouncer no longer builds or installs the client; `optdepends` |
| 6 | `infra/packaging/aur/.SRCINFO` | mirrors the new `optdepends` |
| 7 | `infra/packaging/aur/regen.sh` | derives **two** recipes, two sentinels, two `.SRCINFO` |
| 8 | `infra/packaging/README.md` | the "where the split stands" paragraph was written in the future tense |
| 9 | `infra/packaging/aur/README.md` | publish path for the **second** AUR package, plus the rename |
| 10 | `docs/OPERATIONS.md` | the section that argued AGAINST the split |
| 11 | `docs/DESIGN_NOTES.md` | entry, marker `<!-- entry #1447 slice B -->` |
| 12 | `test/infra/packaging_shottino_pkg_test.bats` | the red that buys the drop + the 6 AUR assertions |
| 13 | `test/infra/release_assets_test.bats` | the new kinds and their counts |
| **14** | `infra/packaging/aur/shottino/PKGBUILD` | **dragged in**: the second recipe |
| **15** | `infra/packaging/aur/shottino/.SRCINFO` | **dragged in**: its committed metadata |
| **16** | `test/grappa/version_single_source_test.exs` | **dragged in**: the pin for the two new sentinels |

## Why this is ONE slice

The two halves are not shippable apart: the drop alone deletes the client from anyone who
has it, the publication alone ships a pair that is not co-installable.

**`Recommends:` is the upgrade path, not a nicety.** Without it, `apt upgrade` removes
`/usr/bin/shottino` and pulls nothing in. apt installs Recommends by default and dnf
installs weak deps by default, so the replacement arrives **in the same transaction**.
**pacman has no equivalent** ⇒ `optdepends`, advisory by construction — pacman's
asymmetry, not a choice made here.

## The `pkgver` knot, closed as ruled (`0.3.0`, vjt)

A separate recipe at `infra/packaging/aur/shottino/`, **not** a split package:
`PKGBUILD(5)` § PACKAGE SPLITTING lists the 14 variables a `package_*()` may override and
`pkgver` is **not** among them — a split would stamp the client with the bouncer's
version. Two version lines ⇒ two pkgbase. The client recipe carries **two** sentinels:
`pkgver=@SHOTTINO_VERSION@` (its own carrier) and `_grappaver=@GRAPPA_VERSION@` (the tag
that actually owns the tarball). `regen.sh` fills both in one run. This point is closed:
no divergence on Arch.

## A risk found on the way, and closed

Release assets are keyed by **BASENAME**, and the `publish` job's fallback uploads with
`--clobber`: two files named `PKGBUILD` would have left the release with **only one of
them, silently**. The client recipe stages as `shottino.PKGBUILD` / `shottino.SRCINFO`,
and the audit demands them as kinds of their own — so a rename that drifts is a noisy
missing kind, not a mute substitution.

## What is bought, and how

- **The drop** — `not ok` before, green after (the assertion slice A could not make).
- **`Recommends:`**, **publication from its own step**, **kinds by name**: all red before
  the implementation, green after.
- **Three mutants** against the AUR assertions whose initial red had arrived for the WRONG
  reason (they matched comment prose, not declarations — corrected, then mutated):

| mutant | gesture | kills |
|---|---|---|
| M1 | bouncer recipe goes back to installing the binary | **test 5 only** |
| M2 | client recipe acquires `bun` among `depends` | **test 7 only** |
| M3 | client recipe takes `pkgver=@GRAPPA_VERSION@` | **test 6 only** |

- **Full bats suite: 564 ok / 0 not ok, RC=0.** `scripts/shellcheck.sh` RC=0.
  `scripts/design-notes-gate.sh` green.

## What I refuse to assert

1. **That anything was built.** No `.deb`, `.rpm` or `.pkg.tar.zst` was produced here; no
   `dpkg -i`, `dnf install`, `pacman -U`. The co-installability the workflow now asserts is
   proven by the **first CI run**, not by me.
2. **That the `pkgver` constraint is measured locally.** `makepkg` is absent on this host:
   the constraint is the **upstream man page**, read today.
3. **That the client `.SRCINFO` is verified.** Measured: the Elixir gate pins the sentinels
   and does **not** compare `PKGBUILD` and `.SRCINFO` field by field ⇒ coherence between
   the two stays **UNVERIFIED**; the real regeneration is the arch job's
   `makepkg --printsrcinfo`. *(Measured aside: the bouncer's `.SRCINFO` was ALREADY
   divergent from its `PKGBUILD` on `pkgdesc` before this slice — direct evidence that
   nothing keeps them aligned.)*
4. **That the Elixir pin is green.** `test/grappa/version_single_source_test.exs` was
   **not executed** and its mutant was not run — it is written, not proven. First CI run
   is its first execution.
5. **That the binary weighs ~200 KB.** The figure in the OPERATIONS text is an order of
   magnitude inherited from the preceding paragraph, **not** measured: this host produces
   Mach-O.
