### PR TITLE
test(#1397): hoist await_handshake onto Grappa.IRCServer with an explicit timeout

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47516,3 +47516,77 @@ _Not established: how many of the remaining 105 atoms are actually logged. The
 scan proves absence, never disuse, so the count of dead entries is a floor and
 not a measurement. The 39-arm `do_handle_in` door and the per-verb table that
 #1403's HIGH proposes are untouched by this work._
+<!-- entry #1397-f1 -->
+
+---
+
+## 2026-08-17 — #1397 F1: the handshake barrier takes its timeout as an argument, and the "live decision" was a removed default
+
+The #1397 entry above closes by holding `await_handshake` out of the
+qualified-call reasoning, on the grounds that its timeout axis is "a live
+decision: two files have already found one second insufficient." **That
+sentence is withdrawn. The history does not say it.**
+
+Both 5s sites were born at 5s. `test/grappa/account_deletion_test.exs` arrived
+in `5775e55a` (#157, 2026-06-29) and
+`test/grappa_web/controllers/session_controller_test.exs` in `5e6f7c53` (#126,
+same day); reading each file at the commit that introduced its wrapper shows
+`5_000` already there. Neither was ever raised from `1_000` in response to a
+failure, because neither was ever at `1_000`. Two new files written the same
+day by authors who picked a wider budget is not evidence that one second is
+too tight — it is not evidence about one second at all.
+
+**And the 1s majority was never chosen either.** Eight of the ten majority
+copies trace to a single commit, `84fe0850` (2026-05-08), which removed the
+default timeout from `IRCServer.wait_for_line/3` under the CLAUDE.md
+no-default-arguments rule and stamped the old default explicitly at ~150 call
+sites. The value the copies agree on is the value the default used to hide.
+Thirteen local wrappers then promptly re-hid it behind a zero-argument helper —
+the rule was obeyed at one layer and undone at the next, in the same file.
+
+### So the hoisted verb has no default
+
+`IRCServer.await_handshake(server, timeout)` requires the budget. Giving it a
+default would re-hide, on the same function family, exactly what `84fe0850`
+went to un-hide, and it would silently halve the two 5s sites the moment their
+`defp` disappeared. The timeout was never duplication; it was a parameter with
+thirteen hard-coded callers. It stays at the call site, where the test that
+pays for it can be read.
+
+The other two axes are duplication and they close. The alias axis dies with the
+local definitions. The prefix axis closes on the strict `"USER "`: `lib/` sends
+exactly one line beginning with `USER` (`auth_fsm.ex`) and no `USERHOST`
+anywhere, so both spellings select the same line — the strict one also says so,
+and a test asserts that `USERHOST` does not satisfy the barrier.
+
+### The arity is pinned by a test, not by the comment above it
+
+A rule stated in a docstring is a rule until the next session. `refute
+function_exported?(Grappa.IRCServer, :await_handshake, 1)` is the same rule
+stated in a way that goes red. Bought with the mutant: adding `\\ 1_000` back
+to the definition kills that assertion and only that one — four tests, one
+failure, the other three still green.
+
+### The collision claim above is no longer an inference
+
+The #1397 entry states the import/local collision as "the documented Elixir
+rule plus the 110-to-0 evidence", explicitly not a build anyone watched fail.
+It has now been watched. Adding `admin_session/0` to `Grappa.AuthFixtures` and
+compiling one of the fourteen files that define it locally and import the
+module wholesale:
+
+    error: imported Grappa.AuthFixtures.admin_session/0 conflicts with local function
+    == Compilation error in file .../admin/circuit_controller_test.exs ==
+
+The mutation was reverted. The consequence for the rest of the bucket is
+unchanged in direction and now firm in kind: the `admin_session` slice is
+atomic across fifteen files, and no slicing plan can pretend otherwise.
+
+_Not established: whether one second is the right budget. This work falsified
+the argument for changing it, not the value — no suite timing, no attributed
+flake, no Argon2 measurement was taken, and the design deliberately avoids
+having to answer. Also unmeasured: `start_server` (21 clauses over 20 files)
+and the fixture trio, which needs a ruling first — substituting AuthFixtures'
+placeholder hash for a real Argon2 one changes what fourteen files prove, and
+the local `visitor_fixture` calls the production provisioning verb the
+canonical one bypasses._

--- a/test/grappa/account_deletion_test.exs
+++ b/test/grappa/account_deletion_test.exs
@@ -38,11 +38,6 @@ defmodule Grappa.AccountDeletionTest do
     {server, Grappa.IRCServer.port(server)}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 5_000)
-    :ok
-  end
-
   # A registered visitor = identified on some network. #211 phase 7 —
   # `commit_password/3` writes the per-network secret + flips the credential's
   # `auth_method` to `:nickserv_identify`; registration is DERIVED from that
@@ -83,8 +78,8 @@ defmodule Grappa.AccountDeletionTest do
 
       pid1 = start_session_for(user, network1)
       pid2 = start_session_for(user, network2)
-      :ok = await_handshake(server1)
-      :ok = await_handshake(server2)
+      :ok = Grappa.IRCServer.await_handshake(server1, 5_000)
+      :ok = Grappa.IRCServer.await_handshake(server2, 5_000)
       ref1 = Process.monitor(pid1)
       ref2 = Process.monitor(pid2)
 
@@ -120,7 +115,7 @@ defmodule Grappa.AccountDeletionTest do
       {visitor, network} = registered_visitor(port)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = Grappa.IRCServer.await_handshake(server, 5_000)
       ref = Process.monitor(pid)
 
       session = visitor_session_fixture(visitor)

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -91,11 +91,6 @@ defmodule Grappa.IRC.ClientTest do
   # initial handshake (NICK/USER guaranteed to be the last lines of
   # the always-sent prefix). Eliminates the `Process.sleep(20)` pattern
   # that races on the IRCServer's accept-loop sock assignment.
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
-    :ok
-  end
-
   # Handler that replies CAP * LS :sasl=PLAIN to a CAP LS, ACKs the
   # CAP REQ :sasl, prompts AUTHENTICATE PLAIN with `+`, and answers
   # the base64 payload with the configured numeric (903 by default).
@@ -344,7 +339,7 @@ defmodule Grappa.IRC.ClientTest do
     test "send_nick/2 emits NICK new\\r\\n" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Client.send_nick(client, "vjt-away")
 
@@ -762,7 +757,7 @@ defmodule Grappa.IRC.ClientTest do
     test "send_line/2 returns {:error, :closed} when socket is closed-but-not-nil (no raise)" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Snapshot the live socket, close it underneath the Client, then
       # send. handle_call({:send, _}, _, state) hands the closed-but-
@@ -801,7 +796,7 @@ defmodule Grappa.IRC.ClientTest do
       # before we could send anything).
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :sys.replace_state(client, fn state -> %{state | socket: nil} end)
 
@@ -851,7 +846,7 @@ defmodule Grappa.IRC.ClientTest do
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: "127.0.0.2"})
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {{127, 0, 0, 2}, _}} = IRCServer.peername(server)
     end
@@ -861,7 +856,7 @@ defmodule Grappa.IRC.ClientTest do
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: nil})
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {{127, 0, 0, 1}, _}} = IRCServer.peername(server)
     end
@@ -890,7 +885,7 @@ defmodule Grappa.IRC.ClientTest do
     test "single PRIVMSG line dispatched as parsed Message struct" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
@@ -906,7 +901,7 @@ defmodule Grappa.IRC.ClientTest do
     test "burst of 50 server lines dispatched in order with no loss (active:once re-arm)" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Enum.each(1..50, fn i ->
         IRCServer.feed(server, ":a!~a@h PRIVMSG #x :msg #{i}\r\n")
@@ -923,7 +918,7 @@ defmodule Grappa.IRC.ClientTest do
     test "mid-line server write coalesced via OS-level packet:line buffering" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, "PING :fo")
       # Intentional sleep: half a line in, force the OS-level packet:line
