### PR TITLE
arch(#1399): make the two identity schemas leaves, and narrow four boundaries

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48647,3 +48647,70 @@ this commit would have changed the after-set the move is proven by, and a
 two-sided proof whose two sides measure different things proves nothing. The
 gap is pre-existing, it is not widened by the move, and it wants its own change
 with its own red.
+<!-- entry #1399-leaves -->
+
+---
+
+## 2026-08-18 — #1399: the two identity schemas become leaves, and four boundaries stop taking a context to name one
+
+Bucket J's remaining third. #415 promoted `Visitors.Visitor` to a
+`top_level?: true` leaf so a context could name the identity schema without
+depending on the orchestration verbs around it; #1398 did the same for the four
+`Networks` schemas and retired all five `dirty_xrefs` waivers with it. This
+finishes the pattern on `Grappa.Accounts.User` and `Grappa.Accounts.Session` —
+both now `top_level?: true, deps: []`, both out of `Grappa.Accounts`' `exports:`,
+which takes them as deps instead.
+
+Four boundaries NARROW as a result: `Subject` and `Themes` swap the whole
+`Grappa.Accounts` context for `Grappa.Accounts.User`, `Admission` and `Vhosts`
+for `Grappa.Accounts.Session`. None of the four calls an `Accounts` function.
+Seven others (`Networks`, `Operator`, `Release`, `AccountDeletion`, `GrappaWeb`,
+`TestSupport.SubjectReset`, `AuthFixtures`) do call one, so they declare the leaf
+ALONGSIDE the context rather than instead of it. The population that took a
+whole context to name a schema goes 4 → 0.
+
+### What the compiler decided, and the source parse got wrong
+
+The blast radius was not predicted, it was ENUMERATED: promote the schema, add
+no deps, and read `mix compile --force --warnings-as-errors` — 80 forbidden
+references across exactly 8 boundaries for `User`, 8 across 3 for `Session`. Two
+findings from that run correct beliefs a source-level reference scan had
+produced, and both generalise:
+
+- **`from(s in Module)` in an Ecto query IS a reference Boundary resolves.**
+  Deleting the `Grappa.Accounts` dep from `Admission` and `Vhosts` — neither of
+  which holds a struct literal or calls an `Accounts` function — fails with 3
+  forbidden references (`admission.ex:409`, `:423`, `vhosts.ex:678`). They could
+  not use the declare-nothing resolution; they had to narrow. By contrast
+  `belongs_to :x, Mod`, `Mod.t()` in a typespec and `field :x, Mod` are module
+  atoms in metadata and produce NO edge — which is why `Networks.Credential`, a
+  leaf with `deps: [Grappa.IRC]`, aliases `Accounts.User` and `EncryptedBinary`
+  without declaring either and compiles green.
+- **`MIX_ENV=dev` does not compile `test/support`.** The slice was green in dev
+  and then red in test: 4 forbidden references from `Grappa.AuthFixtures`. A
+  Boundary blast radius measured only in dev under-counts by exactly the
+  test-support boundaries, silently, because the boundary is never compiled.
+
+### Why the whole-context dep was worth removing, measured rather than argued
+
+Green after a deletion proves nothing unless the checker is known to bite, and
+"tidier" is not a reason. So the same mutation was applied twice: a call to
+`Grappa.Accounts.get_user!/1` inserted into `Grappa.Subject`. Before this change
+it compiles GREEN — `Subject` declared the whole context, so the checker had
+nothing to say about a call it never intended to allow. After, the same insertion
+is RED, one forbidden reference to `Grappa.Accounts`. That colour change IS what
+narrowing buys: the annotation now states what the boundary actually needs, and
+the compiler enforces the difference.
+
+### The cost, stated because the review asks for the opposite too
+
+The same review's A7 counts `top_level?: true` boundaries nested inside another
+boundary's namespace and calls the ambiguity a problem: 11 at review time, 15 on
+`main` after #1398, 17 after this. Promotion is A2's fix and A7's regression, one
+per schema promoted, and the two recommendations cannot both be satisfied by
+counting. The rule A7 needs is "a promoted identity or FK schema is a deliberate
+carve-out, not a context internal" — not a smaller number.
+
+`Grappa.BoundaryCycleBudgetTest`'s `@cycle_budget 0` does not move: every edge
+added here points at a leaf with `deps: []`, which can close no cycle. That was a
+prediction until it was run; it is now a measurement.

--- a/lib/grappa/account_deletion.ex
+++ b/lib/grappa/account_deletion.ex
@@ -53,7 +53,14 @@ defmodule Grappa.AccountDeletion do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Grappa.Session, Grappa.Visitors, Grappa.Visitors.Visitor]
+    deps: [
+      Grappa.Accounts,
+      Grappa.Accounts.User,
+      Grappa.Networks,
+      Grappa.Session,
+      Grappa.Visitors,
+      Grappa.Visitors.Visitor
+    ]
 
   alias Grappa.{Accounts, Session, Visitors}
   alias Grappa.Accounts.User

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -81,13 +81,15 @@ defmodule Grappa.Accounts do
     top_level?: true,
     deps: [
       Grappa.Accounts.Revocations,
+      Grappa.Accounts.Session,
+      Grappa.Accounts.User,
       Grappa.Ecto.Like,
       Grappa.EncryptedBinary,
       Grappa.IRC,
       Grappa.Repo,
       Grappa.Visitors.Visitor
     ],
