### PR TITLE
cic(#1396): move 47 of the 59 dispatch arms behind a command seam

### DIFF
--- a/cicchetto/src/lib/commands/context.ts
+++ b/cicchetto/src/lib/commands/context.ts
@@ -1,0 +1,46 @@
+import type { ChannelKey } from "../channelKey";
+import type { SlashCommand } from "../slashCommands";
+
+// #1396 — the dispatch vocabulary, lifted out of `compose.ts` so a command
+// handler can live outside the store module. `compose.ts` keeps the store and
+// the send pipeline; what moves here is the part that only ever needed a few
+// named values.
+//
+// The record is deliberately NARROW. Of the 87 identifiers the 59-arm switch
+// calls, 69 are ordinary module imports a handler can import for itself and 4
+// are `compose.ts` top-level consts; only the values below cannot be reached
+// that way, because they close over the submitting window. Anything a handler
+// can import, it imports — the context carries what is per-submission, not
+// what is merely convenient.
+export type SubmitResult = { ok: true | string } | { error: string };
+
+// The pump owns the composer buffer and hands the text back on failure, so a
+// handler that manages its own residue says so with `keptBuffer`.
+export type DispatchOutcome = SubmitResult | { error: string; keptBuffer: true };
+
+export type CommandContext = {
+  /** The submitting window. */
+  key: ChannelKey;
+  networkSlug: string;
+  channelName: string;
+  /** The raw draft, before parsing — the one arm that re-reads it needs it. */
+  text: string;
+  /** The session bearer, already proven present by the dispatcher. */
+  token: string;
+  /**
+   * The ACTIVE window's channel, or null when the active window is not a
+   * channel. Distinct from `channelName`: a submit can be queued across a
+   * window switch, so the two can disagree, and the arms that default a
+   * target want the active one.
+   */
+  getActiveChannel: () => string | null;
+};
+
+/**
+ * A handler for one verb. Returns what the arm returned: the dispatcher
+ * neither inspects nor re-wraps it.
+ */
+export type CommandHandler<K extends SlashCommand["kind"]> = (
+  cmd: Extract<SlashCommand, { kind: K }>,
+  ctx: CommandContext,
+) => Promise<DispatchOutcome>;

--- a/cicchetto/src/lib/commands/context.ts
+++ b/cicchetto/src/lib/commands/context.ts
@@ -34,6 +34,33 @@ export type CommandContext = {
    * target want the active one.
    */
   getActiveChannel: () => string | null;
+  /**
+   * The channel sigils THIS network advertised (005 CHANTYPES). Per-submission
+   * because it is keyed on the submitting window's network; the resolver
+   * behind it also answers for other slugs, which is why it stays in
+   * `compose.ts` rather than becoming an import a handler could reach.
+   *
+   * A THUNK, not a value, and the characterization net is why: resolving it
+   * when the record is built puts a `networkIdBySlug` on EVERY submission,
+   * including the 58 arms that never ask. That is the same eager-resolution
+   * trap `requireNetworkId` documents, and the net caught it.
+   */
+  sigils: () => readonly string[];
+  /**
+   * Require a channel window, or the inline error the operator reads.
+   * Thirteen arms call it FIRST, before resolving a network: when both would
+   * fail the operator must still see the channel error, so the call ORDER is
+   * part of the contract, not an accident of layout.
+   */
+  requireChannel: (verb: string) => string | { error: string };
+  /**
+   * The network twin: a SLUG resolves to the live network id, or to the
+   * inline error. Called FROM the handler rather than resolved once up front,
+   * which keeps it LAZY (14 arms never ask — the REST verbs address the
+   * network by slug) and keeps the slug a PARAMETER (two arms resolve one
+   * other than `networkSlug`).
+   */
+  requireNetworkId: (slug: string, subject: string) => number | { error: string };
 };
 
 /**

--- a/cicchetto/src/lib/commands/context.ts
+++ b/cicchetto/src/lib/commands/context.ts
@@ -61,6 +61,13 @@ export type CommandContext = {
    * other than `networkSlug`).
    */
   requireNetworkId: (slug: string, subject: string) => number | { error: string };
+  /**
+   * The NICK twin of `requireChannel`, for the arms that take a bare nick:
+   * a query window resolves to the partner, every other network-scoped window
+   * to the operator's own nick on this network. Lives on the record for the
+   * same reason its two siblings do — it closes over the selected window.
+   */
+  resolveBareWhoisNick: (verb: string) => string | { error: string };
 };
 
 /**

--- a/cicchetto/src/lib/commands/highlight.ts
+++ b/cicchetto/src/lib/commands/highlight.ts
@@ -1,0 +1,9 @@
+import { addHighlight, delHighlight } from "../highlightList";
+import type { CommandHandler } from "./context";
+
+/** `/hilight` + `/dehilight` — the keyword watchlist, add and remove. */
+export const watchlistCommand: CommandHandler<"watchlist"> = async (cmd) => {
+  const patterns =
+    cmd.action === "add" ? await addHighlight(cmd.pattern) : await delHighlight(cmd.pattern);
+  return { ok: `highlight (${patterns.length}): ${patterns.join(", ") || "(empty)"}` };
+};

