### PR TITLE
cic(#1396): the last six dispatch arms leave the switch, at zero new fields

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -4968,7 +4968,11 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "info", draft: "/info" },
   { kind: "version", draft: "/version" },
   { kind: "stats", draft: "/stats m" },
-  { kind: "admin", draft: "/admin" },
+  // #1396 — the target is NOT optional here even though the verb's grammar
+  // makes it so: a bare `/admin` row cannot tell `pushAdmin(id, cmd.target)`
+  // from `pushAdmin(id, null)`, because the fixture's target IS null. Measured,
+  // not reasoned: that mutant killed nothing across all 290 files.
+  { kind: "admin", draft: "/admin irc.example.org" },
   { kind: "oper", draft: "/oper root secret" },
   { kind: "kill", draft: "/kill bob spam" },
   { kind: "rehash", draft: "/rehash" },
@@ -5132,7 +5136,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "socket.pushAdmin(1, null)",
+            "socket.pushAdmin(1, "irc.example.org")",
           ],
           "result": {
             "ok": true,

--- a/cicchetto/src/lib/commands/local.ts
+++ b/cicchetto/src/lib/commands/local.ts
@@ -1,0 +1,49 @@
+import { addAlias, delAlias } from "../aliasList";
+import { requestOpenSettings } from "../settingsNav";
+import type { CommandHandler } from "./context";
+
+/**
+ * The arms that reach no network: two client-side stores, one UI deep-link,
+ * and the parser's own failure arriving as a pseudo-verb. None of them resolves
+ * a network id or puts a frame on the wire, which is why none of them reads
+ * anything off the context record.
+ */
+
+/**
+ * #356 — a bare watch-family verb (`/notify`, `/watch`, `/hilight`,
+ * `/highlight`, `/dehilight`) opens the unified watch-lists settings section
+ * rather than printing inline. Opening the drawer IS the feedback, so this is a
+ * silent success.
+ */
+export const openSettingsCommand: CommandHandler<"open-settings"> = async (cmd) => {
+  requestOpenSettings(cmd.section);
+  return { ok: true };
+};
+
+/**
+ * #385 — `/alias <name> <expansion>` defines or overwrites a user alias.
+ * Round-tripped through the aliasList store (full-map PUT, server normalizes +
+ * validates); a 422 (bad name/expansion, cap exceeded) is thrown as an ApiError
+ * and surfaces via `friendlyError` in the dispatcher's catch with the per-field
+ * message. The green confirmation echoes the normalized definition.
+ */
+export const aliasDefineCommand: CommandHandler<"alias-define"> = async (cmd) => {
+  await addAlias(cmd.name, cmd.expansion);
+  return { ok: `alias: /${cmd.name} → ${cmd.expansion}` };
+};
+
+/** #385 — `/unalias <name>` removes a user alias. */
+export const unaliasCommand: CommandHandler<"unalias"> = async (cmd) => {
+  await delAlias(cmd.name);
+  return { ok: `alias: removed /${cmd.name}` };
+};
+
+/**
+ * A parser-level failure — an unknown verb, or a verb whose arguments did not
+ * validate. Not a command: `parseSlash` returns it in the same union so the
+ * dispatcher has one shape to route, and the message it carries is the
+ * parser's, not this module's.
+ */
+export const errorCommand: CommandHandler<"error"> = async (cmd) => {
+  return { error: cmd.message };
+};

--- a/cicchetto/src/lib/commands/server.ts
+++ b/cicchetto/src/lib/commands/server.ts
@@ -1,5 +1,6 @@
 import { markLusersRequested } from "../lusersBundle";
 import {
+  pushAdmin,
   pushInfo,
   pushLinks,
   pushLusers,
@@ -117,6 +118,19 @@ export const motdCommand: CommandHandler<"motd"> = async (cmd, ctx) => {
   // for an unknown target surfaces via the same server_reply modal, never a
   // wrong-server MOTD.
   await pushMotd(networkId, cmd.target); // S6 (#364): await verb-ack
+  return { ok: true };
+};
+
+/**
+ * #992 — `/admin [<target>]`. Same door as /motd: bahamut's `m_admin` routes
+ * through the same `hunt_server`, so a target sends the query to another
+ * server and the reply lands in the same `server_reply` modal under the
+ * `admin` source.
+ */
+export const adminCommand: CommandHandler<"admin"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "admin");
+  if (typeof networkId !== "number") return networkId;
+  await pushAdmin(networkId, cmd.target); // S6 (#364): await verb-ack
   return { ok: true };
 };
 

--- a/cicchetto/src/lib/commands/session.ts
+++ b/cicchetto/src/lib/commands/session.ts
@@ -2,7 +2,7 @@ import { patchNetwork, postNick, postNotifyAdd } from "../api";
 import { friendlyError } from "../friendlyError";
 import { clearMentionsBundle } from "../mentionsWindow";
 import { quitAll } from "../quit";
