### PR TITLE
push(#1404): hand the detached work to the supervisor that exists for it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46985,3 +46985,53 @@ the CONFIGURATION — that the package is thin, that its version comes from
 the header, that its output directory is outside every upload glob — which
 is what can be held still without a Linux toolchain. Whether nfpm accepts
 these two files is proven by the first CI run, not here._
+<!-- entry #1404e -->
+
+---
+
+## 2026-08-17 — #1404: the detached hand-offs become supervised work, and only that
+
+Three places hand work off the session hot path so the session never blocks
+on it: the window-counts snapshot and the two push-notification dispatches.
+All three started that work with a bare spawn, so the worker belonged to
+nobody — outside the supervision tree, invisible to the operator, and its
+crash a disappearance rather than a report. Every other detached spawn in the
+tree already goes through `Grappa.TaskSupervisor`, and S37 wrote the rule
+down; these three predate it. They now follow it, and a test asserts each of
+them does.
+
+**What this buys, stated narrowly on purpose: supervision and visibility. Not
+a ceiling.** The concurrency of that work is exactly what it was. A ceiling on
+detached work is a child-spec setting (`max_children`) and the tree configures
+none, so routing the spawn through a supervisor cannot add one — routing
+changes the spawn verb, not the child spec. The moduledocs that used to say
+"unlinked task" are corrected, and they are corrected to say what is true
+rather than to say something better: a docstring that implied a bound here
+would be the very shape of defect this work exists to remove, moved out of the
+code and into the prose where it is harder to notice.
+
+**Why the start result is discarded rather than matched.** This is the one way
+the change is not a mechanical verb swap. `Task.start/1` cannot fail, so a
+`{:ok, _} =` around it was free. `Task.Supervisor.start_child/2` can refuse —
+`{:error, :max_children}` — the day a ceiling exists. A strict match would then
+turn a skipped best-effort optimisation into a crash on the session hot path,
+which is the opposite of what a ceiling is for. Two older call sites already
+carry that strict match; this change deliberately declines to add two more, and
+disarming those two is a separate decision with a separate blast radius.
+
+**How the guard catches the worker.** A worker that has already finished is
+indistinguishable from one that was never supervised, since the supervisor's
+child list is empty either way, so each test parks its worker and asks while it
+is parked. Both parks are real infrastructure rather than a stand-in for the
+subject: a process registered where the session would be, which never answers,
+holds the snapshot worker inside its live-count call; and OTP's own
+`:sys.suspend/1` on the presence singleton holds the two notification workers
+where they consult it. The assertion is the pid's membership in the child set,
+not the size of that set — a count cannot distinguish "one arrived" from "one
+left", and an earlier version of this guard failed against correct code because
+another test's worker was still dying while it measured.
+
+_Not established: nothing here measures how many of these workers can be alive
+at once, or what happens at any particular number, and the file says so. The
+question of whether that concurrency wants a bound is open and is not answered
+by this change._

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -14,9 +14,10 @@ defmodule Grappa.Push.Triggers do
   still calls directly: a presence transition persists no row, so there is
   nothing for `Persistor` to be the guardian of.
 
-  Both calls are fire-and-forget — Triggers spawns an unlinked `Task` so
-  the hot path stays sub-millisecond and Sender failures don't bleed into
-  the mailbox.
+  Both calls are fire-and-forget — Triggers hands the work to
+  `Grappa.TaskSupervisor` so the hot path stays sub-millisecond and Sender
+  failures don't bleed into the mailbox. Detached but supervised: the
+  worker is visible and its crash is a report, not a disappearance.
 
   ## Decision logic — `should_notify?/5`
 
@@ -169,7 +170,7 @@ defmodule Grappa.Push.Triggers do
   notification preferences and, on a match, fires the Web Push
   fan-out via `Push.Sender.send_to_subject/2`.
 
-  Fire-and-forget — spawns an unlinked `Task` and returns `:ok`
+  Fire-and-forget — starts a supervised task and returns `:ok`
   immediately. Per-message work (prefs lookup, mention regex,
   Sender fan-out) happens out-of-band so the Session.Server hot
   path never blocks on it.
@@ -189,8 +190,11 @@ defmodule Grappa.Push.Triggers do
       own_nick: own_nick
     } = ctx
 
