### PR TITLE
test(#1397): give admin_session and start_server one home each

### DIFF
--- a/test/grappa/bootstrap_test.exs
+++ b/test/grappa/bootstrap_test.exs
@@ -42,11 +42,6 @@ defmodule Grappa.BootstrapTest do
     :ok
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   # Bind a DB credential + server for `(user, slug)` so
   # Session.Server.init can resolve them at boot. `port` is the
   # IRCServer fake's listening port.
@@ -134,8 +129,8 @@ defmodule Grappa.BootstrapTest do
   describe "run/0 with bound credentials" do
     test "spawns one session per Credential row" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port_a} = start_server()
-      {_, port_b} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       net_a = bind_db(vjt, "neta-#{System.unique_integer([:positive])}", port_a)
       net_b = bind_db(vjt, "netb-#{System.unique_integer([:positive])}", port_b)
@@ -151,7 +146,7 @@ defmodule Grappa.BootstrapTest do
 
     test "logs structured summary line with 5-bucket honest counts" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       net = bind_db(vjt, "summary-#{System.unique_integer([:positive])}", port)
 
       on_exit(fn -> stop_session(vjt.id, net.id) end)
@@ -183,7 +178,7 @@ defmodule Grappa.BootstrapTest do
       # "this row didn't run because capacity policy tripped" from
       # "this row tried to connect and the upstream refused."
       vjt = user_fixture(name: "uhl-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       net = bind_db(vjt, "uhl-#{System.unique_integer([:positive])}", port)
 
       {:ok, _} =
@@ -221,7 +216,7 @@ defmodule Grappa.BootstrapTest do
       # Operator saw "DB is empty" lie + chased the wrong root cause.
       # Post-T-4, count_by_state/0 surfaces the truth.
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       net_parked = bind_db(vjt, "park-#{System.unique_integer([:positive])}", port)
       net_failed = bind_db(vjt, "fail-#{System.unique_integer([:positive])}", port)
@@ -266,7 +261,7 @@ defmodule Grappa.BootstrapTest do
       # (distinct from `:capacity_rejected` which is the policy-tripped
       # bucket the legacy `:skipped` also collapsed into).
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       net = bind_db(vjt, "idem-#{System.unique_integer([:positive])}", port)
 
       on_exit(fn -> stop_session(vjt.id, net.id) end)
@@ -327,7 +322,7 @@ defmodule Grappa.BootstrapTest do
       # `(stop) {:connect_failed, _}` from the Session GenServer
       # terminate path).
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port_ok} = start_server()
+      {_, port_ok} = IRCServer.start_server(IRCServer.passthrough_handler())
       # 1 is a privileged port; connect from container as non-root will fail.
       port_bad = 1
 
@@ -353,7 +348,7 @@ defmodule Grappa.BootstrapTest do
 
   describe "run/0 with active visitors" do
     test "spawns Session.Server per active visitor row" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
 
       on_exit(fn -> stop_visitor_session(visitor.id, network.id) end)
@@ -373,7 +368,7 @@ defmodule Grappa.BootstrapTest do
     end
 
     test "registered visitor (password set) respawns alongside anon visitors" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       {:ok, _} = Visitors.commit_password(visitor.id, network.id, "s3cret")
 
@@ -388,10 +383,10 @@ defmodule Grappa.BootstrapTest do
       # A single visitor identity with credentials on TWO networks
       # (post-accretion). Bootstrap must restore BOTH sessions, not just the
       # primary network_slug.
-      {_, port_a} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, net_a} = visitor_with_network(port_a)
 
-      {_, port_b} = start_server()
+      {_, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {net_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
 
       # Accrete B: attach a (visitor_id, net_b) credential to the SAME
@@ -422,10 +417,10 @@ defmodule Grappa.BootstrapTest do
       # (the visitor /disconnected B before the reboot). Bootstrap must
       # restore A but SKIP B — visitor per-network disconnect persists
       # across reboot (vjt: "of course cazzo").
-      {_, port_a} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, net_a} = visitor_with_network(port_a)
 
-      {_, port_b} = start_server()
+      {_, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {net_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
 
       {:ok, rep} = Credentials.representative_visitor_credential(visitor.id)
@@ -486,7 +481,7 @@ defmodule Grappa.BootstrapTest do
     # `Ecto.NoResultsError`), crash-looping Bootstrap into app
     # termination on the boot after the visitor backfill.
     test "backfilled visitor credential is NOT spawned via the user path (no crash)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       # `visitor_with_network` already provisions the visitor's per-network
       # credential (the phase-3 write-through) — the same shape the phase-1
       # backfill migration produced. No manual insert needed.
@@ -504,7 +499,7 @@ defmodule Grappa.BootstrapTest do
     end
 
     test "list_credentials_for_all_users/0 excludes visitor credentials" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       # `visitor_with_network` provisions the visitor's credential.
       {visitor, network} = visitor_with_network(port)
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
@@ -529,7 +524,7 @@ defmodule Grappa.BootstrapTest do
     # slug simply doesn't resolve, no credential is created, and Bootstrap
     # skips the credential-less visitor (logged, non-fatal).
     test "does not raise when a visitor's network is configured" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       on_exit(fn -> stop_visitor_session(visitor.id, network.id) end)
 
@@ -608,7 +603,7 @@ defmodule Grappa.BootstrapTest do
 
     test "does not raise when every referenced network has an enabled server" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       net = bind_db(vjt, "ok-#{System.unique_integer([:positive])}", port)
       on_exit(fn -> stop_session(vjt.id, net.id) end)
 
@@ -623,7 +618,7 @@ defmodule Grappa.BootstrapTest do
     # over-cap rows are skipped + warned. No queue, no retry — clean
     # skip-and-log per the Bootstrap moduledoc's best-effort contract.
     test "respawn skips visitors over network cap" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "azzurra-#{System.unique_integer([:positive])}"
       {:ok, fresh_network} = Networks.find_or_create_network(%{slug: slug})
 
@@ -676,7 +671,7 @@ defmodule Grappa.BootstrapTest do
       # `:skipped` bucket alongside `:already_running` (idempotent
       # no-op); the honest 5-bucket split separates all three so the
       # operator dashboard surfaces the right action per condition.
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "tri-#{System.unique_integer([:positive])}"
       {:ok, fresh_network} = Networks.find_or_create_network(%{slug: slug})
 
@@ -722,7 +717,7 @@ defmodule Grappa.BootstrapTest do
 
     test "installs in_pool vhosts minus overlapping fixed sources, honest log" do
       vjt = user_fixture(name: "pool-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       # Two in_pool vhosts; one of them is ALSO a per-server fixed source
       # → must be excluded from the effective rotation pool (spec §3).
@@ -766,7 +761,7 @@ defmodule Grappa.BootstrapTest do
 
     test "in_pool vhosts with no overlapping fixed source install as-is" do
       vjt = user_fixture(name: "pool-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {:ok, _} = Grappa.Vhosts.create_vhost(%{address: "2a03:4000:2:33c::9000", in_pool: true})
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -23,11 +23,6 @@ defmodule Grappa.IRC.ClientTest do
   alias Grappa.IRC.{AuthFSM, Client, FakeLag, Message}
   alias Grappa.IRCServer
 
-  defp start_server(handler \\ IRCServer.passthrough_handler()) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   # #676 — a realistic 433: the numeric echoes the nick the SERVER rejected,
   # i.e. the one we just sent (an ircd that truncates to its NICKLEN echoes
   # the SHORTENED spelling, which is how the FSM learns the cap). A fake
@@ -156,7 +151,7 @@ defmodule Grappa.IRC.ClientTest do
       # Session.Server can cache it without round-tripping the socket per
       # admin read. The client dialed the in-process IRCServer on
       # 127.0.0.1:<port>, so the pushed peer reflects exactly that.
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       _ = start_client(port)
 
       assert_receive {:irc_peer, {:ok, {{127, 0, 0, 1}, ^port}}}, 1_000
@@ -165,7 +160,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "outbound: client → server" do
     test "send_line/2 writes the raw bytes to the server socket" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_line(client, "PING :foo\r\n")
@@ -180,7 +175,7 @@ defmodule Grappa.IRC.ClientTest do
       # frame concatenated and corrupted the wire. ensure_crlf at the
       # transport boundary makes the helper safe-by-default — every line
       # that hits the socket has CRLF, regardless of caller hygiene.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_line(client, "PING :no-crlf")
@@ -193,7 +188,7 @@ defmodule Grappa.IRC.ClientTest do
       # Some sources (HTTP-derived headers, hand-typed payloads) end with
       # bare \n. IRC framing requires \r\n; the transport boundary fixes
       # the LF→CRLF mismatch instead of writing a malformed frame.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_line(client, "PING :bare-lf\n")
@@ -203,7 +198,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_privmsg/3 emits the canonical PRIVMSG framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_privmsg(client, "#sniffo", "ciao raga")
@@ -213,7 +208,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_join/3 emits JOIN with channel param (no key)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, "#sniffo", nil)
@@ -224,7 +219,7 @@ defmodule Grappa.IRC.ClientTest do
 
     # UX-4 bucket F: +k channel-key support.
     test "send_join/3 emits JOIN with channel + key when key is non-nil" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, "#sniffo", "secret")
@@ -234,7 +229,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_join/3 with empty-string key emits the no-key form" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, "#sniffo", "")
@@ -248,7 +243,7 @@ defmodule Grappa.IRC.ClientTest do
     # `JOIN #a,#b\r\n` (never N looped JOINs). The list clause is the
     # server-side path cic's existing comma-list contract already feeds.
     test "send_join/3 list clause emits ONE JOIN line for a comma list (no key)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, ["#a", "#b", "#c"], nil)
@@ -258,7 +253,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_join/3 list clause emits ONE JOIN line with a single key" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, ["#a", "#b"], "secret")
@@ -268,7 +263,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_join/3 list clause with a single-element list matches the single-channel form" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_join(client, ["#solo"], nil)
@@ -282,7 +277,7 @@ defmodule Grappa.IRC.ClientTest do
     # close, an autojoin drop) passes `nil`, so a stray `PART #chan :` there
     # would be a visible regression on the wire for every one of them.
     test "send_part/3 with a nil reason emits the bare PART form" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_part(client, "#sniffo", nil)
@@ -292,7 +287,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_part/3 emits PART #chan :reason when a reason is given" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_part(client, "#sniffo", "non trovo utili le bestemmie")
@@ -304,7 +299,7 @@ defmodule Grappa.IRC.ClientTest do
     # Mirrors `send_join/3`'s empty-key clause: an empty reason is the
     # ABSENCE of a reason, not `PART #chan :`.
     test "send_part/3 with an empty reason emits the bare PART form" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_part(client, "#sniffo", "")
@@ -317,7 +312,7 @@ defmodule Grappa.IRC.ClientTest do
     # this is the whole point of the colon and the exact case (#1208) that
     # the sigil-less parser used to shred into a phantom channel.
     test "send_part/3 keeps spaces in the reason verbatim behind the colon" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_part(client, "#sniffo", "a  b   c")
@@ -327,7 +322,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_topic/3 emits TOPIC #chan :body framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_topic(client, "#italia", "ciao mondo")
@@ -337,7 +332,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_nick/2 emits NICK new\\r\\n" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -356,7 +351,7 @@ defmodule Grappa.IRC.ClientTest do
     # `Client.send_line(client, "<RAW>\r\n")`.
 
     test "send_kick/4 emits KICK #chan nick :reason framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_kick(client, "#sniffo", "alice", "bad behaviour")
@@ -366,7 +361,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_kick/4 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} =
@@ -374,7 +369,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_kick/4 rejects malformed nick with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} =
@@ -382,7 +377,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_kick/4 rejects CR/LF/NUL in reason with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} =
@@ -390,7 +385,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_invite/3 emits INVITE nick #chan framing (RFC 2812 order)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_invite(client, "#sniffo", "alice")
@@ -400,7 +395,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_invite/3 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} =
@@ -408,7 +403,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_invite/3 rejects malformed nick with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} =
@@ -416,7 +411,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_list_mode/3 emits MODE #chan b framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_list_mode(client, "#sniffo", "b")
@@ -428,7 +423,7 @@ defmodule Grappa.IRC.ClientTest do
     # #1251 — the letter is not `b` any more. `I` also pins that the case is
     # carried verbatim: lowercasing it would query the invite-ONLY flag.
     test "send_list_mode/3 emits the requested letter, case verbatim" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_list_mode(client, "#sniffo", "I")
@@ -438,7 +433,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_list_mode/3 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_list_mode(client, "no-prefix", "b")
@@ -447,7 +442,7 @@ defmodule Grappa.IRC.ClientTest do
     # #1251 — `mode` arrives from a client frame, so the wire builder gates
     # its SHAPE: anything but one ASCII letter could forge MODE arguments.
     test "send_list_mode/3 rejects a multi-token mode (argument forgery)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_list_mode(client, "#sniffo", "b *!*@x")
@@ -456,7 +451,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_channel_modes/2 emits bare MODE #chan query framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_channel_modes(client, "#sniffo")
@@ -466,14 +461,14 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_channel_modes/2 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_channel_modes(client, "no-prefix")
     end
 
     test "send_umode/3 emits MODE nick modes framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_umode(client, "vjt", "+i")
@@ -483,21 +478,21 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_umode/3 rejects malformed nick with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_umode(client, "bad nick", "+i")
     end
 
     test "send_umode/3 rejects CR/LF/NUL in modes with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_umode(client, "vjt", "+i\r\nQUIT")
     end
 
     test "send_umode_query/2 emits bare MODE nick query framing (#229)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_umode_query(client, "vjt")
@@ -507,14 +502,14 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_umode_query/2 rejects malformed nick with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_umode_query(client, "bad nick")
     end
 
     test "send_names/2 emits NAMES #chan framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_names(client, "#sniffo")
@@ -524,7 +519,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_names/2 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_names(client, "no-prefix")
@@ -538,7 +533,7 @@ defmodule Grappa.IRC.ClientTest do
     # extended WHO takes flag ARGS separated by spaces (`+s <server>`), so a
     # space is a legitimate arg separator, not a "splice" to reject.
     test "send_who/2 emits WHO #chan framing (channel target)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_who(client, "#sniffo")
