### PR TITLE
arch(#1398)+docs(#1410): pin the waiver cycle count, and stop denying that init/1 reads the DB

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47376,3 +47376,68 @@ boot-time figure — it says the cost exists and is unmeasured. Likewise the
 claim that a fix belongs in the code rather than the prose is **not** made here:
 the code was measured to be right and the prose wrong, which is the whole reason
 this slice touches no `.ex` behaviour.
+<!-- entry #1398 -->
+
+---
+
+## 2026-08-17 — #1398: pin the cycle count the acyclicity proof cannot see
+
+The declared Boundary graph is acyclic and the compiler enforces that: `mix.exs`
+puts `:boundary` in `compilers` with `check: [in: true, out: true]`, so a declared
+cycle never reaches CI. What nothing watches is the other half.
+
+### Why a waiver is an invisible edge
+
+A `dirty_xrefs` entry is a real dependency the checker has been told to ignore.
+Counting the five current waivers as the edges they are turns the acyclic graph
+into **31 elementary cycles over 12 boundaries**. That is not a new defect — it is
+the same one the 2026-08-15 architecture review found, and the one the 2026-07-20
+review found before it with three waivers instead of five. The population grew and
+nothing noticed, twice, until a human read the annotations by hand.
+
+This entry adds no fix. It adds a **ratchet**: a test that counts the cycles closed
+by declared deps plus waivers and fails when the number rises above a pinned
+budget. The next waiver that closes a cycle now has to be argued for in the diff
+that introduces it.
+
+### What the number is, and how it was reached
+
+31, measured on `236dd328`: 1 cycle of length 2, 4 of length 3, 11 of length 4,
+11 of length 5, 4 of length 6, all fed by five waivers that every one of them
+names `Grappa.Networks.Network`. The shortest is `Networks -> Scrollback ->
+Networks` — two nodes, touching neither `Session` nor `LiveIntrospection`, which
+is why the review's "five cycles sharing one prefix" does not describe the shape.
+The highest-leverage single arc is `Scrollback -> Networks` at 19 of the 31, and
+**no single arc cuts all of them.**
+
+Three independent measurements agree on 31: two hand-written source parsers and
+this gate. The gate is the one to trust, because it reads the **compiled
+`Boundary` attribute** — the same annotation `GrappaWeb.BoundaryTest` and
+`Grappa.Visitors.VisitorBoundaryTest` read, and the source CLAUDE.md's
+architecture-test rule points at ("use `Boundary` annotations — not
+string-matching"). The two source parsers disagreed with each other about how many
+`use Boundary` blocks even exist (99 against 107) while agreeing on the cycles; a
+disagreement about the input is exactly the failure mode reading the compiler's
+own record avoids.
+
+### The declared limit of this gate
+
+It counts DECLARED edges plus waivers, and nothing else. The runtime edges this
+codebase relies on for cycle avoidance — the injected closures, the behaviours
+resolved from `:persistent_term`, the supervisor-level `held_source_fn` — carry no
+module reference, so no compile-time mechanism can see them and none of them move
+this number. A closure that opens a cycle passes this gate silently. That limit is
+written into the test body rather than left for a reader to infer, because a gate
+whose blind spot is undocumented gets read as broader than it is.
+
+### Direction, recorded but not taken
+
+Removing the five waivers is equivalent to zeroing the set, since the declared
+graph is already acyclic. All five name the same target, and this repo has
+executed that move once before: the twelve `dirty_xrefs: [Grappa.Visitors.Visitor]`
+waivers went to zero by promoting the schema to a `top_level?: true` boundary with
+empty `deps:`. The same move here cannot be scoped to `Network` alone —
+`networks/network.ex` aliases the `has_many` siblings it binds, so the minimum unit
+is the four-schema cluster, priced at roughly fifteen files and atomic. That is a
+purchase, not a slice, and it is deliberately left to #1398 rather than smuggled in
+behind a gate.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47291,3 +47291,88 @@ _Not established: nothing here measures how many of these workers can be alive
 at once, or what happens at any particular number, and the file says so. The
 question of whether that concurrency wants a bound is open and is not answered
 by this change._
+<!-- entry #1410 -->
+
+---
+
+## 2026-08-17 — #1410: `init/1` does read the DB; the two sentences that denied it now say so
+
+Two live documents claimed `Grappa.Session.Server.init/1` performs no DB reads.
+Both were false, in different ways and to different degrees, and this entry
+records which half of each was wrong, why the obvious code fix is the wrong fix,
+and what the correction deliberately leaves open.
+
+### What the code actually does
+
+`init/1` invokes the injected `refresh_plan` closure before building any state.
+There are **two** injectors, not one: `Grappa.Networks.SessionPlan` (user side)
+and `Grappa.Visitors.SessionPlan` (visitor side). Both walk the DB — the user
+side reads the credential, preloads `network: :servers` and fetches the user;
+the visitor side reads the visitor row, reloads the network, then resolves.
+So the reads happen on every spawn and every `:transient` restart, for both
+subject kinds, inside the Session process.
+
+### Why the obvious fix is wrong
+
+Moving the re-resolve into `handle_continue` would restore the "non-blocking"
+sentence literally and is the first idea anyone has. It is wrong, and the
+reason is a boundary contract rather than a performance argument: `init/1`
+returning `:ignore` is the **only synchronous** "this subject is no longer
+viable" signal the spawn door has. `Grappa.SpawnOrchestrator` maps it to
+`{:ok, :ignored}` and `Grappa.Bootstrap.classify_outcome/3` counts it. From
+`handle_continue` the caller would instead observe `{:ok, pid}` followed by a
+silent death a moment later — precisely the "No silent-swallow at boundaries"
+failure CLAUDE.md names. The end-to-end path is already pinned by
+`spawn_orchestrator_test.exs` ("refresh_plan returning `{:error, :not_found}`
+-> `{:ok, :ignored}`, no session spawned"), so the refactor would go red rather
+than ship quietly. No new test was added here: buying a guard that already
+exists would be ornament.
+
+The reads are also load-bearing for a second, independent reason. The #93
+endpoint ring advances by resolving at the failure count, and that counter is
+authoritative only at this moment: `Backoff.record_failure/2` is a synchronous
+call from the dying session's `terminate/2`, so the bump has landed before the
+supervisor reaches `init/1`. Deferring the read moves it away from the only
+instant at which it is correct.
+
+### Which sentence was wrong, and how
+
+The A2 paragraph in `Grappa.Session` conflated two different claims. The one it
+should make — no `Credential` / `Network` / `Server` / `Visitor` struct refs
+cross the Session boundary — is **intact**, and is what the `Boundary` deps
+enforce. The parenthetical it added on top ("no `Repo`, no `Networks`, no
+`Accounts`, no `Visitors` reads") was an over-claim about runtime behaviour that
+the dependency mechanism never bought. The comment above `init/1` was false only
+in half: the upstream-socket deferral to `handle_continue({:start_client, _})`
+holds; the DB half did not.
+
+### What stays open, deliberately
+
+Two things are named in the corrected text rather than fixed.
+
+First, on the **spawn** door the re-resolve is redundant: `Bootstrap` calls
+`SessionPlan.resolve/1` and hands the resolved plan to `start_child`, whose
+`init/1` immediately resolves it again. Only the **respawn** door needs the
+re-read. One closure cannot tell the two doors apart, and the obvious flag does
+not work — `DynamicSupervisor` caches the spawn-time child spec, so a
+"plan is already fresh" key in `opts` would be replayed on every restart, which
+is the opposite of what it must mean. Anything that does work (a one-shot side
+channel, a stateful closure) is heavier than the duplication it removes.
+
+Second, `Boundary` is **structurally blind** to this class. A closure built in
+`Networks` and invoked in `Session` carries no module reference, so no
+compile-time checker can see the edge. That is why the deps list can honestly
+omit `Repo` / `Networks` / `Accounts` while those reads happen — and why the
+next closure of this shape will be equally invisible. #1398 (bucket I) reasons
+about the `Networks -> Session` inversion partly from the sentence corrected
+here; its premise has moved and is being told so.
+
+### Not established
+
+Nothing was executed for this entry: no query log, no timing of the spawn loop,
+no `EXPLAIN`. The issue's "N x 3 queries" remains a derivation from the call
+chain, not a measurement, and this correction deliberately declines to quote a
+boot-time figure — it says the cost exists and is unmeasured. Likewise the
+claim that a fix belongs in the code rather than the prose is **not** made here:
+the code was measured to be right and the prose wrong, which is the whole reason
+this slice touches no `.ex` behaviour.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -39,9 +39,28 @@ defmodule Grappa.Session do
   `Grappa.Networks.SessionPlan.resolve/1` (user-side) and
   `Grappa.Visitors.SessionPlan.resolve/1` (visitor-side) are the
   canonical producers of that plan; `Bootstrap` threads the resolved
-  opts in. The Server's `init/1` is therefore a pure data consumer
-  (no `Repo`, no `Networks`, no `Accounts`, no `Visitors` reads),
-  which keeps the Session boundary deps minimal.
+  opts in. That struct-ref ban IS the invariant, and it is what the
+  `Boundary` deps below enforce.
+
+  It does NOT mean `init/1` performs no DB reads. Both producers also
+  inject a `refresh_plan` closure, and `Server.init/1` invokes it, so
+  each spawn AND each `:transient` restart re-resolves the plan from
+  the DB inside the Session process. Deliberate on both counts: the
+  respawn door needs live truth (the 2026-05-27 zombie class) and the
+  #93 endpoint ring reads a failure counter that is authoritative only
+  there; and it is SYNCHRONOUS because `init/1`'s `:ignore` is the
+  spawn door's only synchronous "subject no longer viable" signal —
+  `Grappa.SpawnOrchestrator` maps it to `{:ok, :ignored}` and
+  `Bootstrap` counts it, so deferring the re-resolve to
+  `handle_continue` would turn a reported failure into a silent death.
+
+  Two consequences stay open. On the SPAWN door the re-resolve
+  duplicates the resolution its caller performed microseconds earlier,
+  and one closure cannot tell the two doors apart. And `Boundary` is
+  structurally blind to this class: a closure built in `Networks` or
+  `Visitors` and invoked here carries no module reference for a
+  compile-time checker to see, which is why the deps list below can
+  omit `Repo` / `Networks` / `Accounts` while those reads happen.
   """
 
   # `Server` is exported for the test path only — `server_test.exs`

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -850,12 +850,21 @@ defmodule Grappa.Session.Server do
 
   ## GenServer callbacks
 
-  # `init/1` is intentionally non-blocking — `Client.start_link/1` runs
-  # in `handle_continue(:start_client, _)` so a slow upstream cannot
-  # serialize Bootstrap's per-credential `Enum.reduce` start_child
-  # loop. Pairs with `Grappa.IRC.Client.init/1`'s own `{:continue,
-  # :connect}` deferral; together they keep boot O(1) per session
-  # regardless of upstream reachability.
+  # `init/1` defers the UPSTREAM SOCKET, not everything —
+  # `Client.start_link/1` runs in `handle_continue(:start_client, _)`
+  # so a slow upstream cannot serialize Bootstrap's per-credential
+  # `Enum.reduce` start_child loop. Pairs with
+  # `Grappa.IRC.Client.init/1`'s own `{:continue, :connect}` deferral;
+  # together they keep boot O(1) in upstream reachability.
+  #
+  # It is NOT read-free, and the older wording ("intentionally
+  # non-blocking", full stop) read as if it were: the `refresh_plan`
+  # closure below re-resolves the plan from the DB, so Bootstrap's loop
+  # does pay those queries per credential. Synchronous by necessity —
+  # `:ignore` is the spawn door's only synchronous "not viable" signal
+  # (see `Grappa.Session`'s A2 section for why `handle_continue` cannot
+  # carry it). The boot cost has never been measured; measure before
+  # quoting a figure for it.
   @impl GenServer
   def init(opts) do
     :ok = Log.set_session_context(opts.subject_label, opts.network_slug)

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -95,7 +95,7 @@ defmodule Grappa.BoundaryCycleBudgetTest do
     end
   end
 
-  defp dep_name({module, _mode}), do: module
+  defp dep_name({module, _}), do: module
   defp dep_name(module) when is_atom(module), do: module
 
   @spec owning_boundary(module(), MapSet.t(module())) :: module() | nil

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -1,0 +1,149 @@
+defmodule Grappa.BoundaryCycleBudgetTest do
+  use ExUnit.Case, async: true
+
+  # #1398 — the declared Boundary graph is acyclic, and the compiler already
+  # enforces that half: `mix.exs` puts `:boundary` in `compilers` with
+  # `check: [in: true, out: true]`, so a declared cycle cannot reach CI.
+  #
+  # The half nothing watches is `dirty_xrefs`. A waiver is a real dependency
+  # the checker has been told to ignore, so every waiver is an edge the
+  # acyclicity proof does not see — and counting them turns the acyclic graph
+  # into a large cyclic one. That population grew from 3 waivers to 5 between
+  # the 2026-07-20 and 2026-08-15 reviews with nothing to notice it; the growth
+  # was found by a human reading annotations, twice.
+  #
+  # This gate is a ratchet, not a fix. It pins the number so the next waiver
+  # that closes a cycle has to be argued for in a diff instead of arriving
+  # unremarked. Lowering @cycle_budget when the number drops is the point;
+  # raising it is a decision that belongs in review.
+  @cycle_budget 31
+
+  # Measured 2026-08-17 on `origin/main` = 236dd328: 31 elementary cycles over
+  # 12 boundaries (1 of length 2, 4 of length 3, 11 of length 4, 11 of length 5,
+  # 4 of length 6), from 5 waivers all naming `Grappa.Networks.Network`. The
+  # single highest-leverage arc is `Scrollback -> Networks` at 19 of the 31; no
+  # single arc kills them all. Method: the compiled `Boundary` attribute, the
+  # same source `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest`
+  # read — NOT a source parse. An earlier hand-rolled regex parser disagreed with
+  # a second one about how many `use Boundary` blocks even exist (99 vs 107),
+  # which is exactly why this reads the annotation the compiler kept.
+  #
+  # Declared scope, stated so it is not mistaken for more: this counts DECLARED
+  # deps plus waivers. Runtime edges — the injected closures, behaviours resolved
+  # from `:persistent_term`, the supervisor-level `held_source_fn` — carry no
+  # module reference for any compile-time mechanism to see, so they are absent
+  # here and the true runtime graph is denser. A closure that opens a cycle will
+  # not move this number.
+  test "dirty_xref waivers close no more boundary cycles than the pinned budget" do
+    graph = boundary_graph()
+    cycles = elementary_cycles(graph)
+    count = length(cycles)
+
+    assert count <= @cycle_budget, """
+    Boundary cycle count rose to #{count}, above the pinned budget of #{@cycle_budget}.
+
+    A `dirty_xrefs` waiver is an edge the Boundary checker was told to ignore, so
+    the compiler stays green while the dependency graph gains a cycle. Either the
+    new waiver is wrong, or the budget moves — deliberately, in this diff, with the
+    reason written down.
+
+    Cycles now closed (shortest first):
+    #{format_cycles(cycles)}
+    """
+  end
+
+  @spec boundary_graph() :: %{module() => MapSet.t(module())}
+  defp boundary_graph do
+    defs = boundary_defs()
+    names = defs |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+
+    Map.new(defs, fn {name, opts} ->
+      deps =
+        opts
+        |> Keyword.get(:deps, [])
+        |> Enum.map(&dep_name/1)
+        |> Enum.filter(&MapSet.member?(names, &1))
+
+      # A waiver names a MODULE, not a boundary — resolve it to the boundary
+      # that owns it (longest declared prefix), which is the edge it really is.
+      waived =
+        opts
+        |> Keyword.get(:dirty_xrefs, [])
+        |> Enum.map(&owning_boundary(&1, names))
+        |> Enum.reject(&is_nil/1)
+
+      {name, (deps ++ waived) |> Enum.reject(&(&1 == name)) |> MapSet.new()}
+    end)
+  end
+
+  @spec boundary_defs() :: [{module(), keyword()}]
+  defp boundary_defs do
+    {:ok, modules} = :application.get_key(:grappa, :modules)
+
+    for module <- modules,
+        Code.ensure_loaded?(module),
+        opts = boundary_opts(module),
+        not is_nil(opts),
+        do: {module, opts}
+  end
+
+  @spec boundary_opts(module()) :: keyword() | nil
+  defp boundary_opts(module) do
+    case Keyword.get(module.__info__(:attributes), Boundary) do
+      [%{opts: opts}] when is_list(opts) -> opts
+      _ -> nil
+    end
+  end
+
+  defp dep_name({module, _mode}), do: module
+  defp dep_name(module) when is_atom(module), do: module
+
+  @spec owning_boundary(module(), MapSet.t(module())) :: module() | nil
+  defp owning_boundary(module, names) do
+    prefix = Module.split(module)
+
+    prefix
+    |> Enum.count()
+    |> then(&Enum.to_list(&1..1//-1))
+    |> Enum.map(&Module.concat(Enum.take(prefix, &1)))
+    |> Enum.find(&MapSet.member?(names, &1))
+  end
+
+  # Elementary cycles by DFS from each node, admitting only successors whose
+  # position is at or after the start node's — the standard trick that yields
+  # each cycle once, at its lowest-ordered member, instead of once per rotation.
+  @spec elementary_cycles(%{module() => MapSet.t(module())}) :: [[module()]]
+  defp elementary_cycles(graph) do
+    nodes = graph |> Map.keys() |> Enum.sort()
+    position = nodes |> Enum.with_index() |> Map.new()
+
+    Enum.flat_map(nodes, fn start ->
+      walk(graph, position, start, start, [start], MapSet.new([start]), [])
+    end)
+  end
+
+  defp walk(graph, position, start, node, path, on_path, acc) do
+    graph
+    |> Map.fetch!(node)
+    |> Enum.sort()
+    |> Enum.reduce(acc, fn next, acc ->
+      cond do
+        Map.fetch!(position, next) < Map.fetch!(position, start) -> acc
+        next == start -> [Enum.reverse(path) | acc]
+        MapSet.member?(on_path, next) -> acc
+        true -> walk(graph, position, start, next, [next | path], MapSet.put(on_path, next), acc)
+      end
+    end)
+  end
+
+  defp format_cycles(cycles) do
+    cycles
+    |> Enum.sort_by(&{length(&1), &1})
+    |> Enum.map_join("\n", fn cycle ->
+      hops = Enum.map_join(cycle, " -> ", &short/1)
+      "      #{hops} -> #{short(hd(cycle))}"
+    end)
+  end
+
+  defp short(module), do: module |> Module.split() |> Enum.join(".")
+end


### PR DESCRIPTION
Union of #1488 (#1410) and #1490 (#1398), rebuilt on `origin/main` = `d8b58e2d`
by cherry-picking each branch from its own merge-base — `236dd328` for both.
No conflicts, and the union's contribution is line-for-line the sum of the two
branch patches, so nothing was dropped or invented in the transplant.

| source PR | issue | branch | commits |
|---|---|---|---|
| #1488 | #1410 — `init/1` does read the DB | `w1-1410-docs` | 1 |
| #1490 | #1398 — pin the cycle count | `w1-1398-gate` | 2 |

The replay rewrites the SHAs, so GitHub cannot close the two source PRs on merge;
they are closed by content, by hand, after this lands.

## What is in here

**#1410 — say that `init/1` reads the DB, because it does.** Two sentences in
`lib/grappa/session.ex` and `lib/grappa/session/server.ex` claimed the session
`init/1` does no database work. It does. Prose only: no behaviour change, and no
cost figure is asserted, because none was measured.

**#1398 — pin the cycle count the acyclicity proof cannot see.** The compiler
already enforces that the *declared* Boundary graph is acyclic. It cannot see a
`dirty_xrefs` waiver, which is a real dependency the checker was told to ignore —
so counting waivers turns the acyclic graph into a cyclic one. That population
grew from 3 waivers to 5 between the 2026-07-20 and 2026-08-15 reviews with
nothing to notice it; both times a human found it by reading annotations.
`test/grappa/boundary_cycle_budget_test.exs` pins the count at 31 so the next
waiver that closes a cycle has to be argued for in a diff. It reads the compiled
`Boundary` attribute — the same source `GrappaWeb.BoundaryTest` and
`Grappa.Visitors.VisitorBoundaryTest` read — not a source parse.

## Scope, stated so it is not read as more

- The gate counts **declared** deps plus waivers. Runtime edges — injected
  closures, behaviours resolved from `:persistent_term`, the supervisor-level
  `held_source_fn` — carry no module reference any compile-time mechanism can
  see. A closure that opens a cycle will not move this number. This is a ratchet
  on the declared count, not a proof that the runtime graph is acyclic.
- 31 is therefore not "the number of real cycles".
- The #1410 half measures nothing about concurrency or boot cost. It corrects two
  false sentences.

## Verification done here

- The union diff against `origin/main` equals the sum of the two per-branch
  patches, each measured from its own merge-base: identical line sets, no
  additions, no losses.
- `scripts/design-notes-gate.sh` reports **"2 new entry heading(s), separator and
  marker present"** — the measuring line, not the diff-empty `nothing to check`
  one that shares its exit code. Both `<!-- entry #NNNN -->` markers occur exactly
  once in the file.
- The gate's pinned 31 still holds at this base. The test comment records the
  measurement at `236dd328`; between there and `d8b58e2d` no commit changes a
  `deps:`, an `exports:` or a `dirty_xrefs:`, and the five waivers still name only
  `Grappa.Networks.Network`.

## Not verified here

- **`scripts/check.sh` has not been run on this branch.** It was green on every
  phase on `w1-1398-gate` at its own base; the base has moved and the build caches
  are shared between worktrees, so that green does not transfer and is not claimed.
- The re-check of the pinned 31 at `d8b58e2d` above was made by reading the tree,
  **not by running the test** — no compile lane was held. CI is the first place the
  compiled attribute is consulted at this base.
- Nothing in either half has been exercised against production or a live session.
