### PR TITLE
e2e(#1336): give ux-4-z bucket J a population instead of a guard

### DIFF
--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -61,8 +61,10 @@
 //     query window present in BottomBar after seeded connect (004
 //     RPL_MYINFO usermodes letters must NOT leak into archive /
 //     query tabs).
-//   * J — MembersPane sort: open #bofh, scroll members list, assert
-//     ops cluster before plain members. Visitor-spec parity needs
+//   * J — MembersPane sort: mint a per-arm channel (self first → op,
+//     peer second → plain), assert ops cluster before plain members
+//     on a population that is 1 + 1 by construction rather than by
+//     autojoin race (#1137). Visitor-spec parity needs
 //     members-list presence per `feedback_e2e_visitor_members_list`
 //     — this spec runs the registered class only (visitor pathway
 //     blocked), but the members-list-non-empty assertion satisfies
@@ -88,6 +90,7 @@
 import {
   closeMembersDrawer,
   closeSettings,
+  composeSend,
   loginAs,
   openAdminConsole,
   openSettingsMobile,
@@ -95,6 +98,7 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -204,54 +208,79 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
     // the assertion satisfies the rule for the matrix that will exist
     // once visitor cold-start is unblocked.
     //
-    // On mobile, MembersPane lives behind the hamburger drawer. Open
-    // it via ShellChrome's hamburger (aria-label "open members
-    // sidebar" on mobile when a channel is selected).
-    //
-    // The pane is conditional on `isActiveChannelJoined()` in
-    // Shell.tsx (returns true only when selectedChannel.kind ===
-    // "channel" AND windowStateByChannel[key] === "joined"). The
-    // `selectChannel({ ownNick })` above awaits the own-JOIN wire
-    // echo, which co-arrives with the typed `:joined` event from
-    // EventRouter. Anchor on `.topic-bar` first — its visibility
-    // proves selectedChannel().kind === "channel" — so the members
-    // hamburger and drawer wire to the right gate. Then anchor on
-    // `.members-pane h3` (renders once isActiveChannelJoined() is
-    // true), then poll for `<li>` items once members_seeded lands.
-    await expect(page.locator(".topic-bar")).toBeVisible({ timeout: 10_000 });
-    await page.getByLabel("open members sidebar").tap();
-    const membersDrawer = page.locator(".shell-members.open");
-    await expect(membersDrawer).toBeVisible({ timeout: 5_000 });
-    // Pane mount: `<h3>members (N)</h3>` renders unconditionally once
-    // the pane is in the DOM, regardless of join-state. If it
-    // doesn't appear within 10s the pane never mounted (channel
-    // isActiveChannelJoined() returned false) — that IS a regression
-    // signal.
-    await expect(membersDrawer.locator(".members-pane h3")).toBeVisible({
-      timeout: 10_000,
+    // #1137 — this arm runs on a channel the spec MINTS, with a peer it
+    // brings itself, instead of on the shared autojoin channel. The
+    // ordering claim needs one op AND one plain member simultaneously,
+    // and on `#bofh` that population is a three-way autojoin race whose
+    // opless outcome `members-prefix-op-not-clipped`'s header documents:
+    // if `m9b-victim` wins +o and a destructive admin spec terminates
+    // its session, the channel is left with no op at all. The previous
+    // arm hid exactly that behind `if (opCount > 0 && plainCount > 0)`,
+    // so on an opless run the ordering claim silently evaporated — the
+    // #1117 family of self-disabling assertion, wearing an `if` instead
+    // of an empty recorder. Self joins FIRST so bahamut grants it +o,
+    // the peer joins SECOND and stays plain: the population is 1 + 1 by
+    // construction, both counts are asserted, and the guard is gone.
+    // Same mint-and-peer shape as `members-prefix-op-not-clipped`.
+    const membersChannel = `#ux4zj-${crypto.randomUUID().slice(0, 6)}`;
+    const membersPeer = await IrcPeer.connect({
+      nick: `ux4zj-${crypto.randomUUID().slice(0, 6)}`,
     });
-    const memberItems = membersDrawer.locator(".members-pane li");
-    await expect(memberItems.first()).toBeVisible({ timeout: 15_000 });
-    const memberCount = await memberItems.count();
-    expect(memberCount).toBeGreaterThan(0);
+    try {
+      await composeSend(page, `/join ${membersChannel}`);
+      await expect(sidebarWindow(page, NETWORK_SLUG, membersChannel)).toHaveCount(1, {
+        timeout: 10_000,
+      });
+      // Awaits the own-JOIN echo + the WS-ready barrier, which is also
+      // the proof that self is in BEFORE the peer — the thing that makes
+      // self the op rather than a coin toss.
+      await selectChannel(page, NETWORK_SLUG, membersChannel, { ownNick: specNick() });
+      await membersPeer.join(membersChannel);
 
-    // Own-nick MUST be in the members list (members-list-presence rule).
-    const ownNickItem = membersDrawer.locator(".members-pane li", {
-      hasText: specNick(),
-    });
-    await expect(ownNickItem.first()).toBeVisible();
+      // On mobile, MembersPane lives behind the hamburger drawer. Open
+      // it via ShellChrome's hamburger (aria-label "open members
+      // sidebar" on mobile when a channel is selected).
+      //
+      // The pane is conditional on `isActiveChannelJoined()` in
+      // Shell.tsx (returns true only when selectedChannel.kind ===
+      // "channel" AND windowStateByChannel[key] === "joined"). The
+      // `selectChannel({ ownNick })` above awaits the own-JOIN wire
+      // echo, which co-arrives with the typed `:joined` event from
+      // EventRouter. Anchor on `.topic-bar` first — its visibility
+      // proves selectedChannel().kind === "channel" — so the members
+      // hamburger and drawer wire to the right gate. Then anchor on
+      // `.members-pane h3` (renders once isActiveChannelJoined() is
+      // true), then poll for `<li>` items once members_seeded lands.
+      await expect(page.locator(".topic-bar")).toBeVisible({ timeout: 10_000 });
+      await page.getByLabel("open members sidebar").tap();
+      const membersDrawer = page.locator(".shell-members.open");
+      await expect(membersDrawer).toBeVisible({ timeout: 5_000 });
+      // Pane mount: `<h3>members (N)</h3>` renders unconditionally once
+      // the pane is in the DOM, regardless of join-state. If it
+      // doesn't appear within 10s the pane never mounted (channel
+      // isActiveChannelJoined() returned false) — that IS a regression
+      // signal.
+      await expect(membersDrawer.locator(".members-pane h3")).toBeVisible({
+        timeout: 10_000,
+      });
 
-    // Bucket J sort: ops cluster before plain members. If the channel
-    // has at least one op AND at least one plain member, assert the
-    // first op's DOM index < first plain's DOM index. Skip the order
-    // assertion if the seeded channel has only one tier present (the
-    // single-tier case trivially preserves order; we still get the
-    // members-list-non-empty signal).
-    const opItems = membersDrawer.locator(".members-pane li.member-op");
-    const plainItems = membersDrawer.locator(".members-pane li.member-plain");
-    const opCount = await opItems.count();
-    const plainCount = await plainItems.count();
-    if (opCount > 0 && plainCount > 0) {
+      // Population, asserted instead of sampled. These two counts are
+      // the arm's own positive control: the ordering claim below can
+      // only mean something with one row of each tier present, so a
+      // missing tier fails HERE, loudly, naming which one — it does not
+      // skip the claim.
+      const opItems = membersDrawer.locator(".members-pane li.member-op");
+      const plainItems = membersDrawer.locator(".members-pane li.member-plain");
+      await expect(opItems).toHaveCount(1, { timeout: 15_000 });
+      await expect(plainItems).toHaveCount(1, { timeout: 15_000 });
+      // Own-nick MUST be in the members list (members-list-presence rule
+      // per `feedback_e2e_visitor_members_list`) — and on this channel it
+      // is specifically the op row, the peer being the plain one.
+      await expect(opItems.first()).toContainText(specNick());
+      await expect(plainItems.first()).toContainText(membersPeer.nick);
+
+      // Bucket J sort: ops cluster before plain members — the first op's
+      // DOM index must precede the first plain's.
       const firstOpHandle = await opItems.first().elementHandle();
       const firstPlainHandle = await plainItems.first().elementHandle();
       const order = await page.evaluate(
@@ -263,13 +292,20 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
         [firstOpHandle, firstPlainHandle] as const,
       );
       expect(order).toBe("op-first");
+
+      // Close the members drawer so subsequent arms (scroll, /join,
+      // /msg) interact with the compose surface uncovered. Uses the
+      // shared `closeMembersDrawer` helper (see cicchettoPage.ts) for
+      // the why behind `.click({position})` vs `.tap()` — same layout
+      // gotcha as UX-6-A's mobile members-scroll spec.
+      await closeMembersDrawer(page);
+      // Hand the shared channel back to the buckets below: C reads the
+      // network header and K taps `channelTab`, both of which assume the
+      // journey is still on the autojoin channel.
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+    } finally {
+      await membersPeer.disconnect("ux-4-z bucket J done");
     }
-    // Close the members drawer so subsequent arms (scroll, /join,
-    // /msg) interact with the compose surface uncovered. Uses the
-    // shared `closeMembersDrawer` helper (see cicchettoPage.ts) for
-    // the why behind `.click({position})` vs `.tap()` — same layout
-    // gotcha as UX-6-A's mobile members-scroll spec.
-    await closeMembersDrawer(page);
 
     // ─── Bucket C — sidebar header collapse + ShellChrome archive ─────
     // BottomBar renders ONE "Server" tab per network (no duplicate

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48900,3 +48900,94 @@ The unit suite is the whole of it. Eight e2e specs drive these verbs
 (`issue992-admin-command`, `issue148-visitor-oper`, `issue385-user-aliases`,
 `issue409-alias-edit`, `issue409-alias-tab-scope`, `issue427-alias-shadow-builtins`,
 `issue1047-alias-range-param`, `issue460-settings-index`) and none was run here.
+<!-- entry #1336-bucket-j -->
+
+---
+
+## 2026-08-18 — #1336: an e2e arm brings its own population, and the mutant that proves it reddens only AFTER the cure
+
+`ux-4-z-cluster-journey`'s bucket J claimed that ops cluster before plain
+members in the MembersPane. It made that claim behind a guard:
+
+```ts
+if (opCount > 0 && plainCount > 0) { … expect(order).toBe("op-first"); }
+```
+
+read off the **shared** autojoin channel. That population is not a fixture,
+it is a three-way race: `#bofh` is joined by `vjt`, `m9b-test` and
+`m9b-victim`, bahamut grants `+o` to whoever lands first, and
+`members-prefix-op-not-clipped`'s header documents the run where
+`m9b-victim` wins it and a destructive admin spec then terminates that
+session — leaving the channel with **no op at all**. On such a run
+`opCount == 0`, the `if` is false, and the ordering claim evaporates
+without a word in the report. It is the same self-disabling assertion
+#1117 has been curing across this suite, wearing an `if` where its
+siblings wore an empty recorder.
+
+This is the first slice of the per-spec-channel work tracked under #1336,
+which absorbed the closed #1137 (`NOT_PLANNED`, consolidated 2026-08-15)
+along with its census and its numbers. Cite #1336; #1137 is where the
+measurement below was first registered, not a live tracker.
+
+**The cure is a population, not a comparator.** The arm now mints its own
+channel and brings its own peer: self joins FIRST so bahamut ops it, the
+peer joins SECOND and stays plain. `1 op + 1 plain` holds by
+construction, so both counts are asserted exactly — a missing tier now
+fails naming which one instead of skipping the claim — and the op row is
+pinned to the own nick, the plain row to the peer. Same mint-and-peer
+shape as `members-prefix-op-not-clipped`, so nothing in the fixture or in
+the provisioned autojoin had to change: the channel comes from a `/join`
+typed into the compose box.
+
+### 🔴 The mutant's direction is green→red, and that is the point
+
+Read the four rounds below before concluding a red was introduced here.
+The mutation is the same in R1 and R4 — **run the arm on a channel whose
+only occupant is self** — and it is applied once to the old code and once
+to the new. Measured on `origin/main` `038a33ca`, project
+`webkit-iphone-15`, one worker, one stack kept up across all four:
+
+| round | code | population | result |
+|---|---|---|---|
+| R1 | pre-cure (the `if`) | single occupant | **rc=0, 1 passed** (16.6s) |
+| R2 | pre-cure, untouched | shared `#bofh` | rc=0, 1 passed (12.2s) |
+| R3 | post-cure | minted + peer | rc=0, 1 passed (15.3s) |
+| R4 | post-cure | single occupant | **rc=1, 1 failed** (22.7s) |
+
+R1 is the vacuity **executed**: deprive the old arm of a second tier and
+it reports success, because the claim it exists to make was skipped. R2 is
+the reality check that the arm runs at all. R4 kills exactly one
+assertion — `.members-pane li.member-plain` expected `1`, received `0`,
+after 18 retries — which is the arm refusing to pass on a population it
+cannot judge.
+
+So a mutant that *used* to be survivable is now lethal. Anywhere else in
+this cluster of work the direction has been red→green; here the inverse
+IS the evidence, and R1's green is the defect rather than a baseline.
+
+The R1 mutant was built to move ONE variable: its diff against the
+pre-cure file is additions only, zero deletions, leaving the assertion
+block byte-identical — otherwise the round would have measured the
+rewrite and the population at once.
+
+### Boundary: this does not reduce the row residue
+
+The headline measurement inherited from #1137 is ~2.9 scrollback rows
+per test accruing to the
+long-lived co-residents of the shared channel. **This slice does not
+touch that**, and no measurement here should be read as if it did. It
+removes one assertion's dependence on the shared channel's population,
+which is a precondition for the codemod that will move ~250 spec files
+off `#bofh`. The condition that governs the elimination lives with that
+later slice and is restated so it cannot be lost: **the per-spec channel
+must REPLACE `#bofh` in the provisioned subject's `autojoin_channels`,
+never sit alongside it** — added alongside, provision and teardown keep
+JOINing and QUITting the shared channel and the co-residents accrue
+exactly as today.
+
+### Not asserted
+
+That bucket J's vacuity ever fired on a real CI run. The opless path is
+documented by a sibling spec's header and reproduced here deliberately;
+that it occurred unprompted in some past run is not something these four
+rounds establish.


### PR DESCRIPTION
## What

`ux-4-z-cluster-journey`'s bucket J claimed that ops cluster before plain members in the MembersPane — behind a guard:

```ts
if (opCount > 0 && plainCount > 0) { … expect(order).toBe("op-first"); }
```

read off the **shared** autojoin channel, whose population is a three-way race (`vjt` / `m9b-test` / `m9b-victim`, bahamut ops whoever lands first). `members-prefix-op-not-clipped`'s header documents the run where `m9b-victim` wins `+o` and a destructive admin spec terminates that session, leaving `#bofh` **opless**: `opCount == 0`, the `if` is false, and the claim evaporates silently. Same self-disabling shape #1117 has been curing, wearing an `if` instead of an empty recorder.

The arm now **mints its own channel and brings its own peer**: self joins FIRST (bahamut ops it), the peer joins SECOND and stays plain. `1 op + 1 plain` by construction, both counts asserted exactly, op row pinned to the own nick and plain row to the peer, guard deleted. Same mint-and-peer shape as `members-prefix-op-not-clipped` — no fixture and no autojoin change, the channel comes from a `/join` in the compose box.

## 🔴 The mutant's direction is green→red

One mutation — **run the arm on a single-occupant channel** — applied once to each side. `webkit-iphone-15`, one worker, one stack across all four rounds, on `origin/main` `038a33ca`:

| round | code | population | result |
|---|---|---|---|
| R1 | pre-cure (the `if`) | single occupant | **rc=0, 1 passed** (16.6s) |
| R2 | pre-cure, untouched | shared `#bofh` | rc=0, 1 passed (12.2s) |
| R3 | post-cure | minted + peer | rc=0, 1 passed (15.3s) |
| R4 | post-cure | single occupant | **rc=1, 1 failed** (22.7s) |

R1 **is** the defect, executed: deprive the old arm of a tier and it reports success. R4 kills exactly one assertion — `.members-pane li.member-plain` expected `1`, received `0` after 18 retries. A mutant that used to be survivable is now lethal; the red belongs to the mutation, not to this change. The R1 mutant's diff against the pre-cure file is **additions only, zero deletions**, so the assertion block stayed byte-identical and the round moved one variable.

## Boundary

This does **not** reduce the ~2.9 rows/test residue. It removes one assertion's dependence on the shared channel's population, a precondition for the codemod that moves ~250 spec files off `#bofh`. The condition governing the actual elimination stays with that later slice: the per-spec channel must **REPLACE** `#bofh` in the provisioned subject's `autojoin_channels`, never sit alongside it.

Tracked under #1336; #1137 is the closed issue it was consolidated from.

## Test plan

- [x] `bun run check` (biome + tsc + e2e tsconfig) — rc=0, zero diagnostics on the touched file
- [x] `scripts/design-notes-gate.sh` — rc=0, 1 new entry, separator + unique marker `#1336-bucket-j`
- [x] Four scoped e2e rounds above
- [ ] Full `scripts/integration.sh` in CI