### PR TITLE
accounts(#1395): give the user login decision a non-HTTP entry point

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46985,3 +46985,65 @@ the CONFIGURATION — that the package is thin, that its version comes from
 the header, that its output directory is outside every upload glob — which
 is what can be held still without a Linux toolchain. Whether nfpm accepts
 these two files is proven by the first CI run, not here._
+<!-- entry #1395 -->
+
+---
+
+## 2026-08-17 — #1395: the user login DECISION moves; the throttle, the challenge and the render do not
+
+The user ladder was a `defp` chain inside `GrappaWeb.AuthController`, reachable
+only from an HTTP action: all 64 tests over that controller need a `Plug.Conn`,
+against 33 conn-free tests for the visitor twin. `Grappa.Accounts.Login.authenticate/1`
+now answers the decision — name plus password in, and the door the account still
+has to walk through out — with no `conn` anywhere in it.
+
+**What the issue proposed and this did NOT do.** #1395 asked for a full sibling
+of `Grappa.Visitors.Login`, with the second-factor ladder, the challenge minting
+and the throttles all lifted, and the 22 `visitor_error_response/4` clauses moved
+to `FallbackController`. Measurement refuted three of those four, and the ruling
+kept only the residue:
+
+  * **The throttles stay at the edge.** `Grappa.Visitors.Login` — the twin held
+    up as the model — contains no rate limiting at all: the visitor window lives
+    in the controller, above the call into the context. `GrappaWeb.LoginThrottle`
+    argues the placement in its own moduledoc, and `Grappa.Accounts` depends on
+    neither `Grappa.RateLimit` nor `Grappa.AdminEvents`, exactly as
+    `Grappa.Visitors` does not. Lifting the window would be the trade a shipped
+    module refuses, for a context standing in the identical position.
+
+  * **The challenge cannot be lifted.** Minting it needs `Phoenix.Token.sign/3`
+    against `GrappaWeb.Endpoint`, and the passkey options need
+    `GrappaWeb.PasskeyOrigin`. `GrappaWeb` already depends on `Grappa.Accounts`,
+    so carrying either into the context closes a cycle `Boundary` rejects.
+
+  * **The 22 error clauses stay put**, and are visitor-half code that has nothing
+    to do with this door. Twenty are pure identity pass-throughs whose relocation
+    would change no behaviour while deleting a documented audit index (L-web-1);
+    one inverts a written decision about who may query `Visitors`; and the
+    catch-all is load-bearing. `FallbackController` has 71 `call/2` clauses and
+    **no** catch-all, and `:no_server` is the one member of
+    `Visitors.Login.login_error()` no clause names — so today it renders a clean
+    `500 {"error":"internal"}` only because that catch-all totalises. Removing it
+    turns a declared error into a `FunctionClauseError` and a raw 500.
+
+**The one thing that had to become explicit.** The throttle used to be charged
+inside `authenticate_mode1/3`, upstream of the ladder, so "was this a guess?" was
+answered by call order rather than by a value. With one function answering the
+whole decision, the two refusals must be distinguishable: `{:error,
+:invalid_credentials}` is a wrong credential and charges the window, `{:error,
+:passwordless}` presented the RIGHT password and is refused because the password
+door is shut for that account. Both render the same uniform 401 — the caller maps
+them — but collapsing the tags would silently start charging a user's own window
+for a configuration choice. **This is the general rule the slice pays for: when a
+decision moves out of a chain, every distinction the chain expressed positionally
+has to reappear in the return type, or it is lost without a diff to show for it.**
+
+**Naming.** The call site is spelled `Accounts.Login.authenticate/1`, not
+aliased. `Login` inside `AuthController` is already `Grappa.Visitors.Login`, the
+other half of the same polymorphism; an alias would have made the two
+confusable at a glance, and — measured while writing this — a bare `Login.` in
+that module silently resolves to the visitor one.
+
+_Not established here: no timing claim about Argon2 or suite duration, and the
+`:passwordless` ordering (password verified first, mode checked second) is
+preserved from the original `cond` rather than re-derived from the domain._

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -87,7 +87,7 @@ defmodule Grappa.Accounts do
       Grappa.Repo,
       Grappa.Visitors.Visitor
     ],