@@ -548,7 +543,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_who/2 emits WHO framing for a host mask (#221)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_who(client, "*!*@*.libera.chat")
@@ -564,7 +559,7 @@ defmodule Grappa.IRC.ClientTest do
     # the first token, so `WHO +s` reached upstream and bahamut answered
     # 522 ERR_WHOSYNTAX (the `s` flag's server arg was NULL).
     test "send_who/2 emits WHO with extended flag args, spaces forwarded (#540)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_who(client, "+s server.azzurra.chat")
@@ -578,7 +573,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_who/2 rejects CRLF/NUL injection with {:error, :invalid_line} (#540)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       # A space is a legitimate WHO arg separator now (#540); only CRLF
@@ -588,7 +583,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_who/2 rejects an empty target with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_who(client, "")
@@ -600,7 +595,7 @@ defmodule Grappa.IRC.ClientTest do
     # target: nil → bare MOTD; a server token → `MOTD <target>`. The gate is
     # safe_oper_token? (single wire token) so injection can't splice a slot.
     test "send_motd/2 with nil emits bare MOTD framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_motd(client, nil)
@@ -610,7 +605,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_motd/2 with a target emits MOTD <target> framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_motd(client, "void.azzurra.chat")
@@ -620,7 +615,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_motd/2 rejects an injection target with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       # A space would splice an extra MOTD wire slot; CRLF would inject a
@@ -636,7 +631,7 @@ defmodule Grappa.IRC.ClientTest do
     # gate applies: a space would splice an extra ADMIN slot, CRLF would
     # inject a follow-up command.
     test "send_admin/2 with nil emits bare ADMIN framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_admin(client, nil)
@@ -646,7 +641,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_admin/2 with a target emits ADMIN <target> framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_admin(client, "void.azzurra.chat")
@@ -656,7 +651,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_admin/2 rejects an injection target with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_admin(client, "srv a")
@@ -672,7 +667,7 @@ defmodule Grappa.IRC.ClientTest do
     # mask/server → `LUSERS <mask> <server>`. Each token is gated by
     # safe_oper_token? (single wire token) so injection can't splice a slot.
     test "send_lusers/3 with nil/nil emits bare LUSERS framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_lusers(client, nil, nil)
@@ -682,7 +677,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_lusers/3 with a mask emits LUSERS <mask> framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_lusers(client, "*.azzurra.org", nil)
@@ -692,7 +687,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_lusers/3 with mask + server emits LUSERS <mask> <server> framing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_lusers(client, "*.azzurra.org", "void.azzurra.chat")
@@ -706,7 +701,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_lusers/3 rejects an injection mask/server with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       # A space would splice an extra LUSERS wire slot; CRLF would inject a
@@ -717,7 +712,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_lusers/3 rejects a server without a mask with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       # LUSERS routes <server> positionally AFTER <mask> (RFC 2812 §3.4.2), so
@@ -726,7 +721,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_topic_clear/2 emits TOPIC #chan : framing (empty trailing param)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_topic_clear(client, "#italia")
@@ -736,7 +731,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_topic_clear/2 rejects malformed channel with {:error, :invalid_line}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       assert {:error, :invalid_line} = Client.send_topic_clear(client, "no-prefix")
@@ -755,7 +750,7 @@ defmodule Grappa.IRC.ClientTest do
     # registry-clear budget. Origin: U-5 CI failure on commit 010054d,
     # run 25975442301, BootstrapTest:506 + class siblings.
     test "send_line/2 returns {:error, :closed} when socket is closed-but-not-nil (no raise)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -794,7 +789,7 @@ defmodule Grappa.IRC.ClientTest do
       # We inject `socket: nil` via `:sys.replace_state` rather than
       # racing connect_failed (which would crash the linked Client
       # before we could send anything).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -816,7 +811,7 @@ defmodule Grappa.IRC.ClientTest do
 
     # Bundle C (#20 follow-up)
     test "send_oper/3 emits OPER <name> <password>\\r\\n" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_oper(client, "vjt", "s3cret")
@@ -826,7 +821,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "send_raw/2 ships the line verbatim with trailing CRLF" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
 
       :ok = Client.send_raw(client, "PING :foo.bar")
@@ -883,7 +878,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "inbound: server → client → dispatch_to" do
     test "single PRIVMSG line dispatched as parsed Message struct" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       _ = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -899,7 +894,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "burst of 50 server lines dispatched in order with no loss (active:once re-arm)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       _ = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -916,7 +911,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "mid-line server write coalesced via OS-level packet:line buffering" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       _ = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -932,7 +927,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "malformed inbound line: parse error is logged, client stays alive" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 
@@ -997,7 +992,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :none" do
     test "sends only NICK + USER; no PASS, no CAP, no IDENTIFY" do
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
       _ = start_client(port, %{auth_method: :none})
 
       assert {:ok, _} =
@@ -1012,7 +1007,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :server_pass" do
     test "sends PASS BEFORE NICK + USER; no CAP" do
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
 
       _ =
         start_client(port, %{
@@ -1038,7 +1033,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :nickserv_identify" do
     test "sends NICK + USER only; the built-in identify moved to Session.Server (#189)" do
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
 
       _ =
         start_client(port, %{
@@ -1068,7 +1063,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :sasl" do
     test "sasl-supported: CAP REQ :sasl + AUTHENTICATE PLAIN + base64 payload + CAP END on 903" do
-      {server, port} = start_server(sasl_handler())
+      {server, port} = IRCServer.start_server(sasl_handler())
 
       _ =
         start_client(port, %{
@@ -1117,7 +1112,7 @@ defmodule Grappa.IRC.ClientTest do
 
     test "sasl-failed: 904 from server crashes the client (let it crash)" do
       {server, port} =
-        start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+        IRCServer.start_server(sasl_handler("904 grappa-test :SASL auth failed"))
 
       Process.flag(:trap_exit, true)
 
@@ -1153,7 +1148,7 @@ defmodule Grappa.IRC.ClientTest do
     # :console` allowlist — the call site and the test would both read
     # correctly while the operator gets nothing.
     test "a 904 failure line carries the mechanism and authzid as metadata (#1169)" do
-      {_, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+      {_, port} = IRCServer.start_server(sasl_handler("904 grappa-test :SASL auth failed"))
 
       Process.flag(:trap_exit, true)
 
@@ -1189,7 +1184,7 @@ defmodule Grappa.IRC.ClientTest do
     # client actually put on the wire and check the first NUL-delimited
     # field is empty, exactly when the breadcrumb claims it is.
     test "the authzid breadcrumb describes the payload the client really sent (#1169)" do
-      {server, port} = start_server(sasl_handler())
+      {server, port} = IRCServer.start_server(sasl_handler())
 
       _ = start_client(port, %{auth_method: :sasl, sasl_user: "vjt", password: "swordfish"})
 
@@ -1244,7 +1239,7 @@ defmodule Grappa.IRC.ClientTest do
     # in `auth_fsm_test.exs`; asserting the number here too would be a
     # second copy of someone else's assertion, failing for their reason.
     test "the 904 line reports the field count of the payload really sent (#1169)" do
-      {server, port} = start_server(sasl_handler("904 grappa-test :SASL auth failed"))
+      {server, port} = IRCServer.start_server(sasl_handler("904 grappa-test :SASL auth failed"))
 
       Process.flag(:trap_exit, true)
 
@@ -1306,7 +1301,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {_, port} = start_server(refuse_mechanism)
+      {_, port} = IRCServer.start_server(refuse_mechanism)
 
       Process.flag(:trap_exit, true)
 
@@ -1337,7 +1332,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :auto" do
     test "sasl-supported: behaves identically to :sasl on a SASL-capable server" do
-      {server, port} = start_server(sasl_handler())
+      {server, port} = IRCServer.start_server(sasl_handler())
 
       _ =
         start_client(port, %{
@@ -1354,7 +1349,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "sasl-not-supported (Bahamut/Azzurra sim): PASS+CAP LS+NICK/USER, server 421s the CAP, registration proceeds" do
-      {server, port} = start_server(bahamut_handler())
+      {server, port} = IRCServer.start_server(bahamut_handler())
 
       # auto + password sends PASS at register-time; server processes
       # PASS and triggers NickServ IDENTIFY internally (the Bahamut
@@ -1388,7 +1383,7 @@ defmodule Grappa.IRC.ClientTest do
       # Server fires 001 immediately on USER (rfc_handler) and IGNORES
       # CAP LS entirely. Without the registered-state transition on 001,
       # the client would sit forever waiting for a CAP LS reply.
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
 
       _ =
         start_client(port, %{
@@ -1428,7 +1423,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {server, port} = start_server(naking_handler)
+      {server, port} = IRCServer.start_server(naking_handler)
       Process.flag(:trap_exit, true)
 
       {:ok, client} =
@@ -1483,7 +1478,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {server, port} = start_server(multi_line_handler)
+      {server, port} = IRCServer.start_server(multi_line_handler)
 
       _ =
         start_client(port, %{
@@ -1528,7 +1523,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {server, port} = start_server(registered_then_spam)
+      {server, port} = IRCServer.start_server(registered_then_spam)
 
       client =
         start_client(port, %{
@@ -1583,7 +1578,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {server, port} = start_server(direct_001_handler)
+      {server, port} = IRCServer.start_server(direct_001_handler)
 
       client =
         start_client(port, %{
@@ -1618,7 +1613,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {server, port} = start_server(retry_handler)
+      {server, port} = IRCServer.start_server(retry_handler)
 
       {:ok, client} = start_collision_client(port)
 
@@ -1642,7 +1637,7 @@ defmodule Grappa.IRC.ClientTest do
         end
       end
 
-      {_, port} = start_server(always_clash)
+      {_, port} = IRCServer.start_server(always_clash)
       Process.flag(:trap_exit, true)
 
       {:ok, client} = start_collision_client(port)
@@ -1661,7 +1656,7 @@ defmodule Grappa.IRC.ClientTest do
     # only the raw send_line/2 escape hatch is unguarded by design (it
     # is the SASL chain's bytes-in/bytes-out contract).
     setup do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       client = start_client(port)
       {:ok, server: server, client: client}
     end
@@ -2006,7 +2001,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "init/1 contract enforcement" do
     test ":sasl without password returns {:error, {:missing_password, :sasl}} via :stop" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       Process.flag(:trap_exit, true)
 
       assert {:error, {:missing_password, :sasl}} =
@@ -2025,7 +2020,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test ":nickserv_identify without password is rejected at boot, NOT mid-001" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       Process.flag(:trap_exit, true)
 
       assert {:error, {:missing_password, :nickserv_identify}} =
@@ -2044,7 +2039,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test ":none with no password is allowed (the only no-secret branch)" do
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
 
       _ =
         start_client(port, %{
@@ -2164,7 +2159,7 @@ defmodule Grappa.IRC.ClientTest do
       # passthrough server: accepts the connection, buffers our PING, never
       # replies. No inbound ever reaches the client → idle fires → self-PING
       # → still no inbound → timeout fires → {:stop, :ping_timeout, _}.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       Process.flag(:trap_exit, true)
 
       client = start_client(port, %{liveness_idle_ms: 100, liveness_timeout_ms: 200})
@@ -2184,7 +2179,7 @@ defmodule Grappa.IRC.ClientTest do
       # so the timeout timer is cancelled before it can fire. The client must
       # survive well past idle+timeout. This is the load-bearing "don't kill a
       # healthy-but-quiet connection" assertion.
-      {server, port} = start_server(liveness_pong_handler())
+      {server, port} = IRCServer.start_server(liveness_pong_handler())
       Process.flag(:trap_exit, true)
 
       client = start_client(port, %{liveness_idle_ms: 100, liveness_timeout_ms: 200})
@@ -2214,7 +2209,7 @@ defmodule Grappa.IRC.ClientTest do
       # Any inbound line proves liveness — a busy channel keeps the socket
       # alive without the client ever needing to self-PING. Server feeds a
       # PRIVMSG every 40ms (< the 100ms idle) so the idle timer never elapses.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       Process.flag(:trap_exit, true)
 
       client = start_client(port, %{liveness_idle_ms: 100, liveness_timeout_ms: 200})
@@ -2513,7 +2508,7 @@ defmodule Grappa.IRC.ClientTest do
       # an under-count is what would kill the fake-lag hypothesis for the
       # wrong reason. The fake server's own tally is the oracle: whatever
       # it received is what the model must have charged for.
-      {server, port} = start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(rfc_handler())
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -23,11 +23,6 @@ defmodule Grappa.Networks.ConnectionStateTest do
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_credential(port, attrs \\ %{}) do
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
@@ -60,7 +55,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
   describe "connect/1" do
     test "transitions :parked → :connected, clears reason, broadcasts" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, fresh} = setup_credential(port)
       cred = set_state(fresh, :parked, "manual")
 
@@ -101,7 +96,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "transitions :failed → :connected, clears reason, broadcasts" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _, fresh} = setup_credential(port)
       cred = set_state(fresh, :failed, "k-line: trial")
 
@@ -123,7 +118,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "idempotent on :connected — returns row unchanged, no broadcast" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _, cred} = setup_credential(port)
       assert cred.connection_state == :connected
       original_changed_at = cred.connection_state_changed_at
@@ -141,7 +136,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
   describe "disconnect/2" do
     test "from :connected with live session: sends QUIT upstream, terminates session, transitions :parked, broadcasts" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, cred} = setup_credential(port)
       assert cred.connection_state == :connected
 
@@ -176,7 +171,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "from :connected with no live session: transitions :parked, broadcasts (best-effort QUIT skipped silently)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _, cred} = setup_credential(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -197,7 +192,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "from :parked: returns {:error, :not_connected} unchanged" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _, fresh} = setup_credential(port)
       cred = set_state(fresh, :parked, "first")
 
@@ -212,7 +207,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "from :failed: returns {:error, :not_connected} unchanged" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {_, _, fresh} = setup_credential(port)
       cred = set_state(fresh, :failed, "k-line: trial")
 
@@ -225,7 +220,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
   describe "mark_failed/2" do
     test "from :connected with live session: terminates session, transitions :failed, broadcasts" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, cred} = setup_credential(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -255,7 +250,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "idempotent on :failed: returns row unchanged, no broadcast" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _, fresh} = setup_credential(port)
       cred = set_state(fresh, :failed, "old reason")
 
@@ -269,7 +264,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
 
     test "rejects from :parked: returns {:error, :user_parked}" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {_, _, fresh} = setup_credential(port)
       cred = set_state(fresh, :parked, "user wants out")
 
@@ -283,7 +278,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
   describe "Credentials.list_credentials_for_all_users/0 — filter on :connected" do
     test "returns only :connected credentials, skips :parked + :failed" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {_, _, cred_connected} = setup_credential(port)
       {_, _, cred_parked} = setup_credential(port)
       {_, _, cred_failed} = setup_credential(port)

--- a/test/grappa/session/directory_ingest_test.exs
+++ b/test/grappa/session/directory_ingest_test.exs
@@ -4,8 +4,8 @@ defmodule Grappa.Session.DirectoryIngestTest do
 
   This file is the boundary claim made falsifiable. It runs `async: true`
   on plain `ExUnit.Case`: no `DataCase`, no Repo, no `Session.Server`, no
-  fake ircd. Its sibling `directory_test.exs` needs all four (240 lines,
-  `async: false`, 25 references to `start_server`/`IRCServer`) because
+  fake ircd. Its sibling `directory_test.exs` needs all four (228 lines,
+  `async: false`, 23 lines naming `start_server`/`IRCServer`) because
   before this extraction the parse / batch / throttle decisions were only
   reachable by booting a GenServer.
 

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -19,11 +19,6 @@ defmodule Grappa.Session.DirectoryTest do
   alias Grappa.{ChannelDirectory, IRCServer, PubSub.Topic, Scrollback, Session}
   alias Grappa.Networks.{Credentials, SessionPlan}
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_user_and_network(port) do
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
@@ -35,7 +30,7 @@ defmodule Grappa.Session.DirectoryTest do
   end
 
   test "refresh issues LIST upstream" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
@@ -48,7 +43,7 @@ defmodule Grappa.Session.DirectoryTest do
   end
 
   test "a second refresh while one is in-flight returns {:error, :already_refreshing}" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
@@ -61,7 +56,7 @@ defmodule Grappa.Session.DirectoryTest do
   end
 
   test "a refresh that never sees 323 times out, clears state, emits directory_failed" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     # `start_session_for/2` resolves the plan and spawns with the boot-time
@@ -107,7 +102,7 @@ defmodule Grappa.Session.DirectoryTest do
   # has never joined. This test is the one that fails on the real wire; the
   # `NumericRouterTest` cases pin the decision itself.
   test "a 322 arriving after the watchdog fired lands on $server, not in the listed channel" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     credential = Credentials.get_credential!(user, network)
@@ -147,7 +142,7 @@ defmodule Grappa.Session.DirectoryTest do
   end
 
   test "a 322/323 burst fills and finalizes the snapshot" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     _ = start_session_for(user, network)
@@ -189,7 +184,7 @@ defmodule Grappa.Session.DirectoryTest do
   end
 
   test "emits at least one directory_progress before completing" do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
     # Inject a 0ms progress throttle so EVERY 322 emits a ping (the default

--- a/test/grappa/session/lifecycle_log_integration_test.exs
+++ b/test/grappa/session/lifecycle_log_integration_test.exs
@@ -42,11 +42,6 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     :ok
   end
 
-  defp start_server(handler) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   defp passthrough, do: fn state, _ -> {:reply, nil, state} end
 
   defp setup_user_and_network(port) do
@@ -60,7 +55,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "connect handshake emits :connected with the composite session_id" do
-    {server, port} = start_server(passthrough())
+    {server, port} = IRCServer.start_server(passthrough())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -74,7 +69,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "001 RPL_WELCOME emits :registered" do
-    {server, port} = start_server(passthrough())
+    {server, port} = IRCServer.start_server(passthrough())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -89,7 +84,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "clean stop emits :disconnected clean=true with a non-negative duration_ms" do
-    {server, port} = start_server(passthrough())
+    {server, port} = IRCServer.start_server(passthrough())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -120,7 +115,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "self-MODE +r after registration emits :identified" do
-    {server, port} = start_server(passthrough())
+    {server, port} = IRCServer.start_server(passthrough())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)

--- a/test/grappa/session/presence_push_test.exs
+++ b/test/grappa/session/presence_push_test.exs
@@ -42,11 +42,6 @@ defmodule Grappa.Session.PresencePushTest do
     {:ok, bypass: bypass, endpoint: "http://localhost:#{bypass.port}/wp"}
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
-    {server, IRCServer.port(server)}
-  end
-
   defp attach_telemetry(events) do
     test_pid = self()
     handler_id = "presence-push-#{System.unique_integer([:positive])}"
@@ -121,7 +116,7 @@ defmodule Grappa.Session.PresencePushTest do
       Plug.Conn.resp(conn, 201, "")
     end)
 
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, subject} = watching_session(port, endpoint, [])
 
     pid = start_session_for(user, network)
@@ -157,7 +152,7 @@ defmodule Grappa.Session.PresencePushTest do
       Plug.Conn.resp(conn, 500, "should-not-happen")
     end)
 
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = watching_session(port, endpoint, ["#pp"])
 
     pid = start_session_for(user, network)
@@ -206,7 +201,7 @@ defmodule Grappa.Session.PresencePushTest do
     attach_telemetry([[:grappa, :push, :send, :start], [:grappa, :push, :send, :stop]])
     Bypass.expect(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
 
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, subject} = watching_session(port, endpoint, ["#pp"])
 
     pid = start_session_for(user, network)

--- a/test/grappa/session/rejoin_snapshot_test.exs
+++ b/test/grappa/session/rejoin_snapshot_test.exs
@@ -25,17 +25,12 @@ defmodule Grappa.Session.RejoinSnapshotTest do
 
   @snapshot ["#a", "#b", "#c"]
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
-    {server, IRCServer.port(server)}
-  end
-
   # A session mid-restore: the credential carries the complete pre-drop
   # snapshot, the three planned JOINs are on the wire, and NOT ONE self-JOIN
   # echo has come back yet. This is the exact state the `Read/Dead Error`
   # wave of 2026-08-16 04:40 interrupted.
   defp restoring_session do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
     {network, _} =

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -74,11 +74,6 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
-  defp start_server(handler \\ IRCServer.passthrough_handler()) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   # See `Grappa.IRC.ClientTest` — same trick. Bind ephemeral, capture,
   # release. The connect attempt that follows refuses fast on localhost
   # because nothing took the port back over in the meantime.
@@ -185,7 +180,7 @@ defmodule Grappa.Session.ServerTest do
         else: {:reply, nil, state}
     end
 
-    {server, port} = start_server(handler)
+    {server, port} = IRCServer.start_server(handler)
 
     {network, _} =
       network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
@@ -241,7 +236,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "injected dependency bundle (#1390)" do
     test "a live session carries the callbacks in one Deps struct" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -251,7 +246,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the ten callback names are gone from the top level of state" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -277,7 +272,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "channel-directory ingest bundle (#1390)" do
     test "a live session carries the directory ingest in one struct, idle" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -287,7 +282,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the four directory names are gone from the top level of state" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -310,7 +305,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "ISUPPORT MODES/LINELEN bundle (#1390)" do
     test "a live session carries both limits inside the capability table" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -326,7 +321,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the two scanner names are gone from the top level of state" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -342,7 +337,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "DB-driven init (sub-task 2g)" do
     test "threads credential password + auth_method to IRC.Client (server_pass branch)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {network, _} = network_with_server(port: port, slug: "azzurra-#{System.unique_integer([:positive])}")
@@ -391,7 +386,7 @@ defmodule Grappa.Session.ServerTest do
       # cached peer reflects exactly that. `await_handshake` blocks until the
       # USER line reaches the server, which the Client sends AFTER pushing
       # `{:irc_peer, _}` — so the peer is in the mailbox before this call.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -415,7 +410,7 @@ defmodule Grappa.Session.ServerTest do
       # IRC traffic. The session dialled the in-process IRCServer on
       # 127.0.0.1:<port> over plain TCP and no +r umode has been observed yet,
       # so tls + registered are both false.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       _ = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -438,7 +433,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -473,7 +468,7 @@ defmodule Grappa.Session.ServerTest do
       # {:connect, _}), so a fake server that has SEEN the USER line proves
       # the message is already in the Session's mailbox — the subsequent
       # GenServer.call is serialised behind it.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       before = DateTime.utc_now()
       _ = start_session_for(user, network)
@@ -509,7 +504,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -544,7 +539,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -577,7 +572,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -610,7 +605,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -691,7 +686,7 @@ defmodule Grappa.Session.ServerTest do
     # `:ignore` semantics, strictly more informative shape.
 
     test "refresh_plan return value overrides stale opts (nick + autojoin)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       # autojoin_channels: [] so the merge result equals last_joined_channels
       # alone — keeps the assertion focused on the fresh-vs-stale axis,
@@ -870,7 +865,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a mode-2 derived source is acquired before connect and registered as a live holder" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       addr = "2a03:4000:20:2d3:cb::a1"
 
@@ -894,7 +889,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the derived source alias is released on stop" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       addr = "2a03:4000:20:2d3:cb::a2"
 
@@ -911,8 +906,8 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "two sessions sharing one derived address bind once, release on the last stop" do
-      {server1, port1} = start_server()
-      {server2, port2} = start_server()
+      {server1, port1} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {server2, port2} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user1, net1, _} = setup_user_and_network(port1)
       {user2, net2, _} = setup_user_and_network(port2)
       addr = "2a03:4000:20:2d3:cb::a3"
@@ -942,7 +937,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a non-derived source never touches the alias manager" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       # managed_source_alias nil → NO ensure_source (no expect set — an
@@ -963,7 +958,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "an acquire failure stops the session loudly (never a shared-source connect)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       addr = "2a03:4000:20:2d3:cb::a4"
 
@@ -995,7 +990,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "registration" do
     test "registers via {user_id, network_id} in Grappa.SessionRegistry" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1004,8 +999,8 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "two sessions with different (user, network) keys coexist" do
-      {_, port1} = start_server()
-      {_, port2} = start_server()
+      {_, port1} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, port2} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       alice = user_fixture(name: "alice-#{System.unique_integer([:positive])}")
@@ -1041,7 +1036,7 @@ defmodule Grappa.Session.ServerTest do
       # happens to coincide. Visitor.SessionPlan + visitor wiring land
       # in Task 7+; this test hand-crafts the visitor opts to isolate
       # the subject-tuple registry behavior at the Session boundary.
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       user_pid = start_session_for(user, network)
 
@@ -1091,7 +1086,7 @@ defmodule Grappa.Session.ServerTest do
     # …) record a failure.
 
     test ":shutdown exit from linked Client does NOT record a Backoff failure" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1131,7 +1126,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test ":normal exit from linked Client does NOT record a Backoff failure" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1164,7 +1159,7 @@ defmodule Grappa.Session.ServerTest do
       # mirrors what tcp_closed / parser-crash would produce in production:
       # the linked Client dies with a non-:normal/:shutdown reason and the
       # session's EXIT clause must still bump Backoff).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1205,7 +1200,7 @@ defmodule Grappa.Session.ServerTest do
     # the abnormal reason → terminate/2 fires with non-`:normal`/`:shutdown`
     # → Backoff.record_failure runs.
     test "non-Client-EXIT crash DOES record a Backoff failure (H12)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1248,7 +1243,7 @@ defmodule Grappa.Session.ServerTest do
     # introduces a clean Client.stop/1 path doesn't trip the silent
     # restart.
     test "clean Client :normal exit does NOT trigger supervisor auto-restart" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1282,7 +1277,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "clean Client :shutdown exit does NOT trigger supervisor auto-restart" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1338,7 +1333,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "every credential-bearing state key is redacted in the status dump" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
@@ -1364,7 +1359,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "absent stays absent — redaction does not invent a secret that was never held" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
@@ -1392,7 +1387,7 @@ defmodule Grappa.Session.ServerTest do
     # shutting down)".
 
     test ":shutdown reason emits a QUIT line upstream before exiting" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1416,7 +1411,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "{:shutdown, reason} variant also emits QUIT" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1444,7 +1439,7 @@ defmodule Grappa.Session.ServerTest do
       # in that case — server would see two QUIT lines for the same
       # session (the second on a half-closed socket would silently
       # drop, but the noise is real).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1486,7 +1481,7 @@ defmodule Grappa.Session.ServerTest do
     for reason <- [:tcp_closed, :ssl_closed] do
       test "terminate(:shutdown) treats a #{inspect(reason)} QUIT-call exit as a no-op, not a crash" do
         reason = unquote(reason)
-        {server, port} = start_server()
+        {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
         {user, network, _} = setup_user_and_network(port)
         pid = start_session_for(user, network)
         :ok = IRCServer.await_handshake(server, 1_000)
@@ -1610,7 +1605,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "stop_session/2 tears down a running Session and clears the registry" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1631,7 +1626,7 @@ defmodule Grappa.Session.ServerTest do
     # the `:transient` restart would loop forever (init can't reload
     # the now-absent credential).
     test "Credentials.unbind_credential/2 tears down the running session" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1646,7 +1641,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "handshake" do
     test "sends NICK + USER on init (auth_method :none, no realname override)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -1661,7 +1656,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "credential :realname overrides nick-based default in USER line" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{nick: "vjt-grappa", realname: "Marcello Barnaba"})
@@ -1677,7 +1672,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "autojoin on 001" do
     test "sends JOIN for each configured channel after server welcome" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#sniffo", "#other"]})
@@ -1697,7 +1692,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "no JOIN sent when credential autojoin_channels empty" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
 
@@ -1728,7 +1723,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "does NOT fire autojoin on 001 — waits for the +r self-MODE echo" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1761,7 +1756,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "fires autojoin on the ~0.5s fallback when no +r ever arrives" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1792,7 +1787,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "deferred autojoin fires EXACTLY once when +r and the timeout race" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1822,7 +1817,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "SASL is unaffected: autojoin still fires immediately on 001 (no +r needed)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{
@@ -1880,7 +1875,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "runs each perform line at 001, then the built-in identify (not consumed)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1917,7 +1912,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "suppresses the built-in identify when the list consumed $nickserv_pass" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1946,7 +1941,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a LITERAL-password identify line does NOT suppress the built-in identify (structural, not a text scan)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -1983,7 +1978,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "runs the perform list before autojoin (autojoin still gated on +r)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2040,7 +2035,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a :server_pass credential does NOT identify — the second secret is gone" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2073,7 +2068,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "the credential password drives the identify, NOT the other secret slot" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2107,7 +2102,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "$nick expands to the CONFIGURED nick, not the nick the session is wearing (#885)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2155,7 +2150,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a perform line consuming $nickserv_pass still suppresses the built-in identify" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2186,7 +2181,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "autojoin fires immediately for :server_pass carrying only the server-PASS slot" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2216,7 +2211,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test ":server_pass with NO nickserv secret still fires autojoin immediately on 001 (unregressed)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
@@ -2261,7 +2256,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "WATCH network: arms the DB list with WATCH +nick lines after 376" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
@@ -2276,7 +2271,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "MONITOR network: arms with MONITOR + comma list (MONITOR wins over WATCH)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo", "Bar"], user.name)
 
@@ -2296,7 +2291,7 @@ defmodule Grappa.Session.ServerTest do
       # WATCH command without listing `WATCH=` in 005 (common bahamut
       # forks). No advertisement therefore probes WATCH instead of
       # skipping the arm.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
@@ -2313,7 +2308,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "421 for the WATCH probe falls back to a MONITOR burst" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
@@ -2331,7 +2326,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "421 for MONITOR too resolves :none — no third attempt, map stays :unknown" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
@@ -2355,7 +2350,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "baseline 604 is initial (no-toast), live 601 flip is a transition" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2393,7 +2388,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "second 376 (explicit /motd) does not re-send the arm burst" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
@@ -2411,7 +2406,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "notify_changed live sync sends WATCH +new / WATCH -old and updates the map" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       {:ok, _} = Grappa.Notify.add({:user, user.id}, network.id, ["Foo"], user.name)
 
@@ -2450,7 +2445,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2482,7 +2477,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "PING/PONG" do
     test "responds to server PING with matching PONG" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -2509,7 +2504,7 @@ defmodule Grappa.Session.ServerTest do
     # inbound PONG has already been fully processed, so the subsequent
     # $server fetch observes its (non-)effect deterministically.
     test "inbound server PONG does NOT persist to $server scrollback (#210)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -2550,7 +2545,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2589,7 +2584,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2620,7 +2615,7 @@ defmodule Grappa.Session.ServerTest do
   # EventRouter's), so they live here, driven end-to-end through IRCServer.
   describe "/links in-flight guard + mask carry (#513)" do
     test "#513a — a mask matching nothing carries the mask on the empty bundle" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -2645,7 +2640,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#513a — a bare (full-mesh) request carries mask nil" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -2669,7 +2664,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#513b — a second /links WHILE one is in flight is refused, first bundle survives" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -2699,7 +2694,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#513b — a 481-denied request (no 365) does NOT brick /links: past the staleness window a fresh request re-sends" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -2758,7 +2753,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "inbound PRIVMSG fires the window_counts push with the row's window ctx" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       pid = start_session_for(user, network)
@@ -2786,7 +2781,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "outbound send_privmsg persists + broadcasts but fires NO window_counts push" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok =
@@ -2819,7 +2814,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "join_failed (473) persists + broadcasts the notice but fires NO window_counts push" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok =
@@ -2862,7 +2857,7 @@ defmodule Grappa.Session.ServerTest do
     # carries `dm_with: nil` and MUST NOT mint a window.
 
     test "inbound PRIVMSG to own nick opens a server-side query window + broadcasts the list" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2900,7 +2895,7 @@ defmodule Grappa.Session.ServerTest do
     # positive half comes first: the row must ARRIVE on the `$server` window.
     # Only then is "no query window" a statement about routing.
     test "#546 inbound peer NOTICE routes to $server and opens NO query window" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -2943,7 +2938,7 @@ defmodule Grappa.Session.ServerTest do
     # "notices go to status" — and it is the arm `open_query_or_server/2`
     # already implemented for services since #400.
     test "#546 inbound peer NOTICE lands in the peer's window when it is already open" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       {:ok, _} = QueryWindows.open({:user, user.id}, network.id, "bob", user.name)
@@ -2984,7 +2979,7 @@ defmodule Grappa.Session.ServerTest do
     # #546 test above records: the row must ARRIVE first, or `refute log =~`
     # is vacuous — it would pass on a session that never processed the line.
     test "#1500 a server NOTICE with an empty trailing persists and logs no error" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok =
@@ -3030,7 +3025,7 @@ defmodule Grappa.Session.ServerTest do
     # about a path #546 does not visit, and nobody should have to re-derive
     # that from the routing table six months from now.
     test "#546 a peer CTCP VERSION query still opens the peer's query window" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -3070,7 +3065,7 @@ defmodule Grappa.Session.ServerTest do
     # second helping while the feed is in flight; `sent + 1` absorbs at
     # most one token of slack should the box be slow enough to cross it.
     test "#1404 a burst of peer CTCP queries is answered under a ceiling, line and row together" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       # The per-channel topic, not the user topic: these rows land at
@@ -3134,7 +3129,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a services PRIVMSG to own nick does NOT open a query window (routes to $server)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -3158,7 +3153,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "outbound DM (send_privmsg to a peer) opens the server-side query window" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       net_id = network.id
 
@@ -3185,7 +3180,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "outbound message to a CHANNEL does NOT open a query window" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       net_id = network.id
 
@@ -3215,7 +3210,7 @@ defmodule Grappa.Session.ServerTest do
     # exactly the class of bug that put the original arm in, and the only thing
     # pinning it is this test.
     test "a sustained DB busy on the auto-open logs + the session survives" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       net_id = network.id
 
@@ -3265,7 +3260,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "PRIVMSG persistence + broadcast" do
     test "persists row and broadcasts canonical wire-shape event on PRIVMSG" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#sniffo")
@@ -3310,7 +3305,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "broadcast scoped per (user, network, channel) — does not leak across channels" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok =
@@ -3329,7 +3324,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "topic discriminator scopes by user_name — bare-slug subscriber gets nothing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok =
@@ -3348,7 +3343,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "server-prefixed PRIVMSG (rare but valid) records server name as sender" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#sniffo")
@@ -3386,7 +3381,7 @@ defmodule Grappa.Session.ServerTest do
     # afterwards and asserting it persists: the session is alive AND still
     # processing the upstream stream (the client never disconnected).
     test "a persist failure keeps the session alive and still processing (#336)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok =
@@ -3452,7 +3447,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(welcomed_handler)
+      {server, port} = IRCServer.start_server(welcomed_handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -3520,7 +3515,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#373 — query window follows a peer NICK change" do
     test "peer NICK migrates the open query window + its DM scrollback old -> new" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
 
@@ -3583,7 +3578,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#1340 K-S2 — the per-conversation MUTE follows the peer NICK too" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
 
@@ -3639,7 +3634,7 @@ defmodule Grappa.Session.ServerTest do
     # 2026-07-19 incident, and the trigger — a netsplit rejoin renaming many
     # peers at once — is precisely the correlated write burst.
     test "a sustained DB busy during a peer rename drops it whole and the session survives" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
       subject = {:user, user.id}
@@ -3720,7 +3715,7 @@ defmodule Grappa.Session.ServerTest do
     # the raise escaped the persister closure into the GenServer. Bootstrap
     # spawning N sessions x M autojoin channels is that write burst.
     test "a sustained DB busy on the rejoin snapshot drops it and the session survives" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -3757,7 +3752,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#948 — the SELF window follows OUR OWN NICK change" do
     test "a self /nick migrates the self window row, its scrollback and its read cursor" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
       subject = {:user, user.id}
@@ -3824,7 +3819,7 @@ defmodule Grappa.Session.ServerTest do
     # bore it before us, and following our rename would file their identity
     # under our new nick. No self rows, no migration, no barrier broadcast.
     test "a self /nick with no self conversation leaves a same-named peer window alone" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
       subject = {:user, user.id}
@@ -3873,7 +3868,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#1340 K-S2 — the self window's MUTE follows our own NICK" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
       subject = {:user, user.id}
@@ -3918,7 +3913,7 @@ defmodule Grappa.Session.ServerTest do
     # standing on that key. Migrating it would silence our new identity on
     # their behalf and un-silence them.
     test "#1340 K-S2 — a self /nick with no self conversation leaves a same-named peer's MUTE alone" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       own = "grappa-test"
       subject = {:user, user.id}
@@ -4022,7 +4017,7 @@ defmodule Grappa.Session.ServerTest do
         [:grappa, :push, :send, :stop]
       ])
 
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       # Credential nick = "vjt" — the per-network IRC nick used as own_nick
       # for the trigger eval (NOT user.name — see CP15 H3 hazard).
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
@@ -4054,7 +4049,7 @@ defmodule Grappa.Session.ServerTest do
 
       attach_push_telemetry([[:grappa, :push, :send, :start]])
 
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       _ = push_subscription_fixture(user, endpoint)
 
@@ -4077,7 +4072,7 @@ defmodule Grappa.Session.ServerTest do
 
       attach_push_telemetry([[:grappa, :push, :send, :stop]])
 
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       _ = push_subscription_fixture(user, endpoint)
 
@@ -4104,7 +4099,7 @@ defmodule Grappa.Session.ServerTest do
 
       attach_push_telemetry([[:grappa, :push, :send, :start]])
 
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       _ = push_subscription_fixture(user, endpoint)
 
@@ -4122,7 +4117,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "non-PRIVMSG events (post-E1: persisted + broadcast via EventRouter)" do
     test "JOIN + PART are persisted to scrollback + broadcast on PubSub" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok =
@@ -4179,7 +4174,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(welcomed_nick_handler)
+      {server, port} = IRCServer.start_server(welcomed_nick_handler)
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#sniffo")
@@ -4218,7 +4213,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -4255,7 +4250,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -4292,7 +4287,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#sniffo")
@@ -4342,7 +4337,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -4399,7 +4394,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -4547,7 +4542,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: @notice_nick})
       pid = start_session_for(user, network)
 
@@ -4723,7 +4718,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -4791,7 +4786,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
 
       topic = Topic.channel(user.name, network.slug, "#test")
@@ -4822,7 +4817,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "malformed inbound" do
     test "parse error logged, session stays alive" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -4843,7 +4838,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "EventRouter delegation — members tracking" do
     test "Session.Server starts with empty members map" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -4862,7 +4857,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -4893,7 +4888,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -4934,7 +4929,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -4982,7 +4977,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#a", "#b"]})
@@ -5017,7 +5012,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "CP15 B1 — :joined window-state event" do
     test "Session.Server starts with empty window_state struct" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -5041,7 +5036,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -5106,7 +5101,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -5137,7 +5132,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -5191,7 +5186,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -5234,7 +5229,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5281,7 +5276,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5312,7 +5307,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5365,7 +5360,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5409,7 +5404,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5434,7 +5429,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5474,7 +5469,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5499,7 +5494,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5541,7 +5536,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5593,7 +5588,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a session with no oper umode is :ordinary" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5612,7 +5607,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "an oper'd session is :oper" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5629,7 +5624,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "an oper with the flavour's no-throttle umode is :exempt" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
       {network, _} =
@@ -5657,7 +5652,7 @@ defmodule Grappa.Session.ServerTest do
       # The exempt letter is per-flavour and only bahamut's was read at
       # source. `setup_user_and_network` leaves services_flavor nil, which
       # is what an operator who never classified the network has.
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5677,7 +5672,7 @@ defmodule Grappa.Session.ServerTest do
       # reload does not rewrite live process state, and the throttle asks
       # this on EVERY send — a KeyError here would crash-wave the sessions
       # under load rather than degrade to today's numbers.
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5692,7 +5687,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "no live session for (subject, network) is :no_session, not a class" do
-      {_, port} = start_server(welcome_handler())
+      {_, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       assert {:error, :no_session} =
@@ -5715,7 +5710,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5758,7 +5753,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5784,7 +5779,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5820,7 +5815,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "CP15 B2 — in_flight_joins map" do
     test "Session.Server starts with empty in_flight_joins map" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -5842,7 +5837,7 @@ defmodule Grappa.Session.ServerTest do
       # becomes `#sniffo` before it ever reaches Session.Server. The
       # in_flight_joins display-value follows suit — there is no
       # mixed-case form to preserve once the boundary has folded.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -5869,7 +5864,7 @@ defmodule Grappa.Session.ServerTest do
       # windowStateByChannel without a parallel client-side state
       # machine. User-topic (NOT per-channel) — chicken-and-egg: cic
       # only joins per-channel after seeing :pending.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5906,7 +5901,7 @@ defmodule Grappa.Session.ServerTest do
       # in_flight_joins entry PER channel, flips window_states[ch] to
       # :pending PER channel, and broadcasts window_pending PER channel on
       # the user-topic so BOTH sidebar rows appear.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5945,7 +5940,7 @@ defmodule Grappa.Session.ServerTest do
       # moved off the facade and the wire stays as-typed — while the
       # in_flight_joins / window_state KEYS are network-folded (ASCII here →
       # `#alfa`/`#beta`), so cic still sees one canonical key per channel.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5980,7 +5975,7 @@ defmodule Grappa.Session.ServerTest do
       #     duplicate was a second place to look for what is already on
       #     screen. Asserting absence here is what keeps it from creeping
       #     back as an "extra effect, harmless" edit.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6045,7 +6040,7 @@ defmodule Grappa.Session.ServerTest do
       # such verb — an implementation that "told the peer" would be inventing
       # protocol. Sampled after a PING/PONG round-trip, so "no line" is a
       # settled observation rather than a race against a slow write.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6108,7 +6103,7 @@ defmodule Grappa.Session.ServerTest do
       # window the operator is actually using. `:joined` is the case that
       # matters: it is the state a just-accepted invite lands in, so a
       # double-click on [Join]-then-× must not evict a live channel.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -6135,7 +6130,7 @@ defmodule Grappa.Session.ServerTest do
       # flip the optimistic :pending tab to a greyed :invited one (nor
       # re-broadcast). The JOIN echo resolves :pending → :joined / :failed;
       # the invite is moot while a join is already in flight.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6170,7 +6165,7 @@ defmodule Grappa.Session.ServerTest do
       # leaves only when the operator joins or declines. So this is the one
       # window state a stranger creates and only the subject clears, which is
       # why it is the one with a top.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6219,7 +6214,7 @@ defmodule Grappa.Session.ServerTest do
       # UX-4 bucket A: `Session.Server.init/1` canonicalises the
       # autojoin list at boot, so the broadcast carries the canonical
       # channel name regardless of the operator's case-as-typed input.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#Sniffo", "#OTHER"]})
@@ -6260,7 +6255,7 @@ defmodule Grappa.Session.ServerTest do
       # user-topic broadcast, so the snapshot can't deliver new info;
       # broadcasting it would also carry a different `kind:` than the
       # user-topic origin). Documented design choice — verified here.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -6290,7 +6285,7 @@ defmodule Grappa.Session.ServerTest do
       # the in-flight window. Skipping just the state mutation +
       # broadcast keeps cic stable while preserving server-side
       # tracking.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6357,7 +6352,7 @@ defmodule Grappa.Session.ServerTest do
       # UX-4 bucket A: `Session.Server.init/1` canonicalises the
       # autojoin list, so both the outbound wire line and the in-flight
       # display value carry the canonical channel form.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#Sniffo", "#OTHER"]})
@@ -6392,7 +6387,7 @@ defmodule Grappa.Session.ServerTest do
       # the persisted notice row as a `kind: :message` event on the
       # per-channel topic. Subscribe to BOTH topics so we can assert each
       # path lands in one cycle for cic to render the failure correctly.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6468,7 +6463,7 @@ defmodule Grappa.Session.ServerTest do
       # dismisses the failed pseudo-row via Sidebar ×. Without this
       # event the pseudo-row would vanish but the archive section
       # would stay empty until manual archive-section toggle.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6502,7 +6497,7 @@ defmodule Grappa.Session.ServerTest do
       # :join_failed, and the router must not delegate it either — it
       # takes the param scan to the channel window (#1345; the sibling
       # test below asserts that landing). The user-topic stays silent (F1).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6536,7 +6531,7 @@ defmodule Grappa.Session.ServerTest do
       # now missing from BOTH the handler guard and the delegated set, so
       # the JOIN produced no effect at all: the window sat at `:pending`
       # forever and cic drew a greyed tab that never resolved.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -6599,7 +6594,7 @@ defmodule Grappa.Session.ServerTest do
       # EventRouter's numeric catch-all → no effect → nothing persisted
       # anywhere: a `/topic #nowhere` 403 answered with silence. Delegating
       # only the correlated occurrence puts it back on the scan route.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -6627,7 +6622,7 @@ defmodule Grappa.Session.ServerTest do
       # dropping any entry whose at_ms is more than 30s behind monotonic
       # now. Avoids Process.sleep(31_000) (too slow) and avoids injecting
       # a clock fn (overkill — we control what's seeded).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -6656,7 +6651,7 @@ defmodule Grappa.Session.ServerTest do
       # Without this, a JOIN issued ~25s before another JOIN would lose
       # its in-flight tracker prematurely and a real failure numeric
       # afterwards would fall through unannotated.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -6697,7 +6692,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6755,7 +6750,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6798,7 +6793,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6856,7 +6851,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6896,7 +6891,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6940,7 +6935,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -6984,7 +6979,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "channel not in members returns :uninitialized (web/S8)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -7009,7 +7004,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -7040,7 +7035,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#empty"]})
@@ -7071,9 +7066,10 @@ defmodule Grappa.Session.ServerTest do
   # `list_members/3` would be one GenServer call per channel at logon, which
   # is exactly the per-window fan-out #396 collapsed. One call, whole map.
   describe "list_member_counts/2" do
-    # The file's default `start_server/0` is a PASSTHROUGH: it never answers
-    # 001, so registration never completes and no JOIN is ever sent. These
-    # tests need the session to actually reach the channels.
+    # `IRCServer.passthrough_handler/0` — what every other case in this file
+    # hands to `start_server/1` — never answers 001, so registration never
+    # completes and no JOIN is ever sent. These tests need the session to
+    # actually reach the channels.
     defp counts_welcome_handler do
       fn state, line ->
         if String.starts_with?(line, "USER ") do
@@ -7085,7 +7081,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "returns the count per SEEDED channel in one call" do
-      {server, port} = start_server(counts_welcome_handler())
+      {server, port} = IRCServer.start_server(counts_welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#one", "#two"]})
@@ -7115,7 +7111,7 @@ defmodule Grappa.Session.ServerTest do
     # twin must OMIT the key, or the caller reads 0 members and shows presence
     # on a channel that is about to turn out to have 900.
     test "omits a channel that has not yet observed 366 (pre-NAMES)" do
-      {server, port} = start_server(counts_welcome_handler())
+      {server, port} = IRCServer.start_server(counts_welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#seeded", "#pending"]})
@@ -7153,7 +7149,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "list_channels via GenServer.call" do
     test "returns Map.keys(SessionStateHelpers.members(state)) sorted alphabetically" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7175,7 +7171,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "returns empty list when SessionStateHelpers.members(state) is empty" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7187,7 +7183,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "Session.list_channels/2 facade" do
     test "returns sorted channel-name list from session state" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7210,7 +7206,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "send_topic/4" do
     test "writes TOPIC upstream; upstream echo persists row + broadcasts (single path, #22)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#italia")
@@ -7273,7 +7269,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "send_nick/3" do
     test "writes NICK upstream" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -7320,7 +7316,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-JOIN broadcasts channels_changed on user topic" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -7336,7 +7332,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-PART broadcasts channels_changed on user topic" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7357,7 +7353,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-KICK broadcasts channels_changed on user topic" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7378,7 +7374,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "other-user JOIN does NOT broadcast (keyset unchanged)" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7406,7 +7402,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "PRIVMSG does NOT broadcast (keyset unchanged)" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7450,7 +7446,7 @@ defmodule Grappa.Session.ServerTest do
     # channels_changed heartbeat emitted right beside it in the cast handler.
 
     test "send_part broadcasts archive_changed on the user topic post-cleanup" do
-      {server, port} = start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7489,7 +7485,7 @@ defmodule Grappa.Session.ServerTest do
     # re-fire to a long-dead login probe.
 
     test "caller receives {:session_ready, ref} on first 001 RPL_WELCOME" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, credential} = setup_user_and_network(port)
 
       parent = self()
@@ -7507,7 +7503,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "notify is one-shot — second 001 does NOT re-fire" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, credential} = setup_user_and_network(port)
 
       parent = self()
@@ -7528,7 +7524,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "no notify opts — Session.Server runs normally without firing" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7549,7 +7545,7 @@ defmodule Grappa.Session.ServerTest do
     # the Session is still alive when it elapses.
 
     test "record_success is DEFERRED — does NOT fire immediately on 001" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, credential} = setup_user_and_network(port)
 
       # Seed a non-zero ladder so a reset would be observable as a count drop.
@@ -7585,7 +7581,7 @@ defmodule Grappa.Session.ServerTest do
           [:grappa, :session, :backoff, :success]
         ])
 
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, credential} = setup_user_and_network(port)
 
       :ok = Backoff.reset({:user, user.id}, network.id)
@@ -7627,7 +7623,7 @@ defmodule Grappa.Session.ServerTest do
     # This is NOT a connection_state DB transition — purely presentational.
 
     test "emits connecting on client-start then connected on 001" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -7668,7 +7664,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "*Serv-targeted PRIVMSG skips scrollback + PubSub (W12 privacy)" do
     test "NickServ target: no row, no broadcast, returns {:ok, :no_persist}" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7690,7 +7686,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "ChanServ target: skipped same as NickServ (suffix-serv rule)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7705,7 +7701,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "case-insensitive: nickserv (lowercase) also skipped" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7720,7 +7716,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "non-*Serv channel target: persists + broadcasts as before" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7750,7 +7746,7 @@ defmodule Grappa.Session.ServerTest do
     # NOT services — services are nicks (PRIVMSG to a channel goes to
     # the room, not a service bot).
     test "channel target #dataserv: persists + broadcasts (NOT misclassified as service)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7771,7 +7767,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "nick target Conserv: persists + broadcasts (NOT misclassified as service)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7792,7 +7788,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "BotServ + OperServ + HostServ + HelpServ + MemoServ also skipped (full allowlist)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7813,7 +7809,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "outbound NickServ verb capture into pending_auth" do
     test "send_privmsg NickServ IDENTIFY stages password + arms timer" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7899,7 +7895,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(handler)
+      {server, port} = IRCServer.start_server(handler)
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       visitor = Grappa.Repo.reload!(anon_visitor)
@@ -7920,7 +7916,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "second IDENTIFY overwrites first (latest-wins via mailbox FIFO, W8)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7936,7 +7932,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test ":pending_auth_timeout discards pending_auth + clears timer" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7954,7 +7950,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "non-NickServ *Serv (e.g. ChanServ REGISTER) does NOT stage pending_auth" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7970,7 +7966,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "non-*Serv channel PRIVMSG does NOT stage pending_auth" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -7989,7 +7985,7 @@ defmodule Grappa.Session.ServerTest do
     alias Grappa.Repo
 
     test "visitor session: send IDENTIFY → simulate +r → password_encrypted set + expires_at cleared" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8029,7 +8025,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a /quote raw NickServ identify line stages pending_auth and commits on +r" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8068,7 +8064,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session: :pending_auth_timeout → no commit, password_encrypted stays nil" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8087,7 +8083,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session: +r without staged pending_auth → no commit" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8109,7 +8105,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "user session with staged pending_auth: +r logs warning + clears state, no commit" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -8152,7 +8148,7 @@ defmodule Grappa.Session.ServerTest do
   # reply) — they must NOT prime the WHO accumulator.
   describe "#540 — raw /quote WHO primes the WHO accumulator" do
     test "a /quote WHO line primes who_pending (keyed by folded args, display raw)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -8180,7 +8176,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a /quote WHOIS line does NOT prime the WHO accumulator" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -8197,7 +8193,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "+r MODE on own nick → USER registration commit (#349)" do
     test "user session: REGISTER stages the secret → +r commits password + flips auth_method" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       # Wizard scenario: a --auth none binding (credential_fixture default).
       {user, network, cred} = setup_user_and_network(port)
       assert cred.auth_method == :none
@@ -8240,7 +8236,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "user session: +r with only pending_auth (no registration) does NOT touch the credential" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -8285,7 +8281,7 @@ defmodule Grappa.Session.ServerTest do
   # persisted unconfirmed, GC'd with the session on terminate.
   describe "register→auth-code +r promotion (#129)" do
     test "NickServ REGISTER stages the untimed slot; no timer; pending_auth_timeout leaves it" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8315,7 +8311,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "REGISTER → +r (no pending_auth) → password committed + expires_at cleared" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8351,7 +8347,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "integration: REGISTER → 10s pending_auth window elapses → later +r → promoted" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8388,7 +8384,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "both slots set on +r → register wins, both cleared" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8423,7 +8419,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "regression: identify fast-path still commits on +r and clears both slots" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8457,7 +8453,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "terminate GCs the untimed slot — unconfirmed REGISTER secret never persists" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8494,7 +8490,7 @@ defmodule Grappa.Session.ServerTest do
   # genuine nick change, so a forced Guest can never carry +r → never binds.
   describe "visitor NICK self-echo — identity protection (#561)" do
     test "IDENTIFIED visitor: a services-forced Guest rename does NOT overwrite the credential nick" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       # NickServ-identified BEFORE connect — a login identity that must
       # survive a force-guest (auth_method :nickserv_identify + password).
@@ -8523,7 +8519,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "ANON visitor: a NICK self-echo still persists (no login identity to protect)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       original_nick = visitor_nick(visitor)
 
@@ -8558,7 +8554,7 @@ defmodule Grappa.Session.ServerTest do
   # Azzurra would accept it, since an optimistic commit has no take-backs.
   describe "in-session SET PASSWD → optimistic commit-on-send (#131, #977)" do
     test "user session: SET PASSWD rotates the bound credential password, no +r needed" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8587,7 +8583,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "#977 user session: a spaced new password is NOT committed — services refuse it" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8614,7 +8610,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session (already identified): SET PASSWD rotates the visitor password, no +r" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       # The visitor is ALREADY NickServ-identified (permanent, has a
       # password) — the only state in which SET PASSWD is meaningful.
@@ -8643,7 +8639,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session (anon, NOT identified): SET PASSWD is a no-op — never pins the row permanent" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       # Anon visitor: ephemeral (expires_at set), no committed password.
       pid = start_visitor_session_for(visitor, network)
@@ -8671,7 +8667,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "regression: SET EMAIL (non-PASSWD SET) is passthrough — no commit, no staging" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8699,7 +8695,7 @@ defmodule Grappa.Session.ServerTest do
   # capture would wait for can never arrive.
   describe "RESETPASS → optimistic commit-on-send (#978)" do
     test "user session: RESETPASS on our own nick stores the THIRD token" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8730,7 +8726,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "user session: RESETPASS on ANOTHER nick leaves our credential alone" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8756,7 +8752,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "user session: a RESETPASS Azzurra would refuse is not committed" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
@@ -8781,7 +8777,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session: RESETPASS rotates the stored visitor secret" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       # The incident shape: grappa holds a secret that no longer works, and
       # the visitor recovers the account from inside grappa.
@@ -8818,7 +8814,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -8854,7 +8850,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {server, port} = start_server(rfc_handler)
+      {server, port} = IRCServer.start_server(rfc_handler)
       {visitor, network} = visitor_with_network(port, nick: nick)
       pid = start_visitor_session_for(visitor, network)
 
@@ -8885,7 +8881,7 @@ defmodule Grappa.Session.ServerTest do
     # is both the correct completion gate AND the behavioural assertion.
 
     test "465 ERR_YOUREBANNEDCREEP: calls mark_failed with k-line reason, session terminates with :normal" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
 
       # Subscribe before starting the session so we don't miss the broadcast
@@ -8946,7 +8942,7 @@ defmodule Grappa.Session.ServerTest do
     # generic delegate (persist $server_event) and the tcp_closed handed the
     # drop to Backoff, which reconnected straight into the just-applied ban.
     test "KILL targeting own nick: marks :failed with 'killed:' reason, session exits :normal" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
 
       topic = Topic.user(user.name)
@@ -8992,7 +8988,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "KILL targeting own nick with different case still terminal (fold match)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.user(user.name)
@@ -9022,7 +9018,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "KILL targeting another nick keeps flowing: session stays alive, DB :connected" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -9056,7 +9052,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "malformed KILL (no params) is non-terminal, session stays alive" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -9075,7 +9071,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "904 with 'SASL authentication failed' (permanent cred error): marks :failed, session exits :normal" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.user(user.name)
@@ -9118,7 +9114,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "904 with 'SASL authentication aborted' (transient): does NOT mark failed, session continues" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -9155,7 +9151,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "904 with 'SASL authentication timed out' (transient): does NOT mark failed" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -9208,7 +9204,7 @@ defmodule Grappa.Session.ServerTest do
       # Visitors have ephemeral credentials — connection_state is irrelevant
       # and there is no credential_failer in the plan. The session simply
       # exits :normal without attempting any DB write.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       visitor_id = Ecto.UUID.generate()
       visitor_subject = {:visitor, visitor_id}
 
@@ -9292,7 +9288,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "S2.3 — topic cache (332/333/331/TOPIC events)" do
     test "332 then 333: cache populated with text + set_by + set_at" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -9348,7 +9344,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "333 before 332 (out-of-order): set_by/set_at stored, text remains nil" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#oot"]})
@@ -9377,7 +9373,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "331 RPL_NOTOPIC: explicit-empty entry stored" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#quiet"]})
@@ -9407,7 +9403,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unsolicited TOPIC: cache updated with server-side timestamp + broadcast" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#live"]})
@@ -9439,7 +9435,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "PART removes topic entry for self-parted channel" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#leavetest"]})
@@ -9464,7 +9460,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_topic/3 returns cached entry" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#get"]})
@@ -9482,7 +9478,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_topic/3 returns :no_topic for uncached channel" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -9498,7 +9494,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "channel-key case-insensitivity: 332 via #FooBar, get via #foobar" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#FooBar"]})
@@ -9521,7 +9517,7 @@ defmodule Grappa.Session.ServerTest do
       # brackets preserved); get_topic MUST read with the SAME fold. A
       # case-variant spelling resolves; the brace twin `#foo{1}` is a
       # DIFFERENT channel to the ircd (#525).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#foo[1]"]})
