### PR TITLE
cic(#1400 slice 1): validate the nine REST doors whose schema already existed

### DIFF
--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1241,3 +1241,179 @@ describe("converted REST doors fail loud on a shape mismatch (#1400)", () => {
     await expect(api.adminCreateVhost("t", { address: "1.2.3.4" })).resolves.toEqual(vhost);
   });
 });
+
+// ── #1400 slice 1 — the doors whose schema was ALREADY generated ───
+//
+// Nine casts sat on shapes the codegen had already emitted, envelope
+// included: five `*IndexPayload` types byte-identical to the `{ key: T[] }`
+// written by hand in `api.ts`, the archive index, and three bare arrays of an
+// aliased element. Nothing had to be emitted for these — only wired.
+//
+// Each door gets exactly one absence test, removing ONE named required field
+// from an otherwise complete row, so a green cannot come from a fixture that
+// was malformed in several ways at once. The two additive cases at the end
+// hold the other half of the contract (#447): an undeclared key is dropped,
+// never fatal.
+
+const VISITOR_ROW = {
+  id: "3f1b9c1e-0000-4000-8000-000000000001",
+  expires_at: "2026-08-18T10:00:00Z",
+  identified: true,
+  ip: "203.0.113.7",
+  session_ip: "203.0.113.7",
+  inserted_at: "2026-08-17T09:00:00Z",
+  last_seen_at: "2026-08-17T11:30:00Z",
+  networks: [
+    {
+      network_slug: "azzurra",
+      network_id: 1,
+      nick: "ospite",
+      connection_state: "connected",
+      live_state: null,
+    },
+  ],
+};
+
+const SESSION_ROW = {
+  subject_kind: "user",
+  subject_id: "3f1b9c1e-0000-4000-8000-000000000002",
+  subject_label: "vjt",
+  last_seen_at: "2026-08-17T11:30:00Z",
+  network_id: 1,
+  live_state: {
+    nick: "vjt",
+    alive: true,
+    pid_inspect: "#PID<0.812.0>",
+    mailbox_len: 0,
+    memory_bytes: 148_312,
+    joined_channels: ["#italia"],
+    peer_address: "203.0.113.9",
+    peer_port: 6697,
+    peer_name: null,
+    introspection_degraded: [],
+  },
+};
+
+const CHANNEL_ROW = { name: "#italia", joined: true, source: "autojoin" };
+
+const MESSAGE_ROW = {
+  id: 4321,
+  network: "azzurra",
+  channel: "#italia",
+  server_time: 1_700_000_000,
+  kind: "privmsg",
+  sender: "vjt",
+  body: "ciao",
+  meta: {},
+};
+
+const ARCHIVE_ROW = {
+  target: "#italia",
+  kind: "channel",
+  last_activity: 1_700_000_000,
+  row_count: 942,
+};
+
+const USER_ROW = {
+  id: "3f1b9c1e-0000-4000-8000-000000000003",
+  name: "vjt",
+  is_admin: true,
+  inserted_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-17T09:00:00Z",
+  live_session_count: 2,
+};
+
+const SERVER_ROW = {
+  id: 7,
+  network_id: 1,
+  host: "irc.azzurra.org",
+  port: 6697,
+  tls: true,
+  priority: 0,
+  enabled: true,
+  source_address: null,
+  inserted_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-17T09:00:00Z",
+};
+
+const FEATURED_ROW = {
+  id: 11,
+  network_id: 1,
+  name: "#italia",
+  description: "il canale",
+  position: 0,
+  enabled: true,
+  inserted_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-17T09:00:00Z",
+};
+
+// One removal per case. `delete` on a copy rather than a rest-destructure so
+// the dropped key is named at the call site and reads as the mutation it is.
+function without(row: Record<string, unknown>, key: string): Record<string, unknown> {
+  const copy = { ...row };
+  delete copy[key];
+  return copy;
+}
+
+describe("#1400 slice 1 — the nine class-A doors reject an incomplete row", () => {
+  it("adminListVisitors rejects a visitor missing `identified`", async () => {
+    stubFetch(200, { visitors: [without(VISITOR_ROW, "identified")] });
+    await expect(api.adminListVisitors("t")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("adminListSessions rejects a session missing `subject_id`", async () => {
+    stubFetch(200, { sessions: [without(SESSION_ROW, "subject_id")] });
+    await expect(api.adminListSessions("t")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("listChannels rejects a channel missing `joined`", async () => {
+    stubFetch(200, [without(CHANNEL_ROW, "joined")]);
+    await expect(api.listChannels("t", "azzurra")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("listMessages rejects a row missing `server_time`", async () => {
+    stubFetch(200, [without(MESSAGE_ROW, "server_time")]);
+    await expect(api.listMessages("t", "azzurra", "#italia")).rejects.toBeInstanceOf(
+      WireShapeError,
+    );
+  });
+
+  it("listMessagesAfter rejects a row missing `kind`", async () => {
+    stubFetch(200, [without(MESSAGE_ROW, "kind")]);
+    await expect(api.listMessagesAfter("t", "azzurra", "#italia", 1)).rejects.toBeInstanceOf(
+      WireShapeError,
+    );
+  });
+
+  it("listArchive rejects an entry missing `row_count`", async () => {
+    stubFetch(200, { archive: [without(ARCHIVE_ROW, "row_count")] });
+    await expect(api.listArchive("t", "azzurra")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("adminListUsers rejects a user missing `is_admin`", async () => {
+    stubFetch(200, { users: [without(USER_ROW, "is_admin")] });
+    await expect(api.adminListUsers("t")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("adminListServers rejects a server missing `tls`", async () => {
+    stubFetch(200, { servers: [without(SERVER_ROW, "tls")] });
+    await expect(api.adminListServers("t", 1)).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  it("adminListFeaturedChannels rejects a channel missing `position`", async () => {
+    stubFetch(200, { featured_channels: [without(FEATURED_ROW, "position")] });
+    await expect(api.adminListFeaturedChannels("t", 1)).rejects.toBeInstanceOf(WireShapeError);
+  });
+});
+
+describe("#1400 slice 1 — an undeclared key is dropped, never fatal (#447)", () => {
+  it("tolerates a key the ENVELOPE schema does not declare", async () => {
+    stubFetch(200, { users: [USER_ROW], total: 1 });
+    await expect(api.adminListUsers("t")).resolves.toEqual([USER_ROW]);
+  });
+
+  it("tolerates a key the ELEMENT schema does not declare, and drops it", async () => {
+    stubFetch(200, [{ ...CHANNEL_ROW, topic: "benvenuti" }]);
+    await expect(api.listChannels("t", "azzurra")).resolves.toEqual([CHANNEL_ROW]);
+  });
+});

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -20,13 +20,21 @@ import type { MemberEntry } from "./memberTypes";
 // schema constants stay in one place and the failure mode stays in one place.
 import {
   narrowAdminFeaturedChannelResponse,
+  narrowAdminFeaturedChannelsResponse,
   narrowAdminServerResponse,
+  narrowAdminServersResponse,
+  narrowAdminSessionsResponse,
   narrowAdminUserResponse,
+  narrowAdminUsersResponse,
   narrowAdminVhostGrantResponse,
   narrowAdminVhostResponse,
+  narrowAdminVisitorsResponse,
+  narrowArchiveResponse,
+  narrowChannelListResponse,
   narrowCredentialResponse,
   narrowDirectoryPageResponse,
   narrowFeaturedChannelsResponse,
+  narrowMessagePageResponse,
   narrowMessageResponse,
   narrowSessionLogListResponse,
   narrowSessionLogSessionsResponse,
@@ -1835,13 +1843,10 @@ export type AdminVisitorNetwork = VisitorsAdminWireNetworkJson;
 // server-side from the credentials (any network holds a NickServ secret).
 export type AdminVisitor = VisitorsAdminWireT;
 
-export type AdminVisitorsResponse = { visitors: AdminVisitor[] };
-
 export async function adminListVisitors(token: string): Promise<AdminVisitor[]> {
   const res = await fetch("/admin/visitors", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as AdminVisitorsResponse;
-  return body.visitors;
+  return narrowAdminVisitorsResponse(await res.json()).visitors;
 }
 
 export async function adminDeleteVisitor(token: string, id: string): Promise<void> {
@@ -1871,8 +1876,6 @@ export type AdminSessionLiveState = AdminLiveState;
 
 export type AdminSession = LiveIntrospectionAdminWireT;
 
-export type AdminSessionsResponse = { sessions: AdminSession[] };
-
 // Composite session id constructor — single source for the wire
 // shape. Mirrors the server-side parse_session_id/1 in
 // `lib/grappa_web/controllers/admin/sessions_controller.ex`.
@@ -1892,8 +1895,7 @@ export function adminVisitorSessionId(v: AdminVisitor, net: AdminVisitorNetwork)
 export async function adminListSessions(token: string): Promise<AdminSession[]> {
   const res = await fetch("/admin/sessions", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as AdminSessionsResponse;
-  return body.sessions;
+  return narrowAdminSessionsResponse(await res.json()).sessions;
 }
 
 export async function adminDisconnectSession(token: string, id: string): Promise<void> {
@@ -2304,7 +2306,7 @@ export async function listChannels(token: string, networkSlug: string): Promise<
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ChannelEntry[];
+  return narrowChannelListResponse(await res.json());
 }
 
 // Mirror of `GrappaWeb.DirectoryController.index/2`. The response IS the
@@ -2358,7 +2360,7 @@ export async function listMessages(
     { headers: buildHeaders(token) },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ScrollbackMessage[];
+  return narrowMessagePageResponse(await res.json());
 }
 
 // Sole consumer (today): the WS-reconnect refresh flow in
@@ -2386,7 +2388,7 @@ export async function listMessagesAfter(
     { headers: buildHeaders(token) },
   );
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ScrollbackMessage[];
+  return narrowMessagePageResponse(await res.json());
 }
 
 // #693 — the gap probe. Mirror of `GrappaWeb.MessagesController.count/2`:
@@ -2601,8 +2603,7 @@ export async function listArchive(token: string, networkSlug: string): Promise<A
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as { archive: ArchiveEntry[] };
-  return body.archive;
+  return narrowArchiveResponse(await res.json()).archive;
 }
 
 // UX-1 (2026-05-17) — mirror of `GrappaWeb.ArchiveController.delete/2`.
@@ -2825,13 +2826,10 @@ export async function putPerform(
 
 export type AdminUser = AccountsAdminWireT;
 
-export type AdminUsersResponse = { users: AdminUser[] };
-
 export async function adminListUsers(token: string): Promise<AdminUser[]> {
   const res = await fetch("/admin/users", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as AdminUsersResponse;
-  return body.users;
+  return narrowAdminUsersResponse(await res.json()).users;
 }
 
 export type AdminUserCreate = {
@@ -2935,15 +2933,12 @@ export type AdminServerUpdate = Partial<AdminServerCreate>;
 
 export type AdminServerDeleteResponse = { network_session_count: number };
 
-export type AdminServersResponse = { servers: AdminServer[] };
-
 export async function adminListServers(token: string, networkId: number): Promise<AdminServer[]> {
   const res = await fetch(`/admin/networks/${encodeURIComponent(String(networkId))}/servers`, {
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as AdminServersResponse;
-  return body.servers;
+  return narrowAdminServersResponse(await res.json()).servers;
 }
 
 export async function adminAddServer(
@@ -3017,8 +3012,6 @@ export type AdminFeaturedChannelCreate = {
 
 export type AdminFeaturedChannelUpdate = Partial<AdminFeaturedChannelCreate>;
 
-export type AdminFeaturedChannelsResponse = { featured_channels: AdminFeaturedChannel[] };
-
 // Public on-display read consumed by HomePane. `networkSlug` resolves
 // via the :resolve_network plug (cross-user iso); 404 for a network the
 // subject isn't on.
@@ -3042,7 +3035,7 @@ export async function adminListFeaturedChannels(
     { headers: buildHeaders(token) },
   );
   if (!res.ok) throw await readError(res);
-  return ((await res.json()) as AdminFeaturedChannelsResponse).featured_channels;
+  return narrowAdminFeaturedChannelsResponse(await res.json()).featured_channels;
 }
 
 export async function adminAddFeaturedChannel(

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -12,14 +12,20 @@ import type { MemberEntry } from "./memberTypes";
 // `wireTypes.ts` mirrors at compile time, emitted as data so the boundary can
 // enforce them after tsc has erased the types.
 import {
+  S_AccountsAdminWireIndexPayload,
   S_AccountsAdminWireT,
   S_AdminEventsWireEvent,
   S_AdminOverviewWireT,
   S_ChannelDirectoryWireIndexPayload,
+  S_LiveIntrospectionAdminWireIndexPayload,
+  S_NetworksFeaturedChannelsAdminWireIndexPayload,
   S_NetworksFeaturedChannelsAdminWireT,
   S_NetworksFeaturedChannelsWireIndexPayload,
+  S_NetworksServersAdminWireIndexPayload,
   S_NetworksServersAdminWireT,
+  S_NetworksWireChannelJson,
   S_NetworksWireCredentialJson,
+  S_ScrollbackWireArchiveWireIndex,
   S_ScrollbackWireT,
   S_SessionLogWireListResult,
   S_SessionLogWireSessionsResult,
@@ -27,15 +33,22 @@ import {
   S_ThemesWireT,
   S_VhostsAdminWireGrantJson,
   S_VhostsAdminWireVhostJson,
+  S_VisitorsAdminWireIndexPayload,
 } from "./wireSchema";
 import type {
+  AccountsAdminWireIndexPayload,
   AccountsAdminWireT,
   AdminOverviewWireT,
   ChannelDirectoryWireIndexPayload,
+  LiveIntrospectionAdminWireIndexPayload,
+  NetworksFeaturedChannelsAdminWireIndexPayload,
   NetworksFeaturedChannelsAdminWireT,
   NetworksFeaturedChannelsWireIndexPayload,
+  NetworksServersAdminWireIndexPayload,
   NetworksServersAdminWireT,
+  NetworksWireChannelJson,
   NetworksWireCredentialJson,
+  ScrollbackWireArchiveWireIndex,
   ScrollbackWireT,
   SessionISupportCasemapping,
   SessionLogWireListResult,
@@ -44,6 +57,7 @@ import type {
   ThemesWireT,
   VhostsAdminWireGrantJson,
   VhostsAdminWireVhostJson,
+  VisitorsAdminWireIndexPayload,
   WindowCountsSeverity,
 } from "./wireTypes";
 // #410 — the runtime allowlists derive from the codegen-emitted `as const`
@@ -838,4 +852,79 @@ export function narrowFeaturedChannelsResponse(
 /** `GET /networks/:slug/directory`. */
 export function narrowDirectoryPageResponse(raw: unknown): ChannelDirectoryWireIndexPayload {
   return narrowRest(S_ChannelDirectoryWireIndexPayload, raw, "channel directory page");
+}
+
+// ── #1400 slice 1 — the doors whose envelope was already generated ──
+//
+// The first tranche converted the doors whose response IS a single generated
+// shape. These are the LIST doors, and #1400's body reads them as blocked:
+// "the REST envelope types are hand-written mirrors in `api.ts` … that makes
+// the first step emitting the missing envelope schemas". Measured at
+// `236dd328`, that is true of most of the remaining casts and false of these
+// nine: the codegen already emits five `*IndexPayload` types byte-identical
+// to the `{ key: T[] }` written by hand in `api.ts`, plus the archive index —
+// so `api.ts` was carrying a second copy of a shape that already existed,
+// with a runtime schema already sitting beside it. Nothing is emitted here.
+// The hand-written twins are deleted rather than pinned: an alias cannot
+// drift, and a deleted type cannot either.
+//
+// The three bare-array doors take an inline `{ a: … }` node. That introduces
+// no field NAME on this side — the array-ness is the wire's, and the element
+// schema is the generated one — so it is not a mirror creeping back in.
+//
+// Same reconstruction caveat as the tranche above, and re-measured for these
+// nine before landing: every element type here is a plain alias of its
+// generated counterpart (`AdminUser = AccountsAdminWireT` and so on), so no
+// consumer can even NAME a field the schema omits, and none of the eleven
+// call sites behind them casts its way around that. Two shapes deliberately
+// stay out of this slice for the opposite reason — `AdminNetwork` and
+// `AdminCredential` INTERSECT extra fields onto their generated type
+// (`circuit_state`, `live_counts`, `session_action`, `session_error`), which
+// the server sends and the typespec does not declare, so validating them here
+// would silently drop the four. They need the server-side declaration first.
+
+/** `GET /admin/visitors`. */
+export function narrowAdminVisitorsResponse(raw: unknown): VisitorsAdminWireIndexPayload {
+  return narrowRest(S_VisitorsAdminWireIndexPayload, raw, "visitor list");
+}
+
+/** `GET /admin/sessions`. */
+export function narrowAdminSessionsResponse(raw: unknown): LiveIntrospectionAdminWireIndexPayload {
+  return narrowRest(S_LiveIntrospectionAdminWireIndexPayload, raw, "live session list");
+}
+
+/** `GET /admin/users`. */
+export function narrowAdminUsersResponse(raw: unknown): AccountsAdminWireIndexPayload {
+  return narrowRest(S_AccountsAdminWireIndexPayload, raw, "user list");
+}
+
+/** `GET /admin/networks/:id/servers`. */
+export function narrowAdminServersResponse(raw: unknown): NetworksServersAdminWireIndexPayload {
+  return narrowRest(S_NetworksServersAdminWireIndexPayload, raw, "server list");
+}
+
+/** `GET /admin/networks/:id/featured_channels`. */
+export function narrowAdminFeaturedChannelsResponse(
+  raw: unknown,
+): NetworksFeaturedChannelsAdminWireIndexPayload {
+  return narrowRest(
+    S_NetworksFeaturedChannelsAdminWireIndexPayload,
+    raw,
+    "admin featured channel list",
+  );
+}
+
+/** `GET /networks/:slug/archive`. */
+export function narrowArchiveResponse(raw: unknown): ScrollbackWireArchiveWireIndex {
+  return narrowRest(S_ScrollbackWireArchiveWireIndex, raw, "archive index");
+}
+
+/** `GET /networks/:slug/channels`. */
+export function narrowChannelListResponse(raw: unknown): NetworksWireChannelJson[] {
+  return narrowRest({ a: S_NetworksWireChannelJson }, raw, "channel list");
+}
+
+/** `GET /networks/:slug/channels/:name/messages`, both the `before` and `after` pages. */
+export function narrowMessagePageResponse(raw: unknown): ScrollbackWireT[] {
+  return narrowRest({ a: S_ScrollbackWireT }, raw, "message page");
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47516,3 +47516,96 @@ _Not established: how many of the remaining 105 atoms are actually logged. The
 scan proves absence, never disuse, so the count of dead entries is a floor and
 not a measurement. The 39-arm `do_handle_in` door and the per-verb table that
 #1403's HIGH proposes are untouched by this work._
+<!-- entry #1400 slice 1 -->
+
+---
+
+## 2026-08-17 — #1400 slice 1: the envelope was not missing, it was already emitted
+
+#1400 records 83 `(await res.json()) as X` casts at the REST edge. Recounted
+from the blobs at `origin/main` `236dd328` they are **59**: the first tranche
+converted 24 doors (`341d6b0c`), and the difference is exactly those. Nothing
+new has been cast since.
+
+The body names the blocker: "the REST envelope types are hand-written mirrors
+in `api.ts` … that makes the first step **emitting the missing envelope
+schemas**, not rewiring call sites." That is true of most of the remaining 59
+and **false of nine of them**, and the nine are what this slice converts.
+
+Five of the hand-written envelopes have a generated twin that is byte-identical
+to them:
+
+| `api.ts` | generated | runtime schema |
+|---|---|---|
+| `AdminUsersResponse = { users: AdminUser[] }` | `AccountsAdminWireIndexPayload` | `S_AccountsAdminWireIndexPayload` |
+| `AdminVisitorsResponse` | `VisitorsAdminWireIndexPayload` | present |
+| `AdminSessionsResponse` | `LiveIntrospectionAdminWireIndexPayload` | present |
+| `AdminServersResponse` | `NetworksServersAdminWireIndexPayload` | present |
+| `AdminFeaturedChannelsResponse` | `NetworksFeaturedChannelsAdminWireIndexPayload` | present |
+
+plus the archive door, whose cast was an INLINE literal
+(`as { archive: ArchiveEntry[] }`) equal to the emitted
+`ScrollbackWireArchiveWireIndex`, and three bare-array doors whose element is a
+plain alias of a generated type. So `api.ts` was carrying a second copy of a
+shape that already existed, with the runtime schema already sitting beside it.
+The nine are wiring, not emission.
+
+The hand-written twins are DELETED rather than pinned against their generated
+counterpart. A pin would be a third artefact to keep true; an absent type
+cannot drift at all, which is the #410 posture applied to an envelope.
+
+### How the triage found them, and why the count is a ceiling
+
+The archive door was found by accident — it is an inline literal, so no type
+NAME connects it to `ScrollbackWireArchiveWireIndex`, and a search over the
+declared envelope types could not see it. Which means the same could be true of
+the shapes this slice leaves behind: the remaining classification rests on a
+by-NAME probe over the 183 emitted `S_*` consts, not a shape comparison. **The
+"needs a server-side `@type` first" population is an upper bound, not a
+measurement.** Anyone taking the next tranche should compare shapes.
+
+### Two shapes deliberately left in the cast
+
+`AdminNetwork` and `AdminCredential` INTERSECT extra fields onto their
+generated type — `circuit_state` and `live_counts` on one, `session_action` and
+`session_error` on the other. Those are not cic enrichments: the comment beside
+`session_error` says the server "has always sent it; nothing declared it here".
+
+That matters because `validate` implements the additive-only rule (#447) as a
+DROP, not a passthrough — `walkObject` builds a fresh object from the declared
+fields and ignores every other key. So converting those four doors would not
+fail; it would silently strip four fields the admin panes render, and pass
+`tsc` doing it. They need the server-side declaration first, and until then the
+cast is the more honest of the two wrongs.
+
+### What was measured
+
+**The red first, and read rather than asserted.** Ten of the eleven new cases
+failed before the conversion, each one naming the defect: nine
+`promise resolved "[ { …(N) } ]" instead of rejecting` — the cast handing back
+a row one required field short — and one
+`expected [ { name: '#italia', …(3) } ] to deeply equal [ … (2) ]`, the cast
+carrying an undeclared key through instead of dropping it. Each case removes
+exactly ONE named field from an otherwise complete row, so a green cannot come
+from a fixture that was broken several ways at once.
+
+**The eleventh case was green before and after, deliberately.** An undeclared
+key on the ENVELOPE (`{ users: [...], total: 1 }`) survives a cast trivially,
+so it discriminates nothing on the old code. It is a regression guard, not a
+mutant: it holds the conversion to the additive rule if someone later reaches
+for a stricter walk.
+
+**The reconstruction is shape-preserving for these nine.** Same check the first
+tranche recorded for its twelve: every element type here is a plain alias of
+its generated counterpart, so no consumer can NAME a field the schema omits,
+and none of the eleven call sites behind them casts around that (the one `as`
+that appears is an `as const` on a tuple in `networks.ts`).
+
+### What this does not establish
+
+It does not touch the residue vjt owns — whether a REQUIRED field absent
+because the bundle is newer than its server should fail loud or degrade to
+`undefined`. This slice inherits the standing behaviour, which is the one the
+first tranche shipped on 24 doors. Nor does it convert anything whose schema
+had to be emitted: the classes that need a server-side `@type` are untouched,
+and the count of them is the ceiling described above.


### PR DESCRIPTION
## What

Converts **9 of the 59** remaining `(await res.json()) as X` casts at the REST edge onto `narrowRest`, the boundary helper the first tranche shipped. No new machinery, no new schema: every one of the nine validates against a schema that `wireSchema.ts` already emits.

**Declared file cap: 4.** Touched exactly 4 — `cicchetto/src/lib/wireNarrow.ts`, `cicchetto/src/lib/api.ts`, `cicchetto/src/__tests__/api.test.ts`, `docs/DESIGN_NOTES.md`.

## Why these nine, and not the others

#1400's body reads the remaining casts as blocked: *"the REST envelope types are hand-written mirrors in `api.ts` … that makes the first step **emitting the missing envelope schemas**, not rewiring call sites."*

Measured against the blobs, that is true of most of the 59 and **false of these nine**. Five of the hand-written envelopes have a generated twin that is byte-identical:

| `api.ts` (hand-written) | generated | schema |
|---|---|---|
| `AdminUsersResponse = { users: AdminUser[] }` | `AccountsAdminWireIndexPayload` | `S_AccountsAdminWireIndexPayload` |
| `AdminVisitorsResponse` | `VisitorsAdminWireIndexPayload` | present |
| `AdminSessionsResponse` | `LiveIntrospectionAdminWireIndexPayload` | present |
| `AdminServersResponse` | `NetworksServersAdminWireIndexPayload` | present |
| `AdminFeaturedChannelsResponse` | `NetworksFeaturedChannelsAdminWireIndexPayload` | present |

Plus the archive door — whose cast was an inline literal `as { archive: ArchiveEntry[] }`, equal to the emitted `ScrollbackWireArchiveWireIndex` — and three bare-array doors whose element is a plain alias of a generated type.

The hand-written twins are **deleted**, not pinned against their counterpart: a pin is a third artefact to keep true, an absent type cannot drift at all. That is the #410 posture applied to an envelope.

## What is deliberately NOT in this PR

**`AdminNetwork` and `AdminCredential` stay cast, on purpose — do not bundle them into a follow-up by reflex.**

Both INTERSECT extra fields onto their generated type: `circuit_state` and `live_counts` on one, `session_action` and `session_error` on the other. Those are not client enrichments — the comment beside `session_error` says the server *"has always sent it; nothing declared it here"*.

`validate` implements the additive-only rule (#447) as a **DROP**, not a passthrough: `walkObject` builds a fresh object out of the declared fields and ignores every other key. So converting those doors would not fail loudly — it would **silently strip four fields the admin panes render, and pass `tsc` while doing it**. They need the server-side declaration first, which is a server change and a separate slice.

Slice 3 (the envelopes that genuinely need a server-side `@type`) is also out of scope here.

The open question of whether a REQUIRED field absent because the bundle is newer than its server should fail loud or degrade to `undefined` is **not decided or pre-decided here**. This slice inherits the standing behaviour, which is what the first tranche already shipped on 24 doors.

## Test plan — the red was read, not asserted

Eleven cases. Each absence case removes **exactly one named required field** from an otherwise complete row, so a green cannot come from a fixture broken several ways at once.

**Ten failed before the conversion**, and the failures named the defect:

```
× adminListVisitors rejects a visitor missing `identified`
  AssertionError: promise resolved "[ { …(7) } ]" instead of rejecting
… (9 of these, one per door)

× tolerates a key the ELEMENT schema does not declare, and drops it
  AssertionError: expected [ { name: '#italia', …(3) } ] to deeply equal [ … (2) ]
```

— the cast handing back a row one field short, and the cast carrying an undeclared key through instead of dropping it.

**The eleventh is honestly not a mutant.** An undeclared key on the *envelope* (`{ users: [...], total: 1 }`) survives a cast trivially, so it discriminates nothing on the old code. It is kept as a regression guard against someone later reaching for a stricter walk, and is not claimed as a red.

Gates, all re-run **after** the rebase onto `d8b58e2d` (the earlier green attested a base that would not be pushed):

- `bun run check` (biome + tsc, both tsconfigs)
- `bun run test` — full suite
- `scripts/design-notes-gate.sh origin/main` — *1 new entry heading, separator and marker present*

Rebase verified rather than eyeballed: the branch's `--numstat` was pinned to a file before the rebase and re-diffed after (**identical**, additions unchanged and deletions zero-drift), and `head -47293 docs/DESIGN_NOTES.md | diff - <origin/main copy>` is **empty** — every pre-existing entry byte-identical, not merely the right line count.

The cic green does **not** transfer across this rebase and I did not claim it did: `git diff 236dd328 d8b58e2d -- cicchetto/` is non-empty (`modalChrome.test.ts`, +16).

## Instruments found blind while measuring

Recording these because a `NOT FOUND` from an unsupported regex is indistinguishable from a real one:

1. **`git grep -E` does not support `\b`.** Nine types read as `NOT FOUND` while being declared in plain sight (`ServerSettingsWireUploadView` at `wireTypes.ts:926`). Nine false negatives would have shipped in the triage.
2. **Filtering tests by `__tests__/` is not enough** — co-located `*.test.ts` files are outside that directory, and `bootFetch.test.ts` had entered the cast census.
3. **A `grep -A4` capture truncates multi-line type declarations**: 18 of the 59 sites landed in "declaration not found" until the four files were read whole.

## What this does not establish

- **The count of casts that still need a server-side `@type` is an upper bound, not a measurement.** The remaining classification rests on a by-NAME probe over the emitted `S_*` consts, not a shape comparison — and the archive door here was found *by accident*, precisely because an inline literal has no name to probe. The next tranche should compare shapes.
- The reconstruction is shape-preserving **for these nine**, measured the same way the first tranche recorded for its twelve (every element type is a plain alias, so no consumer can name a field the schema omits, and no call site casts around it). It is not guaranteed to stay so by anything but that measurement.
- `scripts/bats.sh` was started and **stopped before completing** (230 `ok`, 0 `not ok` at the point it was stopped) so the rebase could proceed. This diff touches no shell script; the DESIGN_NOTES gate it would have exercised was run directly and is green. I am not claiming a full bats pass.
- No server-side gate was run: this is cic-only and nothing under `lib/` is touched.
