### PR TITLE
fix(#1500): keep the empty trailing a NOTICE actually carried

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47844,3 +47844,124 @@ wraps its fetch in `try {} catch {}` behind an `if (!res.ok) return`. A
 of fail-loud while producing ZERO observable noise. Converting it is therefore a
 decision about that door's ERROR POSTURE, not part of a cast sweep, and it is
 left for vjt to rule.
+<!-- entry #1500 -->
+
+---
+
+## 2026-08-18 — #1500: the empty body was never rejected, it was deleted before the validator ran
+
+A `$server` NOTICE with an empty trailing was dropped from scrollback and error-logged on
+every arrival — 1440 lines a day on the reporting session, which buries the failures an
+operator needs to see. The path the issue traced holds, re-verified at `8b6ed99d`: a dotted
+sender routes to `$server` (`EventRouter.route_non_channel_notice_non_chanserv/3`), the body
+travels verbatim, and `Message.@body_required_kinds` rejects it. The MECHANISM named in the
+issue is one step off, and the correction is what decides the fix.
+
+### The body never reached the validator
+
+`Message.changeset/2` cast `:body` with no `empty_values` option, so Ecto's default
+`empty_values: [""]` mapped the blank to MISSING and the change never landed. By the time
+`validate_body_for_kind/1` ran, `body` was `nil` — which is why the operator's log said
+`can't be blank` rather than anything about emptiness.
+
+The consequence for the fix is not cosmetic: relaxing `:notice` out of
+`@body_required_kinds` ALONE would have persisted `body: NULL`. The row would arrive, the
+log would go quiet, both halves of the reported symptom would clear — and the stored value
+would still not be what the wire carried.
+
+### Why `""` and not `NULL`
+
+`""` is true. The wire carried an empty trailing, which is an empty string, not an absence.
+`NULL` asserts a different fact — that the row has no body at all, which is what a `:join`
+row means. Storing it would make an empty server notice indistinguishable from a presence
+event.
+
+The client boundary does not rescue the wrong choice, and this is the part worth recording
+because it inverts the intuition: the generated schema declares `body: { u: ["s", "z"] }`,
+string-OR-null, and it must, because the presence kinds legitimately carry no body. So a
+`NULL` body would NOT be rejected by `wireValidate` — it would validate cleanly and arrive
+in a renderer as an absent body. `NULL` is the more dangerous option precisely BECAUSE
+validation passes it: it is the undefined-in-a-renderer shape #1400 exists to remove,
+arriving through the door that is supposed to catch exactly that.
+
+So the fix is two edits: `:notice` leaves `@body_required_kinds`, and `:body` is re-cast
+with `empty_values: []` so an explicit `""` survives as a real change. The scoped re-cast is
+the idiom already carried by `Networks.Credential`, `Networks.Server` and `Vhosts.Vhost` —
+reused rather than reinvented.
+
+### Relaxed for `:notice` only, and the blast radius that says it is safe
+
+`@body_required_kinds` is now `[:privmsg, :action, :topic]`. Before widening the mesh, every
+producer of a `:notice` row was checked for whether it leans on that validation to reject
+something. None does:
+
+* the inbound wire routes (`event_router` DM / channel / `$server` / CTCP arms) are the
+  defect itself — an empty trailing is legal on all of them;
+* the CTCP-PING acknowledgement persists a literal, never-empty body;
+* `join_failed` and the numeric→`$server` rows derive their body from a numeric's trailing,
+  so an empty one is the SAME defect in the same class — relaxing fixes them rather than
+  breaking them;
+* the OUTBOUND echo (`persist_and_send_notice_fragments/5`) looked like the real risk: its
+  `with` persists BEFORE it sends, so today a rejected row also blocks the wire write. But
+  `split_privmsg_body("")` returns `[""]`, not `[]`, so the guard that actually protects
+  that path is upstream at the boundary — `MessagesController.create/2`'s function head,
+  `when is_binary(body) and body != ""`. The changeset was never the load-bearing gate
+  there, and no test asserts a `:notice` rejection (the three `can't be blank` tests are
+  `:privmsg` twice and `:topic`).
+
+`:privmsg` and `:action` stay required: an empty one of those has no reported arrival and no
+decided semantics, and widening past the measured case is how a rule stops meaning anything.
+
+**`:topic` is the known next candidate, it is the SAME defect, and it is still deliberately
+not taken here — for a measured reason, not a scoping one.** `TOPIC #chan :` is how an
+operator CLEARS a topic; it produces `body: ""`, and today the row drops and error-logs
+exactly as the NOTICE did (the `{:topic_changed, …}` effect still fires, so the topic bar
+clears correctly and only the HISTORY is lost). Server-side the extension really would be
+free — the same atom out of the same list, already covered by the same re-cast. The blocker
+is on the client, and it was read rather than assumed:
+
+* `ScrollbackPane.tsx`'s `case "topic"` renders
+  `* {sender} changed topic: <MircBody body={msg.body ?? ""} emphasis />`;
+* `parseMircFormat("")` returns ZERO runs (`flush/0` returns early on `buf.length === 0`),
+  so `<For>` renders nothing;
+* and the pane applies no empty-body filter, so the row does reach that arm.
+
+So an empty `:topic` row would render as `* alice changed topic:` — a label, a colon, and
+nothing. It does not crash and it does not print `undefined`; it simply asserts *changed*
+and then shows a blank, which reads as a truncated render rather than as "the topic was
+cleared". **Persisting a row that misdescribes the event is the same damage moved from the
+log to the scrollback, where it additionally persists.** Making it honest needs a renderer
+arm that says *cleared*, which is a cic change with its own test and its own decision.
+
+So `:topic` keeps its body requirement here, and the whole case — server relaxation plus the
+renderer arm, taken together or not at all — is **out of scope for #1500 and tracked as
+#1505**. Anyone reaching for the one-atom server fix on its own should read that issue
+first: the reason it is not free is on the client, and it is not visible from `message.ex`.
+
+### The oracle
+
+Both halves, in that order, because the order is the discipline: the row must ARRIVE first,
+or `refute log =~ "scrollback insert failed"` is vacuous — it would pass on a session that
+never processed the line. The red was read, not assumed, and it reproduced the operator's
+line verbatim, `error=[body: {"can't be blank", [validation: :required]}]`. The green
+asserts the STORED value (`""`, via `Scrollback.fetch`), not merely the broadcast one.
+
+### The open question stays open
+
+The issue asks where the minute-cadence notice comes from, and does not answer it. Neither
+does this. What the CODE can say: grappa runs its own 60s generator — the `Client` liveness
+watchdog, `@liveness_idle_ms` 60_000, whose cycle is driven by INBOUND silence and is reset
+by ANY inbound line. That is a discriminator, because a wall-clock cadence upstream fires
+regardless of what we do, while a reset-on-inbound timer skips and shifts — and the report
+observes precisely a skip (no line at 18:00:50) and a shift (one at 18:01:20). What the code
+CANNOT say is what the line is: nothing here shows an ircd answering a PING with an empty
+NOTICE, and the reporter's reconnect at 18:00:40 does not line up with the 18:00:20 the
+timer arithmetic wants. The raw IRC line is still missing and the upstream source remains
+UNIDENTIFIED.
+
+One useful consequence of this fix: the line now lands in `$server` instead of being
+dropped, so the instrument for identifying it is the fix itself.
+
+_Not established: that a wrong-typed or empty body was ever observed on any kind other than
+`:notice` in production — the `:topic` case above is derived from the source, not from an
+incident. No claim is made about what the upstream peer is or why it emits on that cadence._

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -110,7 +110,14 @@ defmodule Grappa.Scrollback.Message do
     :server_event
   ]
 