@@ -9545,7 +9541,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "S2.3 — channel_modes cache (324/MODE events)" do
     test "324 RPL_CHANNELMODEIS: cache populated from server snapshot" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#modes"]})
@@ -9578,7 +9574,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "324 with mode params: key mode stored with param value" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#keyed"]})
@@ -9600,7 +9596,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unsolicited MODE +nt: delta applied to channel_modes cache" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#delta"]})
@@ -9631,7 +9627,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unsolicited MODE -t: delta removes 't' from channel_modes" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#remove"]})
@@ -9658,7 +9654,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "MODE +o user: per-user role update, NO channel_modes_changed broadcast" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#roles"]})
@@ -9694,7 +9690,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "mixed MODE +nt-k: delta correctly applied" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#mixed"]})
@@ -9724,7 +9720,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "PART removes channel_modes entry for self-parted channel" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#leavemodes"]})
@@ -9748,7 +9744,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_channel_modes/3 returns cached entry" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#getmodes"]})
@@ -9769,7 +9765,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_channel_modes/3 returns :no_modes for uncached channel" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -9785,7 +9781,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "channel-key case-insensitivity: 324 via #FooBar, get via #foobar" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#CaseModes"]})
@@ -9877,7 +9873,7 @@ defmodule Grappa.Session.ServerTest do
     test "registered visitor 433 → arms ghost_recovery + emits NICK_ + GHOST + 8s timer" do
       nick = "v_t18_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -9921,7 +9917,7 @@ defmodule Grappa.Session.ServerTest do
     test "#1390 a dropped GhostRecovery line still names the ghost" do
       nick = "v_t18o_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -9956,7 +9952,7 @@ defmodule Grappa.Session.ServerTest do
     test "anon visitor (no cached password) 433 does NOT arm ghost_recovery" do
       nick = "v_t18a_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {visitor, network} = visitor_with_network(port, nick: nick)
 
       # Anon visitor has auth_method :none and no cached password, so
