### PR TITLE
Union of #1496 (Networks boundaries) and #1498 (handshake barrier)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48136,3 +48136,80 @@ reference built by macro or `Module.concat/1` would be invisible to it; the
 compiler, not the parser, is what makes the set safe, and a file appearing
 beyond the declared set would mean the parser missed a consumer rather than
 that the set grew._
+<!-- entry #1399 -->
+
+---
+
+## 2026-08-17 — #1399: seven boundaries stop declaring a dependency they never had
+
+Bucket J of the 2026-08-15 architecture review says one problem — "a boundary
+needs only a schema" — has three incompatible resolutions, and asks for the
+thirteen struct-only `Grappa.Accounts` deps to be *narrowed*. Measuring the tree
+first changed the answer for seven of them: there is nothing to narrow, because
+there was never an edge.
+
+`Grappa.ChannelDirectory`, `Grappa.Notify`, `Grappa.Push`, `Grappa.QueryWindows`,
+`Grappa.ReadCursor`, `Grappa.Scrollback` and `Grappa.UserSettings` each declared
+`Grappa.Accounts` in `deps:`. Each reaches `Accounts.User` exactly twice, in one
+schema file, in the same two shapes: a `belongs_to :user, User` association
+argument and a `user: User.t()` typespec. Both are module names that end up as
+atoms in metadata rather than as remote calls, so the xref-based checker has no
+reference to police. The dep bought nothing.
+
+**The tree already answered this, and nobody had noticed.** `Grappa.Uploads`
+holds the identical pair — `uploads/upload.ex` aliases `Grappa.Accounts.User`
+and declares `belongs_to :user, User` — with **no** `Grappa.Accounts` dep and no
+waiver, and it has been compiling green for as long as it has existed.
+`Grappa.TestSupport.SubjectSession` is a second instance, via a typespec. So the
+review's "three resolutions" undercounts: a fourth, *declare nothing*, was
+already live and already correct. Seven of the thirteen belong to it.
+
+**Why deleting rather than narrowing.** Narrowing `Grappa.Accounts` to
+`Grappa.Accounts.User` would encode a dependency the compiler cannot see, on a
+module that is not a boundary today, to satisfy a rule none of these seven
+actually violate — and it would have to be undone the day `Accounts.User` is
+promoted. Deleting states the truth that the compiler can check: these
+boundaries do not depend on `Grappa.Accounts`. Where an issue's prose and the
+measured tree disagree, the tree wins.
+
+**The deletion is falsifiable, and the falsifier was armed first.** Boundary
+reports cross-boundary references as advisory warnings; only
+`mix compile --warnings-as-errors` — the first step of the `ci.check` alias, for
+exactly this reason — turns them into a failed build. So a green compile after
+seven deletions proves nothing unless the checker is known to bite. Before the
+deletions, one mutant removed the `Grappa.Accounts` dep from `Grappa.Subject`,
+which holds a real reference (`%User{}` in `from_assigns/1`). The build went red
+with exactly one violation, at exactly that line, naming exactly
+`Grappa.Accounts.User` — one mutant, one assertion, nothing else moved. With the
+mutant reverted and the seven deps gone, the same command is green with zero
+forbidden references. Had any of the seven carried an edge the source
+measurement missed, this is where it would have surfaced.
+
+**A stale number, settled while the lane was held.** Two hand-written parsers
+had disagreed about how many `use Boundary` declarations the tree even contains
+— 99 against 107 — and that disagreement was written into the #1398 cycle-budget
+gate as an open question. The compiled attribute settles it: **99**, counted from
+`Boundary` module attributes over `:application.get_key(:grappa, :modules)`. The
+source measurement agrees exactly, and the arithmetic explains itself — `lib`
+holds 111 textual occurrences of `use Boundary`, of which 12 are prose in
+moduledocs and comments, leaving 99 declarations. 107 corresponds to no
+population that could be reconstructed here, and no explanation for it is
+offered rather than invented.
+
+Comments at the seven sites say why the dep is absent, because absence is not
+self-documenting: the next reader finds a `belongs_to` pointing at another
+boundary's schema and, without a note, closes the "gap".
+
+_Not established: the other six of the thirteen are untouched — four hold real
+edges (`Subject`, `Themes`, `Admission`, `Vhosts`) and need `Accounts.User` and
+`Accounts.Session` promoted first, which is a separate change with a larger
+population than the review states, since promoting them removes both from
+`Grappa.Accounts`' `exports:` and forces every boundary holding a real edge to
+declare the new dep. The `Networks.Network` half of the bucket is a schema-cluster
+move, not an annotation change, and is tracked separately. The A7 finding — 11
+`top_level?: true` boundaries nested in another boundary's namespace — is
+deliberately not addressed: without a convention distinguishing a carve-out from
+a context internal there is no oracle to satisfy. The rule this entry describes
+is not written next to the Boundary paragraph in CLAUDE.md, so a future boundary
+that needs only a schema can still invent a fifth resolution; that edit is
+vjt's._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48038,3 +48038,101 @@ with a mutant rather than deduced.
 tuple changes arity: a `{:reply, line}` still in flight across a hot reload
 would meet only the 3-tuple clause and raise `FunctionClauseError`. Reload the
 node, do not hot-patch it.
+<!-- entry #1398p -->
+
+---
+
+## 2026-08-17 — #1398: the four Networks schemas own themselves, and 31 cycles go with them
+
+Every `dirty_xrefs` waiver in the tree named `Grappa.Networks.Network` — five
+of them, grown from three between two reviews with nothing watching. Counting
+those waivers as the edges they are turned an acyclic declared graph into one
+with 31 elementary cycles over 12 boundaries. The waivers existed because the
+only alternative on offer was worse: a consumer that needed the schema struct
+had to declare a dep on the entire `Grappa.Networks` context, and that edge is
+what closed the cycles.
+
+The fix is that the schemas stop being part of the context. `Network`, `Server`,
+`Credential` and `FeaturedChannel` each carry `use Boundary, top_level?: true`
+with a deps list measured from their real outbound edges — `Grappa.IRC` for
+three of them, nothing at all for `Server`. A consumer now declares an edge to a
+leaf, and a leaf closes nothing.
+
+**The premise this was planned under was wrong, and the correction is the
+interesting part.** Two earlier reconnaissance passes, including one of mine,
+concluded that four separate leaves were impossible: `server.ex`,
+`credential.ex` and `featured_channel.ex` all name `Network`, so four leaves
+looked like four two-cycles, and the only Boundary-expressible form looked like
+one boundary holding all four schemas — which, since no namespace contains
+exactly those four, meant moving files and renaming modules. Roughly fifteen
+files of rename, and a cold deploy, because renamed modules are beams that
+disappear.
+
+None of that was needed. Every reference among the four is a `has_many` or
+`belongs_to` argument and a typespec, and #1399 had just established against the
+compiler — by deleting seven deps of exactly that shape and staying green under
+`--warnings-as-errors` — that those are atoms in metadata rather than references
+the checker resolves. There is no back-edge, so there is no cycle, so there is
+nothing to merge into a shared namespace. The move is four annotations. No
+module is renamed, no file moves, and the deploy stays hot.
+
+The general lesson is about the measurement, not the outcome: **counting
+references without classifying them measures the wrong population.** Both
+earlier passes counted names and got a real number; the number just did not
+answer the question being asked of it. The reference *kind* is what decides
+whether an edge exists.
+
+**How the five waivers split.** `ReadCursor` holds three `join: n in Network`
+slug lookups and `Scrollback` matches `%Network{slug: slug}` in its wire
+contract, so those two trade a waiver for a declared edge. The other three —
+`ChannelDirectory`, `Notify`, `QueryWindows` — held none, and their waivers are
+deleted with nothing declared in their place, which the compiler accepts.
+
+That last clause is deliberately narrow, because a measurement taken while
+proving the mutant contradicts the wider claim this entry originally made.
+Boundary has a second check: it warns when a `dirty_xrefs` entry is
+unnecessary, and under `--warnings-as-errors` that warning fails the build. The
+mutant tripped it. So the three waivers were run against that check on every
+green build of `main` and never tripped it — measured directly, `origin/main`
+compiles with zero such warnings while still carrying all three. Boundary
+therefore considered them USED, and yet deleting them here produces no
+forbidden reference.
+
+Both halves are measured and they are not obviously compatible; the mechanism
+that reconciles them was not established, and is not guessed at here. What the
+promotion does establish is narrower and sufficient: after it, those three
+boundaries need no declaration of any kind. The earlier sentence in this entry
+— that the waivers "never covered anything" — claimed more than the evidence
+supports and is withdrawn.
+
+**One judgement call was left for the compiler rather than settled by reading.**
+`Notify` and `QueryWindows` pass the schema module as a plain argument to
+`check_exists/4`, the way `Admission` passes it to `Repo.get/2`. Whether that
+is a reference Boundary resolves is not something source inspection answers.
+Declaring the dep would have been the comfortable choice and the wrong one: an
+undeclarable dependency asserted anyway is exactly the defect being removed
+here, and it fails silently. Omitting it fails loudly, at the build, with the
+line number. The choice was made for falsifiability.
+
+**What the gate proves and what it does not.** The budget moves to the number
+the gate itself measures after the promotion, not to a number this entry
+asserts. It is a count over DECLARED deps plus waivers: injected closures,
+behaviours resolved from `:persistent_term` and the supervisor-level
+`held_source_fn` carry no module reference any compile-time mechanism can see,
+so the runtime graph remains denser than anything measured here, and a closure
+that opens a cycle still moves nothing.
+
+A second limit is new and worth recording, because it inverts how a future
+waiver reads: now that the schemas are leaves, a `dirty_xrefs:` pointed at one
+of them would close no cycle and the gate would stay green. The 31 were never
+about waivers as such — they were about waivers pointed at a module owned by a
+large boundary. The gate lost sensitivity on that target by making the target
+harmless.
+
+_Not established: no behaviour changes and nothing here was exercised against
+production or a live session — these are compile-time annotations. The
+reference measurement that selected the file set is a regex over source, so a
+reference built by macro or `Module.concat/1` would be invisible to it; the
+compiler, not the parser, is what makes the set safe, and a file appearing
+beyond the declared set would mean the parser missed a consumer rather than
+that the set grew._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48213,3 +48213,77 @@ a context internal there is no oracle to satisfy. The rule this entry describes
 is not written next to the Boundary paragraph in CLAUDE.md, so a future boundary
 that needs only a schema can still invent a fifth resolution; that edit is
 vjt's._