-    {:ok, _} =
-      Task.start(fn ->
+    # Discarded, not matched: a supervisor can refuse to start a child,
+    # and a strict match would turn a skipped notification into a crash
+    # on the session hot path the day a ceiling is configured.
+    _ =
+      Task.Supervisor.start_child(Grappa.TaskSupervisor, fn ->
         prefs = UserSettings.get_notification_prefs(subject)
         patterns = UserSettings.get_highlight_patterns(subject)
 
@@ -222,8 +226,8 @@ defmodule Grappa.Push.Triggers do
   @doc """
   Dispatches the Web Push for one `/notify` presence report (#378).
 
-  Same fire-and-forget shape as `evaluate_and_dispatch/2`: unlinked `Task`,
-  always `:ok`, no `try/rescue` (the no-silent-drops contract above).
+  Same fire-and-forget shape as `evaluate_and_dispatch/2`: supervised
+  task, always `:ok`, no `try/rescue` (the no-silent-drops contract above).
 
   A baseline (`:initial`) short-circuits in the FUNCTION HEAD, before the
   Task spawn — that is the whole point of splitting the clause rather than
@@ -240,8 +244,11 @@ defmodule Grappa.Push.Triggers do
       when is_binary(nick) and presence in [:online, :offline] and is_map(ctx) do
     %{subject: subject, subject_label: subject_label, network_slug: network_slug} = ctx
 
-    {:ok, _} =
-      Task.start(fn ->
+    # Discarded, not matched: a supervisor can refuse to start a child,
+    # and a strict match would turn a skipped notification into a crash
+    # on the session hot path the day a ceiling is configured.
+    _ =
+      Task.Supervisor.start_child(Grappa.TaskSupervisor, fn ->
         prefs = UserSettings.get_notification_prefs(subject)
 
         # #182 — the same foreground-suppression gate as the message path,

--- a/lib/grappa/window_counts/pusher.ex
+++ b/lib/grappa/window_counts/pusher.ex
@@ -16,9 +16,9 @@ defmodule Grappa.WindowCounts.Pusher do
   `push/1` gates on live WS presence (`WSPresence.ws_count/1` > 0): if
   no socket is connected for the subject, it skips — the next
   `join_reply` / `/me` re-seeds the absolute snapshot on reconnect, so a
-  disconnected subject costs nothing. When connected, it spawns an
-  unlinked `Task` (like `Push.Triggers`) so the Session hot path never
-  blocks on the snapshot's DB work, then `emit/1` computes the fresh
+  disconnected subject costs nothing. When connected, it hands the work
+  to `Grappa.TaskSupervisor` (like `Push.Triggers`) so the Session hot
+  path never blocks on the snapshot's DB work, then `emit/1` computes the fresh
   `WindowCounts.snapshot/7` (cursor from `ReadCursor`, highlight patterns
   from `UserSettings`) and broadcasts the `window_counts` event on the
   per-channel topic. cic replaces its stored snapshot verbatim.
@@ -46,15 +46,23 @@ defmodule Grappa.WindowCounts.Pusher do
   @impl PushSource
   @spec push(PushSource.ctx()) :: :ok
   def push(%{subject_label: subject_label} = ctx) do
-    # `_ =` — the `if` is evaluated for its side effect (spawning the
-    # emit Task); its `{:ok, pid} | nil` value is intentionally discarded
-    # (dialyzer `:unmatched_returns`).
+    # `_ =` — the `if` is evaluated for its side effect (starting the
+    # emit task); its value is intentionally discarded (dialyzer
+    # `:unmatched_returns`).
     _ =
       if WSPresence.ws_count(subject_label) > 0 do
-        # Fire-and-forget — the snapshot DB work stays off the Session hot
-        # path. A dead Task just means the live-render optimization is
-        # skipped for this row; the next seed re-bases the count.
-        {:ok, _} = Task.start(fn -> emit(ctx) end)
+        # Detached, but not orphaned: under `Grappa.TaskSupervisor` (S37)
+        # the worker is visible to the operator and a crash in it is a
+        # report rather than a silent disappearance. The snapshot DB work
+        # stays off the Session hot path either way. A worker that never
+        # runs just means the live-render optimization is skipped for this
+        # row; the next seed re-bases the count.
+        #
+        # The return is DISCARDED, not matched. `Task.start/1` could not
+        # fail, but a supervisor can refuse — and the day this supervisor
+        # is given a child ceiling, a strict match here would turn a
+        # skipped optimization into a crash on the session hot path.
+        Task.Supervisor.start_child(Grappa.TaskSupervisor, fn -> emit(ctx) end)
       end
 
     :ok

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -225,7 +225,7 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   defp assert_supervised_worker_appears(before, which, attempts) do
-    if MapSet.difference(supervised_pids(), before) |> Enum.any?() do
+    if Enum.any?(MapSet.difference(supervised_pids(), before)) do
       :ok
     else
       Process.sleep(10)

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -77,7 +77,6 @@ defmodule Grappa.DetachedWorkSupervisionTest do
       })
 
     park_session(ctx.subject, ctx.network.id)
-    before = supervised_count()
 
     :ok =
       Pusher.push(%{
@@ -89,20 +88,21 @@ defmodule Grappa.DetachedWorkSupervisionTest do
         own_nick: @own_nick
       })
 
-    # The worker exists and is parked — without this the count below could
-    # be read before it ever started, and an empty list would read as
-    # "unsupervised" when it means "not yet spawned".
-    assert_receive :worker_parked, 2_000
+    # The parked worker names ITSELF: the stand-in reports the pid blocked
+    # inside the call. Identity, not a count — a count is inflated by a
+    # worker another test left dying, which is exactly what made an earlier
+    # version of this test fail while the code was already correct.
+    assert_receive {:worker_parked, worker}, 2_000
 
-    assert supervised_count() > before,
+    assert MapSet.member?(supervised_pids(), worker),
            "the window-counts worker is not a child of the task supervisor"
   end
 
   test "the message-notification worker runs under the task supervisor", ctx do
-    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{private_messages_all: true})
+    set_pref(ctx.subject, :private_messages_all, true)
 
     park_presence()
-    before = supervised_count()
+    before = supervised_pids()
 
     :ok = Triggers.evaluate_and_dispatch(inbound_dm(ctx), trigger_ctx(ctx))
 
@@ -110,20 +110,36 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   test "the presence-notification worker runs under the task supervisor", ctx do
-    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{presence_online: true})
+    set_pref(ctx.subject, :presence_online, true)
 
     park_presence()
-    before = supervised_count()
+    before = supervised_pids()
 
     :ok = Triggers.dispatch_presence(@peer, :online, :transition, trigger_ctx(ctx))
 
     assert_supervised_worker_appears(before, "presence-notification")
   end
 
-  defp supervised_count do
+  # The setter validates the WHOLE preference map, so flipping one key
+  # means reading the current map through the same context that writes it
+  # rather than hand-rolling a literal here — a literal would be a second
+  # copy of the defaults, silently stale the day one of them changes.
+  defp set_pref(subject, key, value) do
+    prefs =
+      subject
+      |> UserSettings.get_notification_prefs()
+      |> Map.put(key, value)
+
+    {:ok, _} = UserSettings.put_notification_prefs(subject, prefs)
+    :ok
+  end
+
+  # A SET, not a count. Another test's worker can still be dying while this
+  # one starts; a count cannot tell "one arrived" from "one left".
+  defp supervised_pids do
     Grappa.TaskSupervisor
     |> Task.Supervisor.children()
-    |> length()
+    |> MapSet.new()
   end
 
   # An inbound DM: `channel` carries the own nick, which is what marks the
@@ -170,8 +186,8 @@ defmodule Grappa.DetachedWorkSupervisionTest do
 
   defp park_loop(notify) do
     receive do
-      {:"$gen_call", _, {:list_members, _}} ->
-        send(notify, :worker_parked)
+      {:"$gen_call", {caller, _}, {:list_members, _}} ->
+        send(notify, {:worker_parked, caller})
         park_loop(notify)
 
       _ ->
@@ -209,7 +225,7 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   defp assert_supervised_worker_appears(before, which, attempts) do
-    if supervised_count() > before do
+    if MapSet.difference(supervised_pids(), before) |> Enum.any?() do
       :ok
     else
       Process.sleep(10)

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -1,0 +1,219 @@
+defmodule Grappa.DetachedWorkSupervisionTest do
+  @moduledoc """
+  The work handed off the session hot path belongs to the application's
+  task supervisor, not to nobody.
+
+  Three places take work off the session process so the session is not
+  blocked by it. Being SUPERVISED and being BOUNDED are different
+  properties, and only the first is asserted here: a supervised worker is
+  visible to the operator, its crash is a report instead of a silent
+  disappearance, and it is attached to a place where a ceiling could later
+  be configured. **It is not itself a ceiling.** Nothing in the tree
+  configures one, and this file deliberately asserts nothing about how
+  many workers may exist at once — an assertion of that kind would claim
+  a control the code does not have.
+
+  ## Why each test holds its worker still
+
+  A worker that has already finished looks exactly like one that was never
+  supervised: the supervisor's child list is empty either way. So each
+  test parks its worker and asks the supervisor while it is parked.
+
+  The two paths park in different places, because they block on different
+  things, and both parks are real infrastructure rather than a stand-in
+  for the thing under test:
+
+    * the window-counts worker resolves a live member count, which is a
+      call into the session — so a process registered where the session
+      would be, which never answers, parks it;
+
+    * the notification workers consult the presence singleton before they
+      fan out — so suspending that singleton with OTP's own `:sys.suspend/1`
+      parks them. Their preferences are set so the predicate ahead of that
+      consultation is true; otherwise the worker would short-circuit and
+      retire before it could be observed.
+
+  `async: false` — parks a node-wide singleton and reads a supervisor
+  every other test also feeds.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{AuthFixtures, ScrollbackHelpers, UserSettings, WSPresence}
+  alias Grappa.Push.Triggers
+  alias Grappa.Scrollback.Message
+  alias Grappa.Session.Server
+  alias Grappa.WindowCounts.Pusher
+
+  @channel "#chan"
+  @own_nick "vjt"
+  @peer "alice"
+
+  setup do
+    user = AuthFixtures.user_fixture()
+    network = AuthFixtures.network_fixture()
+    subject = {:user, user.id}
+
+    :ok = WSPresence.reset_for_test()
+    :ok = WSPresence.register(user.name, self())
+
+    on_exit(fn ->
+      resume_presence()
+      WSPresence.reset_for_test()
+    end)
+
+    %{user: user, network: network, subject: subject, label: user.name}
+  end
+
+  test "the window-counts worker runs under the task supervisor", ctx do
+    {:ok, _} =
+      ScrollbackHelpers.insert(%{
+        user_id: ctx.user.id,
+        network_id: ctx.network.id,
+        channel: @channel,
+        server_time: System.unique_integer([:positive]),
+        kind: :privmsg,
+        sender: @peer,
+        body: "hi"
+      })
+
+    park_session(ctx.subject, ctx.network.id)
+    before = supervised_count()
+
+    :ok =
+      Pusher.push(%{
+        subject: ctx.subject,
+        network_id: ctx.network.id,
+        network_slug: ctx.network.slug,
+        subject_label: ctx.label,
+        channel: @channel,
+        own_nick: @own_nick
+      })
+
+    # The worker exists and is parked — without this the count below could
+    # be read before it ever started, and an empty list would read as
+    # "unsupervised" when it means "not yet spawned".
+    assert_receive :worker_parked, 2_000
+
+    assert supervised_count() > before,
+           "the window-counts worker is not a child of the task supervisor"
+  end
+
+  test "the message-notification worker runs under the task supervisor", ctx do
+    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{private_messages_all: true})
+
+    park_presence()
+    before = supervised_count()
+
+    :ok = Triggers.evaluate_and_dispatch(inbound_dm(ctx), trigger_ctx(ctx))
+
+    assert_supervised_worker_appears(before, "message-notification")
+  end
+
+  test "the presence-notification worker runs under the task supervisor", ctx do
+    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{presence_online: true})
+
+    park_presence()
+    before = supervised_count()
+
+    :ok = Triggers.dispatch_presence(@peer, :online, :transition, trigger_ctx(ctx))
+
+    assert_supervised_worker_appears(before, "presence-notification")
+  end
+
+  defp supervised_count do
+    Grappa.TaskSupervisor
+    |> Task.Supervisor.children()
+    |> length()
+  end
+
+  # An inbound DM: `channel` carries the own nick, which is what marks the
+  # row as a DM to the notification predicate, and the sender is someone
+  # else so the own-row exclusion does not fire.
+  defp inbound_dm(ctx) do
+    %Message{
+      kind: :privmsg,
+      channel: @own_nick,
+      dm_with: @peer,
+      sender: @peer,
+      body: "ping",
+      network_id: ctx.network.id,
+      server_time: DateTime.utc_now()
+    }
+  end
+
+  defp trigger_ctx(ctx) do
+    %{
+      subject: ctx.subject,
+      subject_label: ctx.label,
+      network_slug: ctx.network.slug,
+      own_nick: @own_nick
+    }
+  end
+
+  # Registered where the session would be; answers nothing, so the caller
+  # stays inside its call for as long as the test needs it there.
+  defp park_session(subject, network_id) do
+    key = Server.registry_key(subject, network_id)
+    ready = self()
+
+    pid =
+      spawn(fn ->
+        {:ok, _} = Registry.register(Grappa.SessionRegistry, key, nil)
+        send(ready, :parker_ready)
+        park_loop(ready)
+      end)
+
+    assert_receive :parker_ready, 1_000
+    on_exit(fn -> Process.exit(pid, :kill) end)
+    pid
+  end
+
+  defp park_loop(notify) do
+    receive do
+      {:"$gen_call", _, {:list_members, _}} ->
+        send(notify, :worker_parked)
+        park_loop(notify)
+
+      _ ->
+        park_loop(notify)
+    end
+  end
+
+  # OTP's own suspend: the singleton stops serving calls, so anything that
+  # consults it waits. Not a stub — the real process, held.
+  defp park_presence do
+    WSPresence |> Process.whereis() |> :sys.suspend()
+  end
+
+  defp resume_presence do
+    case Process.whereis(WSPresence) do
+      nil -> :ok
+      pid -> :sys.resume(pid)
+    end
+  end
+
+  # These workers give no signal of their own, so there is nothing to wait
+  # for that is independent of the property under test: the appearance of a
+  # supervised child IS the assertion, and its absence within the window is
+  # the failure. Deliberately NOT followed by a second `assert` on the same
+  # count — that assert could never fail, and a pair of statements where one
+  # cannot fail reads like two checks while being one.
+  #
+  # Polled rather than slept on: a fixed sleep would be a guess about spawn
+  # latency, and the guess would decide the verdict on a loaded machine.
+  defp assert_supervised_worker_appears(before, which),
+    do: assert_supervised_worker_appears(before, which, 200)
+
+  defp assert_supervised_worker_appears(_, which, 0) do
+    flunk("the #{which} worker is not a child of the task supervisor")
+  end
+
+  defp assert_supervised_worker_appears(before, which, attempts) do
+    if supervised_count() > before do
+      :ok
+    else
+      Process.sleep(10)
+      assert_supervised_worker_appears(before, which, attempts - 1)
+    end
+  end
+end


