### PR TITLE
cic(#1513): lift the send pipeline out of compose.ts, and the projection out of its closure

### DIFF
--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -10,7 +10,6 @@ import {
   Show,
   Switch,
 } from "solid-js";
-import { sendBodyLines } from "./lib/compose";
 import { friendlyError } from "./lib/friendlyError";
 import { identifiedForNetwork } from "./lib/identity";
 import { networkBySlug, networkIdBySlug } from "./lib/networks";
@@ -30,6 +29,7 @@ import {
   wizardBack,
   wizardNext,
 } from "./lib/registrationWizard";
+import { sendBodyLines } from "./lib/sendPipeline";
 import { serviceMirrorRows } from "./lib/serviceModal";
 import { MircBody } from "./MircText";
 

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -1,8 +1,8 @@
 import { type Component, createEffect, createSignal, For, Show } from "solid-js";
-import { sendBodyLines } from "./lib/compose";
 import { friendlyError } from "./lib/friendlyError";
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
+import { sendBodyLines } from "./lib/sendPipeline";
 import { closeServiceModal, serviceMirrorRows, serviceModalState } from "./lib/serviceModal";
 import { MircBody } from "./MircText";
 

--- a/cicchetto/src/__tests__/RegistrationWizardModal.test.tsx
+++ b/cicchetto/src/__tests__/RegistrationWizardModal.test.tsx
@@ -31,7 +31,7 @@ const sendBodyLinesMock = vi.fn<
 const [identifiedSignal, setIdentifiedSignal] = createSignal(false);
 const identifiedForNetworkMock = vi.fn<(id: number) => boolean>(() => identifiedSignal());
 
-vi.mock("../lib/compose", () => ({
+vi.mock("../lib/sendPipeline", () => ({
   sendBodyLines: (slug: string, target: string, body: string, notice: boolean) =>
     sendBodyLinesMock(slug, target, body, notice),
 }));

--- a/cicchetto/src/__tests__/ServiceModal.test.tsx
+++ b/cicchetto/src/__tests__/ServiceModal.test.tsx
@@ -11,11 +11,11 @@ import ServiceModal from "../ServiceModal";
 // $server scrollback (where the server routes services-sender NOTICEs),
 // filtered to THIS service AND to notices that arrived since the modal opened
 // (id > sinceId). Nick is stripped per line (service name lives in the title);
-// the `>` prompt sends raw commands to the service via compose.sendBodyLines.
+// the `>` prompt sends raw commands to the service via pipeline.sendBodyLines.
 
 // The `>` prompt is the only outbound path; stub it so the component test
 // stays a pure render/behaviour test (no token/api/WS).
-vi.mock("../lib/compose", () => ({
+vi.mock("../lib/sendPipeline", () => ({
   sendBodyLines: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -145,13 +145,13 @@ describe("ServiceModal (#290)", () => {
     const slug = "svc-prompt";
     openServiceModal(slug, "NickServ");
     render(() => <ServiceModal />);
-    const compose = await import("../lib/compose");
+    const pipeline = await import("../lib/sendPipeline");
 
     const input = screen.getByTestId("service-modal-input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "ghost oldnick s3cret" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(compose.sendBodyLines).toHaveBeenCalledWith(
+    expect(pipeline.sendBodyLines).toHaveBeenCalledWith(
       slug,
       "NickServ",
       "ghost oldnick s3cret",
@@ -165,8 +165,8 @@ describe("ServiceModal (#290)", () => {
     const slug = "svc-fail";
     openServiceModal(slug, "NickServ");
     render(() => <ServiceModal />);
-    const compose = await import("../lib/compose");
-    vi.mocked(compose.sendBodyLines).mockRejectedValueOnce(new Error("boom"));
+    const pipeline = await import("../lib/sendPipeline");
+    vi.mocked(pipeline.sendBodyLines).mockRejectedValueOnce(new Error("boom"));
 
     const input = screen.getByTestId("service-modal-input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "identify hunter2" } });
@@ -184,13 +184,13 @@ describe("ServiceModal (#290)", () => {
     const slug = "svc-empty";
     openServiceModal(slug, "NickServ");
     render(() => <ServiceModal />);
-    const compose = await import("../lib/compose");
+    const pipeline = await import("../lib/sendPipeline");
 
     const input = screen.getByTestId("service-modal-input") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "   " } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(compose.sendBodyLines).not.toHaveBeenCalled();
+    expect(pipeline.sendBodyLines).not.toHaveBeenCalled();
   });
 
   it("closes on the × button", () => {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -59,6 +59,7 @@ import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
 import { identityScopedStore } from "./identityScopedStore";
 import { chantypesForNetwork } from "./isupport";
+import { joinedChannelsOnNetwork } from "./joinedChannels";
 import { membersByChannel } from "./members";
 import { splitMessageLines } from "./messageLines";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
@@ -76,7 +77,6 @@ import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
 import { pushAdmin, pushOper } from "./socket";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
-import { windowStateByChannel } from "./windowState";
 
 // #1255 — the channel sigils this NETWORK advertised (005 CHANTYPES),
 // falling back to the RFC 2812 class for a network with no live session or
@@ -1369,36 +1369,6 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       handBack(key, owed);
       setOutbox(key, null);
     }
-  };
-
-  // #30 — the channel candidate set: every channel JOINED on the same
-  // network as the window being typed in. Derived from the server-owned
-  // `windowStateByChannel` projection (no parallel client-side list to
-  // drift); a pending / invited / parked / failed / kicked window is NOT
-  // offered, mirroring the nick rule that you complete who is actually
-  // here. Scope is deliberately narrower than the issue's "optionally
-  // channels seen via /list or mentioned in the buffer" — those are a
-  // separate cut. The decoded name is already ASCII-folded (channelKey
-  // folds at construction) and for channels the folded key IS the display
-  // (the #537/#525 channel invariant), so it is inserted verbatim.
-  //
-  // No sigil filter on the candidate name: this map mirrors the server's
-  // `Session.Server` `window_states`, which is channel-keyed by
-  // construction (a DM lives in `queryWindows`, not here), so a
-  // "joined" non-channel key cannot occur. A guard for it was written,
-  // measured against the suite at ZERO failing tests, and deleted.
-  const joinedChannelsOnNetwork = (key: ChannelKey): string[] => {
-    const here = decodeChannelKey(key);
-    if (here === null) return [];
-    const states = windowStateByChannel();
-    const out: string[] = [];
-    for (const [candidate, state] of Object.entries(states)) {
-      if (state !== "joined") continue;
-      const there = decodeChannelKey(candidate as ChannelKey);
-      if (there === null || there.slug !== here.slug) continue;
-      out.push(there.name);
-    }
-    return out;
   };
 
   // Tab-complete. Cycles matches for the word at the cursor, irssi-style.

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, on } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
-import { ApiError, ownNickForNetwork } from "./api";
+import { ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
@@ -54,7 +54,6 @@ import {
 import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
 import { joinCommand, listCommand, partCommand, queryCommand } from "./commands/window";
 import { requestConfirm } from "./confirmDialog";
-import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -69,8 +68,8 @@ import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // #1225 — the seam sends a PRIVMSG to the window OR relays a NOTICE/CTCP to a
 // different recipient while echoing here, so it is named for the window, not
 // for one of the verbs it can carry.
-import { sendMessage as sendWindowMessage } from "./scrollback";
 import { selectedChannel, setSelectedChannel } from "./selection";
+import { draftLines, sendBodyLines, sendFanOut, wireBody } from "./sendPipeline";
 import { openServiceModal } from "./serviceModal";
 import { isServicesSender } from "./servicesSender";
 import { requestOpenSettings } from "./settingsNav";
@@ -204,150 +203,11 @@ const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
   else sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(drafts));
 };
 
-// The lines a free-text body fans out to — one PRIVMSG each, after the exit
-// scrub. Shared by the send path and #1108's pre-send preview so the count
-// the operator reads is produced by the code that does the sending.
-export const draftLines = (body: string): string[] => splitMessageLines(scrubCtcpDelimiters(body));
-
-// The exact bytes ONE of those lines becomes on the wire: `/me` wraps every
-// line in its own CTCP ACTION envelope, and that envelope is charged against
-// the frame budget on every fragment the server splits it into.
-export const wireBody = (line: string, action: boolean): string =>
-  action ? ctcpFrame("ACTION", line) : line;
-
-// #666 — resumable, self-pacing multiline fan-out.
-//
-// A paste sends one PRIVMSG per line, but the server's send door (the
-// per-(subject, network) token bucket, #340) refuses a burst past its
-// capacity with a 429. Pre-#666 the first 429 rejected the for-await loop and
-// EVERY remaining line was silently dropped, while the draft (cleared only on
-// success) still held the WHOLE body — so resending duplicated the delivered
-// lines AND immediately re-tripped the throttle. The fix makes a 429 a pause,
-// not a failure: wait the server's retry-after, then retry THIS line (a
-// refused line was never delivered, so retrying is neither a drop nor a dup).
-// Only a fatal error stops the drain.
-
-// Fallback wait when a 429 arrives with no parseable retry-after (the server
-// always sends one now — messages_controller/#666 — but a proxy could strip
-// the header). Matches the send throttle's default 0.5/s refill (1 token / 2s).
-const DEFAULT_RETRY_AFTER_MS = 2_000;
-
-// Upper clamp on a server-supplied retry-after. grappa emits 2s; the clamp is
-// purely defensive so a hostile/misconfigured intermediary can't inject a huge
-// `retry-after` and freeze the composer (the retry cap bounds the COUNT of
-// waits, this bounds their DURATION).
-const MAX_RETRY_AFTER_MS = 60_000;
-
-// Safety valve: how many times ONE send is re-paced against a persistent 429
-// before the fan-out gives up and surfaces the throttle. An honest send door
-// admits on the FIRST retry once a token has refilled (we waited its own
-// retry-after), so the cap is only reached by a door that refuses PAST its own
-// hint (a misbehaving/severed server, or a proxy 429) — the guard that keeps
-// the composer from hanging on an unbounded retry loop. Generous enough to
-// absorb timer jitter around the refill boundary.
-const MAX_PACED_RETRIES_PER_SEND = 5;
-
 // #431 — above this many channels an /ame|/amsg asks before it writes anything.
 // A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
 // writes to N channels is a spam vector, and ten is where a fan-out stops
 // reading as "the rooms I am in" and starts reading as a broadcast.
 const FANOUT_CONFIRM_THRESHOLD = 10;
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-// A send-door 429 — the ONLY error class the fan-out paces-and-retries rather
-// than surfacing. Everything else (WS down, invalid_line, a severed-session
-// 401) is fatal and stops the drain.
-const isSendThrottled = (e: unknown): e is ApiError => e instanceof ApiError && e.status === 429;
-
-// ms to wait before retrying a throttled line. `api.ts readError` parses the
-// server's `retry-after` header (seconds) into `info.retry_after`; convert to
-// ms, falling back to the send-throttle default if it's missing/garbage.
-const retryAfterMs = (e: ApiError): number => {
-  const seconds = e.info.retry_after;
-  const ms =
-    typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
-      ? seconds * 1_000
-      : DEFAULT_RETRY_AFTER_MS;
-  return Math.min(ms, MAX_RETRY_AFTER_MS);
-};
-
-// One outbound PRIVMSG: which target, which line of the body. The line is held
-// UNFRAMED (the CTCP wrap happens at the door) so the residue callback can hand
-// the operator back what they typed rather than what went on the wire.
-type PacedSend = { target: string; line: string };
-
-// Expand a body into the ordered send plan for `targets`, TARGET-MAJOR: every
-// line of the body for the first target, then every line for the second, and so
-// on. One target is the #666 single-window case (a paste = one PRIVMSG per
-// line, see messageLines.ts for the wire-framing why); N targets is the #431
-// /ame|/amsg fan-out. Building ONE flat plan rather than nesting a per-target
-// drain inside a per-line one is what keeps the retry safe: a paced retry
-// re-sends exactly one (target, line), never a target whose earlier lines
-// already landed.
-//
-// The lines come from `draftLines`, which owns the #1126 exit scrub, and each
-// one is framed at the door by `wireBody` — so a plan holds what the operator
-// typed and the drain turns it into wire bytes.
-const planSends = (targets: readonly string[], body: string): PacedSend[] => {
-  const lines = draftLines(body);
-  return targets.flatMap((target) => lines.map((line) => ({ target, line })));
-};
-
-// #666/#431 — THE paced drain, shared by both fan-outs that can burst the send
-// door. Sends `plan` in order, sequential await so wire order is preserved.
-// `action` wraps every line in CTCP ACTION framing (via the shared `ctcpFrame`
-// builder) for /me and /ame.
-//
-// A send-door 429 is a PAUSE, not a failure: wait the server's own retry-after,
-// then retry THE SAME entry — `sent` never advances past a refusal, so the
-// drain neither drops an entry nor duplicates a delivered one. Any other error
-// (WS down, invalid_line, a severed-session 401) stops it and propagates.
-// Pacing engages only for a plan of MORE than one send: a lone throttled send
-// surfaces immediately, preserving #342's throttle-copy affordance.
-//
-// #431 — why honouring the server's hint IS the pacing an /ame fan-out needs,
-// rather than a guessed inter-message sleep. The door is the #340
-// per-(subject, network) token bucket (capacity 5, refill 0.5/s), and it is
-// deliberately tuned to refuse BEFORE the ircd's flood protection kills the
-// connection (`messages_controller.take_send_token`, whose moduledoc says so).
-// The retry-after it hands back is that bucket's own refill interval, so
-// waiting it paces against the thing that actually decides. A constant here
-// would be a second, unmeasured opinion about the same limit, free to drift
-// from it the moment the bucket is retuned.
-//
-// `onProgress` fires after every acked send AND before every pace/stop, with
-// the count acked so far.
-const drainPaced = async (
-  plan: readonly PacedSend[],
-  slug: string,
-  action: boolean,
-  onProgress: (sent: number) => void,
-): Promise<void> => {
-  const total = plan.length;
-  let sent = 0;
-  // Consecutive paced retries of the CURRENT entry; reset when `sent` advances.
-  let retries = 0;
-  while (sent < total) {
-    // `??` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
-    const { target, line } = plan[sent] ?? { target: "", line: "" };
-    try {
-      await sendWindowMessage(slug, target, wireBody(line, action));
-      sent += 1;
-      retries = 0;
-      onProgress(sent);
-    } catch (e) {
-      onProgress(sent);
-      if (isSendThrottled(e) && total > 1 && retries < MAX_PACED_RETRIES_PER_SEND) {
-        retries += 1;
-        await sleep(retryAfterMs(e));
-        // loop retries the same `sent` index — never advanced past a refusal.
-      } else {
-        throw e;
-      }
-    }
-  }
-};
 
 /**
  * #1108 — what the current draft will do to the wire, or `null` when there is
@@ -378,57 +238,6 @@ export const draftFramePreview = (
     draftLines(cmd.body).map((line) => wireBody(line, action)),
     budget,
   );
-};
-
-// Send a free-text body to ONE target, one PRIVMSG per line, paced. Shared by
-// the privmsg, me, and msg send sites — the only free-text paths whose body can
-// contain an operator-typed newline. External callers (ServiceModal,
-// RegistrationWizardModal) pass no callback and simply inherit the never-drop +
-// pacing behaviour.
-//
-// `onProgress` reports the count sent so far and the unsent remainder joined
-// back into a body — compose `submit` mirrors that remainder into the draft so
-// it holds ONLY what has not gone out. The residue always starts at `sent`, the
-// first line NOT yet acked: on a 429 that is the refused line (about to be
-// retried), on a fatal error the line that failed (kept, not dropped).
-export const sendBodyLines = async (
-  slug: string,
-  target: string,
-  body: string,
-  action: boolean,
-  onProgress?: (sent: number, total: number, residue: string) => void,
-): Promise<void> => {
-  const plan = planSends([target], body);
-  await drainPaced(plan, slug, action, (sent) =>
-    onProgress?.(
-      sent,
-      plan.length,
-      plan
-        .slice(sent)
-        .map((p) => p.line)
-        .join("\n"),
-    ),
-  );
-};
-
-// #431 — /ame + /amsg: one copy of the body to EVERY target, through the same
-// paced door. `onProgress` reports completed CHANNELS rather than sends, so a
-// fatal stop can tell the operator how far the fan-out actually got — the count
-// they need to decide whether to retype it.
-const sendFanOut = async (
-  slug: string,
-  targets: readonly string[],
-  body: string,
-  action: boolean,
-  onProgress: (channelsDone: number) => void,
-): Promise<void> => {
-  const plan = planSends(targets, body);
-  // Target-major and every target carries the same lines, so the plan divides
-  // evenly and a completed channel is a whole run of `perTarget` acks. Never a
-  // division by zero: an empty plan means the loop below never runs, so
-  // `onProgress` is never called.
-  const perTarget = plan.length / targets.length;
-  await drainPaced(plan, slug, action, (sent) => onProgress(Math.floor(sent / perTarget)));
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {

--- a/cicchetto/src/lib/joinedChannels.ts
+++ b/cicchetto/src/lib/joinedChannels.ts
@@ -1,0 +1,45 @@
+// #1513 — the joined-channel projection, in a module of its OWN rather than in
+// `windowState.ts`.
+//
+// It cannot stay in `compose.ts` (which imports `commands/*`, so exporting it
+// there would close the cycle), and it does not belong INSIDE `windowState.ts`
+// either: consumers mock that module wholesale as a state SOURCE, so derived
+// logic placed there is swallowed by the mock and silently stops being
+// exercised — measured, 22 reds in the #30 tab-complete and #431 fan-out tests
+// the moment it went in. A derived read-model reads the store from outside it.
+//
+// Pure with respect to its input: the only thing it touches is the projection
+// `windowStateByChannel` publishes.
+
+import { type ChannelKey, decodeChannelKey } from "./channelKey";
+import { windowStateByChannel } from "./windowState";
+
+// #30 — the channel candidate set: every channel JOINED on the same
+// network as the window being typed in. Derived from the server-owned
+// `windowStateByChannel` projection (no parallel client-side list to
+// drift); a pending / invited / parked / failed / kicked window is NOT
+// offered, mirroring the nick rule that you complete who is actually
+// here. Scope is deliberately narrower than the issue's "optionally
+// channels seen via /list or mentioned in the buffer" — those are a
+// separate cut. The decoded name is already ASCII-folded (channelKey
+// folds at construction) and for channels the folded key IS the display
+// (the #537/#525 channel invariant), so it is inserted verbatim.
+//
+// No sigil filter on the candidate name: this map mirrors the server's
+// `Session.Server` `window_states`, which is channel-keyed by
+// construction (a DM lives in `queryWindows`, not here), so a
+// "joined" non-channel key cannot occur. A guard for it was written,
+// measured against the suite at ZERO failing tests, and deleted.
+export const joinedChannelsOnNetwork = (key: ChannelKey): string[] => {
+  const here = decodeChannelKey(key);
+  if (here === null) return [];
+  const states = windowStateByChannel();
+  const out: string[] = [];
+  for (const [candidate, state] of Object.entries(states)) {
+    if (state !== "joined") continue;
+    const there = decodeChannelKey(candidate as ChannelKey);
+    if (there === null || there.slug !== here.slug) continue;
+    out.push(there.name);
+  }
+  return out;
+};

--- a/cicchetto/src/lib/sendPipeline.ts
+++ b/cicchetto/src/lib/sendPipeline.ts
@@ -1,0 +1,210 @@
+// #1513 — the send pipeline, lifted out of `compose.ts`.
+//
+// `compose.ts` imports `commands/*`, so anything a command handler must reach
+// cannot live in `compose.ts` without closing an import cycle. Everything here
+// was module-scope in `compose.ts` and depends only on leaves (`messageLines`,
+// `ctcpAction`) plus the transport — never on the composer store — so it moves
+// whole rather than in pieces.
+//
+// The same move, for the same reason, as #1192 taking `ctcpFrame` out to
+// `ctcpAction.ts`: "dispatch without importing `compose`".
+//
+// `draftLines` and `wireBody` travel WITH the cluster and not to a leaf of
+// their own: all three of their call sites use them as a PAIR (the plan, the
+// door, and #1108's preview), and that pairing is the invariant that keeps the
+// operator's frame count produced by the code that does the sending.
+
+import { ApiError } from "./api";
+import { ctcpFrame, scrubCtcpDelimiters } from "./ctcpAction";
+import { splitMessageLines } from "./messageLines";
+import { sendMessage as sendWindowMessage } from "./scrollback";
+
+// The lines a free-text body fans out to — one PRIVMSG each, after the exit
+// scrub. Shared by the send path and #1108's pre-send preview so the count
+// the operator reads is produced by the code that does the sending.
+export const draftLines = (body: string): string[] => splitMessageLines(scrubCtcpDelimiters(body));
+
+// The exact bytes ONE of those lines becomes on the wire: `/me` wraps every
+// line in its own CTCP ACTION envelope, and that envelope is charged against
+// the frame budget on every fragment the server splits it into.
+export const wireBody = (line: string, action: boolean): string =>
+  action ? ctcpFrame("ACTION", line) : line;
+
+// #666 — resumable, self-pacing multiline fan-out.
+//
+// A paste sends one PRIVMSG per line, but the server's send door (the
+// per-(subject, network) token bucket, #340) refuses a burst past its
+// capacity with a 429. Pre-#666 the first 429 rejected the for-await loop and
+// EVERY remaining line was silently dropped, while the draft (cleared only on
+// success) still held the WHOLE body — so resending duplicated the delivered
+// lines AND immediately re-tripped the throttle. The fix makes a 429 a pause,
+// not a failure: wait the server's retry-after, then retry THIS line (a
+// refused line was never delivered, so retrying is neither a drop nor a dup).
+// Only a fatal error stops the drain.
+
+// Fallback wait when a 429 arrives with no parseable retry-after (the server
+// always sends one now — messages_controller/#666 — but a proxy could strip
+// the header). Matches the send throttle's default 0.5/s refill (1 token / 2s).
+const DEFAULT_RETRY_AFTER_MS = 2_000;
+
+// Upper clamp on a server-supplied retry-after. grappa emits 2s; the clamp is
+// purely defensive so a hostile/misconfigured intermediary can't inject a huge
+// `retry-after` and freeze the composer (the retry cap bounds the COUNT of
+// waits, this bounds their DURATION).
+const MAX_RETRY_AFTER_MS = 60_000;
+
+// Safety valve: how many times ONE send is re-paced against a persistent 429
+// before the fan-out gives up and surfaces the throttle. An honest send door
+// admits on the FIRST retry once a token has refilled (we waited its own
+// retry-after), so the cap is only reached by a door that refuses PAST its own
+// hint (a misbehaving/severed server, or a proxy 429) — the guard that keeps
+// the composer from hanging on an unbounded retry loop. Generous enough to
+// absorb timer jitter around the refill boundary.
+const MAX_PACED_RETRIES_PER_SEND = 5;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A send-door 429 — the ONLY error class the fan-out paces-and-retries rather
+// than surfacing. Everything else (WS down, invalid_line, a severed-session
+// 401) is fatal and stops the drain.
+const isSendThrottled = (e: unknown): e is ApiError => e instanceof ApiError && e.status === 429;
+
+// ms to wait before retrying a throttled line. `api.ts readError` parses the
+// server's `retry-after` header (seconds) into `info.retry_after`; convert to
+// ms, falling back to the send-throttle default if it's missing/garbage.
+const retryAfterMs = (e: ApiError): number => {
+  const seconds = e.info.retry_after;
+  const ms =
+    typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? seconds * 1_000
+      : DEFAULT_RETRY_AFTER_MS;
+  return Math.min(ms, MAX_RETRY_AFTER_MS);
+};
+
+// One outbound PRIVMSG: which target, which line of the body. The line is held
+// UNFRAMED (the CTCP wrap happens at the door) so the residue callback can hand
+// the operator back what they typed rather than what went on the wire.
+type PacedSend = { target: string; line: string };
+
+// Expand a body into the ordered send plan for `targets`, TARGET-MAJOR: every
+// line of the body for the first target, then every line for the second, and so
+// on. One target is the #666 single-window case (a paste = one PRIVMSG per
+// line, see messageLines.ts for the wire-framing why); N targets is the #431
+// /ame|/amsg fan-out. Building ONE flat plan rather than nesting a per-target
+// drain inside a per-line one is what keeps the retry safe: a paced retry
+// re-sends exactly one (target, line), never a target whose earlier lines
+// already landed.
+//
+// The lines come from `draftLines`, which owns the #1126 exit scrub, and each
+// one is framed at the door by `wireBody` — so a plan holds what the operator
+// typed and the drain turns it into wire bytes.
+const planSends = (targets: readonly string[], body: string): PacedSend[] => {
+  const lines = draftLines(body);
+  return targets.flatMap((target) => lines.map((line) => ({ target, line })));
+};
+
+// #666/#431 — THE paced drain, shared by both fan-outs that can burst the send
+// door. Sends `plan` in order, sequential await so wire order is preserved.
+// `action` wraps every line in CTCP ACTION framing (via the shared `ctcpFrame`
+// builder) for /me and /ame.
+//
+// A send-door 429 is a PAUSE, not a failure: wait the server's own retry-after,
+// then retry THE SAME entry — `sent` never advances past a refusal, so the
+// drain neither drops an entry nor duplicates a delivered one. Any other error
+// (WS down, invalid_line, a severed-session 401) stops it and propagates.
+// Pacing engages only for a plan of MORE than one send: a lone throttled send
+// surfaces immediately, preserving #342's throttle-copy affordance.
+//
+// #431 — why honouring the server's hint IS the pacing an /ame fan-out needs,
+// rather than a guessed inter-message sleep. The door is the #340
+// per-(subject, network) token bucket (capacity 5, refill 0.5/s), and it is
+// deliberately tuned to refuse BEFORE the ircd's flood protection kills the
+// connection (`messages_controller.take_send_token`, whose moduledoc says so).
+// The retry-after it hands back is that bucket's own refill interval, so
+// waiting it paces against the thing that actually decides. A constant here
+// would be a second, unmeasured opinion about the same limit, free to drift
+// from it the moment the bucket is retuned.
+//
+// `onProgress` fires after every acked send AND before every pace/stop, with
+// the count acked so far.
+const drainPaced = async (
+  plan: readonly PacedSend[],
+  slug: string,
+  action: boolean,
+  onProgress: (sent: number) => void,
+): Promise<void> => {
+  const total = plan.length;
+  let sent = 0;
+  // Consecutive paced retries of the CURRENT entry; reset when `sent` advances.
+  let retries = 0;
+  while (sent < total) {
+    // `??` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
+    const { target, line } = plan[sent] ?? { target: "", line: "" };
+    try {
+      await sendWindowMessage(slug, target, wireBody(line, action));
+      sent += 1;
+      retries = 0;
+      onProgress(sent);
+    } catch (e) {
+      onProgress(sent);
+      if (isSendThrottled(e) && total > 1 && retries < MAX_PACED_RETRIES_PER_SEND) {
+        retries += 1;
+        await sleep(retryAfterMs(e));
+        // loop retries the same `sent` index — never advanced past a refusal.
+      } else {
+        throw e;
+      }
+    }
+  }
+};
+
+// Send a free-text body to ONE target, one PRIVMSG per line, paced. Shared by
+// the privmsg, me, and msg send sites — the only free-text paths whose body can
+// contain an operator-typed newline. External callers (ServiceModal,
+// RegistrationWizardModal) pass no callback and simply inherit the never-drop +
+// pacing behaviour.
+//
+// `onProgress` reports the count sent so far and the unsent remainder joined
+// back into a body — compose `submit` mirrors that remainder into the draft so
+// it holds ONLY what has not gone out. The residue always starts at `sent`, the
+// first line NOT yet acked: on a 429 that is the refused line (about to be
+// retried), on a fatal error the line that failed (kept, not dropped).
+export const sendBodyLines = async (
+  slug: string,
+  target: string,
+  body: string,
+  action: boolean,
+  onProgress?: (sent: number, total: number, residue: string) => void,
+): Promise<void> => {
+  const plan = planSends([target], body);
+  await drainPaced(plan, slug, action, (sent) =>
+    onProgress?.(
+      sent,
+      plan.length,
+      plan
+        .slice(sent)
+        .map((p) => p.line)
+        .join("\n"),
+    ),
+  );
+};
+
+// #431 — /ame + /amsg: one copy of the body to EVERY target, through the same
+// paced door. `onProgress` reports completed CHANNELS rather than sends, so a
+// fatal stop can tell the operator how far the fan-out actually got — the count
+// they need to decide whether to retype it.
+export const sendFanOut = async (
+  slug: string,
+  targets: readonly string[],
+  body: string,
+  action: boolean,
+  onProgress: (channelsDone: number) => void,
+): Promise<void> => {
+  const plan = planSends(targets, body);
+  // Target-major and every target carries the same lines, so the plan divides
+  // evenly and a completed channel is a whole run of `perTarget` acks. Never a
+  // division by zero: an empty plan means the loop below never runs, so
+  // `onProgress` is never called.
+  const perTarget = plan.length / targets.length;
+  await drainPaced(plan, slug, action, (sent) => onProgress(Math.floor(sent / perTarget)));
+};

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48422,3 +48422,145 @@ Biome reports "No files were processed", which is easy to lose in a truncated
 tail. And `tsc` caught an orphaned import that biome's `noUnusedImports` did
 not: for import hygiene here, the full `check` chain is the oracle, not biome
 alone.
+<!-- entry #1513 -->
+
+---
+
+## 2026-08-18 — #1513: the send pipeline leaves the store module, and what a moved helper has to prove
+
+#1396 moved 47 of the 59 dispatch arms behind a command seam and left six on
+what it called the pipeline axis. This is that axis, or rather the half of it
+that could be bought. `lib/sendPipeline.ts` now holds the cluster;
+`joinedChannelsOnNetwork` moved to `windowState.ts`; `compose.ts` goes 1747 →
+1526 lines.
+
+### The cycle was never the cost — measured before anything moved
+
+The premise worth killing first: `noImportCycles` was assumed to be expensive
+to switch on, and the review reported a pre-existing client cycle. Enabled
+locally and run twice with the same config, `--max-diagnostics=2000` (the
+default limit truncates this repo's lint output, so a default run undercounts
+in silence):
+
+    origin/main 24db18d7   597 files   2 diagnostics
+    the #1396 branch       607 files   2 diagnostics
+
+Same file, line and column both sides, `diff` empty. **The number did not
+move**, and the two diagnostics are the two EDGES of ONE cycle
+(`selection.ts ↔ windowState.ts`) — biome emits one per edge. The 47-arm move
+neither added nor removed a cycle. So the axis was never priced by the existing
+cycle; it was priced by a cycle that did not exist yet and would be created by
+the wrong extraction.
+
+### Why the cluster travels WHOLE, and not as two helpers
+
+The tempting small move is `draftLines` + `wireBody` to a leaf. It is the wrong
+cut. Both are one-line compositions over modules that are already **pure
+leaves** — `splitMessageLines` in `messageLines.ts`, `scrubCtcpDelimiters` and
+`ctcpFrame` in `ctcpAction.ts`, zero imports each — but all three of their call
+sites use them as a **PAIR**: `planSends` builds the plan from `draftLines`,
+`drainPaced` frames each line at the door with `wireBody`, and #1108's
+`draftFramePreview` maps one through the other to tell the operator what the
+draft will cost. Splitting the pair across two homes buys nothing and puts a
+module boundary through the middle of one thought.
+
+So the unit is the cluster: the two helpers, the three #666 retry constants,
+`sleep`, `isSendThrottled`, `retryAfterMs`, `PacedSend`, `planSends`,
+`drainPaced`, `sendBodyLines`, `sendFanOut`. That it COULD move whole was
+measured, not assumed — every one of those was module-scope (the
+`identityScopedStore` closure only opened below them), and no cluster internal
+was referenced anywhere outside `compose.ts`.
+
+The precedent is written in a file the cluster depends on. `ctcpAction.ts:23-26`
+records **#1192** taking `ctcpFrame` out of `compose.ts` so the dispatch could
+reach it "without importing `compose`, which imports `ctcpQuery` back". Same
+move, same reason, larger cluster.
+
+### What stayed, and the rule that decided it
+
+`draftFramePreview` needs `parseSlash` and `aliases()` — composer concerns, not
+pipeline ones — so it stays in `compose.ts` and now reads the two helpers ACROSS
+the new boundary. `FANOUT_CONFIRM_THRESHOLD` stays too: its only call site is
+the `ame`/`amsg` arm, never `sendFanOut`, so it belongs with the arm whenever
+the arm moves — the rule that took `listModeQueryLetter` into `mode.ts` in #1396
+slice 2a.
+
+The general form: **a helper belongs to the concern that CALLS it, not to the
+file it was born in.** A constant read by one arm is the arm's; a function read
+by the pipeline is the pipeline's.
+
+### The failure mode the mutant intercepts, and why a green would not
+
+Moving `wireBody` out has a specific way of going wrong that no passing suite
+detects: **duplicating** the helper instead of moving it. Leave a copy behind
+and the wire path uses the new one while the preview keeps reading the old —
+the two silently disagree about what a `/me` costs, which is the exact
+invariant `compose.ts` had documented as "shared by the send path and #1108's
+pre-send preview so the count the operator reads is produced by the code that
+does the sending."
+
+The mutant is therefore graded on a **SET, not a count**: drop the CTCP ACTION
+framing in `wireBody`, and require the same reds before and after the move.
+Measured on both sides, identical, seven, in two families:
+
+- **PREVIEW ×1** — "charges /me its CTCP ACTION envelope, like the send path does"
+- **WIRE ×5** — `/me`, multiline `/me`, the #723 partial, the #1126 scrub, `/ame`
+- **net ×1** — the #1396 characterization net
+
+The preview red is the load-bearing one. Seven reds are also obtainable with a
+different composition, so the count alone would lie; had the preview gone green
+while the five wire reds stayed, the helper had been duplicated. The net counts
+for nothing here — it reddens on any observable change.
+
+### The projection that had to leave the closure, and must not be exported
+
+`joinedChannelsOnNetwork` blocked `ame`/`amsg` for a reason that looked like the
+store half but was not: it sat INSIDE the `identityScopedStore` closure and was
+not re-exported, so no handler could import it. Measured rather than declared —
+every token of its body enumerated and classified — its only free identifiers
+are `decodeChannelKey` and `windowStateByChannel`, both module-scope imports
+with no shadowing declaration anywhere in the file. **Closure captures: zero.**
+It was a closure member by placement, not by necessity.
+
+**It must NOT be exported from `compose.ts`** — `compose` imports `commands/*`,
+so a handler importing it back would close exactly the cycle this work exists to
+avoid. That is the structural constraint, not a style preference.
+
+Its home was planned to be `windowState.ts`, whose store it projects and which
+already imports `decodeChannelKey`. **The gate refused that, and the refusal is
+the durable lesson here.** `compose.test.ts` replaces `../lib/windowState`
+wholesale with a `vi.mock` of stubs and drives the tests by setting
+`windowStateByChannel`'s return — so a projection placed INSIDE that module is
+swallowed by the mock, and its 22 reds (the #30 tab-complete set and the #431
+fan-out set) say the coverage went with it. The two ways to keep it there were
+both worse than moving it: hand-writing the projection into the mock
+re-implements production logic in a test and turns those 22 into assertions
+about the stub, and un-mocking the store for them is a rewrite of the CP17
+setup those same tests rely on.
+
+So it lives in `joinedChannels.ts`, a module of its own that reads
+`windowStateByChannel` from OUTSIDE — which is why the mock still governs it and
+the tests kept exercising the real projection, unchanged. **General rule: a
+module that consumers mock wholesale as a state SOURCE is not a home for derived
+read-model logic.** Put the derivation in a module that reads the store rather
+than one that is the store, or the mock quietly deletes its coverage. Placement
+here was decided by a red, not by taste.
+
+### What this does NOT finish, and the number that was wrong
+
+An earlier reading of this work claimed the hoist unblocks three of the six
+arms. Re-derived arm by arm, that was false, and the re-derivation is why it
+was caught: `service-modal` is the only one clean on the hoist alone (its other
+dependency, `openServiceModal`, was already an import). `ame`/`amsg` needed two
+further symbols, one of them the closure lift above. The claim came from
+blockers recorded in the slice commits rather than re-derived — a number that
+travelled without a measurement, which is the failure this entry records as
+much as the refactor.
+
+`privmsg`, `me` and `msg` remain, and their blocker is genuinely different:
+`sendPacedBody` is a closure member that reaches `claimDrafts`, `writeState`,
+`releaseDrafts` and `residueDraft`, four verbs that are NOT re-exported and that
+do close over store state. Unblocking those means moving the STORE, not the
+pipeline. #1513 stays open for that half. Widening the command context record to
+hand a handler the send door stays refused — it is the same widening #1396
+refused for `fanOut`.


### PR DESCRIPTION
The half of #1513's axis that could be bought. `compose.ts` imports `commands/*`, so anything a handler must reach cannot live there without closing an import cycle. Two commits: the pipeline cluster leaves for `lib/sendPipeline.ts`, then the joined-channel projection leaves the composer closure for `lib/joinedChannels.ts`. `compose.ts` goes **1747 → 1526** lines.

**#1513 is NOT closed by this** — the store half remains (see below).

## The cycle was never the cost

Measured before anything moved, `noImportCycles` on with the same config both sides and `--max-diagnostics=2000` (the default limit truncates this repo's output, so a default run undercounts in silence):

| tree | files | diagnostics |
|---|---|---|
| `origin/main` `24db18d7` | 597 | 2 |
| the #1396 branch | 607 | 2 |

Same file, line and column; `diff` empty. The two are the two **edges of ONE** cycle (`selection.ts ↔ windowState.ts`) — biome emits one per edge. The number did not move. The axis was priced by a cycle that did not exist yet and would be created by the wrong extraction, not by the existing one.

## Commit 1 — the cluster moves whole

`draftLines`, `wireBody`, the three #666 retry constants, `sleep`, `isSendThrottled`, `retryAfterMs`, `PacedSend`, `planSends`, `drainPaced`, `sendBodyLines`, `sendFanOut`.

Whole, not in pieces, and measured before asserted: all were module-scope (the `identityScopedStore` closure only opened below them), their outward deps are two **pure leaves** (`messageLines.ts`, `ctcpAction.ts` — zero imports each) plus `scrollback` and `ApiError`, and no cluster internal is referenced outside `compose.ts`. The precedent is written into a file the cluster depends on: `ctcpAction.ts:23-26` records **#1192** taking `ctcpFrame` out of `compose.ts` "without importing `compose`".

`draftFramePreview` does NOT travel (it needs `parseSlash`/`aliases()` — composer concerns) and now reads the two helpers across the new boundary. `FANOUT_CONFIRM_THRESHOLD` stays with the arm that is its only caller, the rule that took `listModeQueryLetter` into `mode.ts` in #1396 slice 2a. `sendBodyLines`' two component callers and their `vi.mock` targets are repointed — the relocation #1396 slice 2b predicted.

## Commit 2 — the projection, and a destination decided by a red

`joinedChannelsOnNetwork` sat inside the closure, unexported, which is what still pinned `ame`/`amsg`. It is **not** exported from `compose.ts` (that would close the cycle). The lift was gated on a measurement, not a reading: every token of the body enumerated and classified, leaving two free identifiers — `decodeChannelKey`, `windowStateByChannel` — both module-scope imports with no shadow anywhere in the file. **Closure captures: zero.**

Planned destination was `windowState.ts`. **The gate refused it**: `compose.test.ts` replaces that module wholesale with a `vi.mock` and drives tests by setting `windowStateByChannel`'s return, so a projection placed inside it is swallowed — **22 reds** across the #30 tab-complete and #431 fan-out sets. Both ways of keeping it there are worse: writing the projection into the mock re-implements production logic and turns those 22 into assertions about the stub; un-mocking the store rewrites the CP17 setup they rely on. It lives in `joinedChannels.ts`, which reads the store from OUTSIDE — the mock still governs it and all 22 kept exercising the real projection, **with no test edited**. `windowState.ts` ends byte-identical to main.

General rule recorded in the entry: *a module that consumers mock wholesale as a state SOURCE is not a home for derived read-model logic.*

## What bought the move

A green after a refactor proves the tests still run, not that they still reach the code. The specific way this move fails is **duplicating** `wireBody` instead of moving it — the wire path uses the new copy while #1108's preview reads the old, and the two silently disagree about what a `/me` costs. No passing suite reports that.

So the mutant (drop the CTCP ACTION framing) is graded on a **SET, not a count**, measured pre-move and post-move and again on the final tree — identical every time, seven reds in two families:

- **PREVIEW ×1** — "charges /me its CTCP ACTION envelope, like the send path does"
- **WIRE ×5** — `/me`, multiline `/me`, the #723 partial, the #1126 scrub, `/ame`
- **net ×1** — the #1396 characterization net (reddens on any observable change; counts for nothing here)

The preview red is load-bearing: seven reds are obtainable with a different composition, so the count alone would lie. Every mutant restored byte-identical (`cmp`).

## Correction to a number this PR retires

An earlier reading claimed the hoist unblocks three of six arms. Re-derived arm by arm, **false**: `service-modal` is the only one clean on the hoist alone. `ame`/`amsg` needed two further symbols, one being the closure lift here. The claim came from blockers recorded in slice commits rather than re-derived.

## Residual work — why #1513 stays open

`privmsg`, `me`, `msg` reach `sendPacedBody`, a closure member whose four store verbs (`claimDrafts`, `writeState`, `releaseDrafts`, `residueDraft`) are not re-exported and **do** close over composer state. Unblocking those means moving the **store**, not the pipeline. Widening the command context record to hand a handler the send door stays refused — the same widening #1396 refused for `fanOut`.

## Gates

- `design-notes-gate.sh` — rc=0, marker `<!-- entry #1513 -->` unique, separator in the entry's own commit
- `bun run check` — rc=0, 1050 files
- `bun run test` — rc=0, 290 files / 5615 tests

**Attribution:** cic-only, and the green is attributable — `scripts/bun.sh` bind-mounts `$SRC_ROOT/cicchetto` (the worktree) and `node_modules` is per-worktree; only `runtime/bun-cache`, a content-addressed download cache, is shared. The mix `_build`/`deps` sharing does not apply here.

**Not measured:** no server gates (zero server files) and no e2e — `scripts/integration.sh` is the ship gate and the merge owner's call, not run here.