### PR TITLE
test(#1397): give GRAPPA_BASE_URL one home

### DIFF
--- a/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
@@ -57,7 +57,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -101,7 +101,7 @@ async function fetchScrollbackPage(
   token: string,
   channel: string,
 ): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -53,6 +53,7 @@
 // gets the row back to its baseline live state.
 
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -110,8 +111,8 @@ test.afterEach(async () => {
   }).catch(() => {});
 
   const headers = { authorization: `Bearer ${vjt.token}` };
-  const channelsUrl = `http://grappa-test:4000/networks/${NETWORK_SLUG}/channels`;
-  const membersUrl = `http://grappa-test:4000/networks/${NETWORK_SLUG}/channels/${encodeURIComponent(
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
+  const membersUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels/${encodeURIComponent(
     SEED_CHANNEL,
   )}/members`;
   for (let attempt = 0; attempt < 60; attempt++) {

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -41,7 +41,7 @@ import {
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -55,12 +55,10 @@ const SETTLE_DEBOUNCE_MS = 500;
 const SETTLE_WAIT_MS = SETTLE_DEBOUNCE_MS + 500;
 const SETTLE_WAIT_LONG_MS = SETTLE_DEBOUNCE_MS + 1000;
 
-const GRAPPA_TEST_BASE = "http://grappa-test:4000";
-
 // ─── shared helpers ─────────────────────────────────────────────────
 
 async function fetchCursor(token: string, channel: string): Promise<number | null> {
-  const res = await fetch(`${GRAPPA_TEST_BASE}/me`, {
+  const res = await fetch(`${GRAPPA_BASE_URL}/me`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
@@ -73,7 +71,7 @@ async function fetchCursor(token: string, channel: string): Promise<number | nul
 }
 
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_TEST_BASE}/networks/${encodeURIComponent(NETWORK_SLUG)}/channels/${encodeURIComponent(channel)}/messages`;
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(NETWORK_SLUG)}/channels/${encodeURIComponent(channel)}/messages`;
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!res.ok) {
     throw new Error(`fetchScrollbackPage: ${res.status} ${await res.text()}`);

--- a/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
@@ -27,6 +27,7 @@
 // session.
 
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -48,7 +49,7 @@ test.afterEach(async () => {
     connection_state: "connected",
   }).catch(() => {});
 
-  const channelsUrl = `http://grappa-test:4000/networks/${NETWORK_SLUG}/channels`;
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
   for (let attempt = 0; attempt < 60; attempt++) {
     const res = await fetch(channelsUrl, {
       headers: { authorization: `Bearer ${vjt.token}` },

--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -60,7 +60,7 @@ import {
   sidebarWindow,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
@@ -424,7 +424,7 @@ async function assertNoVisibleJump(page: Page, tag: string): Promise<Frame[]> {
 // Fetch the latest scrollback page via REST (same shape as
 // scroll-on-window-switch / issue625) — used to place the cursor mid-page.
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
@@ -41,6 +41,7 @@ import {
   openSettingsSection,
   selectChannel,
 } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { pushCatcherEndpoint, resetPushSubscriptions } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -66,7 +67,7 @@ const LONG_CHANNEL = `#${"z".repeat(31)}`;
 // nothing: the row's GEOMETRY is what is under test, and the server takes the
 // same row either way.
 async function seedOneDevice(token: string, id: string): Promise<void> {
-  const res = await fetch("http://grappa-test:4000/push/subscriptions", {
+  const res = await fetch(`${GRAPPA_BASE_URL}/push/subscriptions`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${token}`,

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -46,7 +46,7 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -84,7 +84,7 @@ async function fetchScrollbackPage(
   token: string,
   channel: string,
 ): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
+++ b/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
@@ -31,7 +31,12 @@ import {
   sidebarCloseButton,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { joinChannel, partChannel, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  joinChannel,
+  partChannel,
+  patchNetworkConnectionState,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -55,7 +60,7 @@ test.afterEach(async () => {
     connection_state: "connected",
   }).catch(() => {});
 
-  const channelsUrl = `http://grappa-test:4000/networks/${NETWORK_SLUG}/channels`;
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
   for (let attempt = 0; attempt < 60; attempt++) {
     const res = await fetch(channelsUrl, {
       headers: { authorization: `Bearer ${vjt.token}` },

--- a/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
@@ -48,7 +48,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -74,7 +74,7 @@ async function scrollbackGeometry(
 // Latest REST page (DESC by server_time) — used to pick the HEAD id for the
 // read-cursor seed. Same shape cp14-b1 / issue168 / scroll-on-window-switch use.
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
+++ b/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
@@ -38,6 +38,7 @@
 // a Playwright e2e via scripts/integration.sh.
 
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -59,7 +60,7 @@ test.afterEach(async () => {
     connection_state: "connected",
   }).catch(() => {});
 
-  const channelsUrl = `http://grappa-test:4000/networks/${NETWORK_SLUG}/channels`;
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
   for (let attempt = 0; attempt < 60; attempt++) {
     const res = await fetch(channelsUrl, {
       headers: { authorization: `Bearer ${vjt.token}` },

--- a/cicchetto/e2e/tests/issue283-home-disconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue283-home-disconnect.spec.ts
@@ -30,11 +30,14 @@ import {
   loginAs,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import { patchNetworkConnectionState, type SeededUser } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  patchNetworkConnectionState,
+  type SeededUser,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 async function fetchNetworkState(token: string, slug: string): Promise<string | null> {

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -21,11 +21,11 @@
 // then reverted in afterEach so the shared stack baseline is restored.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -24,11 +24,11 @@
 // shared baseline is restored (mirrors #291).
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -47,7 +47,12 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { getReadCursor, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  getReadCursor,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -72,7 +77,7 @@ async function distFromBottom(page: Page): Promise<number> {
 // known message id for the mid-page cursor seed + the tail id we expect the tap
 // to advance to. Mirror of the #168 local helper.
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -58,7 +58,7 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -82,7 +82,7 @@ async function distanceToBottom(page: Page): Promise<number> {
 // Latest REST page in wire shape (DESC by server_time) — used to pick a known
 // message id for the mid-page cursor seed (mirror of issue168).
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -37,7 +37,7 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -83,7 +83,7 @@ async function distanceToBottom(page: Page): Promise<number> {
 }
 
 async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
@@ -42,10 +42,9 @@
 
 import { expect, test } from "@playwright/test";
 import { expectShellReady, openAdminConsole, openRailMenu } from "../fixtures/cicchettoPage";
-import { mintVisitor } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const AZZURRA_SLUG = "azzurra";
 const AZZURRA_BASELINE_CAP = 100;
 

--- a/cicchetto/e2e/tests/push-181-resubscribe-supersede.spec.ts
+++ b/cicchetto/e2e/tests/push-181-resubscribe-supersede.spec.ts
@@ -27,13 +27,13 @@
 
 import type { BrowserContext } from "@playwright/test";
 import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { resetPushCatcher, resetPushSubscriptions } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const ENDPOINT_A = "https://push.example/e2e/resub-A";
 const ENDPOINT_B = "https://push.example/e2e/resub-B";
-const GRAPPA_BASE = "http://grappa-test:4000";
 
 // Real ECDSA P-256 public key + auth secret (same pair the Sender Bypass
 // tests use) so the server changeset length caps + any encrypt step pass.
@@ -103,7 +103,7 @@ async function stubRotatingPushManager(
 }
 
 async function listDeviceCount(token: string): Promise<number> {
-  const res = await fetch(`${GRAPPA_BASE}/push/subscriptions`, {
+  const res = await fetch(`${GRAPPA_BASE_URL}/push/subscriptions`, {
     headers: { authorization: `Bearer ${token}` },
   });
   if (!res.ok) return 0;

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -87,7 +87,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { setReadCursorToId } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -143,7 +143,7 @@ async function fetchScrollbackPage(
   token: string,
   channel: string,
 ): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });

--- a/cicchetto/e2e/tests/u-2-admission-split.spec.ts
+++ b/cicchetto/e2e/tests/u-2-admission-split.spec.ts
@@ -36,7 +36,7 @@
 // afterEach restores caps to permissive defaults so subsequent specs
 // see the seeder baseline.
 
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -45,7 +45,6 @@ import {
 } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 type CapDimension = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions";

--- a/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
+++ b/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
@@ -42,7 +42,7 @@
 // afterEach restores caps to permissive defaults.
 
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -53,7 +53,6 @@ import {
 } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";

--- a/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
@@ -92,7 +92,7 @@
 // restores vjt to :connected so subsequent specs see the seeder
 // baseline. Mirrors u-2 + u-3 cleanup pattern.
 
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -101,7 +101,6 @@ import {
 } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";

--- a/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
@@ -41,11 +41,10 @@
 // where /connect succeeds at the HTTP boundary but the spawn dance
 // half-completes (Session.Server up, autojoin loop silently failing).
 
-import { patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Production cap default is 1 (config/config.exs:68). Pre-BC, any

--- a/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
@@ -36,7 +36,12 @@
 // for user-cap, `too_many_sessions` for client-cap).
 
 import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
-import { login, patchNetworkConnectionState, type SeededUser } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  login,
+  patchNetworkConnectionState,
+  type SeededUser,
+} from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -45,7 +50,6 @@ import {
 } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -29,12 +29,11 @@
 // channel + rail drawer) without ripple-affecting other specs.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
-
 test.setTimeout(60_000);
 
 async function findVjtUserId(adminToken: string): Promise<string> {

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -38,10 +38,10 @@
 // references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(60_000);

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -53,13 +53,16 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { listSessionLogSessions, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  listSessionLogSessions,
+  mintVisitor,
+  reapVisitors,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-const GRAPPA_BASE_URL = "http://grappa-test:4000";
-
 // Every tab AdminPane mounts (`TABS` in AdminPane.tsx).
 const ADMIN_TABS = [
   "sessions",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48806,6 +48806,13 @@ to get a behavioural number. It aborts `globalSetup`, which means the run
 reports a small figure that is **vacuous rather than small** — no spec got far
 enough to have an opinion.
 
-_Not established: `scroll-on-window-switch.spec.ts:252` is red on both sides.
-It cancels in the delta and is deliberately left unclassified here — neither
-flake nor real defect was demonstrated, and this slice does not touch it._
+_Not established: in the mutant measurement above,
+`scroll-on-window-switch.spec.ts:252` was red on both sides. It cancels in the
+delta and was left unclassified — and the ship-gate run afterwards showed why
+that was the right call: it passed there, while three different specs went
+red, none of them touched by this slice. Iso-reruns put two of those three at
+3/3 and 12/12 green (cascade) and the third at 1-of-3 red **in isolation**,
+where none of the 27 files run at all. A rotating red set is the suite's own
+property here, not a signal about the change under test — which is exactly why
+a spec's red is attributed by re-running it, never by reading the diff next to
+it._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48714,3 +48714,98 @@ carve-out, not a context internal" — not a smaller number.
 `Grappa.BoundaryCycleBudgetTest`'s `@cycle_budget 0` does not move: every edge
 added here points at a leaf with `deps: []`, which can close no cycle. That was a
 prediction until it was run; it is now a measurement.
+<!-- entry #1397-f2 -->
+
+---
+
+## 2026-08-18 — #1397 F2: `GRAPPA_BASE_URL` gets one home, and the grep that said it already had one
+
+`cicchetto/e2e/fixtures/grappaApi.ts` has exported
+`GRAPPA_BASE_URL = "http://grappa-test:4000"` for as long as the fixture has
+existed. Asked whether the e2e suite uses it, `git grep -l GRAPPA_BASE_URL`
+answered with 51 files — a number that reads as "51 use it properly" and is
+wrong in both directions at once.
+
+### The grep lies twice, in opposite directions
+
+Measured on `24db18d7`, the pre-change tree:
+
+- **51 files** name `GRAPPA_BASE_URL`. **Twelve of them do not consume the
+  export at all** — they open with their own
+  `const GRAPPA_BASE_URL = "http://grappa-test:4000";`. A shadow answers the
+  grep on the canonical name, so it inflates the adoption count with the exact
+  files that have opted out of it. The other 39 are the export's own file, 37
+  real importers, and one docs page.
+- **A further 15 files** hardcode the literal and never name the constant, so
+  the grep cannot see them at all. Two had built a half-home under a different
+  spelling — `GRAPPA_TEST_BASE` (`cursor-forward-only`) and `GRAPPA_BASE`
+  (`push-181`) — which is the same drift wearing a disguise, invisible to a
+  grep on the canonical name for the same reason.
+
+27 files, 28 literal occurrences: 12 shadow declarations plus 16 bare uses.
+The constant always had one home; 27 files walked past it.
+
+The general lesson is about the instrument, not this constant. **A grep on a
+name measures who says the name, not who obeys it.** For a "is this constant
+adopted?" question the honest instrument is the pair: grep the name AND grep
+the value, then subtract. Either grep alone reports a number with the wrong
+sign of error.
+
+### What the drift actually costs: 45 tests against 1
+
+The before-side was measured with a mirror mutant — 28 fake literals injected
+into the 27 files, `grappaApi.ts` left untouched, so only the divergent copies
+moved:
+
+| | tests | passed | failed | red files |
+|---|---|---|---|---|
+| baseline | 56 | 55 | 1 | 1 |
+| mutant | 56 | 11 | 45 | 23 |
+
+**+44 tests, +22 files.** The prediction going in was 27 of 27 files red; the
+measure was 23. The gap is worth more than the agreement, because of what the
+four survivors have in common.
+
+### The four survivors are the interesting half
+
+`cp15-b6-parked-disconnect-reconnect`, `issue100`, `issue195` and `issue248`
+stayed green because each uses the literal only inside a `test.afterEach`
+whose failures are swallowed by design — the whole loop was read before the
+verdict, and the initial suspicion that this was a fail-open assertion barrier
+was withdrawn. It is declared cleanup, and swallowing is the right posture for
+cleanup.
+
+That makes their failure mode worse, not better. Under base-URL drift these
+four specs **keep passing while their cleanup silently stops running**, and
+what the cleanup was there to undo is a parked network handed to whichever
+spec runs next. The damage surfaces somewhere else, attributed to someone
+else. A test that goes red under drift is cheap; a cleanup that goes quiet
+under drift is what makes the following morning expensive.
+
+### The after-side is a no-op, and that is the point
+
+The same mutant against the post-change tree has **zero sites to mutate**, so
+it produces no number at all. This is not a green worth reporting — a suite
+that passes because nothing was injected proves nothing. **The claim after the
+change is structural, not behavioural**, and it is carried by one POSIX grep
+run identically against both trees so the zero has a positive control:
+
+| grep (POSIX, no `\s`/`\b`/`\y`) | `24db18d7` | HEAD |
+|---|---|---|
+| `http://grappa-test:4000` under `e2e/tests/` | 28 | 0 |
+| files carrying it | 27 | 0 |
+| `^const GRAPPA_BASE_URL[ ]*=` | 12 | 0 |
+| `^export const GRAPPA_BASE_URL[ ]*=` | 1 | 1 |
+
+The last row is the one that states the shape of the defect: **the export
+count never changed.** There was always exactly one home. What is new is that
+it is now the only one.
+
+⛔ Do not reach for the obvious follow-up of mutating the *exported* constant
+to get a behavioural number. It aborts `globalSetup`, which means the run
+reports a small figure that is **vacuous rather than small** — no spec got far
+enough to have an opinion.
+
+_Not established: `scroll-on-window-switch.spec.ts:252` is red on both sides.
+It cancels in the delta and is deliberately left unclassified here — neither
+flake nor real defect was demonstrated, and this slice does not touch it._


### PR DESCRIPTION
## What

`cicchetto/e2e/fixtures/grappaApi.ts` has always exported
`GRAPPA_BASE_URL`. 27 spec files did not use it. This branch routes all of
them through the export and deletes the private copies.

| | before (`24db18d7`) | after |
|---|---|---|
| `http://grappa-test:4000` under `e2e/tests/` | 28 | **0** |
| files carrying it | 27 | **0** |
| `^const GRAPPA_BASE_URL[ ]*=` (shadows) | 12 | **0** |
| `^export const GRAPPA_BASE_URL[ ]*=` | 1 | **1** |

The last row states the shape of the defect: the export count never changed.
There was always exactly one home — it is now the only one.

Behaviour is byte-identical; the imported constant holds the same string the
literals spelled out.

## The grep that lied

`git grep -l GRAPPA_BASE_URL` returned **51** files, which reads as "51 use it
properly". Measured, that 51 was 39 genuine references plus **12 shadows** —
files that re-declare the constant locally and so answer a grep on the
canonical name while having opted out of the export. Separately, **15 files**
carried the literal without ever naming the constant and were invisible to
that grep entirely. Two of those had a half-home under a different spelling
(`GRAPPA_TEST_BASE`, `GRAPPA_BASE`), which is the same drift in disguise.

General rule, recorded in DESIGN_NOTES: a grep on a NAME measures who says the
name, not who obeys it. The honest instrument is name-grep AND value-grep,
then subtract.

## Evidence

**Before** — mirror mutant (28 fake literals into the 27 files, `grappaApi.ts`
untouched): baseline 56 tests / 55 passed / 1 failed / 1 red file; mutant
56 / 11 / **45 failed** / 23 red files. **+44 tests, +22 files.** Prediction
was 27-of-27 files red; measure was 23.

The four survivors are the interesting half: each uses the literal only inside
a best-effort `test.afterEach`. Under base-URL drift those specs keep passing
while their cleanup **silently stops running**, stranding a parked network for
whichever spec runs next.

**After** — the same mutant has zero sites and produces no number. That is a
no-op by construction, not a green worth reporting, so the claim is
**structural**: the table at the top is one POSIX grep (no `\s`/`\b`/`\y`) run
identically against both trees, with the unchanged export count as the
positive control. Mutating the *exported* constant was deliberately not done —
it aborts `globalSetup` and yields a vacuous number, not a small one.

## Gates

- `bun run check` (biome + `tsc` src + `tsc` e2e) — rc=0
- vitest cic — 290 files / 5615 tests green
- `scripts/design-notes-gate.sh` — separator + unique marker `#1397-f2` present
- `scripts/integration.sh`, **full suite** (not scoped — a scoped run cannot
  see the cross-spec cleanup damage this slice is about) — **751 passed, 3
  failed**

The 3 reds are **not attributable to this branch**, established by iso-rerun
per `docs/TESTING.md`, not by reading the diff:

| spec | iso-rerun | verdict |
|---|---|---|
| `issue535-visibility-return-preserve-scroll:204` | 12/12 green | cascade |
| `issue606-query-rail-whois:44` | 3/3 green | cascade |
| `cp15-b6-part-archive-rejoin:55` | 1-of-3 **red in isolation** | flake |

The third is the one that mattered: it runs immediately after
`cp15-b6-parked-disconnect-reconnect`, one of the four best-effort-cleanup
specs this branch touches, and its symptom (members pane missing own nick) fits
a stranded network. The adjacency hypothesis was **falsified** — it reproduces
in isolation, where none of the 27 files load. `git diff` confirms the isolated
run executes byte-identical code on both trees (spec, fixtures, playwright
config, `cicchetto/src`, `lib/` all unchanged), so a baseline re-run would be a
tautology.

Worth noting for the flake bucket: the red set **rotates**. The earlier
baseline's red (`scroll-on-window-switch:252`) passed in this gate.

## Caveats for the merger

- Branched from `24db18d7`. `origin/main` has since advanced to `7176e85d`
  (#1396, which decomposes `cicchetto/src/lib/compose.ts`). **The app under
  test changed, so the integration gate above does not carry over to the
  post-merge state** — PR CI is the authority there.
- Only file overlapping main's movement is `docs/DESIGN_NOTES.md`
  (`merge=union`); the entry carries a unique `<!-- entry #1397-f2 -->` marker.
  Pre-rebase measurements for the two-sided check are captured: DESIGN_NOTES
  additions 102 / deletions **0**, previous entry `#1397-f1` = 74 lines, mine =
  102, marker unique by `grep -Fxc`.
- #1397 stays open — it is an umbrella.