### PR TITLE
cic(#1396): move service-modal behind the seam, the one arm #1513 unblocked

### DIFF
--- a/cicchetto/src/lib/commands/services.ts
+++ b/cicchetto/src/lib/commands/services.ts
@@ -1,0 +1,25 @@
+import { sendBodyLines } from "../sendPipeline";
+import { openServiceModal } from "../serviceModal";
+import type { CommandHandler } from "./context";
+
+/**
+ * #290 — a BARE services command (`/ns`, `/cs`, `/ms`, …) opens the dedicated
+ * services console modal and fires `help`, so the service's multi-NOTICE help
+ * wall lands confined in the modal (ServiceModal mirrors the $server service
+ * notices) instead of flooding the server window. `openServiceModal` FIRST
+ * captures the $server high-water mark, THEN `help` is sent, so the reply
+ * notices count as while-open arrivals (spec: capture only while open). A full
+ * command WITH args stays the `msg` arm (inline execute, reply inline) — no
+ * unsolicited popup for power users.
+ *
+ * #1396 — it could only move here once #1513 lifted `sendBodyLines` out of the
+ * store closure: that import was its whole blocker, and it is the ONLY arm the
+ * hoist unblocked. It reads `ctx.networkSlug` and nothing else off the record —
+ * both the modal and the send address the SUBMITTING window's network, never
+ * the selected one.
+ */
+export const serviceModalCommand: CommandHandler<"service-modal"> = async (cmd, ctx) => {
+  openServiceModal(ctx.networkSlug, cmd.service);
+  await sendBodyLines(ctx.networkSlug, cmd.service, "help", false);
+  return { ok: true };
+};

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -43,6 +43,7 @@ import {
   whoisCommand,
   whowasCommand,
 } from "./commands/server";
+import { serviceModalCommand } from "./commands/services";
 import {
   awayCommand,
   disconnectCommand,
@@ -71,7 +72,6 @@ import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // for one of the verbs it can carry.
 import { selectedChannel, setSelectedChannel } from "./selection";
 import { draftLines, sendBodyLines, sendFanOut, wireBody } from "./sendPipeline";
-import { openServiceModal } from "./serviceModal";
 import { isServicesSender } from "./servicesSender";
 import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
@@ -955,18 +955,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "service-modal": {
-          // #290 — a BARE services command (`/ns`, `/cs`, `/ms`, …) opens
-          // the dedicated services console modal and fires `help`, so the
-          // service's multi-NOTICE help wall lands confined in the modal
-          // (ServiceModal mirrors the $server service notices) instead of
-          // flooding the server window. `openServiceModal` FIRST captures the
-          // $server high-water mark, THEN `help` is sent, so the reply
-          // notices count as while-open arrivals (spec: capture only while
-          // open). A full command WITH args stays the `msg` arm above (inline
-          // execute, reply inline) — no unsolicited popup for power users.
-          openServiceModal(networkSlug, cmd.service);
-          await sendBodyLines(networkSlug, cmd.service, "help", false);
-          result = { ok: true };
+          result = await serviceModalCommand(cmd, ctx);
           break;
         }
         case "query": {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48564,3 +48564,86 @@ do close over store state. Unblocking those means moving the STORE, not the
 pipeline. #1513 stays open for that half. Widening the command context record to
 hand a handler the send door stays refused — it is the same widening #1396
 refused for `fanOut`.
+<!-- entry #1396 services -->
+
+---
+
+## 2026-08-18 — #1396: the one arm the #1513 hoist unblocked, and the invariant its net does not hold
+
+`service-modal` moves behind the dispatch seam, into a new
+`cicchetto/src/lib/commands/services.ts`. It is the ONLY arm the #1513 hoist
+unblocked, and it was blocked by exactly one thing: it calls `sendBodyLines`,
+which until #1513 lived inside the composer store closure and could not be
+imported from `commands/`. Now that the send pipeline is its own module, the
+handler reaches it like any other import and needs nothing off the context
+record but `ctx.networkSlug`.
+
+A one-handler module is not a new shape here: `commands/highlight.ts` is nine
+lines and carries one verb. The alternative — folding it into `relay.ts` — was
+rejected because that module's own header defines itself as "the verbs that
+address someone who is NOT this window, while the echo stays here", and a
+services console that opens a modal is a different job that would have made
+that sentence false.
+
+### What stays inline, and the three different reasons
+
+Ten arms remain inline after this slice, and they are not one class:
+
+* `privmsg`, `me`, `msg`, `ame`, `amsg` — the STORE-coupled arms, held by the
+  #1513 ruling. Moving them means publishing `claimDrafts`, `writeState` and
+  `releaseDrafts` at module scope, and `writeState` is the door that BYPASSES
+  the #737 drain lock (`setDraft` refuses a write while a drain owns the
+  window; `writeState` does not, because it is the door for the writer that
+  HOLDS the lock). Exporting it makes that invariant optional for every
+  importer. The import cycle such an export would close is NOT the objection —
+  measured innocuous: cic already carries one runtime cycle
+  (`windowState.ts` ↔ `selection.ts`, both eval-time stores consumed at call
+  time), biome's recommended set has no cycle rule, and a probe that closed
+  exactly the `compose.ts` ↔ `commands/*` cycle passed the full vitest suite,
+  `tsc --noEmit` and a production `vite build`. The objection is the lock.
+* `error` — structural: no red protects it. It returns the parser's own
+  message, so a mutant that changes the arm changes nothing a test observes.
+  Moving code that no test holds is moving it blind.
+* `admin`, `oper`, `open-settings`, `alias-define`, `unalias` — SCOPE CLOSURE,
+  declared as such. They are two-to-four-line bodies, movable at zero cost and
+  protected by the characterization net. They stay because this campaign stops
+  here, not because anything in the code resists them. Saying so plainly is the
+  point: a scope decision dressed up as a technical reason is how the next
+  reader inherits a constraint that was never real.
+
+### The red, measured on both sides of the move
+
+Protection was measured BEFORE the move and re-measured AFTER, with the same
+mutants and the same demand: same failing SET, same cardinality.
+
+| mutant | before | after |
+|---|---|---|
+| drop the `openServiceModal` call | 4 red | 4 red |
+| send `HELP` instead of `help` | 4 red | 4 red |
+| swap the two statements (order) | 0 red | 0 red |
+
+The four are the three `it.each` rows of "%s bare opens the services modal for
+%s and fires help (#290)" plus the #1396 characterization pin, "each arm's
+observable effects are pinned". Same four names on both sides, so the move is
+covered by the tests it was covered by, and nothing swallowed it — no test
+mocks `../lib/compose`, `../lib/sendPipeline` or any `commands/*` module in the
+file that exercises this arm.
+
+### The invariant this arm declares and nothing holds
+
+The third row is the finding. The arm's own comment states an ORDER:
+`openServiceModal` FIRST captures the `$server` high-water mark, THEN `help`
+goes out, so the reply notices count as while-open arrivals. Swapping the two
+statements leaves the suite fully green — before the move and after it.
+
+Two reasons, both by design elsewhere: `effectSignature()` SORTS what it
+collects ("the net pins WHAT left the module, not the order it left in"), and
+the three `it.each` rows assert that each mock was called with the right
+arguments, never their relative order. So an invariant that is written down in
+prose is bought by nothing.
+
+It is named here rather than fixed here, deliberately. Adding the guard inside
+this commit would have changed the after-set the move is proven by, and a
+two-sided proof whose two sides measure different things proves nothing. The
+gap is pre-existing, it is not widened by the move, and it wants its own change
+with its own red.


### PR DESCRIPTION
## What

Moves the `service-modal` arm (`/ns`, `/cs`, `/ms`, … bare) out of the
`compose.ts` dispatch switch into a new `cicchetto/src/lib/commands/services.ts`.

It is the ONLY arm the #1513 hoist unblocked. Its single blocker was
`sendBodyLines`, which lived inside the composer store closure until #1513
lifted the send pipeline into its own module; the handler needs nothing else
from the closure and reads only `ctx.networkSlug` off the context record.

A one-handler module rather than a fold into `relay.ts`: that module's header
defines itself as *the verbs that address someone who is NOT this window, while
the echo stays here*, which a services console opening a modal would falsify.
`commands/highlight.ts` (nine lines, one verb) is the precedent.

## The red, measured on both sides

Same mutants before the move and after it, demanding set equality AND
cardinality equality — not just a count.

| mutant | before | after |
|---|---|---|
| drop the `openServiceModal` call | 4 red | 4 red |
| send `HELP` instead of `help` | 4 red | 4 red |
| swap the two statements (ORDER) | 0 red | 0 red |

The four are the three `it.each` rows of *"%s bare opens the services modal for
%s and fires help (#290)"* plus the #1396 characterization pin *"each arm's
observable effects are pinned"* — the same four names on both sides.

Mock radius checked FIRST, not after: no test mocks `../lib/compose`,
`../lib/sendPipeline` or any `commands/*` module in the file that exercises
this arm, so nothing swallows the moved code.

## Finding: an invariant with no guard

The third row is a result, not a nil. The arm's own comment declares an ORDER —
`openServiceModal` FIRST captures the `$server` high-water mark, THEN `help` is
sent — and swapping the two statements leaves the suite green, before and
after. `effectSignature()` sorts by design ("the net pins WHAT left the module,
not the order it left in") and the `it.each` rows assert calls, not sequence.

Recorded in the entry and deliberately NOT closed here: adding the guard inside
this commit would have changed the after-set the move is proven by. It is
pre-existing and not widened by the move.

## What stays inline, and why (three different reasons)

- `privmsg`, `me`, `msg`, `ame`, `amsg` — the #1513 ruling: moving them means
  publishing `writeState`, the door that BYPASSES the #737 drain lock. The
  import cycle such an export would close is NOT the objection (measured
  innocuous: cic already carries one runtime cycle, biome has no cycle rule, a
  probe closing that exact cycle passed vitest + tsc + a production build).
- `error` — no red protects it; moving code no test holds is moving it blind.
- `admin`, `oper`, `open-settings`, `alias-define`, `unalias` — declared scope
  closure, not a technical obstacle. Said plainly so the next reader does not
  inherit a constraint that was never real.

## Gates

- `scripts/bun.sh run test` — 290 files / 5615 tests green
- `scripts/bun.sh run check` — rc=0 (biome + `tsc --noEmit` ×2; 59 warnings are
  the pre-existing baseline, unchanged)
- `scripts/design-notes-gate.sh` — rc=0, 1 new entry heading, separator and
  unique marker present (`<!-- entry #1396 services -->`, exact-line count 1,
  zero duplicate marker lines, 99 → 100)

Refs #1396. Refs #1513.