### PR TITLE
refactor(#1390) slice 6: retire the second effect vocabulary's output half

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47965,3 +47965,76 @@ dropped, so the instrument for identifying it is the fix itself.
 _Not established: that a wrong-typed or empty body was ever observed on any kind other than
 `:notice` in production — the `:topic` case above is derived from the source, not from an
 incident. No claim is made about what the upstream peer is or why it emits on that cadence._
+<!-- entry #1390 slice 6 -->
+
+---
+
+## 2026-08-18 — #1390 slice 6: the second effect vocabulary loses its output half, and a warning stops lying
+
+`Session.Server` interpreted effects in two grammars. The declared one is
+`EventRouter.effect()`, drained by `apply_effects/2`. The private one was the
+`lines` element of `{verdict, next, lines}`, returned by `GhostRecovery.step/2`
+and `RecoverIdentity.step/2` and drained by `flush_lines/2` — three lines
+`apply_effects/2` could not see. That second grammar is what the issue title
+counts, and this slice removes its output half.
+
+### The behaviour change, declared
+
+`flush_lines/2` hard-coded `send_outbound(acc, line, :ghost_recovery)`. It had
+**five** call sites and **two** of them — `handle_call(:recover_identity, …)`
+and `advance_recover/2` — are RecoverIdentity's. So when `Client.send_line/2`
+failed during a visitor identity recovery, the operator read
+
+    outbound line dropped: send_line failed  origin=ghost_recovery
+
+and was told the wrong sub-machine had failed. The `origin` metadata exists for
+exactly one purpose — it is read nowhere else, only on that warning's error
+branch — so a tag that names the wrong producer is the whole field being wrong.
+
+The fix carries the origin on the effect: `{:reply, iodata(), origin()}`, with
+`@type origin :: :event_router_reply | :ghost_recovery | :recover_identity`.
+Each producer now names itself.
+
+The cheaper alternative was rejected: collapsing both sub-machines onto
+`:event_router_reply` would have deleted the only field distinguishing the drop
+sites, a silent diagnostic loss on precisely the path #676 exists to catch —
+NickServ never answering. Least surprise says a machine names itself.
+
+### Why it was safe to do now, and would not have been before
+
+#1394 had already wired the `{:reply, _}` arm through `send_outbound/3`, the
+one sniff-then-send door, and left a pin plus a comment saying why: nothing
+emitted a secret onto that arm *yet*, and #1390 was going to move
+`GHOST <nick> <pwd>` and `IDENTIFY <pwd>` onto it. In the other order the merge
+would have opened a secret-bypassing hole **with no test turning red**. The
+order held. `flush_lines/2` is now `emit_reply_lines/3`, an adapter that maps
+onto the one grammar and hands the list to `apply_effects/2` — not a second
+interpreter with a new name.
+
+Parity is preserved where it counts: `capture_outbound_ns_secret/2` lives
+inside `send_outbound/3`, which both the old reduce and the new recursion cross
+once per line, in list order, threading state.
+
+### The issue text is stale — measured, and recorded so the next reader does not redo landed work
+
+#1390's body describes a module that no longer exists. Measured at `a8174d70`:
+`server.ex` is **7078** lines, not 7230; the state map declares **71** keys, not
+87 or 83; `deps: Deps.t()` — the "eight injected-callback fields" the proposed
+direction offers as behaviour-free — is **already bundled**. The
+channel-directory ETL (A6) left in `f89e6e45`, the double 005 parse (A5) in
+`2a849f97`, the recover-progress projection in `c5dc5588`, the state-contract
+pin in `655ac551`. **Where an issue's text conflicts with measured code, the
+code wins**; the text is data, not instruction.
+
+Two directions were left alone on purpose: the `*_pending` accumulator bundle
+(11 fields, 439 lines across 17 files, and its prime side sits inside the
+`:send_<verb>` arms #1403 contends) and the `EventRouter` projection of A1,
+which #1391 measured false with two mutants and which must therefore be bought
+with a mutant rather than deduced.
+
+### Deploy
+
+**COLD.** `Session.Server` is in `HotReload.LongLivedModules` and the effect
+tuple changes arity: a `{:reply, line}` still in flight across a hot reload
+would meet only the 3-tuple clause and raise `FunctionClauseError`. Reload the
+node, do not hot-patch it.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -9,7 +9,7 @@ defmodule Grappa.Session.EventRouter do
 
       @type effect ::
               {:persist, kind, persist_attrs}    -- write a Scrollback row
-              | {:reply, iodata()}                -- send a line upstream
+              | {:reply, iodata(), origin()}      -- send a line upstream, tagged
               | {:auto_reply, iodata(), persist}   -- both, or neither, under a ceiling
               | {:topic_changed, channel, topic_entry()}
               | {:channel_modes_changed, channel, channel_mode_entry()}
@@ -222,9 +222,15 @@ defmodule Grappa.Session.EventRouter do
   """
   @type userhost_cache :: %{(nick :: String.t()) => userhost_entry()}
 
+  # #1390 slice 6 — which producer built a `{:reply, _, _}` line. Carried on the
+  # effect rather than pinned at the interpreter because there are now three
+  # producers, and `send_outbound/3` reports this on the drop warning: an
+  # operator reading it must learn which machine failed, not which arm ran.
+  @type origin :: :event_router_reply | :ghost_recovery | :recover_identity
+
   @type effect ::
           {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}
-          | {:reply, iodata()}
+          | {:reply, iodata(), origin()}
           | {:auto_reply, iodata(), {:persist, Grappa.Scrollback.Message.kind(), persist_attrs()}}
           | {:identity_secret_confirmed, String.t()}
           | {:visitor_nick_changed, String.t()}

--- a/lib/grappa/session/recover_identity.ex
+++ b/lib/grappa/session/recover_identity.ex
@@ -147,7 +147,7 @@ defmodule Grappa.Session.RecoverIdentity do
   Drives one semantic input through the FSM. Returns `{:cont, state,
   [lines]}` to continue or `{:stop, state, [lines]}` at a terminal phase;
   `lines` are CRLF-framed IRC strings the host must push via
-  `Grappa.IRC.Client.send_line/2` (through `Server.flush_lines/2`, so the
+  `Grappa.IRC.Client.send_line/2` (through `Server.emit_reply_lines/3`, so
   outbound `IDENTIFY` still stages the `+r` rendezvous).
 
   Inputs that don't match the current phase's expected transition are

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1970,7 +1970,7 @@ defmodule Grappa.Session.Server do
 
           state =
             state
-            |> flush_lines(lines)
+            |> emit_reply_lines(lines, :recover_identity)
             |> broadcast_recover_events(:idle, next)
 
           timer = Process.send_after(self(), :recover_timeout, @recover_timeout_ms)
@@ -3165,7 +3165,7 @@ defmodule Grappa.Session.Server do
     # arming no timer and stranding the FSM.
     {:cont, next, lines} = GhostRecovery.step(GhostRecovery.init(state.nick, pwd), msg)
 
-    state = flush_lines(state, lines)
+    state = emit_reply_lines(state, lines, :ghost_recovery)
     timer = Process.send_after(self(), :ghost_timeout, @ghost_recovery_timeout_ms)
     {:noreply, %{state | ghost_recovery: next, ghost_timer: timer}}
   end
@@ -3194,7 +3194,7 @@ defmodule Grappa.Session.Server do
   # `:failed` by definition, so the parked advisory is released here too.
   def handle_info(:ghost_timeout, %{ghost_recovery: %GhostRecovery{} = gr} = state) do
     {_, _, lines} = GhostRecovery.step(gr, :timeout)
-    state = state |> flush_lines(lines) |> release_nick_fallback()
+    state = state |> emit_reply_lines(lines, :ghost_recovery) |> release_nick_fallback()
     {:noreply, clear_ghost(state)}
   end
 
@@ -4285,7 +4285,7 @@ defmodule Grappa.Session.Server do
   # MatchError the Session, which a strict `:ok =` bind used to do on both
   # paths. Supervisor restart owns reconnect. The line is never logged — it
   # may BE the secret.
-  @spec send_outbound(t(), String.t(), :ghost_recovery | :event_router_reply) :: t()
+  @spec send_outbound(t(), String.t(), EventRouter.origin()) :: t()
   defp send_outbound(state, line, origin) do
     state = capture_outbound_ns_secret(state, line)
 
@@ -4484,7 +4484,7 @@ defmodule Grappa.Session.Server do
   # fields; non-terminal transitions just update the FSM struct.
   defp advance_ghost(state, input) do
     {_, next, lines} = GhostRecovery.step(state.ghost_recovery, input)
-    state = flush_lines(state, lines)
+    state = emit_reply_lines(state, lines, :ghost_recovery)
 
     case next.phase do
       # The nick came back, so the fallback the 001 wanted to announce never
@@ -4525,7 +4525,7 @@ defmodule Grappa.Session.Server do
     apply_effects([{:persist, kind, fresh}], %{state | parked_nick_fallback: nil})
   end
 
-  # Lines emitted by GhostRecovery bypass `handle_call({:send_privmsg,
+  # Sub-machine lines (ghost AND recover) bypass `handle_call({:send_privmsg,
   # ...})`, so they reach the wire through the #1394 door, which runs
   # NSInterceptor over each one and stages `pending_auth` on capture. This is
   # what keeps the +r MODE rendezvous (Task 15) firing for the `IDENTIFY`
@@ -4534,8 +4534,15 @@ defmodule Grappa.Session.Server do
   # choke point by `run_perform_and_identify/1`). A dead socket mid-recovery
   # is survivable: the next reconnect retries GHOST + IDENTIFY from scratch,
   # and the staging that already happened is discarded on terminate/2.
-  defp flush_lines(state, lines) do
-    Enum.reduce(lines, state, fn line, acc -> send_outbound(acc, line, :ghost_recovery) end)
+  # #1390 slice 6 — the sub-machines' `lines` travel on the ONE effect grammar
+  # now. This is an adapter, not a second interpreter: it maps them onto
+  # `{:reply, _, _}` and hands the list to `apply_effects/2`, which owns the
+  # door. `origin` is a parameter because the hard-coded `:ghost_recovery` it
+  # replaces named the ghost FSM for RecoverIdentity's two call sites too —
+  # the drop warning accused the wrong machine.
+  @spec emit_reply_lines(t(), [String.t()], EventRouter.origin()) :: t()
+  defp emit_reply_lines(state, lines, origin) do
+    apply_effects(Enum.map(lines, &{:reply, &1, origin}), state)
   end
 
   # #581 — resolve the PERSISTENT recover target (the registered nick + the
@@ -4573,7 +4580,7 @@ defmodule Grappa.Session.Server do
 
     state =
       state
-      |> flush_lines(lines)
+      |> emit_reply_lines(lines, :recover_identity)
       |> broadcast_recover_events(old_phase, next)
 
     case next.phase do
@@ -5820,7 +5827,7 @@ defmodule Grappa.Session.Server do
     case AutoReplyBudget.take(budget, now_ms) do
       {:ok, spent} ->
         apply_effects(
-          [{:reply, line}, persist_eff | rest],
+          [{:reply, line, :event_router_reply}, persist_eff | rest],
           Map.put(state, :auto_reply_budget, spent)
         )
 
@@ -5829,25 +5836,28 @@ defmodule Grappa.Session.Server do
     end
   end
 
-  # EventRouter-emitted outbound (today: the CTCP VERSION / PING NOTICE
-  # replies). #1394 routes it through the outbound door rather than calling
-  # the sender directly — this arm was the one free-form path that reached
-  # the wire without the NickServ sniff. Nothing emits a secret onto it
-  # today, which is precisely why it had to be wired before something does:
-  # #1390 moves the GhostRecovery/RecoverIdentity lines onto this grammar,
-  # and those lines carry `GHOST <nick> <pwd>` and `IDENTIFY <pwd>`. Done in
-  # the other order, that merge opens the hole with no test turning red.
+  # The one outbound arm. #1394 routed it through the outbound door rather
+  # than calling the sender directly — it was the one free-form path that
+  # reached the wire without the NickServ sniff — and warned that #1390 was
+  # about to move the GhostRecovery/RecoverIdentity lines onto this grammar,
+  # whose lines DO carry `GHOST <nick> <pwd>` and `IDENTIFY <pwd>`. Slice 6
+  # made that move: it is safe only because #1394 landed first, and the hole
+  # would have opened here with no test turning red in the other order.
+  #
+  # `origin` rides on the effect because the three producers are no longer
+  # distinguishable at this arm; the door reports it on the drop warning.
   #
   # The door THREADS state, so the recursion continues with what the sniff
   # staged; the pre-#1394 arm discarded it, which would have made a capture
   # here invisible even once one was possible.
   #
   # REV-E (H11) still holds through the door: a dead socket does not stop the
-  # paired `:persist` effect (EventRouter emits `[{:reply, _}, {:persist, _,
-  # _}]` in the SAME list) from running on the next recursion, so the
-  # user-visible scrollback row lands either way.
-  defp apply_effects([{:reply, line} | rest], state) do
-    apply_effects(rest, send_outbound(state, line, :event_router_reply))
+  # paired `:persist` effect from running on the next recursion, so the
+  # user-visible scrollback row lands either way. The pair is emitted by the
+  # `:auto_reply` arm above as `[{:reply, _, _}, {:persist, _, _}]` in ONE
+  # list — not by EventRouter, which declares the effect but produces none.
+  defp apply_effects([{:reply, line, origin} | rest], state) do
+    apply_effects(rest, send_outbound(state, line, origin))
   end
 
   # S3.4: 305 RPL_UNAWAY / 306 RPL_NOWAWAY confirmed by the upstream.

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -7855,7 +7855,11 @@ defmodule Grappa.Session.ServerTest do
       source = File.read!("lib/grappa/session/server.ex")
 
       [_, after_head] =
-        String.split(source, "defp apply_effects([{:reply, line} | rest], state) do", parts: 2)
+        String.split(
+          source,
+          "defp apply_effects([{:reply, line, origin} | rest], state) do",
+          parts: 2
+        )
 
       # Cut at the function's own `end` (two-space indent), not at the next
       # `defp`: the latter would drag the FOLLOWING arm's comment block into
@@ -9901,6 +9905,55 @@ defmodule Grappa.Session.ServerTest do
                SessionStateHelpers.ghost_recovery(state)
 
       assert is_reference(SessionStateHelpers.ghost_timer(state))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #1390 slice 6 — the other end of the pair. Its sibling (in the
+    # recover_identity describe) dies if the slice relabels NOTHING; this one
+    # dies if it relabels EVERYTHING onto a single tag. Neither alone is a
+    # guard: one mutant each is the point.
+    #
+    # Unlike the recover sibling this one is GREEN before the slice, on
+    # purpose. It is not buying the fix, it is fencing it.
+    #
+    # Arming needs the socket (the 433 comes from upstream), so the socket is
+    # nilled only once the FSM sits in `:awaiting_ghost_notice`. The NickServ
+    # NOTICE is then delivered as a plain process message — `{:irc, msg}` is
+    # the same door the MODE tests use — and the `WHOIS <orig>` it emits is
+    # the line that gets dropped. `:ghost_timeout` cannot serve here: its
+    # `step/2` clause returns `[]`, so it would log nothing and assert nothing.
+    test "#1390 a dropped GhostRecovery line still names the ghost" do
+      nick = "v_t18o_#{System.unique_integer([:positive])}"
+
+      {server, port} = start_server(ghost_handler(nick))
+      {anon_visitor, network} = visitor_with_network(port, nick: nick)
+      {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
+      registered_visitor = Grappa.Repo.reload!(anon_visitor)
+
+      pid = start_visitor_session_for(registered_visitor, network)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :GHOST #{nick} s3cret\r\n"),
+          1_000
+        )
+
+      _ = :sys.replace_state(pid, fn state -> %{state | client: nil} end)
+
+      {:ok, notice} =
+        Grappa.IRC.Parser.parse(":NickServ!service@services. NOTICE #{nick}_ :#{nick} has been ghosted.\r\n")
+
+      log =
+        capture_log(fn ->
+          send(pid, {:irc, notice})
+          # `:sys.get_state` serialises after the callback that logged.
+          _ = SessionStateHelpers.fetch(pid)
+        end)
+
+      assert log =~ "origin=ghost_recovery",
+             "a dropped GhostRecovery line must keep naming the ghost FSM"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -13145,6 +13198,38 @@ defmodule Grappa.Session.ServerTest do
 
       assert :ok = Session.recover_identity(subject, network.id)
       assert {:error, :in_progress} = Session.recover_identity(subject, network.id)
+    end
+
+    # #1390 slice 6 — RED before the slice. The two sub-machines used to flush
+    # through `flush_lines/2`, which hard-coded `origin: :ghost_recovery` for
+    # BOTH its callers, so a RECOVER line dropped on a dead socket told the
+    # operator the GHOST machine had failed. Two of the five call sites were
+    # RecoverIdentity's; the warning named the wrong machine on both.
+    #
+    # `client: nil` takes `Client.send_line/2`'s second clause
+    # (`{:error, :no_socket}`), which is the door's error branch without the
+    # socket-teardown dance the CTCP sibling documents. `recover_identity` is a
+    # `handle_call`, so it needs no socket to ARRIVE, and its reply serialises
+    # past the callback that logged — the reply IS the barrier.
+    #
+    # The fixture MUST drive the RECOVER FSM: pointed at the ghost path this
+    # assert passes on the unfixed code and proves nothing. Its sibling in the
+    # GhostRecovery describe holds the other end.
+    test "#1390 a dropped RecoverIdentity line names recover, not the ghost" do
+      %{pid: pid, subject: subject, network: network} = start_recover_visitor("s3cret")
+
+      _ = :sys.replace_state(pid, fn state -> %{state | client: nil} end)
+
+      log =
+        capture_log(fn ->
+          assert :ok = Session.recover_identity(subject, network.id)
+        end)
+
+      assert log =~ "outbound line dropped: send_line failed",
+             "the outbound door must still log the drop"
+
+      assert log =~ "origin=recover_identity",
+             "a dropped RecoverIdentity line must name its OWN sub-machine"
     end
 
     test "happy path: reads the PERSISTENT secret past 001, NICK+IDENTIFY out, +r → succeeded" do


### PR DESCRIPTION
# refactor(#1390) slice 6: retire the second effect vocabulary's output half

`Session.Server` ran two effect grammars. The declared one is
`EventRouter.effect()`, drained by `apply_effects/2`. The private one was the
`lines` element of `{verdict, next, lines}` — returned by `GhostRecovery.step/2`
and `RecoverIdentity.step/2`, drained by `flush_lines/2`, invisible to
`apply_effects/2`. That second grammar is what this issue's title counts. This
slice removes its output half.

`flush_lines/2` becomes `emit_reply_lines/3`: an **adapter** that maps the lines
onto the one grammar and hands the list to `apply_effects/2`. Not a second
interpreter with a new name — it no longer reaches the sender itself.

## Behaviour change, declared not smuggled

`flush_lines/2` hard-coded `send_outbound(acc, line, :ghost_recovery)`. It had
**five** call sites, and **two** of them are RecoverIdentity's
(`handle_call(:recover_identity, …)` and `advance_recover/2`). So a line dropped
on a dead socket during a visitor identity recovery logged:

```
outbound line dropped: send_line failed  origin=ghost_recovery
```

— naming the wrong sub-machine. `origin` is read nowhere else: its only consumer
is that warning's error branch. A tag that names the wrong producer is the whole
field being wrong.

The origin now rides on the effect —
`@type origin :: :event_router_reply | :ghost_recovery | :recover_identity` —
so each producer names itself.

**Alternative rejected:** collapsing both sub-machines onto
`:event_router_reply` is cheaper and deletes the only field that distinguishes
the drop sites. That is a silent diagnostic loss on exactly the path #676 exists
to catch (NickServ never answering). Least surprise says a machine names itself.

## Three files in `lib/`, the third one declared

The slice was scoped to two files. A third was added deliberately, not
smuggled: `lib/grappa/session/recover_identity.ex:150`'s moduledoc named
`Server.flush_lines/2` — a function this slice deletes. Leaving it would ship
a moduledoc pointing at code that no longer exists.

One further comment was corrected in `server.ex`: the block above the adapter
opened with *"Lines emitted by GhostRecovery bypass `handle_call(...)`"* while
the function serves RecoverIdentity too. That is the same defect class as the
tag being fixed here — something naming the wrong sub-machine — so fixing the
log and leaving the comment would have been incoherent.

## Why this was safe now and would not have been in the other order

#1394 had already routed the `{:reply, _}` arm through `send_outbound/3`, the one
sniff-then-send door, and left a pin plus a comment stating why: nothing emitted
a secret onto that arm *yet*, and #1390 was going to move `GHOST <nick> <pwd>`
and `IDENTIFY <pwd>` onto it. Done the other way round, the merge opens a
secret-bypassing hole **with no test turning red**. The order held.

Parity holds where it matters: `capture_outbound_ns_secret/2` lives inside
`send_outbound/3`, which both the old `Enum.reduce` and the new recursion cross
once per line, in list order, threading state.

The #1394 pin is **re-pointed, not weakened** — its `String.split/3` anchored on
the old arm head and would have raised `MatchError`; both of its asserts are
unchanged.

## 🔴 This issue's text is stale — measured, so the next reader does not redo landed work

#1390's body describes a module that no longer exists. Measured at `a8174d70`:

| the issue says | measured |
| --- | --- |
| `server.ex` is 7,230 lines | **7078** |
| 87 (or 83) state fields | **71** keys |
| "the eight injected-callback fields … pulling that bundle alone drops 9 keys" | `deps: Deps.t()` is **already bundled** |
| A6 channel-directory ETL inline | left in `f89e6e45` |
| A5 double 005 parse | unified in `2a849f97` |
| recover-progress projection inline | extracted in `c5dc5588` |
| state contract unenforced | pinned in `655ac551` |

**Where the issue text conflicts with measured code, the code wins.** The text is
data, not instruction.

Two remaining directions were deliberately left alone:

- the `*_pending` accumulator bundle — 11 fields, **439 lines across 17 files**
  (188 in `lib/`, 251 in `test/`, 224 of those in `event_router_test.exs`), and
  its prime side sits inside the `:send_<verb>` arms that #1403 contends;
- the A1 `EventRouter` projection — #1391 measured that direction false with two
  mutants, so it must be bought with a mutant, not deduced.

## Tests

Two asserts, one mutant each. Both are needed: one dies if the slice relabels
nothing, the other if it relabels everything onto a single tag.

1. **RED before the slice** — `#1390 a dropped RecoverIdentity line names recover,
   not the ghost`. Fails today with `origin=ghost_recovery`.
2. **Green by construction, fencing the fix** — `#1390 a dropped GhostRecovery
   line still names the ghost`.

The recover fixture **must** drive the recover FSM: pointed at the ghost path the
first assert passes on unfixed code and proves nothing — the `target == context`
degeneration.

`client: nil` takes `Client.send_line/2`'s second clause (`{:error, :no_socket}`),
which reaches the door's error branch without a socket-teardown dance.
`:ghost_timeout` could not serve as the ghost trigger: its `step/2` clause returns
`[]`, so it would log nothing and assert nothing.

## Deploy

**COLD.** `Session.Server` is in `HotReload.LongLivedModules` and the effect tuple
changes arity: a `{:reply, line}` still in flight across a hot reload would meet
only the 3-tuple clause and raise `FunctionClauseError`.