@@ -9993,7 +9989,7 @@ defmodule Grappa.Session.ServerTest do
     test "GhostRecovery success path: NickServ NOTICE → 401 → :succeeded + pending_auth staged + IDENTIFY emitted" do
       nick = "v_t18s_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -10041,7 +10037,7 @@ defmodule Grappa.Session.ServerTest do
     test ":ghost_timeout in :awaiting_ghost_notice clears ghost_recovery + ghost_timer" do
       nick = "v_t18t_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -10070,7 +10066,7 @@ defmodule Grappa.Session.ServerTest do
     # simply never answers. A release wired to one door goes silent on the
     # other, which is the accident #676 exists to prevent.
     defp ghosting_session(nick) do
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       visitor = Grappa.Repo.reload!(anon_visitor)
@@ -10170,7 +10166,7 @@ defmodule Grappa.Session.ServerTest do
     test "non-NickServ NOTICE during :awaiting_ghost_notice does NOT advance the FSM" do
       nick = "v_t18n_#{System.unique_integer([:positive])}"
 
-      {server, port} = start_server(ghost_handler(nick))
+      {server, port} = IRCServer.start_server(ghost_handler(nick))
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
       {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
       registered_visitor = Grappa.Repo.reload!(anon_visitor)
@@ -10210,7 +10206,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "S2.4 — userhost_cache (311 + 352 + Session.lookup_userhost/3)" do
     test "311 RPL_WHOISUSER populates cache, lookup returns :ok entry" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#whoistest"]})
@@ -10233,7 +10229,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "352 RPL_WHOREPLY populates cache, lookup returns :ok entry" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#whotest"]})
@@ -10256,7 +10252,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "JOIN with user@host in prefix populates cache" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#joincache"]})
@@ -10275,7 +10271,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "lookup_userhost/3 is case-insensitive for nick key" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#casetest"]})
@@ -10301,7 +10297,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "lookup_userhost/3 returns :not_cached for unknown nick" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10317,7 +10313,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "QUIT evicts the nick from userhost_cache" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#quitevict"]})
@@ -10346,7 +10342,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "NICK renames cache entry preserving user+host" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#nickrename"]})
@@ -10417,7 +10413,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      start_server(handler)
+      IRCServer.start_server(handler)
     end
 
     # Condition-poll until at least `want` sent lines match `pred`, or the
@@ -12397,7 +12393,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "send_topic_clear/3" do
     test "sends TOPIC #chan : (empty trailing) upstream" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -12424,7 +12420,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "send_oper/4" do
     test "writes OPER <name> <password> upstream" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -12445,7 +12441,7 @@ defmodule Grappa.Session.ServerTest do
     # `#{password}` interpolation OR swaps the positional args, this
     # sentinel catches it before ship.
     test "logs OPER submission with redacted password (no interpolation of secret)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -12488,7 +12484,7 @@ defmodule Grappa.Session.ServerTest do
     # secret reaches no sink and the session does not die for having been
     # asked to oper while reconnecting.
     test "an OPER submitted in the Backoff respawn window leaks nothing and does not kill the session" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       subject = {:user, user.id}
       sentinel = "sentinel-oper-pw-961"
@@ -12568,7 +12564,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "send_raw/3" do
     test "ships the raw IRC line verbatim with trailing CRLF" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -12609,7 +12605,7 @@ defmodule Grappa.Session.ServerTest do
     # event; CP13 makes it durable + replayable.
 
     test "404 ERR_CANNOTSENDTOCHAN persists on the channel with severity :error" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "#sniffo")
