### PR TITLE
cic(#1396): the fan-out pair leaves the switch, at zero new fields

### DIFF
--- a/cicchetto/src/lib/commands/fanout.ts
+++ b/cicchetto/src/lib/commands/fanout.ts
@@ -1,0 +1,84 @@
+import { requestConfirm } from "../confirmDialog";
+import { friendlyError } from "../friendlyError";
+import { joinedChannelsOnNetwork } from "../joinedChannels";
+import { sendFanOut } from "../sendPipeline";
+import type { CommandHandler } from "./context";
+
+// #431 — above this many channels an /ame|/amsg asks before it writes anything.
+// A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
+// writes to N channels is a spam vector, and ten is where a fan-out stops
+// reading as "the rooms I am in" and starts reading as a broadcast.
+const FANOUT_CONFIRM_THRESHOLD = 10;
+
+/**
+ * #431 — /ame + /amsg: the same body to EVERY joined channel of THIS network.
+ * Deliberately not addressed to the active window: the fan-out is per-NETWORK
+ * (vjt 2026-08-09 — cross-network is out of scope, and no flag for it), so it
+ * works from the $server window just as well as from a channel, and it
+ * includes the window it was typed in.
+ *
+ * ONE handler for two kinds: the pair differ only by the ACTION framing, which
+ * `cmd.kind` already decides, so splitting them would duplicate the confirm
+ * gate and the partial-failure accounting.
+ *
+ * #1396 — it reaches the seam at zero new fields on the record. Everything it
+ * needs beyond `ctx.key` and `ctx.networkSlug` is an ordinary module import,
+ * which is what tells it apart from `privmsg`/`me`/`msg`: those close over the
+ * composer's draft store (`sendPacedBody`), this one never touches the buffer.
+ */
+export const fanOutCommand: CommandHandler<"ame" | "amsg"> = async (cmd, ctx) => {
+  const action = cmd.kind === "ame";
+  // The joined-channel projection #30's channel tab-completion already reads:
+  // server-owned, so `invited` (the window an unsolicited INVITE opens),
+  // `pending`, `failed`, `kicked` and `parked` are all excluded by the same
+  // `joined` predicate, and there is no parallel client-side channel list to
+  // drift from it. Queries and $server cannot appear at all — `window_states`
+  // is channel-keyed by construction on the server, a DM lives in
+  // `queryWindows`.
+  const targets = joinedChannelsOnNetwork(ctx.key).sort();
+  if (targets.length === 0) {
+    return { error: `/${cmd.kind}: no joined channel on ${ctx.networkSlug}` };
+  }
+  // Channels the fan-out has finished, for the "how far did it get" half of a
+  // failure — the number that tells the operator whether retyping the line
+  // would double-send it.
+  let done = 0;
+  const run = (): Promise<void> =>
+    sendFanOut(ctx.networkSlug, targets, cmd.body, action, (n) => {
+      done = n;
+    });
+  if (targets.length > FANOUT_CONFIRM_THRESHOLD) {
+    // The question names every target, not just the count: the blast radius IS
+    // the thing being consented to, so "11 channels" alone would be consent
+    // without disclosure.
+    requestConfirm({
+      title: action ? "Send action to every channel" : "Send message to every channel",
+      body: `Send to ${targets.length} channels on ${ctx.networkSlug}? ${targets.join(", ")}`,
+      confirmLabel: "Send",
+      // Detached: `requestConfirm` resolves nothing, so the send cannot be
+      // awaited here and its failure cannot surface inline the way the
+      // un-gated path's does below. Logged with a grep key instead, mirroring
+      // `windowClose.disconnectNetwork` — the same shape of
+      // destructive-action-behind-a-confirm. Never bare: an unhandled
+      // rejection here would be a fan-out that stopped in silence.
+      onConfirm: () => {
+        void run().catch((err) => {
+          console.warn(
+            `[/${cmd.kind}] fan-out stopped after ${done} of ${targets.length} channels on ${ctx.networkSlug}:`,
+            err,
+          );
+        });
+      },
+      alternative: null,
+    });
+    return { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
+  }
+  try {
+    await run();
+  } catch (e) {
+    return {
+      error: `${friendlyError(e)} — sent to ${done} of ${targets.length} channels`,
+    };
+  }
+  return { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
+};

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -5,6 +5,7 @@ import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
+import { fanOutCommand } from "./commands/fanout";
 import { watchlistCommand } from "./commands/highlight";
 import {
   aliasDefineCommand,
@@ -62,7 +63,6 @@ import {
 } from "./commands/session";
 import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
 import { joinCommand, listCommand, partCommand, queryCommand } from "./commands/window";
-import { requestConfirm } from "./confirmDialog";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -79,7 +79,7 @@ import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // different recipient while echoing here, so it is named for the window, not
 // for one of the verbs it can carry.
 import { selectedChannel, setSelectedChannel } from "./selection";
-import { draftLines, sendBodyLines, sendFanOut, wireBody } from "./sendPipeline";
+import { draftLines, sendBodyLines, wireBody } from "./sendPipeline";
 import { isServicesSender } from "./servicesSender";
 import { parseSlash } from "./slashCommands";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
@@ -208,12 +208,6 @@ const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
   if (keys.length === 0) sessionStorage.removeItem(DRAFTS_KEY);
   else sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(drafts));
 };
-
-// #431 — above this many channels an /ame|/amsg asks before it writes anything.
-// A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
-// writes to N channels is a spam vector, and ten is where a fan-out stops
-// reading as "the rooms I am in" and starts reading as a broadcast.
-const FANOUT_CONFIRM_THRESHOLD = 10;
 
 /**
  * #1108 — what the current draft will do to the wire, or `null` when there is
@@ -779,68 +773,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = r;
           break;
         }
-        // #431 — /ame + /amsg: the same body to EVERY joined channel of THIS
-        // network. Deliberately not addressed to the active window: the fan-out
-        // is per-NETWORK (vjt 2026-08-09 — cross-network is out of scope, and
-        // no flag for it), so it works from the $server window just as well as
-        // from a channel, and it includes the window it was typed in.
         case "ame":
         case "amsg": {
-          const action = cmd.kind === "ame";
-          // The joined-channel projection #30's channel tab-completion already
-          // reads: server-owned, so `invited` (the window an unsolicited INVITE
-          // opens), `pending`, `failed`, `kicked` and `parked` are all excluded
-          // by the same `joined` predicate, and there is no parallel
-          // client-side channel list to drift from it. Queries and $server
-          // cannot appear at all — `window_states` is channel-keyed by
-          // construction on the server, a DM lives in `queryWindows`.
-          const targets = joinedChannelsOnNetwork(key).sort();
-          if (targets.length === 0) {
-            return { error: `/${cmd.kind}: no joined channel on ${networkSlug}` };
-          }
-          // Channels the fan-out has finished, for the "how far did it get"
-          // half of a failure — the number that tells the operator whether
-          // retyping the line would double-send it.
-          let done = 0;
-          const run = (): Promise<void> =>
-            sendFanOut(networkSlug, targets, cmd.body, action, (n) => {
-              done = n;
-            });
-          if (targets.length > FANOUT_CONFIRM_THRESHOLD) {
-            // The question names every target, not just the count: the blast
-            // radius IS the thing being consented to, so "11 channels" alone
-            // would be consent without disclosure.
-            requestConfirm({
-              title: action ? "Send action to every channel" : "Send message to every channel",
-              body: `Send to ${targets.length} channels on ${networkSlug}? ${targets.join(", ")}`,
-              confirmLabel: "Send",
-              // Detached: `requestConfirm` resolves nothing, so the send cannot
-              // be awaited here and its failure cannot surface inline the way
-              // the un-gated path's does below. Logged with a grep key instead,
-              // mirroring `windowClose.disconnectNetwork` — the same shape of
-              // destructive-action-behind-a-confirm. Never bare: an unhandled
-              // rejection here would be a fan-out that stopped in silence.
-              onConfirm: () => {
-                void run().catch((err) => {
-                  console.warn(
-                    `[/${cmd.kind}] fan-out stopped after ${done} of ${targets.length} channels on ${networkSlug}:`,
-                    err,
-                  );
-                });
-              },
-              alternative: null,
-            });
-            result = { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
-            break;
-          }
-          try {
-            await run();
-          } catch (e) {
-            return {
-              error: `${friendlyError(e)} — sent to ${done} of ${targets.length} channels`,
-            };
-          }
-          result = { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
+          result = await fanOutCommand(cmd, ctx);
           break;
         }
         case "ctcp": {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48900,3 +48900,103 @@ The unit suite is the whole of it. Eight e2e specs drive these verbs
 (`issue992-admin-command`, `issue148-visitor-oper`, `issue385-user-aliases`,
 `issue409-alias-edit`, `issue409-alias-tab-scope`, `issue427-alias-shadow-builtins`,
 `issue1047-alias-range-param`, `issue460-settings-index`) and none was run here.
+<!-- entry #1396-fanout -->
+
+---
+
+## 2026-08-18 — #1396: the fan-out pair was never blocked, and the boundary is the draft store
+
+`/ame` and `/amsg` were the last pair anyone believed the send pipeline held
+back. They were not blocked, and this entry records the correction rather than
+the conclusion, because the wrong premise is the part that cost time.
+
+### The premise that fell
+
+Carried for weeks, and stated again when this slice was briefed: the fan-out
+pair is held in `compose.ts` by "the pipeline axis", the same force that holds
+`privmsg` / `me` / `msg`. Measured on `d60a7a72`, that is false, and it was
+already false when the belief was last repeated.
+
+Every value the pair reads is an ordinary module import: `sendFanOut`
+(`./sendPipeline`), `requestConfirm` (`./confirmDialog`),
+`joinedChannelsOnNetwork` (`./joinedChannels`), `friendlyError`. It touches the
+composer buffer nowhere — no `sendPacedBody`, no `claimDrafts`, no `getDraft`.
+`FANOUT_CONFIRM_THRESHOLD` was a module-level const in `compose.ts` with exactly
+one reader, so it travelled with the handler.
+
+### What actually changed under it, and what did not
+
+Two lifts made the pair movable, both landed under #1513 and neither of them
+about this pair. They are NOT the same kind of change, and collapsing them into
+"the hoist moved `sendFanOut`" is what let the premise survive:
+
+* `6ef878fe` moved `sendFanOut` into `./sendPipeline`. It had never been a
+  closure — it was already a module-level `const` at column 0 of `compose.ts`.
+  What blocked `commands/` was that it was never EXPORTED, and `compose.ts`
+  imports `commands/*`, so publishing it there would have pointed the
+  dependency back at the importer. The lift is what removed the obstacle, but
+  the obstacle was reachability, not the draft store.
+* `5779c755` lifted `joinedChannelsOnNetwork` out of the controller closure.
+  THIS one had genuinely been a closure. It is the harder half of the
+  unblocking and the half the premise never named.
+
+So the pair was unblocked by a lift that was not aimed at it, and nobody
+re-measured. The lesson is narrow and worth keeping: **when a slice is declined
+for a stated blocker, the blocker is a measurement with an expiry date, not a
+property.** Re-measure it before repeating it.
+
+### Where the boundary really is
+
+The three arms that remain inline — `privmsg`, `me`, `msg` — are held by
+`sendPacedBody`, a closure over `claimDrafts` / `releaseDrafts` / `getDraft`.
+The boundary is the **draft store**, not the send pipeline, and
+`commands/context.ts` has been saying so in its own words ("`compose.ts` keeps
+the store and the send pipeline") while the spoken version drifted to the
+second half of that sentence. The #1513 ruling stands on its own reason (#737:
+publishing `writeState` would make the drain-lock bypass importable) and is not
+reopened here.
+
+State of the switch after this slice: 55 of 59 arms delegate to a
+`*Command(cmd, ctx)` handler; three bodies remain inline, plus the `default`
+exhaustiveness guard, which is not a verb.
+
+### What bought the move
+
+Five mutants on the arm, run against the FULL unit suite before and after, with
+the set of killing tests compared — not just the count:
+
+| mutant | killers before | after | same set |
+|---|---|---|---|
+| fan-out sends to ONE channel | 7 | 7 | yes |
+| confirm gate never fires | 4 | 4 | yes |
+| ACTION framing forced off | 1 | 1 | yes |
+| empty-target guard removed | 1 | 1 | yes |
+| target list left unsorted | 1 | 1 | yes |
+
+The fan-out mutant is the one that matters for a pair whose whole job is
+reaching every channel, and it reddens the same seven tests on both sides.
+
+### A degeneration measured and deliberately not fixed here
+
+The #1396 characterization net does NOT protect the fan-out. Its `ame` and
+`amsg` rows submit into eleven joined channels leaked from the preceding
+`describe` (the net never seeds `windowStateByChannel` itself), so both rows
+stop at the confirm gate and send nothing. The evidence is the mutant table
+above: the fan-out mutant kills seven tests and NONE of them is a net row,
+while the gate mutant kills two net rows.
+
+The net already declares `indistinguishablePairs: [["ame", "amsg"]]`, but the
+CAUSE of that pairing was not declared — seeding the net with two joined
+channels instead of the leaked eleven flips both inline snapshots, which is how
+the leak was established rather than inferred.
+
+Not repaired inside this slice, deliberately: the move is already bought by the
+dedicated `#431` describes, the degeneration is identical before and after, and
+strengthening the net changes two inline snapshots and needs its own red. Same
+call as #1518.
+
+### Limits of this measurement
+
+The unit suite and `bun run check` are the whole of it. No e2e spec was run.
+The `console.warn` on the detached confirm path is unasserted before and after,
+so the mutant table says nothing about it.


### PR DESCRIPTION
## What

`/ame` + `/amsg` move out of the `dispatchDraft` switch into
`lib/commands/fanout.ts`, behind the same seam as the other 54 arms.
`CommandContext` gains **zero** fields.

## Why it was possible, against the standing premise

The pair was believed blocked by "the pipeline axis". Measured on
`d60a7a72`, that is false: every value the arm reads is an ordinary module
import (`sendFanOut`, `requestConfirm`, `joinedChannelsOnNetwork`,
`friendlyError`) and it touches the composer buffer nowhere.

Two lifts under #1513 made that true, neither aimed at this pair, and they
are **not the same kind of change**:

- `6ef878fe` moved `sendFanOut` into `./sendPipeline`. It had never been a
  closure — a module-level const that `commands/` could not import because
  it was never exported.
- `5779c755` lifted `joinedChannelsOnNetwork` out of the controller
  closure. That one genuinely had been a closure.

The real boundary for the three arms that remain (`privmsg`, `me`, `msg`)
is the **draft store** — `sendPacedBody` closes over `claimDrafts` /
`releaseDrafts` / `getDraft` — not the send pipeline. The #1513 ruling on
those three stands on its own reason (#737) and is not reopened here.

`FANOUT_CONFIRM_THRESHOLD` travels with the handler: one reader, and the
move keeps it that way.

## Evidence

Five mutants on the arm, run against the **full** unit suite before and
after, comparing the SET of killing tests, not just the count:

| mutant | before | after | same set |
|---|---|---|---|
| fan-out sends to ONE channel | 7 | 7 | yes |
| confirm gate never fires | 4 | 4 | yes |
| ACTION framing forced off | 1 | 1 | yes |
| empty-target guard removed | 1 | 1 | yes |
| target list left unsorted | 1 | 1 | yes |

Gates: `bun run test` 290 files / 5615 tests green before and after;
`bun run check` rc=0 with a warning delta of zero against clean `main`
(59 = 59, none in the new file); `scripts/bats.sh` 564 ok / 0 not ok;
`design-notes-gate.sh` green.

## A degeneration measured and deliberately NOT fixed here

The #1396 characterization net does not protect the fan-out. Its `ame` and
`amsg` rows submit into eleven joined channels **leaked from the preceding
`describe`**, so both stop at the confirm gate and send nothing. Proof is
in the table above: the fan-out mutant kills seven tests and none is a net
row, while the gate mutant kills two net rows. Established by displacement,
not inference — seeding the net with two channels flips both inline
snapshots.

Left alone on purpose: the move is bought by the dedicated `#431`
describes, the degeneration is identical on both sides, and strengthening
the net changes two inline snapshots and needs its own red. Same call as
#1518.

## Limits

Unit suite + check + bats only. No e2e spec was run. The `console.warn` on
the detached confirm path is unasserted before and after.