-  @body_required_kinds [:privmsg, :notice, :action, :topic]
+  # #1500 — `:notice` is NOT here. A NOTICE with an empty trailing is legal
+  # (RFC 1459 §2.3.1: `:` followed by nothing is a valid, empty last param),
+  # and the empty body is itself the diagnosable event. Requiring a body
+  # dropped the row AND error-logged the drop on every arrival. The other
+  # three stay: an empty PRIVMSG/ACTION/TOPIC has no reported arrival and no
+  # decided semantics, and widening past the measured case is how a rule
+  # stops meaning anything.
+  @body_required_kinds [:privmsg, :action, :topic]
 
   # S17 (2026-07-08 review) / #395 — the human-content kinds and their
   # unread PROJECTION, declared ONCE. Each content kind maps to whether it
@@ -343,6 +350,14 @@ defmodule Grappa.Scrollback.Message do
       :meta,
       :dm_with
     ])
+    # #1500 — re-cast `:body` with `empty_values: []` so an explicit `""`
+    # survives as a real change. `cast/3`'s default `empty_values: [""]` maps
+    # a blank to MISSING, so a NOTICE carrying an empty trailing arrived here
+    # as `nil` — which is why the drop reported `can't be blank` rather than
+    # anything about emptiness. `""` is what the wire carried; `nil` would
+    # assert the row has no body at all, a different fact. Same scoped-re-cast
+    # idiom as `Networks.Credential`, `Networks.Server` and `Vhosts.Vhost`.
+    |> cast(attrs, [:body], empty_values: [])
     |> canonicalize_channel()
     |> validate_required([:network_id, :channel, :server_time, :kind, :sender])
     |> validate_subject_xor()

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2976,6 +2976,56 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #1500 — a NOTICE whose trailing is EMPTY. RFC 1459 §2.3.1 makes `:`
+    # followed by nothing a valid, empty last param, so this is legal input,
+    # not something to reject. A server-shaped (dotted) sender routes it to
+    # `$server` and the body travels verbatim.
+    #
+    # Before this the row was dropped and the drop was error-logged on every
+    # arrival — the reporting session took 1440 of those a day, which buries
+    # the failures an operator actually needs to see.
+    #
+    # BOTH halves are load-bearing, and the order is the same discipline the
+    # #546 test above records: the row must ARRIVE first, or `refute log =~`
+    # is vacuous — it would pass on a session that never processed the line.
+    test "#1500 a server NOTICE with an empty trailing persists and logs no error" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":irc.example.org NOTICE vjt :\r\n")
+
+          assert_receive %Phoenix.Socket.Broadcast{
+                           event: "event",
+                           payload: %{
+                             kind: :message,
+                             message: %{kind: :notice, channel: "$server", body: ""}
+                           }
+                         },
+                         2_000
+        end)
+
+      # The STORED value, not merely the broadcast one. `""` is what the wire
+      # carried; `nil` would claim the row has no body at all, which is a
+      # different fact about a different kind of row.
+      assert [%{kind: :notice, body: ""}] =
+               Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 10, nil, false)
+
+      refute log =~ "scrollback insert failed"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     # #546 regression the issue called out as the one concrete casualty: the
     # "CTCP VERSION query → grappa X" visibility row. It does NOT ride the
     # NOTICE door at all — it is emitted by the inbound-PRIVMSG CTCP arm,