@@ -939,7 +934,7 @@ defmodule Grappa.IRC.ClientTest do
     test "malformed inbound line: parse error is logged, client stays alive" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       log =
         capture_log(fn ->
@@ -1374,7 +1369,7 @@ defmodule Grappa.IRC.ClientTest do
       # Client should have sent: PASS, CAP LS, NICK, USER. Then on 421,
       # no further action. No PRIVMSG NickServ from the client side
       # (server-side handoff handles it).
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # 421 :Unknown command CAP arrives in the dispatch_to mailbox AFTER
       # the client has parsed it — deterministic synchronisation point.
@@ -1864,7 +1859,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "rejected lines never reach the server socket", %{server: server, client: client} do
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       lines_before = IRCServer.sent_lines(server)
 
       _ = Client.send_privmsg(client, "#chan", "hi\r\nQUIT :pwn")
@@ -2520,7 +2515,7 @@ defmodule Grappa.IRC.ClientTest do
       # it received is what the model must have charged for.
       {server, port} = start_server(rfc_handler())
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Client.send_line(client, "PING :probe\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PING :probe\r\n"), 1_000)

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -38,7 +38,7 @@ defmodule Grappa.IRCServerTest do
 
   test "raises when the registration line never arrives inside the budget" do
     {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    _sock = connected_client(server)
+    connected_client(server)
 
     assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
   end

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -1,0 +1,61 @@
+defmodule Grappa.IRCServerTest do
+  @moduledoc """
+  Unit tests for the `Grappa.IRCServer` handshake barrier (#1397 F1).
+
+  The fake server is otherwise exercised through its consumers, which is
+  why it has had no test of its own. `await_handshake/2` gets one because
+  it is the first barrier hoisted out of the thirteen local copies, and
+  the property that matters about it is not behavioural but structural:
+  it must NOT grow a default timeout.
+
+  Commit `84fe0850` removed the default timeout from `wait_for_line/3`
+  under the CLAUDE.md no-default-arguments rule, then stamped the value
+  explicitly at every call site. The thirteen local `await_handshake`
+  wrappers this replaces had immediately re-hidden that same value behind
+  a zero-argument helper — eleven at 1s, two at 5s. A default here would
+  restore the silent-degradation path that ruling removed AND quietly
+  halve the budget of the two 5s sites, so the arity is pinned.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRCServer
+
+  defp connected_client(server) do
+    {:ok, sock} = :gen_tcp.connect({127, 0, 0, 1}, IRCServer.port(server), [:binary, active: false])
+    on_exit(fn -> :gen_tcp.close(sock) end)
+    sock
+  end
+
+  test "returns :ok once the client has sent its USER registration line" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    sock = connected_client(server)
+
+    :ok = :gen_tcp.send(sock, "NICK vjt\r\n")
+    :ok = :gen_tcp.send(sock, "USER vjt 0 * :Marcello\r\n")
+
+    assert :ok = IRCServer.await_handshake(server, 1_000)
+  end
+
+  test "raises when the registration line never arrives inside the budget" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    _sock = connected_client(server)
+
+    assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
+  end
+
+  test "a line that merely starts with USER but is not the registration verb does not satisfy it" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    sock = connected_client(server)
+
+    :ok = :gen_tcp.send(sock, "USERHOST vjt\r\n")
+
+    assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
+  end
+
+  test "carries no default timeout" do
+    Code.ensure_loaded!(IRCServer)
+
+    assert function_exported?(IRCServer, :await_handshake, 2)
+    refute function_exported?(IRCServer, :await_handshake, 1)
+  end
+end

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -58,11 +58,6 @@ defmodule Grappa.Networks.ConnectionStateTest do
     Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "connect/1" do
     test "transitions :parked → :connected, clears reason, broadcasts" do
       {_, port} = start_server()
@@ -153,7 +148,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       assert {:ok, updated} = Networks.disconnect(cred, "user-disconnect")
@@ -236,7 +231,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       assert {:ok, updated} = Networks.mark_failed(cred, "k-line: G:Lined")

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -34,17 +34,12 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, credential}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   test "refresh issues LIST upstream" do
     {server, port} = start_server()
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)
 
@@ -57,7 +52,7 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)
 
@@ -83,7 +78,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     # Subscribe BEFORE triggering so the (50ms-out) failed ping can't race
     # the subscribe. `subject_label` for a user session is `user.name`.
@@ -124,7 +119,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "$server"))
 
@@ -156,7 +151,7 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     # Subscribe before triggering so the `directory_complete` ping can't race
     # the subscribe. The broadcast (323 processed) is the sync point — once it
@@ -209,7 +204,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -99,11 +99,6 @@ defmodule Grappa.Session.ServerTest do
     {user, network, credential}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   # Poll until the fake ircd has seen `target` CTCP PING answers, or the
   # deadline passes — a condition, not a sleep. Returns whatever the last
   # sample was so the caller asserts on a number rather than on a timeout.
@@ -225,7 +220,7 @@ defmodule Grappa.Session.ServerTest do
           1_000
         )
     else
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
     end
 
     %{server: server, pid: pid, network: network, subject: subject, label: label}
@@ -399,7 +394,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {"127.0.0.1", ^port}} =
                Session.peer_address({:user, user.id}, network.id)
@@ -423,7 +418,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, %{server: "127.0.0.1", port: ^port, tls: false, registered: false}} =
                Session.connection_info({:user, user.id}, network.id)
@@ -448,7 +443,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +r\r\n")
 
@@ -482,7 +477,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       before = DateTime.utc_now()
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, %{connected_at: %DateTime{} = at}} =
                Session.connection_info({:user, user.id}, network.id)
@@ -520,7 +515,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # CASEMAPPING alongside PREFIX so the isupport_changed broadcast fires
       # and serves as the "005 processed" barrier before we read the facade.
@@ -553,7 +548,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert Session.casemapping({:user, user.id}, network.id) == :ascii
 
@@ -588,7 +583,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -619,7 +614,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert Session.statusmsg({:user, user.id}, network.id) == ISupport.default_statusmsg()
 
@@ -731,7 +726,7 @@ defmodule Grappa.Session.ServerTest do
       init_opts = Map.put(stale_opts, :refresh_plan, refresh_plan)
 
       {:ok, pid} = Server.start_link(init_opts)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
 
@@ -887,7 +882,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
 
       # The crash-survival holder index the manager reads at reconcile.
       assert addr in Session.live_derived_sources()
@@ -911,7 +906,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
@@ -934,8 +929,8 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid2} =
         Session.start_session({:user, user2.id}, net2.id, derived_alias_opts(user2, net2, port2, addr))
 
-      await_handshake(server1)
-      await_handshake(server2)
+      IRCServer.await_handshake(server1, 1_000)
+      IRCServer.await_handshake(server2, 1_000)
 
       # The de-duplicated holder set reports the shared address ONCE despite two
       # live holders. Scoped to `addr` (not `== [addr]`) so an async-GC-lagged
@@ -955,7 +950,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, nil))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
 
       # This session registered NO holder entry — pid-scoped so it's robust to
       # async-GC-lagged entries from other tests (proves the manager + holder
@@ -1100,7 +1095,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Reset Backoff to a known-zero baseline (handshake/connect could
       # have left a stale entry from a previous run in the singleton ETS
@@ -1140,7 +1135,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       state = SessionStateHelpers.fetch(pid)
@@ -1173,7 +1168,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       state = SessionStateHelpers.fetch(pid)
@@ -1214,7 +1209,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       ref = Process.monitor(pid)
@@ -1257,7 +1252,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
       client_pid = SessionStateHelpers.client(state)
@@ -1291,7 +1286,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
       client_pid = SessionStateHelpers.client(state)
@@ -1347,7 +1342,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :sys.replace_state(pid, &Map.merge(&1, @secrets))
 
@@ -1373,7 +1368,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       status = Server.format_status(%{state: :sys.get_state(pid)})
 
@@ -1401,7 +1396,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1425,7 +1420,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1453,7 +1448,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1494,7 +1489,7 @@ defmodule Grappa.Session.ServerTest do
         {server, port} = start_server()
         {user, network, _} = setup_user_and_network(port)
         pid = start_session_for(user, network)
-        :ok = await_handshake(server)
+        :ok = IRCServer.await_handshake(server, 1_000)
 
         # Model the production race: swap the linked Client for a bare
         # (unlinked, non-GenServer) process that, on the first {:send, _}
@@ -1689,7 +1684,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -1708,7 +1703,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       Process.sleep(100)
 
@@ -1746,7 +1741,7 @@ defmodule Grappa.Session.ServerTest do
       # Long fallback so ONLY the +r echo can trigger the JOINs in-window.
       pid = nickserv_plan(user, network, credential, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # 001 alone must NOT fire autojoin: identify is still async, no +r yet.
@@ -1782,7 +1777,7 @@ defmodule Grappa.Session.ServerTest do
       # timer elapses, so a silent/slow NickServ never hangs autojoin.
       pid = nickserv_plan(user, network, credential, 400)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Deferred: no JOIN on 001, and none before the fallback elapses.
@@ -1811,7 +1806,7 @@ defmodule Grappa.Session.ServerTest do
       # latch must ensure the JOIN is emitted once, never twice.
       pid = nickserv_plan(user, network, credential, 120)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       IRCServer.feed(server, ":irc.test.org MODE grappa-test :+r\r\n")
 
@@ -1842,7 +1837,7 @@ defmodule Grappa.Session.ServerTest do
       # on 001 exactly as it did pre-#347.
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -1898,7 +1893,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "MODE grappa-test +x\nWHOIS grappa-test")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # The built-in identify still fires — the list did not consume the var.
@@ -1938,7 +1933,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "NS IDENTIFY $nickserv_pass")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -1970,7 +1965,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "NS IDENTIFY hunter2")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2001,7 +1996,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "MODE grappa-test +x")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Perform line runs at 001…
@@ -2061,7 +2056,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "ns-secret")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # The umode query is emitted at the END of the same 001 clause that runs
@@ -2096,7 +2091,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "stale-override")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2133,7 +2128,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "MODE grappa-test +x\r\n"), 1_000)
@@ -2177,7 +2172,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2211,7 +2206,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "ns-secret")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -2237,7 +2232,7 @@ defmodule Grappa.Session.ServerTest do
       # window and this "fires immediately" test would pass either way (mirror).
       pid = nickserv_plan(user, network, credential, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # No identify expected → no defer; the JOIN lands on 001 as before #509.
@@ -2271,7 +2266,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
 
       assert {:ok, "WATCH +Foo +Bar\r\n"} =
@@ -2286,7 +2281,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "MONITOR=100 WATCH=128")
 
       assert {:ok, "MONITOR + Foo,Bar\r\n"} =
@@ -2306,7 +2301,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
 
       assert {:ok, "WATCH +Foo\r\n"} =
@@ -2323,7 +2318,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2341,7 +2336,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
       IRCServer.feed(server, ":irc.test.org 421 grappa-test WATCH :Unknown command\r\n")
@@ -2366,7 +2361,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
@@ -2403,7 +2398,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2421,7 +2416,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2461,7 +2456,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
 
@@ -2491,7 +2486,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, "PING :irc.test.org\r\n")
 
       assert {:ok, "PONG :irc.test.org\r\n"} =
@@ -2518,7 +2513,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org PONG irc.test.org :grappa-liveness\r\n")
       IRCServer.feed(server, "PING :irc.test.org\r\n")
@@ -2561,7 +2556,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Upstream confirms away-set.
       IRCServer.feed(server, ":irc.test.org 306 grappa-test :You have been marked as being away\r\n")
@@ -2600,7 +2595,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 305 grappa-test :You are no longer marked as being away\r\n")
 
@@ -2630,7 +2625,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, "all", nil)
@@ -2655,7 +2650,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2679,7 +2674,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2708,7 +2703,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2767,7 +2762,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
@@ -2801,7 +2796,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, msg} =
                Session.send_privmsg({:user, user.id}, network.id, "#sniffo", "hi all")
@@ -2834,7 +2829,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -2873,7 +2868,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hey there\r\n")
 
@@ -2917,7 +2912,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
 
@@ -2960,7 +2955,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
 
@@ -2991,7 +2986,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01VERSION\x01\r\n")
 
@@ -3035,7 +3030,7 @@ defmodule Grappa.Session.ServerTest do
         Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       queries = @auto_reply_capacity * 4
 
@@ -3095,7 +3090,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":NickServ!serv@services PRIVMSG vjt :You are now identified\r\n")
 
@@ -3120,7 +3115,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The operator DMs a NEW peer — with no browser attached (or another
       # device connected), the window must still open server-side so
@@ -3145,7 +3140,7 @@ defmodule Grappa.Session.ServerTest do
       net_id = network.id
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, net_id, "#sniffo", "hi all")
 
@@ -3182,7 +3177,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Arm the fault on the SESSION pid, firing on the auto-open's
       # `BusyRetry.run` — NOT the persist's. The session-pid fault-CHECKS that
@@ -3236,7 +3231,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       msg =
@@ -3276,7 +3271,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       refute_receive %Phoenix.Socket.Broadcast{event: "event", payload: _}, 200
@@ -3295,7 +3290,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       refute_receive %Phoenix.Socket.Broadcast{event: "event", payload: _}, 200
@@ -3311,7 +3306,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org PRIVMSG #sniffo :system message\r\n")
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -3351,7 +3346,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Empty body → :privmsg is a body-required kind → changeset error →
       # persist_event returns {:error, %Ecto.Changeset{}}. Pre-#336 the
@@ -3412,7 +3407,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Force linelen so fragmentation is deterministic on any IRC server
@@ -3480,7 +3475,7 @@ defmodule Grappa.Session.ServerTest do
       own = "grappa-test"
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       topic = Topic.user(user.name)
@@ -3543,7 +3538,7 @@ defmodule Grappa.Session.ServerTest do
       own = "grappa-test"
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3600,7 +3595,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3679,7 +3674,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
       on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
@@ -3718,7 +3713,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -3785,7 +3780,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
 
@@ -3834,7 +3829,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3879,7 +3874,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3984,7 +3979,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :vjt: ping\r\n")
 
@@ -4014,7 +4009,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Default prefs: channel_messages_all=false, channel_mentions=true.
       # Body has no mention → no notify.
@@ -4037,7 +4032,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Inbound DM → channel == own_nick ("vjt").
       IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hi there\r\n")
@@ -4064,7 +4059,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host JOIN #sniffo\r\n")
       IRCServer.feed(server, ":alice!~a@host NOTICE #sniffo :vjt fyi\r\n")
@@ -4088,7 +4083,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":bob!~b@host JOIN #sniffo\r\n")
       IRCServer.feed(server, ":bob!~b@host PART #sniffo :bye\r\n")
 
@@ -4142,7 +4137,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       # Autojoin JOIN signals Session has processed `001` fully.
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -4177,7 +4172,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Forced upstream rename — services or operator-driven.
@@ -4214,7 +4209,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":alice!~a@host NICK :alice2\r\n")
@@ -4255,7 +4250,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       action_body = "\x01ACTION waves at the channel\x01"
@@ -4301,7 +4296,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # /ctcp #sniffo VERSION → cic sends \x01VERSION\x01 as the PRIVMSG body.
@@ -4357,7 +4352,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       %{server: server, user: user, network: network, pid: pid}
     end
 
@@ -4681,7 +4676,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       %{server: server, user: user, network: network, pid: pid}
     end
 
@@ -4753,7 +4748,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Seed members so grappa-test is op (@) in #test, then wait for the
@@ -4781,7 +4776,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       log =
         capture_log(fn ->
@@ -4824,7 +4819,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4855,7 +4850,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4899,7 +4894,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4944,7 +4939,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #a"), 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #b"), 1_000)
 
@@ -5009,7 +5004,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5068,7 +5063,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5105,7 +5100,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5156,7 +5151,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN echo + its `joined` broadcast first so the
@@ -5195,7 +5190,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -5240,7 +5235,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, isupport} = Session.get_isupport({:user, user.id}, network.id)
       assert isupport == ISupport.default()
@@ -5273,7 +5268,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :isupport from the live state.
       # (`:sys.replace_state` returns the NEW state, not `:ok`.)
@@ -5326,7 +5321,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # No CHANMODES / PREFIX / STATUSMSG / CASEMAPPING token: the isupport
       # capability table is byte-for-byte what it was.
@@ -5368,7 +5363,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, "MODE grappa-test\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE grappa-test\r\n"), 1_000)
@@ -5395,7 +5390,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Upstream answers the umode query with the current set.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +iwS\r\n")
@@ -5433,7 +5428,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, []} = Session.get_umodes({:user, user.id}, network.id)
 
@@ -5460,7 +5455,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed the base set via 221, then apply a mid-session delta.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +i\r\n")
@@ -5502,7 +5497,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :umodes from the live state.
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
@@ -5553,7 +5548,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Before any 221 the set is empty — the safe direction, not a crash.
       assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
@@ -5572,7 +5567,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The broadcast is the barrier: the fold has landed before we ask.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +io\r\n")
@@ -5598,7 +5593,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
       :ok = await_umodes(["F", "o"])
@@ -5617,7 +5612,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
       :ok = await_umodes(["F", "o"])
@@ -5636,7 +5631,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
 
@@ -5676,7 +5671,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -5717,7 +5712,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, []} = Session.get_supported_umodes({:user, user.id}, network.id)
 
@@ -5745,7 +5740,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :supported_umodes from live state.
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :supported_umodes) end)
@@ -5801,7 +5796,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#Sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -5831,7 +5826,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#Sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -5867,7 +5862,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Session.send_join({:user, user.id}, network.id, "#alfa,#beta", nil)
 
@@ -5904,7 +5899,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Session.send_join({:user, user.id}, network.id, "#Alfa,#BETA", nil)
 
@@ -5941,7 +5936,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#random\r\n")
 
@@ -6006,7 +6001,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#random\r\n")
       assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :window_invited}}, 1_000
@@ -6067,7 +6062,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#live\r\n")
       IRCServer.feed(server, "PING :flush\r\n")
@@ -6096,7 +6091,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Operator initiates a JOIN → window goes :pending.
       :ok = Session.send_join({:user, user.id}, network.id, "#pendingchan", nil)
@@ -6131,7 +6126,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       cap = WindowState.invited_cap()
 
@@ -6183,7 +6178,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -6219,7 +6214,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6252,7 +6247,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6319,7 +6314,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "JOIN #sniffo\r\n"), 1_000)
@@ -6354,7 +6349,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6430,7 +6425,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo-bk", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6464,7 +6459,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Feed 473 BEFORE any send_join — in_flight_joins is empty.
       IRCServer.feed(
@@ -6498,7 +6493,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#registrati", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6559,7 +6554,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # No send_join → in_flight_joins is empty.
       IRCServer.feed(server, ":irc.test.org 403 grappa-test #nowhere :No such channel\r\n")
@@ -6586,7 +6581,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       stale_at = System.monotonic_time(:millisecond) - 60_000
 
@@ -6615,7 +6610,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       recent_at = System.monotonic_time(:millisecond) - 5_000
 
@@ -6659,7 +6654,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drive into :joined state via self-JOIN echo, then seed a stale
@@ -6722,7 +6717,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN echo + its `joined` broadcast first.
@@ -6765,7 +6760,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drive into :joined state via self-JOIN echo.
@@ -6823,7 +6818,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -6863,7 +6858,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN broadcast so the mailbox is clean.
@@ -6902,7 +6897,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -6971,7 +6966,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Self-JOIN echo only — no 353/366. SessionStateHelpers.members(state)[#test] exists
@@ -7002,7 +6997,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Self-JOIN, then a 353 with ONLY own_nick, then 366. Since the
@@ -7047,7 +7042,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#one\r\n")
@@ -7077,7 +7072,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#seeded\r\n")
@@ -7172,7 +7167,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok =
                Session.send_topic({:user, user.id}, network.id, "#italia", "new topic")
@@ -7231,7 +7226,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_nick({:user, user.id}, network.id, "vjt-away")
 
@@ -7281,7 +7276,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#newchan\r\n")
 
@@ -7299,7 +7294,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7320,7 +7315,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7339,7 +7334,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7367,7 +7362,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7413,7 +7408,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7454,7 +7449,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.merge(base_plan, %{notify_pid: parent, notify_ref: ref})
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert_receive {:session_ready, ^ref}, 5_000
@@ -7472,7 +7467,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.merge(base_plan, %{notify_pid: parent, notify_ref: ref})
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       assert_receive {:session_ready, ^ref}, 5_000
 
@@ -7487,7 +7482,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       refute_receive {:session_ready, _}, 200
@@ -7518,7 +7513,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.put(base_plan, :connection_stable_ms, 60_000)
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Autojoin JOIN proves 001 was fully processed — record_success, if it
@@ -7552,7 +7547,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.put(base_plan, :connection_stable_ms, 500)
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       expected_key = {{:user, user.id}, network.id}
@@ -7603,7 +7598,7 @@ defmodule Grappa.Session.ServerTest do
 
       assert network_slug == network.slug
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # "connected" clears the badge the instant 001 lands.
@@ -7627,7 +7622,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7649,7 +7644,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "ChanServ", "REGISTER #x pwd")
@@ -7664,7 +7659,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "nickserv", "IDENTIFY pwd")
@@ -7679,7 +7674,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7709,7 +7704,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7730,7 +7725,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7751,7 +7746,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       for target <- ["BotServ", "OperServ", "HostServ", "HelpServ", "MemoServ"] do
         assert {:ok, :no_persist} =
@@ -7772,7 +7767,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
@@ -7875,7 +7870,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY old")
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY new")
@@ -7891,7 +7886,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
       send(pid, :pending_auth_timeout)
@@ -7909,7 +7904,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "ChanServ", "REGISTER #x pwd")
 
@@ -7925,7 +7920,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "#italia", "ciao")
 
@@ -7944,7 +7939,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -7984,7 +7979,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Drive the identify through the RAW `/quote` path, NOT send_privmsg.
       # `:id` lowercase exercises the Task-1 broadened grammar; the raw
@@ -8023,7 +8018,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:visitor, visitor.id}, network.id, "NickServ", "IDENTIFY wrong")
       send(pid, :pending_auth_timeout)
@@ -8042,7 +8037,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       mode_msg = %Message{
         command: :mode,
@@ -8064,7 +8059,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
       assert match?({"s3cret", _}, SessionStateHelpers.pending_auth(SessionStateHelpers.fetch(pid)))
@@ -8107,7 +8102,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok =
                Session.send_raw(
@@ -8135,7 +8130,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_raw({:user, user.id}, network.id, "WHOIS somebody")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WHOIS somebody\r\n"), 1_000)
@@ -8154,7 +8149,7 @@ defmodule Grappa.Session.ServerTest do
       assert cred.auth_method == :none
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The wizard's REGISTER leaves the wire (wire-only, no scrollback) and
       # stages the untimed registration secret.
@@ -8195,7 +8190,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # A manual NickServ IDENTIFY stages the TIMED pending_auth slot — not a
       # registration. This is #124's territory, not commit-on-+r: the +r must
@@ -8240,7 +8235,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8270,7 +8265,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8306,7 +8301,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8343,7 +8338,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Stage the timed identify slot AND the untimed register slot.
       Session.send_privmsg({:visitor, visitor.id}, network.id, "NickServ", "IDENTIFY identifypass")
@@ -8378,7 +8373,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # A plain identify stages the TIMED slot only — the register slot
       # stays nil (the slots are independent).
@@ -8412,7 +8407,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8453,7 +8448,7 @@ defmodule Grappa.Session.ServerTest do
       original_nick = visitor_nick(visitor)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Services rename us to a Guest — a self-NICK echo (sender == our nick).
       nick_msg = %Message{
@@ -8479,7 +8474,7 @@ defmodule Grappa.Session.ServerTest do
       original_nick = visitor_nick(visitor)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       nick_msg = %Message{
         command: :nick,
@@ -8515,7 +8510,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8544,7 +8539,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8571,7 +8566,7 @@ defmodule Grappa.Session.ServerTest do
       # password) — the only state in which SET PASSWD is meaningful.
       {:ok, _} = Grappa.Visitors.commit_password(visitor.id, network.id, "oldpass")
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8598,7 +8593,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       # Anon visitor: ephemeral (expires_at set), no committed password.
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       refute is_nil(Repo.reload!(visitor).expires_at)
 
       assert {:ok, :no_persist} =
@@ -8628,7 +8623,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "NickServ", "SET EMAIL me@x.io")
@@ -8656,7 +8651,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8687,7 +8682,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8713,7 +8708,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Under 5 bytes — CSNS_ERROR_INSECURE_PASSWORD. Services change
       # nothing, so an optimistic commit would desync the credential.
@@ -8738,7 +8733,7 @@ defmodule Grappa.Session.ServerTest do
       # the visitor recovers the account from inside grappa.
       {:ok, _} = Grappa.Visitors.commit_password(visitor.id, network.id, "oldpass")
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8809,7 +8804,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port, nick: nick)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, "PING :flush\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
 
@@ -8850,7 +8845,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Wait for autojoin so 001 is fully processed
@@ -8906,7 +8901,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -8952,7 +8947,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # state.nick == "grappa-test"; "GRAPPA-TEST" folds equal (ascii).
       msg = %Message{
@@ -8978,7 +8973,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: :kill,
@@ -9012,7 +9007,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{command: :kill, params: [], prefix: {:server, "irc.test.org"}, tags: %{}}
       send(pid, {:irc, msg})
@@ -9035,7 +9030,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # "SASL authentication failed" = upstream rejected SASL credentials permanently.
       msg = %Message{
@@ -9074,7 +9069,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # "SASL authentication aborted" is transient — client/server abort, not wrong password.
       msg = %Message{
@@ -9111,7 +9106,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: {:numeric, 904},
@@ -9186,7 +9181,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, visitor_pid} = Grappa.Session.start_session(visitor_subject, network.id, visitor_plan)
       ref = Process.monitor(visitor_pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: {:numeric, 465},
@@ -9209,7 +9204,7 @@ defmodule Grappa.Session.ServerTest do
   # Shared helper: boot a session, send 001 + autojoin JOIN-self, then
   # flush to ensure both numerics are processed before tests inspect state.
   defp welcome_session_on_channel(server, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
     # UX-4 bucket A: outbound JOIN line carries the canonical
@@ -9873,7 +9868,7 @@ defmodule Grappa.Session.ServerTest do
       # `ghost_recovery` FSM is armed on the Session.
       capture_log(fn ->
         pid = start_visitor_session_for(visitor, network)
-        :ok = await_handshake(server)
+        :ok = IRCServer.await_handshake(server, 1_000)
 
         {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "NICK #{nick}_\r\n"), 1_000)
 
@@ -10352,7 +10347,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.set_explicit_away({:user, user.id}, network.id, "brb")
@@ -10380,7 +10375,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Credentials.update_away(user.id, network.id, "lunch", since)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # User-visible behaviour: other IRC users must see us away again, so
       # the bouncer re-emits AWAY :lunch to the (fresh, away-forgetting)
@@ -10403,7 +10398,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # GenServer.call returns only after the synchronous persist, so the DB
@@ -10424,7 +10419,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "gone")
@@ -10444,7 +10439,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -10465,7 +10460,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Auto-away held ONLY in memory (never persisted). A same-process
@@ -10492,7 +10487,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "gone")
@@ -10511,7 +10506,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Present state — no explicit away set
@@ -10526,7 +10521,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -10552,7 +10547,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # The session subscribes to Topic.ws_presence(user.name); WSPresence
@@ -10607,7 +10602,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = WSPresence.reset_for_test()
@@ -10665,7 +10660,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10694,7 +10689,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10717,7 +10712,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10746,7 +10741,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # The session booted with the 600s default; the user retunes it
@@ -10775,7 +10770,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10820,7 +10815,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = WSPresence.reset_for_test()
       device = spawn(fn -> Process.sleep(:infinity) end)
@@ -10842,7 +10837,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Set explicit away first
@@ -10865,7 +10860,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # First set auto
@@ -10886,7 +10881,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -10905,7 +10900,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "manual")
@@ -10926,7 +10921,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.unset_auto_away({:user, user.id}, network.id)
@@ -10961,7 +10956,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Subscribe to the user-level PubSub topic before the away round-trip.
@@ -11015,7 +11010,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       user_topic = Topic.user(user.name)
@@ -12302,7 +12297,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_topic_clear({:user, user.id}, network.id, "#test")
 
@@ -12329,7 +12324,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_oper({:user, user.id}, network.id, "vjt", "s3cret")
 
@@ -12350,7 +12345,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Test env sets `config :logger, level: :warning` (config/test.exs)
       # so :info-level logs are filtered globally before any capture
@@ -12473,7 +12468,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_raw({:user, user.id}, network.id, "PING :foo.bar")
 
@@ -12518,7 +12513,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 404 vjt #sniffo :Cannot send to channel\r\n")
 
       assert_message_event(
@@ -12554,7 +12549,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 421 vjt BLEH :Unknown command\r\n")
 
       assert_message_event(
@@ -12589,7 +12584,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 401 vjt ghost :No such nick/channel\r\n")
 
       assert_message_event(
@@ -12618,7 +12613,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # /msg ghost hi — the outbound DM opens the server-side query window for
       # ghost (#422 maybe_open_query_window), exactly as compose.ts's /msg does.
@@ -12654,7 +12649,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 372 vjt :- Welcome to TestNet\r\n")
 
       # Exactly one event for this MOTD line.
@@ -12697,7 +12692,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -12919,7 +12914,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # 001 RPL_WELCOME drives the autojoin loop → JOIN #secret upstream.
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
@@ -12947,7 +12942,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#keyed"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #keyed"), 1_000)
       IRCServer.feed(server, ":irc.test 475 grappa-test #keyed :Cannot join channel (+k)\r\n")
@@ -12966,7 +12961,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#bofh"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #bofh"), 1_000)
       # A 473 for a channel never in autojoin (simulates a manual /join fail).
@@ -12982,7 +12977,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#full"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #full"), 1_000)
 
@@ -13001,7 +12996,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #secret"), 1_000)
       IRCServer.feed(server, ":irc.test 473 grappa-test #secret :Cannot join channel (+i)\r\n")
@@ -13026,7 +13021,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #secret"), 1_000)
       IRCServer.feed(server, ":irc.test 473 grappa-test #secret :Cannot join channel (+i)\r\n")
@@ -13418,7 +13413,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
 
@@ -13454,7 +13449,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -66,11 +66,6 @@ defmodule Grappa.Visitors.LoginTest do
     c
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp login_input(overrides \\ %{}) do
     Map.merge(
       %{
@@ -117,7 +112,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v, token: token}} = Task.await(task, 10_000)
@@ -137,7 +132,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{incognito: true}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -236,7 +231,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: "freshpass"}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       # Case 1 provisions an anon visitor, but a non-nil login password
@@ -274,7 +269,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: ""}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v, token: token}} = Task.await(task, 10_000)
@@ -445,7 +440,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       # AuthFSM emits `PRIVMSG NickServ :IDENTIFY s3cret` at 001 for the
@@ -506,7 +501,7 @@ defmodule Grappa.Visitors.LoginTest do
       # (live session + :parked row) and the next reboot's Bootstrap
       # parked-skip would silently drop the just-established session.
       task = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, _} = Task.await(task, 10_000)
 
@@ -519,7 +514,7 @@ defmodule Grappa.Visitors.LoginTest do
          %{server: server, network: network, visitor: visitor} do
       # First login spawns the live session for this identity.
       task1 = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, %{token: first_token}} = Task.await(task1, 10_000)
 
@@ -777,7 +772,7 @@ defmodule Grappa.Visitors.LoginTest do
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: nil}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -792,7 +787,7 @@ defmodule Grappa.Visitors.LoginTest do
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: "not-an-ip"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -842,7 +837,7 @@ defmodule Grappa.Visitors.LoginTest do
       #    connects to the fake cleanly). The login carries the trusted client
       #    IP through to record_login_client_source.
       task = Task.async(fn -> Login.login(login_input(%{ip: client_ip}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -198,13 +198,8 @@ defmodule GrappaWeb.GrappaChannelTest do
     cred.nick
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp welcome_session_on_channel(server, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #{channel}"), 1_000)
     IRCServer.feed(server, ":grappa-snap!u@h JOIN :#{channel}\r\n")
@@ -218,7 +213,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # row), so the JOIN is driven explicitly via `Session.send_join/4` rather
   # than waiting for the 001-autojoin loop.
   defp welcome_visitor_on_channel(server, subject, network_id, nick, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 #{nick} :Welcome\r\n")
     :ok = Session.send_join(subject, network_id, channel, nil)
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #{channel}"), 1_000)
@@ -541,7 +536,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       {irc_server, port} = start_irc_server()
       {user, network} = setup_user_and_network_with_session(port)
 
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(irc_server, &String.starts_with?(&1, "JOIN #snap"), 1_000)
 
@@ -844,7 +839,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Seed the watch list BEFORE end-of-MOTD so arm_presence reads it.
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
       IRCServer.feed(irc_server, ":irc.test.org 005 grappa-snap WATCH=128 :are supported\r\n")
       IRCServer.feed(irc_server, ":irc.test.org 376 grappa-snap :End of MOTD\r\n")
@@ -1023,7 +1018,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Registration WITHOUT joining any channel — the deliberate difference
       # from `welcome_session_on_channel/2`, which is the only reason this
       # test does the handshake by hand.
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
 
       IRCServer.feed(
@@ -1703,7 +1698,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "op: visitor socket ships MODE upstream (issue #153 — no visitor gate)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1807,7 +1802,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "topic_set: visitor socket ships TOPIC upstream (issue #153)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1873,7 +1868,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "oper: visitor socket ships OPER upstream (issue #148 — not visitor_not_allowed)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1998,7 +1993,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "raw: visitor socket ships the line verbatim upstream (issue #153)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -2408,7 +2403,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: whois with live session sends WHOIS upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2437,7 +2432,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: whois with server emits WHOIS <server> <nick> upstream (#198)" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2495,7 +2490,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # `Session.send_whois/4` is called).
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2525,7 +2520,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "whois with source: rail marks the broadcast bundle source: :rail" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2590,7 +2585,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: away set with live session sends AWAY :reason upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2616,7 +2611,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: away unset after set issues bare AWAY upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2690,7 +2685,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: invite with live session sends INVITE nick #chan upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2745,7 +2740,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # users do (mirror of the C3 WHOIS malformed-nick test).
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2788,7 +2783,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       test "visitor socket: #{@verb} with live session sends upstream line" do
         {irc_server, port} = start_irc_server()
         {visitor, network} = setup_visitor_and_network_with_session(port)
-        :ok = await_handshake(irc_server)
+        :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
         flush_server(irc_server)
 
@@ -2845,7 +2840,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       test "visitor socket: #{@verb} with malformed channel returns a validation error" do
         {irc_server, port} = start_irc_server()
         {visitor, network} = setup_visitor_and_network_with_session(port)
-        :ok = await_handshake(irc_server)
+        :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
         flush_server(irc_server)
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -61,11 +61,6 @@ defmodule GrappaWeb.AuthControllerTest do
   defp feed_001(server, nick),
     do: IRCServer.feed(server, ":irc.test.org 001 #{nick} :Welcome\r\n")
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp stop_visitor_session(visitor_id, network_id),
     do: :ok = Grappa.Session.stop_session({:visitor, visitor_id}, network_id)
 
@@ -647,7 +642,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt"}) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       result = Task.await(task, 10_000)
@@ -722,7 +717,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt "}) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       result = Task.await(task, 10_000)
@@ -951,7 +946,7 @@ defmodule GrappaWeb.AuthControllerTest do
           post(conn, "/auth/login", %{"identifier" => "ghost", "incognito" => true})
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "ghost")
 
       resp = Task.await(task, 10_000)
@@ -1060,7 +1055,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1129,7 +1124,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1180,7 +1175,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1228,7 +1223,7 @@ defmodule GrappaWeb.AuthControllerTest do
       _ = credential_fixture(user, network)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       {:ok, session} = Accounts.create_session({:user, user.id}, "1.2.3.4", nil, [])
@@ -1270,8 +1265,8 @@ defmodule GrappaWeb.AuthControllerTest do
 
       pid1 = start_session_for(user, network1)
       pid2 = start_session_for(user, network2)
-      :ok = await_handshake(server1)
-      :ok = await_handshake(server2)
+      :ok = IRCServer.await_handshake(server1, 1_000)
+      :ok = IRCServer.await_handshake(server2, 1_000)
       ref1 = Process.monitor(pid1)
       ref2 = Process.monitor(pid2)
 
@@ -1376,7 +1371,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)

--- a/test/grappa_web/controllers/channels_controller_test.exs
+++ b/test/grappa_web/controllers/channels_controller_test.exs
@@ -52,17 +52,12 @@ defmodule GrappaWeb.ChannelsControllerTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "POST /networks/:network_id/channels" do
     test "with active session sends JOIN upstream and returns 202", %{conn: conn, vjt: vjt} do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -82,7 +77,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -231,7 +226,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -284,7 +279,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -323,7 +318,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo")
 
@@ -385,7 +380,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         delete(
@@ -407,7 +402,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=")
 
@@ -428,7 +423,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-1208-crlf-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#sniffo", "#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=bye%0AQUIT+%3Apwn")
@@ -449,7 +444,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       oversize = String.duplicate("a", GrappaWeb.BodyLimit.max_body_bytes() + 1)
 
@@ -483,7 +478,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-bug5a-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa", "#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23grappa")
       assert json_response(conn, 202) == %{"ok" => true}
@@ -502,7 +497,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-bug5a-noop-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # #grappa is NOT in autojoin_channels — DELETE should still succeed and
       # leave the list unchanged.
@@ -530,7 +525,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-m16-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Race-synthesis: delete the credential row out from under the
       # request after the session is up. The controller's
@@ -568,7 +563,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed window_state[#unjoined] = :failed (e.g. prior +i JOIN rejection)
       # so the eager wipe has something to clear. Without this seed the
@@ -615,7 +610,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed state.members[#chan] + window_state[#chan]=:joined to mirror a
       # post-JOIN session. The eager-wipe path must clean both even though
@@ -659,7 +654,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-lastjoined-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed two live-joined channels synchronously; last_joined starts empty.
       :sys.replace_state(pid, fn s ->
@@ -810,7 +805,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       slug = "az-topic-#{u()}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -906,7 +901,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -928,7 +923,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -973,7 +968,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed live membership synchronously (dodges the self-JOIN echo race).
       {:ok, cred} = Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
@@ -1019,7 +1014,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()

--- a/test/grappa_web/controllers/invites_controller_test.exs
+++ b/test/grappa_web/controllers/invites_controller_test.exs
@@ -46,11 +46,6 @@ defmodule GrappaWeb.InvitesControllerTest do
 
   defp u, do: System.unique_integer([:positive])
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   # Drive a real inbound INVITE through the parser + EventRouter rather than
   # poking window state directly — the fold that keys the window happens on
   # that ingress path, and a test that bypassed it would pass while the real
@@ -71,7 +66,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       network = setup_network(vjt, port, "azzurra-#{u()}")
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(vjt.name))
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = invite(server, "#random")
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23random")
@@ -96,7 +91,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = invite(server, "#random")
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23RANDOM")
@@ -112,7 +107,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#live\r\n")
       IRCServer.feed(server, "PING :flush\r\n")
@@ -130,7 +125,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23never")
 

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -51,18 +51,13 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "GET presence filter — #458 member-count (unset) branch" do
     test "unset pref on a LARGE channel (>= threshold members) hides presence via the size default",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed the live Session with >= LARGE_CHANNEL_THRESHOLD members so the
       # controller reads the count and an UNSET pref resolves to HIDE. This is
@@ -126,7 +121,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -182,7 +177,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # /ping carol typed in #sniffo: cic POSTs to the SOURCE window (the URL
       # channel_id, #sniffo) with ctcp_target=carol (the wire recipient). The
@@ -221,7 +216,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The wire recipient is validated with validate_post_target_name, which
       # rejects the read-only $server synthetic (a CTCP frame can't target it).
@@ -243,7 +238,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # `/notice carol heads up` typed in #sniffo: cic POSTs to the SOURCE window
       # (the URL channel_id) with notice_target=carol. Mirror of the #640
@@ -277,7 +272,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -297,7 +292,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # `/notice @#sniffo heads up` — the form operators use most, refused as
       # malformed before #1301 because the raw `@#sniffo` matched neither the
@@ -329,7 +324,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The control for the test above. On the plain arm the URL channel is
       # BOTH the wire target and the persist key, so admitting a sigil here
@@ -353,7 +348,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The W12 carve-out at the DOOR, not just in the session: a fat-fingered
       # `/notice nickserv identify <pass>` must reach the wire and leave nothing
@@ -385,7 +380,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Two relay verbs in one POST is not a shape the client can mean. Refusing
       # it out loud beats letting clause ORDER silently pick a winner.
@@ -408,7 +403,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       handler_id = {__MODULE__, System.unique_integer([:positive])}
       test_pid = self()
@@ -447,7 +442,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn1 =
         conn
@@ -475,7 +470,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn1 =
         conn
@@ -512,7 +507,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -644,7 +639,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -692,7 +687,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # capacity == 3 (test config): three sends ride the burst.
       for n <- 1..3 do
@@ -718,7 +713,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Drain the burst (capacity 3 in test config), then trip the empty bucket.
       for n <- 1..3, do: assert(json_response(post_body(conn, network, "line #{n}"), 201))
@@ -738,12 +733,12 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server1, port1} = start_server()
       net1 = setup_network(vjt, port1, "azzurra")
       pid1 = start_session_for(vjt, net1)
-      :ok = await_handshake(server1)
+      :ok = IRCServer.await_handshake(server1, 1_000)
 
       {server2, port2} = start_server()
       net2 = setup_network(vjt, port2, "second-net")
       pid2 = start_session_for(vjt, net2)
-      :ok = await_handshake(server2)
+      :ok = IRCServer.await_handshake(server2, 1_000)
 
       # Drain net1's bucket entirely (capacity 3 + one throttled).
       for n <- 1..3, do: assert(json_response(post_body(conn, net1, "n1-#{n}"), 201))
@@ -784,7 +779,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+io")
 
       # Sends 4, 5 and 6 are the discriminating ones: under the ordinary
@@ -806,7 +801,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+io")
 
       for n <- 1..6, do: assert(json_response(post_body(conn, network, "oper #{n}"), 201))
@@ -832,7 +827,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       # at source, so the network has to say it is one.
       network = setup_network(vjt, port, "azzurra", :azzurra)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+Fio")
 
       # Well past BOTH ceilings (3 ordinary, 6 oper): there is no upstream
@@ -852,7 +847,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+Fio")
 
       for n <- 1..6, do: assert(json_response(post_body(conn, network, "unclassified #{n}"), 201))
@@ -867,7 +862,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+iw")
 
       for n <- 1..3, do: assert(json_response(post_body(conn, network, "plain #{n}"), 201))
@@ -900,7 +895,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -932,7 +927,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -46,11 +46,6 @@ defmodule GrappaWeb.NickControllerTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   setup %{conn: conn} do
     vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
     session = session_fixture(vjt)
@@ -63,7 +58,7 @@ defmodule GrappaWeb.NickControllerTest do
       slug = "az-nick-#{System.unique_integer([:positive])}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -134,7 +129,7 @@ defmodule GrappaWeb.NickControllerTest do
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       new_nick = "v9new-#{System.unique_integer([:positive])}"
 
@@ -188,7 +183,7 @@ defmodule GrappaWeb.NickControllerTest do
       _ = visitor_fixture(nick: target_nick, network_slug: network.slug)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -217,7 +212,7 @@ defmodule GrappaWeb.NickControllerTest do
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Free in the registry — nothing squats it locally. Upstream is the
       # one that says no.
@@ -269,7 +264,7 @@ defmodule GrappaWeb.NickControllerTest do
       {:ok, _} = Visitors.commit_password(holder.id, network.id, "s3cret")
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       # Snapshot lines after handshake: NICK + USER are emitted at
       # connect-time. Asserting "no NEW NICK line" against a fresh
       # snapshot is the right granularity — `wait_for_line/3` matches

--- a/test/grappa_web/controllers/session_controller_test.exs
+++ b/test/grappa_web/controllers/session_controller_test.exs
@@ -52,11 +52,6 @@ defmodule GrappaWeb.SessionControllerTest do
     port
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 5_000)
-    :ok
-  end
-
   # A registered visitor = identified on some network. #211 phase 7 —
   # `commit_password/3` writes the per-network Cloak-encrypted secret on
   # the `(visitor, network)` credential; "registered/permanent" is DERIVED
@@ -77,7 +72,7 @@ defmodule GrappaWeb.SessionControllerTest do
 
       # The visitor is live on network A.
       _ = start_visitor_session_for(visitor, network_a)
-      :ok = await_handshake(server_a)
+      :ok = IRCServer.await_handshake(server_a, 5_000)
       assert is_pid(Grappa.Session.whereis({:visitor, visitor.id}, network_a.id))
 
       # A SECOND visitor_enabled network B with its own fake upstream.
@@ -340,7 +335,7 @@ defmodule GrappaWeb.SessionControllerTest do
       # #211 phase 7 — anon ⟺ NOT registered (derived from the credentials).
       refute Credentials.visitor_registered?(visitor.id)
       _ = start_visitor_session_for(visitor, network_a)
-      :ok = await_handshake(server_a)
+      :ok = IRCServer.await_handshake(server_a, 5_000)
 
       {server_b, port_b} = start_server()
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -32,6 +32,10 @@ defmodule Grappa.IRCServer do
   on `Process.sleep` constants. Returns `{:ok, matched_line}` or
   `{:error, :timeout}`.
 
+  `await_handshake/2` is the one named barrier built on it: registration
+  is what a session test waits for before it can assert anything, and it
+  used to be re-declared locally in thirteen files (#1397).
+
   Implementation (M-irc-2): the wait is a single GenServer call that
   either replies immediately (the predicate matches some buffered line)
   or registers a `{ref, predicate, from}` waiter on server state and
@@ -120,6 +124,32 @@ defmodule Grappa.IRCServer do
     # of leaving them to time out — the timeout loss-of-signal hid
     # genuine close races behind the same deadline as no-line cases.
     GenServer.call(server, {:wait_for, predicate, timeout}, timeout + 100)
+  end
+
+  @doc """
+  Blocks until the client has sent its `USER` registration line, then
+  returns `:ok`. A miss raises the `MatchError` from the `{:ok, _}`
+  match, which is the failure a test wants to see: the barrier the rest
+  of the test leans on never happened.
+
+  `timeout` carries NO default, deliberately. Commit `84fe0850` removed
+  the default timeout from `wait_for_line/3` under the CLAUDE.md
+  no-default-arguments rule and spelled the value at every call site;
+  the thirteen local copies this replaces (#1397) had re-hidden that
+  same value behind a zero-argument wrapper — eleven at `1_000`, two at
+  `5_000`. A default here restores the silent-degradation path that
+  ruling removed and halves the budget of the two 5s sites by accident.
+  The budget stays where it is decidable: at the call site.
+
+  The predicate keeps the trailing space, the stricter of the two
+  spellings the copies had drifted into. `lib/` sends exactly one line
+  beginning with `USER` and never `USERHOST`, so both spellings select
+  the same line today — the strict one also says so.
+  """
+  @spec await_handshake(pid(), pos_integer()) :: :ok
+  def await_handshake(server, timeout) do
+    {:ok, _} = wait_for_line(server, &String.starts_with?(&1, "USER "), timeout)
+    :ok
   end
 
   ## GenServer


### PR DESCRIPTION
Slice **F1** of #1397 (bucket H test-harness): the thirteen local
`await_handshake/1` wrappers become one `IRCServer.await_handshake/2`, and the
timeout stops being hidden.

This follows the `passthrough_handler` slice (`412579cb`) in shape — hoist onto
the module that already owns the domain, call it qualified, touch no case
template — so it stays independently reviewable.

## The archaeology reverses the issue's reading of the timeout

The issue holds `await_handshake` out of consolidation because "two files have
already found one second insufficient", making the timeout "a live decision".
**That is withdrawn.** Reading both files at the commit that introduced their
wrapper:

| site | introduced | value at birth |
|---|---|---|
| `test/grappa/account_deletion_test.exs` | `5775e55a` (#157, 2026-06-29) | `5_000` |
| `test/grappa_web/controllers/session_controller_test.exs` | `5e6f7c53` (#126, same day) | `5_000` |

Neither was ever raised from `1_000`, because neither was ever at `1_000`. Two
new files written the same day by authors who picked a wider budget is not
evidence about one second.

And the majority was not chosen either: eight of the ten `1_000` copies trace to
`84fe0850` (2026-05-08), which removed the default timeout from
`wait_for_line/3` under the CLAUDE.md no-default-arguments rule and stamped the
old default explicitly at ~150 call sites. The thirteen local wrappers then
re-hid that same value behind a zero-argument helper.

## So the hoisted verb takes the budget as an argument

`IRCServer.await_handshake(server, timeout)` has no default. Adding one would
undo `84fe0850` on the same function family and would silently halve the two 5s
sites the moment their `defp` disappeared. Eleven files keep 1s, two keep 5s,
each spelled where it is paid for. 380 call sites, each carrying its own value —
that is the same shape `84fe0850` chose for ~150 calls, and it is noisy on
purpose.

The other two axes are duplication and they close: the alias axis dies with the
definitions, and the prefix axis closes on the strict `"USER "` (`lib/` sends
exactly one line beginning with `USER` and no `USERHOST` at all, so both
spellings select the same line — a test asserts `USERHOST` does not satisfy the
barrier).

## The arity is pinned by a test, and the pin was bought

`refute function_exported?(Grappa.IRCServer, :await_handshake, 1)`. Mutant:
re-adding the default argument to the definition. Result — 4 tests, 1 failure,
exactly that assertion, the other three still green. Committed before mutating,
reverted after, working tree verified clean.

## While the compile lane was held: the collision claim is no longer inferred

The DESIGN_NOTES entry from the first slice states the import/local collision as
"the documented Elixir rule plus the 110-to-0 evidence ... not a build we watched
fail". It has now been watched. Adding `admin_session/0` to `Grappa.AuthFixtures`
and compiling one of the fourteen files that define it locally while importing
the module wholesale:

```
error: imported Grappa.AuthFixtures.admin_session/0 conflicts with local function
== Compilation error in file test/grappa_web/controllers/admin/circuit_controller_test.exs ==
```

The mutation was reverted; nothing of it is in this branch. The consequence for
the bucket is now firm in kind rather than in direction: the `admin_session`
slice is atomic across fifteen files.

## Declared overrun: 15 → 16 files

The ceiling declared for this slice was 15. It came out at **16**, and the
sixteenth is `docs/DESIGN_NOTES.md`. Thirteen converted files plus the
destination `test/support/irc_server.ex` is 14; the new
`test/grappa/irc_server_test.exs` is 15; the decision-log entry is 16.

The overrun is entirely the retraction above. Splitting it into a docs-only PR
would separate the withdrawn claim from the measurement that supports it, so it
rides here, declared rather than absorbed.

## Gates

Full `scripts/check.sh`, RC read from file, every phase marker read one by one:

- Credo — `6124 mods/funs, found no issues.`
- ExUnit — `8 doctests, 61 properties, 6542 tests, 0 failures`
- Sobelow — `Total errors: 0, Skipped: 0, Unnecessary Skips: 0`
- Dialyzer — `done (passed successfully)`
- bats — 564 `ok`, 0 `not ok`

An earlier run was red on Credo (a named `_sock` discard where the file's
strategy is `_`). It was fixed and `check.sh` re-run from the top, because
`check.sh` aborts at the first red phase and the green below it did not exist.

`scripts/design-notes-gate.sh` separately: `1 new entry heading(s), separator and
marker present.` — the measuring line, not `nothing to check`. Entry numstat: 74
additions, 0 deletions.

## Not established

- **Whether one second is the right budget.** The argument for changing it was
  falsified; the value was not measured. No suite timing, no attributed flake,
  no Argon2 number. The design deliberately avoids having to answer.
- **The prefix change beyond what was measured.** `"USER "` holds because `lib/`
  has one USER-prefixed send and zero `USERHOST` today. Static measurement over
  `lib/`, not a guarantee about future senders.
- **That the green transfers to another tree.** `_build`, `deps` and `priv/plts`
  are shared across worktrees on this host and no forced rebuild was done; the
  run is on base `c2e64901`.
- **Anything against production or a live session.** This is the suite.
- **The rest of the bucket.** `start_server` (21 clauses over 20 files) and
  `admin_session` (14, one shape) are queued behind this. The fixture trio needs
  a ruling first: substituting `AuthFixtures`' placeholder hash for a real Argon2
  one changes what fourteen files prove, and the local `visitor_fixture` calls
  the production provisioning verb the canonical one bypasses.