### PR DESCRIPTION
Part of #1404 — the structural half of one of the thirteen. The measurement half of the same item was settled separately and needed no code; this is what remained.

## What changes

Three places hand work off the session hot path so the session never blocks on it: the window-counts snapshot and the two push-notification dispatches. All three started that work with a bare spawn, so the worker belonged to nobody — outside the supervision tree, invisible to the operator, and its crash a disappearance rather than a report. Every other detached spawn in the tree already goes through `Grappa.TaskSupervisor`, and S37 wrote the rule down; these three predate it.

They now follow it, and a test asserts that each of them does.

## What this buys — and what it does not

**Supervision and visibility. Not a concurrency ceiling.**

The number of these workers that can run at once is exactly what it was before. A ceiling on detached work is a child-spec setting (`max_children`) and the tree configures none — measured: the string appears nowhere in `lib/` or `config/`. Routing a spawn through a supervisor changes the spawn verb, not the child spec, so it cannot add a bound that is not configured.

This is stated narrowly on purpose. The moduledocs that described these workers as unlinked are corrected, and they are corrected to say what is true rather than something better: a docstring implying a bound here would be the same shape of defect this issue exists to remove, relocated from the code into the prose where it is harder to notice.

## The one part that is not a mechanical verb swap

**The start result is discarded, not matched.** A bare spawn could not fail, so a strict match around it was free. A supervisor can refuse. Matching strictly would convert a skipped best-effort optimisation into a crash on the session hot path the day a ceiling is introduced — the opposite of what a ceiling would be for. Two older call sites already carry that strict match; this change declines to add two more, and disarming those two is a separate decision with its own blast radius.