@@ -12645,7 +12641,7 @@ defmodule Grappa.Session.ServerTest do
       # 421 is in @active_numerics → routes to {:server, nil} regardless of
       # params (BLEH-as-nick problem). Chosen over 432/433/437 because the
       # latter trigger the AuthFSM's nick-rejection path mid-handshake.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "$server")
@@ -12680,7 +12676,7 @@ defmodule Grappa.Session.ServerTest do
       # is part of the #640 fix, not a weakening (CLAUDE.md "Never assert buggy
       # behavior"). The OPEN-window counterpart is the very next test — the two
       # together pin both arms of the gate.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "$server")
@@ -12712,7 +12708,7 @@ defmodule Grappa.Session.ServerTest do
       # "ghost"}. Server twin of the cp13-s5-msg-ghost-401 e2e; the
       # falsification companion to the no-window test above — the gate must
       # route to the window when it exists, never blanket-redirect.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -12745,7 +12741,7 @@ defmodule Grappa.Session.ServerTest do
     test "delegated numeric (372 MOTD) does NOT double-persist via the routing path" do
       # 372 is :delegated → existing MOTD handler in EventRouter persists it.
       # If the new routing path also persisted, we'd get two rows on $server.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "$server")
@@ -12788,7 +12784,7 @@ defmodule Grappa.Session.ServerTest do
       # `meta.raw_params`, mirroring EventRouter's `persist_raw_event/3`, so cic
       # can render the whole reply. This is the CLASS fix (every middle-param
       # numeric), not just the STATS example.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
 
       topic = Topic.channel(user.name, network.slug, "$server")
