### PR TITLE
arch(#1398): pin the cycle count the acyclicity proof cannot see

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47121,3 +47121,68 @@ three axes (timeout `1_000` ×11 vs `5_000` ×2, prefix `"USER"` ×12 vs `"USER 
 decision: two files have already found one second insufficient. Consolidating it
 is choosing a barrier value, not removing a duplicate, and it must be bought with
 its own reason.
+<!-- entry #1398 -->
+
+---
+
+## 2026-08-17 — #1398: pin the cycle count the acyclicity proof cannot see
+
+The declared Boundary graph is acyclic and the compiler enforces that: `mix.exs`
+puts `:boundary` in `compilers` with `check: [in: true, out: true]`, so a declared
+cycle never reaches CI. What nothing watches is the other half.
+
+### Why a waiver is an invisible edge
+
+A `dirty_xrefs` entry is a real dependency the checker has been told to ignore.
+Counting the five current waivers as the edges they are turns the acyclic graph
+into **31 elementary cycles over 12 boundaries**. That is not a new defect — it is
+the same one the 2026-08-15 architecture review found, and the one the 2026-07-20
+review found before it with three waivers instead of five. The population grew and
+nothing noticed, twice, until a human read the annotations by hand.
+
+This entry adds no fix. It adds a **ratchet**: a test that counts the cycles closed
+by declared deps plus waivers and fails when the number rises above a pinned
+budget. The next waiver that closes a cycle now has to be argued for in the diff
+that introduces it.
+
+### What the number is, and how it was reached
+
+31, measured on `236dd328`: 1 cycle of length 2, 4 of length 3, 11 of length 4,
+11 of length 5, 4 of length 6, all fed by five waivers that every one of them
+names `Grappa.Networks.Network`. The shortest is `Networks -> Scrollback ->
+Networks` — two nodes, touching neither `Session` nor `LiveIntrospection`, which
+is why the review's "five cycles sharing one prefix" does not describe the shape.
+The highest-leverage single arc is `Scrollback -> Networks` at 19 of the 31, and
+**no single arc cuts all of them.**
+
+Three independent measurements agree on 31: two hand-written source parsers and
+this gate. The gate is the one to trust, because it reads the **compiled
+`Boundary` attribute** — the same annotation `GrappaWeb.BoundaryTest` and
+`Grappa.Visitors.VisitorBoundaryTest` read, and the source CLAUDE.md's
+architecture-test rule points at ("use `Boundary` annotations — not
+string-matching"). The two source parsers disagreed with each other about how many
+`use Boundary` blocks even exist (99 against 107) while agreeing on the cycles; a
+disagreement about the input is exactly the failure mode reading the compiler's
+own record avoids.
+
+### The declared limit of this gate
+
+It counts DECLARED edges plus waivers, and nothing else. The runtime edges this
+codebase relies on for cycle avoidance — the injected closures, the behaviours
+resolved from `:persistent_term`, the supervisor-level `held_source_fn` — carry no
+module reference, so no compile-time mechanism can see them and none of them move
+this number. A closure that opens a cycle passes this gate silently. That limit is
+written into the test body rather than left for a reader to infer, because a gate
+whose blind spot is undocumented gets read as broader than it is.
+
+### Direction, recorded but not taken
+
+Removing the five waivers is equivalent to zeroing the set, since the declared
+graph is already acyclic. All five name the same target, and this repo has
+executed that move once before: the twelve `dirty_xrefs: [Grappa.Visitors.Visitor]`
+waivers went to zero by promoting the schema to a `top_level?: true` boundary with
+empty `deps:`. The same move here cannot be scoped to `Network` alone —
+`networks/network.ex` aliases the `has_many` siblings it binds, so the minimum unit
+is the four-schema cluster, priced at roughly fifteen files and atomic. That is a
+purchase, not a slice, and it is deliberately left to #1398 rather than smuggled in
+behind a gate.

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -95,7 +95,7 @@ defmodule Grappa.BoundaryCycleBudgetTest do
     end
   end
 
-  defp dep_name({module, _mode}), do: module
+  defp dep_name({module, _}), do: module
   defp dep_name(module) when is_atom(module), do: module
 
   @spec owning_boundary(module(), MapSet.t(module())) :: module() | nil

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -1,0 +1,149 @@
+defmodule Grappa.BoundaryCycleBudgetTest do
+  use ExUnit.Case, async: true
+
+  # #1398 — the declared Boundary graph is acyclic, and the compiler already
+  # enforces that half: `mix.exs` puts `:boundary` in `compilers` with
+  # `check: [in: true, out: true]`, so a declared cycle cannot reach CI.
+  #
+  # The half nothing watches is `dirty_xrefs`. A waiver is a real dependency
+  # the checker has been told to ignore, so every waiver is an edge the
+  # acyclicity proof does not see — and counting them turns the acyclic graph
+  # into a large cyclic one. That population grew from 3 waivers to 5 between
+  # the 2026-07-20 and 2026-08-15 reviews with nothing to notice it; the growth
+  # was found by a human reading annotations, twice.
+  #
+  # This gate is a ratchet, not a fix. It pins the number so the next waiver
+  # that closes a cycle has to be argued for in a diff instead of arriving
+  # unremarked. Lowering @cycle_budget when the number drops is the point;
+  # raising it is a decision that belongs in review.
+  @cycle_budget 31
+
+  # Measured 2026-08-17 on `origin/main` = 236dd328: 31 elementary cycles over
+  # 12 boundaries (1 of length 2, 4 of length 3, 11 of length 4, 11 of length 5,
+  # 4 of length 6), from 5 waivers all naming `Grappa.Networks.Network`. The
+  # single highest-leverage arc is `Scrollback -> Networks` at 19 of the 31; no
+  # single arc kills them all. Method: the compiled `Boundary` attribute, the
+  # same source `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest`
+  # read — NOT a source parse. An earlier hand-rolled regex parser disagreed with
+  # a second one about how many `use Boundary` blocks even exist (99 vs 107),
+  # which is exactly why this reads the annotation the compiler kept.
+  #
+  # Declared scope, stated so it is not mistaken for more: this counts DECLARED
+  # deps plus waivers. Runtime edges — the injected closures, behaviours resolved
+  # from `:persistent_term`, the supervisor-level `held_source_fn` — carry no
+  # module reference for any compile-time mechanism to see, so they are absent
+  # here and the true runtime graph is denser. A closure that opens a cycle will
+  # not move this number.
+  test "dirty_xref waivers close no more boundary cycles than the pinned budget" do
+    graph = boundary_graph()
+    cycles = elementary_cycles(graph)
+    count = length(cycles)
+
+    assert count <= @cycle_budget, """
+    Boundary cycle count rose to #{count}, above the pinned budget of #{@cycle_budget}.
+
+    A `dirty_xrefs` waiver is an edge the Boundary checker was told to ignore, so
+    the compiler stays green while the dependency graph gains a cycle. Either the
+    new waiver is wrong, or the budget moves — deliberately, in this diff, with the
+    reason written down.
+
+    Cycles now closed (shortest first):
+    #{format_cycles(cycles)}
+    """
+  end
+
+  @spec boundary_graph() :: %{module() => MapSet.t(module())}
+  defp boundary_graph do
+    defs = boundary_defs()
+    names = defs |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+
+    Map.new(defs, fn {name, opts} ->
+      deps =
+        opts
+        |> Keyword.get(:deps, [])
+        |> Enum.map(&dep_name/1)
+        |> Enum.filter(&MapSet.member?(names, &1))
+
+      # A waiver names a MODULE, not a boundary — resolve it to the boundary
+      # that owns it (longest declared prefix), which is the edge it really is.
+      waived =
+        opts
+        |> Keyword.get(:dirty_xrefs, [])
+        |> Enum.map(&owning_boundary(&1, names))
+        |> Enum.reject(&is_nil/1)
+
+      {name, (deps ++ waived) |> Enum.reject(&(&1 == name)) |> MapSet.new()}
+    end)
+  end
+
+  @spec boundary_defs() :: [{module(), keyword()}]
+  defp boundary_defs do
+    {:ok, modules} = :application.get_key(:grappa, :modules)
+
+    for module <- modules,
+        Code.ensure_loaded?(module),
+        opts = boundary_opts(module),
+        not is_nil(opts),
+        do: {module, opts}
+  end
+
+  @spec boundary_opts(module()) :: keyword() | nil
+  defp boundary_opts(module) do
+    case Keyword.get(module.__info__(:attributes), Boundary) do
+      [%{opts: opts}] when is_list(opts) -> opts
+      _ -> nil
+    end
+  end
+
+  defp dep_name({module, _mode}), do: module
+  defp dep_name(module) when is_atom(module), do: module
+
+  @spec owning_boundary(module(), MapSet.t(module())) :: module() | nil
+  defp owning_boundary(module, names) do
+    prefix = Module.split(module)
+
+    prefix
+    |> Enum.count()
+    |> then(&Enum.to_list(&1..1//-1))
+    |> Enum.map(&Module.concat(Enum.take(prefix, &1)))
+    |> Enum.find(&MapSet.member?(names, &1))
+  end
+
+  # Elementary cycles by DFS from each node, admitting only successors whose
+  # position is at or after the start node's — the standard trick that yields
+  # each cycle once, at its lowest-ordered member, instead of once per rotation.
+  @spec elementary_cycles(%{module() => MapSet.t(module())}) :: [[module()]]
+  defp elementary_cycles(graph) do
+    nodes = graph |> Map.keys() |> Enum.sort()
+    position = nodes |> Enum.with_index() |> Map.new()
+
+    Enum.flat_map(nodes, fn start ->
+      walk(graph, position, start, start, [start], MapSet.new([start]), [])
+    end)
+  end
+
+  defp walk(graph, position, start, node, path, on_path, acc) do
+    graph
+    |> Map.fetch!(node)
+    |> Enum.sort()
+    |> Enum.reduce(acc, fn next, acc ->
+      cond do
+        Map.fetch!(position, next) < Map.fetch!(position, start) -> acc
+        next == start -> [Enum.reverse(path) | acc]
+        MapSet.member?(on_path, next) -> acc
+        true -> walk(graph, position, start, next, [next | path], MapSet.put(on_path, next), acc)
+      end
+    end)
+  end
+
+  defp format_cycles(cycles) do
+    cycles
+    |> Enum.sort_by(&{length(&1), &1})
+    |> Enum.map_join("\n", fn cycle ->
+      hops = Enum.map_join(cycle, " -> ", &short/1)
+      "      #{hops} -> #{short(hd(cycle))}"
+    end)
+  end
+
+  defp short(module), do: module |> Module.split() |> Enum.join(".")
+end


### PR DESCRIPTION
A ratchet for the half of the Boundary graph nothing watches. Two files, no
production code, no new behaviour.

## What this pins

The declared graph is acyclic and the compiler already enforces that half —
`mix.exs` puts `:boundary` in `compilers` with `check: [in: true, out: true]`.
The half nothing watches is `dirty_xrefs`: a waiver is a real dependency the
checker was told to ignore, so counting the five current waivers as the edges
they are yields **31 elementary cycles over 12 boundaries** while the build stays
green.

That population went from 3 waivers to 5 between the 2026-07-20 and 2026-08-15
reviews with nothing to notice it. Both times a human found it by reading
annotations. This gate makes the next one argue for itself in the diff that
introduces it.

It is explicitly **not** a fix for #1398. The direction that would zero the set is
recorded in the decision-log entry and deliberately left unspent.

## Why it reads the compiled attribute, not the source

The gate reads the `Boundary` module attribute the compiler persists — the same
annotation `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest`
read, and what CLAUDE.md's architecture-test rule points at ("use `Boundary`
annotations — not string-matching").

That choice is load-bearing rather than stylistic. Two independently written
source parsers agreed that there are 31 cycles but **disagreed with each other
about how many `use Boundary` blocks exist at all** (99 against 107). Agreeing on
the output while disagreeing on the input is precisely the failure mode reading
the compiler's own record removes. Three measurements now agree on 31, and this
one has no parser of its own.

## Red first, and actually made to fail

The gate was committed green, then a mutant was applied to production source: a
sixth waiver on `Grappa.Mentions`, plus a real reference so the waiver is not
merely unused.

- With the mutant: **red — "cycle count rose to 37, above the pinned budget of 31"**,
  and all **6** new cycles listed in the failure message carry the injected
  `Mentions -> Networks` arc. One mutant, one assertion killed, the delta
  attributable.
- Mutant reverted, `git status --porcelain` empty, re-run: green.

`check.sh` was run twice. The first run **aborted at Credo** on a named discard
(`_mode`), which means nothing downstream of that phase had run — that is fixed in
the second commit and the suite was re-run from the start: Credo clean, 6522
tests / 0 failures, Sobelow 0 errors, Dialyzer passed, bats green.

## The blind spot, stated in the test body

The gate counts declared edges plus waivers and nothing else. The runtime
mechanisms this codebase actually leans on for cycle avoidance — the injected
closures, behaviours resolved from `:persistent_term`, the supervisor-level
`held_source_fn` — carry no module reference, so no compile-time mechanism can see
them and **none of them move this number**. A closure that opens a cycle passes
this gate silently. That limit is written into the test rather than left for a
reader to infer, because an undocumented blind spot gets read as coverage.

## Not established

The 31 is a count over declared plus waived edges on one commit; the true runtime
graph is denser and was not enumerated. Nothing here was tested against production
or a live session.
