### PR TITLE
arch(#1399): drop seven Accounts deps that never carried an edge

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47291,3 +47291,80 @@ _Not established: nothing here measures how many of these workers can be alive
 at once, or what happens at any particular number, and the file says so. The
 question of whether that concurrency wants a bound is open and is not answered
 by this change._
+<!-- entry #1399 -->
+
+---
+
+## 2026-08-17 — #1399: seven boundaries stop declaring a dependency they never had
+
+Bucket J of the 2026-08-15 architecture review says one problem — "a boundary
+needs only a schema" — has three incompatible resolutions, and asks for the
+thirteen struct-only `Grappa.Accounts` deps to be *narrowed*. Measuring the tree
+first changed the answer for seven of them: there is nothing to narrow, because
+there was never an edge.
+
+`Grappa.ChannelDirectory`, `Grappa.Notify`, `Grappa.Push`, `Grappa.QueryWindows`,
+`Grappa.ReadCursor`, `Grappa.Scrollback` and `Grappa.UserSettings` each declared
+`Grappa.Accounts` in `deps:`. Each reaches `Accounts.User` exactly twice, in one
+schema file, in the same two shapes: a `belongs_to :user, User` association
+argument and a `user: User.t()` typespec. Both are module names that end up as
+atoms in metadata rather than as remote calls, so the xref-based checker has no
+reference to police. The dep bought nothing.
+
+**The tree already answered this, and nobody had noticed.** `Grappa.Uploads`
+holds the identical pair — `uploads/upload.ex` aliases `Grappa.Accounts.User`
+and declares `belongs_to :user, User` — with **no** `Grappa.Accounts` dep and no
+waiver, and it has been compiling green for as long as it has existed.
+`Grappa.TestSupport.SubjectSession` is a second instance, via a typespec. So the
+review's "three resolutions" undercounts: a fourth, *declare nothing*, was
+already live and already correct. Seven of the thirteen belong to it.
+
+**Why deleting rather than narrowing.** Narrowing `Grappa.Accounts` to
+`Grappa.Accounts.User` would encode a dependency the compiler cannot see, on a
+module that is not a boundary today, to satisfy a rule none of these seven
+actually violate — and it would have to be undone the day `Accounts.User` is
+promoted. Deleting states the truth that the compiler can check: these
+boundaries do not depend on `Grappa.Accounts`. Where an issue's prose and the
+measured tree disagree, the tree wins.
+
+**The deletion is falsifiable, and the falsifier was armed first.** Boundary
+reports cross-boundary references as advisory warnings; only
+`mix compile --warnings-as-errors` — the first step of the `ci.check` alias, for
+exactly this reason — turns them into a failed build. So a green compile after
+seven deletions proves nothing unless the checker is known to bite. Before the
+deletions, one mutant removed the `Grappa.Accounts` dep from `Grappa.Subject`,
+which holds a real reference (`%User{}` in `from_assigns/1`). The build went red
+with exactly one violation, at exactly that line, naming exactly
+`Grappa.Accounts.User` — one mutant, one assertion, nothing else moved. With the
+mutant reverted and the seven deps gone, the same command is green with zero
+forbidden references. Had any of the seven carried an edge the source
+measurement missed, this is where it would have surfaced.
+
+**A stale number, settled while the lane was held.** Two hand-written parsers
+had disagreed about how many `use Boundary` declarations the tree even contains
+— 99 against 107 — and that disagreement was written into the #1398 cycle-budget
+gate as an open question. The compiled attribute settles it: **99**, counted from
+`Boundary` module attributes over `:application.get_key(:grappa, :modules)`. The
+source measurement agrees exactly, and the arithmetic explains itself — `lib`
+holds 111 textual occurrences of `use Boundary`, of which 12 are prose in
+moduledocs and comments, leaving 99 declarations. 107 corresponds to no
+population that could be reconstructed here, and no explanation for it is
+offered rather than invented.
+
+Comments at the seven sites say why the dep is absent, because absence is not
+self-documenting: the next reader finds a `belongs_to` pointing at another
+boundary's schema and, without a note, closes the "gap".
+
+_Not established: the other six of the thirteen are untouched — four hold real
+edges (`Subject`, `Themes`, `Admission`, `Vhosts`) and need `Accounts.User` and
+`Accounts.Session` promoted first, which is a separate change with a larger
+population than the review states, since promoting them removes both from
+`Grappa.Accounts`' `exports:` and forces every boundary holding a real edge to
+declare the new dep. The `Networks.Network` half of the bucket is a schema-cluster
+move, not an annotation change, and is tracked separately. The A7 finding — 11
+`top_level?: true` boundaries nested in another boundary's namespace — is
+deliberately not addressed: without a convention distinguishing a carve-out from
+a context internal there is no oracle to satisfy. The rule this entry describes
+is not written next to the Boundary paragraph in CLAUDE.md, so a future boundary
+that needs only a schema can still invent a fifth resolution; that edit is
+vjt's._

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -15,7 +15,10 @@ defmodule Grappa.ChannelDirectory do
     # `Grappa.IRC` — `Wire.mark_featured/2` folds directory names via
     # `Identifier.canonical_target/1` (ASCII, #364/#525/#537) to key them against
     # the canonical featured set.
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
+    # No `Grappa.Accounts` dep: `User` is reached only by `Entry`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
+    deps: [Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # `Networks.Network` is referenced ONLY by `Entry`'s
     # `belongs_to :network` (struct/schema access — no `Grappa.Networks`
     # function call anywhere in this boundary). A full `Grappa.Networks`

--- a/lib/grappa/notify.ex
+++ b/lib/grappa/notify.ex
@@ -79,7 +79,10 @@ defmodule Grappa.Notify do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
+    # No `Grappa.Accounts` dep: `User` is reached only by `Entry`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # Networks.Network is an FK-reference-only xref (belongs_to + the
     # existence pre-check), NOT a full dep: a `deps:` edge would close
     # the cycle Session -> Notify -> Networks -> LiveIntrospection ->

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -68,8 +68,10 @@ defmodule Grappa.Push do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Subscription`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.Mentions,
       Grappa.Repo,

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -96,7 +96,10 @@ defmodule Grappa.QueryWindows do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
+    # No `Grappa.Accounts` dep: `User` is reached only by `Window`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # `Networks.Network` is referenced ONLY as a schema — the
     # `belongs_to :network` association + the FK-existence `Repo.exists?`
     # query in `check_exists/4`. Declared a dirty xref (NOT a real dep),

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -71,8 +71,10 @@ defmodule Grappa.ReadCursor do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Cursor`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,7 +33,10 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
+    # No `Grappa.Accounts` dep: `User` is reached only by `Message`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
+    deps: [Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     # `Networks.Network` is referenced by `Scrollback.Message` (the
     # `belongs_to :network` association) and `Scrollback.Wire` (the
     # `%Network{slug: _}` pattern that A1+A26 made the wire-shape

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -99,8 +99,10 @@ defmodule Grappa.UserSettings do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Settings`'
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,


### PR DESCRIPTION
Slice A of bucket J (#1399): the seven boundaries that declared `Grappa.Accounts`
without ever holding a reference the checker could see now stop declaring it.

`Grappa.ChannelDirectory`, `Grappa.Notify`, `Grappa.Push`, `Grappa.QueryWindows`,
`Grappa.ReadCursor`, `Grappa.Scrollback`, `Grappa.UserSettings`.

**Declared ceiling: 9 files. Actual: 8** — the seven boundary files plus the
`docs/DESIGN_NOTES.md` entry. No test was added; see "Why no test" below.

## This contradicts the issue text, deliberately

#1399 asks to **narrow** the struct-only `Grappa.Accounts` deps. For these seven
there is nothing to narrow, and the proof is in the tree:

- Each reaches `Accounts.User` exactly twice, in one schema file, in the same two
  shapes — a `belongs_to :user, User` association argument and a
  `user: User.t()` typespec. Both are module names that become atoms in
  metadata, not remote calls, so no xref edge exists for Boundary to police.
- `Grappa.Uploads` holds that identical pair — `uploads/upload.ex:48` aliases
  `Grappa.Accounts.User`, `:75` declares `belongs_to :user, User` — with **no**
  `Grappa.Accounts` dep and no waiver, and compiles green today.
  `Grappa.TestSupport.SubjectSession` is a second instance, via a typespec.

So the review's "three incompatible resolutions" undercounts. A fourth —
*declare nothing* — was already live and already correct, and seven of the
thirteen belong to it. Narrowing them would encode a dependency the compiler
cannot see, on a module that is not a boundary today, and would have to be
undone the day `Accounts.User` is promoted. Deleting states what the compiler
can check. Where the prose and the measured tree disagree, the tree wins.

## The green here is worth something, because the red was armed first

Boundary reports cross-boundary references as **advisory warnings**; only
`mix compile --warnings-as-errors` — the first step of `ci.check`, for exactly
this reason (`mix.exs`) — makes them fail a build. A green compile after seven
deletions therefore proves nothing unless the checker is known to bite.

| step | command | result |
|---|---|---|
| baseline | `mix compile --force` at `d8b58e2d` | rc=0, 326 files |
| **mutant** | drop the `Grappa.Accounts` dep from `Grappa.Subject`, which holds a real `%User{}` reference, then `mix compile --force --warnings-as-errors` | **rc=1**, exactly **one** `forbidden reference to Grappa.Accounts.User`, at `lib/grappa/subject.ex:134`, `(references from Grappa.Subject to Grappa.Accounts are not allowed)` |
| restore | revert the mutant | `git status --porcelain` empty |
| **slice** | seven deps deleted, `mix compile --force --warnings-as-errors` | **rc=0**, `forbidden reference` count **0** |

One mutant, one assertion, the predicted line and the predicted target — nothing
else moved. Had any of the seven carried an edge the source measurement missed,
that is where it would have surfaced. The slice was designed to be falsified by
the compiler and was not.

## A stale number settled while the lane was held

The #1398 cycle-budget gate records an open question: two hand-written parsers
disagreed on how many `use Boundary` declarations the tree contains, **99 against
107**. The compiled attribute settles it at **99** — counted from the `Boundary`
module attribute over `:application.get_key(:grappa, :modules)`, the same source
`GrappaWeb.BoundaryTest` reads. The source measurement agrees exactly, and the
arithmetic explains itself: `lib` holds 111 textual occurrences of
`use Boundary`, 12 of them prose in moduledocs and comments, leaving 99.

**107 corresponds to no population that could be reconstructed here** (99
compiled, 99 line-anchored in `lib`, 104 adding `test/support`, 111 textual). No
explanation for it is offered rather than invented. The gate's comment still
carries the 99-vs-107 wording and lives in PR #1492, which this branch does not
touch — updating it there is a separate, one-line follow-up.

## Why no test

The compiler is the gate. `mix compile --warnings-as-errors` already fails the
build on a boundary violation, and CI runs it as the first step of `ci.check`, so
a test asserting "these seven do not declare `Grappa.Accounts`" would restate the
diff rather than check behaviour. The mutant above is the evidence that the
existing gate is live.

## What this deliberately leaves open

- **The other six of the thirteen are untouched.** Four hold real edges
  (`Subject`, `Themes`, `Admission`, `Vhosts`) and need `Accounts.User` and
  `Accounts.Session` promoted first. That change is larger than the review
  states: promoting them removes both from `Grappa.Accounts`' `exports:`, so
  every boundary holding a real edge must declare the new dep — measured at 19
  boundaries, not 11.
- **The `Networks.Network` half is not an annotation change** but a
  schema-cluster move, and is tracked separately.
- **A7 — the 11 nested `top_level?: true` boundaries — is not addressed.**
  Without a convention distinguishing a deliberate carve-out from a context
  internal there is no oracle to satisfy.
- **The rule is not written next to the Boundary paragraph in CLAUDE.md**, which
  is what #1399 asks for last. That file is not edited here; the edit is vjt's.
  Until it lands, a future boundary that needs only a schema can still invent a
  fifth resolution, so this issue is not closed by this PR.

## Not established

- Nothing here is exercised against production or a live session; these are
  compile-time annotations and no runtime behaviour changes.
- The seven deletions are proven by the compiler on this branch at this base.
  The source-level reference measurement that selected them is a regex over
  source, so a reference built by macro or `Module.concat/1` would be invisible
  to it — the compiler, not the parser, is what makes the claim safe.