## How the guard catches the worker

A worker that has already finished is indistinguishable from one that was never supervised — the supervisor's child list is empty either way. So each test parks its worker and asks while it is parked, and both parks are real infrastructure rather than a stand-in for the subject under test: a process registered where the session would be, which never answers, holds the snapshot worker inside its live-count call; OTP's own `:sys.suspend/1` on the presence singleton holds the two notification workers where they consult it.

The assertion is the worker pid's membership in the supervisor's child set, not the size of that set. An earlier version compared counts and failed against code that was already correct, because another test's worker was still dying while it measured — a count cannot tell "one arrived" from "one left".

## Evidence

- **Red read before the fix, and the first red was the wrong red.** Two of the three assertions initially failed because the preference setter validates the whole map and rejected a partial one — the same colour as the real failure with the opposite diagnosis. Corrected, then re-read: three red for the property itself.
- **Three mutants, one per site**, injected by line number with an assertion on the expected shape and a verified clean restore. Each kills **exactly one** assertion: the snapshot site kills only the window-counts test, the first notification site only the message test, the second only the presence test. Never two, never zero.
- **Green on two seeds**, including the seed that exposed the count-based flake.
- **`scripts/check.sh` RC=0** — 8 doctests, 61 properties, 6521 tests, 0 failures; Dialyzer `Total errors: 0`; Sobelow passed; bats 0 not-ok. The first run of the gate was RED on two Credo strict findings, both this branch's own; they were fixed in their own commit and the gate was re-run **from the start**.

## Not established

- **Nothing here measures concurrency.** How many of these workers can be alive at once, and whether that wants a bound, is untouched and unanswered. Both the test and the decision-log entry say so.
- **The two older strict matches are still armed.** They are named, not fixed.
- **The gates ran on the previous `main`.** The branch has not been rebased since `main` moved; the intersection with what `main` brought is `docs/DESIGN_NOTES.md` alone, which is append-only and marker-protected, but the green above was measured on the earlier base.
- One prose site outside this change still describes these workers as unsupervised. It is in a file this slice deliberately did not open, and it is left for a follow-up rather than silently widened here.