@@ -13014,7 +13010,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "autojoin +i/+k recovery via ChanServ INVITE (#116)" do
     test "473 on an autojoin channel sends PRIVMSG ChanServ :INVITE + marks awaiting_invite" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13042,7 +13038,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "475 (+k) on an autojoin channel also sends ChanServ INVITE" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#keyed"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13061,7 +13057,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "473 on a NON-autojoin (manual-shape) channel does NOT invite" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#bofh"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13077,7 +13073,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "non-invitable numerics (471/474/403/405) do NOT invite even for an autojoin channel" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#full"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13096,7 +13092,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "dedupe — a second 473 for the same channel does not re-invite" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13121,7 +13117,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "inbound ChanServ INVITE for an awaiting channel re-JOINs keyless" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#secret"]})
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13157,7 +13153,7 @@ defmodule Grappa.Session.ServerTest do
   # to recover (auth_method :none sends no built-in identify without a 001).
   describe "recover_identity (#581) — server integration" do
     test "a user subject is refused with :not_visitor" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -13545,7 +13541,7 @@ defmodule Grappa.Session.ServerTest do
       # #1338 a second tuple published by `Grappa.UserSettings` reached 40
       # clauses and no catch-all: FunctionClauseError, supervisor restart,
       # and the user's IRC connection dropped by an unrelated context.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -13581,7 +13577,7 @@ defmodule Grappa.Session.ServerTest do
       # rebuilds it. Green before #1338 (FunctionClauseError) and after
       # (an explicit `{:stop, reason, state}`): the mutant it kills is a
       # catch-all placed ahead of the EXIT class.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)

--- a/test/grappa/spawn_orchestrator_test.exs
+++ b/test/grappa/spawn_orchestrator_test.exs
@@ -40,11 +40,6 @@ defmodule Grappa.SpawnOrchestratorTest do
     :ok
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_credential(user, slug, port, opts \\ %{}) do
     {:ok, base_network} = Networks.find_or_create_network(%{slug: slug})
     {:ok, _} = Servers.add_server(base_network, %{host: "127.0.0.1", port: port, tls: false})
@@ -178,7 +173,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "spawn/4 happy path" do
     test "admission ok + fresh session — returns {:ok, :spawned, pid}" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "happy-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -203,7 +198,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "spawn/4 idempotency" do
     test "second call against live session returns {:ok, :already_started, pid}" do
       vjt = user_fixture(name: "idempot-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "idempot-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -223,7 +218,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "spawn/4 operator-delete fail-fast" do
     test "refresh_plan returning {:error, :not_found} → {:ok, :ignored}, no session spawned" do
       vjt = user_fixture(name: "ignored-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "ignored-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -252,7 +247,7 @@ defmodule Grappa.SpawnOrchestratorTest do
     test "user_cap_exceeded — returns {:error, :user_cap_exceeded}, no session spawned" do
       vjt_a = user_fixture(name: "capa-#{System.unique_integer([:positive])}")
       vjt_b = user_fixture(name: "capb-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "cap-#{System.unique_integer([:positive])}"
 
       {network, plan_a} = setup_credential(vjt_a, slug, port, %{max_concurrent_user_sessions: 1})
@@ -291,7 +286,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "spawn/4 idempotent connect against a network at its cap (#1147)" do
     test "already-live subject keeps its session and records no capacity reject" do
       vjt = user_fixture(name: "idemcap-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "idemcap-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port, %{max_concurrent_user_sessions: 1})
       :ok = clear_registry_for(network.id)
@@ -317,7 +312,7 @@ defmodule Grappa.SpawnOrchestratorTest do
     test "subject with no live session still gets the capacity error, and it IS recorded" do
       vjt_a = user_fixture(name: "capgate-a-#{System.unique_integer([:positive])}")
       vjt_b = user_fixture(name: "capgate-b-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "capgate-#{System.unique_integer([:positive])}"
 
       {network, plan_a} = setup_credential(vjt_a, slug, port, %{max_concurrent_user_sessions: 1})
@@ -359,7 +354,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "spawn/4 backoff reset semantics (M-life-5)" do
     test "successful admission clears prior Backoff failure history before spawn" do
       vjt = user_fixture(name: "bo-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "bo-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -392,7 +387,7 @@ defmodule Grappa.SpawnOrchestratorTest do
     test "rejected admission does NOT reset Backoff (no operator action took effect)" do
       vjt_a = user_fixture(name: "bo-noreset-#{System.unique_integer([:positive])}")
       vjt_b = user_fixture(name: "bo-noreset-b-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "boreject-#{System.unique_integer([:positive])}"
 
       {network, plan_a} = setup_credential(vjt_a, slug, port, %{max_concurrent_user_sessions: 1})
@@ -439,7 +434,7 @@ defmodule Grappa.SpawnOrchestratorTest do
   describe "reconnect/5 bounce semantics" do
     test "tears down the LIVE session and respawns a FRESH pid (never :already_started)" do
       vjt = user_fixture(name: "bounce-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "bounce-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -469,7 +464,7 @@ defmodule Grappa.SpawnOrchestratorTest do
 
     test "no live session — stop is a no-op, then spawns fresh {:ok, :spawned, pid}" do
       vjt = user_fixture(name: "recon-nolive-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "recon-nolive-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)
@@ -496,7 +491,7 @@ defmodule Grappa.SpawnOrchestratorTest do
     test "admission rejection propagates — {:error, :user_cap_exceeded}, no session spawned" do
       vjt_a = user_fixture(name: "recon-capa-#{System.unique_integer([:positive])}")
       vjt_b = user_fixture(name: "recon-capb-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "recon-cap-#{System.unique_integer([:positive])}"
 
       {network, plan_a} = setup_credential(vjt_a, slug, port, %{max_concurrent_user_sessions: 1})
@@ -529,7 +524,7 @@ defmodule Grappa.SpawnOrchestratorTest do
 
     test "successful reconnect clears prior Backoff failure history (single reset, no double)" do
       vjt = user_fixture(name: "recon-bo-#{System.unique_integer([:positive])}")
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "recon-bo-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
       :ok = clear_registry_for(network.id)

--- a/test/grappa/visitors/autoconnect_test.exs
+++ b/test/grappa/visitors/autoconnect_test.exs
@@ -21,15 +21,10 @@ defmodule Grappa.Visitors.AutoconnectTest do
     :ok
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
-    {server, IRCServer.port(server)}
-  end
-
   # A visitor identity already live on `anchor` (an autoconnect network),
   # mirroring the post-login anchor state. Returns {visitor, anchor}.
   defp visitor_on_anchor do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {visitor, anchor} = visitor_with_network(port)
     {:ok, _} = Networks.update_network_settings(anchor, %{visitor_enabled: true, visitor_autoconnect: true})
     _ = start_visitor_session_for(visitor, anchor)
@@ -40,7 +35,7 @@ defmodule Grappa.Visitors.AutoconnectTest do
   test "spawns each visitor_autoconnect network minus the anchor" do
     {visitor, anchor} = visitor_on_anchor()
 
-    {server_b, port_b} = start_server()
+    {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
 
     {:ok, net_b} =
       Networks.create_network(%{slug: "b-auto", visitor_enabled: true, visitor_autoconnect: true})
@@ -60,7 +55,7 @@ defmodule Grappa.Visitors.AutoconnectTest do
   test "a PARKED autoconnect network stays parked (not respawned)" do
     {visitor, anchor} = visitor_on_anchor()
 
-    {_, port_b} = start_server()
+    {_, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
 
     {:ok, net_b} =
       Networks.create_network(%{slug: "b-parked", visitor_enabled: true, visitor_autoconnect: true})

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -38,11 +38,6 @@ defmodule Grappa.Visitors.LoginTest do
     :ok
   end
 
-  defp start_server(handler \\ IRCServer.passthrough_handler()) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   defp pick_unused_port do
     {:ok, l} = :gen_tcp.listen(0, [])
     {:ok, port} = :inet.port(l)
@@ -107,7 +102,7 @@ defmodule Grappa.Visitors.LoginTest do
 
   describe "case 1 — no visitor row (anon provisioning)" do
     test "spawns session, awaits 001, creates accounts_session, returns {:ok, %{visitor, token}}" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(), []) end)
@@ -127,7 +122,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "#363 incognito login provisions the visitor with incognito=true + a ~1h linger TTL" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{incognito: true}), []) end)
@@ -144,7 +139,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "fresh-nick login with ident + realname persists them and emits them in USER (#152)" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =
@@ -170,7 +165,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "malformed login-Advanced ident → :malformed_ident AND purges the fresh anon row (#152)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       # An 11-char ident fails the shape guard. The fresh anon row provisioned
@@ -186,7 +181,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "a full threshold of malformed-ident logins leaves the circuit closed (#960)" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       # The circuit is a fail-fast signal about the UPSTREAM's health, and its
@@ -226,7 +221,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "fresh-nick login with a password identifies via :nickserv_identify at 001" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{password: "freshpass"}), []) end)
@@ -264,7 +259,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "fresh-nick login with an EMPTY password stays anon — NO IDENTIFY on the wire" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{password: ""}), []) end)
@@ -337,7 +332,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "no 001 within budget → {:error, :welcome_timeout}, session torn down + anon row purged" do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       # U-2 (UD7): timeout split into :connect_timeout (TCP/TLS) +
@@ -369,7 +364,7 @@ defmodule Grappa.Visitors.LoginTest do
         end
       end
 
-      {_, port} = start_server(collide_once)
+      {_, port} = IRCServer.start_server(collide_once)
       {network, _} = setup_visitor_network(port)
 
       assert {:ok, %{visitor: visitor}} = Login.login(login_input(), [])
@@ -392,7 +387,7 @@ defmodule Grappa.Visitors.LoginTest do
         end
       end
 
-      {_, port} = start_server(always_clash)
+      {_, port} = IRCServer.start_server(always_clash)
       {network, _} = setup_visitor_network(port)
 
       assert {:error, :nick_in_use} = Login.login(login_input(), [])
@@ -413,7 +408,7 @@ defmodule Grappa.Visitors.LoginTest do
 
   describe "case 2 — registered visitor (password gate)" do
     setup do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       {:ok, anon} = Visitors.find_or_provision_anon("vjt", "azzurra", "1.2.3.4")
@@ -547,7 +542,7 @@ defmodule Grappa.Visitors.LoginTest do
   # drives case-2 (registered) dispatch.
   describe "case dispatch reads the Credential secret (#211 phase 7)" do
     setup do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
       {:ok, anon} = Visitors.find_or_provision_anon("vjt", "azzurra", "1.2.3.4")
 
@@ -572,7 +567,7 @@ defmodule Grappa.Visitors.LoginTest do
 
   describe "case 3 — anon collision (token gate)" do
     setup do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       {:ok, visitor} = Visitors.find_or_provision_anon("vjt", "azzurra", "1.2.3.4")
@@ -768,7 +763,7 @@ defmodule Grappa.Visitors.LoginTest do
   # crashes → RED.
   describe "#647 — client-source capture at login is best-effort" do
     test "a login with an absent (nil) ip still succeeds — no sample taken" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: nil}), []) end)
@@ -783,7 +778,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "a login with an unparseable ip still succeeds — no sample taken" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> Login.login(login_input(%{ip: "not-an-ip"}), []) end)
@@ -827,7 +822,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "a fresh visitor login lets the mode-2 plan resolve a derived source, not a hold" do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
       client_ip = "2001:db8:1:2:3:4:5:6"
       {:ok, ip_tuple} = :inet.parse_address(String.to_charlist(client_ip))

--- a/test/grappa_web/controllers/admin/circuit_controller_test.exs
+++ b/test/grappa_web/controllers/admin/circuit_controller_test.exs
@@ -21,18 +21,12 @@ defmodule GrappaWeb.Admin.CircuitControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdmissionStateHelpers, Networks}
   alias Grappa.Admission.NetworkCircuit
+  alias Grappa.{AdmissionStateHelpers, Networks}
 
   setup do
     AdmissionStateHelpers.reset_network_circuit()
     :ok
-  end
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
   end
 
   describe "POST /admin/circuit/:network_id/reset — auth gate" do

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -33,12 +33,6 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
     :ok
   end
 
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
-
   defp bound_credential do
     user = user_fixture(name: "u-#{System.unique_integer([:positive])}")
     {:ok, network} = Networks.find_or_create_network(%{slug: "n-#{System.unique_integer([:positive])}"})

--- a/test/grappa_web/controllers/admin/db_latency_controller_test.exs
+++ b/test/grappa_web/controllers/admin/db_latency_controller_test.exs
@@ -13,19 +13,13 @@ defmodule GrappaWeb.Admin.DbLatencyControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, DbLatency}
+  alias Grappa.DbLatency
 
   @handler_id "grappa-db-latency"
 
   setup do
     :ok = DbLatency.reset()
     :ok
-  end
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
   end
 
   describe "GET /admin/db_latency — auth gate" do

--- a/test/grappa_web/controllers/admin/featured_channels_controller_test.exs
+++ b/test/grappa_web/controllers/admin/featured_channels_controller_test.exs
@@ -3,14 +3,8 @@ defmodule GrappaWeb.Admin.FeaturedChannelsControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, Networks}
+  alias Grappa.Networks
   alias Grappa.Networks.FeaturedChannels
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
 
   defp fresh_network do
     {:ok, net} =

