### PR TITLE
test(#1419): memoise the stylesheet parse the clone census re-runs

### DIFF
--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -74,8 +74,24 @@ type Rule = { selectors: string[]; body: string };
  * rules nested inside one, which resolve under a condition this file does not
  * model. The "bare class selectors only" assertion below is what makes that
  * safe: it fails if a site is ever reached from inside a media query.
+ *
+ * Memoised, because the clone census below resolves EVERY bare class in the
+ * sheet and each `resolve` re-parses: 1427 parses of a 435 KB stylesheet for
+ * one assertion pair, measured at 1117 ms of that test's 1185 ms — 94%, and
+ * the 5 s default is what #1419 kept tripping on. `themeCss` is read once at
+ * import, so the parse is a pure function of a constant and the cache cannot
+ * go stale. The budget is left at the default deliberately: nothing here
+ * asserts a duration, so a timeout bump would have hidden the cost instead of
+ * removing it.
  */
+let parsedRules: Rule[] | undefined;
+
 function topLevelRules(): Rule[] {
+  parsedRules ??= parseTopLevelRules();
+  return parsedRules;
+}
+
+function parseTopLevelRules(): Rule[] {
   const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
   const rules: Rule[] = [];
   for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {


### PR DESCRIPTION
## What

Memoises the stylesheet parse inside `cicchetto/src/__tests__/modalChrome.test.ts`.
One file, one commit, +16/-0.

## Why now

The test *"leaves no rule outside the bases carrying a base's whole shape"*
has hit the 5000 ms vitest default **nine times**, twice in one day on
branches that cannot touch modal chrome (#1471 wire bench, #1478 packaging).
Most recent CI sighting: **5201 ms — a 201 ms, 4% overshoot** in a run that
was otherwise 289/290 files and 5586/5587 tests green. It taxes every PR.

## The measurement that chose the cure

Two cures were available and they are not interchangeable, so the cost was
measured before either was written. `topLevelRules()` was instrumented with a
call counter and a `performance.now()` accumulator for the duration of that
one test:

| | |
|---|---|
| stylesheet | **434 793 bytes** (`src/themes/default.css`) |
| bare class selectors, `N` | **712** |
| `topLevelRules()` calls in the test | **1427** |
| time inside those calls | **1117.2 ms** |
| test wall time | **1184.8 ms** |
| **share spent re-parsing** | **94.3 %** |

1427 is exactly `2 × (N + 1)` plus the one probe call: `classesResolvingTo`
parses once to build the name list, then `resolve([name])` parses again for
each of the 712 names, and the test calls it twice. So the re-parsing does
dominate, and the cure that **removes** the cost was the available one.

After: that test runs in **49 ms** (24×), and the file's tests drop from
**1750 ms to 372 ms**.

## Why not a bigger timeout

This body has no temporal oracle — it asserts *which CSS rules carry a base's
shape*. The 5 s was vitest's default, never an assertion, so a raised budget
would have hidden 1117 ms rather than removed it. Distinct from #1336, where
the deadline WAS the measurement.

## Why the memo is safe

`themeCss` is a `readFileSync` evaluated once at import time, so the parse is
a pure function of a constant and the cache cannot go stale. No caller mutates
the returned array — `resolve` and the census only read it.

## Positive control

The test must still blush for the right reason. Injecting a clone of
`.modal-chrome-button` under a fresh class name — the exact #740 failure mode
this assertion guards — into the stylesheet:

```
× leaves no rule outside the bases carrying a base's whole shape
  AssertionError: expected [ 'modal-chrome-button', …(1) ] to deeply equal [ 'modal-chrome-button' ]
  +   "zzz-clone-mutant"
  Tests  1 failed | 28 passed (29)
```

**One mutant, exactly one reddened assertion**, naming the offender.

## Gates

- `scripts/bun.sh run check` — **RC=0** (`biome && tsc && tsc`; the chain is
  `&&`, so RC=0 means all three ran). The 59 biome warnings are pre-existing
  CSS-specificity notices, zero errors.
- `scripts/bun.sh run test` — **RC=0, 290/290 files, 5598/5598 tests**, run on
  this branch rebased onto `97b0ee3a`.

## Not claimed

The 5201 ms was measured on CI and the 1184.8 ms on a developer host. I make
**no claim** about why they differ, having measured neither host's load.