-    exports: [User, Session, Wire, AdminWire, Login, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
+    exports: [Wire, AdminWire, Login, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
 
   import Ecto.Query
 

--- a/lib/grappa/accounts/session.ex
+++ b/lib/grappa/accounts/session.ex
@@ -61,6 +61,8 @@ defmodule Grappa.Accounts.Session do
   listed back — `handle/1` is the public, one-way name a device list
   and an operator log line use instead.
   """
+  use Boundary, top_level?: true, deps: []
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/grappa/accounts/user.ex
+++ b/lib/grappa/accounts/user.ex
@@ -22,6 +22,8 @@ defmodule Grappa.Accounts.User do
   `inspect/1` output. Length bounds (8..256) are deliberately loose —
   password STRENGTH is the user's problem; password STORAGE is ours.
   """
+  use Boundary, top_level?: true, deps: []
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/grappa/admission.ex
+++ b/lib/grappa/admission.ex
@@ -52,7 +52,7 @@ defmodule Grappa.Admission do
   use Boundary,
     top_level?: true,
     deps: [
-      Grappa.Accounts,
+      Grappa.Accounts.Session,
       Grappa.Networks,
       Grappa.Networks.Credential,
       Grappa.Networks.Network,

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -41,6 +41,7 @@ defmodule Grappa.Networks do
     top_level?: true,
     deps: [
       Grappa.Accounts,
+      Grappa.Accounts.User,
       Grappa.Ecto.Like,
       Grappa.EncryptedBinary,
       Grappa.IRC,

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -59,6 +59,7 @@ defmodule Grappa.Operator do
     top_level?: true,
     deps: [
       Grappa.Accounts,
+      Grappa.Accounts.User,
       Grappa.Admission,
       Grappa.AdminEvents,
       # #357 — the `db-latency` / `db-latency-reset` verbs render the

--- a/lib/grappa/release.ex
+++ b/lib/grappa/release.ex
@@ -44,6 +44,7 @@ defmodule Grappa.Release do
     top_level?: true,
     deps: [
       Grappa.Accounts,
+      Grappa.Accounts.User,
       Grappa.Deploy.MigrationAudit,
       Grappa.Networks,
       Grappa.Networks.Network,

--- a/lib/grappa/subject.ex
+++ b/lib/grappa/subject.ex
@@ -30,7 +30,7 @@ defmodule Grappa.Subject do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Visitors.Visitor]
+    deps: [Grappa.Accounts.User, Grappa.Visitors.Visitor]
 
   import Ecto.Query
 

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -69,6 +69,7 @@ if Mix.env() in [:dev, :test] do
       top_level?: true,
       deps: [
         Grappa.Accounts,
+        Grappa.Accounts.User,
         Grappa.Admission,
         Grappa.Networks,
         Grappa.Networks.Credential,

--- a/lib/grappa/themes.ex
+++ b/lib/grappa/themes.ex
@@ -43,7 +43,7 @@ defmodule Grappa.Themes do
   use Boundary,
     top_level?: true,
     deps: [
-      Grappa.Accounts,
+      Grappa.Accounts.User,
       Grappa.Net.Ssrf,
       # #299 amendment (author model A): publish snapshots the visitor's
       # representative nick from the credential anchor.

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -70,7 +70,7 @@ defmodule Grappa.Vhosts do
   use Boundary,
     top_level?: true,
     deps: [
-      Grappa.Accounts,
+      Grappa.Accounts.Session,
       Grappa.Net.HostAddresses,
       Grappa.Net.IpLiteral,
       Grappa.OutboundV6Pool,

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -14,6 +14,8 @@ defmodule GrappaWeb do
       [
         Grappa.AccountDeletion,
         Grappa.Accounts,
+        Grappa.Accounts.Session,
+        Grappa.Accounts.User,
         Grappa.Accounts.Revocations,
         Grappa.Admission,
         Grappa.AdminEvents,

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -19,6 +19,7 @@ defmodule Grappa.AuthFixtures do
     top_level?: true,
     deps: [
       Grappa.Accounts,
+      Grappa.Accounts.User,
       Grappa.Networks,
       Grappa.Networks.Network,
       Grappa.Repo,


### PR DESCRIPTION
Bucket J of #1399, the third that was still open. #415 promoted
`Visitors.Visitor` to a `top_level?: true` leaf so a context could name the
identity schema without depending on the orchestration verbs wrapped around it;
#1398 did the same for the four `Networks` schemas and retired all five
`dirty_xrefs` waivers with it. This finishes the pattern on
`Grappa.Accounts.User` and `Grappa.Accounts.Session`.

**Declared ceiling: 15 files. Actual: 15** — 14 code, plus the `DESIGN_NOTES`
entry.

## What changes

- `Accounts.User` and `Accounts.Session` become `top_level?: true, deps: []`
  leaves, leave `Grappa.Accounts`' `exports:`, and enter its `deps:`.
- **Four boundaries narrow**, which is the point: `Subject` and `Themes` swap
  the whole `Grappa.Accounts` context for `Grappa.Accounts.User`, `Admission`
  and `Vhosts` for `Grappa.Accounts.Session`. None of the four calls an
  `Accounts` function.
- Seven that *do* call one (`Networks`, `Operator`, `Release`,
  `AccountDeletion`, `GrappaWeb`, `TestSupport.SubjectReset`, `AuthFixtures`)
  declare the leaf **alongside** the context, not instead of it.

Boundaries taking a whole context to name one schema: **4 → 0**. Boundaries
declaring `Grappa.Accounts` at all: **20 → 16**.

## The green is worth something, because the value was measured as a colour change

A deletion that compiles is not evidence, and "tidier" is not a reason. So the
same mutation was applied twice: a call to `Grappa.Accounts.get_user!/1`
inserted into `Grappa.Subject`.

| state | mutation | result |
|---|---|---|
| baseline `5779c755` | none | rc=0, 326 files, 0 forbidden |
| main as-is | insert the `Accounts` call into `Subject` | **rc=0, 0 forbidden — GREEN** |
| after this change | *the identical insertion* | **rc=1, exactly 1 forbidden**, `subject.ex:177`, `references from Grappa.Subject to Grappa.Accounts are not allowed` |

Same mutant, opposite colour. Today `Subject` declares the whole context and may
call anything in it unremarked; after, it may name the schema and nothing else.
That difference is what the narrowing buys.

The checker was independently confirmed live on today's `main` (the #1493 shape,
re-armed rather than cited): dropping `Grappa.Accounts` from `Subject` gives
rc=1, exactly **1** forbidden reference at `subject.ex:134`; restoring gives
rc=0, 0. And on the new edge: dropping `Grappa.Accounts.User` from the narrowed
`Subject` gives rc=1, 1 forbidden, same line. One mutant, one assertion, the
predicted line each time.

## The blast radius was enumerated by the compiler, not predicted

Method: apply the promotion, add no deps, and read
`mix compile --force --warnings-as-errors`. `Accounts.User` → **80 forbidden
references across exactly 8 boundaries** (`GrappaWeb` 35, `Networks` 18,
`Themes` 11, `Release` 8, `Operator` 3, `AccountDeletion` 3,
`TestSupport.SubjectReset` 1, `Subject` 1). `Accounts.Session` → 8 across 3.

Two beliefs a source-level scan had produced were corrected by that run, and
both generalise beyond this diff:

- **`from(s in Module)` in an Ecto query IS a reference Boundary resolves.**
  Deleting the dep from `Admission` and `Vhosts` — neither holds a struct
  literal, neither calls an `Accounts` function — fails with 3 forbidden
  references (`admission.ex:409`, `:423`, `vhosts.ex:678`). They could not use
  the declare-nothing resolution; they had to narrow. By contrast
  `belongs_to :x, Mod`, `Mod.t()` in a typespec and `field :x, Mod` produce no
  edge — the live proof is `Networks.Credential`, a leaf with
  `deps: [Grappa.IRC]` that aliases `Accounts.User` and `EncryptedBinary`
  without declaring either.
- **`MIX_ENV=dev` never compiles `test/support`.** The slice was green in dev
  and then red in test: 4 forbidden references from `Grappa.AuthFixtures`
  (`auth_fixtures.ex:229`). A Boundary blast radius measured only in dev
  under-counts by exactly the test-support boundaries, silently.

## The cost, stated because the same review asks for the opposite

The 2026-08-15 review's A7 counts `top_level?: true` boundaries nested in
another boundary's namespace and calls the ambiguity a problem: **11** at review
time, **15** on `main` after #1398, **17** after this. Promotion is A2's fix and
A7's regression, one per schema promoted; the two recommendations cannot both be
satisfied by counting. What A7 needs is the rule — "a promoted identity or FK
schema is a deliberate carve-out, not a context internal" — not a smaller
number. Recorded in the `DESIGN_NOTES` entry so the next reader is not surprised
by it.

`Grappa.BoundaryCycleBudgetTest`'s `@cycle_budget 0` does not move: every edge
added here points at a leaf with `deps: []`, which can close no cycle. That was
a stated prediction until it was run.

## Gates

| gate | result |
|---|---|
| `compile --env=dev --force --warnings-as-errors` | rc=0, 0 forbidden |
| `compile --env=test --force --warnings-as-errors` | rc=0, 0 forbidden |
| `mix format --check-formatted`, Credo strict, Sobelow | clean |
| ExUnit | 8 doctests, 61 properties, **6546 tests, 0 failures** |
| Dialyzer | **Total errors: 0**, `done (passed successfully)` |
| `scripts/design-notes-gate.sh` | 1 new entry, separator and marker present |
| `scripts/bats.sh` (full 564, standalone) | **564/564** |

### ⚠️ `scripts/check.sh` exits 1 on this branch — and on `main`, identically

`check.sh` reports **8 bats failures out of 564** (136–139 the standalone
migrate door; 508–510 deploy reload verify; 512 the deploy worktree guard).
None of them is in a file this branch touches — no script is modified here.
They were not dismissed as pre-existing; that was measured, in four steps:

| run | result |
|---|---|
| the 2 failing files alone, main checkout | 10/10 green |
| the 2 failing files alone, this worktree | 10/10 green |
| full 564-test bats, clean `origin/main` worktree | **564/564 green** |
| full 564-test bats, this branch | **564/564 green** |
| **`check.sh` on a clean `origin/main` worktree, no commit from this branch** | **rc=1, the same 8, same names** |

So the failures live only *inside* `check.sh` — the standing hypothesis is that
its mix steps leave a grappa container up, and these deploy tests read container
liveness, taking a different path than they do standalone. The delta
attributable to this branch is zero. The remedy belongs to the gate, not here,
and is worth its own issue.

An earlier hypothesis — "`origin/main` moved mid-run" — was wrong and is
recorded as wrong: it did move twice while this was in flight, but after
rebasing onto the stable base the same 8 reappeared.

## Not established

- No runtime behaviour changes: these are compile-time annotations, and nothing
  here was exercised against a live session or production.
- The last thing #1399 asks for — recording the rule in `CLAUDE.md` next to the
  Boundary paragraph — is **not** in this branch; #1493 records that edit as
  vjt's. Until it lands, a boundary that needs only a schema can still invent a
  further resolution, so this does not close the issue.
- The compiler is what makes the selection safe, not the parser that proposed
  it: a reference built by macro or `Module.concat/1` is invisible to a source
  scan, and the source scan was in fact wrong twice (above).