+<!-- entry #1397-f1 -->
+
+---
+
+## 2026-08-17 — #1397 F1: the handshake barrier takes its timeout as an argument, and the "live decision" was a removed default
+
+The #1397 entry above closes by holding `await_handshake` out of the
+qualified-call reasoning, on the grounds that its timeout axis is "a live
+decision: two files have already found one second insufficient." **That
+sentence is withdrawn. The history does not say it.**
+
+Both 5s sites were born at 5s. `test/grappa/account_deletion_test.exs` arrived
+in `5775e55a` (#157, 2026-06-29) and
+`test/grappa_web/controllers/session_controller_test.exs` in `5e6f7c53` (#126,
+same day); reading each file at the commit that introduced its wrapper shows
+`5_000` already there. Neither was ever raised from `1_000` in response to a
+failure, because neither was ever at `1_000`. Two new files written the same
+day by authors who picked a wider budget is not evidence that one second is
+too tight — it is not evidence about one second at all.
+
+**And the 1s majority was never chosen either.** Eight of the ten majority
+copies trace to a single commit, `84fe0850` (2026-05-08), which removed the
+default timeout from `IRCServer.wait_for_line/3` under the CLAUDE.md
+no-default-arguments rule and stamped the old default explicitly at ~150 call
+sites. The value the copies agree on is the value the default used to hide.
+Thirteen local wrappers then promptly re-hid it behind a zero-argument helper —
+the rule was obeyed at one layer and undone at the next, in the same file.
+
+### So the hoisted verb has no default
+
+`IRCServer.await_handshake(server, timeout)` requires the budget. Giving it a
+default would re-hide, on the same function family, exactly what `84fe0850`
+went to un-hide, and it would silently halve the two 5s sites the moment their
+`defp` disappeared. The timeout was never duplication; it was a parameter with
+thirteen hard-coded callers. It stays at the call site, where the test that
+pays for it can be read.
+
+The other two axes are duplication and they close. The alias axis dies with the
+local definitions. The prefix axis closes on the strict `"USER "`: `lib/` sends
+exactly one line beginning with `USER` (`auth_fsm.ex`) and no `USERHOST`
+anywhere, so both spellings select the same line — the strict one also says so,
+and a test asserts that `USERHOST` does not satisfy the barrier.
+
+### The arity is pinned by a test, not by the comment above it
+
+A rule stated in a docstring is a rule until the next session. `refute
+function_exported?(Grappa.IRCServer, :await_handshake, 1)` is the same rule
+stated in a way that goes red. Bought with the mutant: adding `\\ 1_000` back
+to the definition kills that assertion and only that one — four tests, one
+failure, the other three still green.
+
+### The collision claim above is no longer an inference
+
+The #1397 entry states the import/local collision as "the documented Elixir
+rule plus the 110-to-0 evidence", explicitly not a build anyone watched fail.
+It has now been watched. Adding `admin_session/0` to `Grappa.AuthFixtures` and
+compiling one of the fourteen files that define it locally and import the
+module wholesale:
+
+    error: imported Grappa.AuthFixtures.admin_session/0 conflicts with local function
+    == Compilation error in file .../admin/circuit_controller_test.exs ==
+
+The mutation was reverted. The consequence for the rest of the bucket is
+unchanged in direction and now firm in kind: the `admin_session` slice is
+atomic across fifteen files, and no slicing plan can pretend otherwise.
+
+_Not established: whether one second is the right budget. This work falsified
+the argument for changing it, not the value — no suite timing, no attributed
+flake, no Argon2 measurement was taken, and the design deliberately avoids
+having to answer. Also unmeasured: `start_server` (21 clauses over 20 files)
+and the fixture trio, which needs a ruling first — substituting AuthFixtures'
+placeholder hash for a real Argon2 one changes what fourteen files prove, and
+the local `visitor_fixture` calls the production provisioning verb the
+canonical one bypasses._

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -55,6 +55,7 @@ defmodule Grappa.Admission do
       Grappa.Accounts,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.RateLimit,
       Grappa.Repo
     ],

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -51,7 +51,13 @@ defmodule Grappa.Admission do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Grappa.RateLimit, Grappa.Repo],
+    deps: [
+      Grappa.Accounts,
+      Grappa.Networks,
+      Grappa.Networks.Credential,
+      Grappa.RateLimit,
+      Grappa.Repo
+    ],
     exports: [Captcha, Config, NetworkCircuit, NetworkCircuit.AdminWire, Telemetry]
 
   import Ecto.Query

