### PR TITLE
test(#1390): pin Session.Server's state contract against its own typedef

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47700,3 +47700,91 @@ census: an automatic discriminator (look for the message body in a positive
 assertion nearby) flagged 7 of them as unproven and all 7 were false alarms — the
 proof was a badge count, a loop variable, or an outcome, none of which names the
 body.
+<!-- entry #1390 slice 5 -->
+
+---
+
+## 2026-08-17 — #1390 slice 5: the state contract gets a guard, and the guard caught itself first
+
+Slices 1–4 moved things out of `Session.Server`. This one moves nothing. It
+buys the check that the issue's central sentence presupposes: renaming a
+`*_pending` field produces no compile error and no warning, only a `nil` at
+runtime in whichever `apply_effects/2` arm drains it. The module declares its
+state twice — `@type t :: %{...}` and the map its init path builds — both as
+bare maps, so neither the compiler nor Dialyzer has anything to disagree with.
+
+Measured before a line was written: the two sides declare **71 keys each** and
+their set difference is empty in both directions. So the agreement is intact
+and unguarded. That measured pre-state is the whole argument for calling this a
+pin rather than a regression guard — a guard protects behaviour something else
+already covers, and here the mutant is killed by nothing at all today.
+
+### The two mutants, one per side
+
+Each was injected on a committed tree, run, and the failure READ rather than
+predicted. Renaming `pending_auth` to `pendign_auth` in the built map alone:
+
+```
+Built by the init path but MISSING from `@type t` (declare them):
+  [:pendign_auth]
+Declared in `@type t` but never built by the init path (remove
+them, or build them — a declared-only key reads as `nil` forever):
+  [:pending_auth]
+```
+
+The same rename in the typedef alone gives the mirror image. The second mutant
+is not the first one twice: it is what proves the declared side is read from
+the live BEAM, because a stale chunk would answer `pending_auth` on both sides
+and pass green.
+
+### The extraction, and why it is anchored on a return
+
+The declared side comes from the COMPILED typespec via
+`Code.Typespec.fetch_types/1` — the type Dialyzer sees, not a re-parse of the
+source — mirroring `GrappaWeb.ErrorTokensDriftTest`, which already does exactly
+this for the wire error tokens. The built side has no such door: it is a bound
+variable in a 3-tuple return, so it has to be walked out of the AST.
+
+The walk is anchored on the RETURN, not on a function name: the state map is
+the one bound to `state` in the function answering `{:ok, state, {:continue, _}}`.
+There is exactly one.
+
+### A correction to the record, because it is the useful part
+
+The first version of this test anchored on the name `init/1`, and **that was
+wrong**: `Session.Server.init/1` delegates through `init_or_hold/1`, and the
+71-key map is built in `defp do_init/1`. The extractor found zero maps.
+
+It was caught by the test's own guard rather than by review. The `flunk` for
+"not found exactly once" fired and named the shape it expected, instead of
+comparing two empty sets and passing — which is precisely the failure mode the
+guard exists for, and the reason it stays alongside the two anchor keys that
+must survive on both sides. An extractor that quietly finds nothing makes every
+assertion below it vacuously true, forever.
+
+The recon comment on #1390 that preceded this slice needs the same correction.
+It gave one reason why `Grappa.Deploy.Preflight` cannot serve as the oracle
+here — that `init/1` returns `{:ok, state, {:continue, _}}` with `state` a
+bound variable rather than the `{:ok, %{...}}` literal Preflight's clause
+collects. True as far as it goes, and incomplete: the map is not in `init/1` at
+all. So the conclusion holds and is stronger than stated. Preflight sees the
+typedef — enough for its own job, classifying the deploy COLD — and never the
+state map.
+
+### What this does not cover, stated so nobody reads the green as wider
+
+The pin compares KEY NAMES on the two declared sides. It says nothing about the
+values or types behind them (measured today: zero fields seeded `nil` against a
+type that excludes `nil`), nothing about the seven fields still typed `map()`,
+nothing about the 29 tolerant `Map.get(state, :k, default)` reads whose defaults
+are a third place the contract is written, and nothing about the READERS — a
+`state.pendign_auth` anywhere in the module still compiles, warns nothing and
+evaluates to `nil`. It also does not reach `EventRouter`'s own declared
+contract, which is the separate and larger finding, nor the four test files
+that hand-build a state-shaped map.
+
+### Deploy
+
+Unlike slices 1–4, this one touches no production file, so it does not move the
+`@type t` of a module in `HotReload.LongLivedModules`. It is the first #1390
+slice that is **not** a COLD deploy.

--- a/test/grappa/session/state_contract_drift_test.exs
+++ b/test/grappa/session/state_contract_drift_test.exs
@@ -1,0 +1,177 @@
+defmodule Grappa.Session.StateContractDriftTest do
+  @moduledoc """
+  Drift pin for `Session.Server`'s state contract (#1390 bucket A).
+
+  The module declares its state twice — once as `@type t :: %{...}` and
+  once as the map its init path builds — and nothing keeps the two in
+  agreement. That is the mechanism behind the bucket's central sentence:
+  renaming a `*_pending` field produces no compile error and no warning,
+  only a `nil` at runtime in whichever `apply_effects/2` arm drains it.
+  Both halves are bare maps, so neither the compiler nor Dialyzer has
+  anything to disagree with.
+
+  Measured on `origin/main` = `f75b0e05` before this test existed: the
+  two sides declare **71** keys each and their set difference is empty in
+  both directions. So the agreement is currently intact and unguarded —
+  this pin buys the guard, not a fix.
+
+  DERIVED from both sources, never manifested (CLAUDE.md — derive, don't
+  duplicate): a hand-kept key list here would be a third copy to drift.
+  The declared side is read from the COMPILED typespec
+  (`Code.Typespec.fetch_types/1`, the same mechanism as
+  `GrappaWeb.ErrorTokensDriftTest`) so it is the type Dialyzer sees, not
+  a re-parse of the source; the built side has to be AST-walked, because
+  it is a bound variable in a 3-tuple return and no introspection reaches
+  it.
+
+  The walk is anchored on the RETURN, not on a function name: the state
+  map is the one bound to `state` in the function that answers
+  `{:ok, state, {:continue, _}}`. Today that is `do_init/1`, not `init/1`
+  — `init/1` delegates through `init_or_hold/1` — and pinning the name
+  was this test's own first bug, caught by its own guard rather than by
+  review. A semantic anchor survives renaming the delegate; restructuring
+  the return breaks it loudly, which is the trade wanted here.
+
+  That indirection is also why this test exists rather than a reuse.
+  `Grappa.Deploy.Preflight` already walks both shapes, but its clause
+  collects `{:ok, %{...}}` LITERALS returned by `init/1`, and this module
+  neither returns a literal nor builds the map in `init/1` at all.
+  Preflight sees the typedef — enough for its own job, classifying the
+  deploy COLD — and never the state map, so it cannot serve as the oracle
+  here.
+  """
+
+  # async: true — one file read, one typespec fetch, no Repo, no process,
+  # no global state.
+  use ExUnit.Case, async: true
+
+  @server_source "lib/grappa/session/server.ex"
+
+  test "Session.Server's @type t and the map its init path builds declare the same keys" do
+    declared = declared_keys()
+    built = built_keys()
+
+    # Instrument the instrument: an extractor that quietly finds nothing
+    # would make every assertion below vacuously true, forever. These two
+    # keys are load-bearing enough that their disappearance is a real
+    # failure rather than a rename — `EventRouter`'s own declared contract
+    # requires both.
+    assert :subject in declared and :network_id in declared,
+           "the @type t extractor found no recognisable state keys — it is broken, " <>
+             "not the contract"
+
+    assert :subject in built and :network_id in built,
+           "the init-map extractor found no recognisable state keys — it is broken, " <>
+             "not the contract"
+
+    undeclared = built |> MapSet.difference(declared) |> Enum.sort()
+    unbuilt = declared |> MapSet.difference(built) |> Enum.sort()
+
+    assert undeclared == [] and unbuilt == [],
+           """
+           Session.Server's state contract drifted.
+
+           Built by the init path but MISSING from `@type t` (declare them):
+             #{inspect(undeclared)}
+
+           Declared in `@type t` but never built by the init path (remove
+           them, or build them — a declared-only key reads as `nil` forever):
+             #{inspect(unbuilt)}
+           """
+  end
+
+  # ── declared side (the COMPILED typespec) ───────────────────────────
+
+  defp declared_keys do
+    {:ok, types} = Code.Typespec.fetch_types(Grappa.Session.Server)
+
+    {:type, {:t, ast, _}} =
+      Enum.find(types, fn
+        {:type, {:t, _, _}} -> true
+        _ -> false
+      end)
+
+    map_keys(ast)
+  end
+
+  # Erlang abstract-form typespec AST, as returned by
+  # Code.Typespec.fetch_types/1: `%{key: value}` in Elixir is an EXACT
+  # map field (`#{key := value}`), so an associative field would mean the
+  # typedef changed shape rather than the key set — and it lands in
+  # neither set, which the anchor assertions above catch.
+  defp map_keys({:type, _, :map, fields}) do
+    for {:type, _, :map_field_exact, [{:atom, _, key}, _]} <- fields,
+        into: MapSet.new(),
+        do: key
+  end
+
+  # ── built side (AST-walk the init path) ─────────────────────────────
+
+  defp built_keys do
+    maps =
+      @server_source
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> init_state_maps()
+
+    case maps do
+      [kvs] ->
+        for {key, _} <- kvs, is_atom(key), into: MapSet.new(), do: key
+
+      found ->
+        flunk("""
+        expected exactly one `state = %{...}` literal in the function of
+        #{@server_source} that answers `{:ok, state, {:continue, _}}`, found
+        #{length(found)}. The extractor is anchored on that return, not on a
+        function name; if the init path legitimately builds its state some
+        other way now, teach this test the new shape — do not delete the pin.
+        """)
+    end
+  end
+
+  defp init_state_maps(ast) do
+    {_, found} =
+      Macro.prewalk(ast, [], fn
+        {kind, _, [_, _]} = node, acc when kind in [:def, :defp] ->
+          if returns_init_tuple?(node),
+            do: {node, state_assignments(node) ++ acc},
+            else: {node, acc}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found
+  end
+
+  # The GenServer init return, `{:ok, state, {:continue, _}}` — a 3-tuple,
+  # so `{:{}, _, [...]}` in quoted form. This is the anchor: whichever
+  # function answers it is the one that built the state map, whatever it
+  # is called.
+  defp returns_init_tuple?(node) do
+    {_, hit} =
+      Macro.prewalk(node, false, fn
+        {:{}, _, [:ok, {:state, _, ctx}, {:continue, _}]} = n, _ when is_atom(ctx) ->
+          {n, true}
+
+        n, acc ->
+          {n, acc}
+      end)
+
+    hit
+  end
+
+  defp state_assignments(init_node) do
+    {_, found} =
+      Macro.prewalk(init_node, [], fn
+        {:=, _, [{:state, _, ctx}, {:%{}, _, kvs}]} = node, acc
+        when is_atom(ctx) and is_list(kvs) ->
+          {node, [kvs | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found
+  end
+end


### PR DESCRIPTION
## What this buys

`Session.Server` declares its state twice — `@type t :: %{...}` and the map its
init path builds — and nothing keeps the two in agreement. That gap is the
mechanism behind #1390's central sentence: renaming a `*_pending` field produces
no compile error and no warning, only a `nil` at runtime in whichever
`apply_effects/2` arm drains it. Both halves are bare maps, so neither the
compiler nor Dialyzer has anything to disagree with.

This adds one test file and one DESIGN_NOTES entry. **No production file is
touched.**

## Why it is a pin and not a regression guard

Measured on `f75b0e05`, before the test was written: the two sides declare **71
keys each** and their set difference is empty in both directions. The agreement
is intact and unguarded, so the mutant this test kills is killed by **nothing
else today**. A regression guard protects behaviour something already covers;
this pre-state is measured, so this is not that.

## The two reds, read rather than predicted

Both injected on a committed tree, run, transcribed, then restored with a
`git diff --stat` check immediately after the restore.

**Mutant A** — rename `pending_auth` → `pendign_auth` in the built map only:

```
  1) test Session.Server's @type t and the map its init path builds declare the same keys
     Session.Server's state contract drifted.

     Built by the init path but MISSING from `@type t` (declare them):
       [:pendign_auth]

     Declared in `@type t` but never built by the init path (remove
     them, or build them — a declared-only key reads as `nil` forever):
       [:pending_auth]
```

**Mutant B** — the same rename in the typedef only — gives the mirror image
(`[:pending_auth]` built, `[:pendign_auth]` declared). B is not A twice: it is
what proves the declared side is read from the live BEAM, since a stale chunk
would answer `pending_auth` on both sides and pass green.

## The extractor's own bug, which its own guard caught

The first version anchored on the name `init/1`. That is wrong: `init/1`
delegates through `init_or_hold/1`, and the 71-key map is built in
`defp do_init/1`. The extractor found **zero** maps — and the run said so,
because the "not found exactly once" `flunk` fired and named the shape it
expected, instead of comparing two empty sets and passing. That is the failure
mode this file is written to refuse, so the guard stays: two anchor keys must
survive on both sides, and a missing state map is a `flunk` telling the reader
to teach the extractor the new shape rather than delete the pin.

It is now anchored on the RETURN, not on a name: the state map is the one bound
to `state` in the function answering `{:ok, state, {:continue, _}}`. There is
exactly one. Renaming the delegate does not break it; restructuring the return
breaks it loudly.

The same finding corrects the recon comment on #1390: it explained Preflight's
blindness by the bound-variable return, which is true and incomplete — the map
is not in `init/1` at all. The conclusion is unchanged and stronger.

## Where the two sides are read from

Declared side: the COMPILED typespec via `Code.Typespec.fetch_types/1`, so it is
the type Dialyzer sees rather than a re-parse. Precedent in-tree:
`test/grappa_web/error_tokens_drift_test.exs:48` does exactly this for the wire
error tokens. Built side: AST, because there is no other door.

`Grappa.Deploy.Preflight` already walks both shapes and was the obvious reuse,
but its clause collects `{:ok, %{...}}` literals returned by `init/1`. It sees
the typedef — all its own job needs, to classify the deploy COLD — and never the
state map.

## A measurement blindness worth carrying, since it is general

While sizing this, `grep -oE 'state\.<field>'` reported **0 fields** for three
sibling modules (`broadcaster.ex`, `persistor.ex`, `identity_state.ex`). They do
read state; the binding there simply is not called `state`. A census run only
that way would have concluded "three innocent modules". The measure is bound to
a variable NAME, not to the thing it claims to count — and the same grep also
counts prose inside comments, which is where two phantom out-of-contract readers
in `server.ex` came from.

## What the green does NOT say

Key names on the two declared sides, and nothing else: not the values or types
behind them (measured: zero fields seeded `nil` against a type excluding `nil`),
not the seven fields still typed `map()`, not the 29 tolerant
`Map.get(state, :k, default)` reads whose defaults are a third copy of the
contract, and **not the readers** — a `state.pendign_auth` still compiles, warns
nothing and evaluates to `nil`. It does not reach `EventRouter`'s 4-declared /
32-touched contract, which is the separate and larger finding, nor the four test
files that hand-build a state-shaped map.

## Deploy

Unlike #1390 slices 1–4, this touches no production file and does not move the
`@type t` of a module in `HotReload.LongLivedModules`. First slice of this issue
that is **not** a COLD deploy.