--- a/cicchetto/src/lib/commands/mode.ts
+++ b/cicchetto/src/lib/commands/mode.ts
@@ -1,0 +1,159 @@
+import { ownNickForNetwork } from "../api";
+import { openBanlistModal } from "../banlistModal";
+import { isChannelName } from "../chantypes";
+import { isupportForNetwork } from "../isupport";
+import { openModeModal } from "../modeModal";
+import { networkBySlug, user } from "../networks";
+import { nickEquals } from "../nickEquals";
+import { pushChannelBanlist, pushChannelMode, pushChannelUmode } from "../socket";
+import { openUmodeModal } from "../umodeModal";
+import type { CommandHandler } from "./context";
+
+/**
+ * The mode family: channel modes, user modes, and the list-mode surfaces they
+ * share. `/banlist` lives here rather than with the operator verbs because it
+ * is a type-A list QUERY — the same modal-plus-requery pair `/mode #chan +b`
+ * opens, reached by a different spelling.
+ */
+
+// #536/#1251 — is this `/mode` a type-A LIST QUERY rather than a mode change?
+// Three conditions, all necessary: no parameter (a mask makes it a MUTATION,
+// `/mode #chan +b nick!*@*`), exactly one optionally-signed letter, and that
+// letter is one this NETWORK offers as a queryable list (server-published, in
+// `isupport.listModesQueryable` — cic never derives it).
+//
+// Why it is not in the pure parser: the third condition is 005 data.
+// `/mode #chan +i` on a network where `i` is a flag must stay a mode change,
+// and no letter is a list mode everywhere — `q` is a LIST on solanum and a
+// founder-status prefix elsewhere. Returns the bare letter, or null when the
+// caller should execute the MODE verbatim.
+const listModeQueryLetter = (modes: string, params: string[], networkId: number): string | null => {
+  if (params.length > 0) return null;
+  const letter = /^[+-]?([A-Za-z])$/.exec(modes)?.[1];
+  if (letter === undefined) return null;
+  return isupportForNetwork(networkId).listModesQueryable.includes(letter) ? letter : null;
+};
+
+/**
+ * #386 — `/banlist` is the channel list-mode MODAL surface (it supersedes the
+ * #376 inline BanlistCard, mirroring how the #169 /who modal replaced the
+ * inline WHO dump). Open the modal AND fire a fresh re-query so the list is
+ * live on open (pre-#386 it was fire-and-forget only).
+ *
+ * An explicit `/banlist #chan` resolves in the parser; a bare `/banlist`
+ * carries null → the current channel (same resolver every channel-scoped verb
+ * uses).
+ */
+export const banlistCommand: CommandHandler<"banlist"> = async (cmd, ctx) => {
+  const chanOrErr = cmd.channel ?? ctx.requireChannel("banlist");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "banlist");
+  if (typeof networkId !== "number") return networkId;
+  // #1251 — an explicitly typed letter this network cannot answer is an ERROR,
+  // not a silent fallback to bans: the operator asked for a specific list and
+  // would otherwise read the ban list as the exempt list. The offered set is
+  // server-published, never derived.
+  const offered = isupportForNetwork(networkId).listModesQueryable;
+  if (!offered.includes(cmd.mode)) {
+    return {
+      error: `/banlist: this network has no +${cmd.mode} list (it offers ${offered.map((m) => `+${m}`).join(" ")})`,
+    };
+  }
+  openBanlistModal(ctx.networkSlug, chanOrErr, cmd.mode);
+  pushChannelBanlist(networkId, chanOrErr, cmd.mode);
+  return { ok: true };
+};
+
+/** `/umode <modes>` — user-mode on own nick, no channel context required. */
+export const umodeCommand: CommandHandler<"umode"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "umode");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelUmode(networkId, cmd.modes);
+  return { ok: true };
+};
+
+/**
+ * #229 — bare `/umode`: open the umode viewer/editor modal for the active
+ * window's network. Umodes are per-session (no channel context needed), so any
+ * window kind can open it.
+ */
+export const umodeViewCommand: CommandHandler<"umode-view"> = async (_cmd, ctx) => {
+  openUmodeModal(ctx.networkSlug);
+  return { ok: true };
+};
+
+/**
+ * #229 — `/mode <nick>` with no mode args. Open the umode modal ONLY when the
+ * target resolves to the operator's OWN nick (the modal edits your own umodes;
+ * there is no viewer for another user's). Resolve via `ownNickForNetwork`
+ * (visitor → me.nick; user → per-credential net.nick) — the same canonical
+ * resolver the /whois self-default uses; `nickEquals` for the
+ * case-insensitive compare (ASCII, #121/#525). A non-self target is a friendly
+ * error rather than a phantom modal.
+ */
+export const umodeTargetViewCommand: CommandHandler<"umode-target-view"> = async (cmd, ctx) => {
+  const net = networkBySlug(ctx.networkSlug);
+  const own = net ? ownNickForNetwork(net, user()) : null;
+  if (own && nickEquals(cmd.target, own)) {
+    openUmodeModal(ctx.networkSlug);
+    return { ok: true };
+  }
+  return {
+    error: `/mode ${cmd.target}: viewing another user's modes isn't supported — use /mode <#channel> for a channel, or /mode ${own ?? "<yournick>"} for your own user modes`,
+  };
+};
+
+/**
+ * `/mode <#chan> <modes> [params]` — execute directly, raw verbatim, target
+ * explicit in args. No modal, no channel-window requirement (#216: mode-args
+ * present → apply).
+ */
+export const modeCommand: CommandHandler<"mode"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "mode");
+  if (typeof networkId !== "number") return networkId;
+  // #536/#1251 — a bare list letter with NO mask is a QUERY, not a mutation:
+  // open the list modal instead of putting a raw MODE on the wire whose reply
+  // rows nothing is primed to collect.
+  const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
+  if (listMode !== null && isChannelName(cmd.target, ctx.sigils())) {
+    openBanlistModal(ctx.networkSlug, cmd.target, listMode);
+    pushChannelBanlist(networkId, cmd.target, listMode);
+    return { ok: true };
+  }
+  await pushChannelMode(networkId, cmd.target, cmd.modes, cmd.params);
+  return { ok: true };
+};
+
+/**
+ * #216 — no mode-args: open the viewer/editor modal. Explicit `/mode #chan`
+ * targets that channel; bare `/mode` targets the current channel window (error
+ * if not in one — the same resolver every channel-scoped verb uses).
+ */
+export const modeViewCommand: CommandHandler<"mode-view"> = async (cmd, ctx) => {
+  const ch = cmd.channel ?? ctx.getActiveChannel();
+  if (!ch) return { error: "/mode requires a channel — switch to one or use /mode #chan" };
+  openModeModal(ctx.networkSlug, ch);
+  return { ok: true };
+};
+
+/**
+ * #216 — `/mode +s` (mode string, no channel token) applies to the current
+ * channel. Mode-args present → execute directly, no modal; requires a channel
+ * window.
+ */
+export const modeApplyCurrentCommand: CommandHandler<"mode-apply-current"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("mode");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "mode");
+  if (typeof networkId !== "number") return networkId;
+  // #536/#1251 — same list-QUERY interception as the explicit-channel arm
+  // above; `/mode +b` and `/mode #chan +b` must behave alike.
+  const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
+  if (listMode !== null) {
+    openBanlistModal(ctx.networkSlug, chanOrErr, listMode);
+    pushChannelBanlist(networkId, chanOrErr, listMode);
+    return { ok: true };
+  }
+  await pushChannelMode(networkId, chanOrErr, cmd.modes, cmd.params);
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/network.ts
+++ b/cicchetto/src/lib/commands/network.ts
@@ -1,0 +1,11 @@
+import { patchNetwork } from "../api";
+import type { CommandHandler } from "./context";
+
+/**
+ * `/connect <network>` — unpark + respawn. Network slug guaranteed by the
+ * parser (bare `/connect` surfaces as `kind: "error"` instead).
+ */
+export const connectCommand: CommandHandler<"connect"> = async (cmd, ctx) => {
+  await patchNetwork(ctx.token, cmd.network, { connection_state: "connected" });
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/ops.ts
+++ b/cicchetto/src/lib/commands/ops.ts
@@ -1,0 +1,173 @@
+import { buildBanMask } from "../banMask";
+import { friendlyError } from "../friendlyError";
+import {
+  pushChannelBan,
+  pushChannelDeop,
+  pushChannelDevoice,
+  pushChannelInvite,
+  pushChannelKick,
+  pushChannelOp,
+  pushChannelUnban,
+  pushChannelVoice,
+  pushRaw,
+  resolveUserhost,
+} from "../socket";
+import type { CommandHandler } from "./context";
+
+/**
+ * The channel-operator verbs. Every one of them wants the same two
+ * resolutions in the same order — the channel first, the network second —
+ * and the order is load-bearing: when both would fail the operator must
+ * still read the channel error.
+ */
+
+export const opCommand: CommandHandler<"op"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("op");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "op");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelOp(networkId, chanOrErr, cmd.nicks);
+  return { ok: true };
+};
+
+export const deopCommand: CommandHandler<"deop"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("deop");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "deop");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelDeop(networkId, chanOrErr, cmd.nicks);
+  return { ok: true };
+};
+
+export const voiceCommand: CommandHandler<"voice"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("voice");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "voice");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelVoice(networkId, chanOrErr, cmd.nicks);
+  return { ok: true };
+};
+
+export const devoiceCommand: CommandHandler<"devoice"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("devoice");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "devoice");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelDevoice(networkId, chanOrErr, cmd.nicks);
+  return { ok: true };
+};
+
+export const kickCommand: CommandHandler<"kick"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("kick");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "kick");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelKick(networkId, chanOrErr, cmd.nick, cmd.reason);
+  return { ok: true };
+};
+
+export const banCommand: CommandHandler<"ban"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("ban");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "ban");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelBan(networkId, chanOrErr, cmd.mask);
+  return { ok: true };
+};
+
+/**
+ * #386 — kickban. Ban FIRST (`*!*@host`, no rejoin window), THEN kick — two
+ * frames, attempt BOTH regardless (vjt decision #4). The host comes from the
+ * on-demand `resolveUserhost` lookup (cic has none client-side); a cache MISS
+ * → null → fail-closed (vjt decision #1: never guess a wider mask), so the ban
+ * is NOT sent — but the kick still fires (immediate intent) and the ban error
+ * is surfaced.
+ */
+export const kbCommand: CommandHandler<"kb"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("kb");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "kb");
+  if (typeof networkId !== "number") return networkId;
+
+  let banError: string | null = null;
+  try {
+    const uh = await resolveUserhost(networkId, cmd.nick);
+    const mask = uh ? buildBanMask("host", { nick: cmd.nick, user: uh.user, host: uh.host }) : null;
+    if (mask === null) {
+      banError = `/kb: host unknown for ${cmd.nick} — ban not set (run /whois ${cmd.nick} first); kicking anyway`;
+    } else {
+      await pushChannelBan(networkId, chanOrErr, mask);
+    }
+  } catch (e) {
+    banError = `/kb: ban failed — ${friendlyError(e)}`;
+  }
+
+  // Always attempt the kick (getting the person out is the intent).
+  try {
+    await pushChannelKick(networkId, chanOrErr, cmd.nick, cmd.reason);
+  } catch (kickErr) {
+    // Both failed → surface the ban error (primary) if present, else the kick's.
+    return { error: banError ?? `/kb: kick failed — ${friendlyError(kickErr)}` };
+  }
+
+  if (banError !== null) return { error: banError };
+  return { ok: true };
+};
+
+/**
+ * #557 — `/kill <nick> [reason]`: first-class operator KILL. Unlike
+ * `/kick`/`/kb` this targets a NICK (no channel, no `requireChannel`) and
+ * ships a RAW frame via `pushRaw`, mirroring `/quote` — the server already
+ * accepts KILL through the raw passthrough (that is what operators do today
+ * with `/quote KILL ...`). The whole win is the trailing colon being composed
+ * HERE, downstream: `KILL <nick> :<reason>` keeps a multi-word reason intact
+ * instead of the `/quote` foot-gun where a forgotten `:` truncates the reason
+ * at its first space. A bare `/kill` (empty reason) sends `KILL <nick>` and
+ * lets the server answer (481 for a non-oper, or the ircd's own
+ * missing-comment error). AWAIT the push so a WS-down / server `{:error,_}`
+ * surfaces as an inline compose alert, never a silent green ✓ (the #154
+ * no-silent-drop lesson).
+ */
+export const killCommand: CommandHandler<"kill"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "kill");
+  if (typeof networkId !== "number") return networkId;
+  const line = cmd.reason === "" ? `KILL ${cmd.nick}` : `KILL ${cmd.nick} :${cmd.reason}`;
+  await pushRaw(networkId, line);
+  return { ok: true };
+};
+
+export const unbanCommand: CommandHandler<"unban"> = async (cmd, ctx) => {
+  const chanOrErr = ctx.requireChannel("unban");
+  if (typeof chanOrErr !== "string") return chanOrErr;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "unban");
+  if (typeof networkId !== "number") return networkId;
+  await pushChannelUnban(networkId, chanOrErr, cmd.mask);
+  return { ok: true };
+};
+
+/**
+ * `/invite <nick> [#chan]` — channel defaults to the active window.
+ *
+ * P-0f follow-up (no-silent-drops bucket 0): when the channel arg is supplied
+ * explicitly, SKIP `requireChannel` — typing `/invite foo #it-opers` from
+ * $server (or any non-channel window) was the common workflow that pre-fix
+ * silently errored ("requires an active channel window") because
+ * `requireChannel` was unconditionally evaluated.
+ */
+export const inviteCommand: CommandHandler<"invite"> = async (cmd, ctx) => {
+  let chan: string;
+  if (cmd.channel !== null) {
+    chan = cmd.channel;
+  } else {
+    const chanOrErr = ctx.requireChannel("invite");
+    if (typeof chanOrErr !== "string") return chanOrErr;
+    chan = chanOrErr;
+  }
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "invite");
+  if (typeof networkId !== "number") return networkId;
+  // S6 (#364): await the verb-ack so a server {:error,_} / WS-down surfaces
+  // inline (shared catch → friendlyChannelError), not a false green ✓.
+  // Mirror of kick/ban.
+  await pushChannelInvite(networkId, chan, cmd.nick);
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/relay.ts
+++ b/cicchetto/src/lib/commands/relay.ts
@@ -1,0 +1,100 @@
+import { ctcpFrame } from "../ctcpAction";
+import { sendCtcpQuery } from "../ctcpQuery";
+import { sendMessage as sendWindowMessage } from "../scrollback";
+import type { CommandHandler } from "./context";
+
+/**
+ * The verbs that address someone who is NOT this window, while the echo stays
+ * here.
+ *
+ * #1396 — all three read `ctx.channelName`, and all three mean the same thing
+ * by it: the window the echo lands in, NOT the recipient. That is a different
+ * meaning from `part`'s (where the context is the default TARGET), which is why
+ * the record hands over the raw channel and lets each handler say what it is
+ * for.
+ */
+
+/**
+ * #591 — `/ctcp <target> <VERB> [args]`: a single CTCP frame to an EXPLICIT
+ * target (not the current window). Non-ACTION CTCP is single-line by convention
+ * (Grappa.IRC.LineSplit) so there is no multiline fan-out. AWAIT the send: a
+ * CTCP verb MUST NOT silently no-op when the WS is down.
+ */
+export const ctcpCommand: CommandHandler<"ctcp"> = async (cmd, ctx) => {
+  // ACTION is the exception this door keeps for itself: it IS conversation
+  // (`/me` to an explicit target), so it belongs in the TARGET window and rides
+  // the normal send path (the server also rejects an ACTION through the CTCP
+  // route — `Session.send_ctcp`'s non-ACTION gate). The parser upper-cases the
+  // verb; guard case-insensitively regardless.
+  if (cmd.verb.toUpperCase() === "ACTION") {
+    await sendWindowMessage(ctx.networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
+    return { ok: true };
+  }
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "ctcp");
+  if (typeof networkId !== "number") return networkId;
+  // Everything else is a control-surface probe and goes through the #1192 seam,
+  // which owns the #640 source-window echo and the #600 register-before-send
+  // ordering.
+  //
+  // Consequence worth naming: `/ctcp <t> PING` CORRELATES, where it used to
+  // drop its reply into `$server` as an uncorrelated "← CTCP PING reply from …"
+  // row. The verb was always a ping; only the sugar knew to correlate it.
+  // Nothing changes on the WIRE — the seam mints no token, so a bare
+  // `/ctcp bob PING` still frames `\x01PING\x01` and rides the #637 token-less
+  // fallback home.
+  await sendCtcpQuery({
+    networkSlug: ctx.networkSlug,
+    networkId,
+    sourceChannel: ctx.channelName,
+    targetNick: cmd.target,
+    verb: cmd.verb,
+    args: cmd.args,
+    sentAtMs: Date.now(),
+  });
+  return { ok: true };
+};
+
+/**
+ * #591 — `/ping <target>`: CTCP PING sugar over the same seam. The token is a
+ * client timestamp; it travels in the frame, comes back verbatim in the reply's
+ * server-typed meta.ctcp_args, and the RTT is `now - sentAt` (synthesized in
+ * subscribe.ts, irssi behavior). Minting the token is ALL this sugar adds — the
+ * correlation bookkeeping and its ordering belong to the seam, and did not
+ * survive being held by hand once a third caller appeared.
+ */
+export const pingCommand: CommandHandler<"ping"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "ping");
+  if (typeof networkId !== "number") return networkId;
+  const sentAtMs = Date.now();
+  await sendCtcpQuery({
+    networkSlug: ctx.networkSlug,
+    networkId,
+    sourceChannel: ctx.channelName,
+    targetNick: cmd.target,
+    verb: "PING",
+    args: String(sentAtMs),
+    sentAtMs,
+  });
+  return { ok: true };
+};
+
+/**
+ * #1225 — `/notice <target> <text>`. Routed like a CTCP query, not like /msg:
+ * the echo persists in the window it was TYPED in (`ctx.channelName`) and no
+ * window is opened for the recipient, because a NOTICE opens none by convention
+ * (RFC 2812 §3.3.2 — it is the verb you must not reply to) and every client the
+ * operators come from echoes it where they are looking. That is also why a
+ * CHANNEL recipient is fine here while /msg refuses one: /msg's refusal exists
+ * to stop a phantom query window, and this path opens no window at all.
+ *
+ * Single await, no #666 pacing plan: a slash command is one line, so there is
+ * no multi-send to pace. A throttled send surfaces its 429 the same way a lone
+ * /msg does.
+ */
+export const noticeCommand: CommandHandler<"notice"> = async (cmd, ctx) => {
+  await sendWindowMessage(ctx.networkSlug, ctx.channelName, cmd.body, {
+    kind: "notice",
+    target: cmd.target,
+  });
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/server.ts
+++ b/cicchetto/src/lib/commands/server.ts
@@ -1,0 +1,210 @@
+import { markLusersRequested } from "../lusersBundle";
+import {
+  pushInfo,
+  pushLinks,
+  pushLusers,
+  pushMotd,
+  pushNames,
+  pushRaw,
+  pushVersion,
+  pushWho,
+  pushWhois,
+  pushWhowas,
+} from "../socket";
+import type { CommandHandler } from "./context";
+
+/**
+ * The verbs addressed TO the server: the numeric-reply queries and the raw
+ * escape hatch. None of them changes anything on this side — each primes a
+ * server-side accumulator and the reply burst drains into a modal or a card.
+ */
+
+/**
+ * #169 — `/who <#chan|nick>`. The server primes who_pending and emits WHO
+ * upstream; the 352 burst folds server-side and 315 RPL_ENDOFWHO drains into
+ * ONE ephemeral `who_reply` event on the user topic, which WhoModal renders.
+ * NOTHING lands in scrollback (mirrors /names).
+ *
+ * #122 — bare /who defaults to the current channel (shares the requireChannel
+ * resolver with /names); it errors only outside one, because the server
+ * requires a channel target (RFC 2812 §3.6.1 mask form is out of MVP scope).
+ */
+export const whoCommand: CommandHandler<"who"> = async (cmd, ctx) => {
+  const target = cmd.target ?? ctx.requireChannel("who");
+  if (typeof target !== "string") return target;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "who");
+  if (typeof networkId !== "number") return networkId;
+  await pushWho(networkId, target); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * #140 — `/names [#channel]`. The server buffers the 353/366 burst and emits
+ * ONE ephemeral `names_reply` on the user topic; NamesModal renders the
+ * grouped, scrollable, dismissable roster. The modal is network-scoped
+ * (last-write-wins), so the originating window is irrelevant — no origin
+ * passed. #122 — bare /names (and the /n alias) defaults to the current
+ * channel, sharing the requireChannel resolver with /who.
+ */
+export const namesCommand: CommandHandler<"names"> = async (cmd, ctx) => {
+  const target = cmd.target ?? ctx.requireChannel("names");
+  if (typeof target !== "string") return target;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "names");
+  if (typeof networkId !== "number") return networkId;
+  await pushNames(networkId, target); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * #238 — `/links [<mask>]`. The server primes links_pending and emits LINKS
+ * upstream; the 364 burst folds server-side and 365 RPL_ENDOFLINKS drains ONE
+ * ephemeral `links_bundle` event, which LinksModal (mounted in Shell,
+ * network-scoped) renders as the interactive topology map. No focus change and
+ * no scrollback rows (mirrors /who + /names). An empty bundle (a restricted or
+ * oper-only network) still opens the modal, to its "hides topology" state.
+ */
+export const linksCommand: CommandHandler<"links"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "links");
+  if (typeof networkId !== "number") return networkId;
+  await pushLinks(networkId, cmd.pattern); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * P-0d — `/lusers [<mask> [<server>]]`. The server emits the 7-numeric LUSERS
+ * bundle; cic dispatches the typed `:lusers_bundle` wire event in userTopic.ts
+ * and renders the LusersCard pinned at the top of the current window (#231).
+ * #579 — the mask and target server ride along (they used to be dropped at the
+ * parser, so a routed request silently answered from the local server and any
+ * mask never reached the wire at all).
+ */
+export const lusersCommand: CommandHandler<"lusers"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "lusers");
+  if (typeof networkId !== "number") return networkId;
+  // #248 — mark the request solicited BEFORE pushing so the incoming bundle
+  // surfaces the card. The store's gate drops any unsolicited bundle (the
+  // Bahamut connect-welcome auto-emit), so an operator /lusers that skipped
+  // this mark would show nothing.
+  markLusersRequested(ctx.networkSlug);
+  await pushLusers(networkId, cmd.mask, cmd.server); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+// #127 — /info, /version, /motd. No-arg server-text queries; the server primes
+// the matching accumulator and emits the command, and the reply burst drains a
+// typed `server_reply` event that userTopic.ts routes into the
+// serverReplyModal store (ServerReplyModal renders it).
+
+export const infoCommand: CommandHandler<"info"> = async (_cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "info");
+  if (typeof networkId !== "number") return networkId;
+  await pushInfo(networkId); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+export const versionCommand: CommandHandler<"version"> = async (_cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "version");
+  if (typeof networkId !== "number") return networkId;
+  await pushVersion(networkId); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+export const motdCommand: CommandHandler<"motd"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "motd");
+  if (typeof networkId !== "number") return networkId;
+  // #374 — thread the optional target server through so grappa emits
+  // `MOTD <target>` upstream (or bare MOTD when null). A 402 ERR_NOSUCHSERVER
+  // for an unknown target surfaces via the same server_reply modal, never a
+  // wrong-server MOTD.
+  await pushMotd(networkId, cmd.target); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * #155 — `/stats [query] [server]`. Native parser sugar over the #153-de-gated
+ * raw transport (mirrors /quote): build the raw STATS frame and ship it via
+ * pushRaw. Server routing: the STATS reply family (211-219, 240-250) is
+ * server-directed — grappa's numeric_router pins the whole family to the
+ * `$server` window as :notice rows via its @active_numerics deny list (#184).
+ * Before that fix the terminating 219 RPL_ENDOFSTATS's stats-letter param was
+ * mis-read by the scan fallback as a query target, forking a bogus window named
+ * after the letter; #155's original "no server change" premise was wrong.
+ * AWAIT the push so a WS-disconnected / server {:error,_} surfaces as an inline
+ * compose error instead of a silent green ✓ (the #154 no-silent-drop lesson).
+ */
+export const statsCommand: CommandHandler<"stats"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "stats");
+  if (typeof networkId !== "number") return networkId;
+  // STATS [query] [server] — omit trailing nulls. IRC STATS is a 2-arg frame;
+  // the parser guarantees target is only set when query is, so filtering nulls
+  // preserves positional order.
+  const line = ["STATS", cmd.query, cmd.target].filter((t): t is string => t !== null).join(" ");
+  await pushRaw(networkId, line);
+  return { ok: true };
+};
+
+/**
+ * #155 — `/rehash [option]`. The REHASH/permission numerics (e.g. 481) land on
+ * `$server` like the STATS family above. #375: mirror the /stats null filter so
+ * the option (MOTD/DNS/GC/…) rides the raw frame instead of being dropped into
+ * a bare REHASH.
+ */
+export const rehashCommand: CommandHandler<"rehash"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "rehash");
+  if (typeof networkId !== "number") return networkId;
+  const line = ["REHASH", cmd.opt].filter((t): t is string => t !== null).join(" ");
+  await pushRaw(networkId, line);
+  return { ok: true };
+};
+
+/**
+ * C2 — `/whois <nick>`. The server primes its accumulator and emits WHOIS
+ * upstream; the bundle arrives later as `whois_bundle` on the user topic
+ * (userTopic.ts → setWhoisBundle). WHOIS with an explicit nick works from any
+ * window kind; the bundle render targets the active window at arrival time.
+ *
+ * #122 + #132 + #137 — bare /whois (and the /w alias) resolves a context
+ * default: a query window gives the partner, every other network-scoped window
+ * gives self.
+ */
+export const whoisCommand: CommandHandler<"whois"> = async (cmd, ctx) => {
+  const nick = cmd.nick ?? ctx.resolveBareWhoisNick("whois");
+  if (typeof nick !== "string") return nick;
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "whois");
+  if (typeof networkId !== "number") return networkId;
+  // #198 — cmd.server is set only for the two-arg `/whois <server> <nick>`
+  // form; null for single-arg and bare. The bouncer emits `WHOIS <server>
+  // <nick>` upstream when present, plain `WHOIS <nick>` otherwise.
+  // S6 (#364): await so a validation reject (e.g. invalid_nick, which fires
+  // BEFORE the upstream write → no bundle, no numeric) surfaces inline instead
+  // of leaving the operator with nothing.
+  await pushWhois(networkId, nick, cmd.server);
+  return { ok: true };
+};
+
+/**
+ * P-0c — `/whowas <nick>`. The server primes whowas_pending and emits WHOWAS
+ * upstream; the bundle arrives later as `whowas_bundle` on the user topic
+ * (userTopic.ts → setWhowasBundle), or as a not_found bundle on 406
+ * ERR_WASNOSUCHNICK.
+ */
+export const whowasCommand: CommandHandler<"whowas"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "whowas");
+  if (typeof networkId !== "number") return networkId;
+  await pushWhowas(networkId, cmd.nick); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * Bundle C (#20 follow-up) — `/quote <raw IRC line>`. Pushed to
+ * GrappaChannel.handle_in("raw", _); the server validates CRLF/NUL then ships
+ * it verbatim to the upstream socket. AWAIT the push so disconnected/error
+ * replies surface as inline compose-box alerts (no silent green ✓ on a dropped
+ * escape-hatch frame).
+ */
+export const quoteCommand: CommandHandler<"quote"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "quote");
+  if (typeof networkId !== "number") return networkId;
+  await pushRaw(networkId, cmd.line);
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/session.ts
+++ b/cicchetto/src/lib/commands/session.ts
@@ -1,4 +1,8 @@
+import { patchNetwork, postNick, postNotifyAdd } from "../api";
+import { friendlyError } from "../friendlyError";
+import { clearMentionsBundle } from "../mentionsWindow";
 import { quitAll } from "../quit";
