### PR TITLE
arch(#1398): give the four Networks schemas their own boundaries, and retire every waiver

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47539,3 +47539,80 @@ reference built by macro or `Module.concat/1` would be invisible to it; the
 compiler, not the parser, is what makes the set safe, and a file appearing
 beyond the declared set would mean the parser missed a consumer rather than
 that the set grew._
+<!-- entry #1399 -->
+
+---
+
+## 2026-08-17 — #1399: seven boundaries stop declaring a dependency they never had
+
+Bucket J of the 2026-08-15 architecture review says one problem — "a boundary
+needs only a schema" — has three incompatible resolutions, and asks for the
+thirteen struct-only `Grappa.Accounts` deps to be *narrowed*. Measuring the tree
+first changed the answer for seven of them: there is nothing to narrow, because
+there was never an edge.
+
+`Grappa.ChannelDirectory`, `Grappa.Notify`, `Grappa.Push`, `Grappa.QueryWindows`,
+`Grappa.ReadCursor`, `Grappa.Scrollback` and `Grappa.UserSettings` each declared
+`Grappa.Accounts` in `deps:`. Each reaches `Accounts.User` exactly twice, in one
+schema file, in the same two shapes: a `belongs_to :user, User` association
+argument and a `user: User.t()` typespec. Both are module names that end up as
+atoms in metadata rather than as remote calls, so the xref-based checker has no
+reference to police. The dep bought nothing.
+
+**The tree already answered this, and nobody had noticed.** `Grappa.Uploads`
+holds the identical pair — `uploads/upload.ex` aliases `Grappa.Accounts.User`
+and declares `belongs_to :user, User` — with **no** `Grappa.Accounts` dep and no
+waiver, and it has been compiling green for as long as it has existed.
+`Grappa.TestSupport.SubjectSession` is a second instance, via a typespec. So the
+review's "three resolutions" undercounts: a fourth, *declare nothing*, was
+already live and already correct. Seven of the thirteen belong to it.
+
+**Why deleting rather than narrowing.** Narrowing `Grappa.Accounts` to
+`Grappa.Accounts.User` would encode a dependency the compiler cannot see, on a
+module that is not a boundary today, to satisfy a rule none of these seven
+actually violate — and it would have to be undone the day `Accounts.User` is
+promoted. Deleting states the truth that the compiler can check: these
+boundaries do not depend on `Grappa.Accounts`. Where an issue's prose and the
+measured tree disagree, the tree wins.
+
+**The deletion is falsifiable, and the falsifier was armed first.** Boundary
+reports cross-boundary references as advisory warnings; only
+`mix compile --warnings-as-errors` — the first step of the `ci.check` alias, for
+exactly this reason — turns them into a failed build. So a green compile after
+seven deletions proves nothing unless the checker is known to bite. Before the
+deletions, one mutant removed the `Grappa.Accounts` dep from `Grappa.Subject`,
+which holds a real reference (`%User{}` in `from_assigns/1`). The build went red
+with exactly one violation, at exactly that line, naming exactly
+`Grappa.Accounts.User` — one mutant, one assertion, nothing else moved. With the
+mutant reverted and the seven deps gone, the same command is green with zero
+forbidden references. Had any of the seven carried an edge the source
+measurement missed, this is where it would have surfaced.
+
+**A stale number, settled while the lane was held.** Two hand-written parsers
+had disagreed about how many `use Boundary` declarations the tree even contains
+— 99 against 107 — and that disagreement was written into the #1398 cycle-budget
+gate as an open question. The compiled attribute settles it: **99**, counted from
+`Boundary` module attributes over `:application.get_key(:grappa, :modules)`. The
+source measurement agrees exactly, and the arithmetic explains itself — `lib`
+holds 111 textual occurrences of `use Boundary`, of which 12 are prose in
+moduledocs and comments, leaving 99 declarations. 107 corresponds to no
+population that could be reconstructed here, and no explanation for it is
+offered rather than invented.
+
+Comments at the seven sites say why the dep is absent, because absence is not
+self-documenting: the next reader finds a `belongs_to` pointing at another
+boundary's schema and, without a note, closes the "gap".
+
+_Not established: the other six of the thirteen are untouched — four hold real
+edges (`Subject`, `Themes`, `Admission`, `Vhosts`) and need `Accounts.User` and
+`Accounts.Session` promoted first, which is a separate change with a larger
+population than the review states, since promoting them removes both from
+`Grappa.Accounts`' `exports:` and forces every boundary holding a real edge to
+declare the new dep. The `Networks.Network` half of the bucket is a schema-cluster
+move, not an annotation change, and is tracked separately. The A7 finding — 11
+`top_level?: true` boundaries nested in another boundary's namespace — is
+deliberately not addressed: without a convention distinguishing a carve-out from
+a context internal there is no oracle to satisfy. The rule this entry describes
+is not written next to the Boundary paragraph in CLAUDE.md, so a future boundary
+that needs only a schema can still invent a fifth resolution; that edit is
+vjt's._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47441,3 +47441,101 @@ empty `deps:`. The same move here cannot be scoped to `Network` alone —
 is the four-schema cluster, priced at roughly fifteen files and atomic. That is a
 purchase, not a slice, and it is deliberately left to #1398 rather than smuggled in
 behind a gate.
+<!-- entry #1398p -->
+
+---
+
+## 2026-08-17 — #1398: the four Networks schemas own themselves, and 31 cycles go with them
+
+Every `dirty_xrefs` waiver in the tree named `Grappa.Networks.Network` — five
+of them, grown from three between two reviews with nothing watching. Counting
+those waivers as the edges they are turned an acyclic declared graph into one
+with 31 elementary cycles over 12 boundaries. The waivers existed because the
+only alternative on offer was worse: a consumer that needed the schema struct
+had to declare a dep on the entire `Grappa.Networks` context, and that edge is
+what closed the cycles.
+
+The fix is that the schemas stop being part of the context. `Network`, `Server`,
+`Credential` and `FeaturedChannel` each carry `use Boundary, top_level?: true`
+with a deps list measured from their real outbound edges — `Grappa.IRC` for
+three of them, nothing at all for `Server`. A consumer now declares an edge to a
+leaf, and a leaf closes nothing.
+
+**The premise this was planned under was wrong, and the correction is the
+interesting part.** Two earlier reconnaissance passes, including one of mine,
+concluded that four separate leaves were impossible: `server.ex`,
+`credential.ex` and `featured_channel.ex` all name `Network`, so four leaves
+looked like four two-cycles, and the only Boundary-expressible form looked like
+one boundary holding all four schemas — which, since no namespace contains
+exactly those four, meant moving files and renaming modules. Roughly fifteen
+files of rename, and a cold deploy, because renamed modules are beams that
+disappear.
+
+None of that was needed. Every reference among the four is a `has_many` or
+`belongs_to` argument and a typespec, and #1399 had just established against the
+compiler — by deleting seven deps of exactly that shape and staying green under
+`--warnings-as-errors` — that those are atoms in metadata rather than references
+the checker resolves. There is no back-edge, so there is no cycle, so there is
+nothing to merge into a shared namespace. The move is four annotations. No
+module is renamed, no file moves, and the deploy stays hot.
+
+The general lesson is about the measurement, not the outcome: **counting
+references without classifying them measures the wrong population.** Both
+earlier passes counted names and got a real number; the number just did not
+answer the question being asked of it. The reference *kind* is what decides
+whether an edge exists.
+
+**How the five waivers split.** `ReadCursor` holds three `join: n in Network`
+slug lookups and `Scrollback` matches `%Network{slug: slug}` in its wire
+contract, so those two trade a waiver for a declared edge. The other three —
+`ChannelDirectory`, `Notify`, `QueryWindows` — held none, and their waivers are
+deleted with nothing declared in their place, which the compiler accepts.
+
+That last clause is deliberately narrow, because a measurement taken while
+proving the mutant contradicts the wider claim this entry originally made.
+Boundary has a second check: it warns when a `dirty_xrefs` entry is
+unnecessary, and under `--warnings-as-errors` that warning fails the build. The
+mutant tripped it. So the three waivers were run against that check on every
+green build of `main` and never tripped it — measured directly, `origin/main`
+compiles with zero such warnings while still carrying all three. Boundary
+therefore considered them USED, and yet deleting them here produces no
+forbidden reference.
+
+Both halves are measured and they are not obviously compatible; the mechanism
+that reconciles them was not established, and is not guessed at here. What the
+promotion does establish is narrower and sufficient: after it, those three
+boundaries need no declaration of any kind. The earlier sentence in this entry
+— that the waivers "never covered anything" — claimed more than the evidence
+supports and is withdrawn.
+
+**One judgement call was left for the compiler rather than settled by reading.**
+`Notify` and `QueryWindows` pass the schema module as a plain argument to
+`check_exists/4`, the way `Admission` passes it to `Repo.get/2`. Whether that
+is a reference Boundary resolves is not something source inspection answers.
+Declaring the dep would have been the comfortable choice and the wrong one: an
+undeclarable dependency asserted anyway is exactly the defect being removed
+here, and it fails silently. Omitting it fails loudly, at the build, with the
+line number. The choice was made for falsifiability.
+
+**What the gate proves and what it does not.** The budget moves to the number
+the gate itself measures after the promotion, not to a number this entry
+asserts. It is a count over DECLARED deps plus waivers: injected closures,
+behaviours resolved from `:persistent_term` and the supervisor-level
+`held_source_fn` carry no module reference any compile-time mechanism can see,
+so the runtime graph remains denser than anything measured here, and a closure
+that opens a cycle still moves nothing.
+
+A second limit is new and worth recording, because it inverts how a future
+waiver reads: now that the schemas are leaves, a `dirty_xrefs:` pointed at one
+of them would close no cycle and the gate would stay green. The 31 were never
+about waivers as such — they were about waivers pointed at a module owned by a
+large boundary. The gate lost sensitivity on that target by making the target
+harmless.
+
+_Not established: no behaviour changes and nothing here was exercised against
+production or a live session — these are compile-time annotations. The
+reference measurement that selected the file set is a regex over source, so a
+reference built by macro or `Module.concat/1` would be invisible to it; the
+compiler, not the parser, is what makes the set safe, and a file appearing
+beyond the declared set would mean the parser missed a consumer rather than
+that the set grew._

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -55,6 +55,7 @@ defmodule Grappa.Admission do
       Grappa.Accounts,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.RateLimit,
       Grappa.Repo
     ],

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -51,7 +51,13 @@ defmodule Grappa.Admission do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Grappa.RateLimit, Grappa.Repo],
+    deps: [
+      Grappa.Accounts,
+      Grappa.Networks,
+      Grappa.Networks.Credential,
+      Grappa.RateLimit,
+      Grappa.Repo
+    ],
     exports: [Captcha, Config, NetworkCircuit, NetworkCircuit.AdminWire, Telemetry]
 
   import Ecto.Query