-import { pushAwaySet, pushAwayUnset, pushRecover } from "../socket";
+import { pushAwaySet, pushAwayUnset, pushOper, pushRecover } from "../socket";
 import type { CommandHandler } from "./context";
 
 /**
@@ -112,4 +112,27 @@ export const notifyCommand: CommandHandler<"notify"> = async (cmd, ctx) => {
   if (typeof notifyNet !== "number") return notifyNet;
   await postNotifyAdd(ctx.token, ctx.networkSlug, cmd.nicks);
   return { ok: `notify: watching ${cmd.nicks.join(", ")}` };
+};
+
+/**
+ * Bundle C (#20 follow-up) — `/oper <name> <password>`. The password travels
+ * over the WS frame; the bouncer redacts it from logs by emitting a static log
+ * body before sending OPER upstream. The result lands as a 381 RPL_YOUREOPER
+ * (success) / 491 (bad host) / 464 (bad pw) numeric, which the numeric-routing
+ * path persists as :notice rows.
+ *
+ * AWAIT the push: a credential-bearing verb MUST NOT silently no-op when the WS
+ * is down or the server-side validator rejects
+ * (`feedback_no_silent_drops_closed`).
+ *
+ * #1396 — it lives with the session verbs rather than with the server queries
+ * in `server.ts`, whose contract is that none of them changes anything: this
+ * one changes the operator's own standing on the network for the rest of the
+ * session.
+ */
+export const operCommand: CommandHandler<"oper"> = async (cmd, ctx) => {
+  const networkId = ctx.requireNetworkId(ctx.networkSlug, "oper");
+  if (typeof networkId !== "number") return networkId;
+  await pushOper(networkId, cmd.name, cmd.password);
+  return { ok: true };
 };

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,11 +1,17 @@
 import { createEffect, createSignal, on } from "solid-js";