+import { pushAwaySet, pushAwayUnset, pushRecover } from "../socket";
 import type { CommandHandler } from "./context";
 
 /**
@@ -13,4 +17,99 @@ import type { CommandHandler } from "./context";
 export const quitCommand: CommandHandler<"quit"> = async (cmd) => {
   await quitAll(cmd.reason);
   return { ok: true };
+};
+
+/**
+ * `/disconnect [network] [reason]` — surgical: park ONE network. `network` from
+ * the parser is null (bare /disconnect) or a named slug; null means the active
+ * window's.
+ */
+export const disconnectCommand: CommandHandler<"disconnect"> = async (cmd, ctx) => {
+  const targetSlug = cmd.network ?? ctx.networkSlug;
+  const body: { connection_state: "parked"; reason?: string } = { connection_state: "parked" };
+  if (cmd.reason !== null) body.reason = cmd.reason;
+  await patchNetwork(ctx.token, targetSlug, body);
+  return { ok: true };
+};
+
+/**
+ * S3.4 — explicit away set/unset via the user-level Phoenix Channel. The push
+ * reaches GrappaChannel.handle_in("away", …) which routes to
+ * Session.set_explicit_away / unset_explicit_away.
+ *
+ * #268 — the going-away arm clears THIS network's stale mentions bundle here,
+ * on the user's own action, NOT on the `away_confirmed:"away"` echo. The clear
+ * MUST be causally ordered with the away lifecycle: the return-from-away
+ * `mentions_bundle` is broadcast SYNCHRONOUSLY by grappa on the un-away
+ * command, but `away_confirmed` is emitted only on the upstream 305/306 numeric
+ * echo (event_router.ex) — a different-latency channel. Under bahamut fake-lag
+ * a going-away's delayed 306 could arrive AFTER a subsequent return's bundle
+ * and clobber it (the "0 messages in 0 channels" bug). Triggering the clear on
+ * the compose action makes it ordered with the user's own commands, so a fresh
+ * bundle set on RETURN can never be wiped by a stale echo. The mentions bundle
+ * is a client-ephemeral render store (not server-mirrored window/away state),
+ * so clearing it on a user action does not violate the "cic never originates
+ * state" invariant. Tradeoff: auto-away / cross-device going-away (no compose)
+ * no longer clear, so a stale bundle can linger IF the next return carries zero
+ * new mentions (the server suppresses the empty broadcast) — a timestamped,
+ * secondary-button digest, strictly less harmful than the fresh-bundle-wipe it
+ * replaces. A robust auto-away clear would need a server sync-broadcast (out of
+ * the "lato client" scope). See docs/DESIGN_NOTES.md 2026-07-16.
+ */
+export const awayCommand: CommandHandler<"away"> = async (cmd, ctx) => {
+  if (cmd.action === "set") {
+    clearMentionsBundle(ctx.networkSlug);
+    await pushAwaySet(ctx.networkSlug, cmd.reason);
+  } else {
+    await pushAwayUnset(ctx.networkSlug);
+  }
+  return { ok: true };
+};
+
+/** `/nick <nick>` — rename on this network, over REST (addressed by SLUG). */
+export const nickCommand: CommandHandler<"nick"> = async (cmd, ctx) => {
+  await postNick(ctx.token, ctx.networkSlug, cmd.nick);
+  return { ok: true };
+};
+
+/**
+ * #581 — `/recover [network]`: guided "recover my identity". The server runs
+ * the NickServ recovery sequence and streams recover_progress / recover_result
+ * events on the user topic (RecoverModal mirrors them). The modal opens off the
+ * SERVER's first recover_progress — NOT optimistically here (cic never
+ * originates state). Bare /recover uses the active window's network.
+ */
+export const recoverCommand: CommandHandler<"recover"> = async (cmd, ctx) => {
+  const targetSlug = cmd.network ?? ctx.networkSlug;
+  const networkId = ctx.requireNetworkId(targetSlug, "recover");
+  if (typeof networkId !== "number") return networkId;
+  try {
+    await pushRecover(networkId);
+  } catch (e) {
+    // #581 — the recover rejection tokens (nothing_to_recover /
+    // already_identified / recovery_in_progress / forbidden) are in the
+    // generated channel-error union, so `friendlyError` → `friendlyChannelError`
+    // owns the copy. No local bridge needed.
+    return { error: friendlyError(e) };
+  }
+  return { ok: true };
+};
+
+/**
+ * #247/#356 — `/notify` + `/watch` presence watch (irssi-direct add). POSTs to
+ * the per-network REST surface; the server broadcasts the updated notify_list
+ * and live-syncs the session's MONITOR/WATCH. The green confirmation names the
+ * nicks from the COMMAND input, not the store — the notify_list broadcast that
+ * would let us re-render the full list may not have landed by the time the POST
+ * resolves, so reading watchByNetwork() here would race. Removal is the
+ * settings × (bare /notify opens it). Per-network: the active window's network.
+ */
+export const notifyCommand: CommandHandler<"notify"> = async (cmd, ctx) => {
+  // The id is not used — this arm addresses the network by SLUG over REST — but
+  // the network must still exist, so the check is kept and the value
+  // deliberately discarded.
+  const notifyNet = ctx.requireNetworkId(ctx.networkSlug, "notify");
+  if (typeof notifyNet !== "number") return notifyNet;
+  await postNotifyAdd(ctx.token, ctx.networkSlug, cmd.nicks);
+  return { ok: `notify: watching ${cmd.nicks.join(", ")}` };
 };

--- a/cicchetto/src/lib/commands/session.ts
+++ b/cicchetto/src/lib/commands/session.ts
@@ -1,0 +1,16 @@
+import { quitAll } from "../quit";
+import type { CommandHandler } from "./context";
+
+/**
+ * `/quit [reason]` — nuclear: park ALL bound networks, then logout. The
+ * implementation lives in `lib/quit.ts` so the sidebar server-window ×
+ * (UX-4 bucket D) can call the same path for visitors without re-parsing
+ * through here.
+ *
+ * After logout the component tree unmounts, so nothing downstream of this
+ * outcome runs.
+ */
+export const quitCommand: CommandHandler<"quit"> = async (cmd) => {
+  await quitAll(cmd.reason);
+  return { ok: true };
+};

--- a/cicchetto/src/lib/commands/topic.ts
+++ b/cicchetto/src/lib/commands/topic.ts
@@ -1,0 +1,13 @@
+import type { CommandHandler } from "./context";
+
+/**
+ * Bare `/topic` or `/topic #chan` — render the cached topic inline. The
+ * cached topic lives in `channelTopic.ts`; rendering is pure UI.
+ *
+ * TODO(C3): wire to TopicBar's cached topic for inline render.
+ */
+export const topicShowCommand: CommandHandler<"topic-show"> = async (cmd, ctx) => {
+  const ch = cmd.channel ?? ctx.getActiveChannel();
+  if (!ch) return { error: "/topic requires a channel — switch to one or use /topic #chan" };
+  return { error: `/topic ${ch} (bare) — inline render wired in C3 (TopicBar)` };
+};

--- a/cicchetto/src/lib/commands/topic.ts
+++ b/cicchetto/src/lib/commands/topic.ts
@@ -1,3 +1,4 @@
+import { pushChannelTopicClear } from "../socket";
 import type { CommandHandler } from "./context";
 
 /**
@@ -10,4 +11,20 @@ export const topicShowCommand: CommandHandler<"topic-show"> = async (cmd, ctx) =
   const ch = cmd.channel ?? ctx.getActiveChannel();
   if (!ch) return { error: "/topic requires a channel — switch to one or use /topic #chan" };
   return { error: `/topic ${ch} (bare) — inline render wired in C3 (TopicBar)` };
+};
+
+/** `/topic -delete` or `/topic #chan -delete` — clear the topic via channel event. */
+export const topicClearCommand: CommandHandler<"topic-clear"> = async (cmd, ctx) => {
+  const ch = cmd.channel ?? ctx.getActiveChannel();
+  if (!ch)
+    return {
+      error: "/topic -delete requires a channel — switch to one or use /topic #chan -delete",
+    };
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "topic -delete");
+  if (typeof networkId !== "number") return networkId;
+  // S21: AWAIT the verb ack (#154 no-silent-drops). A WS-down / server
+  // {:error,_} rejects into the dispatcher's shared catch → friendlyChannelError
+  // inline alert, instead of painting a green ✓ on a dropped frame.
+  await pushChannelTopicClear(networkId, ch);
+  return { ok: true };
 };

--- a/cicchetto/src/lib/commands/topic.ts
+++ b/cicchetto/src/lib/commands/topic.ts
@@ -1,3 +1,4 @@
+import { postTopic } from "../api";
 import { pushChannelTopicClear } from "../socket";
 import type { CommandHandler } from "./context";
 
@@ -11,6 +12,20 @@ export const topicShowCommand: CommandHandler<"topic-show"> = async (cmd, ctx) =
   const ch = cmd.channel ?? ctx.getActiveChannel();
   if (!ch) return { error: "/topic requires a channel — switch to one or use /topic #chan" };
   return { error: `/topic ${ch} (bare) — inline render wired in C3 (TopicBar)` };
+};
+
+/**
+ * `/topic <text>` or `/topic #chan <text>` — set the topic via REST. An
+ * explicit channel wins; otherwise the current channel; otherwise bail.
+ */
+export const topicSetCommand: CommandHandler<"topic-set"> = async (cmd, ctx) => {
+  const ch = cmd.channel ?? ctx.getActiveChannel();
+  if (!ch)
+    return {
+      error: "/topic requires a channel — switch to one or use /topic #chan <text>",
+    };
+  await postTopic(ctx.token, ctx.networkSlug, ch, cmd.text);
+  return { ok: true };
 };
 
 /** `/topic -delete` or `/topic #chan -delete` — clear the topic via channel event. */