--- a/lib/grappa/bootstrap.ex
+++ b/lib/grappa/bootstrap.ex
@@ -146,6 +146,7 @@ defmodule Grappa.Bootstrap do
     deps: [
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.OutboundV6Pool,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/bootstrap.ex
+++ b/lib/grappa/bootstrap.ex
@@ -145,6 +145,7 @@ defmodule Grappa.Bootstrap do
     top_level?: true,
     deps: [
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.OutboundV6Pool,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -16,18 +16,8 @@ defmodule Grappa.ChannelDirectory do
     # `Identifier.canonical_target/1` (ASCII, #364/#525/#537) to key them against
     # the canonical featured set.
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced ONLY by `Entry`'s
-    # `belongs_to :network` (struct/schema access — no `Grappa.Networks`
-    # function call anywhere in this boundary). A full `Grappa.Networks`
-    # dep would close the Cluster-2 cycle
-    # `ChannelDirectory → Networks → Session → ChannelDirectory` the moment
-    # `Session.Server` drives the refresh lifecycle (#84 —
-    # `replace_start/2` / `ingest/3` / `finalize/2`). Mirror of the
-    # `Networks.Network` dirty_xref in `Grappa.Scrollback`: schema-only
-    # access whose Boundary checks we lose on a use case Boundary couldn't
-    # gate anyway (struct field access goes through no function we'd want
-    # to police). Intentional.
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver: `Entry` reaches it only by
+    # `belongs_to` and a typespec, which the checker does not resolve (#1398).
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -15,9 +15,11 @@ defmodule Grappa.ChannelDirectory do
     # `Grappa.IRC` — `Wire.mark_featured/2` folds directory names via
     # `Identifier.canonical_target/1` (ASCII, #364/#525/#537) to key them against
     # the canonical featured set.
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver: `Entry` reaches it only by
-    # `belongs_to` and a typespec, which the checker does not resolve (#1398).
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either: `Entry` reaches `User` and `Network` only by
+    # `belongs_to` and a typespec, which are not references the checker
+    # resolves (#1399 for the first, #1398 for the second).
+    deps: [Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -57,6 +57,9 @@ defmodule Grappa.Networks do
       # the addressing config so effective_source/3 stays the single decision
       # point (a disarmed mode 2 HOLDs :mode2_disarmed).
       Grappa.Net.SourceAliasManager,
+      # The schemas are their own boundaries (#1398): this umbrella holds the
+      # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
       Grappa.Vault,
@@ -75,7 +78,6 @@ defmodule Grappa.Networks do
       FeaturedChannels.Wire,
       Network,
       NoServerError,
-      Server,
       Servers,
       Servers.AdminWire,
       SessionPlan,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -61,6 +61,7 @@ defmodule Grappa.Networks do
       # context verbs and reaches its own schemas across a declared edge.
       Grappa.Networks.Credential,
       Grappa.Networks.FeaturedChannel,
+      Grappa.Networks.Network,
       Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
@@ -76,7 +77,6 @@ defmodule Grappa.Networks do
       FeaturedChannels,
       FeaturedChannels.AdminWire,
       FeaturedChannels.Wire,
-      Network,
       NoServerError,
       Servers,
       Servers.AdminWire,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Networks do
       Grappa.Net.SourceAliasManager,
       # The schemas are their own boundaries (#1398): this umbrella holds the
       # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.FeaturedChannel,
       Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
@@ -72,7 +73,6 @@ defmodule Grappa.Networks do
       Credential,
       Credentials,
       Credentials.AdminWire,
-      FeaturedChannel,
       FeaturedChannels,
       FeaturedChannels.AdminWire,
       FeaturedChannels.Wire,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Networks do
       Grappa.Net.SourceAliasManager,
       # The schemas are their own boundaries (#1398): this umbrella holds the
       # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.Credential,
       Grappa.Networks.FeaturedChannel,
       Grappa.Networks.Server,
       Grappa.Session,
@@ -70,7 +71,6 @@ defmodule Grappa.Networks do
     ],
     exports: [
       AdminWire,
-      Credential,
       Credentials,
       Credentials.AdminWire,
       FeaturedChannels,

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -50,6 +50,16 @@ defmodule Grappa.Networks.Credential do
   uniqueness now lives in the two partial unique indexes above rather
   than the PK.
   """
+
+  # Its own boundary, like the other three Networks schemas (#1398). Of the
+  # five names this module aliases, only `Grappa.IRC` is declared: the
+  # changeset calls `Identity.sanitize_ident/1` and `Identifier`. `User`,
+  # `Visitor` and `EncryptedBinary` arrive only as `belongs_to` and `field`
+  # arguments, and `Network` only as a `belongs_to` and a typespec — none of
+  # them a reference the checker resolves, so declaring them would state a
+  # dependency nothing can verify.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/networks/featured_channel.ex
+++ b/lib/grappa/networks/featured_channel.ex
@@ -15,6 +15,14 @@ defmodule Grappa.Networks.FeaturedChannel do
 
   Mirrors `Grappa.Networks.Server` (the sibling per-network sub-resource).
   """
+
+  # Its own boundary, like the other three Networks schemas (#1398). The dep
+  # on `Grappa.IRC` is a real one — `Identifier.canonical_target/1` and
+  # `valid_channel?/1` are called from the changeset — while `Network` is
+  # reached only as a `belongs_to` argument and a typespec, which the checker
+  # does not resolve, so it is not declared.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/grappa/networks/network.ex
+++ b/lib/grappa/networks/network.ex
@@ -22,6 +22,20 @@ defmodule Grappa.Networks.Network do
   Primary key is an autoincrement INTEGER — networks are an internal
   identifier; the slug is the public handle.
   """
+
+  # Its own boundary, last of the four Networks schemas (#1398). This is the
+  # one the five `dirty_xrefs` waivers all named: a consumer that needed the
+  # struct had to either waive the check or take a dep on the whole
+  # `Grappa.Networks` context, and that second edge is what closed 31 cycles.
+  # With the schema owning itself, the waivers become either a declared edge
+  # to a leaf or nothing at all.
+  #
+  # `deps: [Grappa.IRC]` is the changeset's `Identifier.valid_network_slug?/1`.
+  # The three `has_many` siblings are association arguments, not references
+  # the checker resolves, so this leaf does not depend on them — which is why
+  # four separate leaves work and no namespace move was needed.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/networks/server.ex
+++ b/lib/grappa/networks/server.ex
@@ -12,6 +12,15 @@ defmodule Grappa.Networks.Server do
   surfaces `{:error, :already_exists}` from the context, not a raw
   Ecto changeset error.
   """
+
+  # Its own boundary so that a consumer needing the schema does not have to
+  # take a dep on all of `Grappa.Networks` — the edge that closed 31 cycles
+  # and drove five `dirty_xrefs` waivers (#1398/#1399). `deps: []` because
+  # this module references nothing outside itself: `Network` appears only as
+  # a `belongs_to` argument and in a typespec, neither of which is a
+  # reference the checker resolves. Mirror of `Grappa.Visitors.Visitor` (#415).
+  use Boundary, top_level?: true, deps: []
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/notify.ex
+++ b/lib/grappa/notify.ex
@@ -79,12 +79,12 @@ defmodule Grappa.Notify do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver (#1398). `Entry`'s
-    # `belongs_to` is not a resolved reference; the FK pre-check at
-    # `check_exists/4` passes the module as a plain argument, which the
-    # compiler is left to judge — if that is a reference, this line becomes a
-    # declared dep on the leaf, which no longer closes a cycle either way.
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either. `Entry` reaches `User` and `Network` by
+    # `belongs_to` and typespecs, and the FK pre-check at `check_exists/4`
+    # passes the module as a plain argument — measured, none of those three
+    # shapes is a reference the checker resolves (#1399, #1398).
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/notify.ex
+++ b/lib/grappa/notify.ex
@@ -80,11 +80,11 @@ defmodule Grappa.Notify do
   use Boundary,
     top_level?: true,
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # Networks.Network is an FK-reference-only xref (belongs_to + the
-    # existence pre-check), NOT a full dep: a `deps:` edge would close
-    # the cycle Session -> Notify -> Networks -> LiveIntrospection ->
-    # Session (Session reads the notify list at the end-of-MOTD arm).
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver (#1398). `Entry`'s
+    # `belongs_to` is not a resolved reference; the FK pre-check at
+    # `check_exists/4` passes the module as a plain argument, which the
+    # compiler is left to judge — if that is a reference, this line becomes a
+    # declared dep on the leaf, which no longer closes a cycle either way.
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -66,6 +66,7 @@ defmodule Grappa.Operator do
       Grappa.DbLatency,
       Grappa.LiveIntrospection,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Session,
       # #269 — the admin Visitors-tab Reconnect verb reuses the connect
       # core (admission → backoff-reset → spawn) through the shared

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -67,6 +67,7 @@ defmodule Grappa.Operator do
       Grappa.LiveIntrospection,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.Session,
       # #269 — the admin Visitors-tab Reconnect verb reuses the connect
       # core (admission → backoff-reset → spawn) through the shared

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -68,8 +68,10 @@ defmodule Grappa.Push do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Subscription`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.Mentions,
       Grappa.Repo,

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -96,13 +96,14 @@ defmodule Grappa.QueryWindows do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver (#1398), same call as
-    # `Grappa.Notify`: `Window`'s `belongs_to` is not a resolved reference,
-    # and the FK pre-check at `check_exists/4` passes the module as a plain
-    # argument. The old cycle this waiver avoided,
-    # `Session → QueryWindows → Networks → Session`, cannot form through a
-    # leaf that depends only on `Grappa.IRC`.
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either — same call as `Grappa.Notify`. `Window` reaches
+    # both by `belongs_to` and typespecs, and the FK pre-check at
+    # `check_exists/4` passes the module as a plain argument; measured, none of
+    # those shapes is a reference the checker resolves (#1399, #1398). The old
+    # cycle the waiver avoided, `Session → QueryWindows → Networks → Session`,
+    # cannot form through a leaf that depends only on `Grappa.IRC`.
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Window, Wire]
 
   import Ecto.Query

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -97,15 +97,12 @@ defmodule Grappa.QueryWindows do
   use Boundary,
     top_level?: true,
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced ONLY as a schema — the
-    # `belongs_to :network` association + the FK-existence `Repo.exists?`
-    # query in `check_exists/4`. Declared a dirty xref (NOT a real dep),
-    # mirroring `Grappa.Scrollback` / `Grappa.ReadCursor`: a real
-    # `QueryWindows → Networks` edge would close the cycle
-    # `Session → QueryWindows → Networks → Session` once #373 made
-    # Session depend on QueryWindows (for `rename/4` on a peer NICK).
-    # The struct-only reference carries no behaviour Boundary could gate.
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver (#1398), same call as
+    # `Grappa.Notify`: `Window`'s `belongs_to` is not a resolved reference,
+    # and the FK pre-check at `check_exists/4` passes the module as a plain
+    # argument. The old cycle this waiver avoided,
+    # `Session → QueryWindows → Networks → Session`, cannot form through a
+    # leaf that depends only on `Grappa.IRC`.
     exports: [Window, Wire]
 
   import Ecto.Query

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -77,17 +77,15 @@ defmodule Grappa.ReadCursor do
       Grappa.PubSub,
       Grappa.Repo,
       Grappa.Scrollback,
+      # The three `join: n in Network` slug lookups are a real reference, and
+      # since #1398 made the schema its own leaf boundary this is a declared
+      # edge rather than the waiver it used to be. The cycle the waiver
+      # avoided — `Session → ReadCursor → Networks → Session` — cannot form
+      # through the leaf: it depends on `Grappa.IRC` and nothing else.
+      Grappa.Networks.Network,
       Grappa.Subject,
       Grappa.Visitors.Visitor
     ],
-    # `Networks.Network` is referenced ONLY as a schema — the
-    # `belongs_to :network` FK association + the `join: n in Network`
-    # slug lookup in `bulk_for_subject/1` (field access, no Networks
-    # context call). Demoted from a real dep to a struct-only dirty xref
-    # (#373) so `Session → ReadCursor → Networks → Session` doesn't close
-    # once Session depends on ReadCursor for `rename_dm_peer/4`; mirrors
-    # `Grappa.Scrollback` / `Grappa.QueryWindows`.
-    dirty_xrefs: [Grappa.Networks.Network],
     exports: [Cursor, Wire]
 
   import Ecto.Query

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -71,8 +71,10 @@ defmodule Grappa.ReadCursor do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Cursor`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,

--- a/lib/grappa/release.ex
+++ b/lib/grappa/release.ex
@@ -46,6 +46,7 @@ defmodule Grappa.Release do
       Grappa.Accounts,
       Grappa.Deploy.MigrationAudit,
       Grappa.Networks,
+      Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Themes,
       Grappa.Vault

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,8 +33,10 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Message`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference the
+    # checker resolves (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       # `Wire.to_json/1` matches `%Network{slug: slug}`, the wire-shape
       # contract from A1+A26 — a real reference, declared since #1398 made

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,18 +33,20 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced by `Scrollback.Message` (the
-    # `belongs_to :network` association) and `Scrollback.Wire` (the
-    # `%Network{slug: _}` pattern that A1+A26 made the wire-shape
-    # contract). Declaring that ref a dirty xref lets Cluster 2's
-    # Networks → Session cycle inversion land without a transitive cycle
-    # (which would otherwise close
-    # `Scrollback → Networks → Session → Scrollback`). The struct-only
-    # nature of the dep means we lose Boundary checks on a use case
-    # Boundary couldn't help with anyway (struct field access doesn't go
-    # through any function call we'd want to gate); the cost is intentional.
-    dirty_xrefs: [Grappa.Networks.Network],
+    deps: [
+      Grappa.Accounts,
+      Grappa.IRC,
+      # `Wire.to_json/1` matches `%Network{slug: slug}`, the wire-shape
+      # contract from A1+A26 — a real reference, declared since #1398 made
+      # the schema its own leaf. `Message`'s `belongs_to :network` is not
+      # what pays for this edge; the struct pattern is. The transitive cycle
+      # the waiver avoided, `Scrollback → Networks → Session → Scrollback`,
+      # cannot form through a leaf that depends only on `Grappa.IRC`.
+      Grappa.Networks.Network,
+      Grappa.Repo,
+      Grappa.Subject,
+      Grappa.Visitors.Visitor
+    ],
     exports: [Message, Wire]
 
   import Ecto.Query

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -71,6 +71,7 @@ if Mix.env() in [:dev, :test] do
         Grappa.Accounts,
         Grappa.Admission,
         Grappa.Networks,
+        Grappa.Networks.Credential,
         Grappa.Notify,
         Grappa.Push,
         Grappa.QueryWindows,

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -99,8 +99,10 @@ defmodule Grappa.UserSettings do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Settings`'
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -69,6 +69,7 @@ defmodule Grappa.Visitors do
       Grappa.LiveIntrospection,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -68,6 +68,7 @@ defmodule Grappa.Visitors do
       Grappa.IRC,
       Grappa.LiveIntrospection,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Repo,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -49,6 +49,7 @@ defmodule Grappa.Visitors.Reaper do
     deps: [
       Grappa.AdminEvents,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Session,
       Grappa.Subject,
       Grappa.Visitors,

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -33,6 +33,7 @@ defmodule GrappaWeb do
         Grappa.Net.PtrCache,
         Grappa.Net.SourceAliasManager,
         Grappa.Networks,
+        Grappa.Networks.Credential,
         Grappa.Notify,
         Grappa.Operator,
         Grappa.OutboundV6Pool,

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -34,6 +34,7 @@ defmodule GrappaWeb do
         Grappa.Net.SourceAliasManager,
         Grappa.Networks,
         Grappa.Networks.Credential,
+        Grappa.Networks.Network,
         Grappa.Notify,
         Grappa.Operator,
         Grappa.OutboundV6Pool,

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -70,7 +70,13 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   """
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Networks, Grappa.Session, Mix.Tasks.Grappa.Boot, Mix.Tasks.Grappa.OptionParsing]
+    deps: [
+      Grappa.Networks,
+      Grappa.Networks.Credential,
+      Grappa.Session,
+      Mix.Tasks.Grappa.Boot,
+      Mix.Tasks.Grappa.OptionParsing
+    ]
 
   use Mix.Task
 

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -16,17 +16,31 @@ defmodule Grappa.BoundaryCycleBudgetTest do
   # that closes a cycle has to be argued for in a diff instead of arriving
   # unremarked. Lowering @cycle_budget when the number drops is the point;
   # raising it is a decision that belongs in review.
-  @cycle_budget 31
+  @cycle_budget 0
 
-  # Measured 2026-08-17 on `origin/main` = 236dd328: 31 elementary cycles over
-  # 12 boundaries (1 of length 2, 4 of length 3, 11 of length 4, 11 of length 5,
-  # 4 of length 6), from 5 waivers all naming `Grappa.Networks.Network`. The
-  # single highest-leverage arc is `Scrollback -> Networks` at 19 of the 31; no
-  # single arc kills them all. Method: the compiled `Boundary` attribute, the
-  # same source `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest`
-  # read — NOT a source parse. An earlier hand-rolled regex parser disagreed with
-  # a second one about how many `use Boundary` blocks even exist (99 vs 107),
-  # which is exactly why this reads the annotation the compiler kept.
+  # The budget was 31 when this gate landed, and the promotion of the four
+  # `Networks` schemas to their own boundaries retired every one of them: all
+  # five waivers named `Grappa.Networks.Network`, and each existed because the
+  # alternative was an edge to the whole `Grappa.Networks` context. With the
+  # schemas owning themselves, two of the five became declared edges to a leaf
+  # that depends only on `Grappa.IRC`, and three were deleted outright — they
+  # had been waiving a `belongs_to`, which was never a reference the checker
+  # resolved.
+  #
+  # A consequence worth stating, because it changes what a future waiver means:
+  # a `dirty_xrefs: [Grappa.Networks.Network]` written today resolves to the
+  # leaf, not to the context, so it would close nothing and this gate would not
+  # move. The 31 were never about waivers as such — they were about waivers
+  # pointed at a module owned by a large boundary.
+  #
+  # Method: the compiled `Boundary` attribute, the same source
+  # `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest` read —
+  # NOT a source parse. When this gate landed, two hand-rolled regex parsers
+  # disagreed about how many `use Boundary` blocks even exist, 99 against 107.
+  # The compiled attribute settled it at 99, over
+  # `:application.get_key(:grappa, :modules)`; `lib` holds 111 textual
+  # occurrences of which 12 are prose in moduledocs and comments. 107 matches no
+  # population anyone could reconstruct, and nothing here guesses what it was.
   #
   # Declared scope, stated so it is not mistaken for more: this counts DECLARED
   # deps plus waivers. Runtime edges — the injected closures, behaviours resolved


### PR DESCRIPTION
The four `Grappa.Networks` schemas become their own boundaries, which retires
every `dirty_xrefs` waiver in the tree and takes the 31 declared cycles with
them. **This branch also contains #1399 slice A** (previously PR #1493), folded
in rather than shipped separately — see "Why the two are one branch" below.
#1493 should be closed by content at merge; the replay rewrote its SHA, so
GitHub cannot close it.

## What changes

`Network`, `Server`, `Credential` and `FeaturedChannel` each carry
`use Boundary, top_level?: true` with a deps list measured from their real
outbound edges — `Grappa.IRC` for three of them, nothing at all for `Server`.
A consumer that needs the struct now declares an edge to a leaf, and a leaf
closes nothing.

Five commits, one per schema plus the gate, each of which **compiles on its
own**:

| step | commit | files | `compile --force --warnings-as-errors` |
|---|---|---|---|
| 1 | `Networks.Server` | 2 | rc=0 |
| 2 | `Networks.FeaturedChannel` | 2 | rc=0 |
| 3 | `Networks.Credential` | 9 | rc=0 |
| 4 | `Networks.Network` + waivers retired | 12 | rc=0 |
| 5 | the cycle budget | 2 | rc=0 |

That was not free. The first pass of the same table was rc=1 on steps 3, 4 and
5, and the compiler named two consumers the source measurement had missed —
`Grappa.Operator` (`%Networks.Network{}`, qualified through the parent alias)
and `Grappa.TestSupport.SubjectReset` (`Credential.changeset/2`, reached
through an `alias Grappa.{…, Networks, Networks.Credential}` block whose keys
collide). Both fixes are folded into the step that introduced the breakage, and
the table above is the re-run.

## The premise this was planned under was wrong

Two earlier reconnaissance passes, one of them mine, concluded that four
separate leaves were impossible — the three sibling schemas name `Network`
back, so four leaves looked like four two-cycles, and the only expressible
form looked like one boundary holding all four schemas. Since no namespace
contains exactly those four, that meant moving files and renaming modules:
roughly fifteen files of rename and a cold deploy.

None of it was needed. Every reference among the four is a `has_many` or
`belongs_to` argument and a typespec, and #1399 had just established against
the compiler that those are not references the checker resolves. No back-edge,
no cycle, nothing to merge into a namespace. **No module is renamed, no file
moves, and the deploy stays hot.**

The lesson is about the measurement: counting references without classifying
them measures the wrong population. Both earlier passes counted names and got a
real number that did not answer the question asked of it.

## What the gate now says, read rather than asserted

`@cycle_budget` moves 31 → 0. The number was **read, not assumed**: an
`assert count <= budget` never reveals the count, so the gate was forced red
once with the budget at -1.

```
Boundary cycle count rose to 0, above the pinned budget of -1.
Cycles now closed (shortest first):
```

Zero, with an empty list. Restored afterwards, `git status --porcelain` empty.

**The mutant.** The gate exists for edges the compiler cannot see, so the
mutant is a waiver, not a declared dep — a declared `Server -> Networks` edge
is caught by the boundary compiler itself and the gate would never speak. With
`dirty_xrefs: [Grappa.Networks.Wire]` on `Server` (a module `Grappa.Networks`
owns), the gate goes red with exactly one cycle, exactly the predicted one:

```
Boundary cycle count rose to 1, above the pinned budget of 0.
      Grappa.Networks -> Grappa.Networks.Server -> Grappa.Networks
```

One mutant, one cycle, the predicted pair. Restored, tree clean.

## A question this branch settles, and one it does not

**Settled: a module passed as a plain argument is not a reference Boundary
resolves.** `Notify` and `QueryWindows` pass the schema module to
`check_exists/4` the way `Admission` passes it to `Repo.get/2`. Source reading
does not answer whether that is a reference, so both were written *without* the
dep — the falsifiable choice, since an undeclarable dependency asserted anyway
fails silently while a missing one fails at the build. They compiled green in a
run whose checker was demonstrably live (it named three violations elsewhere in
the same table). `Admission` cannot serve as the witness here: it declares the
dep regardless, having real struct references.

**Not settled: Boundary's two checks disagree about those waivers.** Boundary
also warns when a `dirty_xrefs` entry is *unnecessary*, and that warning fails
the build under `--warnings-as-errors` — the mutant tripped it. Yet
`origin/main` compiles with **zero** such warnings while carrying all three
waivers this branch deletes, so Boundary considered them used; and deleting
them here produces no forbidden reference. Both halves are measured, they are
not obviously compatible, and the mechanism is not guessed at. The DESIGN_NOTES
entry withdraws the wider claim an earlier draft made — that the waivers
"never covered anything" — and states only what the evidence supports.

⚠️ One commit message, on the `Networks.Network` step, still carries that
withdrawn wording. It is left as written rather than rewritten silently; say
the word and it gets reworded.

## Why the two are one branch

#1493 was cut from `d8b58e2d` and main has moved to `5dbe6f68`, so it is not
fast-forwardable, and five of its seven files are files this promotion also
edits. Rebasing it separately buys a second full gate run and leaves this
branch to rebase onto the same five files afterwards. Gating the union once is
cheaper and more honest: the two changes had never been compiled together, and
their overlap is exactly where a conflict would hide. Where both touched the
same `deps:` block the two comments are merged into one — they were making the
same point about two different modules.

The `docs/DESIGN_NOTES.md` union merge was checked for the tail-fusion failure
mode: both entries carry unique `<!-- entry -->` markers, both boundary shapes
are intact, and the file's contribution is additions-only with zero deletions.

## Gates

| gate | result |
|---|---|
| per-step `compile --force --warnings-as-errors` | rc=0 on all five |
| union `compile --force --warnings-as-errors` | rc=0, zero forbidden references |
| the cycle gate | rc=0; count measured at 0 via a forced red |
| the mutant | gate rc=2, exactly one cycle, the predicted one |
| `scripts/design-notes-gate.sh` | "2 new entry heading(s), separator and marker present" |
| `scripts/check.sh` | rc=0 — Credo "found no issues", 6537 tests 0 failures, Sobelow "Total errors: 0", Dialyzer "passed successfully", bats 564 ok / 0 not ok |

## Declared ceiling, and the overrun

The plan declared 20 files. **This is 21 sources plus #1399's contribution**:
`lib/grappa/test_support/subject_reset.ex` was the file the parser missed, and
it is named here as an overrun rather than absorbed. The other missed consumer,
`Grappa.Operator`, was already inside the twenty.

## Not established

- No behaviour changes: these are compile-time annotations. Nothing here was
  exercised against production or a live session.
- The reference measurement that selected the file set is a regex over source,
  and it demonstrably missed two consumers. The compiler, not the parser, is
  what makes the set safe.
- The gate counts DECLARED deps plus waivers. Injected closures, behaviours
  resolved from `:persistent_term` and the supervisor-level `held_source_fn`
  carry no module reference any compile-time mechanism can see, so the runtime
  graph stays denser and a closure that opens a cycle moves nothing.
- A new limit, recorded because it inverts how a future waiver reads: with the
  schemas as leaves, a `dirty_xrefs:` aimed at one of them closes no cycle and
  this gate stays green. The 31 were never about waivers as such, but about
  waivers aimed at a module owned by a large boundary.

## Base note

Every gate above was measured with this branch based on `5dbe6f68`. `main`
moved to `c2e64901` during the run (three #1403 commits). The overlap is
`docs/DESIGN_NOTES.md` only — a `merge=union` file, and both entries here carry
unique markers, which is the protection that exists for exactly that merge.
**No Elixir source file overlaps**, so nothing in the green above is contested
by the move; it simply was not re-measured on top of `c2e64901`.