-import { addAlias, aliases, delAlias } from "./aliasList";
+import { aliases } from "./aliasList";
 import { ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
 import { watchlistCommand } from "./commands/highlight";
+import {
+  aliasDefineCommand,
+  errorCommand,
+  openSettingsCommand,
+  unaliasCommand,
+} from "./commands/local";
 import {
   banlistCommand,
   modeApplyCurrentCommand,
@@ -30,6 +36,7 @@ import {
 } from "./commands/ops";
 import { ctcpCommand, noticeCommand, pingCommand } from "./commands/relay";
 import {
+  adminCommand,
   infoCommand,
   linksCommand,
   lusersCommand,
@@ -49,6 +56,7 @@ import {
   disconnectCommand,
   nickCommand,
   notifyCommand,
+  operCommand,
   quitCommand,
   recoverCommand,
 } from "./commands/session";
@@ -73,9 +81,7 @@ import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 import { selectedChannel, setSelectedChannel } from "./selection";
 import { draftLines, sendBodyLines, sendFanOut, wireBody } from "./sendPipeline";
 import { isServicesSender } from "./servicesSender";
-import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
-import { pushAdmin, pushOper } from "./socket";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
 
 // #1255 — the channel sigils this NETWORK advertised (005 CHANTYPES),
@@ -1111,13 +1117,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = await motdCommand(cmd, ctx);
           break;
         }
-        // #992 — /admin [<target>]. Same door as /motd; the reply lands in
-        // the same server_reply modal under the `admin` source.
         case "admin": {
-          const networkId = requireNetworkId(networkSlug, "admin");
-          if (typeof networkId !== "number") return networkId;
-          await pushAdmin(networkId, cmd.target); // S6 (#364): await verb-ack
-          result = { ok: true };
+          result = await adminCommand(cmd, ctx);
           break;
         }
         case "stats": {
@@ -1153,57 +1154,31 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = await notifyCommand(cmd, ctx);
           break;
         }
-        // #356 — a bare watch-family verb (/notify, /watch, /hilight,
-        // /highlight, /dehilight) opens the unified watch-lists settings
-        // section rather than printing inline. Opening the drawer IS the
-        // feedback, so this is a silent success.
         case "open-settings": {
-          requestOpenSettings(cmd.section);
-          result = { ok: true };
+          result = await openSettingsCommand(cmd, ctx);
           break;
         }
         case "quote": {
           result = await quoteCommand(cmd, ctx);
           break;
         }
-        // Bundle C (#20 follow-up) — /oper <name> <password>. The password
-        // travels over the WS frame; bouncer redacts it from logs by
-        // emitting a static log body before sending OPER upstream.
-        // Result lands as a 381 RPL_YOUREOPER (success) / 491 (bad host)
-        // / 464 (bad pw) numeric — the existing numeric-routing path
-        // persists those as :notice rows. AWAIT the push: a credential-
-        // bearing verb MUST NOT silently no-op when the WS is down or
-        // the server-side validator rejects (CLAUDE.md
-        // `feedback_no_silent_drops_closed`).
         case "oper": {
-          const networkId = requireNetworkId(networkSlug, "oper");
-          if (typeof networkId !== "number") return networkId;
-          await pushOper(networkId, cmd.name, cmd.password);
-          result = { ok: true };
+          result = await operCommand(cmd, ctx);
           break;
         }
-        // #385 — /alias <name> <expansion> defines/overwrites a user alias.
-        // Round-tripped through the aliasList store (full-map PUT, server
-        // normalizes + validates); a 422 (bad name/expansion, cap exceeded)
-        // is thrown as an ApiError and surfaces via friendlyError in the
-        // catch below with the per-field message. The green confirmation
-        // echoes the normalized definition.
         case "alias-define": {
-          await addAlias(cmd.name, cmd.expansion);
-          result = { ok: `alias: /${cmd.name} → ${cmd.expansion}` };
+          result = await aliasDefineCommand(cmd, ctx);
           break;
         }
-        // #385 — /unalias <name> removes a user alias.
         case "unalias": {
-          await delAlias(cmd.name);
-          result = { ok: `alias: removed /${cmd.name}` };
+          result = await unaliasCommand(cmd, ctx);
           break;
         }
-        // ---------------------------------------------------------------
-        // Parser-level error (unknown verb or validation failure).
-        // ---------------------------------------------------------------
-        case "error":
-          return { error: cmd.message };
+        // Not a verb: the parser's own failure, routed like one.
+        case "error": {
+          result = await errorCommand(cmd, ctx);
+          break;
+        }
         default: {
           const _exhaustive: never = cmd;
           void _exhaustive;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48816,3 +48816,87 @@ where none of the 27 files run at all. A rotating red set is the suite's own
 property here, not a signal about the change under test — which is exactly why
 a spec's red is attributed by re-running it, never by reading the diff next to
 it._
+<!-- entry #1396-residue -->
+
+---
+
+## 2026-08-18 — #1396: the last six arms leave the switch, and the row the net could not see
+
+Bucket G's remainder. #1514 moved 47 of the 59 `dispatchDraft` arms behind the
+`lib/commands/` seam, #1517 moved the one the #1513 hoist unblocked, and six
+were held back by a scope ruling that gave one structural reason: *no red
+protects them*. Six more belong to #1513 and are untouched here.
+
+### The premise was false, and the correction is a measurement
+
+The net that makes a pure move provable — `#1396 — dispatch characterization
+over every arm` — landed HOURS AFTER that ruling, in #1514. It pins every arm's
+observable effects, so by the time the ruling was acted on, all six had a red.
+One mutant per arm, the full 290-file unit suite each time, the same seven
+mutants re-run after the move:
+
+| mutant | before | after |
+|---|---|---|
+| `/admin` resolves another network's id | 1 | 1 |
+| `/admin` drops `cmd.target` | **0** | 1 (after the fixture fix below) |
+| `/oper` swaps name and password | 1 | 1 |
+| `/watch` opens a fixed section | 1 | 1 |
+| `/alias` stores expansion as name | 1 | 1 |
+| `/unalias` removes the wrong name | 1 | 1 |
+| a parser error loses the parser's message | **3** | 3 |
+
+Six of the seven are the same single assertion — the pinned row — before and
+after. `error`, the arm named as the genuinely unprotected one, is the BEST
+protected of the six: three assertions die, and two of them are ordinary specs
+rather than the net, because bare `/connect` parses to `kind: "error"` and so a
+second verb's error spec rides this arm.
+
+### The one real hole was somewhere else
+
+`/admin`'s TARGET. The mutant that drops `cmd.target` killed nothing across all
+290 files, because the table's draft was a bare `/admin`: the fixture's target
+is null, and null is also what a handler that dropped it would send. That is
+the `target == context` degeneration the table's own rule is written against,
+in its other form — not "the target equals the window", but "the target equals
+the default". #992's whole point is that a target routes the query through
+bahamut's `hunt_server` to ANOTHER server, so the blind half was the
+interesting one.
+
+Closed FIRST, in its own commit, before anything moved: the row now reads
+`/admin irc.example.org` (neither `#a` nor `freenode`, so the table's rule
+still holds), and the same mutant then kills exactly one assertion — the
+cardinality every sibling arm has. The pre-move and post-move runs of that
+mutant were both taken over the full suite, so the two sides measure the same
+thing.
+
+### Three homes, chosen against the module docs rather than by size
+
+- `admin` → `server.ts`. The same shape as `/motd`, down to `hunt_server`.
+- `oper` → `session.ts`, deliberately NOT `server.ts`, whose module doc states
+  that none of its verbs changes anything on this side. `/oper` changes the
+  operator's standing on the network for the rest of the session. A handler
+  filed under a doc that denies it is how a doc stops being read.
+- `open-settings`, `alias-define`, `unalias`, `error` → a new `local.ts`: the
+  arms that reach no network. None resolves a network id, none puts a frame on
+  the wire, and — the fact that makes it an axis rather than a leftovers
+  drawer — none reads anything off the context record.
+
+`error` is not a verb. It is the parser's failure, arriving in the same union
+so the dispatcher has one shape to route, and its handler deliberately adds
+nothing: an arm that reworded the message would be inventing an error the
+parser never raised. Routing it like a verb is what makes the switch uniform —
+every case is now one call and a `break`.
+
+### What the record did not need
+
+`CommandContext` gains ZERO fields. Two of the six want `requireNetworkId` and
+`networkSlug`, which the record has carried since slice 2a; the other four want
+nothing at all. That is the measurable difference between these five and the
+`ame`/`amsg` pair still parked in #1513, whose blocker was never the record.
+
+### Limits of this measurement
+
+The unit suite is the whole of it. Eight e2e specs drive these verbs
+(`issue992-admin-command`, `issue148-visitor-oper`, `issue385-user-aliases`,
+`issue409-alias-edit`, `issue409-alias-tab-scope`, `issue427-alias-shadow-builtins`,
+`issue1047-alias-range-param`, `issue460-settings-index`) and none was run here.


### PR DESCRIPTION
Bucket G's remainder: the last six `dispatchDraft` arms that are not #1513's.
47 moved in #1514, one in #1517, six belong to #1513 — these are the other six.

## The ruling's premise is false, and a measurement says so

These six were held back on *"no red protects them"*. The characterization net
that makes a pure move provable landed in #1514, **hours after that ruling**,
and it pins every arm's observable effects. So today each of the six has a red.

One mutant per arm, the **full 290-file unit suite** each time, the same seven
re-run after the move:

| mutant | before | after |
|---|---|---|
| `/admin` resolves another network's id | 1 | 1 |
| `/admin` drops `cmd.target` | **0** | 1 (after the fixture fix) |
| `/oper` swaps name and password | 1 | 1 |
| `/watch` opens a fixed section | 1 | 1 |
| `/alias` stores expansion as name | 1 | 1 |
| `/unalias` removes the wrong name | 1 | 1 |
| a parser error loses the parser's message | **3** | 3 |

Same failing assertion, same cardinality, both sides. `error` — the arm named
as the genuinely unprotected one — is the **best protected** of the six: three
assertions die, two of them ordinary specs rather than the net, because bare
`/connect` parses to `kind: "error"` and a second verb's error spec rides this
arm.

## The one real hole was `/admin`'s target, and it is closed first

Dropping `cmd.target` killed **nothing across all 290 files**: the table's draft
was a bare `/admin`, so the fixture's target is null — and null is what a
handler that dropped it would send. That is the `target == context`
degeneration in its other form: not "the target equals the window", but "the
target equals the default". #992's point is that a target routes the query
through bahamut's `hunt_server` to another server, so the blind half was the
interesting one.

Fixed in its own commit, **before** anything moved: the row reads
`/admin irc.example.org` (neither `#a` nor `freenode`, so the table's own
"no draft aims at the window it is submitted from" rule still holds). Both the
pre-move and post-move runs of that mutant were taken over the full suite, so
the two sides measure the same thing.

## Homes chosen against the module docs, not by size

- `admin` → `server.ts`, the same shape as `/motd`.
- `oper` → `session.ts`, deliberately **not** `server.ts`, whose module doc says
  none of its verbs changes anything on this side. `/oper` changes the
  operator's standing for the rest of the session.
- `open-settings`, `alias-define`, `unalias`, `error` → new `local.ts`: the arms
  that reach no network. None resolves a network id, none puts a frame on the
  wire, and none reads anything off the context record — that last fact is the
  axis, not a leftovers drawer.

`error` is not a verb; it is the parser's failure routed like one, and its
handler adds nothing on purpose. The switch is now uniform: every case is one
call and a `break`.

**`CommandContext` gains zero fields.**

## Gates

- `scripts/bun.sh run test` — 290 files / 5615 tests green on this source.
- `scripts/bun.sh run check` — green (biome + tsc + e2e tsc).
- `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present.

## Not covered

Eight e2e specs drive these verbs (`issue992-admin-command`,
`issue148-visitor-oper`, `issue385-user-aliases`, `issue409-alias-edit`,
`issue409-alias-tab-scope`, `issue427-alias-shadow-builtins`,
`issue1047-alias-range-param`, `issue460-settings-index`) and **none was run
here** — the unit suite is the whole measurement.

After this, what remains inline in the switch is #1513's six arms and nothing
else.