--- a/cicchetto/src/lib/commands/window.ts
+++ b/cicchetto/src/lib/commands/window.ts
@@ -1,0 +1,148 @@
+import { postJoin, postPart } from "../api";
+import { setQuery } from "../channelDirectory";
+import { canonicalChannel } from "../channelKey";
+import { networkIdBySlug } from "../networks";
+import { canonicalQueryNick, openQueryWindowState } from "../queryWindows";
+import { selectedChannel, setSelectedChannel } from "../selection";
+import { isServicesSender } from "../servicesSender";
+import { closeQueryWindow } from "../windowClose";
+import { LIST_WINDOW_NAME } from "../windowKinds";
+import type { CommandHandler } from "./context";
+
+/**
+ * The verbs that decide WHICH window the operator is in: channel membership,
+ * and the two that open a pseudo-window.
+ *
+ * #1396 — a note on `ctx.channelName`, because this file is where the trap
+ * lives. Only `part` reads it, and it reads it as a DEFAULT TARGET. The other
+ * three never read it: they WRITE a different channel into the selection. The
+ * record therefore carries the submitting window's channel as ONE raw fact and
+ * lets each handler mean what it means — pre-resolving it into something like
+ * a "default target" field is what would collapse those meanings, so nothing
+ * here does that.
+ */
+
+/**
+ * `/part [#chan] [reason]` — the channel argument defaults to the window the
+ * command was typed in. This is the one genuine `target == context`
+ * degeneration in the dispatch table: a context resolved from the wrong window
+ * parts the wrong channel, silently and successfully.
+ */
+export const partCommand: CommandHandler<"part"> = async (cmd, ctx) => {
+  const target = cmd.channel ?? ctx.channelName;
+  await postPart(ctx.token, ctx.networkSlug, target, cmd.reason);
+  return { ok: true };
+};
+
+/**
+ * `/join #a[,#b] [key]`.
+ *
+ * #516 — the parser returns `channels: string[]`; rejoin with `,` to reproduce
+ * the RFC1459 comma-list on the wire byte-for-byte (the server splits it and
+ * opens a `:pending` window per channel, #382).
+ *
+ * CP17 — window state is server-driven: `record_in_flight_join/2` writes
+ * `window_states[ch] = :pending` and broadcasts `window_pending` on
+ * `Topic.user/1`, which userTopic.ts dispatches into setPending(...). Pre-CP17
+ * cic mutated setPending here optimistically — the only cic-originated state
+ * mutation in the codebase, and a violation of the "cic NEVER originates state"
+ * hard-invariant.
+ *
+ * The focus switch, however, IS ours: the operator just typed /join, so focus
+ * follows intent. Doing it here rather than leaning on subscribe.ts's self-JOIN
+ * handler closes a race — the JOIN is broadcast on the per-channel WS topic
+ * immediately after channels_changed fires, but cic only joins that topic AFTER
+ * the REST refetch completes, and Phoenix PubSub does not replay to late
+ * subscribers, so that handler's setSelectedChannel never fired in practice.
+ * The autojoin / sajoin / NickServ-driven JOINs still go through subscribe.ts
+ * (no race there — the channel was already joined when the event arrives).
+ *
+ * #510/#516 — focus must land on the FIRST channel, folded the SAME way the
+ * server folds window keys (`canonicalChannel` = the
+ * `Identifier.canonical_channel/1` twin, CASEMAPPING=ascii — A-Z only, brackets
+ * untouched; #525). A mixed-case or bracketed first element targets a key no
+ * `window_states` entry matches, which opens the empty phantom window #510
+ * reported.
+ */
+export const joinCommand: CommandHandler<"join"> = async (cmd, ctx) => {
+  await postJoin(ctx.token, ctx.networkSlug, cmd.channels.join(","), cmd.key);
+  setSelectedChannel({
+    networkSlug: ctx.networkSlug,
+    // `channels` is non-empty (the parser errors on a missing name), so `[0]`
+    // is never undefined at runtime; the `?? join(",")` fallback exists only to
+    // satisfy TS noUncheckedIndexedAccess.
+    channelName: canonicalChannel(cmd.channels[0] ?? cmd.channels.join(",")),
+    kind: "channel",
+  });
+  return { ok: true };
+};
+
+/**
+ * `/list [pattern]` — the channel directory browser (#84). Opens the
+ * per-network $list pseudo-window (DirectoryPane); the pane loads the snapshot
+ * on mount (the server auto-refreshes on empty). A pattern pre-seeds the
+ * directory search (setQuery re-GETs filtered). No raw LIST is sent here — the
+ * directory's own refresh path owns that.
+ */
+export const listCommand: CommandHandler<"list"> = async (cmd, ctx) => {
+  setSelectedChannel({
+    networkSlug: ctx.networkSlug,
+    channelName: LIST_WINDOW_NAME,
+    kind: "list",
+  });
+  if (cmd.pattern !== null && cmd.pattern !== "") {
+    void setQuery(ctx.networkSlug, cmd.pattern);
+  }
+  return { ok: true };
+};
+
+/**
+ * `/query <nick>` — open a query window and switch focus. No message is sent
+ * (spec #1). Bare `/query` on a query-kind window CLOSES it (irssi convention);
+ * bare /query on any other window kind is an error — the parser emits
+ * `{target: null}` for both and the semantics are resolved here.
+ *
+ * UX-4 bucket G: *serv targets reject. Opening a query window for NickServ
+ * would be a dead window (services route to $server server-side), so this is a
+ * user-facing error the operator can answer with `/msg <Xserv> ...`.
+ */
+export const queryCommand: CommandHandler<"query"> = async (cmd, ctx) => {
+  if (cmd.target === null) {
+    // Cross-network safety on the bare-close path: resolve the network ID from
+    // the SELECTED window's own networkSlug, not from the submitting one — the
+    // two diverge when the submit was queued across a window switch, and using
+    // the submitting slug with `sel.channelName` would no-op or close a
+    // wrong-network row.
+    const sel = selectedChannel();
+    if (sel?.kind === "query") {
+      // #1396 — the one guard NOT routed through `requireNetworkId`. It is not
+      // the same guard: every other site asks "is the network this operator is
+      // typing in live?", this one asks it of a DIFFERENT network, and its copy
+      // has always said so. The shared message is `/<subject>: network not
+      // found`, which cannot spell "selected window's network" without an extra
+      // colon — so forcing it through would change operator-visible copy to buy
+      // uniformity, which is the wrong trade in a refactor.
+      const selNetId = networkIdBySlug(sel.networkSlug);
+      if (selNetId === undefined) return { error: "/query: selected window's network not found" };
+      closeQueryWindow(selNetId, sel.channelName);
+      return { ok: true };
+    }
+    return {
+      error: "/query <nick> required (bare /query closes the current query window only)",
+    };
+  }
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "query");
+  if (typeof networkId !== "number") return networkId;
+  if (isServicesSender(cmd.target)) {
+    return {
+      error: `/query: ${cmd.target} is a services nick; responses land in the server window — use /msg ${cmd.target} <command>`,
+    };
+  }
+  // canonicalQueryNick: resolve user-input casing to the existing window's
+  // ChannelKey — using cmd.target as-is would create a dead key no sidebar or
+  // scrollback store knows.
+  const canonical = canonicalQueryNick(networkId, cmd.target);
+  openQueryWindowState(networkId, canonical, new Date().toISOString());
+  setSelectedChannel({ networkSlug: ctx.networkSlug, channelName: canonical, kind: "query" });
+  return { ok: true };
+};

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,15 +1,6 @@
 import { createEffect, createSignal, on } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
-import {
-  ApiError,
-  ownNickForNetwork,
-  patchNetwork,
-  postJoin,
-  postNick,
-  postNotifyAdd,
-  postPart,
-  postTopic,
-} from "./api";
+import { ApiError, ownNickForNetwork, postJoin, postPart, postTopic } from "./api";
 import { token } from "./auth";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
@@ -38,7 +29,28 @@ import {
   unbanCommand,
   voiceCommand,
 } from "./commands/ops";
-import { quitCommand } from "./commands/session";
+import {
+  infoCommand,
+  linksCommand,
+  lusersCommand,
+  motdCommand,
+  namesCommand,
+  quoteCommand,
+  rehashCommand,
+  statsCommand,
+  versionCommand,
+  whoCommand,
+  whoisCommand,
+  whowasCommand,
+} from "./commands/server";
+import {
+  awayCommand,
+  disconnectCommand,
+  nickCommand,
+  notifyCommand,
+  quitCommand,
+  recoverCommand,
+} from "./commands/session";
 import { topicClearCommand, topicShowCommand } from "./commands/topic";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
@@ -48,9 +60,7 @@ import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
 import { identityScopedStore } from "./identityScopedStore";
 import { chantypesForNetwork } from "./isupport";
-import { markLusersRequested } from "./lusersBundle";
 import { membersByChannel } from "./members";
-import { clearMentionsBundle } from "./mentionsWindow";
 import { splitMessageLines } from "./messageLines";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
 import { asciiFold } from "./nickEquals";
@@ -65,23 +75,7 @@ import { openServiceModal } from "./serviceModal";
 import { isServicesSender } from "./servicesSender";
 import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
-import {
-  pushAdmin,
-  pushAwaySet,
-  pushAwayUnset,
-  pushInfo,
-  pushLinks,
-  pushLusers,
-  pushMotd,
-  pushNames,
-  pushOper,
-  pushRaw,
-  pushRecover,
-  pushVersion,
-  pushWho,
-  pushWhois,
-  pushWhowas,
-} from "./socket";
+import { pushAdmin, pushOper } from "./socket";
 import { closeQueryWindow } from "./windowClose";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./windowKinds";
 import { windowStateByChannel } from "./windowState";
@@ -923,6 +917,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       sigils: () => sigilsFor(networkSlug),
       requireChannel,
       requireNetworkId,
+      resolveBareWhoisNick,
     };
 
     let result: SubmitResult;