--- a/lib/grappa/bootstrap.ex
+++ b/lib/grappa/bootstrap.ex
@@ -146,6 +146,7 @@ defmodule Grappa.Bootstrap do
     deps: [
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.OutboundV6Pool,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/bootstrap.ex
+++ b/lib/grappa/bootstrap.ex
@@ -145,6 +145,7 @@ defmodule Grappa.Bootstrap do
     top_level?: true,
     deps: [
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.OutboundV6Pool,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -16,18 +16,8 @@ defmodule Grappa.ChannelDirectory do
     # `Identifier.canonical_target/1` (ASCII, #364/#525/#537) to key them against
     # the canonical featured set.
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced ONLY by `Entry`'s
-    # `belongs_to :network` (struct/schema access — no `Grappa.Networks`
-    # function call anywhere in this boundary). A full `Grappa.Networks`
-    # dep would close the Cluster-2 cycle
-    # `ChannelDirectory → Networks → Session → ChannelDirectory` the moment
-    # `Session.Server` drives the refresh lifecycle (#84 —
-    # `replace_start/2` / `ingest/3` / `finalize/2`). Mirror of the
-    # `Networks.Network` dirty_xref in `Grappa.Scrollback`: schema-only
-    # access whose Boundary checks we lose on a use case Boundary couldn't
-    # gate anyway (struct field access goes through no function we'd want
-    # to police). Intentional.
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver: `Entry` reaches it only by
+    # `belongs_to` and a typespec, which the checker does not resolve (#1398).
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -15,9 +15,11 @@ defmodule Grappa.ChannelDirectory do
     # `Grappa.IRC` — `Wire.mark_featured/2` folds directory names via
     # `Identifier.canonical_target/1` (ASCII, #364/#525/#537) to key them against
     # the canonical featured set.
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver: `Entry` reaches it only by
-    # `belongs_to` and a typespec, which the checker does not resolve (#1398).
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either: `Entry` reaches `User` and `Network` only by
+    # `belongs_to` and a typespec, which are not references the checker
+    # resolves (#1399 for the first, #1398 for the second).
+    deps: [Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -57,6 +57,9 @@ defmodule Grappa.Networks do
       # the addressing config so effective_source/3 stays the single decision
       # point (a disarmed mode 2 HOLDs :mode2_disarmed).
       Grappa.Net.SourceAliasManager,
+      # The schemas are their own boundaries (#1398): this umbrella holds the
+      # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
       Grappa.Vault,
@@ -75,7 +78,6 @@ defmodule Grappa.Networks do
       FeaturedChannels.Wire,
       Network,
       NoServerError,
-      Server,
       Servers,
       Servers.AdminWire,
       SessionPlan,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -61,6 +61,7 @@ defmodule Grappa.Networks do
       # context verbs and reaches its own schemas across a declared edge.
       Grappa.Networks.Credential,
       Grappa.Networks.FeaturedChannel,
+      Grappa.Networks.Network,
       Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
@@ -76,7 +77,6 @@ defmodule Grappa.Networks do
       FeaturedChannels,
       FeaturedChannels.AdminWire,
       FeaturedChannels.Wire,
-      Network,
       NoServerError,
       Servers,
       Servers.AdminWire,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Networks do
       Grappa.Net.SourceAliasManager,
       # The schemas are their own boundaries (#1398): this umbrella holds the
       # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.FeaturedChannel,
       Grappa.Networks.Server,
       Grappa.Session,
       Grappa.Subject,
@@ -72,7 +73,6 @@ defmodule Grappa.Networks do
       Credential,
       Credentials,
       Credentials.AdminWire,
-      FeaturedChannel,
       FeaturedChannels,
       FeaturedChannels.AdminWire,
       FeaturedChannels.Wire,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Networks do
       Grappa.Net.SourceAliasManager,
       # The schemas are their own boundaries (#1398): this umbrella holds the
       # context verbs and reaches its own schemas across a declared edge.
+      Grappa.Networks.Credential,
       Grappa.Networks.FeaturedChannel,
       Grappa.Networks.Server,
       Grappa.Session,
@@ -70,7 +71,6 @@ defmodule Grappa.Networks do
     ],
     exports: [
       AdminWire,
-      Credential,
       Credentials,
       Credentials.AdminWire,
       FeaturedChannels,

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -50,6 +50,16 @@ defmodule Grappa.Networks.Credential do
   uniqueness now lives in the two partial unique indexes above rather
   than the PK.
   """
+
+  # Its own boundary, like the other three Networks schemas (#1398). Of the
+  # five names this module aliases, only `Grappa.IRC` is declared: the
+  # changeset calls `Identity.sanitize_ident/1` and `Identifier`. `User`,
+  # `Visitor` and `EncryptedBinary` arrive only as `belongs_to` and `field`
+  # arguments, and `Network` only as a `belongs_to` and a typespec — none of
+  # them a reference the checker resolves, so declaring them would state a
+  # dependency nothing can verify.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/networks/featured_channel.ex
+++ b/lib/grappa/networks/featured_channel.ex
@@ -15,6 +15,14 @@ defmodule Grappa.Networks.FeaturedChannel do
 
   Mirrors `Grappa.Networks.Server` (the sibling per-network sub-resource).
   """
+
+  # Its own boundary, like the other three Networks schemas (#1398). The dep
+  # on `Grappa.IRC` is a real one — `Identifier.canonical_target/1` and
+  # `valid_channel?/1` are called from the changeset — while `Network` is
+  # reached only as a `belongs_to` argument and a typespec, which the checker
+  # does not resolve, so it is not declared.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/grappa/networks/network.ex
+++ b/lib/grappa/networks/network.ex
@@ -22,6 +22,20 @@ defmodule Grappa.Networks.Network do
   Primary key is an autoincrement INTEGER — networks are an internal
   identifier; the slug is the public handle.
   """
+
+  # Its own boundary, last of the four Networks schemas (#1398). This is the
+  # one the five `dirty_xrefs` waivers all named: a consumer that needed the
+  # struct had to either waive the check or take a dep on the whole
+  # `Grappa.Networks` context, and that second edge is what closed 31 cycles.
+  # With the schema owning itself, the waivers become either a declared edge
+  # to a leaf or nothing at all.
+  #
+  # `deps: [Grappa.IRC]` is the changeset's `Identifier.valid_network_slug?/1`.
+  # The three `has_many` siblings are association arguments, not references
+  # the checker resolves, so this leaf does not depend on them — which is why
+  # four separate leaves work and no namespace move was needed.
+  use Boundary, top_level?: true, deps: [Grappa.IRC]
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/networks/server.ex
+++ b/lib/grappa/networks/server.ex
@@ -12,6 +12,15 @@ defmodule Grappa.Networks.Server do
   surfaces `{:error, :already_exists}` from the context, not a raw
   Ecto changeset error.
   """
+
+  # Its own boundary so that a consumer needing the schema does not have to
+  # take a dep on all of `Grappa.Networks` — the edge that closed 31 cycles
+  # and drove five `dirty_xrefs` waivers (#1398/#1399). `deps: []` because
+  # this module references nothing outside itself: `Network` appears only as
+  # a `belongs_to` argument and in a typespec, neither of which is a
+  # reference the checker resolves. Mirror of `Grappa.Visitors.Visitor` (#415).
+  use Boundary, top_level?: true, deps: []
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/notify.ex
+++ b/lib/grappa/notify.ex
@@ -79,12 +79,12 @@ defmodule Grappa.Notify do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver (#1398). `Entry`'s
-    # `belongs_to` is not a resolved reference; the FK pre-check at
-    # `check_exists/4` passes the module as a plain argument, which the
-    # compiler is left to judge — if that is a reference, this line becomes a
-    # declared dep on the leaf, which no longer closes a cycle either way.
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either. `Entry` reaches `User` and `Network` by
+    # `belongs_to` and typespecs, and the FK pre-check at `check_exists/4`
+    # passes the module as a plain argument — measured, none of those three
+    # shapes is a reference the checker resolves (#1399, #1398).
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/notify.ex
+++ b/lib/grappa/notify.ex
@@ -80,11 +80,11 @@ defmodule Grappa.Notify do
   use Boundary,
     top_level?: true,
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # Networks.Network is an FK-reference-only xref (belongs_to + the
-    # existence pre-check), NOT a full dep: a `deps:` edge would close
-    # the cycle Session -> Notify -> Networks -> LiveIntrospection ->
-    # Session (Session reads the notify list at the end-of-MOTD arm).
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver (#1398). `Entry`'s
+    # `belongs_to` is not a resolved reference; the FK pre-check at
+    # `check_exists/4` passes the module as a plain argument, which the
+    # compiler is left to judge — if that is a reference, this line becomes a
+    # declared dep on the leaf, which no longer closes a cycle either way.
     exports: [Entry, Wire]
 
   import Ecto.Query

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -66,6 +66,7 @@ defmodule Grappa.Operator do
       Grappa.DbLatency,
       Grappa.LiveIntrospection,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Session,
       # #269 — the admin Visitors-tab Reconnect verb reuses the connect
       # core (admission → backoff-reset → spawn) through the shared

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -67,6 +67,7 @@ defmodule Grappa.Operator do
       Grappa.LiveIntrospection,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.Session,
       # #269 — the admin Visitors-tab Reconnect verb reuses the connect
       # core (admission → backoff-reset → spawn) through the shared

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -68,8 +68,10 @@ defmodule Grappa.Push do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Subscription`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.Mentions,
       Grappa.Repo,

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -96,13 +96,14 @@ defmodule Grappa.QueryWindows do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # No `Networks.Network` dep and no waiver (#1398), same call as
-    # `Grappa.Notify`: `Window`'s `belongs_to` is not a resolved reference,
-    # and the FK pre-check at `check_exists/4` passes the module as a plain
-    # argument. The old cycle this waiver avoided,
-    # `Session → QueryWindows → Networks → Session`, cannot form through a
-    # leaf that depends only on `Grappa.IRC`.
+    # Neither `Grappa.Accounts` nor `Networks.Network` is declared, and there
+    # is no waiver for either — same call as `Grappa.Notify`. `Window` reaches
+    # both by `belongs_to` and typespecs, and the FK pre-check at
+    # `check_exists/4` passes the module as a plain argument; measured, none of
+    # those shapes is a reference the checker resolves (#1399, #1398). The old
+    # cycle the waiver avoided, `Session → QueryWindows → Networks → Session`,
+    # cannot form through a leaf that depends only on `Grappa.IRC`.
+    deps: [Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
     exports: [Window, Wire]
 
   import Ecto.Query

--- a/lib/grappa/query_windows.ex
+++ b/lib/grappa/query_windows.ex
@@ -97,15 +97,12 @@ defmodule Grappa.QueryWindows do
   use Boundary,
     top_level?: true,
     deps: [Grappa.Accounts, Grappa.IRC, Grappa.PubSub, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced ONLY as a schema — the
-    # `belongs_to :network` association + the FK-existence `Repo.exists?`
-    # query in `check_exists/4`. Declared a dirty xref (NOT a real dep),
-    # mirroring `Grappa.Scrollback` / `Grappa.ReadCursor`: a real
-    # `QueryWindows → Networks` edge would close the cycle
-    # `Session → QueryWindows → Networks → Session` once #373 made
-    # Session depend on QueryWindows (for `rename/4` on a peer NICK).
-    # The struct-only reference carries no behaviour Boundary could gate.
-    dirty_xrefs: [Grappa.Networks.Network],
+    # No `Networks.Network` dep and no waiver (#1398), same call as
+    # `Grappa.Notify`: `Window`'s `belongs_to` is not a resolved reference,
+    # and the FK pre-check at `check_exists/4` passes the module as a plain
+    # argument. The old cycle this waiver avoided,
+    # `Session → QueryWindows → Networks → Session`, cannot form through a
+    # leaf that depends only on `Grappa.IRC`.
     exports: [Window, Wire]
 
   import Ecto.Query

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -77,17 +77,15 @@ defmodule Grappa.ReadCursor do
       Grappa.PubSub,
       Grappa.Repo,
       Grappa.Scrollback,
+      # The three `join: n in Network` slug lookups are a real reference, and
+      # since #1398 made the schema its own leaf boundary this is a declared
+      # edge rather than the waiver it used to be. The cycle the waiver
+      # avoided — `Session → ReadCursor → Networks → Session` — cannot form
+      # through the leaf: it depends on `Grappa.IRC` and nothing else.
+      Grappa.Networks.Network,
       Grappa.Subject,
       Grappa.Visitors.Visitor
     ],
-    # `Networks.Network` is referenced ONLY as a schema — the
-    # `belongs_to :network` FK association + the `join: n in Network`
-    # slug lookup in `bulk_for_subject/1` (field access, no Networks
-    # context call). Demoted from a real dep to a struct-only dirty xref
-    # (#373) so `Session → ReadCursor → Networks → Session` doesn't close
-    # once Session depends on ReadCursor for `rename_dm_peer/4`; mirrors
-    # `Grappa.Scrollback` / `Grappa.QueryWindows`.
-    dirty_xrefs: [Grappa.Networks.Network],
     exports: [Cursor, Wire]
 
   import Ecto.Query

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -71,8 +71,10 @@ defmodule Grappa.ReadCursor do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Cursor`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,

--- a/lib/grappa/release.ex
+++ b/lib/grappa/release.ex
@@ -46,6 +46,7 @@ defmodule Grappa.Release do
       Grappa.Accounts,
       Grappa.Deploy.MigrationAudit,
       Grappa.Networks,
+      Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Themes,
       Grappa.Vault

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,8 +33,10 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Message`'s
+    # `belongs_to` and its typespec — metadata atoms, not a reference the
+    # checker resolves (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       # `Wire.to_json/1` matches `%Network{slug: slug}`, the wire-shape
       # contract from A1+A26 — a real reference, declared since #1398 made

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -33,18 +33,20 @@ defmodule Grappa.Scrollback do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.IRC, Grappa.Repo, Grappa.Subject, Grappa.Visitors.Visitor],
-    # `Networks.Network` is referenced by `Scrollback.Message` (the
-    # `belongs_to :network` association) and `Scrollback.Wire` (the
-    # `%Network{slug: _}` pattern that A1+A26 made the wire-shape
-    # contract). Declaring that ref a dirty xref lets Cluster 2's
-    # Networks → Session cycle inversion land without a transitive cycle
-    # (which would otherwise close
-    # `Scrollback → Networks → Session → Scrollback`). The struct-only
-    # nature of the dep means we lose Boundary checks on a use case
-    # Boundary couldn't help with anyway (struct field access doesn't go
-    # through any function call we'd want to gate); the cost is intentional.
-    dirty_xrefs: [Grappa.Networks.Network],
+    deps: [
+      Grappa.Accounts,
+      Grappa.IRC,
+      # `Wire.to_json/1` matches `%Network{slug: slug}`, the wire-shape
+      # contract from A1+A26 — a real reference, declared since #1398 made
+      # the schema its own leaf. `Message`'s `belongs_to :network` is not
+      # what pays for this edge; the struct pattern is. The transitive cycle
+      # the waiver avoided, `Scrollback → Networks → Session → Scrollback`,
+      # cannot form through a leaf that depends only on `Grappa.IRC`.
+      Grappa.Networks.Network,
+      Grappa.Repo,
+      Grappa.Subject,
+      Grappa.Visitors.Visitor
+    ],
     exports: [Message, Wire]
 
   import Ecto.Query

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -71,6 +71,7 @@ if Mix.env() in [:dev, :test] do
         Grappa.Accounts,
         Grappa.Admission,
         Grappa.Networks,
+        Grappa.Networks.Credential,
         Grappa.Notify,
         Grappa.Push,
         Grappa.QueryWindows,

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -99,8 +99,10 @@ defmodule Grappa.UserSettings do
 
   use Boundary,
     top_level?: true,
+    # No `Grappa.Accounts` dep: `User` is reached only by `Settings`'
+    # `belongs_to` and its typespec — metadata atoms, not a reference
+    # Boundary can gate (#1399).
     deps: [
-      Grappa.Accounts,
       Grappa.IRC,
       Grappa.PubSub,
       Grappa.Repo,

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -69,6 +69,7 @@ defmodule Grappa.Visitors do
       Grappa.LiveIntrospection,
       Grappa.Networks,
       Grappa.Networks.Credential,
+      Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -68,6 +68,7 @@ defmodule Grappa.Visitors do
       Grappa.IRC,
       Grappa.LiveIntrospection,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Repo,
       Grappa.Session,
       Grappa.SpawnOrchestrator,

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -49,6 +49,7 @@ defmodule Grappa.Visitors.Reaper do
     deps: [
       Grappa.AdminEvents,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Session,
       Grappa.Subject,
       Grappa.Visitors,

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -33,6 +33,7 @@ defmodule GrappaWeb do
         Grappa.Net.PtrCache,
         Grappa.Net.SourceAliasManager,
         Grappa.Networks,
+        Grappa.Networks.Credential,
         Grappa.Notify,
         Grappa.Operator,
         Grappa.OutboundV6Pool,

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -34,6 +34,7 @@ defmodule GrappaWeb do
         Grappa.Net.SourceAliasManager,
         Grappa.Networks,
         Grappa.Networks.Credential,
+        Grappa.Networks.Network,
         Grappa.Notify,
         Grappa.Operator,
         Grappa.OutboundV6Pool,

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -70,7 +70,13 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   """
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Networks, Grappa.Session, Mix.Tasks.Grappa.Boot, Mix.Tasks.Grappa.OptionParsing]
+    deps: [
+      Grappa.Networks,
+      Grappa.Networks.Credential,
+      Grappa.Session,
+      Mix.Tasks.Grappa.Boot,
+      Mix.Tasks.Grappa.OptionParsing
+    ]
 
   use Mix.Task
 

--- a/test/grappa/account_deletion_test.exs
+++ b/test/grappa/account_deletion_test.exs
@@ -38,11 +38,6 @@ defmodule Grappa.AccountDeletionTest do
     {server, Grappa.IRCServer.port(server)}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 5_000)
-    :ok
-  end
-
   # A registered visitor = identified on some network. #211 phase 7 —
   # `commit_password/3` writes the per-network secret + flips the credential's
   # `auth_method` to `:nickserv_identify`; registration is DERIVED from that
@@ -83,8 +78,8 @@ defmodule Grappa.AccountDeletionTest do
 
       pid1 = start_session_for(user, network1)
       pid2 = start_session_for(user, network2)
-      :ok = await_handshake(server1)
-      :ok = await_handshake(server2)
+      :ok = Grappa.IRCServer.await_handshake(server1, 5_000)
+      :ok = Grappa.IRCServer.await_handshake(server2, 5_000)
       ref1 = Process.monitor(pid1)
       ref2 = Process.monitor(pid2)
 
@@ -120,7 +115,7 @@ defmodule Grappa.AccountDeletionTest do
       {visitor, network} = registered_visitor(port)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = Grappa.IRCServer.await_handshake(server, 5_000)
       ref = Process.monitor(pid)
 
       session = visitor_session_fixture(visitor)

--- a/test/grappa/boundary_cycle_budget_test.exs
+++ b/test/grappa/boundary_cycle_budget_test.exs
@@ -16,17 +16,31 @@ defmodule Grappa.BoundaryCycleBudgetTest do
   # that closes a cycle has to be argued for in a diff instead of arriving
   # unremarked. Lowering @cycle_budget when the number drops is the point;
   # raising it is a decision that belongs in review.
-  @cycle_budget 31
+  @cycle_budget 0
 
-  # Measured 2026-08-17 on `origin/main` = 236dd328: 31 elementary cycles over
-  # 12 boundaries (1 of length 2, 4 of length 3, 11 of length 4, 11 of length 5,
-  # 4 of length 6), from 5 waivers all naming `Grappa.Networks.Network`. The
-  # single highest-leverage arc is `Scrollback -> Networks` at 19 of the 31; no
-  # single arc kills them all. Method: the compiled `Boundary` attribute, the
-  # same source `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest`
-  # read — NOT a source parse. An earlier hand-rolled regex parser disagreed with
-  # a second one about how many `use Boundary` blocks even exist (99 vs 107),
-  # which is exactly why this reads the annotation the compiler kept.
+  # The budget was 31 when this gate landed, and the promotion of the four
+  # `Networks` schemas to their own boundaries retired every one of them: all
+  # five waivers named `Grappa.Networks.Network`, and each existed because the
+  # alternative was an edge to the whole `Grappa.Networks` context. With the
+  # schemas owning themselves, two of the five became declared edges to a leaf
+  # that depends only on `Grappa.IRC`, and three were deleted outright — they
+  # had been waiving a `belongs_to`, which was never a reference the checker
+  # resolved.
+  #
+  # A consequence worth stating, because it changes what a future waiver means:
+  # a `dirty_xrefs: [Grappa.Networks.Network]` written today resolves to the
+  # leaf, not to the context, so it would close nothing and this gate would not
+  # move. The 31 were never about waivers as such — they were about waivers
+  # pointed at a module owned by a large boundary.
+  #
+  # Method: the compiled `Boundary` attribute, the same source
+  # `GrappaWeb.BoundaryTest` and `Grappa.Visitors.VisitorBoundaryTest` read —
+  # NOT a source parse. When this gate landed, two hand-rolled regex parsers
+  # disagreed about how many `use Boundary` blocks even exist, 99 against 107.
+  # The compiled attribute settled it at 99, over
+  # `:application.get_key(:grappa, :modules)`; `lib` holds 111 textual
+  # occurrences of which 12 are prose in moduledocs and comments. 107 matches no
+  # population anyone could reconstruct, and nothing here guesses what it was.
   #
   # Declared scope, stated so it is not mistaken for more: this counts DECLARED
   # deps plus waivers. Runtime edges — the injected closures, behaviours resolved

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -91,11 +91,6 @@ defmodule Grappa.IRC.ClientTest do
   # initial handshake (NICK/USER guaranteed to be the last lines of
   # the always-sent prefix). Eliminates the `Process.sleep(20)` pattern
   # that races on the IRCServer's accept-loop sock assignment.
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
-    :ok
-  end
-
   # Handler that replies CAP * LS :sasl=PLAIN to a CAP LS, ACKs the
   # CAP REQ :sasl, prompts AUTHENTICATE PLAIN with `+`, and answers
   # the base64 payload with the configured numeric (903 by default).
@@ -344,7 +339,7 @@ defmodule Grappa.IRC.ClientTest do
     test "send_nick/2 emits NICK new\\r\\n" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Client.send_nick(client, "vjt-away")
 
@@ -762,7 +757,7 @@ defmodule Grappa.IRC.ClientTest do
     test "send_line/2 returns {:error, :closed} when socket is closed-but-not-nil (no raise)" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Snapshot the live socket, close it underneath the Client, then
       # send. handle_call({:send, _}, _, state) hands the closed-but-
@@ -801,7 +796,7 @@ defmodule Grappa.IRC.ClientTest do
       # before we could send anything).
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :sys.replace_state(client, fn state -> %{state | socket: nil} end)
 
@@ -851,7 +846,7 @@ defmodule Grappa.IRC.ClientTest do
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: "127.0.0.2"})
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {{127, 0, 0, 2}, _}} = IRCServer.peername(server)
     end
@@ -861,7 +856,7 @@ defmodule Grappa.IRC.ClientTest do
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: nil})
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {{127, 0, 0, 1}, _}} = IRCServer.peername(server)
     end
@@ -890,7 +885,7 @@ defmodule Grappa.IRC.ClientTest do
     test "single PRIVMSG line dispatched as parsed Message struct" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
@@ -906,7 +901,7 @@ defmodule Grappa.IRC.ClientTest do
     test "burst of 50 server lines dispatched in order with no loss (active:once re-arm)" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Enum.each(1..50, fn i ->
         IRCServer.feed(server, ":a!~a@h PRIVMSG #x :msg #{i}\r\n")
@@ -923,7 +918,7 @@ defmodule Grappa.IRC.ClientTest do
     test "mid-line server write coalesced via OS-level packet:line buffering" do
       {server, port} = start_server()
       _ = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, "PING :fo")
       # Intentional sleep: half a line in, force the OS-level packet:line
@@ -939,7 +934,7 @@ defmodule Grappa.IRC.ClientTest do
     test "malformed inbound line: parse error is logged, client stays alive" do
       {server, port} = start_server()
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       log =
         capture_log(fn ->
@@ -1374,7 +1369,7 @@ defmodule Grappa.IRC.ClientTest do
       # Client should have sent: PASS, CAP LS, NICK, USER. Then on 421,
       # no further action. No PRIVMSG NickServ from the client side
       # (server-side handoff handles it).
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # 421 :Unknown command CAP arrives in the dispatch_to mailbox AFTER
       # the client has parsed it — deterministic synchronisation point.
@@ -1864,7 +1859,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "rejected lines never reach the server socket", %{server: server, client: client} do
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       lines_before = IRCServer.sent_lines(server)
 
       _ = Client.send_privmsg(client, "#chan", "hi\r\nQUIT :pwn")
@@ -2520,7 +2515,7 @@ defmodule Grappa.IRC.ClientTest do
       # it received is what the model must have charged for.
       {server, port} = start_server(rfc_handler())
       client = start_client(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Client.send_line(client, "PING :probe\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PING :probe\r\n"), 1_000)

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -38,7 +38,7 @@ defmodule Grappa.IRCServerTest do
 
   test "raises when the registration line never arrives inside the budget" do
     {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    _sock = connected_client(server)
+    connected_client(server)
 
     assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
   end

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -1,0 +1,61 @@
+defmodule Grappa.IRCServerTest do
+  @moduledoc """
+  Unit tests for the `Grappa.IRCServer` handshake barrier (#1397 F1).
+
+  The fake server is otherwise exercised through its consumers, which is
+  why it has had no test of its own. `await_handshake/2` gets one because
+  it is the first barrier hoisted out of the thirteen local copies, and
+  the property that matters about it is not behavioural but structural:
+  it must NOT grow a default timeout.
+
+  Commit `84fe0850` removed the default timeout from `wait_for_line/3`
+  under the CLAUDE.md no-default-arguments rule, then stamped the value
+  explicitly at every call site. The thirteen local `await_handshake`
+  wrappers this replaces had immediately re-hidden that same value behind
+  a zero-argument helper — eleven at 1s, two at 5s. A default here would
+  restore the silent-degradation path that ruling removed AND quietly
+  halve the budget of the two 5s sites, so the arity is pinned.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRCServer
+
+  defp connected_client(server) do
+    {:ok, sock} = :gen_tcp.connect({127, 0, 0, 1}, IRCServer.port(server), [:binary, active: false])
+    on_exit(fn -> :gen_tcp.close(sock) end)
+    sock
+  end
+
+  test "returns :ok once the client has sent its USER registration line" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    sock = connected_client(server)
+
+    :ok = :gen_tcp.send(sock, "NICK vjt\r\n")
+    :ok = :gen_tcp.send(sock, "USER vjt 0 * :Marcello\r\n")
+
+    assert :ok = IRCServer.await_handshake(server, 1_000)
+  end
+
+  test "raises when the registration line never arrives inside the budget" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    _sock = connected_client(server)
+
+    assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
+  end
+
+  test "a line that merely starts with USER but is not the registration verb does not satisfy it" do
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    sock = connected_client(server)
+
+    :ok = :gen_tcp.send(sock, "USERHOST vjt\r\n")
+
+    assert_raise MatchError, fn -> IRCServer.await_handshake(server, 50) end
+  end
+
+  test "carries no default timeout" do
+    Code.ensure_loaded!(IRCServer)
+
+    assert function_exported?(IRCServer, :await_handshake, 2)
+    refute function_exported?(IRCServer, :await_handshake, 1)
+  end
+end

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -58,11 +58,6 @@ defmodule Grappa.Networks.ConnectionStateTest do
     Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "connect/1" do
     test "transitions :parked → :connected, clears reason, broadcasts" do
       {_, port} = start_server()
@@ -153,7 +148,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       assert {:ok, updated} = Networks.disconnect(cred, "user-disconnect")
@@ -236,7 +231,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       assert {:ok, updated} = Networks.mark_failed(cred, "k-line: G:Lined")

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -34,17 +34,12 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, credential}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   test "refresh issues LIST upstream" do
     {server, port} = start_server()
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)
 
@@ -57,7 +52,7 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)
 
@@ -83,7 +78,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     # Subscribe BEFORE triggering so the (50ms-out) failed ping can't race
     # the subscribe. `subject_label` for a user session is `user.name`.
@@ -124,7 +119,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "$server"))
 
@@ -156,7 +151,7 @@ defmodule Grappa.Session.DirectoryTest do
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     # Subscribe before triggering so the `directory_complete` ping can't race
     # the subscribe. The broadcast (323 processed) is the sync point — once it
@@ -209,7 +204,7 @@ defmodule Grappa.Session.DirectoryTest do
       _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
     end)
 
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -99,11 +99,6 @@ defmodule Grappa.Session.ServerTest do
     {user, network, credential}
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   # Poll until the fake ircd has seen `target` CTCP PING answers, or the
   # deadline passes — a condition, not a sleep. Returns whatever the last
   # sample was so the caller asserts on a number rather than on a timeout.
@@ -225,7 +220,7 @@ defmodule Grappa.Session.ServerTest do
           1_000
         )
     else
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
     end
 
     %{server: server, pid: pid, network: network, subject: subject, label: label}
@@ -399,7 +394,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, {"127.0.0.1", ^port}} =
                Session.peer_address({:user, user.id}, network.id)
@@ -423,7 +418,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, %{server: "127.0.0.1", port: ^port, tls: false, registered: false}} =
                Session.connection_info({:user, user.id}, network.id)
@@ -448,7 +443,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +r\r\n")
 
@@ -482,7 +477,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       before = DateTime.utc_now()
       _ = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, %{connected_at: %DateTime{} = at}} =
                Session.connection_info({:user, user.id}, network.id)
@@ -520,7 +515,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # CASEMAPPING alongside PREFIX so the isupport_changed broadcast fires
       # and serves as the "005 processed" barrier before we read the facade.
@@ -553,7 +548,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert Session.casemapping({:user, user.id}, network.id) == :ascii
 
@@ -588,7 +583,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -619,7 +614,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert Session.statusmsg({:user, user.id}, network.id) == ISupport.default_statusmsg()
 
@@ -731,7 +726,7 @@ defmodule Grappa.Session.ServerTest do
       init_opts = Map.put(stale_opts, :refresh_plan, refresh_plan)
 
       {:ok, pid} = Server.start_link(init_opts)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
 
@@ -887,7 +882,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
 
       # The crash-survival holder index the manager reads at reconcile.
       assert addr in Session.live_derived_sources()
@@ -911,7 +906,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
@@ -934,8 +929,8 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid2} =
         Session.start_session({:user, user2.id}, net2.id, derived_alias_opts(user2, net2, port2, addr))
 
-      await_handshake(server1)
-      await_handshake(server2)
+      IRCServer.await_handshake(server1, 1_000)
+      IRCServer.await_handshake(server2, 1_000)
 
       # The de-duplicated holder set reports the shared address ONCE despite two
       # live holders. Scoped to `addr` (not `== [addr]`) so an async-GC-lagged
@@ -955,7 +950,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, pid} =
         Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, nil))
 
-      await_handshake(server)
+      IRCServer.await_handshake(server, 1_000)
 
       # This session registered NO holder entry — pid-scoped so it's robust to
       # async-GC-lagged entries from other tests (proves the manager + holder
@@ -1100,7 +1095,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Reset Backoff to a known-zero baseline (handshake/connect could
       # have left a stale entry from a previous run in the singleton ETS
@@ -1140,7 +1135,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       state = SessionStateHelpers.fetch(pid)
@@ -1173,7 +1168,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       state = SessionStateHelpers.fetch(pid)
@@ -1214,7 +1209,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Backoff.reset({:user, user.id}, network.id)
 
       ref = Process.monitor(pid)
@@ -1257,7 +1252,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
       client_pid = SessionStateHelpers.client(state)
@@ -1291,7 +1286,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       state = SessionStateHelpers.fetch(pid)
       client_pid = SessionStateHelpers.client(state)
@@ -1347,7 +1342,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :sys.replace_state(pid, &Map.merge(&1, @secrets))
 
@@ -1373,7 +1368,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       status = Server.format_status(%{state: :sys.get_state(pid)})
 
@@ -1401,7 +1396,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1425,7 +1420,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1453,7 +1448,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)
@@ -1494,7 +1489,7 @@ defmodule Grappa.Session.ServerTest do
         {server, port} = start_server()
         {user, network, _} = setup_user_and_network(port)
         pid = start_session_for(user, network)
-        :ok = await_handshake(server)
+        :ok = IRCServer.await_handshake(server, 1_000)
 
         # Model the production race: swap the linked Client for a bare
         # (unlinked, non-GenServer) process that, on the first {:send, _}
@@ -1689,7 +1684,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -1708,7 +1703,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       Process.sleep(100)
 
@@ -1746,7 +1741,7 @@ defmodule Grappa.Session.ServerTest do
       # Long fallback so ONLY the +r echo can trigger the JOINs in-window.
       pid = nickserv_plan(user, network, credential, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # 001 alone must NOT fire autojoin: identify is still async, no +r yet.
@@ -1782,7 +1777,7 @@ defmodule Grappa.Session.ServerTest do
       # timer elapses, so a silent/slow NickServ never hangs autojoin.
       pid = nickserv_plan(user, network, credential, 400)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Deferred: no JOIN on 001, and none before the fallback elapses.
@@ -1811,7 +1806,7 @@ defmodule Grappa.Session.ServerTest do
       # latch must ensure the JOIN is emitted once, never twice.
       pid = nickserv_plan(user, network, credential, 120)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       IRCServer.feed(server, ":irc.test.org MODE grappa-test :+r\r\n")
 
@@ -1842,7 +1837,7 @@ defmodule Grappa.Session.ServerTest do
       # on 001 exactly as it did pre-#347.
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -1898,7 +1893,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "MODE grappa-test +x\nWHOIS grappa-test")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # The built-in identify still fires — the list did not consume the var.
@@ -1938,7 +1933,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "NS IDENTIFY $nickserv_pass")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -1970,7 +1965,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "NS IDENTIFY hunter2")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2001,7 +1996,7 @@ defmodule Grappa.Session.ServerTest do
       cred_with_perform = put_perform_list(credential, "MODE grappa-test +x")
       pid = nickserv_plan(user, network, cred_with_perform, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Perform line runs at 001…
@@ -2061,7 +2056,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "ns-secret")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # The umode query is emitted at the END of the same 001 clause that runs
@@ -2096,7 +2091,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "stale-override")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2133,7 +2128,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "MODE grappa-test +x\r\n"), 1_000)
@@ -2177,7 +2172,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} =
@@ -2211,7 +2206,7 @@ defmodule Grappa.Session.ServerTest do
       cred = seed_server_pass_slot(credential, "ns-secret")
       pid = nickserv_plan(user, network, cred, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert {:ok, "JOIN #sniffo\r\n"} =
@@ -2237,7 +2232,7 @@ defmodule Grappa.Session.ServerTest do
       # window and this "fires immediately" test would pass either way (mirror).
       pid = nickserv_plan(user, network, credential, 60_000)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # No identify expected → no defer; the JOIN lands on 001 as before #509.
@@ -2271,7 +2266,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
 
       assert {:ok, "WATCH +Foo +Bar\r\n"} =
@@ -2286,7 +2281,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "MONITOR=100 WATCH=128")
 
       assert {:ok, "MONITOR + Foo,Bar\r\n"} =
@@ -2306,7 +2301,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
 
       assert {:ok, "WATCH +Foo\r\n"} =
@@ -2323,7 +2318,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2341,7 +2336,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
       IRCServer.feed(server, ":irc.test.org 421 grappa-test WATCH :Unknown command\r\n")
@@ -2366,7 +2361,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
@@ -2403,7 +2398,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2421,7 +2416,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_registration(server, "WATCH=128")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WATCH +Foo\r\n"), 1_000)
 
@@ -2461,7 +2456,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
 
@@ -2491,7 +2486,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, "PING :irc.test.org\r\n")
 
       assert {:ok, "PONG :irc.test.org\r\n"} =
@@ -2518,7 +2513,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org PONG irc.test.org :grappa-liveness\r\n")
       IRCServer.feed(server, "PING :irc.test.org\r\n")
@@ -2561,7 +2556,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Upstream confirms away-set.
       IRCServer.feed(server, ":irc.test.org 306 grappa-test :You have been marked as being away\r\n")
@@ -2600,7 +2595,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 305 grappa-test :You are no longer marked as being away\r\n")
 
@@ -2630,7 +2625,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, "all", nil)
@@ -2655,7 +2650,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2679,7 +2674,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2708,7 +2703,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
@@ -2767,7 +2762,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
@@ -2801,7 +2796,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, msg} =
                Session.send_privmsg({:user, user.id}, network.id, "#sniffo", "hi all")
@@ -2834,7 +2829,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -2873,7 +2868,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hey there\r\n")
 
@@ -2917,7 +2912,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
 
@@ -2960,7 +2955,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
 
@@ -2999,7 +2994,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       log =
         capture_log(fn ->
@@ -3041,7 +3036,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01VERSION\x01\r\n")
 
@@ -3085,7 +3080,7 @@ defmodule Grappa.Session.ServerTest do
         Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       queries = @auto_reply_capacity * 4
 
@@ -3145,7 +3140,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":NickServ!serv@services PRIVMSG vjt :You are now identified\r\n")
 
@@ -3170,7 +3165,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The operator DMs a NEW peer — with no browser attached (or another
       # device connected), the window must still open server-side so
@@ -3195,7 +3190,7 @@ defmodule Grappa.Session.ServerTest do
       net_id = network.id
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, net_id, "#sniffo", "hi all")
 
@@ -3232,7 +3227,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Arm the fault on the SESSION pid, firing on the auto-open's
       # `BusyRetry.run` — NOT the persist's. The session-pid fault-CHECKS that
@@ -3286,7 +3281,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       msg =
@@ -3326,7 +3321,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       refute_receive %Phoenix.Socket.Broadcast{event: "event", payload: _}, 200
@@ -3345,7 +3340,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hello\r\n")
 
       refute_receive %Phoenix.Socket.Broadcast{event: "event", payload: _}, 200
@@ -3361,7 +3356,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org PRIVMSG #sniffo :system message\r\n")
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -3401,7 +3396,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Empty body → :privmsg is a body-required kind → changeset error →
       # persist_event returns {:error, %Ecto.Changeset{}}. Pre-#336 the
@@ -3462,7 +3457,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Force linelen so fragmentation is deterministic on any IRC server
@@ -3530,7 +3525,7 @@ defmodule Grappa.Session.ServerTest do
       own = "grappa-test"
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       topic = Topic.user(user.name)
@@ -3593,7 +3588,7 @@ defmodule Grappa.Session.ServerTest do
       own = "grappa-test"
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3650,7 +3645,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3729,7 +3724,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
       on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
@@ -3768,7 +3763,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -3835,7 +3830,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
 
@@ -3884,7 +3879,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -3929,7 +3924,7 @@ defmodule Grappa.Session.ServerTest do
       subject = {:user, user.id}
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       net_id = network.id
       slug = network.slug
@@ -4034,7 +4029,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :vjt: ping\r\n")
 
@@ -4064,7 +4059,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Default prefs: channel_messages_all=false, channel_mentions=true.
       # Body has no mention → no notify.
@@ -4087,7 +4082,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Inbound DM → channel == own_nick ("vjt").
       IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hi there\r\n")
@@ -4114,7 +4109,7 @@ defmodule Grappa.Session.ServerTest do
       _ = push_subscription_fixture(user, endpoint)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":alice!~a@host JOIN #sniffo\r\n")
       IRCServer.feed(server, ":alice!~a@host NOTICE #sniffo :vjt fyi\r\n")
@@ -4138,7 +4133,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":bob!~b@host JOIN #sniffo\r\n")
       IRCServer.feed(server, ":bob!~b@host PART #sniffo :bye\r\n")
 
@@ -4192,7 +4187,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       # Autojoin JOIN signals Session has processed `001` fully.
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -4227,7 +4222,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Forced upstream rename — services or operator-driven.
@@ -4264,7 +4259,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":alice!~a@host NICK :alice2\r\n")
@@ -4305,7 +4300,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       action_body = "\x01ACTION waves at the channel\x01"
@@ -4351,7 +4346,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # /ctcp #sniffo VERSION → cic sends \x01VERSION\x01 as the PRIVMSG body.
@@ -4407,7 +4402,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       %{server: server, user: user, network: network, pid: pid}
     end
 
@@ -4731,7 +4726,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       %{server: server, user: user, network: network, pid: pid}
     end
 
@@ -4803,7 +4798,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Seed members so grappa-test is op (@) in #test, then wait for the
@@ -4831,7 +4826,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       log =
         capture_log(fn ->
@@ -4874,7 +4869,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4905,7 +4900,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4949,7 +4944,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -4994,7 +4989,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #a"), 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #b"), 1_000)
 
@@ -5059,7 +5054,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5118,7 +5113,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5155,7 +5150,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -5206,7 +5201,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN echo + its `joined` broadcast first so the
@@ -5245,7 +5240,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -5290,7 +5285,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, isupport} = Session.get_isupport({:user, user.id}, network.id)
       assert isupport == ISupport.default()
@@ -5323,7 +5318,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :isupport from the live state.
       # (`:sys.replace_state` returns the NEW state, not `:ok`.)
@@ -5376,7 +5371,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # No CHANMODES / PREFIX / STATUSMSG / CASEMAPPING token: the isupport
       # capability table is byte-for-byte what it was.
@@ -5418,7 +5413,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, "MODE grappa-test\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE grappa-test\r\n"), 1_000)
@@ -5445,7 +5440,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Upstream answers the umode query with the current set.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +iwS\r\n")
@@ -5483,7 +5478,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, []} = Session.get_umodes({:user, user.id}, network.id)
 
@@ -5510,7 +5505,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed the base set via 221, then apply a mid-session delta.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +i\r\n")
@@ -5552,7 +5547,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :umodes from the live state.
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
@@ -5603,7 +5598,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Before any 221 the set is empty — the safe direction, not a crash.
       assert {:ok, :ordinary} = Session.get_flood_allowance({:user, user.id}, network.id)
@@ -5622,7 +5617,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The broadcast is the barrier: the fold has landed before we ask.
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +io\r\n")
@@ -5648,7 +5643,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
       :ok = await_umodes(["F", "o"])
@@ -5667,7 +5662,7 @@ defmodule Grappa.Session.ServerTest do
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":irc.test.org 221 grappa-test +Fo\r\n")
       :ok = await_umodes(["F", "o"])
@@ -5686,7 +5681,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :umodes) end)
 
@@ -5726,7 +5721,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -5767,7 +5762,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, []} = Session.get_supported_umodes({:user, user.id}, network.id)
 
@@ -5795,7 +5790,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Simulate the stale-proc shape: strip :supported_umodes from live state.
       _ = :sys.replace_state(pid, fn state -> Map.delete(state, :supported_umodes) end)
@@ -5851,7 +5846,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#Sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -5881,7 +5876,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#Sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -5917,7 +5912,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Session.send_join({:user, user.id}, network.id, "#alfa,#beta", nil)
 
@@ -5954,7 +5949,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = Session.send_join({:user, user.id}, network.id, "#Alfa,#BETA", nil)
 
@@ -5991,7 +5986,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#random\r\n")
 
@@ -6056,7 +6051,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":someguy!u@h INVITE grappa-test :#random\r\n")
       assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :window_invited}}, 1_000
@@ -6117,7 +6112,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#live\r\n")
       IRCServer.feed(server, "PING :flush\r\n")
@@ -6146,7 +6141,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Operator initiates a JOIN → window goes :pending.
       :ok = Session.send_join({:user, user.id}, network.id, "#pendingchan", nil)
@@ -6181,7 +6176,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       cap = WindowState.invited_cap()
 
@@ -6233,7 +6228,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -6269,7 +6264,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6302,7 +6297,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6369,7 +6364,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "JOIN #sniffo\r\n"), 1_000)
@@ -6404,7 +6399,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6480,7 +6475,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#sniffo-bk", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6514,7 +6509,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Feed 473 BEFORE any send_join — in_flight_joins is empty.
       IRCServer.feed(
@@ -6548,7 +6543,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = Session.send_join({:user, user.id}, network.id, "#registrati", nil)
 
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
@@ -6609,7 +6604,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # No send_join → in_flight_joins is empty.
       IRCServer.feed(server, ":irc.test.org 403 grappa-test #nowhere :No such channel\r\n")
@@ -6636,7 +6631,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       stale_at = System.monotonic_time(:millisecond) - 60_000
 
@@ -6665,7 +6660,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       recent_at = System.monotonic_time(:millisecond) - 5_000
 
@@ -6709,7 +6704,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drive into :joined state via self-JOIN echo, then seed a stale
@@ -6772,7 +6767,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN echo + its `joined` broadcast first.
@@ -6815,7 +6810,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drive into :joined state via self-JOIN echo.
@@ -6873,7 +6868,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -6913,7 +6908,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Drain the self-JOIN broadcast so the mailbox is clean.
@@ -6952,7 +6947,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -7021,7 +7016,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Self-JOIN echo only — no 353/366. SessionStateHelpers.members(state)[#test] exists
@@ -7052,7 +7047,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Self-JOIN, then a 353 with ONLY own_nick, then 366. Since the
@@ -7097,7 +7092,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#one\r\n")
@@ -7127,7 +7122,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#seeded\r\n")
@@ -7222,7 +7217,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok =
                Session.send_topic({:user, user.id}, network.id, "#italia", "new topic")
@@ -7281,7 +7276,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_nick({:user, user.id}, network.id, "vjt-away")
 
@@ -7331,7 +7326,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#newchan\r\n")
 
@@ -7349,7 +7344,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7370,7 +7365,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7389,7 +7384,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7417,7 +7412,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7463,7 +7458,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#existing\r\n")
@@ -7504,7 +7499,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.merge(base_plan, %{notify_pid: parent, notify_ref: ref})
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       assert_receive {:session_ready, ^ref}, 5_000
@@ -7522,7 +7517,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.merge(base_plan, %{notify_pid: parent, notify_ref: ref})
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       assert_receive {:session_ready, ^ref}, 5_000
 
@@ -7537,7 +7532,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       refute_receive {:session_ready, _}, 200
@@ -7568,7 +7563,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.put(base_plan, :connection_stable_ms, 60_000)
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Autojoin JOIN proves 001 was fully processed — record_success, if it
@@ -7602,7 +7597,7 @@ defmodule Grappa.Session.ServerTest do
       plan = Map.put(base_plan, :connection_stable_ms, 500)
       {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       expected_key = {{:user, user.id}, network.id}
@@ -7653,7 +7648,7 @@ defmodule Grappa.Session.ServerTest do
 
       assert network_slug == network.slug
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # "connected" clears the badge the instant 001 lands.
@@ -7677,7 +7672,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7699,7 +7694,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "ChanServ", "REGISTER #x pwd")
@@ -7714,7 +7709,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "nickserv", "IDENTIFY pwd")
@@ -7729,7 +7724,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7759,7 +7754,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7780,7 +7775,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok =
         Phoenix.PubSub.subscribe(
@@ -7801,7 +7796,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       for target <- ["BotServ", "OperServ", "HostServ", "HelpServ", "MemoServ"] do
         assert {:ok, :no_persist} =
@@ -7822,7 +7817,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
@@ -7929,7 +7924,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY old")
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY new")
@@ -7945,7 +7940,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
       send(pid, :pending_auth_timeout)
@@ -7963,7 +7958,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "ChanServ", "REGISTER #x pwd")
 
@@ -7979,7 +7974,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "#italia", "ciao")
 
@@ -7998,7 +7993,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8038,7 +8033,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Drive the identify through the RAW `/quote` path, NOT send_privmsg.
       # `:id` lowercase exercises the Task-1 broadened grammar; the raw
@@ -8077,7 +8072,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:visitor, visitor.id}, network.id, "NickServ", "IDENTIFY wrong")
       send(pid, :pending_auth_timeout)
@@ -8096,7 +8091,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       mode_msg = %Message{
         command: :mode,
@@ -8118,7 +8113,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg({:user, user.id}, network.id, "NickServ", "IDENTIFY s3cret")
       assert match?({"s3cret", _}, SessionStateHelpers.pending_auth(SessionStateHelpers.fetch(pid)))
@@ -8161,7 +8156,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok =
                Session.send_raw(
@@ -8189,7 +8184,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_raw({:user, user.id}, network.id, "WHOIS somebody")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WHOIS somebody\r\n"), 1_000)
@@ -8208,7 +8203,7 @@ defmodule Grappa.Session.ServerTest do
       assert cred.auth_method == :none
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The wizard's REGISTER leaves the wire (wire-only, no scrollback) and
       # stages the untimed registration secret.
@@ -8249,7 +8244,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # A manual NickServ IDENTIFY stages the TIMED pending_auth slot — not a
       # registration. This is #124's territory, not commit-on-+r: the +r must
@@ -8294,7 +8289,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8324,7 +8319,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8360,7 +8355,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8397,7 +8392,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Stage the timed identify slot AND the untimed register slot.
       Session.send_privmsg({:visitor, visitor.id}, network.id, "NickServ", "IDENTIFY identifypass")
@@ -8432,7 +8427,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # A plain identify stages the TIMED slot only — the register slot
       # stays nil (the slots are independent).
@@ -8466,7 +8461,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       Session.send_privmsg(
         {:visitor, visitor.id},
@@ -8507,7 +8502,7 @@ defmodule Grappa.Session.ServerTest do
       original_nick = visitor_nick(visitor)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Services rename us to a Guest — a self-NICK echo (sender == our nick).
       nick_msg = %Message{
@@ -8533,7 +8528,7 @@ defmodule Grappa.Session.ServerTest do
       original_nick = visitor_nick(visitor)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       nick_msg = %Message{
         command: :nick,
@@ -8569,7 +8564,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8598,7 +8593,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8625,7 +8620,7 @@ defmodule Grappa.Session.ServerTest do
       # password) — the only state in which SET PASSWD is meaningful.
       {:ok, _} = Grappa.Visitors.commit_password(visitor.id, network.id, "oldpass")
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8652,7 +8647,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port)
       # Anon visitor: ephemeral (expires_at set), no committed password.
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       refute is_nil(Repo.reload!(visitor).expires_at)
 
       assert {:ok, :no_persist} =
@@ -8682,7 +8677,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg({:user, user.id}, network.id, "NickServ", "SET EMAIL me@x.io")
@@ -8710,7 +8705,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8741,7 +8736,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8767,7 +8762,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Under 5 bytes — CSNS_ERROR_INSECURE_PASSWORD. Services change
       # nothing, so an optimistic commit would desync the credential.
@@ -8792,7 +8787,7 @@ defmodule Grappa.Session.ServerTest do
       # the visitor recovers the account from inside grappa.
       {:ok, _} = Grappa.Visitors.commit_password(visitor.id, network.id, "oldpass")
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert {:ok, :no_persist} =
                Session.send_privmsg(
@@ -8863,7 +8858,7 @@ defmodule Grappa.Session.ServerTest do
       {visitor, network} = visitor_with_network(port, nick: nick)
       pid = start_visitor_session_for(visitor, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, "PING :flush\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
 
@@ -8904,7 +8899,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
       # Wait for autojoin so 001 is fully processed
@@ -8960,7 +8955,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
@@ -9006,7 +9001,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # state.nick == "grappa-test"; "GRAPPA-TEST" folds equal (ascii).
       msg = %Message{
@@ -9032,7 +9027,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: :kill,
@@ -9066,7 +9061,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{command: :kill, params: [], prefix: {:server, "irc.test.org"}, tags: %{}}
       send(pid, {:irc, msg})
@@ -9089,7 +9084,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       ref = Process.monitor(pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # "SASL authentication failed" = upstream rejected SASL credentials permanently.
       msg = %Message{
@@ -9128,7 +9123,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # "SASL authentication aborted" is transient — client/server abort, not wrong password.
       msg = %Message{
@@ -9165,7 +9160,7 @@ defmodule Grappa.Session.ServerTest do
 
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: {:numeric, 904},
@@ -9240,7 +9235,7 @@ defmodule Grappa.Session.ServerTest do
       {:ok, visitor_pid} = Grappa.Session.start_session(visitor_subject, network.id, visitor_plan)
       ref = Process.monitor(visitor_pid)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       msg = %Message{
         command: {:numeric, 465},
@@ -9263,7 +9258,7 @@ defmodule Grappa.Session.ServerTest do
   # Shared helper: boot a session, send 001 + autojoin JOIN-self, then
   # flush to ensure both numerics are processed before tests inspect state.
   defp welcome_session_on_channel(server, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
     # UX-4 bucket A: outbound JOIN line carries the canonical
@@ -9976,7 +9971,7 @@ defmodule Grappa.Session.ServerTest do
       # `ghost_recovery` FSM is armed on the Session.
       capture_log(fn ->
         pid = start_visitor_session_for(visitor, network)
-        :ok = await_handshake(server)
+        :ok = IRCServer.await_handshake(server, 1_000)
 
         {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "NICK #{nick}_\r\n"), 1_000)
 
@@ -10455,7 +10450,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.set_explicit_away({:user, user.id}, network.id, "brb")
@@ -10483,7 +10478,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Credentials.update_away(user.id, network.id, "lunch", since)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # User-visible behaviour: other IRC users must see us away again, so
       # the bouncer re-emits AWAY :lunch to the (fresh, away-forgetting)
@@ -10506,7 +10501,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # GenServer.call returns only after the synchronous persist, so the DB
@@ -10527,7 +10522,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "gone")
@@ -10547,7 +10542,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -10568,7 +10563,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Auto-away held ONLY in memory (never persisted). A same-process
@@ -10595,7 +10590,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "gone")
@@ -10614,7 +10609,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Present state — no explicit away set
@@ -10629,7 +10624,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -10655,7 +10650,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # The session subscribes to Topic.ws_presence(user.name); WSPresence
@@ -10710,7 +10705,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = WSPresence.reset_for_test()
@@ -10768,7 +10763,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10797,7 +10792,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10820,7 +10815,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10849,7 +10844,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # The session booted with the 600s default; the user retunes it
@@ -10878,7 +10873,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       device = visible_device(user)
@@ -10923,7 +10918,7 @@ defmodule Grappa.Session.ServerTest do
         )
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       :ok = WSPresence.reset_for_test()
       device = spawn(fn -> Process.sleep(:infinity) end)
@@ -10945,7 +10940,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Set explicit away first
@@ -10968,7 +10963,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # First set auto
@@ -10989,7 +10984,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_auto_away({:user, user.id}, network.id)
@@ -11008,7 +11003,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       :ok = Session.set_explicit_away({:user, user.id}, network.id, "manual")
@@ -11029,7 +11024,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       assert :ok = Session.unset_auto_away({:user, user.id}, network.id)
@@ -11064,7 +11059,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Subscribe to the user-level PubSub topic before the away round-trip.
@@ -11118,7 +11113,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       user_topic = Topic.user(user.name)
@@ -12405,7 +12400,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_topic_clear({:user, user.id}, network.id, "#test")
 
@@ -12432,7 +12427,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_oper({:user, user.id}, network.id, "vjt", "s3cret")
 
@@ -12453,7 +12448,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Test env sets `config :logger, level: :warning` (config/test.exs)
       # so :info-level logs are filtered globally before any capture
@@ -12576,7 +12571,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       assert :ok = Session.send_raw({:user, user.id}, network.id, "PING :foo.bar")
 
@@ -12621,7 +12616,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 404 vjt #sniffo :Cannot send to channel\r\n")
 
       assert_message_event(
@@ -12657,7 +12652,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 421 vjt BLEH :Unknown command\r\n")
 
       assert_message_event(
@@ -12692,7 +12687,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 401 vjt ghost :No such nick/channel\r\n")
 
       assert_message_event(
@@ -12721,7 +12716,7 @@ defmodule Grappa.Session.ServerTest do
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # /msg ghost hi — the outbound DM opens the server-side query window for
       # ghost (#422 maybe_open_query_window), exactly as compose.ts's /msg does.
@@ -12757,7 +12752,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 372 vjt :- Welcome to TestNet\r\n")
 
       # Exactly one event for this MOTD line.
@@ -12800,7 +12795,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(
         server,
@@ -13022,7 +13017,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # 001 RPL_WELCOME drives the autojoin loop → JOIN #secret upstream.
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
@@ -13050,7 +13045,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#keyed"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #keyed"), 1_000)
       IRCServer.feed(server, ":irc.test 475 grappa-test #keyed :Cannot join channel (+k)\r\n")
@@ -13069,7 +13064,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#bofh"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #bofh"), 1_000)
       # A 473 for a channel never in autojoin (simulates a manual /join fail).
@@ -13085,7 +13080,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#full"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #full"), 1_000)
 
@@ -13104,7 +13099,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #secret"), 1_000)
       IRCServer.feed(server, ":irc.test 473 grappa-test #secret :Cannot join channel (+i)\r\n")
@@ -13129,7 +13124,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test 001 grappa-test :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #secret"), 1_000)
       IRCServer.feed(server, ":irc.test 473 grappa-test #secret :Cannot join channel (+i)\r\n")
@@ -13553,7 +13548,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
 
@@ -13589,7 +13584,7 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       ref = Process.monitor(pid)
       Process.flag(:trap_exit, true)

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -66,11 +66,6 @@ defmodule Grappa.Visitors.LoginTest do
     c
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp login_input(overrides \\ %{}) do
     Map.merge(
       %{
@@ -117,7 +112,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v, token: token}} = Task.await(task, 10_000)
@@ -137,7 +132,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{incognito: true}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -236,7 +231,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: "freshpass"}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       # Case 1 provisions an anon visitor, but a non-nil login password
@@ -274,7 +269,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: ""}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v, token: token}} = Task.await(task, 10_000)
@@ -445,7 +440,7 @@ defmodule Grappa.Visitors.LoginTest do
 
       task = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       # AuthFSM emits `PRIVMSG NickServ :IDENTIFY s3cret` at 001 for the
@@ -506,7 +501,7 @@ defmodule Grappa.Visitors.LoginTest do
       # (live session + :parked row) and the next reboot's Bootstrap
       # parked-skip would silently drop the just-established session.
       task = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, _} = Task.await(task, 10_000)
 
@@ -519,7 +514,7 @@ defmodule Grappa.Visitors.LoginTest do
          %{server: server, network: network, visitor: visitor} do
       # First login spawns the live session for this identity.
       task1 = Task.async(fn -> Login.login(login_input(%{password: "s3cret"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, %{token: first_token}} = Task.await(task1, 10_000)
 
@@ -777,7 +772,7 @@ defmodule Grappa.Visitors.LoginTest do
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: nil}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -792,7 +787,7 @@ defmodule Grappa.Visitors.LoginTest do
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: "not-an-ip"}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
@@ -842,7 +837,7 @@ defmodule Grappa.Visitors.LoginTest do
       #    connects to the fake cleanly). The login carries the trusted client
       #    IP through to record_login_client_source.
       task = Task.async(fn -> Login.login(login_input(%{ip: client_ip}), []) end)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
       assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -198,13 +198,8 @@ defmodule GrappaWeb.GrappaChannelTest do
     cred.nick
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp welcome_session_on_channel(server, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #{channel}"), 1_000)
     IRCServer.feed(server, ":grappa-snap!u@h JOIN :#{channel}\r\n")
@@ -218,7 +213,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # row), so the JOIN is driven explicitly via `Session.send_join/4` rather
   # than waiting for the 001-autojoin loop.
   defp welcome_visitor_on_channel(server, subject, network_id, nick, channel) do
-    :ok = await_handshake(server)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 #{nick} :Welcome\r\n")
     :ok = Session.send_join(subject, network_id, channel, nil)
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN #{channel}"), 1_000)
@@ -541,7 +536,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       {irc_server, port} = start_irc_server()
       {user, network} = setup_user_and_network_with_session(port)
 
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
       {:ok, _} = IRCServer.wait_for_line(irc_server, &String.starts_with?(&1, "JOIN #snap"), 1_000)
 
@@ -844,7 +839,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Seed the watch list BEFORE end-of-MOTD so arm_presence reads it.
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
       IRCServer.feed(irc_server, ":irc.test.org 005 grappa-snap WATCH=128 :are supported\r\n")
       IRCServer.feed(irc_server, ":irc.test.org 376 grappa-snap :End of MOTD\r\n")
@@ -1023,7 +1018,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Registration WITHOUT joining any channel — the deliberate difference
       # from `welcome_session_on_channel/2`, which is the only reason this
       # test does the handshake by hand.
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
 
       IRCServer.feed(
@@ -1703,7 +1698,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "op: visitor socket ships MODE upstream (issue #153 — no visitor gate)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1807,7 +1802,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "topic_set: visitor socket ships TOPIC upstream (issue #153)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1873,7 +1868,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "oper: visitor socket ships OPER upstream (issue #148 — not visitor_not_allowed)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -1998,7 +1993,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "raw: visitor socket ships the line verbatim upstream (issue #153)" do
       {server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
 
       visitor_name = "visitor:#{visitor.id}"
@@ -2408,7 +2403,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: whois with live session sends WHOIS upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2437,7 +2432,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: whois with server emits WHOIS <server> <nick> upstream (#198)" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2495,7 +2490,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # `Session.send_whois/4` is called).
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2525,7 +2520,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "whois with source: rail marks the broadcast bundle source: :rail" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2590,7 +2585,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: away set with live session sends AWAY :reason upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2616,7 +2611,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: away unset after set issues bare AWAY upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2690,7 +2685,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     test "visitor socket: invite with live session sends INVITE nick #chan upstream" do
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2745,7 +2740,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # users do (mirror of the C3 WHOIS malformed-nick test).
       {irc_server, port} = start_irc_server()
       {visitor, network} = setup_visitor_and_network_with_session(port)
-      :ok = await_handshake(irc_server)
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
       flush_server(irc_server)
 
@@ -2788,7 +2783,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       test "visitor socket: #{@verb} with live session sends upstream line" do
         {irc_server, port} = start_irc_server()
         {visitor, network} = setup_visitor_and_network_with_session(port)
-        :ok = await_handshake(irc_server)
+        :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
         flush_server(irc_server)
 
@@ -2845,7 +2840,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       test "visitor socket: #{@verb} with malformed channel returns a validation error" do
         {irc_server, port} = start_irc_server()
         {visitor, network} = setup_visitor_and_network_with_session(port)
-        :ok = await_handshake(irc_server)
+        :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
         flush_server(irc_server)
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -61,11 +61,6 @@ defmodule GrappaWeb.AuthControllerTest do
   defp feed_001(server, nick),
     do: IRCServer.feed(server, ":irc.test.org 001 #{nick} :Welcome\r\n")
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   defp stop_visitor_session(visitor_id, network_id),
     do: :ok = Grappa.Session.stop_session({:visitor, visitor_id}, network_id)
 
@@ -647,7 +642,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt"}) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       result = Task.await(task, 10_000)
@@ -722,7 +717,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt "}) end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       result = Task.await(task, 10_000)
@@ -951,7 +946,7 @@ defmodule GrappaWeb.AuthControllerTest do
           post(conn, "/auth/login", %{"identifier" => "ghost", "incognito" => true})
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "ghost")
 
       resp = Task.await(task, 10_000)
@@ -1060,7 +1055,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1129,7 +1124,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1180,7 +1175,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)
@@ -1228,7 +1223,7 @@ defmodule GrappaWeb.AuthControllerTest do
       _ = credential_fixture(user, network)
 
       pid = start_session_for(user, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       ref = Process.monitor(pid)
 
       {:ok, session} = Accounts.create_session({:user, user.id}, "1.2.3.4", nil, [])
@@ -1270,8 +1265,8 @@ defmodule GrappaWeb.AuthControllerTest do
 
       pid1 = start_session_for(user, network1)
       pid2 = start_session_for(user, network2)
-      :ok = await_handshake(server1)
-      :ok = await_handshake(server2)
+      :ok = IRCServer.await_handshake(server1, 1_000)
+      :ok = IRCServer.await_handshake(server2, 1_000)
       ref1 = Process.monitor(pid1)
       ref2 = Process.monitor(pid2)
 
@@ -1376,7 +1371,7 @@ defmodule GrappaWeb.AuthControllerTest do
           )
         end)
 
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       feed_001(server, "vjt")
 
       {:ok, %{visitor: visitor, token: token}} = Task.await(task, 10_000)

--- a/test/grappa_web/controllers/channels_controller_test.exs
+++ b/test/grappa_web/controllers/channels_controller_test.exs
@@ -52,17 +52,12 @@ defmodule GrappaWeb.ChannelsControllerTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "POST /networks/:network_id/channels" do
     test "with active session sends JOIN upstream and returns 202", %{conn: conn, vjt: vjt} do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -82,7 +77,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -231,7 +226,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -284,7 +279,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -323,7 +318,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo")
 
@@ -385,7 +380,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         delete(
@@ -407,7 +402,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=")
 
@@ -428,7 +423,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-1208-crlf-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#sniffo", "#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         delete(conn, "/networks/#{network.slug}/channels/%23sniffo?reason=bye%0AQUIT+%3Apwn")
@@ -449,7 +444,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       oversize = String.duplicate("a", GrappaWeb.BodyLimit.max_body_bytes() + 1)
 
@@ -483,7 +478,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-bug5a-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa", "#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/channels/%23grappa")
       assert json_response(conn, 202) == %{"ok" => true}
@@ -502,7 +497,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-bug5a-noop-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#other"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # #grappa is NOT in autojoin_channels — DELETE should still succeed and
       # leave the list unchanged.
@@ -530,7 +525,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-m16-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa"]})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Race-synthesis: delete the credential row out from under the
       # request after the session is up. The controller's
@@ -568,7 +563,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed window_state[#unjoined] = :failed (e.g. prior +i JOIN rejection)
       # so the eager wipe has something to clear. Without this seed the
@@ -615,7 +610,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed state.members[#chan] + window_state[#chan]=:joined to mirror a
       # post-JOIN session. The eager-wipe path must clean both even though
@@ -659,7 +654,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {network, _} = network_with_server(port: port, slug: "az-lastjoined-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed two live-joined channels synchronously; last_joined starts empty.
       :sys.replace_state(pid, fn s ->
@@ -810,7 +805,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       slug = "az-topic-#{u()}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -906,7 +901,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -928,7 +923,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -973,7 +968,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed live membership synchronously (dodges the self-JOIN echo race).
       {:ok, cred} = Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
@@ -1019,7 +1014,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()

--- a/test/grappa_web/controllers/invites_controller_test.exs
+++ b/test/grappa_web/controllers/invites_controller_test.exs
@@ -46,11 +46,6 @@ defmodule GrappaWeb.InvitesControllerTest do
 
   defp u, do: System.unique_integer([:positive])
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   # Drive a real inbound INVITE through the parser + EventRouter rather than
   # poking window state directly — the fold that keys the window happens on
   # that ingress path, and a test that bypassed it would pass while the real
@@ -71,7 +66,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       network = setup_network(vjt, port, "azzurra-#{u()}")
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(vjt.name))
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = invite(server, "#random")
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23random")
@@ -96,7 +91,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = invite(server, "#random")
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23RANDOM")
@@ -112,7 +107,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#live\r\n")
       IRCServer.feed(server, "PING :flush\r\n")
@@ -130,7 +125,7 @@ defmodule GrappaWeb.InvitesControllerTest do
       {server, port} = start_server()
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = delete(conn, "/networks/#{network.slug}/invites/%23never")
 

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -51,18 +51,13 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   describe "GET presence filter — #458 member-count (unset) branch" do
     test "unset pref on a LARGE channel (>= threshold members) hides presence via the size default",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Seed the live Session with >= LARGE_CHANNEL_THRESHOLD members so the
       # controller reads the count and an UNSET pref resolves to HIDE. This is
@@ -126,7 +121,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -182,7 +177,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # /ping carol typed in #sniffo: cic POSTs to the SOURCE window (the URL
       # channel_id, #sniffo) with ctcp_target=carol (the wire recipient). The
@@ -221,7 +216,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The wire recipient is validated with validate_post_target_name, which
       # rejects the read-only $server synthetic (a CTCP frame can't target it).
@@ -243,7 +238,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # `/notice carol heads up` typed in #sniffo: cic POSTs to the SOURCE window
       # (the URL channel_id) with notice_target=carol. Mirror of the #640
@@ -277,7 +272,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -297,7 +292,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # `/notice @#sniffo heads up` — the form operators use most, refused as
       # malformed before #1301 because the raw `@#sniffo` matched neither the
@@ -329,7 +324,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The control for the test above. On the plain arm the URL channel is
       # BOTH the wire target and the persist key, so admitting a sigil here
@@ -353,7 +348,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # The W12 carve-out at the DOOR, not just in the session: a fat-fingered
       # `/notice nickserv identify <pass>` must reach the wire and leave nothing
@@ -385,7 +380,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Two relay verbs in one POST is not a shape the client can mean. Refusing
       # it out loud beats letting clause ORDER silently pick a winner.
@@ -408,7 +403,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       handler_id = {__MODULE__, System.unique_integer([:positive])}
       test_pid = self()
@@ -447,7 +442,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn1 =
         conn
@@ -475,7 +470,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn1 =
         conn
@@ -512,7 +507,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -644,7 +639,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -692,7 +687,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # capacity == 3 (test config): three sends ride the burst.
       for n <- 1..3 do
@@ -718,7 +713,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Drain the burst (capacity 3 in test config), then trip the empty bucket.
       for n <- 1..3, do: assert(json_response(post_body(conn, network, "line #{n}"), 201))
@@ -738,12 +733,12 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server1, port1} = start_server()
       net1 = setup_network(vjt, port1, "azzurra")
       pid1 = start_session_for(vjt, net1)
-      :ok = await_handshake(server1)
+      :ok = IRCServer.await_handshake(server1, 1_000)
 
       {server2, port2} = start_server()
       net2 = setup_network(vjt, port2, "second-net")
       pid2 = start_session_for(vjt, net2)
-      :ok = await_handshake(server2)
+      :ok = IRCServer.await_handshake(server2, 1_000)
 
       # Drain net1's bucket entirely (capacity 3 + one throttled).
       for n <- 1..3, do: assert(json_response(post_body(conn, net1, "n1-#{n}"), 201))
@@ -784,7 +779,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+io")
 
       # Sends 4, 5 and 6 are the discriminating ones: under the ordinary
@@ -806,7 +801,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+io")
 
       for n <- 1..6, do: assert(json_response(post_body(conn, network, "oper #{n}"), 201))
@@ -832,7 +827,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       # at source, so the network has to say it is one.
       network = setup_network(vjt, port, "azzurra", :azzurra)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+Fio")
 
       # Well past BOTH ceilings (3 ordinary, 6 oper): there is no upstream
@@ -852,7 +847,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+Fio")
 
       for n <- 1..6, do: assert(json_response(post_body(conn, network, "unclassified #{n}"), 201))
@@ -867,7 +862,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       :ok = feed_umodes(server, "+iw")
 
       for n <- 1..3, do: assert(json_response(post_body(conn, network, "plain #{n}"), 201))
@@ -900,7 +895,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
         )
 
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -932,7 +927,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       {server, port} = start_server()
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -46,11 +46,6 @@ defmodule GrappaWeb.NickControllerTest do
     network
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
-    :ok
-  end
-
   setup %{conn: conn} do
     vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
     session = session_fixture(vjt)
@@ -63,7 +58,7 @@ defmodule GrappaWeb.NickControllerTest do
       slug = "az-nick-#{System.unique_integer([:positive])}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         conn
@@ -134,7 +129,7 @@ defmodule GrappaWeb.NickControllerTest do
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       new_nick = "v9new-#{System.unique_integer([:positive])}"
 
@@ -188,7 +183,7 @@ defmodule GrappaWeb.NickControllerTest do
       _ = visitor_fixture(nick: target_nick, network_slug: network.slug)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       conn =
         Phoenix.ConnTest.build_conn()
@@ -217,7 +212,7 @@ defmodule GrappaWeb.NickControllerTest do
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       # Free in the registry — nothing squats it locally. Upstream is the
       # one that says no.
@@ -269,7 +264,7 @@ defmodule GrappaWeb.NickControllerTest do
       {:ok, _} = Visitors.commit_password(holder.id, network.id, "s3cret")
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = await_handshake(server)
+      :ok = IRCServer.await_handshake(server, 1_000)
       # Snapshot lines after handshake: NICK + USER are emitted at
       # connect-time. Asserting "no NEW NICK line" against a fresh
       # snapshot is the right granularity — `wait_for_line/3` matches

--- a/test/grappa_web/controllers/session_controller_test.exs
+++ b/test/grappa_web/controllers/session_controller_test.exs
@@ -52,11 +52,6 @@ defmodule GrappaWeb.SessionControllerTest do
     port
   end
 
-  defp await_handshake(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 5_000)
-    :ok
-  end
-
   # A registered visitor = identified on some network. #211 phase 7 —
   # `commit_password/3` writes the per-network Cloak-encrypted secret on
   # the `(visitor, network)` credential; "registered/permanent" is DERIVED
@@ -77,7 +72,7 @@ defmodule GrappaWeb.SessionControllerTest do
 
       # The visitor is live on network A.
       _ = start_visitor_session_for(visitor, network_a)
-      :ok = await_handshake(server_a)
+      :ok = IRCServer.await_handshake(server_a, 5_000)
       assert is_pid(Grappa.Session.whereis({:visitor, visitor.id}, network_a.id))
 
       # A SECOND visitor_enabled network B with its own fake upstream.
@@ -340,7 +335,7 @@ defmodule GrappaWeb.SessionControllerTest do
       # #211 phase 7 — anon ⟺ NOT registered (derived from the credentials).
       refute Credentials.visitor_registered?(visitor.id)
       _ = start_visitor_session_for(visitor, network_a)
-      :ok = await_handshake(server_a)
+      :ok = IRCServer.await_handshake(server_a, 5_000)
 
       {server_b, port_b} = start_server()
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -17,7 +17,15 @@ defmodule Grappa.AuthFixtures do
   """
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Grappa.Repo, Grappa.Session, Grappa.Visitors, Grappa.Visitors.Visitor]
+    deps: [
+      Grappa.Accounts,
+      Grappa.Networks,
+      Grappa.Networks.Network,
+      Grappa.Repo,
+      Grappa.Session,
+      Grappa.Visitors,
+      Grappa.Visitors.Visitor
+    ]
 
   alias Grappa.{Accounts, Accounts.Session, Accounts.User, Networks, Repo}
   alias Grappa.Networks.{Credential, Credentials, Network, Server, Servers, SessionPlan}

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -32,6 +32,10 @@ defmodule Grappa.IRCServer do
   on `Process.sleep` constants. Returns `{:ok, matched_line}` or
   `{:error, :timeout}`.
 
+  `await_handshake/2` is the one named barrier built on it: registration
+  is what a session test waits for before it can assert anything, and it
+  used to be re-declared locally in thirteen files (#1397).
+
   Implementation (M-irc-2): the wait is a single GenServer call that
   either replies immediately (the predicate matches some buffered line)
   or registers a `{ref, predicate, from}` waiter on server state and
@@ -120,6 +124,32 @@ defmodule Grappa.IRCServer do
     # of leaving them to time out — the timeout loss-of-signal hid
     # genuine close races behind the same deadline as no-line cases.
     GenServer.call(server, {:wait_for, predicate, timeout}, timeout + 100)
+  end
+
+  @doc """
+  Blocks until the client has sent its `USER` registration line, then
+  returns `:ok`. A miss raises the `MatchError` from the `{:ok, _}`
+  match, which is the failure a test wants to see: the barrier the rest
+  of the test leans on never happened.
+
+  `timeout` carries NO default, deliberately. Commit `84fe0850` removed
+  the default timeout from `wait_for_line/3` under the CLAUDE.md
+  no-default-arguments rule and spelled the value at every call site;
+  the thirteen local copies this replaces (#1397) had re-hidden that
+  same value behind a zero-argument wrapper — eleven at `1_000`, two at
+  `5_000`. A default here restores the silent-degradation path that
+  ruling removed and halves the budget of the two 5s sites by accident.
+  The budget stays where it is decidable: at the call site.
+
+  The predicate keeps the trailing space, the stricter of the two
+  spellings the copies had drifted into. `lib/` sends exactly one line
+  beginning with `USER` and never `USERHOST`, so both spellings select
+  the same line today — the strict one also says so.
+  """
+  @spec await_handshake(pid(), pos_integer()) :: :ok
+  def await_handshake(server, timeout) do
+    {:ok, _} = wait_for_line(server, &String.starts_with?(&1, "USER "), timeout)
+    :ok
   end
 
   ## GenServer


### PR DESCRIPTION
This is a single gate over the content of two open PRs, plus one defect the
union itself uncovered.

## What is in here

* **#1496** — the four `Networks` schemas get their own boundaries, the five
  `dirty_xrefs` waivers retire, and the cycle budget moves to what the
  promotion leaves behind. Six commits. This already contains the whole of
  **#1493** (`#1399` slice A, the seven `Grappa.Accounts` deps that never
  carried an edge): the commit is present here by content, so #1493 is
  superseded rather than merged alongside. Cherry-picking its original commit
  too would apply the same removal twice and invalidate the recomputed budget
  pin.
* **#1498** — `Grappa.IRCServer` gains a handshake barrier with no default
  timeout, the thirteen local `await_handshake` wrappers retire, and 384 call
  sites across fourteen test files spell their timeout explicitly. Four
  commits.

`#1493` is not included. All three PRs stay open; they are superseded by
content, not by reference.

## Why one PR

All three were `CONFLICTING` with zero CI ever run against them. There is no
green to preserve on any side, so there is nothing to sum — the union is
simply the first time this content is gated at all, and gating it once costs
one CI round instead of three sequential rebase-and-retry rounds.

## The precondition, applied

`#1500` landed on `main` after #1498 was branched and added one call in the
old wrapper form, at the far end of a 13k-line file. Git auto-merges that
cleanly — there is no conflict, and the result does not compile, because the
`defp` the call resolves to has been deleted in the same range. The hazard is
the *absence* of a conflict, not a conflict.

The wrapper-retiring commit therefore converts that call too, in the same
commit, at the same `1_000` budget the deleted `defp` supplied. Verified
after the fact: zero old-form calls remain anywhere in `test/` or `lib/`, and
zero `defp await_handshake` survive.

`#1508` also landed in that window and added 86 lines to the same file, but
it added no call sites — the count is unchanged across all three of its
commits, checked both by direct diff and by walking the count over the whole
chain.

## The defect this union found in #1496

`0982fa87` promoted `Grappa.Networks.Network` to its own top-level boundary
and added the declared dep to twelve modules under `lib/` plus
`Grappa.TestSupport.SubjectReset`. It missed `Grappa.AuthFixtures`, the
fourteenth consumer, which references `%Network{}` in four places and
declares a dep on `Grappa.Networks` — the context that used to own the
schema. The test-env compile fails under `--warnings-as-errors`.

The final commit here completes that promotion and adds nothing else. It is
one dep, not four: the sibling schemas promoted in the same series appear in
that file only inside `@spec`, which Boundary does not walk, or not at all.

This escaped review because `test/support/` enters `elixirc_paths` only under
`MIX_ENV=test`, so a dev compile never reads the file — and #1496, being
permanently conflicted, never had a CI run to compile it in test env. It was
found on the first compile of the two branches together, which is the
argument for gating them together.

## Cycle budget

Measured, not assumed: the pinned budget is `0` and the gate reports `0`,
both before and after the added boundary edge. Seven `lib/` files changed on
`main` between #1496's base and this branch's base without opening a cycle,
and the new `AuthFixtures -> Networks.Network` edge does not open one either.
**No budget change in this PR.**

## Verified locally

* forced test-env compile with `--warnings-as-errors`: green
* `boundary_cycle_budget_test.exs`: green, count `0`
* Credo: no issues
* formatter: clean

Everything else is for CI. The full suite has not been run locally.