### PR TITLE
union(#1419 #1395 #1468 #1404): one gate for four replayed slices

### DIFF
--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -74,8 +74,24 @@ type Rule = { selectors: string[]; body: string };
  * rules nested inside one, which resolve under a condition this file does not
  * model. The "bare class selectors only" assertion below is what makes that
  * safe: it fails if a site is ever reached from inside a media query.
+ *
+ * Memoised, because the clone census below resolves EVERY bare class in the
+ * sheet and each `resolve` re-parses: 1427 parses of a 435 KB stylesheet for
+ * one assertion pair, measured at 1117 ms of that test's 1185 ms — 94%, and
+ * the 5 s default is what #1419 kept tripping on. `themeCss` is read once at
+ * import, so the parse is a pure function of a constant and the cache cannot
+ * go stale. The budget is left at the default deliberately: nothing here
+ * asserts a duration, so a timeout bump would have hidden the cost instead of
+ * removing it.
  */
+let parsedRules: Rule[] | undefined;
+
 function topLevelRules(): Rule[] {
+  parsedRules ??= parseTopLevelRules();
+  return parsedRules;
+}
+
+function parseTopLevelRules(): Rule[] {
   const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
   const rules: Rule[] = [];
   for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47183,3 +47183,61 @@ that module silently resolves to the visitor one.
 _Not established here: no timing claim about Argon2 or suite duration, and the
 `:passwordless` ordering (password verified first, mode checked second) is
 preserved from the original `cond` rather than re-derived from the domain._
+<!-- entry #1468 -->
+
+---
+
+## 2026-08-17 — #1468: the terminal rule is now proven, not exemplified
+
+#623 pt3 set a rule — no progress step may be left `:running` when the recovery
+reaches a terminal state — and two of the five terminal clauses did not honour
+it. A deadline out of `:awaiting_verb_settle` or `:awaiting_nick` reported one
+step, while every path into those phases had passed through
+`:idle -> :awaiting_r`, which sets `identify: :running`. The client upserts one
+row per step name and never touches a row nobody updates, so the modal closed
+reporting a failed recovery with the identify step spinning forever.
+
+The in-code comment that justified leg (a) claimed the identify step "never
+started". That was false — `:awaiting_nick` is reachable only through
+`:awaiting_r` — and it is deleted rather than softened, in the commit that
+cures the clause it was defending.
+
+### What the red buys, and what it deliberately does not
+
+The cure is two clauses. The interesting part is why the gap survived a rule, a
+test for the rule on the sibling leg, and a review: **each leg was pinned by its
+own example, so a clause nobody wrote an example for answered to nothing.**
+
+The replacement is an **exhaustive walk**, not a StreamData property — a
+breadth-first search to fixpoint over the reachable `{phase, verb, rows}` space,
+asserting the invariant at every terminal. The space is finite and small (seven
+phases, one status per step name), so the search is a PROOF over every reachable
+path, retry loops included, where a generator would be a sample with a seed that
+can get lucky. It carries its own vacuity floors: a minimum state count, a
+minimum terminal count, and the assertion that a terminal is reached out of all
+four phases that can fail. `rows` mirrors the CLIENT's rule (`recoverProgress.ts`
+upserts by step name, last write wins) rather than a convenient one — the
+question being asked is what the modal is showing when the modal closes.
+
+### The other three clauses: two by the rule, one vacuously
+
+The issue left it unestablished whether the remaining clauses were correct for
+the same reason or by accident. Established here:
+
+- `:awaiting_r` and `:awaiting_final_r` are correct **by the rule** — the steps
+  that can still be `:running` at those terminals are exactly the ones they
+  reconcile.
+- The catch-all `terminal_steps(_, _, reason)` is correct **only vacuously**:
+  no reachable path reaches it, because `:failed` is only ever entered from the
+  four named phases. It reconciles `nick` alone and would strand rows the day a
+  new phase could fail. It is left as found — a cure nothing can exercise is a
+  claim, not a fix — and the walk is what makes that safe, since the terminal
+  becomes reachable and checked the moment such a phase exists.
+
+One inaccuracy is knowingly left in place: on the bounded-retry path the settle
+marked the reclaim verb `:ok` and the terminal marks it `:failed` again. It
+predates this issue and strands nothing, so curing it would widen past what the
+red buys.
+
+_Not established: how often leg (a) is reached in production. No frequency was
+measured, here or in the issue._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47241,3 +47241,53 @@ red buys.
 
 _Not established: how often leg (a) is reached in production. No frequency was
 measured, here or in the issue._
+<!-- entry #1404e -->
+
+---
+
+## 2026-08-17 — #1404: the detached hand-offs become supervised work, and only that
+
+Three places hand work off the session hot path so the session never blocks
+on it: the window-counts snapshot and the two push-notification dispatches.
+All three started that work with a bare spawn, so the worker belonged to
+nobody — outside the supervision tree, invisible to the operator, and its
+crash a disappearance rather than a report. Every other detached spawn in the
+tree already goes through `Grappa.TaskSupervisor`, and S37 wrote the rule
+down; these three predate it. They now follow it, and a test asserts each of
+them does.
+
+**What this buys, stated narrowly on purpose: supervision and visibility. Not
+a ceiling.** The concurrency of that work is exactly what it was. A ceiling on
+detached work is a child-spec setting (`max_children`) and the tree configures
+none, so routing the spawn through a supervisor cannot add one — routing
+changes the spawn verb, not the child spec. The moduledocs that used to say
+"unlinked task" are corrected, and they are corrected to say what is true
+rather than to say something better: a docstring that implied a bound here
+would be the very shape of defect this work exists to remove, moved out of the
+code and into the prose where it is harder to notice.
+
+**Why the start result is discarded rather than matched.** This is the one way
+the change is not a mechanical verb swap. `Task.start/1` cannot fail, so a
+`{:ok, _} =` around it was free. `Task.Supervisor.start_child/2` can refuse —
+`{:error, :max_children}` — the day a ceiling exists. A strict match would then
+turn a skipped best-effort optimisation into a crash on the session hot path,
+which is the opposite of what a ceiling is for. Two older call sites already
+carry that strict match; this change deliberately declines to add two more, and
+disarming those two is a separate decision with a separate blast radius.
+
+**How the guard catches the worker.** A worker that has already finished is
+indistinguishable from one that was never supervised, since the supervisor's
+child list is empty either way, so each test parks its worker and asks while it
+is parked. Both parks are real infrastructure rather than a stand-in for the
+subject: a process registered where the session would be, which never answers,
+holds the snapshot worker inside its live-count call; and OTP's own
+`:sys.suspend/1` on the presence singleton holds the two notification workers
+where they consult it. The assertion is the pid's membership in the child set,
+not the size of that set — a count cannot distinguish "one arrived" from "one
+left", and an earlier version of this guard failed against correct code because
+another test's worker was still dying while it measured.
+
+_Not established: nothing here measures how many of these workers can be alive
+at once, or what happens at any particular number, and the file says so. The
+question of whether that concurrency wants a bound is open and is not answered
+by this change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47121,3 +47121,65 @@ three axes (timeout `1_000` ×11 vs `5_000` ×2, prefix `"USER"` ×12 vs `"USER 
 decision: two files have already found one second insufficient. Consolidating it
 is choosing a barrier value, not removing a duplicate, and it must be bought with
 its own reason.
+<!-- entry #1395 -->
+
+---
+
+## 2026-08-17 — #1395: the user login DECISION moves; the throttle, the challenge and the render do not
+
+The user ladder was a `defp` chain inside `GrappaWeb.AuthController`, reachable
+only from an HTTP action: all 64 tests over that controller need a `Plug.Conn`,
+against 33 conn-free tests for the visitor twin. `Grappa.Accounts.Login.authenticate/1`
+now answers the decision — name plus password in, and the door the account still
+has to walk through out — with no `conn` anywhere in it.
+
+**What the issue proposed and this did NOT do.** #1395 asked for a full sibling
+of `Grappa.Visitors.Login`, with the second-factor ladder, the challenge minting
+and the throttles all lifted, and the 22 `visitor_error_response/4` clauses moved
+to `FallbackController`. Measurement refuted three of those four, and the ruling
+kept only the residue:
+
+  * **The throttles stay at the edge.** `Grappa.Visitors.Login` — the twin held
+    up as the model — contains no rate limiting at all: the visitor window lives
+    in the controller, above the call into the context. `GrappaWeb.LoginThrottle`
+    argues the placement in its own moduledoc, and `Grappa.Accounts` depends on
+    neither `Grappa.RateLimit` nor `Grappa.AdminEvents`, exactly as
+    `Grappa.Visitors` does not. Lifting the window would be the trade a shipped
+    module refuses, for a context standing in the identical position.
+
+  * **The challenge cannot be lifted.** Minting it needs `Phoenix.Token.sign/3`
+    against `GrappaWeb.Endpoint`, and the passkey options need
+    `GrappaWeb.PasskeyOrigin`. `GrappaWeb` already depends on `Grappa.Accounts`,
+    so carrying either into the context closes a cycle `Boundary` rejects.
+
+  * **The 22 error clauses stay put**, and are visitor-half code that has nothing
+    to do with this door. Twenty are pure identity pass-throughs whose relocation
+    would change no behaviour while deleting a documented audit index (L-web-1);
+    one inverts a written decision about who may query `Visitors`; and the
+    catch-all is load-bearing. `FallbackController` has 71 `call/2` clauses and
+    **no** catch-all, and `:no_server` is the one member of
+    `Visitors.Login.login_error()` no clause names — so today it renders a clean
+    `500 {"error":"internal"}` only because that catch-all totalises. Removing it
+    turns a declared error into a `FunctionClauseError` and a raw 500.
+
+**The one thing that had to become explicit.** The throttle used to be charged
+inside `authenticate_mode1/3`, upstream of the ladder, so "was this a guess?" was
+answered by call order rather than by a value. With one function answering the
+whole decision, the two refusals must be distinguishable: `{:error,
+:invalid_credentials}` is a wrong credential and charges the window, `{:error,
+:passwordless}` presented the RIGHT password and is refused because the password
+door is shut for that account. Both render the same uniform 401 — the caller maps
+them — but collapsing the tags would silently start charging a user's own window
+for a configuration choice. **This is the general rule the slice pays for: when a
+decision moves out of a chain, every distinction the chain expressed positionally
+has to reappear in the return type, or it is lost without a diff to show for it.**
+
+**Naming.** The call site is spelled `Accounts.Login.authenticate/1`, not
+aliased. `Login` inside `AuthController` is already `Grappa.Visitors.Login`, the
+other half of the same polymorphism; an alias would have made the two
+confusable at a glance, and — measured while writing this — a bare `Login.` in
+that module silently resolves to the visitor one.
+
+_Not established here: no timing claim about Argon2 or suite duration, and the
+`:passwordless` ordering (password verified first, mode checked second) is
+preserved from the original `cond` rather than re-derived from the domain._

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -87,7 +87,7 @@ defmodule Grappa.Accounts do
       Grappa.Repo,
       Grappa.Visitors.Visitor
     ],
-    exports: [User, Session, Wire, AdminWire, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
+    exports: [User, Session, Wire, AdminWire, Login, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
 
   import Ecto.Query
 

--- a/lib/grappa/accounts/login.ex
+++ b/lib/grappa/accounts/login.ex
@@ -1,0 +1,99 @@
+defmodule Grappa.Accounts.Login do
+  @moduledoc """
+  The password door's decision for an account: does this credential open,
+  and which second-factor door (if any) is still in the way.
+
+  ## Why this exists (#1395)
+
+  The user ladder used to be a `defp` chain inside
+  `GrappaWeb.AuthController`, reachable only from an HTTP action and
+  untestable without a `Plug.Conn` — all 64 tests over it needed one. The
+  decision itself needs neither: it is a name, a password and the account's
+  own second-factor configuration. So the decision moved and everything
+  request-shaped stayed at the edge.
+
+  ## What deliberately did NOT move
+
+  This is a decision, not an orchestrator, and the boundary is drawn where
+  the twin `Grappa.Visitors.Login` already draws it:
+
+    * **The throttles.** `Grappa.Visitors.Login` contains no rate limiting at
+      all — the visitor door's window lives in the controller, above the call
+      into the context, and `GrappaWeb.LoginThrottle` argues the placement in
+      its own moduledoc: a window keyed on the source IP is request-edge
+      policy. `Grappa.Accounts` depends on neither `Grappa.RateLimit` nor
+      `Grappa.AdminEvents`, exactly as `Grappa.Visitors` does not, and
+      widening it to hold one would be the trade that module rejects. The
+      caller charges; see the `:passwordless` note below for what makes that
+      possible.
+
+    * **The second-factor challenge.** Minting it needs
+      `Phoenix.Token.sign/3` against `GrappaWeb.Endpoint`, and the passkey
+      options need `GrappaWeb.PasskeyOrigin`. `GrappaWeb` already depends on
+      `Grappa.Accounts`, so reaching back would close a cycle that `Boundary`
+      rejects outright. This function names the door; the caller opens it.
+
+    * **The client-token door.** `Accounts.authenticate_client_token/5` is
+      already a context function and already returns a tagged outcome. It
+      mints a session row, so it is an effect rather than a decision, and it
+      is tried ahead of this function by the caller exactly as before.
+
+    * **Rendering, and the 22 `visitor_error_response/4` clauses**, which
+      belong to the visitor half of that controller and are untouched.
+
+  ## The `:passwordless` outcome is not a spelling of `:invalid_credentials`
+
+  Both reach the client as the same uniform 401 — the caller maps them — but
+  they must stay distinct here because only one of them is a guess. A wrong
+  password charges the login window; an account in `:passwordless` passkey
+  mode presented the RIGHT password and is refused because this door is shut
+  for it, so charging it would spend a user's own window on a configuration
+  choice. Collapsing the two tags would silently change the throttle.
+  """
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.{TOTP, User}
+
+  @type input :: %{required(:name) => String.t(), required(:password) => String.t()}
+
+  @typedoc """
+  `{:ok, user}` — verified, nothing further to prove.
+  `{:second_factor, which, user}` — verified, one door left.
+  `{:error, :invalid_credentials}` — the credential did not verify.
+  `{:error, :passwordless}` — it did, but this door is shut for the account.
+  """
+  @type outcome ::
+          {:ok, User.t()}
+          | {:second_factor, :passkey | :totp, User.t()}
+          | {:error, :invalid_credentials | :passwordless}
+
+  @doc """
+  Verifies `name` + `password` and returns the door the account still has to
+  walk through.
+
+  The name is matched the account way — `Accounts.get_user_by_credentials/2`,
+  which folds it (#1353) — and a miss is indistinguishable from a wrong
+  password, both on the wire and in timing.
+  """
+  @spec authenticate(input()) :: outcome()
+  def authenticate(%{name: name, password: password})
+      when is_binary(name) and is_binary(password) do
+    case Accounts.get_user_by_credentials(name, password) do
+      {:ok, %User{} = user} -> second_factor(user)
+      {:error, :invalid_credentials} = error -> error
+    end
+  end
+
+  # `passkey_mode` is a closed three-value enum, so all three are spelled out:
+  # a fourth value added later must fail here loudly rather than inherit the
+  # no-second-factor exit from a catch-all.
+  @spec second_factor(User.t()) :: outcome()
+  defp second_factor(%User{passkey_mode: :passwordless}), do: {:error, :passwordless}
+
+  defp second_factor(%User{passkey_mode: :second_factor} = user),
+    do: {:second_factor, :passkey, user}
+
+  defp second_factor(%User{passkey_mode: :disabled} = user) do
+    if TOTP.enabled?(user), do: {:second_factor, :totp, user}, else: {:ok, user}
+  end
+end

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -14,9 +14,10 @@ defmodule Grappa.Push.Triggers do
   still calls directly: a presence transition persists no row, so there is
   nothing for `Persistor` to be the guardian of.
 
-  Both calls are fire-and-forget — Triggers spawns an unlinked `Task` so
-  the hot path stays sub-millisecond and Sender failures don't bleed into
-  the mailbox.
+  Both calls are fire-and-forget — Triggers hands the work to
+  `Grappa.TaskSupervisor` so the hot path stays sub-millisecond and Sender
+  failures don't bleed into the mailbox. Detached but supervised: the
+  worker is visible and its crash is a report, not a disappearance.
 
   ## Decision logic — `should_notify?/5`
 
@@ -169,7 +170,7 @@ defmodule Grappa.Push.Triggers do
   notification preferences and, on a match, fires the Web Push
   fan-out via `Push.Sender.send_to_subject/2`.
 
-  Fire-and-forget — spawns an unlinked `Task` and returns `:ok`
+  Fire-and-forget — starts a supervised task and returns `:ok`
   immediately. Per-message work (prefs lookup, mention regex,
   Sender fan-out) happens out-of-band so the Session.Server hot
   path never blocks on it.
@@ -189,8 +190,11 @@ defmodule Grappa.Push.Triggers do
       own_nick: own_nick
     } = ctx
 
-    {:ok, _} =
-      Task.start(fn ->
+    # Discarded, not matched: a supervisor can refuse to start a child,
+    # and a strict match would turn a skipped notification into a crash
+    # on the session hot path the day a ceiling is configured.
+    _ =
+      Task.Supervisor.start_child(Grappa.TaskSupervisor, fn ->
         prefs = UserSettings.get_notification_prefs(subject)
         patterns = UserSettings.get_highlight_patterns(subject)
 
@@ -222,8 +226,8 @@ defmodule Grappa.Push.Triggers do
   @doc """
   Dispatches the Web Push for one `/notify` presence report (#378).
 
-  Same fire-and-forget shape as `evaluate_and_dispatch/2`: unlinked `Task`,
-  always `:ok`, no `try/rescue` (the no-silent-drops contract above).
+  Same fire-and-forget shape as `evaluate_and_dispatch/2`: supervised
+  task, always `:ok`, no `try/rescue` (the no-silent-drops contract above).
 
   A baseline (`:initial`) short-circuits in the FUNCTION HEAD, before the
   Task spawn — that is the whole point of splitting the clause rather than
@@ -240,8 +244,11 @@ defmodule Grappa.Push.Triggers do
       when is_binary(nick) and presence in [:online, :offline] and is_map(ctx) do
     %{subject: subject, subject_label: subject_label, network_slug: network_slug} = ctx
 
-    {:ok, _} =
-      Task.start(fn ->
+    # Discarded, not matched: a supervisor can refuse to start a child,
+    # and a strict match would turn a skipped notification into a crash
+    # on the session hot path the day a ceiling is configured.
+    _ =
+      Task.Supervisor.start_child(Grappa.TaskSupervisor, fn ->
         prefs = UserSettings.get_notification_prefs(subject)
 
         # #182 — the same foreground-suppression gate as the message path,

--- a/lib/grappa/session/recover_progress.ex
+++ b/lib/grappa/session/recover_progress.ex
@@ -28,18 +28,26 @@ defmodule Grappa.Session.RecoverProgress do
   and it can only stay that way while the projection stays pure. Nothing in
   it may reach for session state.
 
-  ## Known defect carried over: #1468
+  ## The terminal rule (#623 pt3, repaired by #1468)
 
-  A terminal out of `:awaiting_verb_settle` or `:awaiting_nick` reports only
-  one step, but EVERY path into those phases ran through
-  `:idle -> :awaiting_r`, which already set `identify: :running`. The client
-  never reconciles a row nobody updates, so the modal ends with `identify`
-  spinning next to a failed outcome — the very thing #623 pt3 set out to
-  prevent ("RECONCILE every in-flight step on terminal `:failed`").
+  No step may be left `:running` when the recovery reaches a terminal state.
+  The client upserts one row per step name and never touches a row nobody
+  updates, so a step the modal was told was `:running` spins forever unless
+  some later event gives it a final status.
 
-  Slice 4 moved this table AT PARITY and deliberately did NOT cure it:
-  a behaviour change buried in a refactor is invisible to a reviewer reading
-  the diff for a move. The fix is #1468, bought by its own red.
+  Two clauses used to break that rule: a terminal out of
+  `:awaiting_verb_settle` or `:awaiting_nick` reported ONE step, while every
+  path into those phases had gone through `:idle -> :awaiting_r`, which sets
+  `identify: :running`. #1468 reconciles them.
+
+  The clause-by-clause fix is the small half. The reason the gap survived a
+  rule, a test for the rule, and a review is that each leg was pinned by its
+  OWN example, so a clause nobody wrote an example for answered to nothing.
+  What holds the rule now is the exhaustive walk in
+  `recover_progress_test.exs`: a breadth-first search over the reachable
+  `{phase, verb, rows}` space that asserts the invariant at every terminal it
+  can reach. A new phase or a new terminal clause is covered the moment it
+  becomes reachable, without anyone remembering to write its example.
 
   Boundary: inherits the parent `Grappa.Session` boundary — same pattern as
   sibling submodules `Server`, `EventRouter`, `RecoverIdentity`. No
@@ -88,8 +96,7 @@ defmodule Grappa.Session.RecoverProgress do
 
   # #623 pt3 — RECONCILE every in-flight step on terminal :failed (not just one)
   # so the modal never strands a step at :running (the trace "hang"), keyed on
-  # the phase we failed OUT of. Two of the five clauses below do not honour
-  # that rule — see the #1468 note in the moduledoc.
+  # the phase we failed OUT of.
   def steps(old, %{phase: :failed, reason: reason, verb: verb}),
     do: terminal_steps(old, verb, reason)
 
@@ -98,19 +105,31 @@ defmodule Grappa.Session.RecoverProgress do
   def steps(_, _), do: []
 
   # #623 pt3 — the reconciled terminal step list, keyed on the phase we failed
-  # OUT of, with the two reclaim legs kept DISTINCT + trace-diagnosable:
+  # OUT of. Each clause names the steps that can still be `:running` on ANY
+  # path into that phase, plus the one that actually failed, with the two
+  # reclaim legs kept DISTINCT + trace-diagnosable:
   #   * `:awaiting_r` — a clean NICK but `+r` never came → the IDENTIFY failed
   #     (`:wrong_password`); the nick itself landed clean (`:ok`).
-  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered → the verb
-  #     failed (`:services_declined`). **#1468: `identify` — running since the
-  #     start transition — is not reconciled here, nor is `nick` after a retry.**
+  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered
+  #     (`:services_declined`). `identify` has been running since the start
+  #     transition, and `nick` is either already `:failed` (first pass) or
+  #     `:running` again (the bounded retry re-entered this phase after the
+  #     settle set it running). A phase-keyed projection cannot tell those two
+  #     paths apart, and it does not need to: `:failed` is true on both.
   #   * `:awaiting_nick` — leg (a): the re-NICK never landed → the nick failed
-  #     (`:nick_unavailable`). **#1468: `identify` is not reconciled here
-  #     either; the comment this clause used to carry claimed the identify step
-  #     never started, which no reachable path makes true.**
+  #     (`:nick_unavailable`), and `identify` — running since the start — is
+  #     reconciled with it. The comment this clause used to carry said the
+  #     identify step "never started"; that was FALSE, since `:awaiting_nick`
+  #     is only reachable through `:awaiting_r`, which starts it. Deleted
+  #     rather than softened.
   #   * `:awaiting_final_r` — leg (b): the re-NICK landed but `+r` never
   #     confirmed → the identify failed (`:identify_unconfirmed`); the nick is
-  #     already `:ok`.
+  #     already `:ok`, and so is the verb.
+  #
+  # The `verb` row on the retry path is the one thing this list does not get
+  # exactly right, and it predates #1468: the settle marked it `:ok`, and the
+  # terminal marks it `:failed` again. It strands nothing, so #1468 leaves it
+  # as found rather than widening past what its red buys.
   @spec terminal_steps(
           RecoverIdentity.phase(),
           RecoverIdentity.verb(),
@@ -120,14 +139,22 @@ defmodule Grappa.Session.RecoverProgress do
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
-    do: [{verb, :failed, reason}]
+    do: [{:nick, :failed, reason}, {verb, :failed, reason}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_nick, _, reason),
-    do: [{:nick, :failed, reason}]
+    do: [{:nick, :failed, reason}, {:identify, :failed, reason}]
 
   defp terminal_steps(:awaiting_final_r, _, reason),
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
+  # No reachable path lands here: `:failed` is only ever entered from the four
+  # phases above (`RecoverIdentity.step/2` has no other clause that stops with
+  # `phase: :failed`), so this default satisfies the rule VACUOUSLY rather than
+  # by honouring it — it reconciles `nick` alone. Left as found, since the
+  # exhaustive walk cannot reach it and a cure nothing can exercise is a claim,
+  # not a fix. The walk is what makes that safe: the day a new phase can fail,
+  # the terminal it produces becomes reachable and the invariant is checked
+  # there, on this clause, without anyone remembering it exists.
   defp terminal_steps(_, _, reason),
     do: [{:nick, :failed, reason}]
 end

--- a/lib/grappa/window_counts/pusher.ex
+++ b/lib/grappa/window_counts/pusher.ex
@@ -16,9 +16,9 @@ defmodule Grappa.WindowCounts.Pusher do
   `push/1` gates on live WS presence (`WSPresence.ws_count/1` > 0): if
   no socket is connected for the subject, it skips — the next
   `join_reply` / `/me` re-seeds the absolute snapshot on reconnect, so a
-  disconnected subject costs nothing. When connected, it spawns an
-  unlinked `Task` (like `Push.Triggers`) so the Session hot path never
-  blocks on the snapshot's DB work, then `emit/1` computes the fresh
+  disconnected subject costs nothing. When connected, it hands the work
+  to `Grappa.TaskSupervisor` (like `Push.Triggers`) so the Session hot
+  path never blocks on the snapshot's DB work, then `emit/1` computes the fresh
   `WindowCounts.snapshot/7` (cursor from `ReadCursor`, highlight patterns
   from `UserSettings`) and broadcasts the `window_counts` event on the
   per-channel topic. cic replaces its stored snapshot verbatim.
@@ -46,15 +46,23 @@ defmodule Grappa.WindowCounts.Pusher do
   @impl PushSource
   @spec push(PushSource.ctx()) :: :ok
   def push(%{subject_label: subject_label} = ctx) do
-    # `_ =` — the `if` is evaluated for its side effect (spawning the
-    # emit Task); its `{:ok, pid} | nil` value is intentionally discarded
-    # (dialyzer `:unmatched_returns`).
+    # `_ =` — the `if` is evaluated for its side effect (starting the
+    # emit task); its value is intentionally discarded (dialyzer
+    # `:unmatched_returns`).
     _ =
       if WSPresence.ws_count(subject_label) > 0 do
-        # Fire-and-forget — the snapshot DB work stays off the Session hot
-        # path. A dead Task just means the live-render optimization is
-        # skipped for this row; the next seed re-bases the count.
-        {:ok, _} = Task.start(fn -> emit(ctx) end)
+        # Detached, but not orphaned: under `Grappa.TaskSupervisor` (S37)
+        # the worker is visible to the operator and a crash in it is a
+        # report rather than a silent disappearance. The snapshot DB work
+        # stays off the Session hot path either way. A worker that never
+        # runs just means the live-render optimization is skipped for this
+        # row; the next seed re-bases the count.
+        #
+        # The return is DISCARDED, not matched. `Task.start/1` could not
+        # fail, but a supervisor can refuse — and the day this supervisor
+        # is given a child ceiling, a strict match here would turn a
+        # skipped optimization into a crash on the session hot path.
+        Task.Supervisor.start_child(Grappa.TaskSupervisor, fn -> emit(ctx) end)
       end
 
     :ok

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -444,33 +444,43 @@ defmodule GrappaWeb.AuthController do
     |> render(:login, token: session.id, subject: {:user, user})
   end
 
+  # #1395 — the DECISION (does the credential verify, and which door is
+  # left) is `Accounts.Login.authenticate/1`, reachable without a `conn`.
+  # What stays here is what is genuinely request-shaped: charging the
+  # throttle, minting the challenge, and rendering.
+  #
+  # The two error tags are NOT interchangeable even though both answer 401
+  # `invalid_credentials` on the wire. `:invalid_credentials` is a guess and
+  # charges the window; `:passwordless` presented the RIGHT password and is
+  # refused because the password door is shut for that account, so charging
+  # it would spend a user's own window on a configuration choice. Before
+  # #1395 the distinction was implicit in the call order — the throttle was
+  # charged inside `authenticate_mode1/3`, upstream of the ladder — and it
+  # has to be explicit now that one function answers both.
   @spec password_login(Plug.Conn.t(), String.t(), String.t(), String.t() | nil) ::
           Plug.Conn.t() | {:error, term()}
   defp password_login(conn, name, password, ip) do
-    with {:ok, user} <- authenticate_mode1(name, password, ip) do
-      second_factor_ladder(conn, user)
-    end
-  end
+    # Spelled `Accounts.Login` rather than aliased: `Login` in this module is
+    # already `Grappa.Visitors.Login`, the other half of the same
+    # polymorphism, and the two must never be confusable at a call site.
+    case Accounts.Login.authenticate(%{name: name, password: password}) do
+      {:ok, user} ->
+        mint_user_session(conn, user)
 
-  # The post-password ladder: which door (if any) the account still has
-  # to walk through before a bearer is minted.
-  @spec second_factor_ladder(Plug.Conn.t(), Accounts.User.t()) ::
-          Plug.Conn.t() | {:error, term()}
-  defp second_factor_ladder(conn, user) do
-    cond do
-      user.passkey_mode == :passwordless ->
-        {:error, :invalid_credentials}
-
-      user.passkey_mode == :second_factor ->
+      {:second_factor, :passkey, user} ->
         passkey_second_factor(conn, user)
 
-      TOTP.enabled?(user) ->
+      {:second_factor, :totp, user} ->
         conn
         |> put_status(:accepted)
         |> json(%{two_factor_required: true, challenge_token: sign_challenge(user, conn)})
 
-      true ->
-        mint_user_session(conn, user)
+      {:error, :invalid_credentials} ->
+        :ok = charge_mode1_failure(ip)
+        {:error, :invalid_credentials}
+
+      {:error, :passwordless} ->
+        {:error, :invalid_credentials}
     end
   end
 
@@ -609,17 +619,17 @@ defmodule GrappaWeb.AuthController do
     end
   end
 
-  @spec authenticate_mode1(String.t() | nil, String.t(), String.t() | nil) ::
-          {:ok, Grappa.Accounts.User.t()} | {:error, :invalid_credentials}
-  defp authenticate_mode1(name, password, ip) do
-    case Accounts.get_user_by_credentials(name, password) do
-      {:ok, _} = ok ->
-        ok
-
-      {:error, _} = err ->
-        _ = LoginThrottle.charge(@mode1_bucket, ip, @mode1_window_ms, @mode1_max_failures)
-        err
-    end
+  # #1395 — the verify half of the former `authenticate_mode1/3` moved into
+  # `Accounts.Login.authenticate/1`; the charge stayed, because the window is
+  # request-edge policy (`LoginThrottle`'s own moduledoc argues it, and
+  # `Grappa.Visitors.Login` holds no throttle at all for the same reason).
+  # Kept beside the constants it reads: they are declared here, below
+  # `password_login/4`, and a module attribute is only in scope after its
+  # declaration.
+  @spec charge_mode1_failure(String.t() | nil) :: :ok
+  defp charge_mode1_failure(ip) do
+    _ = LoginThrottle.charge(@mode1_bucket, ip, @mode1_window_ms, @mode1_max_failures)
+    :ok
   end
 
   # W3: `captcha_token` arrives as a 4th explicit param so the

--- a/test/grappa/accounts/login_test.exs
+++ b/test/grappa/accounts/login_test.exs
@@ -1,0 +1,138 @@
+defmodule Grappa.Accounts.LoginTest do
+  @moduledoc """
+  The password door's decision, exercised WITHOUT a `conn` (#1395).
+
+  All 64 tests in `auth_controller_test.exs` need a `Plug.Conn` — the user
+  ladder had no entry point other than an HTTP action, which is the defect
+  this slice addresses. These are the evidence it now has one: the same
+  decision, driven through `Grappa.Accounts.Login.authenticate/1` with a
+  plain map. The controller tests keep covering the HTTP envelope, the
+  throttles and the challenge minting, all of which deliberately stayed at
+  the edge.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts.{Login, TOTP, User}
+
+  defp set_passkey_mode(%User{} = user, mode) do
+    {:ok, updated} =
+      user
+      |> User.passkey_mode_changeset(%{passkey_mode: mode})
+      |> Repo.update()
+
+    updated
+  end
+
+  # Arms TOTP off a PREVIOUS step so the current one stays unspent.
+  # NOTE: `auth_controller_test.exs` carries an identical `arm_totp/1`. That
+  # duplication is one of the instances #1397 counts; consolidating it into
+  # `Grappa.AuthFixtures` belongs to that issue's slice, not this one.
+  defp arm_totp(%User{} = user) do
+    enrollment = TOTP.new_enrollment(user, "Grappa test")
+    previous_step = System.system_time(:second) - 30
+    {:ok, code} = TOTP.code_at(enrollment.secret, previous_step)
+    {:ok, _recovery_codes} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
+    user
+  end
+
+  describe "authenticate/1 — the credential gate" do
+    test "a correct password on an account with no second factor returns the user" do
+      {user, password} = user_fixture_with_password()
+
+      assert {:ok, %User{id: id}} = Login.authenticate(%{name: user.name, password: password})
+      assert id == user.id
+    end
+
+    test "a wrong password is refused as :invalid_credentials" do
+      {user, _password} = user_fixture_with_password()
+
+      assert {:error, :invalid_credentials} =
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "an unknown account name is refused with the SAME token as a wrong password" do
+      # The uniform oracle is the point: the caller must not be able to tell
+      # which half of the credential was wrong.
+      {user, password} = user_fixture_with_password()
+
+      assert Login.authenticate(%{name: "no-such-account", password: password}) ==
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "the account name matches the way account names match — folded (#1353)" do
+      {user, password} =
+        user_fixture_with_password(name: "VJT-#{System.unique_integer([:positive])}")
+
+      assert {:ok, %User{id: id}} =
+               Login.authenticate(%{name: String.downcase(user.name), password: password})
+
+      assert id == user.id
+    end
+  end
+
+  describe "authenticate/1 — which door the account still has to walk through" do
+    test "an account in passkey :second_factor mode is sent to the passkey door" do
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :second_factor)
+
+      assert {:second_factor, :passkey, %User{id: id}} =
+               Login.authenticate(%{name: user.name, password: password})
+
+      assert id == user.id
+    end
+
+    test "a :passwordless account refuses the password door even with the right password" do
+      # Distinct from :invalid_credentials deliberately. The wire answer is the
+      # same 401, but the throttle must NOT be charged: the credential was
+      # correct, so this is not a guess.
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :passwordless)
+
+      assert {:error, :passwordless} =
+               Login.authenticate(%{name: user.name, password: password})
+    end
+
+    test "a :passwordless account with a WRONG password is a guess, not a closed door" do
+      {user, _password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :passwordless)
+
+      assert {:error, :invalid_credentials} =
+               Login.authenticate(%{name: user.name, password: "not-the-password"})
+    end
+
+    test "an account with TOTP armed is sent to the code door" do
+      {user, password} = user_fixture_with_password()
+      user = arm_totp(user)
+
+      assert {:second_factor, :totp, %User{id: id}} =
+               Login.authenticate(%{name: user.name, password: password})
+
+      assert id == user.id
+    end
+
+    test "passkey :second_factor wins over TOTP when the account holds both" do
+      # Order is load-bearing: the passkey branch is decided before TOTP, so an
+      # account holding both is offered the passkey.
+      {user, password} = user_fixture_with_password()
+
+      user =
+        user
+        |> arm_totp()
+        |> set_passkey_mode(:second_factor)
+
+      assert {:second_factor, :passkey, _} =
+               Login.authenticate(%{name: user.name, password: password})
+    end
+
+    test "a :disabled account with no TOTP takes the no-second-factor exit" do
+      # The third arm of the closed `passkey_mode` set, spelled so the exit is
+      # exercised rather than inherited from a catch-all.
+      {user, password} = user_fixture_with_password()
+      user = set_passkey_mode(user, :disabled)
+
+      assert {:ok, %User{}} = Login.authenticate(%{name: user.name, password: password})
+    end
+  end
+end

--- a/test/grappa/accounts/login_test.exs
+++ b/test/grappa/accounts/login_test.exs
@@ -33,7 +33,7 @@ defmodule Grappa.Accounts.LoginTest do
     enrollment = TOTP.new_enrollment(user, "Grappa test")
     previous_step = System.system_time(:second) - 30
     {:ok, code} = TOTP.code_at(enrollment.secret, previous_step)
-    {:ok, _recovery_codes} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
+    {:ok, _} = TOTP.confirm_enrollment(user, enrollment.secret, code, previous_step)
     user
   end
 
@@ -46,7 +46,7 @@ defmodule Grappa.Accounts.LoginTest do
     end
 
     test "a wrong password is refused as :invalid_credentials" do
-      {user, _password} = user_fixture_with_password()
+      {user, _} = user_fixture_with_password()
 
       assert {:error, :invalid_credentials} =
                Login.authenticate(%{name: user.name, password: "not-the-password"})
@@ -75,7 +75,7 @@ defmodule Grappa.Accounts.LoginTest do
   describe "authenticate/1 — which door the account still has to walk through" do
     test "an account in passkey :second_factor mode is sent to the passkey door" do
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :second_factor)
+      set_passkey_mode(user, :second_factor)
 
       assert {:second_factor, :passkey, %User{id: id}} =
                Login.authenticate(%{name: user.name, password: password})
@@ -88,15 +88,15 @@ defmodule Grappa.Accounts.LoginTest do
       # same 401, but the throttle must NOT be charged: the credential was
       # correct, so this is not a guess.
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :passwordless)
+      set_passkey_mode(user, :passwordless)
 
       assert {:error, :passwordless} =
                Login.authenticate(%{name: user.name, password: password})
     end
 
     test "a :passwordless account with a WRONG password is a guess, not a closed door" do
-      {user, _password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :passwordless)
+      {user, _} = user_fixture_with_password()
+      set_passkey_mode(user, :passwordless)
 
       assert {:error, :invalid_credentials} =
                Login.authenticate(%{name: user.name, password: "not-the-password"})
@@ -104,7 +104,7 @@ defmodule Grappa.Accounts.LoginTest do
 
     test "an account with TOTP armed is sent to the code door" do
       {user, password} = user_fixture_with_password()
-      user = arm_totp(user)
+      arm_totp(user)
 
       assert {:second_factor, :totp, %User{id: id}} =
                Login.authenticate(%{name: user.name, password: password})
@@ -117,10 +117,9 @@ defmodule Grappa.Accounts.LoginTest do
       # account holding both is offered the passkey.
       {user, password} = user_fixture_with_password()
 
-      user =
-        user
-        |> arm_totp()
-        |> set_passkey_mode(:second_factor)
+      user
+      |> arm_totp()
+      |> set_passkey_mode(:second_factor)
 
       assert {:second_factor, :passkey, _} =
                Login.authenticate(%{name: user.name, password: password})
@@ -130,7 +129,7 @@ defmodule Grappa.Accounts.LoginTest do
       # The third arm of the closed `passkey_mode` set, spelled so the exit is
       # exercised rather than inherited from a catch-all.
       {user, password} = user_fixture_with_password()
-      user = set_passkey_mode(user, :disabled)
+      set_passkey_mode(user, :disabled)
 
       assert {:ok, %User{}} = Login.authenticate(%{name: user.name, password: password})
     end

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -225,7 +225,7 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   defp assert_supervised_worker_appears(before, which, attempts) do
-    if MapSet.difference(supervised_pids(), before) |> Enum.any?() do
+    if Enum.any?(MapSet.difference(supervised_pids(), before)) do
       :ok
     else
       Process.sleep(10)

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -77,7 +77,6 @@ defmodule Grappa.DetachedWorkSupervisionTest do
       })
 
     park_session(ctx.subject, ctx.network.id)
-    before = supervised_count()
 
     :ok =
       Pusher.push(%{
@@ -89,20 +88,21 @@ defmodule Grappa.DetachedWorkSupervisionTest do
         own_nick: @own_nick
       })
 
-    # The worker exists and is parked — without this the count below could
-    # be read before it ever started, and an empty list would read as
-    # "unsupervised" when it means "not yet spawned".
-    assert_receive :worker_parked, 2_000
+    # The parked worker names ITSELF: the stand-in reports the pid blocked
+    # inside the call. Identity, not a count — a count is inflated by a
+    # worker another test left dying, which is exactly what made an earlier
+    # version of this test fail while the code was already correct.
+    assert_receive {:worker_parked, worker}, 2_000
 
-    assert supervised_count() > before,
+    assert MapSet.member?(supervised_pids(), worker),
            "the window-counts worker is not a child of the task supervisor"
   end
 
   test "the message-notification worker runs under the task supervisor", ctx do
-    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{private_messages_all: true})
+    set_pref(ctx.subject, :private_messages_all, true)
 
     park_presence()
-    before = supervised_count()
+    before = supervised_pids()
 
     :ok = Triggers.evaluate_and_dispatch(inbound_dm(ctx), trigger_ctx(ctx))
 
@@ -110,20 +110,36 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   test "the presence-notification worker runs under the task supervisor", ctx do
-    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{presence_online: true})
+    set_pref(ctx.subject, :presence_online, true)
 
     park_presence()
-    before = supervised_count()
+    before = supervised_pids()
 
     :ok = Triggers.dispatch_presence(@peer, :online, :transition, trigger_ctx(ctx))
 
     assert_supervised_worker_appears(before, "presence-notification")
   end
 
-  defp supervised_count do
+  # The setter validates the WHOLE preference map, so flipping one key
+  # means reading the current map through the same context that writes it
+  # rather than hand-rolling a literal here — a literal would be a second
+  # copy of the defaults, silently stale the day one of them changes.
+  defp set_pref(subject, key, value) do
+    prefs =
+      subject
+      |> UserSettings.get_notification_prefs()
+      |> Map.put(key, value)
+
+    {:ok, _} = UserSettings.put_notification_prefs(subject, prefs)
+    :ok
+  end
+
+  # A SET, not a count. Another test's worker can still be dying while this
+  # one starts; a count cannot tell "one arrived" from "one left".
+  defp supervised_pids do
     Grappa.TaskSupervisor
     |> Task.Supervisor.children()
-    |> length()
+    |> MapSet.new()
   end
 
   # An inbound DM: `channel` carries the own nick, which is what marks the
@@ -170,8 +186,8 @@ defmodule Grappa.DetachedWorkSupervisionTest do
 
   defp park_loop(notify) do
     receive do
-      {:"$gen_call", _, {:list_members, _}} ->
-        send(notify, :worker_parked)
+      {:"$gen_call", {caller, _}, {:list_members, _}} ->
+        send(notify, {:worker_parked, caller})
         park_loop(notify)
 
       _ ->
@@ -209,7 +225,7 @@ defmodule Grappa.DetachedWorkSupervisionTest do
   end
 
   defp assert_supervised_worker_appears(before, which, attempts) do
-    if supervised_count() > before do
+    if MapSet.difference(supervised_pids(), before) |> Enum.any?() do
       :ok
     else
       Process.sleep(10)

--- a/test/grappa/detached_work_supervision_test.exs
+++ b/test/grappa/detached_work_supervision_test.exs
@@ -1,0 +1,219 @@
+defmodule Grappa.DetachedWorkSupervisionTest do
+  @moduledoc """
+  The work handed off the session hot path belongs to the application's
+  task supervisor, not to nobody.
+
+  Three places take work off the session process so the session is not
+  blocked by it. Being SUPERVISED and being BOUNDED are different
+  properties, and only the first is asserted here: a supervised worker is
+  visible to the operator, its crash is a report instead of a silent
+  disappearance, and it is attached to a place where a ceiling could later
+  be configured. **It is not itself a ceiling.** Nothing in the tree
+  configures one, and this file deliberately asserts nothing about how
+  many workers may exist at once — an assertion of that kind would claim
+  a control the code does not have.
+
+  ## Why each test holds its worker still
+
+  A worker that has already finished looks exactly like one that was never
+  supervised: the supervisor's child list is empty either way. So each
+  test parks its worker and asks the supervisor while it is parked.
+
+  The two paths park in different places, because they block on different
+  things, and both parks are real infrastructure rather than a stand-in
+  for the thing under test:
+
+    * the window-counts worker resolves a live member count, which is a
+      call into the session — so a process registered where the session
+      would be, which never answers, parks it;
+
+    * the notification workers consult the presence singleton before they
+      fan out — so suspending that singleton with OTP's own `:sys.suspend/1`
+      parks them. Their preferences are set so the predicate ahead of that
+      consultation is true; otherwise the worker would short-circuit and
+      retire before it could be observed.
+
+  `async: false` — parks a node-wide singleton and reads a supervisor
+  every other test also feeds.
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{AuthFixtures, ScrollbackHelpers, UserSettings, WSPresence}
+  alias Grappa.Push.Triggers
+  alias Grappa.Scrollback.Message
+  alias Grappa.Session.Server
+  alias Grappa.WindowCounts.Pusher
+
+  @channel "#chan"
+  @own_nick "vjt"
+  @peer "alice"
+
+  setup do
+    user = AuthFixtures.user_fixture()
+    network = AuthFixtures.network_fixture()
+    subject = {:user, user.id}
+
+    :ok = WSPresence.reset_for_test()
+    :ok = WSPresence.register(user.name, self())
+
+    on_exit(fn ->
+      resume_presence()
+      WSPresence.reset_for_test()
+    end)
+
+    %{user: user, network: network, subject: subject, label: user.name}
+  end
+
+  test "the window-counts worker runs under the task supervisor", ctx do
+    {:ok, _} =
+      ScrollbackHelpers.insert(%{
+        user_id: ctx.user.id,
+        network_id: ctx.network.id,
+        channel: @channel,
+        server_time: System.unique_integer([:positive]),
+        kind: :privmsg,
+        sender: @peer,
+        body: "hi"
+      })
+
+    park_session(ctx.subject, ctx.network.id)
+    before = supervised_count()
+
+    :ok =
+      Pusher.push(%{
+        subject: ctx.subject,
+        network_id: ctx.network.id,
+        network_slug: ctx.network.slug,
+        subject_label: ctx.label,
+        channel: @channel,
+        own_nick: @own_nick
+      })
+
+    # The worker exists and is parked — without this the count below could
+    # be read before it ever started, and an empty list would read as
+    # "unsupervised" when it means "not yet spawned".
+    assert_receive :worker_parked, 2_000
+
+    assert supervised_count() > before,
+           "the window-counts worker is not a child of the task supervisor"
+  end
+
+  test "the message-notification worker runs under the task supervisor", ctx do
+    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{private_messages_all: true})
+
+    park_presence()
+    before = supervised_count()
+
+    :ok = Triggers.evaluate_and_dispatch(inbound_dm(ctx), trigger_ctx(ctx))
+
+    assert_supervised_worker_appears(before, "message-notification")
+  end
+
+  test "the presence-notification worker runs under the task supervisor", ctx do
+    {:ok, _} = UserSettings.put_notification_prefs(ctx.subject, %{presence_online: true})
+
+    park_presence()
+    before = supervised_count()
+
+    :ok = Triggers.dispatch_presence(@peer, :online, :transition, trigger_ctx(ctx))
+
+    assert_supervised_worker_appears(before, "presence-notification")
+  end
+
+  defp supervised_count do
+    Grappa.TaskSupervisor
+    |> Task.Supervisor.children()
+    |> length()
+  end
+
+  # An inbound DM: `channel` carries the own nick, which is what marks the
+  # row as a DM to the notification predicate, and the sender is someone
+  # else so the own-row exclusion does not fire.
+  defp inbound_dm(ctx) do
+    %Message{
+      kind: :privmsg,
+      channel: @own_nick,
+      dm_with: @peer,
+      sender: @peer,
+      body: "ping",
+      network_id: ctx.network.id,
+      server_time: DateTime.utc_now()
+    }
+  end
+
+  defp trigger_ctx(ctx) do
+    %{
+      subject: ctx.subject,
+      subject_label: ctx.label,
+      network_slug: ctx.network.slug,
+      own_nick: @own_nick
+    }
+  end
+
+  # Registered where the session would be; answers nothing, so the caller
+  # stays inside its call for as long as the test needs it there.
+  defp park_session(subject, network_id) do
+    key = Server.registry_key(subject, network_id)
+    ready = self()
+
+    pid =
+      spawn(fn ->
+        {:ok, _} = Registry.register(Grappa.SessionRegistry, key, nil)
+        send(ready, :parker_ready)
+        park_loop(ready)
+      end)
+
+    assert_receive :parker_ready, 1_000
+    on_exit(fn -> Process.exit(pid, :kill) end)
+    pid
+  end
+
+  defp park_loop(notify) do
+    receive do
+      {:"$gen_call", _, {:list_members, _}} ->
+        send(notify, :worker_parked)
+        park_loop(notify)
+
+      _ ->
+        park_loop(notify)
+    end
+  end
+
+  # OTP's own suspend: the singleton stops serving calls, so anything that
+  # consults it waits. Not a stub — the real process, held.
+  defp park_presence do
+    WSPresence |> Process.whereis() |> :sys.suspend()
+  end
+
+  defp resume_presence do
+    case Process.whereis(WSPresence) do
+      nil -> :ok
+      pid -> :sys.resume(pid)
+    end
+  end
+
+  # These workers give no signal of their own, so there is nothing to wait
+  # for that is independent of the property under test: the appearance of a
+  # supervised child IS the assertion, and its absence within the window is
+  # the failure. Deliberately NOT followed by a second `assert` on the same
+  # count — that assert could never fail, and a pair of statements where one
+  # cannot fail reads like two checks while being one.
+  #
+  # Polled rather than slept on: a fixed sleep would be a guess about spawn
+  # latency, and the guess would decide the verdict on a loaded machine.
+  defp assert_supervised_worker_appears(before, which),
+    do: assert_supervised_worker_appears(before, which, 200)
+
+  defp assert_supervised_worker_appears(_, which, 0) do
+    flunk("the #{which} worker is not a child of the task supervisor")
+  end
+
+  defp assert_supervised_worker_appears(before, which, attempts) do
+    if supervised_count() > before do
+      :ok
+    else
+      Process.sleep(10)
+      assert_supervised_worker_appears(before, which, attempts - 1)
+    end
+  end
+end

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -62,8 +62,11 @@ defmodule Grappa.Session.RecoverProgressTest do
   defp explore([], seen, terminals), do: %{states: seen, terminals: terminals}
 
   defp explore([{fsm, rows, path} | queue], seen, terminals) do
-    {next_queue, next_seen, next_terminals} =
-      Enum.reduce(@inputs, {queue, seen, terminals}, fn input, {q, s, t} ->
+    # The frontier this node opens is built by PREPENDING and reversed once at
+    # the end, then appended to the queue as a whole — breadth-first order kept
+    # without growing the queue one `++ [item]` at a time.
+    {frontier, next_seen, next_terminals} =
+      Enum.reduce(@inputs, {[], seen, terminals}, fn input, {f, s, t} ->
         {next_fsm, steps} = hop(fsm, input)
         next_rows = upsert(rows, steps)
         next_path = [input | path]
@@ -71,24 +74,24 @@ defmodule Grappa.Session.RecoverProgressTest do
 
         cond do
           Map.has_key?(s, key) ->
-            {q, s, t}
+            {f, s, t}
 
           next_fsm.phase in [:succeeded, :failed] ->
             terminal = %{phase: next_fsm.phase, from: fsm.phase, rows: next_rows, path: next_path}
-            {q, Map.put(s, key, true), [terminal | t]}
+            {f, Map.put(s, key, true), [terminal | t]}
 
           true ->
-            {q ++ [{next_fsm, next_rows, next_path}], Map.put(s, key, true), t}
+            {[{next_fsm, next_rows, next_path} | f], Map.put(s, key, true), t}
         end
       end)
 
-    explore(next_queue, next_seen, next_terminals)
+    explore(queue ++ Enum.reverse(frontier), next_seen, next_terminals)
   end
 
   # The client's rule: one row per step name, last write wins, rows nobody
   # updates are left exactly as they were.
   defp upsert(rows, steps) do
-    Enum.reduce(steps, rows, fn {step, status, _reason}, acc -> Map.put(acc, step, status) end)
+    Enum.reduce(steps, rows, fn {step, status, _}, acc -> Map.put(acc, step, status) end)
   end
 
   describe "the happy path" do

--- a/test/grappa/session/recover_progress_test.exs
+++ b/test/grappa/session/recover_progress_test.exs
@@ -17,13 +17,12 @@ defmodule Grappa.Session.RecoverProgressTest do
   for a handful of paths. These run on plain `ExUnit.Case`, `async: true`,
   with no process, no socket and no database.
 
-  Two cases carry the **#1468** defect: a terminal out of
-  `:awaiting_verb_settle` or `:awaiting_nick` leaves a step the modal already
-  showed as `:running` without a terminal status, so cic renders it spinning
-  forever beside a failed outcome. This slice MOVES the projection at parity
-  and does not cure it — the two tests below assert what the code does today
-  and say so in their names, so the #1468 fix cannot land without turning
-  them red.
+  **#1468 cured here.** Two terminals used to leave a step the modal already
+  showed as `:running` without a terminal status, so cic rendered it spinning
+  forever beside a failed outcome. The examples below pin each cured terminal,
+  but the assertion that actually holds the rule is the exhaustive walk at the
+  bottom: one example per leg is how the gap survived a rule, a test for the
+  rule, and a review.
   """
   use ExUnit.Case, async: true
 
@@ -41,6 +40,56 @@ defmodule Grappa.Session.RecoverProgressTest do
   end
 
   defp advance(fsm, inputs), do: Enum.reduce(inputs, fsm, fn i, acc -> elem(hop(acc, i), 0) end)
+
+  @inputs [
+    :start,
+    :r_observed,
+    {:nick_error, 433},
+    {:nick_error, 437},
+    :settle,
+    :nick_observed,
+    :timeout
+  ]
+
+  # Breadth-first to fixpoint over {phase, verb, rows}. Terminals are
+  # recorded and NOT expanded: what happens after the FSM stops is the
+  # host's business, and a self-loop there would only re-emit the same
+  # terminal projection forever.
+  defp walk do
+    explore([{start_fsm(), %{}, []}], %{}, [])
+  end
+
+  defp explore([], seen, terminals), do: %{states: seen, terminals: terminals}
+
+  defp explore([{fsm, rows, path} | queue], seen, terminals) do
+    {next_queue, next_seen, next_terminals} =
+      Enum.reduce(@inputs, {queue, seen, terminals}, fn input, {q, s, t} ->
+        {next_fsm, steps} = hop(fsm, input)
+        next_rows = upsert(rows, steps)
+        next_path = [input | path]
+        key = {next_fsm.phase, next_fsm.verb, next_rows}
+
+        cond do
+          Map.has_key?(s, key) ->
+            {q, s, t}
+
+          next_fsm.phase in [:succeeded, :failed] ->
+            terminal = %{phase: next_fsm.phase, from: fsm.phase, rows: next_rows, path: next_path}
+            {q, Map.put(s, key, true), [terminal | t]}
+
+          true ->
+            {q ++ [{next_fsm, next_rows, next_path}], Map.put(s, key, true), t}
+        end
+      end)
+
+    explore(next_queue, next_seen, next_terminals)
+  end
+
+  # The client's rule: one row per step name, last write wins, rows nobody
+  # updates are left exactly as they were.
+  defp upsert(rows, steps) do
+    Enum.reduce(steps, rows, fn {step, status, _reason}, acc -> Map.put(acc, step, status) end)
+  end
 
   describe "the happy path" do
     test "the start transition sets BOTH the nick and the identify step running" do
@@ -116,31 +165,85 @@ defmodule Grappa.Session.RecoverProgressTest do
     end
   end
 
-  # #1468 — the two terminals that do NOT reconcile every started step. Both
-  # paths ran through `:idle -> :awaiting_r`, which set `identify: :running`,
-  # and neither terminal ever gives that step a final status. cic upserts step
-  # rows by name (`recoverProgress.ts`) and `RecoverModal` keeps rendering
-  # `is-running` regardless of the outcome, so the modal ends with identify
-  # spinning next to a failed result.
-  #
-  # This slice moves the projection AT PARITY: curing the defect here would be
-  # a behaviour change hidden inside a refactor. The assertions below pin what
-  # the code does today, and their names say it is a defect — the #1468 fix
-  # turns them red, which is exactly what should happen.
-  describe "terminals that strand a step (#1468 — moved here unchanged, not cured)" do
-    test "#1468 — a deadline in :awaiting_verb_settle reports ONLY the verb" do
+  # #1468 — the two terminals that used to strand a step. Both paths ran
+  # through `:idle -> :awaiting_r`, which sets `identify: :running`, and
+  # neither terminal gave that step a final status. cic upserts step rows by
+  # name (`recoverProgress.ts`) and `RecoverModal` keeps rendering `is-running`
+  # regardless of the outcome, so the modal ended with identify spinning beside
+  # a failed result.
+  describe "terminals that used to strand a step (#1468)" do
+    test "#1468 — a deadline in :awaiting_verb_settle reconciles identify and nick too" do
       fsm = advance(start_fsm(), [:start, {:nick_error, 433}])
 
-      # Neither `identify` (running since the start) nor `nick` (running again
-      # after a retry) is reconciled.
-      assert {_, [{:recover, :failed, :services_declined}]} = hop(fsm, :timeout)
+      # `identify` has been running since the start transition; `nick` is
+      # either already :failed (first pass) or :running again (after a retry),
+      # and this projection cannot tell those apart — so it reconciles both.
+      assert {_, steps} = hop(fsm, :timeout)
+      assert {:identify, :failed, :services_declined} in steps
+      assert {:nick, :failed, :services_declined} in steps
+      assert {:recover, :failed, :services_declined} in steps
     end
 
-    test "#1468 — a deadline in :awaiting_nick reports ONLY the nick" do
+    test "#1468 — a deadline in :awaiting_nick reconciles the identify step too" do
       fsm = advance(start_fsm(), [:start, {:nick_error, 433}, :settle])
 
-      # `identify` has been :running since the start transition and stays there.
-      assert {_, [{:nick, :failed, :nick_unavailable}]} = hop(fsm, :timeout)
+      assert {_, steps} = hop(fsm, :timeout)
+      assert {:nick, :failed, :nick_unavailable} in steps
+      assert {:identify, :failed, :nick_unavailable} in steps
+    end
+  end
+
+  # ── The rule itself, over the whole reachable graph ────────────────────────
+  #
+  # #623 pt3's rule is "no step may be left :running when the recovery reaches
+  # a terminal state". One example per leg is exactly how #1468 survived: the
+  # rule existed, a test for the rule existed on the sibling leg, and the
+  # clause next door did not honour it.
+  #
+  # This is an EXHAUSTIVE WALK rather than a StreamData property, and the
+  # difference matters. The reachable space is finite and small — a phase, a
+  # verb, and one status per step name — so a breadth-first search to fixpoint
+  # is a PROOF over every reachable path, retry loops included, instead of a
+  # sample of them. A generator would rediscover the same handful of states
+  # with a seed that can be lucky; this cannot be lucky, and cannot flake.
+  #
+  # The accumulated rows mirror the CLIENT's rule, not a convenient one:
+  # `recoverProgress.ts` upserts by step name, last write wins, and never
+  # touches a row nobody updated. That is why a Map keyed by step name is the
+  # faithful model of "what the modal is showing when the modal closes".
+  describe "#623 pt3, proven over every reachable transition (#1468)" do
+    test "no reachable terminal leaves a step :running" do
+      %{terminals: terminals, states: states} = walk()
+
+      # Vacuity floors. A walk that explored nothing, or never reached a
+      # terminal, would satisfy the assertion below by having nothing to check.
+      assert map_size(states) > 10,
+             "the walk explored only #{map_size(states)} states — the search is broken"
+
+      assert length(terminals) >= 4,
+             "the walk reached only #{length(terminals)} terminals"
+
+      # ...and it must reach a terminal out of EVERY phase that can fail, or a
+      # future clause could strand rows on a leg this never visits.
+      failed_from =
+        terminals
+        |> Enum.filter(fn %{phase: phase} -> phase == :failed end)
+        |> Enum.map(& &1.from)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert failed_from == [:awaiting_final_r, :awaiting_nick, :awaiting_r, :awaiting_verb_settle]
+
+      for %{rows: rows, path: path, phase: phase, from: from} <- terminals do
+        running = for {step, status} <- rows, status == :running, do: step
+
+        assert running == [],
+               """
+               terminal #{inspect(phase)} out of #{inspect(from)} left #{inspect(running)} at :running.
+               path:  #{inspect(Enum.reverse(path))}
+               rows:  #{inspect(rows)}
+               """
+      end
     end
   end
 end

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -1464,6 +1464,35 @@ defmodule GrappaWeb.AuthControllerTest do
       assert json_response(wrong_login(conn, user, 2), 401)["error"] == "invalid_credentials"
     end
 
+    test "a passwordless account's RIGHT password is refused without charging", %{conn: conn} do
+      # #1395 made this distinction explicit: `Accounts.Login.authenticate/1`
+      # answers `:passwordless` rather than `:invalid_credentials`, and only
+      # the latter reaches `charge_mode1_failure/1`. Both leave as the same
+      # uniform 401, so the ONLY observable difference is the counter — and
+      # nothing asserted it before, which is what let the two tags look
+      # interchangeable. Charging here would spend a user's own window on a
+      # configuration choice they made, not on anybody's guess.
+      {user, password} = user_fixture_with_password()
+
+      user
+      |> Ecto.Changeset.change(passkey_mode: :passwordless)
+      |> Repo.update!()
+
+      right_password = fn ->
+        conn
+        |> with_ip(6)
+        |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => password})
+      end
+
+      for _ <- 1..10 do
+        assert json_response(right_password.(), 401)["error"] == "invalid_credentials"
+      end
+
+      # @mode1_max_failures is 10, so the 11th attempt is 429 the moment any
+      # of the ten above charged the window. Still 401 means none did.
+      assert json_response(right_password.(), 401)["error"] == "invalid_credentials"
+    end
+
     test "a tripped IP doesn't affect logins from another IP", %{conn: conn} do
       {user, password} = user_fixture_with_password()
 


### PR DESCRIPTION
## What

One branch carrying four already-reviewed contributions, replayed and rebased
onto `origin/main` **`236dd328`** — the main that will receive it, so the
expensive gate is paid once. Supersedes **#1485**, **#1486**, **#1479** and
**#1487**.

| replayed | source PR | branch | merge-base used | commits | contribution |
|---|---|---|---|---|---|
| 1st | #1485 | `w2-1419-s1` | `97b0ee3a` | 1 | 16/0, 1 file |
| 2nd | #1486 | `w2-1395-s1` | `97b0ee3a` | 3 | 366/29, 6 files |
| 3rd | #1479 | `w1-1468` | `caa3373a` | 2 | 241/50, 3 files |
| 4th | #1487 | `w1-1404-f1` | `97b0ee3a` | 5 | 320/20, 4 files |

**11 commits, 12 files, +943/-99.**

**#1485, #1486, #1479 and #1487 are SUPERSEDED by this branch, for content.**
Every one of their commits is replayed here with a contribution verified
identical to the original (table above, method below). The replay rewrote every
sha, so GitHub cannot close them automatically and they are deliberately left
open — they should be closed by hand once this merges.

## Why one branch instead of four

All four touch `cicchetto/src/**` or `lib/**`, so each triggers the
`integration` job — roughly forty minutes apiece — and merging any one makes
the rest stale. Four separate merges is four full gates in series. This is one
gate and one merge.

## What each part does

- **#1485 / #1419** — memoises the stylesheet parse in `modalChrome.test.ts`.
  Profiled first: 1427 parses of a 435 KB sheet, `2 x (N + 1)` for N = 712 bare
  class selectors, **1117 ms of the test's 1185 ms (94.3%)**. That test drops to
  **49 ms**. The 5 s budget is deliberately left at the default — the body has
  no temporal oracle, so raising it would have hidden the cost.
- **#1486 / #1395** — gives the user password door a decision function callable
  without a `Plug.Conn`, `Grappa.Accounts.Login.authenticate/1`. The throttles,
  the second-factor challenge and the rendering deliberately stay at the request
  edge. Adds the pin that a `:passwordless` refusal never charges the mode-1
  window — the only observable distinguishing it from `:invalid_credentials`.
- **#1479 / #1468** — w1's work on the recover walk's terminal clauses.
- **#1487 / #1404** — w1's work handing the three detached hand-offs to the
  supervisor that exists for them.

**Both of w1's contributions were replayed byte-identical and their content was
not modified in any way.**

## Do the four actually touch each other

Measured at two levels, not assumed.

**Changed-file sets, pairwise:**

```
1485 ∩ 1486 : (empty)      1486 ∩ 1479 : docs/DESIGN_NOTES.md
1485 ∩ 1479 : (empty)      1486 ∩ 1487 : docs/DESIGN_NOTES.md
1485 ∩ 1487 : (empty)      1479 ∩ 1487 : docs/DESIGN_NOTES.md
```

The only contact between any two is the decision log. **Zero code overlap.**

**Symbols** — file names being disjoint is not the same as symbols being
disjoint, so:

- modules defined: `Grappa.Accounts`, `Grappa.Accounts.Login`,
  `GrappaWeb.AuthController` (#1486) · `Grappa.Session.RecoverProgress` (#1479)
  · `Grappa.Push.Triggers`, `Grappa.WindowCounts.Pusher` (#1487). **No module
  defined twice.**
- cross-references between any two parts' changed files: **none, in either
  direction**.
- public surface: the single `1/1` line in `accounts.ex` is a pure **addition**
  to Boundary's `exports:` list (`Login`), which cannot break a consumer; the
  set of public functions in `auth_controller.ex` and `recover_progress.ex` is
  **unchanged** pre/post. The extractor for that was validated arithmetically
  (5 = 5 and 7 = 7 two-space `def`s), so no paren-less `def foo do` escaped it.

What none of that can see is a type flowing through a third module no diff
touches — which is what `check.sh` below is for.

## Replay fidelity

Each part's `--numstat` was pinned to a file against its own merge-base BEFORE
the replay and re-diffed against its span in the union afterwards, and again
after the rebase onto `236dd328`. **All four identical every time**, deletions
preserved exactly.

Union total `+943/-99` over 12 files equals `16+366+241+320` / `0+29+50+20`,
and `1 + 6 + 3 + 4 - 2` files (the `-2` because `DESIGN_NOTES` is shared by
three of the four). Nothing entered the union that did not come from one of
them.

## DESIGN_NOTES

Three entries arrive: **#1395** (62 lines), **#1468** (58) and **#1404e** (50).

| check | result |
|---|---|
| additions / deletions, per part, both sides | 62/0, 58/0, 50/0 — deletions zero |
| total | 170/0 |
| markers | 82 → **85** |
| duplicate markers | **none** |
| `grep -Fxc` per marker | `#1395` = 1, `#1468` = 1, `#1404e` = 1 |
| `_Deploy:` before / after | **66 / 66** |
| line count | **47293 = 47123 + 62 + 58 + 50**, exact |
| boundary shape, read on the file, at ALL THREE boundaries | previous entry's closing line / marker with NO blank before it / blank / `---` / blank / `## <date> — #NNNN: …` |
| marker positions | `#1395` **47124 = 47123 + 1**, `#1468` **47186 = +62**, `#1404e` **47244 = +58** |
| **every previous entry intact** | the file's **first 47123 lines are byte-identical to `origin/main`'s copy** — a `diff`, not a line count — so `#1397`'s freshly-landed entry, and every one before it, survives character for character |

`scripts/design-notes-gate.sh` — **RC=0**, "3 new entry heading(s), separator
and marker present".

### A correction to how that was checked

The marker on #1487's entry is `<!-- entry #1404e -->`, not `#1404`: `#1404a`
through `#1404d` are already on main, so the letter is the established way of
keeping the marker unique across that issue's slices, and `#1404e` is unique.

Finding it exposed a weakness in the duplicate check as it was first run here:
the pattern `^<!-- entry #[0-9]* -->` is blind to every suffixed marker, and
main carries **eleven** of them (`#1308-ip`, `#1406 X-S4`, `#1390 slice 2`,
`#1336 S2`, `#1447 slice A`, …). Redone with `^<!-- entry #[^>]*-->`, which
sees all 85: **no duplicates, exactly three new**. The earlier answer was
right; the check that produced it was weaker than it was described as being.

## Gates

Read from files rather than `$?`, and phase by phase, because both runners
abort at the first red and a green downstream of an abort does not exist.

- `scripts/bun.sh run check` — **RC=0**. The script is `biome && tsc && tsc`,
  so RC=0 means all three ran.
- `scripts/bun.sh run test` — **RC=0, 290/290 files, 5598/5598 tests**.
- `scripts/check.sh` — **RC=0**, phase by phase:

  | phase | result |
  |---|---|
  | Credo strict | 685 source files, no issues |
  | Sobelow | findings only in files no part of this branch touches (uploads, reaper, background_image, isupport, hot_reload, cic/bundle, hardened_cmd, repo) — **none** in `push/triggers.ex`, `window_counts/pusher.ex`, `accounts.ex`, `accounts/login.ex`, `auth_controller.ex` or `recover_progress.ex`. The gate is Medium-or-above; all findings are Low |
  | Doctor | passed |
  | ExUnit | **8 doctests, 61 properties, 6536 tests, 0 failures** |
  | Dialyzer | **Total errors: 0**, Skipped 0 |
  | bats | **564 ok / 0 not ok** |

  Run on the four-part branch at `d8b58e2d`, base `236dd328`. For reference,
  the three-part state of this same branch also gated **RC=0** (6533 tests),
  so the fourth part added 3 tests and broke nothing.

The two cic gates were run on an earlier state of this branch. They still hold,
and not by assumption: `git diff` over `cicchetto/` between the gated tree and
this one is **empty**, and `scripts/bun.sh` bind-mounts **only** `cicchetto/`
as `/app`. Byte-identical input, identical run.

## Not claimed

- CI status: not polled, by instruction.
- The four source PRs are **left open on purpose**. The replay rewrote every
  sha, so GitHub will not close them automatically, and they should be closed
  by hand for content once this merges.