@@ -1191,8 +1186,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "nick":
-          await postNick(t, networkSlug, cmd.nick);
-          result = { ok: true };
+          result = await nickCommand(cmd, ctx);
           break;
         case "msg": {
           // /msg <target> <text> — open query window, switch focus (user
@@ -1353,16 +1347,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         case "quit":
           return await quitCommand(cmd, ctx);
         case "disconnect": {
-          // Surgical: park one network. `network` from parser is null
-          // (bare /disconnect) or a named slug. Null → use active-window's
-          // networkSlug (already in scope from submit's args).
-          const targetSlug = cmd.network ?? networkSlug;
-          const disconnBody: { connection_state: "parked"; reason?: string } = {
-            connection_state: "parked",
-          };
-          if (cmd.reason !== null) disconnBody.reason = cmd.reason;
-          await patchNetwork(t, targetSlug, disconnBody);
-          result = { ok: true };
+          result = await disconnectCommand(cmd, ctx);
           break;
         }
         case "connect": {
@@ -1370,38 +1355,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "away": {
-          // S3.4 — explicit away set/unset via the user-level Phoenix Channel.
-          // The channel push reaches GrappaChannel.handle_in("away", ...) which
-          // routes to Session.set_explicit_away / Session.unset_explicit_away.
-          // networkSlug from submit args is the active window's network.
-          if (cmd.action === "set") {
-            // #268 — clear this network's stale mentions bundle HERE, on the
-            // user's own GOING-away action, NOT on the `away_confirmed:"away"`
-            // echo. The clear MUST be causally ordered with the away lifecycle:
-            // the return-from-away `mentions_bundle` is broadcast SYNCHRONOUSLY
-            // by grappa on the un-away command, but `away_confirmed` is emitted
-            // only on the upstream 305/306 numeric echo (event_router.ex) — a
-            // different-latency channel. Under bahamut fake-lag a going-away's
-            // delayed 306 could arrive AFTER a subsequent return's bundle and
-            // clobber it (the "0 messages in 0 channels" bug). Triggering the
-            // clear on the compose action makes it ordered with the user's own
-            // commands, so a fresh bundle set on RETURN can never be wiped by a
-            // stale echo. The mentions bundle is a client-ephemeral render store
-            // (not server-mirrored window/away state), so clearing it on a user
-            // action does not violate the "cic never originates state" invariant.
-            // Tradeoff: auto-away / cross-device going-away (no compose) no
-            // longer clear, so a stale bundle can linger IF the next return
-            // carries zero new mentions (the server suppresses the empty
-            // broadcast) — a timestamped, secondary-button digest, strictly
-            // less harmful than the fresh-bundle-wipe it replaces. A robust
-            // auto-away clear would need a server sync-broadcast (out of the
-            // "lato client" scope). See docs/DESIGN_NOTES.md 2026-07-16.
-            clearMentionsBundle(networkSlug);
-            await pushAwaySet(networkSlug, cmd.reason);
-          } else {
-            await pushAwayUnset(networkSlug);
-          }
-          result = { ok: true };
+          result = await awayCommand(cmd, ctx);
           break;
         }
         // ---------------------------------------------------------------
@@ -1504,30 +1458,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // form, out of MVP scope).
         // ---------------------------------------------------------------
         case "who": {
-          // #122 — bare /who defaults to the current channel (shares the
-          // requireChannel resolver with /names); errors only outside one.
-          const target = cmd.target ?? requireChannel("who");
-          if (typeof target !== "string") return target;
-          const networkId = requireNetworkId(networkSlug, "who");
-          if (typeof networkId !== "number") return networkId;
-          await pushWho(networkId, target); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await whoCommand(cmd, ctx);
           break;
         }
         case "names": {
-          // #140 — /names [#channel]. Server buffers the 353/366 burst and
-          // emits ONE ephemeral `names_reply` on the user topic; NamesModal
-          // renders the grouped, scrollable, dismissable roster. The modal
-          // is network-scoped (last-write-wins), so the originating window
-          // is irrelevant — no origin passed.
-          // #122 — bare /names (and /n alias) defaults to the current
-          // channel (shares the requireChannel resolver with /who).
-          const target = cmd.target ?? requireChannel("names");
-          if (typeof target !== "string") return target;
-          const networkId = requireNetworkId(networkSlug, "names");
-          if (typeof networkId !== "number") return networkId;
-          await pushNames(networkId, target); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await namesCommand(cmd, ctx);
           break;
         }
         case "list": {
@@ -1544,92 +1479,27 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "links": {
-          // #238 — /links [<mask>]. Push on the user-level channel; server
-          // primes links_pending + emits LINKS upstream. The 364 burst folds
-          // server-side and 365 RPL_ENDOFLINKS drains ONE ephemeral
-          // `links_bundle` event on the user topic; LinksModal (mounted in
-          // Shell, network-scoped) renders the interactive topology map. No
-          // focus change + no scrollback rows (mirrors /who + /names). An empty
-          // bundle (restricted/oper-only network) still opens the modal to the
-          // "hides topology" state. `cmd.pattern` is the optional server mask.
-          const networkId = requireNetworkId(networkSlug, "links");
-          if (typeof networkId !== "number") return networkId;
-          await pushLinks(networkId, cmd.pattern); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await linksCommand(cmd, ctx);
           break;
         }
-        // #581 — /recover [network]: guided "recover my identity". Push on the
-        // user-level channel; the server runs the NickServ recovery sequence and
-        // streams recover_progress / recover_result events on the user topic
-        // (RecoverModal mirrors them). The modal opens off the SERVER's first
-        // recover_progress — NOT optimistically here (cic never originates
-        // state). Bare /recover uses the active window's network. A rejection
-        // (nothing_to_recover / already_identified / not_visitor) maps to
-        // friendly copy; anything else (no_session, WS-down) delegates to the
-        // shared friendlyError catch.
         case "recover": {
-          const targetSlug = cmd.network ?? networkSlug;
-          const networkId = requireNetworkId(targetSlug, "recover");
-          if (typeof networkId !== "number") return networkId;
-          try {
-            await pushRecover(networkId);
-          } catch (e) {
-            // #581 — the recover rejection tokens (nothing_to_recover /
-            // already_identified / recovery_in_progress / forbidden) are now
-            // in the generated channel-error union, so `friendlyError` →
-            // `friendlyChannelError` owns the copy. No local bridge needed.
-            return { error: friendlyError(e) };
-          }
-          result = { ok: true };
+          result = await recoverCommand(cmd, ctx);
           break;
         }
-        // P-0d — /lusers [<mask> [<server>]]. Pushes on user-level channel;
-        // server emits the 7-numeric LUSERS bundle. cic dispatches the
-        // typed `:lusers_bundle` wire event in userTopic.ts and renders
-        // the LusersCard pinned at the top of the current window (#231).
-        // #579 — the mask + target server ride along (they were dropped at
-        // the parser, so a routed request silently answered from the local
-        // server and any mask never reached the wire at all).
         case "lusers": {
-          const networkId = requireNetworkId(networkSlug, "lusers");
-          if (typeof networkId !== "number") return networkId;
-          // #248 — mark the request solicited BEFORE pushing so the
-          // incoming bundle surfaces the card. The store's gate drops
-          // any unsolicited bundle (the Bahamut connect-welcome
-          // auto-emit), so an operator /lusers that skipped this mark
-          // would show nothing.
-          markLusersRequested(networkSlug);
-          await pushLusers(networkId, cmd.mask, cmd.server); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await lusersCommand(cmd, ctx);
           break;
         }
-        // #127 — /info, /version, /motd. No-arg server-text queries; server
-        // primes the matching accumulator + emits the command, the reply
-        // burst drains a typed `server_reply` event that userTopic.ts routes
-        // into the serverReplyModal store (ServerReplyModal renders it).
         case "info": {
-          const networkId = requireNetworkId(networkSlug, "info");
-          if (typeof networkId !== "number") return networkId;
-          await pushInfo(networkId); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await infoCommand(cmd, ctx);
           break;
         }
         case "version": {
-          const networkId = requireNetworkId(networkSlug, "version");
-          if (typeof networkId !== "number") return networkId;
-          await pushVersion(networkId); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await versionCommand(cmd, ctx);
           break;
         }
         case "motd": {
-          const networkId = requireNetworkId(networkSlug, "motd");
-          if (typeof networkId !== "number") return networkId;
-          // #374 — thread the optional target server through so grappa emits
-          // `MOTD <target>` upstream (or bare MOTD when null). A 402
-          // ERR_NOSUCHSERVER for an unknown target surfaces via the same
-          // server_reply modal, never a wrong-server MOTD.
-          await pushMotd(networkId, cmd.target); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await motdCommand(cmd, ctx);
           break;
         }
         // #992 — /admin [<target>]. Same door as /motd; the reply lands in
@@ -1641,82 +1511,20 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
-        // #155 — /stats [query] [server] + /rehash. Native parser sugar over
-        // the #153-de-gated raw transport (mirrors /quote): build the raw
-        // STATS/REHASH frame and ship it via pushRaw. Server routing: the
-        // STATS reply family (211-219, 240-250) is server-directed — grappa's
-        // numeric_router pins the whole family to the `$server` window as
-        // :notice rows via its @active_numerics deny list (#184). Before that
-        // fix the terminating 219 RPL_ENDOFSTATS's stats-letter param was
-        // mis-read by the scan fallback as a query target, forking a bogus
-        // window named after the letter; #155's original "no server change"
-        // premise was wrong. REHASH/permission numerics (e.g. 481) land on
-        // `$server` too. AWAIT the push so a WS-disconnected / server
-        // {:error,_} surfaces as an inline compose error instead of a silent
-        // green ✓ (the #154 no-silent-drop lesson).
         case "stats": {
-          const networkId = requireNetworkId(networkSlug, "stats");
-          if (typeof networkId !== "number") return networkId;
-          // STATS [query] [server] — omit trailing nulls. IRC STATS is a
-          // 2-arg frame; the parser guarantees target is only set when query
-          // is, so filtering nulls preserves positional order.
-          const line = ["STATS", cmd.query, cmd.target]
-            .filter((t): t is string => t !== null)
-            .join(" ");
-          await pushRaw(networkId, line);
-          result = { ok: true };
+          result = await statsCommand(cmd, ctx);
           break;
         }
         case "rehash": {
-          const networkId = requireNetworkId(networkSlug, "rehash");
-          if (typeof networkId !== "number") return networkId;
-          // REHASH [option] — omit a null option (bare /rehash → "REHASH",
-          // the default full-config reload). #375: mirror the /stats null
-          // filter so the option (MOTD/DNS/GC/…) rides the raw frame instead
-          // of being dropped into a bare REHASH.
-          const line = ["REHASH", cmd.opt].filter((t): t is string => t !== null).join(" ");
-          await pushRaw(networkId, line);
-          result = { ok: true };
+          result = await rehashCommand(cmd, ctx);
           break;
         }
-        // ---------------------------------------------------------------
-        // C2 — /whois <nick>. Push on the user-level channel; the server
-        // primes its accumulator and emits WHOIS upstream. The bundle
-        // arrives later as `whois_bundle` on the user topic
-        // (handled by userTopic.ts → setWhoisBundle). WHOIS with an
-        // explicit nick works from any window kind; the bundle render
-        // targets the active window at arrival time. (Bare /whois resolves
-        // a context default — query partner, or self on any network-scoped
-        // window; see resolveBareWhoisNick below.)
-        // ---------------------------------------------------------------
         case "whois": {
-          // #122 + #132 + #137 — bare /whois (and /w alias) context-default:
-          // query window → partner; every other network-scoped window → self.
-          const nick = cmd.nick ?? resolveBareWhoisNick("whois");
-          if (typeof nick !== "string") return nick;
-          const networkId = requireNetworkId(networkSlug, "whois");
-          if (typeof networkId !== "number") return networkId;
-          // #198 — cmd.server is set only for the two-arg `/whois <server>
-          // <nick>` form; null for single-arg + bare. The bouncer emits
-          // `WHOIS <server> <nick>` upstream when present, plain `WHOIS
-          // <nick>` otherwise.
-          // S6 (#364): await so a validation reject (e.g. invalid_nick, which
-          // fires BEFORE the upstream write → no bundle, no numeric) surfaces
-          // inline instead of leaving the operator with nothing.
-          await pushWhois(networkId, nick, cmd.server);
-          result = { ok: true };
+          result = await whoisCommand(cmd, ctx);
           break;
         }
-        // P-0c — /whowas <nick>. Push on the user-level channel; the
-        // server primes whowas_pending and emits WHOWAS upstream. The
-        // bundle arrives later as `whowas_bundle` on the user topic
-        // (handled by userTopic.ts → setWhowasBundle), or as a
-        // not_found bundle on 406 ERR_WASNOSUCHNICK.
         case "whowas": {
-          const networkId = requireNetworkId(networkSlug, "whowas");
-          if (typeof networkId !== "number") return networkId;
-          await pushWhowas(networkId, cmd.nick); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await whowasCommand(cmd, ctx);
           break;
         }
         // ---------------------------------------------------------------
@@ -1732,22 +1540,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = await watchlistCommand(cmd, ctx);
           break;
         }
-        // #247/#356 — /notify + /watch presence watch (irssi-direct add).
-        // POST to the per-network REST surface; the server broadcasts the
-        // updated notify_list + live-syncs the session's MONITOR/WATCH. The
-        // green confirmation names the nicks from the COMMAND input, not the
-        // store — the notify_list broadcast that would let us re-render the
-        // full list may not have landed by the time the POST resolves, so
-        // reading watchByNetwork() here would race. Removal is the settings
-        // × (bare /notify opens it). Per-network: the active window's network.
         case "notify": {
-          // The id is not used — this arm addresses the network by SLUG over
-          // REST — but the network must still exist, so the check is kept and
-          // the value deliberately discarded.
-          const notifyNet = requireNetworkId(networkSlug, "notify");
-          if (typeof notifyNet !== "number") return notifyNet;
-          await postNotifyAdd(t, networkSlug, cmd.nicks);
-          result = { ok: `notify: watching ${cmd.nicks.join(", ")}` };
+          result = await notifyCommand(cmd, ctx);
           break;
         }
         // #356 — a bare watch-family verb (/notify, /watch, /hilight,
@@ -1759,16 +1553,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
-        // Bundle C (#20 follow-up) — /quote <raw IRC line>. Push to
-        // GrappaChannel.handle_in("raw", _); server validates CRLF/NUL
-        // then ships verbatim to the upstream socket. AWAIT the push
-        // so disconnected/error replies surface as inline compose-box
-        // alerts (no silent green ✓ on a dropped escape-hatch frame).
         case "quote": {
-          const networkId = requireNetworkId(networkSlug, "quote");
-          if (typeof networkId !== "number") return networkId;
-          await pushRaw(networkId, cmd.line);
-          result = { ok: true };
+          result = await quoteCommand(cmd, ctx);
           break;
         }
         // Bundle C (#20 follow-up) — /oper <name> <password>. The password

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -16,13 +16,17 @@ import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
+import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
+import { watchlistCommand } from "./commands/highlight";
+import { connectCommand } from "./commands/network";
+import { quitCommand } from "./commands/session";
+import { topicShowCommand } from "./commands/topic";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
 import { sendCtcpQuery } from "./ctcpQuery";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
-import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
 import { chantypesForNetwork, isupportForNetwork } from "./isupport";
 import { markLusersRequested } from "./lusersBundle";
@@ -34,7 +38,6 @@ import { networkBySlug, networkIdBySlug, user } from "./networks";
 import { asciiFold, nickEquals } from "./nickEquals";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
-import { quitAll } from "./quit";
 // #1225 — the seam sends a PRIVMSG to the window OR relays a NOTICE/CTCP to a
 // different recipient while echoing here, so it is named for the window, not
 // for one of the verbs it can carry.
@@ -145,11 +148,6 @@ type ComposeState = {
   stashedDraft: string;
 };
 
-// ok: true = silent success (draft cleared, no feedback to user).
-// ok: string = success with inline feedback (e.g. watchlist list output).
-// error: string = failure, displayed inline; draft preserved.
-type SubmitResult = { ok: true | string } | { error: string };
-
 // #904 — `submit` (the pump) OWNS the composer buffer: it takes the text out
 // at dispatch and hands it back if the submission fails, so every failure
 // path preserves the draft without each of the ~40 arms knowing about it.
@@ -157,7 +155,6 @@ type SubmitResult = { ok: true | string } | { error: string };
 // (#737) and mirrors its own, finer-grained residue into it, so it says
 // `keptBuffer` and the pump keeps its hands off instead of dropping the whole
 // paste back on top of the remainder.
-type DispatchOutcome = SubmitResult | { error: string; keptBuffer: true };
 
 // #904 — one window's send queue: an entry exists while a submission from it
 // is in flight, and `queued` holds the at-most-one message sent behind it.
@@ -926,6 +923,19 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       return own;
     };
 
+    // #1396 — the per-submission values a handler cannot import for itself.
+    // Built once, here, so every handler reads the SAME window: resolving any
+    // of these inside a handler would re-read the store at handler time and
+    // could answer for a different window than the one that submitted.
+    const ctx: CommandContext = {
+      key,
+      networkSlug,
+      channelName,
+      text,
+      token: t,
+      getActiveChannel,
+    };
+
     let result: SubmitResult;
     try {
       switch (cmd.kind) {
@@ -1173,15 +1183,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
-        case "topic-show": {
-          // Bare /topic or /topic #chan — render cached topic inline.
-          // The cached topic lives in channelTopic.ts; rendering is pure UI.
-          // TODO(C3): wire to TopicBar's cached topic for inline render.
-          const ch = cmd.channel ?? getActiveChannel();
-          if (!ch)
-            return { error: "/topic requires a channel — switch to one or use /topic #chan" };
-          return { error: `/topic ${ch} (bare) — inline render wired in C3 (TopicBar)` };
-        }
+        case "topic-show":
+          return await topicShowCommand(cmd, ctx);
         case "topic-set": {
           // /topic <text> or /topic #chan <text> — set topic via REST.
           // Explicit channel wins; otherwise current channel; otherwise bail.
@@ -1371,16 +1374,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
-        case "quit": {
-          // Nuclear: park ALL bound networks, then logout. The
-          // implementation lives in `lib/quit.ts` so the sidebar
-          // server-window × (UX-4 bucket D) can call the same path for
-          // visitors without re-parsing through here.
-          await quitAll(cmd.reason);
-          // After logout the component tree will unmount — no further
-          // result processing needed. Return early to skip history push.
-          return { ok: true };
-        }
+        case "quit":
+          return await quitCommand(cmd, ctx);
         case "disconnect": {
           // Surgical: park one network. `network` from parser is null
           // (bare /disconnect) or a named slug. Null → use active-window's
@@ -1395,10 +1390,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "connect": {
-          // Unpark + respawn. Network slug guaranteed by parser
-          // (bare /connect surfaces as kind: "error" instead).
-          await patchNetwork(t, cmd.network, { connection_state: "connected" });
-          result = { ok: true };
+          result = await connectCommand(cmd, ctx);
           break;
         }
         case "away": {
@@ -1957,13 +1949,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // list, so this is race-free.
         // ---------------------------------------------------------------
         case "watchlist": {
-          const patterns =
-            cmd.action === "add"
-              ? await addHighlight(cmd.pattern)
-              : await delHighlight(cmd.pattern);
-          result = {
-            ok: `highlight (${patterns.length}): ${patterns.join(", ") || "(empty)"}`,
-          };
+          result = await watchlistCommand(cmd, ctx);
           break;
         }
         // #247/#356 — /notify + /watch presence watch (irssi-direct add).

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -11,16 +11,35 @@ import {
   postTopic,
 } from "./api";
 import { token } from "./auth";
-import { openBanlistModal } from "./banlistModal";
-import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
 import { watchlistCommand } from "./commands/highlight";
+import {
+  banlistCommand,
+  modeApplyCurrentCommand,
+  modeCommand,
+  modeViewCommand,
+  umodeCommand,
+  umodeTargetViewCommand,
+  umodeViewCommand,
+} from "./commands/mode";
 import { connectCommand } from "./commands/network";
+import {
+  banCommand,
+  deopCommand,
+  devoiceCommand,
+  inviteCommand,
+  kbCommand,
+  kickCommand,
+  killCommand,
+  opCommand,
+  unbanCommand,
+  voiceCommand,
+} from "./commands/ops";
 import { quitCommand } from "./commands/session";
-import { topicShowCommand } from "./commands/topic";
+import { topicClearCommand, topicShowCommand } from "./commands/topic";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
 import { sendCtcpQuery } from "./ctcpQuery";
@@ -28,14 +47,13 @@ import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
 import { identityScopedStore } from "./identityScopedStore";
-import { chantypesForNetwork, isupportForNetwork } from "./isupport";
+import { chantypesForNetwork } from "./isupport";
 import { markLusersRequested } from "./lusersBundle";
 import { membersByChannel } from "./members";
 import { clearMentionsBundle } from "./mentionsWindow";
 import { splitMessageLines } from "./messageLines";
-import { openModeModal } from "./modeModal";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
-import { asciiFold, nickEquals } from "./nickEquals";
+import { asciiFold } from "./nickEquals";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // #1225 — the seam sends a PRIVMSG to the window OR relays a NOTICE/CTCP to a
@@ -51,18 +69,6 @@ import {
   pushAdmin,
   pushAwaySet,
   pushAwayUnset,
-  pushChannelBan,
-  pushChannelBanlist,
-  pushChannelDeop,
-  pushChannelDevoice,
-  pushChannelInvite,
-  pushChannelKick,
-  pushChannelMode,
-  pushChannelOp,
-  pushChannelTopicClear,
-  pushChannelUmode,
-  pushChannelUnban,
-  pushChannelVoice,
   pushInfo,
   pushLinks,
   pushLusers,
@@ -75,9 +81,7 @@ import {
   pushWho,
   pushWhois,
   pushWhowas,
-  resolveUserhost,
 } from "./socket";
-import { openUmodeModal } from "./umodeModal";
 import { closeQueryWindow } from "./windowClose";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./windowKinds";
 import { windowStateByChannel } from "./windowState";
@@ -90,24 +94,6 @@ import { windowStateByChannel } from "./windowState";
 // to carry a `TODO(#30)`, which pointed at a closed, unrelated issue.)
 const sigilsFor = (slug: string): readonly string[] =>
   chantypesForNetwork(networkIdBySlug(slug) ?? null);
-
-// #536/#1251 — is this `/mode` a type-A LIST QUERY rather than a mode change?
-// Three conditions, all necessary: no parameter (a mask makes it a MUTATION,
-// `/mode #chan +b nick!*@*`), exactly one optionally-signed letter, and that
-// letter is one this NETWORK offers as a queryable list (server-published, in
-// `isupport.listModesQueryable` — cic never derives it).
-//
-// Why it lives here and not in the pure parser: the third condition is 005
-// data. `/mode #chan +i` on a network where `i` is a flag must stay a mode
-// change, and no letter is a list mode everywhere — `q` is a LIST on solanum
-// and a founder-status prefix elsewhere. Returns the bare letter, or null
-// when the caller should execute the MODE verbatim.
-const listModeQueryLetter = (modes: string, params: string[], networkId: number): string | null => {
-  if (params.length > 0) return null;
-  const letter = /^[+-]?([A-Za-z])$/.exec(modes)?.[1];
-  if (letter === undefined) return null;
-  return isupportForNetwork(networkId).listModesQueryable.includes(letter) ? letter : null;
-};
 
 // #1003 — IRC nicks wear decoration (`_omino_`, `bob^`, `gio-vanni`), so
 // Tab must reach `_omino_` from the bare `omi`. Deliberately NOT taught to
@@ -934,6 +920,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       text,
       token: t,
       getActiveChannel,
+      sigils: () => sigilsFor(networkSlug),
+      requireChannel,
+      requireNetworkId,
     };
 
     let result: SubmitResult;
@@ -1198,20 +1187,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "topic-clear": {
-          // /topic -delete or /topic #chan -delete — clear topic via channel event.
-          const ch = cmd.channel ?? getActiveChannel();
-          if (!ch)
-            return {
-              error:
-                "/topic -delete requires a channel — switch to one or use /topic #chan -delete",
-            };
-          const networkId = requireNetworkId(networkSlug, "topic -delete");
-          if (typeof networkId !== "number") return networkId;
-          // S21: AWAIT the verb ack (#154 no-silent-drops). A WS-down / server
-          // {:error,_} now rejects into the shared catch → friendlyChannelError
-          // inline alert, instead of painting a green ✓ on a dropped frame.
-          await pushChannelTopicClear(networkId, ch);
-          result = { ok: true };
+          result = await topicClearCommand(cmd, ctx);
           break;
         }
         case "nick":
@@ -1443,267 +1419,71 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // and surfaces it inline in the compose box — the same contract as
         // `case "oper"` / `case "quote"`.
         case "op": {
-          const chanOrErr = requireChannel("op");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "op");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelOp(networkId, chanOrErr, cmd.nicks);
-          result = { ok: true };
+          result = await opCommand(cmd, ctx);
           break;
         }
         case "deop": {
-          const chanOrErr = requireChannel("deop");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "deop");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelDeop(networkId, chanOrErr, cmd.nicks);
-          result = { ok: true };
+          result = await deopCommand(cmd, ctx);
           break;
         }
         case "voice": {
-          const chanOrErr = requireChannel("voice");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "voice");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelVoice(networkId, chanOrErr, cmd.nicks);
-          result = { ok: true };
+          result = await voiceCommand(cmd, ctx);
           break;
         }
         case "devoice": {
-          const chanOrErr = requireChannel("devoice");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "devoice");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelDevoice(networkId, chanOrErr, cmd.nicks);
-          result = { ok: true };
+          result = await devoiceCommand(cmd, ctx);
           break;
         }
         case "kick": {
-          const chanOrErr = requireChannel("kick");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "kick");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelKick(networkId, chanOrErr, cmd.nick, cmd.reason);
-          result = { ok: true };
+          result = await kickCommand(cmd, ctx);
           break;
         }
         case "ban": {
-          const chanOrErr = requireChannel("ban");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "ban");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelBan(networkId, chanOrErr, cmd.mask);
-          result = { ok: true };
+          result = await banCommand(cmd, ctx);
           break;
         }
         case "kb": {
-          // #386 — kickban. Ban FIRST (`*!*@host`, no rejoin window), THEN
-          // kick — two frames, attempt BOTH regardless (vjt decision #4).
-          // The host comes from the on-demand `resolveUserhost` lookup (cic
-          // has none client-side); a cache MISS → null → fail-closed (vjt
-          // decision #1: never guess a wider mask), so the ban is NOT sent —
-          // but the kick still fires (immediate intent) and the ban error is
-          // surfaced.
-          const chanOrErr = requireChannel("kb");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "kb");
-          if (typeof networkId !== "number") return networkId;
-
-          let banError: string | null = null;
-          try {
-            const uh = await resolveUserhost(networkId, cmd.nick);
-            const mask = uh
-              ? buildBanMask("host", { nick: cmd.nick, user: uh.user, host: uh.host })
-              : null;
-            if (mask === null) {
-              banError = `/kb: host unknown for ${cmd.nick} — ban not set (run /whois ${cmd.nick} first); kicking anyway`;
-            } else {
-              await pushChannelBan(networkId, chanOrErr, mask);
-            }
-          } catch (e) {
-            banError = `/kb: ban failed — ${friendlyError(e)}`;
-          }
-
-          // Always attempt the kick (getting the person out is the intent).
-          try {
-            await pushChannelKick(networkId, chanOrErr, cmd.nick, cmd.reason);
-          } catch (kickErr) {
-            // Both failed → surface the ban error (primary) if present, else the kick's.
-            return { error: banError ?? `/kb: kick failed — ${friendlyError(kickErr)}` };
-          }
-
-          if (banError !== null) return { error: banError };
-          result = { ok: true };
+          result = await kbCommand(cmd, ctx);
           break;
         }
