### PR TITLE
e2e(#1336): make a push arrival prove its own stimulus, by signature

### DIFF
--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -292,9 +292,25 @@ export type CaughtDelivery = {
 type CatcherResponse = { id: string; deliveries: CaughtDelivery[] };
 
 /**
- * Polls `/received/<id>` until at least one delivery has landed for
- * the subscription, or the timeout elapses. Mirrors
- * grappaApi.assertMessagePersisted's poll-with-timeout shape.
+ * Waits for at least one delivery on the subscription — AFTER proving that
+ * the message whose push is expected actually reached grappa.
+ *
+ * The stimulus is a REQUIRED argument for the same reason it is one on
+ * `assertNoPushDelivery`, and #1152 is the measurement that says so. A peer
+ * DM went to a nick nobody was registered under (a 7ms teardown/reconnect
+ * left bahamut holding the ghost, and grappa's #604 reconcile correctly
+ * adopted `vjt-grappa_`); nothing was ever pushed because nothing ever
+ * arrived, and this wait spent five seconds watching a catcher for something
+ * nobody sent. It then reported `timeout after 5000ms`, which accuses the
+ * push pipeline for a failure that happened before the pipeline was reached.
+ * Measured on that run: the peer's nick appears ZERO times in a 240MB log
+ * carrying 135 902 message INSERTs.
+ *
+ * Two things change. The failure now names WHICH half broke — a stimulus
+ * that never landed and a pipeline that never delivered are different
+ * errors. And the delivery window is clocked from the delivery PROOF rather
+ * than from the call, so a slow stimulus transit no longer eats the budget
+ * the pipeline is being judged on.
  *
  * Sender's fan-out is fire-and-forget via `Task.async_stream`, so
  * the spec MUST poll rather than assume synchronous delivery. 5s
@@ -303,8 +319,28 @@ type CatcherResponse = { id: string; deliveries: CaughtDelivery[] };
  */
 export async function awaitPushDelivery(
   id: string,
+  stimulus: PushStimulus,
   opts: { timeoutMs?: number; intervalMs?: number } = {},
 ): Promise<CaughtDelivery[]> {
+  const quoted = `<${stimulus.sender}> ${JSON.stringify(stimulus.body)} → ${stimulus.window}`;
+
+  try {
+    await assertMessagePersisted({
+      token: stimulus.token,
+      networkSlug: stimulus.networkSlug,
+      channel: stimulus.window,
+      sender: stimulus.sender,
+      body: stimulus.body,
+    });
+  } catch (cause) {
+    throw new Error(
+      `awaitPushDelivery: the stimulus never reached grappa, so a missing push for ` +
+        `id=${id} says nothing about the push pipeline — ${quoted}\n  cause: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+    );
+  }
+
   const timeoutMs = opts.timeoutMs ?? 5_000;
   const intervalMs = opts.intervalMs ?? 100;
   const deadline = Date.now() + timeoutMs;
@@ -316,7 +352,10 @@ export async function awaitPushDelivery(
     }
     await sleep(intervalMs);
   }
-  throw new Error(`awaitPushDelivery: timeout after ${timeoutMs}ms — id=${id}`);
+  throw new Error(
+    `awaitPushDelivery: the stimulus reached grappa but no delivery landed for id=${id} ` +
+      `within ${timeoutMs}ms of the proof — ${quoted}`,
+  );
 }
 
 /**

--- a/cicchetto/e2e/tests/issue1038-mute-is-per-network.spec.ts
+++ b/cicchetto/e2e/tests/issue1038-mute-is-per-network.spec.ts
@@ -218,8 +218,15 @@ test("a mute made on one network leaves the same channel on the other still push
     // the assertion the pre-#1038 key fails: with a network-blind mute the
     // entry made on A silences B too and nothing arrives. It also keeps arm 1
     // honest — without it, arm 1 would pass if push were broken outright.
-    peerB.privmsg(SHARED_CHANNEL, `${OWN_NICK}: but you will hear this one`);
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const loudBody = `${OWN_NICK}: but you will hear this one`;
+    peerB.privmsg(SHARED_CHANNEL, loudBody);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: user.token,
+      networkSlug: MUTE1038_NETWORK_B,
+      window: SHARED_CHANNEL,
+      sender: peerB.nick,
+      body: loudBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
   } finally {
     await peerA.disconnect("#1038 done");

--- a/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
+++ b/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
@@ -146,8 +146,15 @@ test("a one-hour snooze picked from the rail silences the channel and says how l
 
     // Positive arm — the same shape in the unmuted sibling, so the negative arm
     // cannot be passing because push broke outright.
-    peer.privmsg(LOUD_CHANNEL, `${specNick()}: but you will hear this`);
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const loudBody = `${specNick()}: but you will hear this`;
+    peer.privmsg(LOUD_CHANNEL, loudBody);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: LOUD_CHANNEL,
+      sender: peer.nick,
+      body: loudBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
   } finally {
     await peer.disconnect("#950 snooze done");

--- a/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
+++ b/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
@@ -122,8 +122,15 @@ test("a muted channel swallows even a direct mention, while its unmuted sibling 
 
     // Positive arm — the same mention shape in the unmuted sibling. This is
     // what keeps the negative arm from passing because push broke outright.
-    peer.privmsg(LOUD_CHANNEL, `${specNick()}: but you will hear this`);
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const loudBody = `${specNick()}: but you will hear this`;
+    peer.privmsg(LOUD_CHANNEL, loudBody);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: LOUD_CHANNEL,
+      sender: peer.nick,
+      body: loudBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
   } finally {
     await peer.disconnect("#866 mute done");

--- a/cicchetto/e2e/tests/push-964-device-row.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-row.spec.ts
@@ -79,8 +79,16 @@ test("device row shows the activity instant + marks the device you are on", asyn
   try {
     // Background the device: a VISIBLE one suppresses the push at source.
     await setPageVisibility(page, false);
-    peer.privmsg(specNick(), "hi from n964-dmer");
-    expect((await awaitPushDelivery(SUB_ID)).length).toBeGreaterThanOrEqual(1);
+    const dmBody = "hi from n964-dmer";
+    peer.privmsg(specNick(), dmBody);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: dmBody,
+    });
+    expect(deliveries.length).toBeGreaterThanOrEqual(1);
     // Barrier: Sender bumps the row AFTER the vendor 200, so the catcher
     // seeing a delivery does not yet mean the DB write has landed.
     await awaitDeviceLastUsed(vjt.token);

--- a/cicchetto/e2e/tests/push-focus-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-focus-suppression.spec.ts
@@ -84,9 +84,16 @@ test("server delivers push once the window is blurred though still on-screen, su
     // stayed suppressed because visibilityState alone reported "visible".
     await resetPushCatcher();
     await setPageFocus(page, false);
-    peer.privmsg(specNick(), "you clicked another app — deliver this one");
+    const blurredBody = "you clicked another app — deliver this one";
+    peer.privmsg(specNick(), blurredBody);
 
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: blurredBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
     expectRfc8291Delivery(deliveries[0]);
 

--- a/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
@@ -79,9 +79,16 @@ test("server suppresses push while a device reports visible, delivers once hidde
     // Phase 2 — device HIDDEN (backgrounded). The server MUST now deliver.
     await resetPushCatcher();
     await setPageVisibility(page, false);
-    peer.privmsg(specNick(), "now you backgrounded it — deliver this one");
+    const hiddenBody = "now you backgrounded it — deliver this one";
+    peer.privmsg(specNick(), hiddenBody);
 
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: hiddenBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
     expectRfc8291Delivery(deliveries[0]);
   } finally {

--- a/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
+++ b/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
@@ -124,8 +124,15 @@ test("notification_prefs whitelist: messages in allow-list push, messages elsewh
 
     // Positive path — peer talks in ALLOW, no mention. Push expected
     // because channel_messages_only includes #b5-allow.
-    peer.privmsg(ALLOW_CHANNEL, "small talk in allow");
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const allowBody = "small talk in allow";
+    peer.privmsg(ALLOW_CHANNEL, allowBody);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: ALLOW_CHANNEL,
+      sender: peer.nick,
+      body: allowBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
     expectRfc8291Delivery(deliveries[0]);
   } finally {

--- a/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
@@ -105,9 +105,16 @@ test("channel mention while push-enabled fires Sender → push-catcher receives 
 
     // Peer mentions the operator. Mentions.mentioned?/3 matches
     // the bare nick at a word boundary.
-    peer.privmsg(TARGET_CHANNEL, `${specNick()}: are you there?`);
+    const mentionBody = `${specNick()}: are you there?`;
+    peer.privmsg(TARGET_CHANNEL, mentionBody);
 
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: TARGET_CHANNEL,
+      sender: peer.nick,
+      body: mentionBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
 
     // #1290 — the wire contract; see `expectRfc8291Delivery`.

--- a/cicchetto/e2e/tests/push-trigger-dm.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-dm.spec.ts
@@ -63,9 +63,16 @@ test("DM while push-enabled fires Sender → push-catcher receives a POST", asyn
     // PRIVMSG straight to the operator's nick — no JOIN needed.
     // Server-side this hits Session.Server's :persist arm with
     // `channel = own_nick`; Triggers' dm? predicate matches.
-    peer.privmsg(specNick(), "hi from b5-dmer");
+    const dmBody = "hi from b5-dmer";
+    peer.privmsg(specNick(), dmBody);
 
-    const deliveries = await awaitPushDelivery(SUB_ID);
+    const deliveries = await awaitPushDelivery(SUB_ID, {
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      window: peer.nick,
+      sender: peer.nick,
+      body: dmBody,
+    });
     expect(deliveries.length).toBeGreaterThanOrEqual(1);
 
     // #1290 — the wire contract, asserted in one place for all five


### PR DESCRIPTION
The positive twin of PR #1370, and the last piece of #1152 that was still open.

## The defect

`awaitPushDelivery` opened a 5 s window on a stimulus that nothing proved had been
delivered. #1152 measured what that costs: a peer DM went to a nick nobody was
registered under — a 7 ms teardown/reconnect left bahamut holding the ghost and
grappa's #604 reconcile correctly adopted `vjt-grappa_` — so nothing was ever
pushed, and the wait reported `timeout after 5000ms`, **accusing the push pipeline
for a failure that happened before the pipeline was reached**. In that run the
peer's nick appears ZERO times in a 240 MB log carrying 135 902 message INSERTs.

PR #1370 closed the absence direction by making the stimulus a required argument of
`assertNoPushDelivery`. This is the same move on the arrival side, for the same
stated reason: a convention the next author can omit is not a barrier, so the proof
goes in the SIGNATURE. All nine call sites now pass a `PushStimulus`.

Two things change, and only one is about diagnosis:

* The failure **names which half broke**. "The stimulus never reached grappa" and
  "the stimulus reached grappa but no delivery landed" are different errors with
  opposite cures; before, both printed the same line.
* The delivery window is **clocked from the delivery proof** rather than from the
  call, so a slow stimulus transit no longer eats the budget the push pipeline is
  being judged on — which is the non-determinism #1152 was filed about.

## The evidence: one displacement, both sides, same test

The injection is one line — the DM addressed to `` `${specNick()}_ghost` ``, i.e.
#1152's ghost nick reproduced deliberately — run against `push-964-device-row`
before and after the change. Verbatim:

**before**

```
Error: awaitPushDelivery: timeout after 5000ms — id=964-device-row
   at ../fixtures/push.ts:319
```

**after**

```
Error: awaitPushDelivery: the stimulus never reached grappa, so a missing push for
id=964-device-row says nothing about the push pipeline — <n964-dmer> "hi from
n964-dmer" → n964-dmer
  cause: assertMessagePersisted: timeout after 5000ms — channel=n964-dmer
  sender=n964-dmer body="hi from n964-dmer" kind=undefined; last seen: []
```

`last seen: []` is the scrollback the DM never reached. The old line named the
subscription id and blamed the pipeline; the new one names the message, the sender,
the window, and the half that actually failed.

## Gates

* Nine specs, chromium, one worker: **9 passed (54.2 s) before** the change and
  **9 passed (53.9 s) after**. Nothing turned red without the injection, so the
  clause under which a red would have been the result never fired.
* `scripts/bun.sh run check` — **RC=0** (`biome check && tsc --noEmit && tsc
  --noEmit -p e2e/tsconfig.json`; 1038 files, 59 warnings / 6 infos, all
  pre-existing CSS-specificity diagnostics in `cicchetto/src`).
* `scripts/integration.sh` (full suite, this branch, dev host) — **751 passed / 3
  failed, RC=1, 29.6 min**. None of the three is one of the nine, none calls
  `awaitPushDelivery` (the signature change means `tsc` enumerates every caller, and
  there are exactly nine), and the failures are not push-shaped: `issue510-join-comma-
  focus:30` and `push-459-optin-banner:122` both die on `locator('.sidebar-network-
  header').first()` never becoming visible at login, and `slash-commands-bundle:152`
  on a `/q` window still present after close. **All three pass in isolation on this
  same tree — 10 passed, 26.2 s**, which is the #653 shape (green in isolation, red
  under the full gate), and none of the three appears in #653's table of eight.
  🔴 **Their attribution is OPEN, not resolved.** "Green in isolation" is a property
  of the failures, not a verdict about their cause, and nothing here shows the same
  three failing on an unmodified base — that comparison is `integration`'s own run on
  `f75b0e05`, which is the baseline, against this PR's run. They are NOT being
  written off as known flakes.
* **Base moved mid-slice, twice.** Every measurement above was taken on `c2e64901`;
  the branch is now rebased onto `f75b0e05` (which is #1491, landed while this was
  running) with the contribution `--numstat` pinned identical across the rebase, 10
  files both sides. On the new base the nine were re-run: **9 passed (59.1 s)**, plus
  a single-spec confirmation run from an explicitly-rooted shell (1 passed, 9.7 s).
  The 29.6-minute full suite was NOT re-run on `f75b0e05` — that number belongs to
  `c2e64901`, and #1491 touches `cicchetto/src/lib/api.ts`, which is in the path
  every spec exercises. CI's run on this PR is the measurement on the current base.

## Scope

Exactly the declared ceiling: **10 files** — `fixtures/push.ts` plus the nine specs
that call it. No product code, no assertion, no threshold and no timeout changed.

## What this does NOT buy, stated because the slice-2 standard asks for more

**There is no fetch-free unit-tested core here, and no mutation table.** PR #1370
extracted `pushAbsence.ts` precisely so the instrument could be judged by unit
mutants without a testnet; the honest thing to say is that the same treatment for
the arrival side would cost two more files (`push.ts` is fetch-bound by
construction, so the core would have to move), which is the ceiling plus two. I
stayed inside the ceiling and bought the change with the in-situ positive control
above instead. **If you want the core extracted and mutated, that is a two-file
follow-up and I will take the ruling** — this note is here so the gap is visible
rather than implied.

**The natural failure is still not reproduced.** Nobody in this epic has reproduced
it, and this PR does not either: the ghost nick was injected, not waited for. What
is shown is that the instrument now names the right half when the stimulus does not
land — not that it lands less often.

**The window-clocking improvement is structural, not measured.** It follows from
where the deadline is now computed; I did not construct a case where transit ate
the delivery budget and showed it passing afterwards.

**Nine positive sites are converted; `assertNoPushDeliveryOnUnusedId` is untouched
and stays that way** — there is no stimulus to prove for an id nobody sent to, and
inventing one is how an honest assertion becomes decorative (the reasoning already
recorded on that function in #1370).
