### PR TITLE
logging(#1403 slice A): gate the metadata allowlist in both directions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -580,11 +580,16 @@ config :logger, :console,
     # the curve fed off.
     :delay_ms,
     :failure_count,
-    # T31 admission — rides admission rejection / circuit transition log
-    # lines so operator can grep cap-exceeded events.
-    :cap_kind,
-    :cap_value,
-    :cap_observed,
+    # T31 admission. The block used to open with `:cap_kind`, `:cap_value`
+    # and `:cap_observed`; #1403's reverse gate found the three occur in no
+    # file under `lib/` at all, and they are gone. There is in fact no
+    # `Logger.` call anywhere in `lib/grappa/admission/`, so the two below
+    # are almost certainly dead as metadata too — they survive the gate on
+    # non-Logger occurrences (`circuit_state` inside the ETS table name
+    # `:admission_network_circuit_state`, `retry_after_seconds` as a field
+    # of `NetworkCircuit.AdminWire`), which is exactly the lower bound that
+    # gate documents about itself. Left in place because nothing PROVED
+    # them dead; prove it and drop them.
     :circuit_state,
     :retry_after_seconds,
     # IRC outbound verb (cluster #10 S10): identifies which

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47441,3 +47441,78 @@ empty `deps:`. The same move here cannot be scoped to `Network` alone —
 is the four-schema cluster, priced at roughly fifteen files and atomic. That is a
 purchase, not a slice, and it is deliberately left to #1398 rather than smuggled in
 behind a gate.
+<!-- entry #1403 -->
+
+---
+
+## 2026-08-17 — #1403: the Logger allowlist gets its missing direction, and it is a lower bound on purpose
+
+`config/config.exs` carries a 318-line `:metadata` allowlist — 108 atoms, 44%
+of the file. One test pinned it, in one direction: `Meta.known_keys() --
+allowlist == []`, so every scrollback meta key must be listed. Nothing pinned
+the other way, and four entries carried a hand-written apology for being
+present-but-unlogged, which is the allowlist admitting in prose what no gate
+was checking.
+
+The reverse gate now exists, and the first thing it did was name three atoms
+nobody had apologised for: `:cap_kind`, `:cap_value` and `:cap_observed`
+occurred in **no file under `lib/` at all**. Not unlogged — absent. The
+comment above them said they rode "admission rejection / circuit transition
+log lines"; there is no `Logger.` call anywhere in `lib/grappa/admission/`, so
+that line was never written. They are gone.
+
+### Why the derivation is a substring scan and not an AST walk
+
+The gate asserts something deliberately weak: an allowlisted atom must occur
+as a substring on a non-comment line of some `lib/**/*.ex`. It proves "cannot
+possibly be logged", never "is not logged".
+
+Anything stricter goes red on live keys, and the codebase already contains
+three shapes that would trip it. `Grappa.Log.session_context/2` hands
+`[user: u, network: n]` to `Logger.metadata/1` through a function call, so an
+AST walk of Logger call sites sees a call node and no keys.
+`Grappa.IRC.Client` receives the same pair as a `start_link` option, one hop
+further from any Logger site. And `@known_keys ~w[...]a` is a sigil, which
+`Code.string_to_quoted!/1` renders as a string payload rather than atom nodes
+— an atom walk would be blind to the very 23 keys the forward gate exists to
+protect. A gate whose false-red rate is non-zero on a 108-entry list is a gate
+someone silences.
+
+`Meta.known_keys/0` is subtracted before the check so the two directions
+cannot fight: a key the forward gate REQUIRES must never be reported as an
+orphan by the reverse one. `:request_id` is declared framework-injected —
+`Plug.RequestId` in the endpoint sets it and nothing here does. That entry is
+belt-and-braces today, since two `@moduledoc` mentions would carry the atom
+past the scan anyway; it is there so rewording a moduledoc cannot turn a live
+framework key into an apparent orphan somebody prunes.
+
+### What the lower bound costs, stated rather than hidden
+
+`:circuit_state` and `:retry_after_seconds` are almost certainly dead for the
+same reason as the three that went — same block, same absent log line — and
+the gate cannot say so. They survive on occurrences that have nothing to do
+with logging: `circuit_state` sits inside the ETS table name
+`:admission_network_circuit_state`, and `retry_after_seconds` is a field of
+`NetworkCircuit.AdminWire`. Both were left in place with the evidence written
+next to them. Pruning on a hunch is what filled this list.
+
+Three more entries stay for a different reason. `:who`, `:who_target` and
+`:names_target` are in `@known_keys` and are never written as scrollback meta
+by any code in `lib/`, but `Meta.load/1` reads that same list to atomise keys
+coming back from SQLite, leniently — an unknown key survives as a string.
+Dropping them therefore does not crash anything; it silently changes the shape
+historical rows load with, atom key to string key, all the way to the render.
+That is a separate decision needing evidence from real rows, not a tidy-up.
+
+### Placement
+
+Both directions now live in `test/grappa/logger_metadata_allowlist_test.exs`.
+The forward test moved there unchanged from `Grappa.Scrollback.MetaTest`: 85
+of the 108 allowlisted atoms have nothing to do with scrollback meta, and
+parking the allowlist's only gate inside one Ecto type's test file is a fair
+part of why the missing half stayed missing for as long as it did.
+
+_Not established: how many of the remaining 105 atoms are actually logged. The
+scan proves absence, never disuse, so the count of dead entries is a floor and
+not a measurement. The 39-arm `do_handle_in` door and the per-verb table that
+#1403's HIGH proposes are untouched by this work._

--- a/test/grappa/logger_metadata_allowlist_test.exs
+++ b/test/grappa/logger_metadata_allowlist_test.exs
@@ -1,0 +1,113 @@
+defmodule Grappa.LoggerMetadataAllowlistTest do
+  @moduledoc """
+  Both drift directions for the Logger `:metadata` allowlist in
+  `config/config.exs` (#1403, architecture review A7, formerly A18).
+
+  The forward direction moved here from `Grappa.Scrollback.MetaTest`: 85 of
+  the 108 allowlisted atoms have nothing to do with scrollback meta, so the
+  invariant does not belong to one Ecto type's test file. Its assertion is
+  unchanged.
+
+  ## Why the reverse direction exists
+
+  The forward gate (`known_keys -- allowlist == []`) forces every scrollback
+  meta key into the allowlist. Nothing gated the other way, and the gap had
+  already filled: `:cap_kind`, `:cap_value` and `:cap_observed` were in the
+  allowlist while the string does not occur in a single file under `lib/`.
+  Four other entries carry a hand-written comment apologising for being
+  present-but-unlogged; those four are the ones somebody happened to notice.
+
+  ## What the reverse gate actually proves
+
+  A LOWER BOUND, deliberately. An allowlisted atom must occur as a substring
+  on a non-comment line of some `lib/**/*.ex` file. That is much weaker than
+  "something logs it":
+
+    * a mention inside a `@moduledoc` / `@doc` heredoc counts (only whole
+      `#` comment lines are dropped);
+    * a substring of a longer identifier counts.
+
+  So the gate catches "cannot possibly be logged", not "is not logged". The
+  weakness is the point: the derivation is a plain substring scan, which
+  cannot go red on a key that is alive but built dynamically. Two such keys
+  exist today and would defeat anything stricter — `Grappa.Log.session_context/2`
+  hands `[user: u, network: n]` to `Logger.metadata/1` through a function call,
+  and `Grappa.IRC.Client` receives the same pair as a `start_link` opt. An
+  AST walk of Logger call sites would report both as orphans.
+
+  `Meta.known_keys/0` is subtracted before the check so the two directions
+  cannot fight: a key the forward gate REQUIRES in the allowlist must never be
+  reported as an orphan by the reverse one.
+  """
+
+  # async: true — file reads plus an Application env read, no global state
+  # mutated. Mirrors `GrappaWeb.ErrorTokensDriftTest`, the sibling
+  # derive-from-source drift pin.
+  use ExUnit.Case, async: true
+
+  alias Grappa.Scrollback.Meta
+
+  @lib_glob "lib/**/*.ex"
+
+  # Injected by the plug stack, never by our own code: `Plug.RequestId` is
+  # mounted in `GrappaWeb.Endpoint` and puts `:request_id` into the process
+  # metadata itself. Today the atom would also survive the substring scan on
+  # two `@moduledoc` mentions (`log.ex`, `endpoint.ex`) — this entry is what
+  # keeps a reworded moduledoc from turning a live framework key into an
+  # apparent orphan somebody then prunes.
+  @framework_injected [:request_id]
+
+  describe "known_keys/0 ↔ Logger metadata allowlist (architecture review A18)" do
+    test "every Meta @known_keys atom is present in the Logger :metadata allowlist" do
+      missing = Meta.known_keys() -- logger_metadata_keys()
+
+      assert missing == [],
+             "Meta.@known_keys not in Logger metadata allowlist: " <>
+               "#{inspect(missing)} — extend config/config.exs :metadata list"
+    end
+  end
+
+  describe "Logger metadata allowlist -> lib/ (reverse direction, #1403)" do
+    test "every allowlisted atom is reachable from lib/, a known_key, or framework-injected" do
+      source = lib_source()
+      known = Meta.known_keys()
+
+      orphans =
+        Enum.reject(logger_metadata_keys(), fn key ->
+          key in known or key in @framework_injected or
+            String.contains?(source, Atom.to_string(key))
+        end)
+
+      assert orphans == [],
+             "Logger :metadata atoms that occur nowhere under lib/: " <>
+               "#{inspect(orphans)} — drop them from config/config.exs, or add " <>
+               "them to @framework_injected with the reason they are set from " <>
+               "outside this codebase"
+    end
+  end
+
+  # Elixir 1.15+ uses :default_formatter; fall back to legacy :console.
+  defp logger_metadata_keys do
+    modern = Application.get_env(:logger, :default_formatter, [])[:metadata] || []
+
+    if modern == [],
+      do: Application.get_env(:logger, :console, [])[:metadata] || [],
+      else: modern
+  end
+
+  # Every `lib/` source line that is not a whole-line `#` comment, joined.
+  # Whole-line comments are dropped so an atom surviving only in a "removed
+  # in #NNN" note does not keep its allowlist entry alive; heredocs are kept
+  # on purpose (see the moduledoc — this is a lower bound, not a census).
+  defp lib_source do
+    @lib_glob
+    |> Path.wildcard()
+    |> Enum.map_join("\n", fn path ->
+      path
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.reject(&String.starts_with?(String.trim_leading(&1), "#"))
+      |> Enum.join("\n")
+    end)
+  end
+end

--- a/test/grappa/scrollback/meta_test.exs
+++ b/test/grappa/scrollback/meta_test.exs
@@ -156,22 +156,9 @@ defmodule Grappa.Scrollback.MetaTest do
     end
   end
 
-  describe "known_keys/0 ↔ Logger metadata allowlist (architecture review A18)" do
-    test "every Meta @known_keys atom is present in the Logger :metadata allowlist" do
-      missing = Meta.known_keys() -- logger_metadata_keys()
-
-      assert missing == [],
-             "Meta.@known_keys not in Logger metadata allowlist: " <>
-               "#{inspect(missing)} — extend config/config.exs :metadata list"
-    end
-
-    defp logger_metadata_keys do
-      # Elixir 1.15+ uses :default_formatter; fall back to legacy :console.
-      modern = Application.get_env(:logger, :default_formatter, [])[:metadata] || []
-
-      if modern == [],
-        do: Application.get_env(:logger, :console, [])[:metadata] || [],
-        else: modern
-    end
-  end
+  # The `known_keys/0 ↔ Logger metadata allowlist` pin moved to
+  # `Grappa.LoggerMetadataAllowlistTest` (#1403), which now owns BOTH
+  # directions. It left here because 85 of the 108 allowlisted atoms have
+  # nothing to do with scrollback meta, and because keeping the forward gate
+  # in this file is how the missing reverse one went unnoticed.
 end


### PR DESCRIPTION
Slice A of #1403 (bucket N verb-plumbing). Addresses the **A7 MEDIUM** only — the
Logger metadata allowlist. **The A5 HIGH (the per-verb table) is NOT touched here**,
and is deliberately blocked on a question in the recon that only vjt can answer.

## What was wrong

`config/config.exs` carries a 318-line `:metadata` allowlist — 108 atoms, 44% of the
file. One test pinned it, **in one direction**: `Meta.known_keys() -- allowlist == []`.
Nothing pinned the other way. Four entries carried a hand-written comment apologising
for being present-but-unlogged, which is the list admitting in prose what no gate was
checking.

The gap had already filled. Three atoms — `:cap_kind`, `:cap_value`, `:cap_observed` —
occur **in no file under `lib/` at all**. Not "nothing logs them": the strings are
absent from the codebase outside that list. None of the three is among the four that
carry an apology, because nobody had noticed them. The comment above them claimed they
"ride admission rejection / circuit transition log lines"; there is no `Logger.` call
anywhere in `lib/grappa/admission/`, so the line they were allowlisted for was never
written.

## The red, verbatim, before the prune

The gate went in first and the three were left in place, so the failure names them:

```
1) test Logger metadata allowlist -> lib/ (reverse direction, #1403) every allowlisted
   atom is reachable from lib/, a known_key, or framework-injected
   (Grappa.LoggerMetadataAllowlistTest)
   test/grappa/logger_metadata_allowlist_test.exs:71
   Logger :metadata atoms that occur nowhere under lib/: [:cap_kind, :cap_value,
   :cap_observed] — drop them from config/config.exs, or add them to
   @framework_injected with the reason they are set from outside this codebase
2 tests, 1 failure
```

The forward test passes in the same run, which is also what rules out a vacuous green:
if the env read returned `[]`, the forward direction would fail on 23 keys.

## Why the reverse gate is a LOWER BOUND on purpose

It asserts something deliberately weak: an allowlisted atom must occur as a substring
on a non-comment line of some `lib/**/*.ex`. It proves **"cannot possibly be logged"**,
never "is not logged".

Anything stricter goes red on live keys, and three shapes already in this codebase would
trip it:

* `Grappa.Log.session_context/2` hands `[user: u, network: n]` to `Logger.metadata/1`
  **through a function call** — an AST walk of Logger call sites sees a call node, no keys.
* `Grappa.IRC.Client` takes the same pair as a `start_link` option, one hop further out.
* `@known_keys ~w[...]a` is a **sigil**, which `Code.string_to_quoted!/1` renders as a
  string payload and not atom nodes — an atom walk would be blind to the exact 23 keys
  the forward gate exists to protect.

A gate with a non-zero false-red rate on a 108-entry list is a gate someone silences.

## What the bound costs, left visible instead of hidden

`:circuit_state` and `:retry_after_seconds` are very probably dead for the identical
reason — same block, same missing log line — and the gate **cannot** prove it. They
survive on occurrences that have nothing to do with logging: `circuit_state` inside the
ETS table name `:admission_network_circuit_state`, `retry_after_seconds` as a field of
`NetworkCircuit.AdminWire`. Both stay, with the evidence written beside them. Pruning on
a hunch is how the list filled.

`:who`, `:who_target` and `:names_target` stay for a different reason, and this one is a
correctness argument rather than caution: they are in `@known_keys`, which `Meta.load/1`
reads to atomise keys coming back **out of** SQLite, leniently. Dropping them crashes
nothing — it silently changes the shape historical rows load with, atom key to string
key, all the way to the render. Separate decision, needs evidence from real rows.

## Placement

Both directions now live in one file. The forward test moved out of
`Grappa.Scrollback.MetaTest` **unchanged** (same `describe` string, same assertion): 85
of the 108 allowlisted atoms have nothing to do with scrollback meta, and parking the
allowlist's only gate inside one Ecto type's test file is a fair part of why the missing
half stayed missing.

## File ceiling

**Declared before starting: 4. Landed: 4.** No fifth file was touched.

| file | why |
|---|---|
| `test/grappa/logger_metadata_allowlist_test.exs` | new, owns both directions |
| `test/grappa/scrollback/meta_test.exs` | forward test moved out, pointer left |
| `config/config.exs` | the three atoms, and an honest comment |
| `docs/DESIGN_NOTES.md` | entry `#1403` |

## 🔴 This is a COLD change

It touches `config/config.exs`. Every modification under `config/` forces a **COLD**
deploy even though the key is resolvable at runtime. Not a problem — the deploy is held
— but whoever ships must read the class.

## Gates

Rebased onto `origin/main` = `5dbe6f68` **first**, then gated: main moved (#1398/#1410)
after the first green, so that green attested a base that would never be pushed and was
discarded.

* `scripts/check.sh` — **rc=0 read from a file**, not from a wrapper notification.
  Phase markers all present: compile, `Checking N source files` (Credo), `Running
  Sobelow`, `Doctor validation`, `Running ExUnit` (**8 doctests, 61 properties, 6538
  tests, 0 failures**), `Total errors: 0` (Dialyzer), `wireTypes.ts`/`wireSchema.ts` in
  sync, bats **564 ok / 0 not ok**. `format --check-formatted` and `deps.audit` print
  nothing on success; they are proven to have passed because the `ci.check` alias halts
  on the first non-zero and every later stage ran.
* Test count moved 6537 to 6538 between the two runs. That is main's, not this branch's:
  #1398 landed `boundary_cycle_budget_test.exs` in between.
* `scripts/design-notes-gate.sh origin/main` — green, marker and separator present, both
  in the same commit.
* Rebase pinned on file: `git diff --numstat <base> HEAD` byte-identical before and
  after (additions unchanged AND deletions zero), and
  `head -47443 docs/DESIGN_NOTES.md | diff - <origin/main copy>` empty, so every
  pre-existing entry is intact.

## Tools found blind while measuring this (worth more than the result)

1. 🔴 **`git log --grep='#NNN'` searches the commit BODY, not just the subject.** It
   inflated four of six measurements in the recon before it was caught — `#374` read
   **32 files against a true 18 (+78%)**, because #992's commits cite #374 in their
   bodies. The correct set is `git log --format='%H%x09%s' | grep -F '(#NNN)'`. Anyone
   repeating the "23 files per verb" measurement with the obvious command gets this.
   (The issue's own 23 is unaffected: for #1225 both methods give the same 7 commits.)
2. 🔴 **`grep` on this host is ugrep 7.5.0, and `grep -oE '[^a-z_0-9]name:'` returns 0
   where `grep -cE '(^|[^a-z_0-9])name:'` returns 16.** Reproduced on a two-line file;
   it fails for `to:`/`xy:` and works for `target:`. That form had been used throughout
   the recon's dead-atom section — all six results were re-verified with the safe form
   and all six hold, but the form is banned.
3. **Searching `:name` instead of `name:` misses keyword syntax entirely.** Metadata keys
   are written `held_ms: v`, not `:held_ms`; the `:name` form alone reported **43 false
   dead atoms out of 108**.
4. **`~w[...]a` yields no atom nodes in the AST** (see above) — which is what ruled the
   stricter derivation out, rather than a preference for the simpler one.
5. **`grep -A1` past an apologetic comment** only finds the atom because it happens to sit
   on the next line; a two-line comment would have hidden it silently.

## What this does NOT claim

* **Not that the remaining 105 atoms are live.** The scan proves absence, never disuse.
  The count of dead entries is a **floor**, not a measurement — `:circuit_state` and
  `:retry_after_seconds` above are two known escapees.
* **Not that `setting_key` would have been caught.** The recon suggested it as a witness;
  re-measured at the review commit, it was a live `Logger.warning(..., setting_key: k)` in
  `admin/settings_controller.ex` and was pruned because its CODE was removed, which is the
  healthy path. The correction is recorded in the recon file too. The three `cap_*` are
  the only measured witnesses this gate has.
* **Not anything about the A5 HIGH.** The 39-arm `do_handle_in` door and the per-verb
  table are untouched. The recon measured the table's leverage at 32%-89% of server code
  lines depending on whether the verb reuses an existing reply family, and 3 files out of
  18-30 — which is why slice B is waiting on a criterion, not on effort.