--- a/test/grappa_web/controllers/admin/networks_controller_test.exs
+++ b/test/grappa_web/controllers/admin/networks_controller_test.exs
@@ -41,12 +41,6 @@ defmodule GrappaWeb.Admin.NetworksControllerTest do
     :ok
   end
 
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
-
   describe "GET /admin/networks — auth gate" do
     test "no bearer returns 401 (Authn upstream)", %{conn: conn} do
       conn = get(conn, "/admin/networks")

--- a/test/grappa_web/controllers/admin/overview_controller_test.exs
+++ b/test/grappa_web/controllers/admin/overview_controller_test.exs
@@ -11,17 +11,11 @@ defmodule GrappaWeb.Admin.OverviewControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdmissionStateHelpers}
+  alias Grappa.AdmissionStateHelpers
 
   setup do
     AdmissionStateHelpers.reset_all()
     :ok
-  end
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
   end
 
   describe "GET /admin/overview — auth gate" do

--- a/test/grappa_web/controllers/admin/reaper_controller_test.exs
+++ b/test/grappa_web/controllers/admin/reaper_controller_test.exs
@@ -16,14 +16,7 @@ defmodule GrappaWeb.Admin.ReaperControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Accounts
   alias Grappa.Visitors.Visitor
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
 
   describe "POST /admin/reaper/run — auth gate" do
     test "no bearer returns 401", %{conn: conn} do

--- a/test/grappa_web/controllers/admin/servers_controller_test.exs
+++ b/test/grappa_web/controllers/admin/servers_controller_test.exs
@@ -20,16 +20,10 @@ defmodule GrappaWeb.Admin.ServersControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, Networks}
   alias Grappa.Net.HostAddresses
+  alias Grappa.Networks
   alias Grappa.Networks.Servers
   alias Grappa.PubSub.Topic
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
 
   defp fresh_network do
     {:ok, net} = Networks.find_or_create_network(%{slug: "srv-c-#{System.unique_integer([:positive])}"})

--- a/test/grappa_web/controllers/admin/session_log_controller_test.exs
+++ b/test/grappa_web/controllers/admin/session_log_controller_test.exs
@@ -12,14 +12,8 @@ defmodule GrappaWeb.Admin.SessionLogControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, Repo}
+  alias Grappa.Repo
   alias Grappa.SessionLog.Event
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
 
   defp insert_event(attrs) do
     defaults = %{

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -49,12 +49,6 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     {server, Grappa.IRCServer.port(server)}
   end
 
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
-
   describe "GET /admin/sessions — auth gate" do
     test "no bearer returns 401 (Authn upstream)", %{conn: conn} do
       conn = get(conn, "/admin/sessions")

--- a/test/grappa_web/controllers/admin/users_controller_test.exs
+++ b/test/grappa_web/controllers/admin/users_controller_test.exs
@@ -39,12 +39,6 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
     :ok
   end
 
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
-
   describe "GET /admin/users — auth gate" do
     test "no bearer returns 401 (Authn upstream)", %{conn: conn} do
       conn = get(conn, "/admin/users")

--- a/test/grappa_web/controllers/admin/vhosts_controller_test.exs
+++ b/test/grappa_web/controllers/admin/vhosts_controller_test.exs
@@ -12,14 +12,8 @@ defmodule GrappaWeb.Admin.VhostsControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, Networks.Credentials, ServerSettings, Vhosts}
   alias Grappa.Net.HostAddresses
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
+  alias Grappa.{Networks.Credentials, ServerSettings, Vhosts}
 
   defp addr do
     n = Bitwise.band(System.unique_integer([:positive]), 0xFFFF)

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -48,12 +48,6 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
     {server, Grappa.IRCServer.port(server)}
   end
 
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
-  end
-
   describe "DELETE /admin/visitors/:id — auth gate" do
     test "no bearer returns 401 (Authn upstream)", %{conn: conn} do
       conn = delete(conn, "/admin/visitors/#{Ecto.UUID.generate()}")

--- a/test/grappa_web/controllers/admin/ws_presence_controller_test.exs
+++ b/test/grappa_web/controllers/admin/ws_presence_controller_test.exs
@@ -15,17 +15,11 @@ defmodule GrappaWeb.Admin.WSPresenceControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, WSPresence}
+  alias Grappa.WSPresence
 
   setup do
     :ok = WSPresence.reset_for_test()
     :ok
-  end
-
-  defp admin_session do
-    {user, session} = user_and_session()
-    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
-    session
   end
 
   defp live_pid do

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -43,11 +43,6 @@ defmodule GrappaWeb.AuthControllerTest do
     :ok
   end
 
-  defp start_server(handler \\ IRCServer.passthrough_handler()) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   defp pick_unused_port do
     {:ok, l} = :gen_tcp.listen(0, [])
     {:ok, port} = :inet.port(l)
@@ -637,7 +632,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
   describe "POST /auth/login (visitor via nick)" do
     test "anon (case 1) → 200 + subject{kind: visitor}", %{conn: conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt"}) end)
@@ -691,7 +686,7 @@ defmodule GrappaWeb.AuthControllerTest do
     # test process).
     test "visitor login → 503 db_unavailable (not 500) under sustained transient DB busy",
          %{conn: conn} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {_, _} = setup_visitor_network(port)
 
       BusyRetry.inject_transient_faults(10_000)
@@ -712,7 +707,7 @@ defmodule GrappaWeb.AuthControllerTest do
     # strip control chars) at the boundary BEFORE classification, so a nick
     # with a trailing space logs in as the trimmed nick.
     test "nick with a trailing space is trimmed → 200 + subject{nick: trimmed}", %{conn: conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task = Task.async(fn -> post(conn, "/auth/login", %{"identifier" => "vjt "}) end)
@@ -891,7 +886,7 @@ defmodule GrappaWeb.AuthControllerTest do
         end
       end
 
-      {_, port} = start_server(nick_in_use_handler)
+      {_, port} = IRCServer.start_server(nick_in_use_handler)
       {network, _} = setup_visitor_network(port)
 
       conn = post(conn, "/auth/login", %{"identifier" => "vjt"})
@@ -902,7 +897,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
     test "anon collision (no bearer) → 409 anon_collision + Retry-After",
          %{conn: conn} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       {:ok, v} = Visitors.find_or_provision_anon("vjt", "azzurra", "5.6.7.8")
@@ -918,7 +913,7 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "anon collision token reuse → 200 + rotated token", %{conn: conn} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       {:ok, v} = Visitors.find_or_provision_anon("vjt", "azzurra", "5.6.7.8")
@@ -938,7 +933,7 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "#363 incognito param provisions an ephemeral (incognito) visitor", %{conn: conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =
@@ -1034,7 +1029,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
     test "visitor logout (anon) kills Session.Server AND purges visitor row per W11",
          %{conn: conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =
@@ -1103,7 +1098,7 @@ defmodule GrappaWeb.AuthControllerTest do
       # whereas `assert_receive 100` would mask the regression by giving the
       # scheduler 100ms of slop to deliver our :DOWN AFTER the 204 came
       # back. Keep `assert_received` (no timeout) for that reason.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =
@@ -1154,7 +1149,7 @@ defmodule GrappaWeb.AuthControllerTest do
       # the fix scopes the stop+purge teardown to ANON visitors only, so
       # a registered visitor's detach keeps the bouncer online. Quit
       # (tear down) is a separate verb (POST /session/disconnect + logout).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =
@@ -1216,7 +1211,7 @@ defmodule GrappaWeb.AuthControllerTest do
       # the ABSENCE of teardown fixes both: the session stays up, so
       # DB == live (connection_state :connected AND whereis returns the
       # live pid).
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       user = user_fixture()
       {network, _} = network_with_server(port: port)
@@ -1254,8 +1249,8 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "user logout (DETACH) keeps ALL the user's bindings up (#126)", %{conn: conn} do
-      {server1, port1} = start_server()
-      {server2, port2} = start_server()
+      {server1, port1} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {server2, port2} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       user = user_fixture()
       {network1, _} = network_with_server(port: port1)
@@ -1350,7 +1345,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
     test "visitor logout when network/credential removed mid-session still 204s + purges",
          %{conn: conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = setup_visitor_network(port)
 
       task =

--- a/test/grappa_web/controllers/channels_controller_test.exs
+++ b/test/grappa_web/controllers/channels_controller_test.exs
@@ -41,11 +41,6 @@ defmodule GrappaWeb.ChannelsControllerTest do
     setup_network(vjt, 1024 + rem(System.unique_integer([:positive]), 60_000), "azzurra")
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_network(vjt, port, slug \\ "azzurra") do
     {network, _} = network_with_server(port: port, slug: slug)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
@@ -54,7 +49,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
   describe "POST /networks/:network_id/channels" do
     test "with active session sends JOIN upstream and returns 202", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -74,7 +69,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "#382 comma-list name sends ONE multi-target JOIN and returns 202",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -223,7 +218,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # frame as `JOIN <chan> <key>\r\n` when present.
     test "with active session + key sends JOIN with key upstream",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -276,7 +271,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "empty-string key sends the no-key JOIN form (bucket F)",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -315,7 +310,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
   describe "DELETE /networks/:network_id/channels/:channel_id" do
     test "with active session sends PART upstream and returns 202", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -377,7 +372,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # the defect this closes.
     test "reason query param lands on the wire as the PART trailing param",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -399,7 +394,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # An empty `?reason=` is the ABSENCE of a reason — byte-identical to the
     # no-param call above, not `PART #sniffo :`.
     test "empty reason query param emits the bare PART form", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -419,7 +414,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # so a refused request leaves no half-applied leave behind.
     test "reason with URL-encoded CRLF returns 400 and does not touch autojoin",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-1208-crlf-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#sniffo", "#other"]})
       pid = start_session_for(vjt, network)
@@ -441,7 +436,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # graphemes. Above the cap it is refused at the door rather than handed to
     # a framing layer that would silently truncate it.
     test "over-cap reason returns 413 and sends nothing upstream", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -474,7 +469,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # fix, cicchetto's channels_changed refetch would return the channel with
     # joined: false and the sidebar would keep showing it as a parted entry.
     test "removes channel from autojoin_channels after PART", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-bug5a-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa", "#other"]})
       pid = start_session_for(vjt, network)
@@ -493,7 +488,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "channel not in autojoin_channels is a no-op on the autojoin list after PART",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-bug5a-noop-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#other"]})
       pid = start_session_for(vjt, network)
@@ -521,7 +516,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # race window where the M16 propagation matters most.
     test "autojoin removal failure propagates as 404 instead of silently 202 (M16)",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-m16-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#grappa"]})
       pid = start_session_for(vjt, network)
@@ -552,7 +547,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # sidebar entry disappears.
     test "eager PART of a never-joined channel drops window_state + emits channels_changed",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-h-eager-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
 
@@ -605,7 +600,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "eager PART of a joined channel drops members + window_state immediately (don't wait for echo)",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-h-joined-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
 
@@ -650,7 +645,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # persister the organic membership-change path uses.
     test "PART persists last_joined_channels snapshot minus the parted channel (reconnect-rejoin fix)",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "az-lastjoined-#{u()}")
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
       pid = start_session_for(vjt, network)
@@ -687,7 +682,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "channel in BOTH autojoin AND session: source: autojoin, joined: true",
          %{conn: conn, vjt: vjt} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-bot-#{u()}"
       {network, _} = network_with_server(port: port, slug: slug)
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#italia"]})
@@ -721,7 +716,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "channel ONLY in session (joined post-boot, not in autojoin): source: joined, joined: true",
          %{conn: conn, vjt: vjt} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-sess-#{u()}"
       {network, _} = network_with_server(port: port, slug: slug)
       _ = credential_fixture(vjt, network, %{autojoin_channels: []})
@@ -740,7 +735,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "merges autojoin + session: union sorted alphabetically",
          %{conn: conn, vjt: vjt} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-merge-#{u()}"
       {network, _} = network_with_server(port: port, slug: slug)
       _ = credential_fixture(vjt, network, %{autojoin_channels: ["#italia", "#azzurra"]})
@@ -801,7 +796,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
   describe "POST /networks/:network_id/channels/:channel_id/topic" do
     test "202 + ok body when session accepts the topic", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-topic-#{u()}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
@@ -897,7 +892,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "POST JOIN sends upstream as the visitor session and returns 202",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
@@ -919,7 +914,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
 
     test "DELETE PART sends upstream as the visitor session and returns 202",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)
@@ -963,7 +958,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # visitors exactly as it does for users.
     test "DELETE PART of a live-joined channel drops it from GET /channels + last_joined (case a)",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)
@@ -1009,7 +1004,7 @@ defmodule GrappaWeb.ChannelsControllerTest do
     # branch of `remove_from_autojoin` was a no-op and the row never went away.
     test "DELETE PART of a stale not-live autojoin entry drops it from GET /channels + last_joined (case b)",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       _ = visitor_channel_fixture(visitor, network.slug, "#italia")
       session = visitor_session_fixture(visitor)

--- a/test/grappa_web/controllers/invites_controller_test.exs
+++ b/test/grappa_web/controllers/invites_controller_test.exs
@@ -27,11 +27,6 @@ defmodule GrappaWeb.InvitesControllerTest do
     {:ok, conn: put_bearer(conn, session_fixture(vjt).id), vjt: vjt}
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_network(vjt, port, slug) do
     {network, _} = network_with_server(port: port, slug: slug)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
@@ -62,7 +57,7 @@ defmodule GrappaWeb.InvitesControllerTest do
 
   describe "DELETE /networks/:network_id/invites/:channel_id" do
     test "declines the invite, returns 200, and drops the window", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port, "azzurra-#{u()}")
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(vjt.name))
       pid = start_session_for(vjt, network)
@@ -88,7 +83,7 @@ defmodule GrappaWeb.InvitesControllerTest do
     end
 
     test "a RAW-cased URL declines the folded window (#537)", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -104,7 +99,7 @@ defmodule GrappaWeb.InvitesControllerTest do
 
     test "declining a JOINED channel returns 404 not_invited and leaves it joined",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -122,7 +117,7 @@ defmodule GrappaWeb.InvitesControllerTest do
     end
 
     test "declining a channel with no invite returns 404 not_invited", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port, "azzurra-#{u()}")
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -36,11 +36,6 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     {:ok, conn: put_bearer(conn, session.id), vjt: vjt}
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_network(vjt, port, slug \\ "azzurra") do
     setup_network(vjt, port, slug, nil)
   end
@@ -54,7 +49,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   describe "GET presence filter — #458 member-count (unset) branch" do
     test "unset pref on a LARGE channel (>= threshold members) hides presence via the size default",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -104,7 +99,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   describe "POST with active session" do
     test "sends PRIVMSG upstream, persists row, broadcasts, returns 201",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
 
       :ok =
@@ -174,7 +169,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#640: ctcp_target routes the echo to the SOURCE window, wire to the recipient, no query window",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -213,7 +208,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#640: ctcp_target = $server is rejected (read-only) as bad_request",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -235,7 +230,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1225: notice_target ships a NOTICE, echoes to the SOURCE window, opens no window",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -269,7 +264,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1225: notice_target = $server is rejected (read-only) as bad_request",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -289,7 +284,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1301: notice_target = @#chan reaches the wire VERBATIM and echoes to the source window",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -321,7 +316,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1301: a sigil is still refused on the URL channel_id — that one IS a window key",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -345,7 +340,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1225: a /notice to NickServ does not archive a mistyped identify password",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -377,7 +372,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#1225: a POST carrying BOTH ctcp_target and notice_target is bad_request",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -400,7 +395,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "#357: the send-path span [:grappa, :session, :send_privmsg] closes with outcome: :ok",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -439,7 +434,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "POST then GET roundtrip — vjt's POST visible via vjt's subsequent GET",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -467,7 +462,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "PER-USER ISO: alice's GET on the same channel returns 404 not_found",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -497,7 +492,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     end
 
     test "broadcast scoped to (user, network, channel) — does not leak", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
 
       :ok =
