### PR TITLE
e2e(#1336): give three empty-recorder assertions a positive control

### DIFF
--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -86,11 +86,20 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
     // genuine $list scrollback fetch still reds it below) while making it
     // deterministic — this is NOT a toHaveLength(<=1) relaxation nor a
     // blanket substring filter that would blind the guard.
+    // Recorded WIDE (every `/messages` request) and filtered NARROW at each
+    // assertion — #1117. A collector armed on the $list path alone can only
+    // ever be empty here, so its emptiness proves nothing: the same `[]`
+    // comes out of a mistyped path, a listener attached after the traffic,
+    // or a handler on the wrong page. Widening costs the guard nothing —
+    // the assertion below still filters to the $list path, so a genuine
+    // $list scrollback fetch still reds it — and it buys a positive control
+    // at the end of the test, where the joined channel's own GET proves
+    // this recorder sees `/channels/<enc>/messages` when one is issued.
     const listMessagesPath = `/channels/${encodeURIComponent(LIST_WINDOW_NAME)}/messages`;
     const messagesRequests: string[] = [];
     page.on("request", (req) => {
       const url = req.url();
-      if (url.includes(listMessagesPath)) {
+      if (url.includes("/messages")) {
         messagesRequests.push(url);
       }
     });
@@ -114,7 +123,7 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
     // selection. Checked here — before any join that would legitimately
     // trigger GET /messages for the newly-joined channel window.
     expect(
-      messagesRequests,
+      messagesRequests.filter((url) => url.includes(listMessagesPath)),
       "GET /messages must NOT fire when selecting kind=list — grappa-irc#81 guard",
     ).toHaveLength(0);
 
@@ -164,6 +173,18 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
     await expect(sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
+
+    // Positive control for the #81 guard above (#1117). The foregrounded
+    // channel hydrates its scrollback, which is exactly the request shape
+    // the guard forbids for $list — same recorder, same `/messages`
+    // predicate, only a different channel segment. If this stays empty the
+    // recorder was blind and the `toHaveLength(0)` above was vacuous.
+    const peerMessagesPath = `/channels/${encodeURIComponent(PEER_CHANNEL)}/messages`;
+    await expect
+      .poll(() => messagesRequests.filter((url) => url.includes(peerMessagesPath)).length, {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
   } finally {
     await peer.disconnect("e2e channel-directory done");
   }

--- a/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
@@ -20,11 +20,12 @@
 // read-cursor POST returned 4xx (the fail2ban trigger). RED before the
 // setReadCursor guard (a $home 404 is captured); GREEN after.
 
-import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
+const RUN_ID = crypto.randomUUID().slice(0, 8);
 
 // The synthetic pseudo-window channel segments, URL-encoded as they appear
 // on the wire ($ → %24). $server is deliberately absent: it is a real
@@ -56,6 +57,27 @@ test.describe("#160 virtual-tab read-cursor suppression", () => {
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await expect
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    // Positive control (#1117) — armed BEFORE the stimulus under test, so
+    // both assertions below are read against a recorder proven to see.
+    // Absence is only evidence once presence has been demonstrated through
+    // the SAME `page.on("response")` predicate: a typo in it, or a listener
+    // attached after the traffic, leaves `cursorPosts` empty and every
+    // filter of it trivially `[]`. An own send is the cheapest real
+    // stimulus — scrollback.ts advances the cursor past the row it just
+    // persisted, which POSTs for the REAL channel and is neither virtual
+    // nor 4xx, so it disturbs neither assertion.
+    const controlBody = `#160 recorder control ${RUN_ID}`;
+    await composeSend(page, controlBody);
+    await expect(
+      page.locator('[data-testid="scrollback-line"]', { hasText: controlBody }),
+    ).toBeVisible({ timeout: 5_000 });
+    const realSegment = `/channels/${encodeURIComponent(CHANNEL)}/read-cursor`;
+    await expect
+      .poll(() => cursorPosts.filter((p) => p.url.includes(realSegment)).length, {
+        timeout: 5_000,
+      })
       .toBeGreaterThan(0);
 
     // Select the Home tab — disposes the ScrollbackPane. Pre-fix, the

--- a/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
@@ -175,4 +175,24 @@ test("re-clicking active sidebar row does NOT POST ReadCursor (BU bug-2 idempote
   await page.waitForTimeout(500);
 
   expect(cursorPosts).toHaveLength(0);
+
+  // Positive control (#1117). The zero above is only evidence if this
+  // recorder can catch a cursor POST at all: `page.route` with a pattern
+  // that never matches — or a handler installed on the wrong page —
+  // produces the same empty array as a working idempotency guard. Send an
+  // own message: scrollback.ts advances the cursor past the row it just
+  // persisted, so a POST goes through the very route filter asserted
+  // empty. Deliberately AFTER the assertion, so the control cannot mask
+  // the defect it guards.
+  const controlBody = `BU bug-2 recorder control ${RUN_ID}`;
+  await composeSend(page, controlBody);
+  await expect(
+    page.locator('[data-testid="scrollback-line"]', { hasText: controlBody }),
+  ).toBeVisible({ timeout: 5_000 });
+  const channelSegment = `/channels/${encodeURIComponent(CHANNEL)}/read-cursor`;
+  await expect
+    .poll(() => cursorPosts.filter((url) => url.includes(channelSegment)).length, {
+      timeout: 5_000,
+    })
+    .toBeGreaterThan(0);
 });


### PR DESCRIPTION
Slice (A) of #1336 — the three `#1117` sites. The M1 half (`push.ts`) is
deliberately **not** here: it edits a fixture five green push specs depend on,
and its spec-level tail needs per-site geometry this slice does not.

## The defect

Four assertions across three specs read *"nothing was recorded"* off a collector
nobody had proven capable of recording anything:

| file | recorder | assertion(s) |
|---|---|---|
| `issue160-virtual-tab-no-cursor.spec.ts` | `cursorPosts` (`page.on("response")`) | 2 × `toEqual([])` over **filters** |
| `channel-directory.spec.ts` | `messagesRequests` (`page.on("request")`) | `toHaveLength(0)` |
| `ux-5-bu-unread-focus.spec.ts` | `cursorPosts` (`page.route`) | `toHaveLength(0)` |

Each passes identically whether the guard under test holds or the predicate
simply never matched — a mistyped path, a listener attached after the traffic,
a route pattern that cannot fire. The test is green in both worlds.

## The cure

A real production request through the **same predicate**, never a synthetic
probe:

* **`issue160` / `ux-5-bu`** — an own send. `scrollback.ts` advances the read
  cursor past the row it just persisted, so a genuine POST for a REAL channel
  goes through the very collector the absence assertions read. It is neither
  virtual nor 4xx, so it disturbs neither #160 assertion.
* **`channel-directory`** — the recorder widens to every `/messages` request and
  the assertion filters to the `$list` path. The #81 guard keeps exactly its old
  strictness (a genuine `$list` fetch still reds it), and the joined channel's
  own hydrate GET — already at the end of the test — witnesses that the recorder
  sees this request shape.

Placement follows what each assertion needs: `#160` arms its control **before**
the Home click, since both its assertions are filters of one array; BU bug-2
puts it **after** the zero, so the control cannot mask the non-idempotent write
it exists to catch.

## Measured, two-sided

Set and cardinality fixed **before** running: **4 vacuous assertions / 3
recorders / 3 files / 3 tests** (counted on `c70e71a3`, not eyeballed).

The mutant breaks each recorder's PREDICATE and leaves every assertion
untouched — injected by a script that aborts unless each replacement matches
exactly once:

| file | mutation |
|---|---|
| `issue160` | `resp.url().includes("/read-cursor")` → `"/read-cursor-NOPE"` |
| `channel-directory` | `url.includes(listMessagesPath)` (base) / `url.includes("/messages")` (fixed) → `… + "-NOPE"` |
| `ux-5-bu` | `page.route(/\/read-cursor(\?\|$)/…)` → `/\/read-cursor-NOPE(\?\|$)/` |

Scoped local runs, `--project chromium`, one testnet:

* **BEFORE (specs at `c70e71a3` + mutant): 3 mutated, 3 run, `0 red`.** That
  green IS the defect — three blind recorders, four assertions that cannot tell.
* **AFTER, unmutated: 3 green** — which is also what proves the stimuli are real
  and not wishful.
* **AFTER + the same mutant: `3 red`**, and each red is the control itself
  (`toBeGreaterThan(0)`, received `0`, at the three control lines) — one mutant,
  one assertion killed per file.

The ship gate is this PR's CI, not the scoped run above.