### PR TITLE
docs(#1410): say that init/1 reads the DB, because it does

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47121,3 +47121,88 @@ three axes (timeout `1_000` ×11 vs `5_000` ×2, prefix `"USER"` ×12 vs `"USER 
 decision: two files have already found one second insufficient. Consolidating it
 is choosing a barrier value, not removing a duplicate, and it must be bought with
 its own reason.
+<!-- entry #1410 -->
+
+---
+
+## 2026-08-17 — #1410: `init/1` does read the DB; the two sentences that denied it now say so
+
+Two live documents claimed `Grappa.Session.Server.init/1` performs no DB reads.
+Both were false, in different ways and to different degrees, and this entry
+records which half of each was wrong, why the obvious code fix is the wrong fix,
+and what the correction deliberately leaves open.
+
+### What the code actually does
+
+`init/1` invokes the injected `refresh_plan` closure before building any state.
+There are **two** injectors, not one: `Grappa.Networks.SessionPlan` (user side)
+and `Grappa.Visitors.SessionPlan` (visitor side). Both walk the DB — the user
+side reads the credential, preloads `network: :servers` and fetches the user;
+the visitor side reads the visitor row, reloads the network, then resolves.
+So the reads happen on every spawn and every `:transient` restart, for both
+subject kinds, inside the Session process.
+
+### Why the obvious fix is wrong
+
+Moving the re-resolve into `handle_continue` would restore the "non-blocking"
+sentence literally and is the first idea anyone has. It is wrong, and the
+reason is a boundary contract rather than a performance argument: `init/1`
+returning `:ignore` is the **only synchronous** "this subject is no longer
+viable" signal the spawn door has. `Grappa.SpawnOrchestrator` maps it to
+`{:ok, :ignored}` and `Grappa.Bootstrap.classify_outcome/3` counts it. From
+`handle_continue` the caller would instead observe `{:ok, pid}` followed by a
+silent death a moment later — precisely the "No silent-swallow at boundaries"
+failure CLAUDE.md names. The end-to-end path is already pinned by
+`spawn_orchestrator_test.exs` ("refresh_plan returning `{:error, :not_found}`
+-> `{:ok, :ignored}`, no session spawned"), so the refactor would go red rather
+than ship quietly. No new test was added here: buying a guard that already
+exists would be ornament.
+
+The reads are also load-bearing for a second, independent reason. The #93
+endpoint ring advances by resolving at the failure count, and that counter is
+authoritative only at this moment: `Backoff.record_failure/2` is a synchronous
+call from the dying session's `terminate/2`, so the bump has landed before the
+supervisor reaches `init/1`. Deferring the read moves it away from the only
+instant at which it is correct.
+
+### Which sentence was wrong, and how
+
+The A2 paragraph in `Grappa.Session` conflated two different claims. The one it
+should make — no `Credential` / `Network` / `Server` / `Visitor` struct refs
+cross the Session boundary — is **intact**, and is what the `Boundary` deps
+enforce. The parenthetical it added on top ("no `Repo`, no `Networks`, no
+`Accounts`, no `Visitors` reads") was an over-claim about runtime behaviour that
+the dependency mechanism never bought. The comment above `init/1` was false only
+in half: the upstream-socket deferral to `handle_continue({:start_client, _})`
+holds; the DB half did not.
+
+### What stays open, deliberately
+
+Two things are named in the corrected text rather than fixed.
+
+First, on the **spawn** door the re-resolve is redundant: `Bootstrap` calls
+`SessionPlan.resolve/1` and hands the resolved plan to `start_child`, whose
+`init/1` immediately resolves it again. Only the **respawn** door needs the
+re-read. One closure cannot tell the two doors apart, and the obvious flag does
+not work — `DynamicSupervisor` caches the spawn-time child spec, so a
+"plan is already fresh" key in `opts` would be replayed on every restart, which
+is the opposite of what it must mean. Anything that does work (a one-shot side
+channel, a stateful closure) is heavier than the duplication it removes.
+
+Second, `Boundary` is **structurally blind** to this class. A closure built in
+`Networks` and invoked in `Session` carries no module reference, so no
+compile-time checker can see the edge. That is why the deps list can honestly
+omit `Repo` / `Networks` / `Accounts` while those reads happen — and why the
+next closure of this shape will be equally invisible. #1398 (bucket I) reasons
+about the `Networks -> Session` inversion partly from the sentence corrected
+here; its premise has moved and is being told so.
+
+### Not established
+
+Nothing was executed for this entry: no query log, no timing of the spawn loop,
+no `EXPLAIN`. The issue's "N x 3 queries" remains a derivation from the call
+chain, not a measurement, and this correction deliberately declines to quote a
+boot-time figure — it says the cost exists and is unmeasured. Likewise the
+claim that a fix belongs in the code rather than the prose is **not** made here:
+the code was measured to be right and the prose wrong, which is the whole reason
+this slice touches no `.ex` behaviour.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -39,9 +39,28 @@ defmodule Grappa.Session do
   `Grappa.Networks.SessionPlan.resolve/1` (user-side) and
   `Grappa.Visitors.SessionPlan.resolve/1` (visitor-side) are the
   canonical producers of that plan; `Bootstrap` threads the resolved
-  opts in. The Server's `init/1` is therefore a pure data consumer
-  (no `Repo`, no `Networks`, no `Accounts`, no `Visitors` reads),
-  which keeps the Session boundary deps minimal.
+  opts in. That struct-ref ban IS the invariant, and it is what the
+  `Boundary` deps below enforce.
+
+  It does NOT mean `init/1` performs no DB reads. Both producers also
+  inject a `refresh_plan` closure, and `Server.init/1` invokes it, so
+  each spawn AND each `:transient` restart re-resolves the plan from
+  the DB inside the Session process. Deliberate on both counts: the
+  respawn door needs live truth (the 2026-05-27 zombie class) and the
+  #93 endpoint ring reads a failure counter that is authoritative only
+  there; and it is SYNCHRONOUS because `init/1`'s `:ignore` is the
+  spawn door's only synchronous "subject no longer viable" signal —
+  `Grappa.SpawnOrchestrator` maps it to `{:ok, :ignored}` and
+  `Bootstrap` counts it, so deferring the re-resolve to
+  `handle_continue` would turn a reported failure into a silent death.
+
+  Two consequences stay open. On the SPAWN door the re-resolve
+  duplicates the resolution its caller performed microseconds earlier,
+  and one closure cannot tell the two doors apart. And `Boundary` is
+  structurally blind to this class: a closure built in `Networks` or
+  `Visitors` and invoked here carries no module reference for a
+  compile-time checker to see, which is why the deps list below can
+  omit `Repo` / `Networks` / `Accounts` while those reads happen.
   """
 
   # `Server` is exported for the test path only — `server_test.exs`

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -850,12 +850,21 @@ defmodule Grappa.Session.Server do
 
   ## GenServer callbacks
 
-  # `init/1` is intentionally non-blocking — `Client.start_link/1` runs
-  # in `handle_continue(:start_client, _)` so a slow upstream cannot
-  # serialize Bootstrap's per-credential `Enum.reduce` start_child
-  # loop. Pairs with `Grappa.IRC.Client.init/1`'s own `{:continue,
-  # :connect}` deferral; together they keep boot O(1) per session
-  # regardless of upstream reachability.
+  # `init/1` defers the UPSTREAM SOCKET, not everything —
+  # `Client.start_link/1` runs in `handle_continue(:start_client, _)`
+  # so a slow upstream cannot serialize Bootstrap's per-credential
+  # `Enum.reduce` start_child loop. Pairs with
+  # `Grappa.IRC.Client.init/1`'s own `{:continue, :connect}` deferral;
+  # together they keep boot O(1) in upstream reachability.
+  #
+  # It is NOT read-free, and the older wording ("intentionally
+  # non-blocking", full stop) read as if it were: the `refresh_plan`
+  # closure below re-resolves the plan from the DB, so Bootstrap's loop
+  # does pay those queries per credential. Synchronous by necessity —
+  # `:ignore` is the spawn door's only synchronous "not viable" signal
+  # (see `Grappa.Session`'s A2 section for why `handle_continue` cannot
+  # carry it). The boot cost has never been measured; measure before
+  # quoting a figure for it.
   @impl GenServer
   def init(opts) do
     :ok = Log.set_session_context(opts.subject_label, opts.network_slug)


### PR DESCRIPTION
Documentary slice for #1410 (L-S2, bucket D of the 2026-08-15 codebase review).
Three files, no behaviour change, no new tests.

## What was measured

The finding is alive on current `main`. `Session.Server.init/1` invokes the
injected `refresh_plan` closure before building any state, and there are **two**
injectors, not the one the issue counts: `Networks.SessionPlan` (user side) and
`Visitors.SessionPlan` (visitor side). Both walk the DB, on every spawn and every
`:transient` restart. The two sentences that said otherwise are both still in the
tree, and both are false — the A2 paragraph in `Grappa.Session` entirely, the
`init/1` comment in half.

## Why this slice corrects the prose instead of the code

The obvious remedy — move the re-resolve into `handle_continue` — is wrong, for a
boundary reason rather than a stylistic one. `init/1` returning `:ignore` is the
only **synchronous** "subject no longer viable" signal the spawn door has:
`SpawnOrchestrator` maps it to `{:ok, :ignored}` and `Bootstrap` counts it.
Deferred, the caller would observe `{:ok, pid}` followed by a silent death, which
is the swallow CLAUDE.md forbids at boundaries. That path is already pinned end to
end by an existing spec in `spawn_orchestrator_test.exs`, so the refactor would go
red rather than ship quietly — and so **no test is added here**, because the claim
being defended is already bought.

The reads are load-bearing for a second, independent reason: the #93 endpoint ring
resolves at the failure count, and that counter is authoritative only at this
instant (the bump is a synchronous call from the dying session's `terminate/2`).

So the code is right and the text was wrong. The text moves.

## What the corrected text now says

- `Grappa.Session` keeps the invariant A2 actually buys — no `Credential` /
  `Network` / `Server` / `Visitor` struct refs cross the boundary, which is what
  `Boundary` enforces — and drops the over-claim about runtime reads that the
  dependency mechanism never bought. Both injectors are named.
- The `init/1` comment keeps the upstream-socket half of "non-blocking" and
  retires the DB half.
- Both passages name what is **not** fixed: the spawn-door re-resolve stays
  redundant (`DynamicSupervisor` caches the child spec, so an "already fresh" flag
  would persist into every respawn — the opposite of what it must mean), and
  `Boundary` stays structurally blind to a closure that carries no module
  reference.

## Not established

Nothing was executed. No query log, no timing of the spawn loop, no `EXPLAIN`. The
issue's "N x 3 queries" stays a derivation from the call chain, and the corrected
text deliberately quotes **no** boot-time figure — it states that the cost exists
and is unmeasured. This slice closes the false statement, not the redundancy and
not the enforcement gap; those are named in the decision-log entry and left open.

#1398 (bucket I) reasons partly from the sentence corrected here, and is being
told its premise moved.