@@ -636,7 +631,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   describe "POST to nick target (DM)" do
     test "sends PRIVMSG upstream to nick target, persists row, returns 201",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -684,7 +679,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "a full burst succeeds (201), the next POST is throttled (429)",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -710,7 +705,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     # contract, not a magic constant.
     test "a throttled POST (429) carries a retry-after header = the send-throttle refill interval",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -730,12 +725,12 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "the bucket is per-(subject, network): a second network is unaffected by the first's flood",
          %{conn: conn, vjt: vjt} do
-      {server1, port1} = start_server()
+      {server1, port1} = IRCServer.start_server(IRCServer.passthrough_handler())
       net1 = setup_network(vjt, port1, "azzurra")
       pid1 = start_session_for(vjt, net1)
       :ok = IRCServer.await_handshake(server1, 1_000)
 
-      {server2, port2} = start_server()
+      {server2, port2} = IRCServer.start_server(IRCServer.passthrough_handler())
       net2 = setup_network(vjt, port2, "second-net")
       pid2 = start_session_for(vjt, net2)
       :ok = IRCServer.await_handshake(server2, 1_000)
@@ -776,7 +771,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "an oper'd session rides the WIDER burst, and still lands on a 429 at its own ceiling",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -798,7 +793,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "the oper 429 carries the OPER refill interval, not the ordinary one",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -822,7 +817,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
 
     test "an oper carrying the network's no-throttle umode is not metered at all",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       # The exempt letter is per-flavour; bahamut's is the one that was read
       # at source, so the network has to say it is one.
       network = setup_network(vjt, port, "azzurra", :azzurra)
@@ -844,7 +839,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       # No services_flavor: grappa has not been told which ircd this is, so
       # `F` carries no verified meaning and the exemption is withheld. The
       # oper tier still applies — the degradation is graceful.
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -859,7 +854,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     end
 
     test "a plain user is metered on today's numbers, unchanged", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -885,7 +880,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
   describe "POST to *serv target (UX-4 bucket G)" do
     test "POST to NickServ returns 202 ok=true, no scrollback row, line on wire",
          %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
 
       :ok =
@@ -924,7 +919,7 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
     end
 
     test "POST to chanserv (lowercase) returns 202", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       network = setup_network(vjt, port)
       pid = start_session_for(vjt, network)
       :ok = IRCServer.await_handshake(server, 1_000)

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -33,13 +33,6 @@ defmodule GrappaWeb.NickControllerTest do
     end
   end
 
-  defp start_server, do: start_server(IRCServer.passthrough_handler())
-
-  defp start_server(handler) do
-    {:ok, server} = IRCServer.start_link(handler)
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_network(vjt, port, slug) do
     {network, _} = network_with_server(port: port, slug: slug)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
@@ -54,7 +47,7 @@ defmodule GrappaWeb.NickControllerTest do
 
   describe "POST /networks/:network_id/nick" do
     test "202 + ok body when nick line goes upstream", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-nick-#{System.unique_integer([:positive])}"
       network = setup_network(vjt, port, slug)
       pid = start_session_for(vjt, network)
@@ -124,7 +117,7 @@ defmodule GrappaWeb.NickControllerTest do
     # as users, gated by the same `(nick, network_slug)` UNIQUE that
     # backs anon-collision detection at login time.
     test "visitor subject — 202 + nick line upstream + DB nick rotated on echo", %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       old_nick = "v9-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
@@ -172,7 +165,7 @@ defmodule GrappaWeb.NickControllerTest do
     # in production on Azzurra, 2026-08-04).
     test "visitor subject — 202 + NICK upstream when only a stale ANON credential holds the target nick (#828)",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       old_nick = "v828a-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
@@ -207,7 +200,7 @@ defmodule GrappaWeb.NickControllerTest do
     # list (`{:server, nil}` — the rejected nick is not a destination).
     test "visitor subject — a nick taken upstream is refused by the ircd's 433, not by the controller (#828)",
          %{conn: _conn} do
-      {server, port} = start_server(welcoming_handler())
+      {server, port} = IRCServer.start_server(welcoming_handler())
       old_nick = "v828c-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
@@ -252,7 +245,7 @@ defmodule GrappaWeb.NickControllerTest do
     # visitor is an identity problem, not a wire-availability question.
     test "visitor subject — 409 nick_in_use when another visitor's IDENTIFIED credential holds the target nick",
          %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       old_nick = "v828e-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)

--- a/test/grappa_web/controllers/notify_controller_live_test.exs
+++ b/test/grappa_web/controllers/notify_controller_live_test.exs
@@ -24,11 +24,6 @@ defmodule GrappaWeb.NotifyControllerLiveTest do
 
   # Passthrough fake ircd — registration + presence numerics are fed
   # explicitly so the test controls the WATCH-vs-MONITOR mechanism.
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
-    {server, IRCServer.port(server)}
-  end
-
   defp flush(server) do
     token = "flush-#{System.unique_integer([:positive])}"
     IRCServer.feed(server, "PING :#{token}\r\n")
@@ -49,7 +44,7 @@ defmodule GrappaWeb.NotifyControllerLiveTest do
     conn: conn,
     user: user
   } do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     slug = "notify-live-net-#{System.unique_integer([:positive])}"
     {network, _} = network_with_server(port: port, slug: slug)
     _ = credential_fixture(user, network, %{nick: "grappa-test", autojoin_channels: []})

--- a/test/grappa_web/controllers/session_controller_test.exs
+++ b/test/grappa_web/controllers/session_controller_test.exs
@@ -37,11 +37,6 @@ defmodule GrappaWeb.SessionControllerTest do
     :ok
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
-  end
-
   # A port nothing listens on — the accretion allowlist-gate test rejects
   # BEFORE any dial, so the disabled network's server endpoint is never
   # contacted; the port just has to be a valid, unused number.
@@ -67,7 +62,7 @@ defmodule GrappaWeb.SessionControllerTest do
 
   describe "POST /session/networks (#211 phase 4c — accretion)" do
     test "registered visitor accretes a 2nd network — ONE identity spans BOTH", %{conn: conn} do
-      {server_a, port_a} = start_server()
+      {server_a, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network_a} = registered_visitor(port_a)
 
       # The visitor is live on network A.
@@ -76,7 +71,7 @@ defmodule GrappaWeb.SessionControllerTest do
       assert is_pid(Grappa.Session.whereis({:visitor, visitor.id}, network_a.id))
 
       # A SECOND visitor_enabled network B with its own fake upstream.
-      {server_b, port_b} = start_server()
+      {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
       on_exit(fn -> Grappa.Session.stop_session({:visitor, visitor.id}, network_b.id) end)
 
@@ -118,7 +113,7 @@ defmodule GrappaWeb.SessionControllerTest do
     end
 
     test "accreting a NON-visitor_enabled network → 403", %{conn: conn} do
-      {_, port_a} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, _} = registered_visitor(port_a)
 
       # A network that is NOT visitor_enabled.
@@ -133,7 +128,7 @@ defmodule GrappaWeb.SessionControllerTest do
     end
 
     test "accreting a network the identity ALREADY holds → 409 already_attached", %{conn: conn} do
-      {_, port_a} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network_a} = registered_visitor(port_a)
 
       # network_a's slug is already the visitor's — flip it visitor_enabled so
@@ -149,7 +144,7 @@ defmodule GrappaWeb.SessionControllerTest do
     end
 
     test "missing network param → 400", %{conn: conn} do
-      {_, port_a} = start_server()
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, _} = registered_visitor(port_a)
       session = visitor_session_fixture(visitor)
 
@@ -169,7 +164,7 @@ defmodule GrappaWeb.SessionControllerTest do
          %{conn: conn} do
       {user, session} = user_and_session()
 
-      {server_b, port_b} = start_server()
+      {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
       on_exit(fn -> Grappa.Session.stop_session({:user, user.id}, network_b.id) end)
 
@@ -202,7 +197,7 @@ defmodule GrappaWeb.SessionControllerTest do
       long_name = String.duplicate("a", 40)
       {user, session} = user_and_session(name: long_name)
 
-      {server_b, port_b} = start_server()
+      {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network_b, _} = network_with_server(port: port_b, slug: "gamma", visitor_enabled: true)
       on_exit(fn -> Grappa.Session.stop_session({:user, user.id}, network_b.id) end)
 
@@ -277,7 +272,7 @@ defmodule GrappaWeb.SessionControllerTest do
          %{conn: conn} do
       {user, session} = user_and_session()
 
-      {server_b, port_b} = start_server()
+      {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
       on_exit(fn -> Grappa.Session.stop_session({:user, user.id}, network_b.id) end)
 
@@ -329,7 +324,7 @@ defmodule GrappaWeb.SessionControllerTest do
     # bounded by the visitor_enabled allowlist (+ per-IP cap) inside
     # accrete_network/3.
     test "anon visitor accretes an available network → 204", %{conn: conn} do
-      {server_a, port_a} = start_server()
+      {server_a, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
       # An anon visitor (no committed password) live on network A.
       {visitor, network_a} = visitor_with_network(port_a)
       # #211 phase 7 — anon ⟺ NOT registered (derived from the credentials).
@@ -337,7 +332,7 @@ defmodule GrappaWeb.SessionControllerTest do
       _ = start_visitor_session_for(visitor, network_a)
       :ok = IRCServer.await_handshake(server_a, 5_000)
 
-      {server_b, port_b} = start_server()
+      {server_b, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network_b, _} = network_with_server(port: port_b, slug: "beta", visitor_enabled: true)
       on_exit(fn -> Grappa.Session.stop_session({:visitor, visitor.id}, network_b.id) end)
 

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -95,6 +95,23 @@ defmodule Grappa.AuthFixtures do
   end
 
   @doc """
+  Mints a session whose subject is an ADMIN user, and returns the
+  session. The bearer token is `session.id`, as everywhere else here.
+
+  Admin is granted after the fact rather than at insert because
+  `is_admin` is not a `user_fixture/1` attribute: it moves through
+  `Accounts.update_admin_flags/2`, the same door the admin surface
+  uses. Returning only the session is what every caller wanted — the
+  user ref was discarded at all fourteen sites this replaces.
+  """
+  @spec admin_session() :: Session.t()
+  def admin_session do
+    {user, session} = user_and_session()
+    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
+    session
+  end
+
+  @doc """
   Mints a live session for `visitor`. Counterpart to `session_fixture/1`
   for visitor subjects — used by REST tests that traverse `:authn`'s
   visitor branch (Task 30 controller surface).

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -99,6 +99,27 @@ defmodule Grappa.IRCServer do
     GenServer.start_link(__MODULE__, {handler, initial_state})
   end
 
+  @doc """
+  Spawns the fake server with `handler` and returns the `{server, port}`
+  pair a test needs to point a client at it — `start_link/1` plus the
+  `port/1` round-trip every caller did by hand.
+
+  `handler` carries NO default, deliberately, for the same reason
+  `await_handshake/2` above carries no timeout: the twenty local copies
+  this replaces (#1397) had hidden `passthrough_handler/0` behind a
+  zero-argument wrapper, so a call site could no longer say whether it
+  wanted a silent peer or merely had not thought about the peer at all.
+  Commit `84fe0850` settled that trade for `wait_for_line/3` — drop the
+  default, spell the value at every call site, no helper to hide it —
+  and the same reading applies here. Which peer the client talks to is
+  decidable at the call site, so it stays there.
+  """
+  @spec start_server(handler()) :: {pid(), :inet.port_number()}
+  def start_server(handler) do
+    {:ok, server} = start_link(handler)
+    {server, port(server)}
+  end
+
   @spec port(pid()) :: :inet.port_number()
   def port(server), do: GenServer.call(server, :port)
 


### PR DESCRIPTION
Two server-side consolidation slices of #1397 (bucket H test-harness), on one branch so
they gate once.

## `4d7ab797` — `admin_session` into `AuthFixtures` (15 files, +25/−93)

14 identical local definitions retired; **one body**, and blanking string literals does not
split it — zero drift on either axis. Zero `defp admin_session` remain.

**The slice is atomic, and that was measured rather than assumed.** Splitting it into
"define + delete one copy" then "delete the other 13" was built and run:

```
error: imported Grappa.AuthFixtures.admin_session/0 conflicts with local function
```

an **error**, not a warning, in every file still holding a copy. The inverse order reds all
14 on `undefined function`. So the shared definition and the 14 deletions are one change.

⚠️ **A false-green found on the way, worth knowing beyond this PR:** `mix compile --force
--warnings-as-errors` returns **rc=0** on that broken intermediate state, because
`mix compile` does not read `.exs` — test files are compiled by `mix test`. A gate that
stops at the compile step is blind to any change under `test/`.

`ConnCase` is untouched: all 14 files already import `Grappa.AuthFixtures`, so the import
the plan called for would have made 14 existing imports redundant and bought nothing.

## `24db18d7` — `start_server` into `Grappa.IRCServer` (20 files, +575/−645, net −70)

`Grappa.IRCServer.start_server/1` takes the handler as a **required argument, no `\\`
default**, and returns `{server, port}`. 19 local clauses over 18 files retired; **548 call
sites** rewritten (447 bare → explicit `passthrough_handler()`, 101 already passing one).

The required-argument shape is not an analogy: `84fe0850` removed the `\\ 1_000` default
from `wait_for_line/3` under the same no-default-arguments rule and wrote the literal at
~150 call sites across 11 files — *"no helper to hide the literal"*. Same rule, same shape,
3× the scale.

### Scope note — 17 clauses were planned, 19 were lifted

The two extra (`lifecycle_log_integration_test.exs`, `nick_controller_test.exs`) have bodies
**byte-identical** to the new shared helper. They are not a divergence to respect, they are
pure duplicates of the target; leaving them would have left two `defp`s identical to the
shared function — the duplication this issue exists to remove, and the half-migration
CLAUDE.md's *"Total consistency or nothing"* forbids. Flagged as a deliberate widening,
reversible in two files.

`nick_controller_test.exs` carried **two** clauses, one calling the other. They are one
helper and move together: lifting either alone leaves a dead local or a call to a function
that no longer exists.

### Left in place, deliberately

`presence_filter/resolver_test.exs` and `admin/members_controller_test.exs` keep their
clauses. They diverge on one axis — the handler is `welcome_handler()` rather than the
passthrough — and converting them is **not** six edits: `welcome_handler` is a second
duplication cluster with no canonical home (two byte-identical copies verified with `cmp`,
two more bodies under different names in `server_test.exs`, and the 001 prefix spelled four
different ways across ~145 sites in 15 files). That belongs to its own slice, with its own
decision about which spelling is canonical.

## Gates

Whole suite in the worktree: **8 doctests, 61 properties, 6546 tests, 0 failures**, rc=0
(`--warnings-as-errors`, zero compiler warnings). `mix format --check-formatted` rc=0.
`mix credo --strict` rc=0, 6102 mods/funs, no issues.

Not claimed: that green is **isolated** — `_build`/`deps` are shared across worktrees and
`compile --force` was not run. CI is the isolated check.

No `DESIGN_NOTES` entry: the no-default-arguments ruling this applies was already recorded,
and no new decision is introduced.