-        // #557 — /kill <nick> [reason]: first-class operator KILL. Unlike
-        // /kick/kb this targets a NICK (no channel, no requireChannel) and
-        // ships a RAW frame via pushRaw, mirroring /quote — the server already
-        // accepts KILL through the raw passthrough (that is what operators do
-        // today with `/quote KILL ...`). The whole win is the trailing colon
-        // being composed HERE, downstream: `KILL <nick> :<reason>` keeps a
-        // multi-word reason intact instead of the /quote foot-gun where a
-        // forgotten `:` truncates the reason at its first space. A bare /kill
-        // (empty reason) sends `KILL <nick>` and lets the server answer (481
-        // for a non-oper, or the ircd's own missing-comment error). AWAIT the
-        // push so a WS-down / server {:error,_} surfaces as an inline compose
-        // alert, never a silent green ✓ (the #154 no-silent-drop lesson).
         case "kill": {
-          const networkId = requireNetworkId(networkSlug, "kill");
-          if (typeof networkId !== "number") return networkId;
-          const line = cmd.reason === "" ? `KILL ${cmd.nick}` : `KILL ${cmd.nick} :${cmd.reason}`;
-          await pushRaw(networkId, line);
-          result = { ok: true };
+          result = await killCommand(cmd, ctx);
           break;
         }
         case "unban": {
-          const chanOrErr = requireChannel("unban");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "unban");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelUnban(networkId, chanOrErr, cmd.mask);
-          result = { ok: true };
+          result = await unbanCommand(cmd, ctx);
           break;
         }
         case "banlist": {
-          // #386 — /banlist is the channel list-mode MODAL surface (it
-          // supersedes the #376 inline BanlistCard, mirroring how the #169
-          // /who modal replaced the inline WHO dump). Open the modal AND fire
-          // a fresh re-query so the list is live on open (pre-#386 it
-          // was fire-and-forget only).
-          // An explicit `/banlist #chan` resolves in the parser; a bare
-          // /banlist carries null → the current channel (same resolver
-          // every channel-scoped verb uses).
-          const chanOrErr = cmd.channel ?? requireChannel("banlist");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "banlist");
-          if (typeof networkId !== "number") return networkId;
-          // #1251 — an explicitly typed letter this network cannot answer is
-          // an ERROR, not a silent fallback to bans: the operator asked for a
-          // specific list and would otherwise read the ban list as the
-          // exempt list. The offered set is server-published, never derived.
-          const offered = isupportForNetwork(networkId).listModesQueryable;
-          if (!offered.includes(cmd.mode)) {
-            return {
-              error: `/banlist: this network has no +${cmd.mode} list (it offers ${offered.map((m) => `+${m}`).join(" ")})`,
-            };
-          }
-          openBanlistModal(networkSlug, chanOrErr, cmd.mode);
-          pushChannelBanlist(networkId, chanOrErr, cmd.mode);
-          result = { ok: true };
+          result = await banlistCommand(cmd, ctx);
           break;
         }
         case "invite": {
-          // /invite <nick> [#chan] — channel defaults to active window.
-          // P-0f follow-up (no-silent-drops bucket 0): when the channel
-          // arg is supplied explicitly, SKIP requireChannel — typing
-          // `/invite foo #it-opers` from $server (or any non-channel
-          // window) was the common workflow that pre-fix silently
-          // errored ("requires an active channel window") because
-          // requireChannel was unconditionally evaluated.
-          let chan: string;
-          if (cmd.channel !== null) {
-            chan = cmd.channel;
-          } else {
-            const chanOrErr = requireChannel("invite");
-            if (typeof chanOrErr !== "string") return chanOrErr;
-            chan = chanOrErr;
-          }
-          const networkId = requireNetworkId(networkSlug, "invite");
-          if (typeof networkId !== "number") return networkId;
-          // S6 (#364): await the verb-ack so a server {:error,_} / WS-down
-          // surfaces inline (shared catch → friendlyChannelError), not a
-          // false green ✓. Mirror of kick/ban.
-          await pushChannelInvite(networkId, chan, cmd.nick);
-          result = { ok: true };
+          result = await inviteCommand(cmd, ctx);
           break;
         }
         case "umode": {
-          // /umode — user-mode on own nick, no channel context required.
-          const networkId = requireNetworkId(networkSlug, "umode");
-          if (typeof networkId !== "number") return networkId;
-          await pushChannelUmode(networkId, cmd.modes);
-          result = { ok: true };
+          result = await umodeCommand(cmd, ctx);
           break;
         }
         case "umode-view": {
-          // #229 — bare /umode: open the umode viewer/editor modal for the
-          // active window's network. Umodes are per-session (no channel
-          // context needed), so any window kind can open it.
-          openUmodeModal(networkSlug);
-          result = { ok: true };
+          result = await umodeViewCommand(cmd, ctx);
           break;
         }
         case "umode-target-view": {
-          // #229 — /mode <nick> with no mode args. Open the umode modal
-          // ONLY when the target resolves to the operator's OWN nick (the
-          // modal edits your own umodes; there's no viewer for another
-          // user's). Resolve via ownNickForNetwork (visitor → me.nick;
-          // user → per-credential net.nick) — the same canonical resolver
-          // /whois self-default uses; nickEquals for case-insensitive
-          // compare (ASCII, #121/#525). A non-self target is a friendly error rather
-          // than a phantom modal.
-          const net = networkBySlug(networkSlug);
-          const own = net ? ownNickForNetwork(net, user()) : null;
-          if (own && nickEquals(cmd.target, own)) {
-            openUmodeModal(networkSlug);
-            result = { ok: true };
-            break;
-          }
-          return {
-            error: `/mode ${cmd.target}: viewing another user's modes isn't supported — use /mode <#channel> for a channel, or /mode ${own ?? "<yournick>"} for your own user modes`,
-          };
+          result = await umodeTargetViewCommand(cmd, ctx);
+          break;
         }
         case "mode": {
-          // /mode <#chan> <modes> [params] — execute directly, raw
-          // verbatim, target explicit in args. No modal, no channel-window
-          // requirement (#216: mode-args present → apply).
-          const networkId = requireNetworkId(networkSlug, "mode");
-          if (typeof networkId !== "number") return networkId;
-          // #536/#1251 — a bare list letter with NO mask is a QUERY, not a
-          // mutation: open the list modal instead of putting a raw MODE on
-          // the wire whose reply rows nothing is primed to collect.
-          const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
-          if (listMode !== null && isChannelName(cmd.target, sigilsFor(networkSlug))) {
-            openBanlistModal(networkSlug, cmd.target, listMode);
-            pushChannelBanlist(networkId, cmd.target, listMode);
-            result = { ok: true };
-            break;
-          }
-          await pushChannelMode(networkId, cmd.target, cmd.modes, cmd.params);
-          result = { ok: true };
+          result = await modeCommand(cmd, ctx);
           break;
         }
         case "mode-view": {
-          // #216 — no mode-args: open the viewer/editor modal. Explicit
-          // `/mode #chan` targets that channel; bare `/mode` targets the
-          // current channel window (error if not in one — the same
-          // resolver every channel-scoped verb uses).
-          const ch = cmd.channel ?? getActiveChannel();
-          if (!ch) return { error: "/mode requires a channel — switch to one or use /mode #chan" };
-          openModeModal(networkSlug, ch);
-          result = { ok: true };
+          result = await modeViewCommand(cmd, ctx);
           break;
         }
         case "mode-apply-current": {
-          // #216 — `/mode +s` (mode string, no channel token) applies to
-          // the current channel. Mode-args present → execute directly, no
-          // modal; requires a channel window.
-          const chanOrErr = requireChannel("mode");
-          if (typeof chanOrErr !== "string") return chanOrErr;
-          const networkId = requireNetworkId(networkSlug, "mode");
-          if (typeof networkId !== "number") return networkId;
-          // #536/#1251 — same list-QUERY interception as the explicit-channel
-          // arm above; `/mode +b` and `/mode #chan +b` must behave alike.
-          const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
-          if (listMode !== null) {
-            openBanlistModal(networkSlug, chanOrErr, listMode);
-            pushChannelBanlist(networkId, chanOrErr, listMode);
-            result = { ok: true };
-            break;
-          }
-          await pushChannelMode(networkId, chanOrErr, cmd.modes, cmd.params);
-          result = { ok: true };
+          result = await modeApplyCurrentCommand(cmd, ctx);
           break;
         }
         // ---------------------------------------------------------------

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, on } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
-import { ApiError, ownNickForNetwork, postJoin, postPart, postTopic } from "./api";
+import { ApiError, ownNickForNetwork, postJoin, postPart } from "./api";
 import { token } from "./auth";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