### PR DESCRIPTION
## What

A `$server` NOTICE with an empty trailing was dropped from scrollback and error-logged on every arrival — 1440 lines a day on the reporting session, which buries the failures an operator needs to see. Refs #1500.

## The mechanism, corrected

The issue traced the path right but named the mechanism one step late. The body never reached the validator: `Message.changeset/2` cast `:body` with no `empty_values`, so Ecto's default `[""]` mapped the blank to MISSING. `validate_required` then reported `can't be blank` about a `nil` — the exact string in the operator's log.

So it is **two edits, not one**. Dropping `:notice` from `@body_required_kinds` alone would persist `body: NULL`: the row arrives, the log goes quiet, and the stored value still is not what the wire carried.

- `:notice` leaves `@body_required_kinds`
- `:body` is re-cast with `empty_values: []` — the idiom `Networks.Credential` / `Networks.Server` / `Vhosts.Vhost` already carry

`""` is the true one: the wire carried an empty trailing, which IS an empty string. `NULL` asserts that the row has no body at all, which is what a `:join` row means. And the client would not catch the wrong choice — the generated schema is `body: { u: ["s", "z"] }` and must be, for the presence kinds, so a `NULL` validates cleanly and reaches a renderer as an absent body. That is the undefined-in-a-renderer shape #1400 exists to remove, arriving through the door meant to stop it.

## Blast radius, measured before widening

Every producer of a `:notice` row was checked for one that leans on the validation to reject something. None does. The outbound echo looked like the risk — its `with` persists BEFORE it sends, and `split_privmsg_body("")` returns `[""]`, not `[]` — but the guard that protects it is upstream, in `MessagesController.create/2`'s function head (`body != ""`). No test asserts a `:notice` rejection either.

`:topic` is the same defect and is deliberately NOT taken here: an empty `:topic` row would render as `* alice changed topic:` — a label, a colon, and nothing. Tracked as #1505.

## Test plan

- [x] New red-then-green case in `server_test.exs`: both halves, in order. The row must ARRIVE (`assert_receive` + the STORED `""` via `Scrollback.fetch`) before `refute log =~ "scrollback insert failed"` means anything.
- [x] The red was read, not assumed, and reproduced the operator's line verbatim: `error=[body: {"can't be blank", [validation: :required]}]`.
- [x] `scripts/check.sh` green end to end (rc from file): compile/format/credo/deps.audit/sobelow/doctor/test/dialyzer/docs, wire codegen in sync, bats 564 ok / 0 not ok.

## Still open

The upstream source of the minute cadence is **unidentified**. The code can say we run a 60s inbound-silence generator whose skip-and-shift signature matches the report; it cannot say what the line is. The raw IRC line is still missing — and this fix is the instrument, since the line now lands in `$server` instead of being dropped.