-    exports: [User, Session, Wire, AdminWire, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
+    exports: [User, Session, Wire, AdminWire, Login, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
 
   import Ecto.Query
 

--- a/lib/grappa/accounts/login.ex
+++ b/lib/grappa/accounts/login.ex
@@ -1,0 +1,99 @@
+defmodule Grappa.Accounts.Login do
+  @moduledoc """
+  The password door's decision for an account: does this credential open,
+  and which second-factor door (if any) is still in the way.
+
+  ## Why this exists (#1395)
+
+  The user ladder used to be a `defp` chain inside
+  `GrappaWeb.AuthController`, reachable only from an HTTP action and
+  untestable without a `Plug.Conn` — all 64 tests over it needed one. The
+  decision itself needs neither: it is a name, a password and the account's
+  own second-factor configuration. So the decision moved and everything
+  request-shaped stayed at the edge.
+
+  ## What deliberately did NOT move
+
+  This is a decision, not an orchestrator, and the boundary is drawn where
+  the twin `Grappa.Visitors.Login` already draws it:
+
+    * **The throttles.** `Grappa.Visitors.Login` contains no rate limiting at
+      all — the visitor door's window lives in the controller, above the call
+      into the context, and `GrappaWeb.LoginThrottle` argues the placement in
+      its own moduledoc: a window keyed on the source IP is request-edge
+      policy. `Grappa.Accounts` depends on neither `Grappa.RateLimit` nor
+      `Grappa.AdminEvents`, exactly as `Grappa.Visitors` does not, and
+      widening it to hold one would be the trade that module rejects. The
+      caller charges; see the `:passwordless` note below for what makes that
+      possible.
+
+    * **The second-factor challenge.** Minting it needs
+      `Phoenix.Token.sign/3` against `GrappaWeb.Endpoint`, and the passkey
+      options need `GrappaWeb.PasskeyOrigin`. `GrappaWeb` already depends on
+      `Grappa.Accounts`, so reaching back would close a cycle that `Boundary`
+      rejects outright. This function names the door; the caller opens it.
+
+    * **The client-token door.** `Accounts.authenticate_client_token/5` is
+      already a context function and already returns a tagged outcome. It
+      mints a session row, so it is an effect rather than a decision, and it
+      is tried ahead of this function by the caller exactly as before.
+
+    * **Rendering, and the 22 `visitor_error_response/4` clauses**, which
+      belong to the visitor half of that controller and are untouched.
+
+  ## The `:passwordless` outcome is not a spelling of `:invalid_credentials`
+
+  Both reach the client as the same uniform 401 — the caller maps them — but
+  they must stay distinct here because only one of them is a guess. A wrong
+  password charges the login window; an account in `:passwordless` passkey
+  mode presented the RIGHT password and is refused because this door is shut
+  for it, so charging it would spend a user's own window on a configuration
+  choice. Collapsing the two tags would silently change the throttle.
+  """
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.{TOTP, User}
+
+  @type input :: %{required(:name) => String.t(), required(:password) => String.t()}
+
+  @typedoc """
+  `{:ok, user}` — verified, nothing further to prove.
+  `{:second_factor, which, user}` — verified, one door left.
+  `{:error, :invalid_credentials}` — the credential did not verify.
+  `{:error, :passwordless}` — it did, but this door is shut for the account.
+  """
+  @type outcome ::
+          {:ok, User.t()}
+          | {:second_factor, :passkey | :totp, User.t()}
+          | {:error, :invalid_credentials | :passwordless}
+
+  @doc """
+  Verifies `name` + `password` and returns the door the account still has to
+  walk through.
+
+  The name is matched the account way — `Accounts.get_user_by_credentials/2`,
+  which folds it (#1353) — and a miss is indistinguishable from a wrong
+  password, both on the wire and in timing.
+  """
+  @spec authenticate(input()) :: outcome()
+  def authenticate(%{name: name, password: password})
+      when is_binary(name) and is_binary(password) do
+    case Accounts.get_user_by_credentials(name, password) do
+      {:ok, %User{} = user} -> second_factor(user)
+      {:error, :invalid_credentials} = error -> error
+    end
+  end
+
+  # `passkey_mode` is a closed three-value enum, so all three are spelled out:
+  # a fourth value added later must fail here loudly rather than inherit the
+  # no-second-factor exit from a catch-all.
+  @spec second_factor(User.t()) :: outcome()
+  defp second_factor(%User{passkey_mode: :passwordless}), do: {:error, :passwordless}
+
+  defp second_factor(%User{passkey_mode: :second_factor} = user),
+    do: {:second_factor, :passkey, user}
+
+  defp second_factor(%User{passkey_mode: :disabled} = user) do
+    if TOTP.enabled?(user), do: {:second_factor, :totp, user}, else: {:ok, user}
+  end
+end

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -444,33 +444,43 @@ defmodule GrappaWeb.AuthController do
     |> render(:login, token: session.id, subject: {:user, user})
   end
 
+  # #1395 — the DECISION (does the credential verify, and which door is
+  # left) is `Accounts.Login.authenticate/1`, reachable without a `conn`.
+  # What stays here is what is genuinely request-shaped: charging the
+  # throttle, minting the challenge, and rendering.
+  #
+  # The two error tags are NOT interchangeable even though both answer 401
+  # `invalid_credentials` on the wire. `:invalid_credentials` is a guess and
+  # charges the window; `:passwordless` presented the RIGHT password and is
+  # refused because the password door is shut for that account, so charging
+  # it would spend a user's own window on a configuration choice. Before
+  # #1395 the distinction was implicit in the call order — the throttle was
+  # charged inside `authenticate_mode1/3`, upstream of the ladder — and it
+  # has to be explicit now that one function answers both.
   @spec password_login(Plug.Conn.t(), String.t(), String.t(), String.t() | nil) ::
           Plug.Conn.t() | {:error, term()}
   defp password_login(conn, name, password, ip) do
-    with {:ok, user} <- authenticate_mode1(name, password, ip) do
-      second_factor_ladder(conn, user)
-    end
-  end
+    # Spelled `Accounts.Login` rather than aliased: `Login` in this module is
+    # already `Grappa.Visitors.Login`, the other half of the same
+    # polymorphism, and the two must never be confusable at a call site.
+    case Accounts.Login.authenticate(%{name: name, password: password}) do
+      {:ok, user} ->
+        mint_user_session(conn, user)
 
-  # The post-password ladder: which door (if any) the account still has
-  # to walk through before a bearer is minted.
-  @spec second_factor_ladder(Plug.Conn.t(), Accounts.User.t()) ::
-          Plug.Conn.t() | {:error, term()}
-  defp second_factor_ladder(conn, user) do
-    cond do
-      user.passkey_mode == :passwordless ->
-        {:error, :invalid_credentials}
-
-      user.passkey_mode == :second_factor ->
+      {:second_factor, :passkey, user} ->
         passkey_second_factor(conn, user)
 
-      TOTP.enabled?(user) ->
+      {:second_factor, :totp, user} ->
         conn
         |> put_status(:accepted)
         |> json(%{two_factor_required: true, challenge_token: sign_challenge(user, conn)})
 
-      true ->
-        mint_user_session(conn, user)
+      {:error, :invalid_credentials} ->
+        :ok = charge_mode1_failure(ip)
+        {:error, :invalid_credentials}
+
+      {:error, :passwordless} ->
+        {:error, :invalid_credentials}
     end
   end
 
@@ -609,17 +619,17 @@ defmodule GrappaWeb.AuthController do
     end
   end
 
-  @spec authenticate_mode1(String.t() | nil, String.t(), String.t() | nil) ::
-          {:ok, Grappa.Accounts.User.t()} | {:error, :invalid_credentials}
-  defp authenticate_mode1(name, password, ip) do
-    case Accounts.get_user_by_credentials(name, password) do
-      {:ok, _} = ok ->
-        ok
-
-      {:error, _} = err ->
-        _ = LoginThrottle.charge(@mode1_bucket, ip, @mode1_window_ms, @mode1_max_failures)
-        err
-    end
+  # #1395 — the verify half of the former `authenticate_mode1/3` moved into
+  # `Accounts.Login.authenticate/1`; the charge stayed, because the window is
+  # request-edge policy (`LoginThrottle`'s own moduledoc argues it, and
+  # `Grappa.Visitors.Login` holds no throttle at all for the same reason).
+  # Kept beside the constants it reads: they are declared here, below
+  # `password_login/4`, and a module attribute is only in scope after its
+  # declaration.
+  @spec charge_mode1_failure(String.t() | nil) :: :ok
+  defp charge_mode1_failure(ip) do
+    _ = LoginThrottle.charge(@mode1_bucket, ip, @mode1_window_ms, @mode1_max_failures)
+    :ok
   end
 
   # W3: `captcha_token` arrives as a 4th explicit param so the

--- a/test/grappa/accounts/login_test.exs
+++ b/test/grappa/accounts/login_test.exs
@@ -1,0 +1,138 @@
+defmodule Grappa.Accounts.LoginTest do
+  @moduledoc """
+  The password door's decision, exercised WITHOUT a `conn` (#1395).
+
+  All 64 tests in `auth_controller_test.exs` need a `Plug.Conn` — the user
+  ladder had no entry point other than an HTTP action, which is the defect
+  this slice addresses. These are the evidence it now has one: the same
+  decision, driven through `Grappa.Accounts.Login.authenticate/1` with a
+  plain map. The controller tests keep covering the HTTP envelope, the
+  throttles and the challenge minting, all of which deliberately stayed at
+  the edge.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts.{Login, TOTP, User}
+
+  defp set_passkey_mode(%User{} = user, mode) do
+    {:ok, updated} =
+      user
+      |> User.passkey_mode_changeset(%{passkey_mode: mode})
+      |> Repo.update()
+
+    updated
+  end
+
+  # Arms TOTP off a PREVIOUS step so the current one stays unspent.
+  # NOTE: `auth_controller_test.exs` carries an identical `arm_totp/1`. That
+  # duplication is one of the instances #1397 counts; consolidating it into
+  # `Grappa.AuthFixtures` belongs to that issue's slice, not this one.
+  defp arm_totp(%User{} = user) do
+    enrollment = TOTP.new_enrollment(user, "Grappa test")
+    previous_step = System.system_time(:second) - 30
+    {:ok, code} = TOTP.code_at(enrollment.secret, previous_step)
+    {:ok, _recovery_codes} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
+    user
+  end
+
+  describe "authenticate/1 — the credential gate" do
+    test "a correct password on an account with no second factor returns the user" do
+      {user, password} = user_fixture_with_password()
+
+      assert {:ok, %User{id: id}} = Login.authenticate(%{name: user.name, password: password})
+      assert id == user.id
+    end
+
+    test "a wrong password is refused as :invalid_credentials" do
+      {user, _password} = user_fixture_with_password()
+
+      assert {:error, :invalid_credentials} =
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "an unknown account name is refused with the SAME token as a wrong password" do
+      # The uniform oracle is the point: the caller must not be able to tell
+      # which half of the credential was wrong.
+      {user, password} = user_fixture_with_password()
+
+      assert Login.authenticate(%{name: "no-such-account", password: password}) ==
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "the account name matches the way account names match — folded (#1353)" do
+      {user, password} =
+        user_fixture_with_password(name: "VJT-#{System.unique_integer([:positive])}")
+
+      assert {:ok, %User{id: id}} =
+               Login.authenticate(%{name: String.downcase(user.name), password: password})
+
+      assert id == user.id
+    end
+  end
+
+  describe "authenticate/1 — which door the account still has to walk through" do
+    test "an account in passkey :second_factor mode is sent to the passkey door" do
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :second_factor)
+
+      assert {:second_factor, :passkey, %User{id: id}} =
+               Login.authenticate(%{name: user.name, password: password})
+
+      assert id == user.id
+    end
+
+    test "a :passwordless account refuses the password door even with the right password" do
+      # Distinct from :invalid_credentials deliberately. The wire answer is the
+      # same 401, but the throttle must NOT be charged: the credential was
+      # correct, so this is not a guess.
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :passwordless)
+
+      assert {:error, :passwordless} =
+               Login.authenticate(%{name: user.name, password: password})
+    end
+
+    test "a :passwordless account with a WRONG password is a guess, not a closed door" do
+      {user, _password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :passwordless)
+
+      assert {:error, :invalid_credentials} =
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "an account with TOTP armed is sent to the code door" do
+      {user, password} = user_fixture_with_password()
+      user = arm_totp(user)
+
+      assert {:second_factor, :totp, %User{id: id}} =
+               Login.authenticate(%{name: user.name, password: password})
+
+      assert id == user.id
+    end
+
+    test "passkey :second_factor wins over TOTP when the account holds both" do
+      # Order is load-bearing: the passkey branch is decided before TOTP, so an
+      # account holding both is offered the passkey.
+      {user, password} = user_fixture_with_password()
+
+      user =
+        user
+        |> arm_totp()
+        |> set_passkey_mode(:second_factor)
+
+      assert {:second_factor, :passkey, _} =
+               Login.authenticate(%{name: user.name, password: password})
+    end
+
+    test "a :disabled account with no TOTP takes the no-second-factor exit" do
+      # The third arm of the closed `passkey_mode` set, spelled so the exit is
+      # exercised rather than inherited from a catch-all.
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :disabled)
+
+      assert {:ok, %User{}} = Login.authenticate(%{name: user.name, password: password})
+    end
+  end
+end

--- a/test/grappa/accounts/login_test.exs
+++ b/test/grappa/accounts/login_test.exs
@@ -33,7 +33,7 @@ defmodule Grappa.Accounts.LoginTest do
     enrollment = TOTP.new_enrollment(user, "Grappa test")
     previous_step = System.system_time(:second) - 30
     {:ok, code} = TOTP.code_at(enrollment.secret, previous_step)
-    {:ok, _recovery_codes} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
+    {:ok, _} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
     user
   end
 
@@ -46,7 +46,7 @@ defmodule Grappa.Accounts.LoginTest do
     end
 
     test "a wrong password is refused as :invalid_credentials" do
-      {user, _password} = user_fixture_with_password()
+      {user, _} = user_fixture_with_password()
 
       assert {:error, :invalid_credentials} =
                Login.authenticate(%{name: user.name, password: "not-the-password"})
@@ -75,7 +75,7 @@ defmodule Grappa.Accounts.LoginTest do
   describe "authenticate/1 — which door the account still has to walk through" do
     test "an account in passkey :second_factor mode is sent to the passkey door" do
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :second_factor)
+      set_passkey_mode(user, :second_factor)
 
       assert {:second_factor, :passkey, %User{id: id}} =
                Login.authenticate(%{name: user.name, password: password})
@@ -88,15 +88,15 @@ defmodule Grappa.Accounts.LoginTest do
       # same 401, but the throttle must NOT be charged: the credential was
       # correct, so this is not a guess.
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :passwordless)
+      set_passkey_mode(user, :passwordless)
 
       assert {:error, :passwordless} =
                Login.authenticate(%{name: user.name, password: password})
     end
 
     test "a :passwordless account with a WRONG password is a guess, not a closed door" do
-      {user, _password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :passwordless)
+      {user, _} = user_fixture_with_password()
+      set_passkey_mode(user, :passwordless)
 
       assert {:error, :invalid_credentials} =
                Login.authenticate(%{name: user.name, password: "not-the-password"})
@@ -104,7 +104,7 @@ defmodule Grappa.Accounts.LoginTest do
 
     test "an account with TOTP armed is sent to the code door" do
       {user, password} = user_fixture_with_password()
-      user = arm_totp(user)
+      arm_totp(user)
 
       assert {:second_factor, :totp, %User{id: id}} =
                Login.authenticate(%{name: user.name, password: password})
@@ -117,10 +117,9 @@ defmodule Grappa.Accounts.LoginTest do
       # account holding both is offered the passkey.
       {user, password} = user_fixture_with_password()
 
-      user =
-        user
-        |> arm_totp()
-        |> set_passkey_mode(:second_factor)
+      user
+      |> arm_totp()
+      |> set_passkey_mode(:second_factor)
 
       assert {:second_factor, :passkey, _} =
                Login.authenticate(%{name: user.name, password: password})
@@ -130,7 +129,7 @@ defmodule Grappa.Accounts.LoginTest do
       # The third arm of the closed `passkey_mode` set, spelled so the exit is
       # exercised rather than inherited from a catch-all.
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :disabled)
+      set_passkey_mode(user, :disabled)
 
       assert {:ok, %User{}} = Login.authenticate(%{name: user.name, password: password})
     end

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -1466,6 +1466,35 @@ defmodule GrappaWeb.AuthControllerTest do
       assert json_response(wrong_login(conn, user, 2), 401)["error"] == "invalid_credentials"
     end
 
+    test "a passwordless account's RIGHT password is refused without charging", %{conn: conn} do
+      # #1395 made this distinction explicit: `Accounts.Login.authenticate/1`
+      # answers `:passwordless` rather than `:invalid_credentials`, and only
+      # the latter reaches `charge_mode1_failure/1`. Both leave as the same
+      # uniform 401, so the ONLY observable difference is the counter — and
+      # nothing asserted it before, which is what let the two tags look
+      # interchangeable. Charging here would spend a user's own window on a
+      # configuration choice they made, not on anybody's guess.
+      {user, password} = user_fixture_with_password()
+
+      user
+      |> Ecto.Changeset.change(passkey_mode: :passwordless)
+      |> Repo.update!()
+
+      right_password = fn ->
+        conn
+        |> with_ip(6)
+        |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => password})
+      end
+
+      for _ <- 1..10 do
+        assert json_response(right_password.(), 401)["error"] == "invalid_credentials"
+      end
+
+      # @mode1_max_failures is 10, so the 11th attempt is 429 the moment any
+      # of the ten above charged the window. Still 401 means none did.
+      assert json_response(right_password.(), 401)["error"] == "invalid_credentials"
+    end
+
     test "a tripped IP doesn't affect logins from another IP", %{conn: conn} do
       {user, password} = user_fixture_with_password()
 


### PR DESCRIPTION
## What

Gives the user password door a decision function reachable without a
`Plug.Conn`: `Grappa.Accounts.Login.authenticate/1`.

```elixir
@spec authenticate(%{name: String.t(), password: String.t()}) ::
        {:ok, User.t()}
        | {:second_factor, :passkey | :totp, User.t()}
        | {:error, :invalid_credentials | :passwordless}
```

6 files, +366/-29. Base `main`.

## Scope — the measured residue only

The ladder was a `defp` chain inside `GrappaWeb.AuthController`, so every
test over it needed an HTTP connection. What moved is the decision: a name,
a password, and the account's own second-factor configuration. What is
genuinely request-shaped stayed at the edge.

**Deliberately NOT moved**, each for a reason that is a boundary and not a
preference — the moduledoc argues all four:

- **The throttles.** The twin `Grappa.Visitors.Login` holds no rate limiting
  at all, and `GrappaWeb.LoginThrottle`'s own moduledoc argues that an
  IP-keyed window is request-edge policy. `Grappa.Accounts` depends on
  neither `Grappa.RateLimit` nor `Grappa.AdminEvents`, exactly as
  `Grappa.Visitors` does not.
- **The second-factor challenge.** Minting it needs `Phoenix.Token` against
  `GrappaWeb.Endpoint` and `GrappaWeb.PasskeyOrigin`. `GrappaWeb` already
  depends on `Grappa.Accounts`, so reaching back would close a cycle
  `Boundary` rejects outright.
- **The client-token door**, already a context function returning a tagged
  outcome, and an effect rather than a decision.
- **The 22 `visitor_error_response/4` clauses**, which belong to the visitor
  half of the controller. 20 are identity no-ops, one inverts a written
  decision, and the catch-all is load-bearing: without it `:no_server`
  answers a raw 500 instead of the JSON envelope.

## `:passwordless` is not a spelling of `:invalid_credentials`

Both leave as the same uniform 401, so the distinction is invisible on the
wire — but only one of them is a guess. A wrong password charges the mode-1
window; an account in `:passwordless` passkey mode presented the RIGHT
password and is refused because this door is shut for it, so charging would
spend a user's own window on a configuration choice they made. Before this
slice the distinction was implicit in the call order (the throttle was
charged upstream of the ladder); one function now answers both, so it had to
become explicit.

**Nothing asserted it.** Measured before writing the test: `passkey_mode:
:passwordless` never appears in `auth_controller_test.exs`, which only ever
sets `:second_factor`. The nearby *"a passwordless login never advances the
counter"* is a false friend — it lives in the VISITOR throttle describe and
means "with no password supplied", not `passkey_mode`.

So the new test: ten right-password attempts against a `:passwordless`
account, all 401; the eleventh still 401. `@mode1_max_failures` is 10, so a
429 on the eleventh is precisely the signal that one of the ten charged.

### Positive control

Collapsing the two tags — adding `charge_mode1_failure/1` to the
`{:error, :passwordless}` arm, making it behave identically to the
`:invalid_credentials` arm:

```
1) test ... a passwordless account's RIGHT password is refused without charging
   ** (RuntimeError) expected response with status 401, got: 429, with body:
   "{\"error\":\"too_many_attempts\"}"
   auth_controller_test.exs:1495

75 tests, 1 failure
```

**One mutant, exactly one reddened assertion** — the eleventh attempt, the
only observable the two tags differ on.

## Two traps this branch walked around

- In `AuthController`, `Login` is ALREADY aliased to `Grappa.Visitors.Login`
  — the other half of the same polymorphism. A bare `Login.authenticate(...)`
  would have pointed at the wrong module **silently**. The call site is
  spelled `Accounts.Login.authenticate(...)`.
- `@mode1_bucket` and its siblings are declared BELOW `password_login/4`, and
  a module attribute is in scope only after its declaration. The charge
  therefore lives in `charge_mode1_failure/1`, next to the constants.

## Gates

Run in this worktree, rebased onto `97b0ee3a` first so the green attests the
tree that is being pushed.

- `scripts/check.sh` — **RC=0**, read from a file rather than `$?`, and
  phase by phase, because this script aborts at the first red and a green
  downstream of an abort does not exist:

  | phase | result |
  |---|---|
  | Credo strict | 684 source files, no issues |
  | Sobelow | 15 findings, **all Low confidence**, none in a file this branch touches (uploads, reaper, background_image, isupport, hot_reload, hardened_cmd, repo) — the gate is Medium-or-above |
  | Doctor | passed |
  | ExUnit | **8 doctests, 61 properties, 6529 tests, 0 failures** |
  | Dialyzer | **Total errors: 0**, Skipped: 0 |
  | bats | **553 ok / 0 not ok** |

- `scripts/design-notes-gate.sh` — **RC=0**, one new entry heading, separator
  and marker present. Contribution numstat pinned to a file before the rebase
  and re-diffed after: **identical**, `docs/DESIGN_NOTES.md` **62/0**
  (deletions zero).

## Not claimed

- The first commit was written in a previous session and had never been
  compiled. `scripts/check.sh` duly halted on it at Credo with 9 issues in
  the new conn-free test file, all of them inert rebinds or unused-variable
  naming; the third commit clears them and explains why the rebinds were
  inert rather than load-bearing.
- The file count is **6**, against the 5 the scope ruling anticipated. The
  sixth is `auth_controller_test.exs`, added deliberately for the
  `:passwordless` pin above; 6 was the declared cap and this is at it.
- `login_test.exs` carries **10** conn-free tests, not the 8 the ruling
  estimated. Counted, not estimated.