@@ -51,7 +51,7 @@ import {
   quitCommand,
   recoverCommand,
 } from "./commands/session";
-import { topicClearCommand, topicShowCommand } from "./commands/topic";
+import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
 import { sendCtcpQuery } from "./ctcpQuery";
@@ -1170,15 +1170,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         case "topic-show":
           return await topicShowCommand(cmd, ctx);
         case "topic-set": {
-          // /topic <text> or /topic #chan <text> — set topic via REST.
-          // Explicit channel wins; otherwise current channel; otherwise bail.
-          const ch = cmd.channel ?? getActiveChannel();
-          if (!ch)
-            return {
-              error: "/topic requires a channel — switch to one or use /topic #chan <text>",
-            };
-          await postTopic(t, networkSlug, ch, cmd.text);
-          result = { ok: true };
+          result = await topicSetCommand(cmd, ctx);
           break;
         }
         case "topic-clear": {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,9 +1,8 @@
 import { createEffect, createSignal, on } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
-import { ApiError, ownNickForNetwork, postJoin, postPart } from "./api";
+import { ApiError, ownNickForNetwork } from "./api";
 import { token } from "./auth";
-import { setQuery } from "./channelDirectory";
-import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
+import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
 import { watchlistCommand } from "./commands/highlight";
@@ -29,6 +28,7 @@ import {
   unbanCommand,
   voiceCommand,
 } from "./commands/ops";
+import { ctcpCommand, noticeCommand, pingCommand } from "./commands/relay";
 import {
   infoCommand,
   linksCommand,
@@ -52,9 +52,9 @@ import {
   recoverCommand,
 } from "./commands/session";
 import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
+import { joinCommand, listCommand, partCommand, queryCommand } from "./commands/window";
 import { requestConfirm } from "./confirmDialog";
 import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
-import { sendCtcpQuery } from "./ctcpQuery";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -76,8 +76,7 @@ import { isServicesSender } from "./servicesSender";
 import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
 import { pushAdmin, pushOper } from "./socket";
-import { closeQueryWindow } from "./windowClose";
-import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./windowKinds";
+import { SERVER_WINDOW_NAME } from "./windowKinds";
 import { windowStateByChannel } from "./windowState";
 
 // #1255 — the channel sigils this NETWORK advertised (005 CHANTYPES),
@@ -1029,142 +1028,23 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
           break;
         }
-        // #591 — /ctcp <target> <VERB> [args]: a single CTCP frame to an
-        // EXPLICIT target (not the current window). Non-ACTION CTCP is
-        // single-line by convention (Grappa.IRC.LineSplit) so there is no
-        // multiline fan-out. AWAIT the send: a CTCP verb MUST NOT silently
-        // no-op when the WS is down.
         case "ctcp": {
-          // ACTION is the exception this door keeps for itself: it IS
-          // conversation (`/me` to an explicit target), so it belongs in the
-          // TARGET window and rides the normal send path (the server also
-          // rejects an ACTION through the CTCP route — `Session.send_ctcp`'s
-          // non-ACTION gate). The parser upper-cases the verb; guard
-          // case-insensitively regardless.
-          if (cmd.verb.toUpperCase() === "ACTION") {
-            await sendWindowMessage(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
-            result = { ok: true };
-            break;
-          }
-          const ctcpNetworkId = requireNetworkId(networkSlug, "ctcp");
-          if (typeof ctcpNetworkId !== "number") return ctcpNetworkId;
-          // Everything else is a control-surface probe and goes through the
-          // #1192 seam, which owns the #640 source-window echo and the #600
-          // register-before-send ordering.
-          //
-          // Consequence worth naming: `/ctcp <t> PING` now CORRELATES, where it
-          // used to drop its reply into `$server` as an uncorrelated
-          // "← CTCP PING reply from …" row. The verb was always a ping; only
-          // the sugar knew to correlate it. Nothing changes on the WIRE — the
-          // seam mints no token, so a bare `/ctcp bob PING` still frames
-          // `\x01PING\x01` and rides the #637 token-less fallback home.
-          await sendCtcpQuery({
-            networkSlug,
-            networkId: ctcpNetworkId,
-            sourceChannel: channelName,
-            targetNick: cmd.target,
-            verb: cmd.verb,
-            args: cmd.args,
-            sentAtMs: Date.now(),
-          });
-          result = { ok: true };
+          result = await ctcpCommand(cmd, ctx);
           break;
         }
-        // #591 — /ping <target>: CTCP PING sugar over the same seam. The token
-        // is a client timestamp; it travels in the frame, comes back verbatim in
-        // the reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`
-        // (synthesized in subscribe.ts, irssi behavior). Minting the token is
-        // ALL this sugar adds — the correlation bookkeeping and its ordering
-        // belong to the seam, and did not survive being held by hand once a
-        // third caller appeared.
         case "ping": {
-          const pingNetworkId = requireNetworkId(networkSlug, "ping");
-          if (typeof pingNetworkId !== "number") return pingNetworkId;
-          const sentAtMs = Date.now();
-          await sendCtcpQuery({
-            networkSlug,
-            networkId: pingNetworkId,
-            sourceChannel: channelName,
-            targetNick: cmd.target,
-            verb: "PING",
-            args: String(sentAtMs),
-            sentAtMs,
-          });
-          result = { ok: true };
+          result = await pingCommand(cmd, ctx);
           break;
         }
-        // #1225 — /notice <target> <text>. Routed like a CTCP query, not like
-        // /msg: the echo persists in the window it was TYPED in (`channelName`)
-        // and no window is opened for the recipient, because a NOTICE opens
-        // none by convention (RFC 2812 §3.3.2 — it is the verb you must not
-        // reply to) and every client the operators come from echoes it where
-        // they are looking. That is also why a CHANNEL recipient is fine here
-        // while /msg refuses one: /msg's refusal exists to stop a phantom query
-        // window, and this path opens no window at all.
-        //
-        // Single await, no #666 pacing plan: a slash command is one line, so
-        // there is no multi-send to pace. A throttled send surfaces its 429 the
-        // same way a lone /msg does.
         case "notice": {
-          await sendWindowMessage(networkSlug, channelName, cmd.body, {
-            kind: "notice",
-            target: cmd.target,
-          });
-          result = { ok: true };
+          result = await noticeCommand(cmd, ctx);
           break;
         }
         case "join":
-          // #516 — the parser now returns `channels: string[]`. Rejoin with
-          // `,` to reproduce the RFC1459 comma-list on the wire byte-for-byte
-          // (the server splits it and opens a `:pending` window per channel,
-          // #382) — behaviour is unchanged from the former single `channel`.
-          await postJoin(t, networkSlug, cmd.channels.join(","), cmd.key);
-          // CP17: server-driven `:pending` window-state origination.
-          // Server's `record_in_flight_join/2` writes
-          // `window_states[ch] = :pending` and broadcasts
-          // `kind: "window_pending"` on `Topic.user/1` — userTopic.ts
-          // dispatches into setPending(...). Pre-CP17 cic mutated
-          // setPending here optimistically (the only cic-originated
-          // state mutation in the codebase) — closed the CLAUDE.md
-          // "cic NEVER originates state" hard-invariant violation.
-          //
-          // Auto-focus the new channel client-side, mirroring the
-          // /msg + /query handlers below. The user just typed /join
-          // — focus follows intent. Doing this here (instead of
-          // relying on subscribe.ts BUG4 self-JOIN handler) closes
-          // a race: the JOIN message is broadcast on the per-channel
-          // WS topic IMMEDIATELY after channels_changed fires, but
-          // cic's subscribe.ts only joins that topic AFTER the REST
-          // refetch from channels_changed completes. Phoenix PubSub
-          // doesn't replay to late subscribers, so the BUG4 handler's
-          // setSelectedChannel never fired in practice. With user-
-          // intent-driven focus here, the autojoin / sajoin / NickServ-
-          // driven JOIN paths still go through the subscribe.ts handler
-          // (no race for those — channel was already joined when JOIN
-          // event arrives via WS).
-          // #510/#516 — the parser owns the comma split now (`cmd.channels`
-          // is already the per-element list). Focus must land on the FIRST
-          // channel, folded the SAME way the server folds window keys
-          // (`canonicalChannel` = the `Identifier.canonical_channel/1` twin,
-          // CASEMAPPING=ascii — A-Z only, brackets untouched; #525). Passing
-          // a mixed-case / bracketed first element targets a key no
-          // `window_states` entry matches, opening the empty phantom window
-          // #510 reported. Single-channel `/join #foo` is a one-element list,
-          // so both paths canonicalise the focus key identically.
-          setSelectedChannel({
-            networkSlug,
-            // `channels` is non-empty (the parser errors on a missing name),
-            // so `[0]` is never undefined at runtime; the `?? join(",")`
-            // fallback exists only to satisfy TS noUncheckedIndexedAccess.
-            channelName: canonicalChannel(cmd.channels[0] ?? cmd.channels.join(",")),
-            kind: "channel",
-          });
-          result = { ok: true };
+          result = await joinCommand(cmd, ctx);
           break;
         case "part": {
-          const target = cmd.channel ?? channelName;
-          await postPart(t, networkSlug, target, cmd.reason);
-          result = { ok: true };
+          result = await partCommand(cmd, ctx);
           break;
         }
         case "topic-show":
@@ -1281,59 +1161,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "query": {
-          // /query <nick> / /q <nick> — open query window and switch focus.
-          // No message sent (spec #1: /query opens window without sending).
-          // /query (bare) / /q (bare) on a query-kind window → CLOSES it
-          // (irssi convention; this bundle, issue follow-up to #12). Bare
-          // /query on any other window kind → error (parser still emits
-          // {target: null} for both — semantics resolved here).
-          //
-          // canonicalQueryNick: see /msg case above.
-          //
-          // UX-4 bucket G: *serv targets reject — opening a query window
-          // for NickServ would be a dead window (services route to $server
-          // server-side). Surface as a user-facing error so the operator
-          // can re-issue `/msg <Xserv> ...` if they wanted to send.
-          //
-          // Cross-network safety (bare-close path): resolve the network
-          // ID from the SELECTED window's own networkSlug, not from
-          // compose's `networkSlug` arg — the two can diverge if the
-          // submit was queued before a window switch. Using compose's
-          // networkSlug with sel.channelName would no-op or close a
-          // wrong-network row when they disagree.
-          if (cmd.target === null) {
-            const sel = selectedChannel();
-            if (sel?.kind === "query") {
-              // #1396 — the one guard NOT routed through `requireNetworkId`.
-              // It is not the same guard: every other site asks "is the
-              // network this operator is typing in live?", this one asks it of
-              // a DIFFERENT network, and its copy has always said so. The
-              // shared message is `/<subject>: network not found`, which
-              // cannot spell "selected window's network" without an extra
-              // colon — so forcing it through would change operator-visible
-              // copy to buy uniformity, which is the wrong trade in a refactor.
-              const selNetId = networkIdBySlug(sel.networkSlug);
-              if (selNetId === undefined)
-                return { error: "/query: selected window's network not found" };
-              closeQueryWindow(selNetId, sel.channelName);
-              result = { ok: true };
-              break;
-            }
-            return {
-              error: "/query <nick> required (bare /query closes the current query window only)",
-            };
-          }
-          const networkId = requireNetworkId(networkSlug, "query");
-          if (typeof networkId !== "number") return networkId;
-          if (isServicesSender(cmd.target)) {
-            return {
-              error: `/query: ${cmd.target} is a services nick; responses land in the server window — use /msg ${cmd.target} <command>`,
-            };
-          }
-          const canonical = canonicalQueryNick(networkId, cmd.target);
-          openQueryWindowState(networkId, canonical, new Date().toISOString());
-          setSelectedChannel({ networkSlug, channelName: canonical, kind: "query" });
-          result = { ok: true };
+          result = await queryCommand(cmd, ctx);
           break;
         }
         case "quit":
@@ -1458,16 +1286,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "list": {
-          // Channel directory browser (#84). Open the per-network $list
-          // pseudo-window (DirectoryPane); the pane loads the snapshot on
-          // mount (server auto-refreshes on empty). A pattern pre-seeds the
-          // directory search (setQuery re-GETs filtered). No raw LIST is
-          // sent here — the directory's own refresh path owns that.
-          setSelectedChannel({ networkSlug, channelName: LIST_WINDOW_NAME, kind: "list" });
-          if (cmd.pattern !== null && cmd.pattern !== "") {
-            void setQuery(networkSlug, cmd.pattern);
-          }
-          result = { ok: true };
+          result = await listCommand(cmd, ctx);
           break;
         }
         case "links": {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48287,3 +48287,138 @@ and the fixture trio, which needs a ruling first — substituting AuthFixtures'
 placeholder hash for a real Argon2 one changes what fourteen files prove, and
 the local `visitor_fixture` calls the production provisioning verb the
 canonical one bypasses._
+<!-- entry #1396 dispatch -->
+
+---
+
+## 2026-08-18 — #1396: the command seam, and the two axes it did not cross
+
+Bucket G's HIGH was one function: `dispatchDraft`'s `switch (cmd.kind)`, 59
+arms wide, inside a module that is also the per-window composer store and the
+send pipeline. Forty-seven of those arms now delegate to `lib/commands/`. The
+switch keeps all fifty-nine labels and the `default: { const _exhaustive: never
+= cmd }` — adding a verb stays a compile error, which was the one property the
+split was not allowed to spend.
+
+### What the context record carries, and what it refuses
+
+Of the 87 identifiers the switch calls, 69 are ordinary module imports a
+handler can import for itself and four are `compose.ts` top-level consts. Only
+the values that close over the submitting window cannot be reached that way,
+and those are the whole of `CommandContext`: `key`, `networkSlug`,
+`channelName`, `text`, `token`, plus five functions — `getActiveChannel`,
+`sigils`, `requireChannel`, `requireNetworkId`, `resolveBareWhoisNick`.
+
+**Anything a handler can import, it imports.** The record carries what is
+per-submission, not what is merely convenient, and it grew one field per slice
+only when a moved arm proved it needed one. That rule is what kept `fanOut` and
+the send door out of it.
+
+Two of the five are functions for a reason worth keeping. `requireChannel` and
+`requireNetworkId` are called FROM the handler rather than resolved when the
+record is built, which keeps them LAZY and keeps the slug a PARAMETER (two arms
+resolve a network other than `networkSlug`). `sigils` is a THUNK on the same
+grounds, and the characterization net is what forced it: the first cut resolved
+it eagerly, which put a `networkIdBySlug` on EVERY submission including the 58
+arms that never ask, and the net caught the extra call as an ambient-effect
+diff. Thirteen arms call `requireChannel` BEFORE resolving a network, so that
+when both would fail the operator still reads the channel error — the call
+ORDER is part of the contract, not an accident of layout.
+
+### The twelve arms that stayed, and why they are two different sets
+
+Twelve arms remain inline, and reading them as one list is the mistake this
+section exists to prevent. They divide by whether the seam CAN take them.
+
+**Six are a declared scope closure, not a structural obstacle.** `error`,
+`open-settings`, `admin`, `oper`, `alias-define` and `unalias` are two-to-five
+line arms; `admin` and `oper` are `requireNetworkId` plus one push, the same
+shape as `stats` and `whowas`, which left in slice 2b. They would move at zero
+new fields. They stay because #1396 is being closed at forty-seven, and they
+remain its residual work — **#1396 stays open for them.** They are NOT part of
+the pipeline issue, which is a different defect.
+
+Only one of the six is genuinely unguarded, and the net says so itself. Its
+honesty test — `"names the arms this net does NOT protect"` — subtracts the
+AMBIENT effects every submission produces (`aliasList.aliases()`,
+`networks.networkIdBySlug`) and pins what remains per arm:
+
+    "unprotected": ["error"],
+    "indistinguishablePairs": [["ame", "amsg"]],
+
+`error` alone has nothing left after the subtraction, because it is a
+parser-level `return { error: cmd.message }` and reaches no store at all. The
+other five DO carry a distinguishing pinned effect — `socket.pushAdmin(1,
+null)`, `aliasList.addAlias(…)` — so a broken move would redden `"each arm's
+observable effects are pinned"`. An earlier reading of this bucket held that no
+red protected all six; measured, that is true of one.
+
+### The send pipeline is ONE axis, not three exceptions
+
+The other six — `service-modal`, `ame`, `amsg`, `privmsg`, `me`, `msg` — were
+refused across three separate slices, each time for what looked like a local
+reason. They are one defect, and naming it as one is the point of this entry.
+
+`sendPacedBody` is not defined at module scope. It lives INSIDE the
+`identityScopedStore((onIdentityChange) => { … })` factory, the same closure
+that holds `dispatchDraft`, and it reaches `claimDrafts`, `getDraft`,
+`writeState`, `releaseDrafts` and `residueDraft` — it is store, not pipeline. A
+handler cannot import a closure member. So an arm that reaches it can only
+delegate by having the send door handed to it through the context record, which
+is the widening already refused for `fanOut`: it would put the buffer-owning
+door into a record whose whole discipline is that it carries per-submission
+values.
+
+Hoisting it is blocked from the other side. `planSends` stands on the EXPORTED
+`draftLines` and `drainPaced` on the EXPORTED `wireBody`, both module-scope
+exports of `compose.ts` — so lifting the cluster into `lib/commands/` makes
+`compose -> commands/* -> compose` a real import cycle, which is the class
+bucket G exists to remove. Stopping halfway leaves the cycle; going all the way
+also moves the mock target under `ServiceModal.test.tsx` and
+`RegistrationWizardModal.test.tsx`.
+
+That is a module-boundary and import-cycle defect, not a dispatch-table one. It
+needs its own red — a mutant on `drainPaced`, or `noImportCycles` switched on —
+and a measurement this work did not make. It is filed separately (#1513);
+**reusing the verbs and not the nouns, widening the context record to reach the
+send door stays refused.**
+
+### Two corrections the plan needed, both measured
+
+**`ame`/`amsg` are not movable, and the three reds that separate them are not
+what blocks them.** Mutant A — inverting the single discriminant `cmd.kind ===
+"ame"` to `"amsg"` — was re-run against the tree forty arms later and still
+reddens exactly three tests, including the two that name the distinction. The
+distinction is bought. What blocks the arms is the import chain above, which no
+amount of test coverage moves. The net corroborates from the other side: the
+pair is its only `indistinguishablePairs` entry, so the coverage that separates
+them is dedicated, not ambient.
+
+**`channelName` has TWO meanings, not three, and the record needs no new
+field.** The plan warned of three. Measured: only `part`, `ctcp`, `ping` and
+`notice` read the parameter at all — `part` as a DEFAULT TARGET, the other
+three as the ECHO window. `join`, `list`, `msg` and `query` never read it; they
+WRITE a different channel into the selection, which is a focus change and not a
+third reading. The meanings stay distinct because the record hands over the raw
+channel and each handler says what it is for. A pre-resolved "default target"
+field is precisely what would have collapsed them into one, so none was added.
+
+### What bought the move
+
+A green after a refactor proves the tests still run; it does not prove they
+still reach the code. Each slice therefore mutated an arm AFTER it moved and
+compared the reds to the pre-move measurement. The load-bearing one is `part`:
+replacing `cmd.channel ?? ctx.channelName` with a literal reddens exactly the
+two tests that named the trap before the move — `"/part with no arg parts the
+current channel"` and `"/part with a sigil-less reason parts the current
+channel with that reason"`. Same tests, same cardinality, on the far side of
+the seam: the record did not lose the channel. Every mutant was restored
+byte-identical (`cmp`) and re-gated green.
+
+One gotcha banked, because it costs a red to rediscover: a scoped `biome check`
+invoked with `cicchetto/src/...` paths silently checks ZERO files — the
+container's cwd is already `/app/cicchetto`, so the prefix must be `src/...`.
+Biome reports "No files were processed", which is easy to lose in a truncated
+tail. And `tsc` caught an orphaned import that biome's `noUnusedImports` did
+not: for import hygiene here, the full `check` chain is the oracle, not biome
+alone.


### PR DESCRIPTION
Bucket G's HIGH (2026-08-15 architecture review): `dispatchDraft`'s `switch (cmd.kind)` is 59 arms wide, inside a module that is also the per-window composer store and the send pipeline. This opens a `lib/commands/` namespace with one explicit context record and moves **47 of the 59 arms** behind it.

`compose.ts` goes 2370 → 1747 lines, the switch 1093 → 487. All 59 case labels and the `default: { const _exhaustive: never = cmd }` stay put — adding a verb remains a compile error, which was the one property the split was not allowed to spend.

## The 47, by slice

| Slice | Arms | Where they landed |
|---|---|---|
| 1 | 4 | the seam itself — `connect`, `quit`, `topic-show`, `watchlist`, chosen because they read neither slug nor channel: if the record had to grow for THESE, the record would be wrong |
| 2a | 18 | 10 operator verbs → `ops.ts`, 7 mode-family → `mode.ts`, `topic-clear` → `topic.ts` |
| 2b | 17 | 12 server-addressed verbs (incl. the raw `quote` escape hatch) → `server.ts`, 5 session verbs → `session.ts` |
| 3 | 1 | `topic-set` → `topic.ts` |
| 4a | 7 | `part`, `join`, `list`, `query` → `window.ts`; `ctcp`, `ping`, `notice` → `relay.ts` |

The context record is narrow by rule: of the 87 identifiers the switch calls, 69 are ordinary imports a handler can import for itself and 4 are `compose.ts` consts, so `CommandContext` carries only what closes over the submitting window. It grew one field per slice, each proven by an arm that moved. `sigils`, `requireChannel` and `requireNetworkId` are functions rather than values to stay LAZY — the first cut resolved `sigils` eagerly and the characterization net caught the extra `networkIdBySlug` on all 58 arms that never ask.

## The 12 that stayed — two different reasons, not one list

**Six are a declared scope closure:** `error`, `open-settings`, `admin`, `oper`, `alias-define`, `unalias`. They would move at zero new context fields (`admin` and `oper` are `requireNetworkId` plus one push — the shape `stats` and `whowas` already left in). They remain **residual work of #1396, which stays open for them.**

**Six are one structural defect, not three local exceptions:** `service-modal`, `ame`, `amsg`, `privmsg`, `me`, `msg`. They were each refused in a different slice for what looked like a local reason; they are one axis. `sendPacedBody` is a member of the `identityScopedStore` factory closure, not a module-scope function, and reaches `claimDrafts`/`getDraft`/`writeState` — it is store, not pipeline, and a handler cannot import a closure member. Hoisting is blocked from the other side: `planSends` stands on the exported `draftLines` and `drainPaced` on the exported `wireBody`, so lifting the cluster makes `compose -> commands/* -> compose` a real import cycle — the class this bucket exists to remove. **That axis is a separate issue (#1513)**; widening the context record to reach the send door stays refused.

## What bought the move

A green after a refactor proves the tests still run, not that they still reach the code. Each slice mutated an arm AFTER it moved and compared reds to the pre-move measurement. The load-bearing one is `part`: replacing `cmd.channel ?? ctx.channelName` with a literal reddens exactly the two tests that named the trap before the move, same cardinality — the record did not lose the channel. Every mutant restored byte-identical (`cmp`) and re-gated green.

Two corrections worth flagging, both measured:
- **`ame`/`amsg` are blocked by the import chain, not by coverage.** Mutant A (inverting the `cmd.kind === "ame"` discriminant) still reddens exactly 3 tests, re-run 40 arms later.
- **`channelName` has TWO meanings, not the three the plan warned of** — a default target (`part`) and an echo window (`ctcp`/`ping`/`notice`). `join`/`list`/`msg`/`query` never read it; they WRITE a different channel into the selection. No "default target" field was added, since that is exactly what would have collapsed the two.

One correction to an earlier reading of this bucket: "no red protects those six" holds for **one**. The net's own honesty test subtracts ambient effects and pins `unprotected: ["error"]`; the other five carry a distinguishing pinned effect, so a broken move would redden `"each arm's observable effects are pinned"`.

## Gates

Run post-rebase onto `24db18d7`, from the worktree:
- `bun run check` (`biome && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json`) — **rc=0**, 1048 files checked
- `bun run test` — **rc=0**, 290 files / 5615 tests

**Attribution:** this green IS attributable to the branch. `scripts/bun.sh` bind-mounts `$SRC_ROOT/cicchetto` (SRC_ROOT=`$PWD`, the worktree) and `node_modules` is per-worktree; the only shared artefact is `runtime/bun-cache`, a content-addressed download cache that cannot carry another branch's source. This is unlike the mix `_build`/`deps`/`priv/plts` sharing, which does not apply to a cic-only gate.

**Not measured:** no server gates were run (zero server files touched), and no e2e run — `scripts/integration.sh` is the ship gate and is the merge owner's call, not run here.

DESIGN_NOTES entry carries the unique marker `<!-- entry #1396 dispatch -->` (the A9 slice already spent a bare `#1396` on 2026-08-17); the boundary gate is green and the rebase was verified two-sided — additions 135/deletions 0 unchanged, and both the previous entry and the new upstream neighbour `#1397-f1` compared byte-identical with `cmp`.