### PR TITLE
#1400: validate the five themes envelope doors, and name the two wire types they needed

### DIFF
--- a/cicchetto/src/lib/__tests__/themesApi.test.ts
+++ b/cicchetto/src/lib/__tests__/themesApi.test.ts
@@ -17,6 +17,7 @@ import {
   updateTheme,
   uploadBackground,
 } from "../themesApi";
+import { WireShapeError } from "../wireNarrow";
 
 // themesApi — typed REST client for the #75 themes surface. Mirrors the
 // api.ts buildHeaders/readError pattern and reuses api.ts's `readError`
@@ -304,5 +305,50 @@ describe("themesApi", () => {
     expect(thrown).toBeInstanceOf(ApiError);
     expect((thrown as ApiError).status).toBe(status);
     expect((thrown as ApiError).code).toBe(token);
+  });
+});
+
+// #1400 — the five envelope doors. `narrowThemeResponse` already covered the
+// six doors that return a bare theme; these five return an ENVELOPE around it
+// (`{themes: […]}`, `{light, dark}`) and had no generated shape to validate
+// against until `Grappa.Themes.Wire` named `index_payload/0` + `active_pair/0`.
+// The case each one models is the deploy window — cic ahead of its server —
+// where a required field the response does not carry used to reach a renderer
+// as `undefined` instead of failing where it broke.
+describe("#1400 — the themes envelope doors fail loud on a shape mismatch", () => {
+  function without(row: Record<string, unknown>, key: string): Record<string, unknown> {
+    const { [key]: _dropped, ...rest } = row;
+    return rest;
+  }
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test("listGallery rejects a theme row missing `in_use`", async () => {
+    fetchSpy.mockResolvedValue(ok({ themes: [without(sampleTheme(), "in_use")] }));
+    await expect(listGallery(TOKEN)).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  test("listMine rejects a body with no `themes` key at all", async () => {
+    fetchSpy.mockResolvedValue(ok({}));
+    await expect(listMine(TOKEN)).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  test("listUnpublishedBuiltins rejects a theme row missing `author`", async () => {
+    fetchSpy.mockResolvedValue(ok({ themes: [without(sampleTheme(), "author")] }));
+    await expect(listUnpublishedBuiltins(TOKEN)).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  test("getActiveThemePair rejects a pair whose light slot is missing `mine`", async () => {
+    fetchSpy.mockResolvedValue(ok({ light: without(sampleTheme(), "mine"), dark: null }));
+    await expect(getActiveThemePair(TOKEN)).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  test("setActiveThemePair rejects a pair with no `dark` slot", async () => {
+    fetchSpy.mockResolvedValue(ok({ light: sampleTheme() }));
+    await expect(setActiveThemePair(TOKEN, 3, null)).rejects.toBeInstanceOf(WireShapeError);
   });
 });

--- a/cicchetto/src/lib/themesApi.ts
+++ b/cicchetto/src/lib/themesApi.ts
@@ -16,8 +16,18 @@
 
 import { buildHeaders, readError } from "./api";
 import { getOrCreateClientId } from "./clientId";
-import { narrowThemeResponse } from "./wireNarrow";
-import type { ThemesWireBackgroundSize, ThemesWireFontFamily, ThemesWireT } from "./wireTypes";
+import {
+  narrowActiveThemePairOrEmpty,
+  narrowActiveThemePairResponse,
+  narrowThemeResponse,
+  narrowThemesResponse,
+} from "./wireNarrow";
+import type {
+  ThemesWireActivePair,
+  ThemesWireBackgroundSize,
+  ThemesWireFontFamily,
+  ThemesWireT,
+} from "./wireTypes";
 
 // The closed font-family allow-list — #1406 X-S9, DERIVED from
 // `Grappa.Themes.TokenModel.font_families/0` (the same list `sanitize_font/1`
@@ -109,18 +119,16 @@ export type UpdateThemeBody = { name?: string; payload?: TokenPayload };
 // fetches (SSRF-guarded). One pipeline, two entry shapes.
 export type BackgroundSource = { file: File } | { url: string };
 
-type ThemesEnvelope = { themes: ThemesWireT[] };
-
 export async function listGallery(token: string): Promise<ThemesWireT[]> {
   const res = await fetch("/themes", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  return ((await res.json()) as ThemesEnvelope).themes;
+  return narrowThemesResponse(await res.json()).themes;
 }
 
 export async function listMine(token: string): Promise<ThemesWireT[]> {
   const res = await fetch("/me/themes", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  return ((await res.json()) as ThemesEnvelope).themes;
+  return narrowThemesResponse(await res.json()).themes;
 }
 
 // GET /themes/unpublished — admin-only view of UNPUBLISHED system built-ins
@@ -129,7 +137,7 @@ export async function listMine(token: string): Promise<ThemesWireT[]> {
 export async function listUnpublishedBuiltins(token: string): Promise<ThemesWireT[]> {
   const res = await fetch("/themes/unpublished", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res);
-  return ((await res.json()) as ThemesEnvelope).themes;
+  return narrowThemesResponse(await res.json()).themes;
 }
 
 // GET /themes/backgrounds — the server-owned built-in background catalog the
@@ -211,13 +219,13 @@ export async function copyTheme(token: string, id: number): Promise<ThemesWireT>
 // (or a dangling pointer); a null `dark` resolves to the light theme in both
 // modes (the #75 single pick). cic picks which slot to paint from the OS
 // `prefers-color-scheme` signal — never the server.
-export type ActiveThemePair = {
-  light: ThemesWireT | null;
-  dark: ThemesWireT | null;
-};
+export type ActiveThemePair = ThemesWireActivePair;
 
-// GET /me/theme — the resolved pair. A bare `null` body (no theme set, or a
-// benign test stub) resolves to an empty pair so callers never branch on it.
+// GET /me/theme — the resolved pair. A bare `null` body still resolves to an
+// empty pair so callers never branch on it, but that tolerance now lives in
+// `narrowActiveThemePairOrEmpty` and is documented there as the one shape this
+// door does not validate. An unset pair is `{light: null, dark: null}` on the
+// wire, not `null` — the server has no path that emits the bare value.
 //
 // #502 — ISOLATED from the dead-token handler (`fireDeadTokenHandler: false`):
 // this is a boot-APPLIED cosmetic fetch (`customTheme.mountCustomThemeSync`
@@ -231,8 +239,7 @@ export type ActiveThemePair = {
 export async function getActiveThemePair(token: string): Promise<ActiveThemePair> {
   const res = await fetch("/me/theme", { headers: buildHeaders(token) });
   if (!res.ok) throw await readError(res, false);
-  const body = (await res.json()) as ActiveThemePair | null;
-  return body ?? { light: null, dark: null };
+  return narrowActiveThemePairOrEmpty(await res.json());
 }
 
 // PUT /me/theme — set the full desired pair. `light` is required; `dark` null
@@ -249,7 +256,7 @@ export async function setActiveThemePair(
     body: JSON.stringify({ light, dark }),
   });
   if (!res.ok) throw await readError(res);
-  return (await res.json()) as ActiveThemePair;
+  return narrowActiveThemePairResponse(await res.json());
 }
 
 // POST /themes/background — upload a File (multipart "file") OR ask the

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -30,6 +30,8 @@ import {
   S_SessionLogWireListResult,
   S_SessionLogWireSessionsResult,
   S_SessionLogWireT,
+  S_ThemesWireActivePair,
+  S_ThemesWireIndexPayload,
   S_ThemesWireT,
   S_VhostsAdminWireGrantJson,
   S_VhostsAdminWireVhostJson,
@@ -54,6 +56,8 @@ import type {
   SessionLogWireListResult,
   SessionLogWireSessionsResult,
   SessionLogWireT,
+  ThemesWireActivePair,
+  ThemesWireIndexPayload,
   ThemesWireT,
   VhostsAdminWireGrantJson,
   VhostsAdminWireVhostJson,
@@ -927,4 +931,50 @@ export function narrowChannelListResponse(raw: unknown): NetworksWireChannelJson
 /** `GET /networks/:slug/channels/:name/messages`, both the `before` and `after` pages. */
 export function narrowMessagePageResponse(raw: unknown): ScrollbackWireT[] {
   return narrowRest({ a: S_ScrollbackWireT }, raw, "message page");
+}
+
+// ── #1400 — the themes envelopes, emitted for this slice ──
+//
+// Unlike slice 1, these two shapes did NOT already exist: `Grappa.Themes.Wire`
+// published `t/0` alone, so the three listings and the day/night pair were the
+// residual hand-written envelopes in `themesApi.ts`. Naming them at the wire
+// boundary (`index_payload/0`, `active_pair/0`, each with the producing
+// function the controllers now call) is what makes them generated shapes with
+// a `--check` drift gate, instead of a client-side mirror.
+//
+// `active_pair` carries a same-module `t() | nil` in both slots. The moduledoc
+// in `themes/wire.ex` records that `BuiltinBackgrounds.t/0` cannot be emitted
+// for exactly that reason — a `user_type` reference the generator cannot
+// resolve — but that limit belongs to the EXTERNAL-type path, which renders
+// one alias at a time with no sibling registry. A type declared INSIDE a
+// `*wire.ex` module is rendered by `render_typedef/2`, which publishes the
+// module so the reference resolves; `NetworksWireConnectionInfo | null` was
+// already on the tree as the precedent. So `GET /themes/backgrounds` stays
+// cast and these two do not.
+
+/** `GET /themes`, `GET /me/themes`, `GET /themes/unpublished`. */
+export function narrowThemesResponse(raw: unknown): ThemesWireIndexPayload {
+  return narrowRest(S_ThemesWireIndexPayload, raw, "theme list");
+}
+
+/** `PUT /me/theme`. */
+export function narrowActiveThemePairResponse(raw: unknown): ThemesWireActivePair {
+  return narrowRest(S_ThemesWireActivePair, raw, "active theme pair");
+}
+
+/**
+ * `GET /me/theme`, which keeps its pre-existing tolerance for a bare `null`
+ * body — a wrapper named as policy, per the section note above, so the
+ * exception is visible rather than hidden inside the strict narrower the PUT
+ * door shares.
+ *
+ * The tolerance is NOT reachable from this server: `MeThemeController.show`
+ * answers `pair_wire/2`, which always emits both keys, so an unset pair is
+ * `{light: null, dark: null}` and never `null`. It is carried forward
+ * unexamined because retiring it is a behaviour change, not a cast removal.
+ * Consequence worth stating plainly: a `null` body skips validation entirely,
+ * so this door is fail-loud for every shape EXCEPT that one.
+ */
+export function narrowActiveThemePairOrEmpty(raw: unknown): ThemesWireActivePair {
+  return raw === null ? { light: null, dark: null } : narrowActiveThemePairResponse(raw);
 }

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1401,12 +1401,6 @@ export const S_ThemesTokenModelFontFamily = { e: [...THEMES_TOKEN_MODEL_FONT_FAM
 // Grappa.Themes.TokenModel.size_mode/0
 export const S_ThemesTokenModelSizeMode = { e: [...THEMES_TOKEN_MODEL_SIZE_MODE] } as const;
 
-// Grappa.Themes.Wire.background_size/0
-export const S_ThemesWireBackgroundSize = S_ThemesTokenModelSizeMode;
-
-// Grappa.Themes.Wire.font_family/0
-export const S_ThemesWireFontFamily = S_ThemesTokenModelFontFamily;
-
 // Grappa.Themes.Wire.t/0
 export const S_ThemesWireT = {
   o: {
@@ -1422,6 +1416,20 @@ export const S_ThemesWireT = {
     inserted_at: "s",
   },
 } as const;
+
+// Grappa.Themes.Wire.active_pair/0
+export const S_ThemesWireActivePair = {
+  o: { light: { u: [S_ThemesWireT, "z"] }, dark: { u: [S_ThemesWireT, "z"] } },
+} as const;
+
+// Grappa.Themes.Wire.background_size/0
+export const S_ThemesWireBackgroundSize = S_ThemesTokenModelSizeMode;
+
+// Grappa.Themes.Wire.font_family/0
+export const S_ThemesWireFontFamily = S_ThemesTokenModelFontFamily;
+
+// Grappa.Themes.Wire.index_payload/0
+export const S_ThemesWireIndexPayload = { o: { themes: { a: S_ThemesWireT } } } as const;
 
 // Grappa.UserSettings.Wire.auto_away_debounce_changed_payload/0
 export const S_UserSettingsWireAutoAwayDebounceChangedPayload = {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1478,6 +1478,15 @@ export type ThemesWireT = {
   inserted_at: string;
 };
 
+export type ThemesWireIndexPayload = {
+  themes: ThemesWireT[];
+};
+
+export type ThemesWireActivePair = {
+  light: ThemesWireT | null;
+  dark: ThemesWireT | null;
+};
+
 // === Grappa.UserSettings.Wire ===
 
 export type UserSettingsWireAutoAwayDebounceChangedPayload = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47788,3 +47788,59 @@ that hand-build a state-shaped map.
 Unlike slices 1–4, this one touches no production file, so it does not move the
 `@type t` of a module in `HotReload.LongLivedModules`. It is the first #1390
 slice that is **not** a COLD deploy.
+<!-- entry #1400-themes -->
+
+---
+
+## 2026-08-18 — #1400: the themes envelopes, and where the codegen's `user_type` hole actually is
+
+Five more REST doors stop casting. `Grappa.Themes.Wire` published `t/0` alone, so
+the three listings (`GET /themes`, `GET /me/themes`, `GET /themes/unpublished`)
+and the day/night pair (`GET`/`PUT /me/theme`) were the residual hand-written
+envelopes in `themesApi.ts`. Naming `index_payload/0` and `active_pair/0` at the
+wire boundary — each with the producing function the controllers now call, the
+shape every other `index_payload` in the tree already has — turns them into
+generated shapes under the `--check` drift gate instead of a client-side mirror.
+
+### The predicted risk was real in kind and false in place
+
+The moduledoc records that `Grappa.Themes.BuiltinBackgrounds.t/0` cannot be
+emitted because it carries a same-module `user_type` the generator cannot
+resolve, and `active_pair/0` carries `t() | nil` in both slots — the same
+construct. It emits fine, and the reason is worth writing down because the
+comment reads as a general limit and is not one: `unresolvable_user_type!/1`
+fires only on the EXTERNAL-type path, which renders one alias at a time with no
+sibling registry. A type declared INSIDE a `*wire.ex` module is rendered by
+`render_typedef/2`, which publishes the module in the process dictionary first,
+so the reference resolves. `NetworksWireConnectionInfo | null` was already on the
+tree as the precedent. The rule: the hole is a property of WHERE the type lives,
+not of what it references. Moving `BuiltinBackgrounds.t/0` into a `*wire.ex`
+home would close it — which is what the moduledoc's "fix the SOURCE" already
+says, and what keeps `GET /themes/backgrounds` cast for now.
+
+### Two doors stay cast, for two different reasons
+
+`GET /themes/backgrounds` is blocked on the emitter, above. `POST
+/themes/background` is not blocked on anything except a producer: its response
+is built inline as `%{image_id: slug}` in the controller, so declaring a type
+for it without moving the construction into `Wire` would add exactly the
+un-produced twin this issue exists to remove.
+
+### A tolerance kept, and named as one
+
+`getActiveThemePair` coerced a bare `null` body to the empty pair. That body is
+not reachable from this server — `MeThemeController.show` answers `pair_wire/2`,
+which always emits both keys — so the tolerance only ever served a test stub. It
+is carried forward anyway, as `narrowActiveThemePairOrEmpty`, a wrapper named as
+policy per the house pattern rather than an `if` inside the shared narrower:
+retiring it is a behaviour change, not a cast removal. Stated plainly so nobody
+over-reads the conversion: that door is fail-loud for every shape EXCEPT `null`.
+
+### The swallow-on-failure door, identified and left alone
+
+`serverSettings.ts`'s `loadServerSettings` is the last `serverSettings` cast and
+wraps its fetch in `try {} catch {}` behind an `if (!res.ok) return`. A
+`WireShapeError` thrown there lands in that catch: it would satisfy the LETTER
+of fail-loud while producing ZERO observable noise. Converting it is therefore a
+decision about that door's ERROR POSTURE, not part of a cast sweep, and it is
+left for vjt to rule.

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -107,6 +107,19 @@ defmodule Grappa.Themes.Wire do
           inserted_at: String.t()
         }
 
+  @typedoc """
+  The listing envelope shared by the three read doors (`GET /themes`,
+  `GET /me/themes`, `GET /themes/unpublished`) — one key, the rendered rows.
+  """
+  @type index_payload :: %{themes: [t()]}
+
+  @typedoc """
+  The resolved day/night pointer pair (#358) returned by `GET /me/theme` and
+  `PUT /me/theme`. Either slot is `nil` when unset (or dangling); a `nil`
+  `dark` means the light theme applies in both modes.
+  """
+  @type active_pair :: %{light: t() | nil, dark: t() | nil}
+
   @doc "The fallback author label for a snapshot-less visitor theme (author model A)."
   @spec guest_author() :: String.t()
   def guest_author, do: @guest_author
@@ -134,6 +147,14 @@ defmodule Grappa.Themes.Wire do
       inserted_at: DateTime.to_iso8601(theme.inserted_at)
     }
   end
+
+  @doc "Wraps the rendered rows as the themes listing envelope."
+  @spec index_payload([t()]) :: index_payload()
+  def index_payload(rows) when is_list(rows), do: %{themes: rows}
+
+  @doc "Wraps two rendered slots (either may be `nil`) as the active-pair envelope."
+  @spec active_pair(t() | nil, t() | nil) :: active_pair()
+  def active_pair(light, dark), do: %{light: light, dark: dark}
 
   # #299 author model A: author prefers the stored publish-time nick snapshot
   # whenever present (so it survives reap + system re-home — a now-system-owned

--- a/lib/grappa_web/controllers/me_theme_controller.ex
+++ b/lib/grappa_web/controllers/me_theme_controller.ex
@@ -53,7 +53,7 @@ defmodule GrappaWeb.MeThemeController do
 
   # A resolved pair → its wire envelope, each slot a full theme wire or null.
   defp pair_wire(%{light: light, dark: dark}, viewer),
-    do: %{"light" => slot_wire(light, viewer), "dark" => slot_wire(dark, viewer)}
+    do: Wire.active_pair(slot_wire(light, viewer), slot_wire(dark, viewer))
 
   defp slot_wire(nil, _), do: nil
   defp slot_wire(theme, viewer), do: Wire.to_wire(theme, viewer, Themes.count_theme_usage(theme.id))

--- a/lib/grappa_web/controllers/themes_controller.ex
+++ b/lib/grappa_web/controllers/themes_controller.ex
@@ -43,9 +43,9 @@ defmodule GrappaWeb.ThemesController do
     viewer = conn.assigns.current_subject
     counts = Themes.active_theme_counts()
 
-    json(conn, %{
-      themes: Enum.map(Themes.list_gallery(), &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0)))
-    })
+    rows = Enum.map(Themes.list_gallery(), &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0)))
+
+    json(conn, Wire.index_payload(rows))
   end
 
   @doc false
@@ -54,9 +54,9 @@ defmodule GrappaWeb.ThemesController do
     viewer = conn.assigns.current_subject
     counts = Themes.active_theme_counts()
 
-    json(conn, %{
-      themes: Enum.map(Themes.list_owned(viewer), &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0)))
-    })
+    rows = Enum.map(Themes.list_owned(viewer), &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0)))
+
+    json(conn, Wire.index_payload(rows))
   end
 
   @doc false
@@ -65,13 +65,13 @@ defmodule GrappaWeb.ThemesController do
     viewer = conn.assigns.current_subject
     counts = Themes.active_theme_counts()
 
-    json(conn, %{
-      themes:
-        Enum.map(
-          Themes.list_unpublished_builtins(viewer),
-          &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0))
-        )
-    })
+    rows =
+      Enum.map(
+        Themes.list_unpublished_builtins(viewer),
+        &Wire.to_wire(&1, viewer, Map.get(counts, &1.id, 0))
+      )
+
+    json(conn, Wire.index_payload(rows))
   end
 
   @doc false


### PR DESCRIPTION
## What this is

Part of #1400 (bucket K, `rest-boundary`). Five more REST doors stop casting
`res.json()`. Residual on `8b6ed99d` was **50** casts — `api.ts` 27,
`userSettings.ts` 12, `themesApi.ts` 7, `push.ts` 3, `serverSettings.ts` 1 —
measured, matching the count this slice was scoped against. This closes **5 of
the 7 in `themesApi.ts`**, leaving 45.

The `themesApi` family was blocked on emission, not wiring: `Grappa.Themes.Wire`
published `t/0` alone, so the three listings and the #358 day/night pair were
the residual hand-written envelopes on the client. Naming `index_payload/0` and
`active_pair/0` at the wire boundary — each with the producing function the
controller now calls, the shape every other `index_payload` in the tree already
has — turns them into generated shapes under the `--check` drift gate.

## The predicted risk did not materialise, and here is why

`Grappa.Themes.Wire`'s moduledoc records that `BuiltinBackgrounds.t/0` cannot be
emitted because it carries a same-module `user_type` reference. `active_pair/0`
carries `t() | nil` in both slots — the same construct — and emits cleanly.

The comment reads as a general limit and is not one. `unresolvable_user_type!/1`
fires only on the **external-type path**, which `format_external_typedef/2`
documents as rendering one alias at a time with no sibling registry. A type
declared INSIDE a `*wire.ex` module goes through `render_typedef/2`, which
publishes the module into `:wire_current_module` first, so the reference
resolves. `NetworksWireConnectionInfo | null` was already on the tree as the
precedent. The hole is a property of **where the type lives**, not of what it
references — which is also what the generator's own "fix the SOURCE" message
says.

## What each door bought

Five doors, five reds, watched failing before the conversion:

| door | red |
|---|---|
| `listGallery` | `promise resolved "[ { id: 7, name: 'Night', …(7) } ]" instead of rejecting` |
| `listMine` | `promise resolved "undefined" instead of rejecting` |
| `listUnpublishedBuiltins` | `promise resolved "[ { id: 7, name: 'Night', …(7) } ]" instead of rejecting` |
| `getActiveThemePair` | `promise resolved "{ light: { id: 7, …(8) }, dark: null }" instead of rejecting` |
| `setActiveThemePair` | `promise resolved "{ light: { id: 7, …(9) } }" instead of rejecting` |

None of the five was covered elsewhere: no spec on this tree asserted a
`WireShapeError` from `themesApi`. The `listMine` red is the defect in its plain
form — `undefined` reaching the caller where a list was promised.

## Two doors stay cast, for two different reasons

* `GET /themes/backgrounds` is blocked on the emitter. `BuiltinBackgrounds.t/0`
  needs a `*wire.ex` home before it can be emitted; restating its four fields
  here would reintroduce the twin this issue removes.
* `POST /themes/background` is blocked on nothing but a producer: its response
  is built inline as `%{image_id: slug}` in the controller, so declaring a type
  without moving the construction into `Wire` would add an un-produced twin.

## One tolerance carried forward, named

`getActiveThemePair` coerced a bare `null` body to the empty pair. That body is
not reachable from this server — `MeThemeController.show` answers `pair_wire/2`,
which always emits both keys, so an unset pair is `{light: null, dark: null}`.
The tolerance only ever served a test stub.

It is kept anyway, as `narrowActiveThemePairOrEmpty` — a wrapper named as
policy, which is where the section note in `wireNarrow.ts` says a tolerance
goes, rather than an `if` inside the strict narrower the PUT door shares.
Retiring it is a behaviour change, not a cast removal. Stated so nobody
over-reads the conversion: **that door is fail-loud for every shape except
`null`.**

## Out of scope, deliberately: the swallow-on-failure door

`serverSettings.ts`'s `loadServerSettings` holds the last `serverSettings` cast,
inside `try {} catch {}` behind an `if (!res.ok) return`. A `WireShapeError`
thrown there lands in that catch: it would satisfy the **letter** of fail-loud
while producing **zero** observable noise. Converting it is a decision about
that door's error posture, not part of a cast sweep. Identified, named, left
exactly as it is.

## Gates

Run from the worktree, on the committed tree, rc captured to file:

* `scripts/check.sh` → **rc 0**. Phase markers: Sobelow ran, `Doctor validation
  has passed!`, `8 doctests, 61 properties, 6538 tests, 0 failures`, Credo
  `Total errors: 0`, Dialyzer `done (passed successfully)`, both codegen
  artefacts `is in sync`, bats `564 ok / 0 not ok`.
* `scripts/bun.sh run check` → **rc 0** (biome + `tsc` src + `tsc` e2e; the 59
  warnings and 6 infos are the pre-existing CSS set, unchanged).
* `scripts/bun.sh run test` → **rc 0**, 290 files / 5615 tests.
* `scripts/design-notes-gate.sh origin/main` → **rc 0**, `1 new entry heading(s),
  separator and marker present.`

`scripts/integration.sh` was NOT run locally — the e2e lane is not allocated to
this worker. The `integration` job on this PR is the signal.
