### PR TITLE
e2e(#1336): take the per-spec subject out of the shared channel

### DIFF
--- a/cicchetto/e2e/fixtures/seedData.ts
+++ b/cicchetto/e2e/fixtures/seedData.ts
@@ -55,7 +55,35 @@ export const VJT_IDENTIFIER = "vjt@grappa.test";
 
 export const NETWORK_SLUG = "bahamut-test";
 export const NETWORK_NICK = "vjt-grappa";
-export const AUTOJOIN_CHANNELS = ["#bofh"];
+
+// #1336 — the per-spec subject (#1078) autojoins THIS channel, and the
+// three long-lived seeded users (`vjt`, `m9b-test`, `m9b-victim`, bound
+// with `--autojoin '#bofh'` in compose.yaml) are NOT in it. Every
+// provision/teardown used to JOIN and QUIT the shared `#bofh`, and
+// bahamut fanned both out to whoever was sitting there: measured on a
+// 6-test pilot, 42 rows landed in the three co-residents' scrollback,
+// 7.00 per test — rows no spec asked for and every later spec reads.
+//
+// It is the CO-RESIDENCE that writes them, not the channel's name, so
+// the cure is to stop sharing a room, not to rename it. `#bofh` stays
+// exactly as seeded for the specs that drive the seeded users directly.
+//
+// 🔴 Worker-scoped, and the scope is load-bearing: `playwright.config.ts`
+// runs `workers: 1, fullyParallel: false`, so at most ONE per-spec
+// subject is alive at a time and a single channel is enough. Derived
+// from `TEST_PARALLEL_INDEX` (Playwright sets it per worker process,
+// `playwright/lib/worker/workerMain.js`) so that if the suite ever
+// parallelises, the subjects do not silently become co-residents of
+// each other and re-grow the residue this removed. The constant is
+// evaluated once per process, which is what keeps the ~292 spec files
+// that read it unchanged.
+//
+// `globalSetup` runs in the runner process, where Playwright sets no
+// worker index — the `setup` spelling is deliberately NOT `0`, so a
+// channel named `#spec-wsetup` in a failure log reads as "resolved
+// outside a worker" instead of impersonating worker zero.
+const SPEC_WORKER = process.env.TEST_PARALLEL_INDEX ?? "setup";
+export const AUTOJOIN_CHANNELS = [`#spec-w${SPEC_WORKER}`];
 
 // M-cluster M-7 — admin user. Seeded via mix run -e in the seeder
 // sidecar after `create_user` (no --admin flag on the mix task; M-7

--- a/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
+++ b/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
@@ -31,7 +31,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "b0-invitee";
@@ -47,7 +47,7 @@ test("B0 — /invite from $server window (no channel context) reaches upstream +
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o (so /invite has the privileges to send). Same template
   // as p0e-invite-ack.spec.ts:53-60.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   await expect(
     page.locator(".sidebar-network-section li").filter({ hasText: CHANNEL }),

--- a/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
@@ -14,10 +14,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("CP13 S10 — peer's bold-formatted PRIVMSG renders with .scrollback-mirc-bold span", async ({
   page,

--- a/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
@@ -28,10 +28,10 @@ import {
   selectChannel,
   sidebarMessageBadge,
 } from "../fixtures/cicchettoPage";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("CP13 S5 — /msg to nonexistent nick: 401 lands in the query window live", async ({ page }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
+++ b/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
@@ -18,11 +18,11 @@ import {
   sidebarMessageBadge,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
 const SERVER_WINDOW_LABEL = "Server";
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.describe("CP13 server-window cluster", () => {
   test("S6 — bottom numeric-inline pane is gone (no `.numeric-inline-pane` in DOM)", async ({

--- a/cicchetto/e2e/tests/issue1336-spec-channel-worker-scoped.spec.ts
+++ b/cicchetto/e2e/tests/issue1336-spec-channel-worker-scoped.spec.ts
@@ -1,0 +1,29 @@
+// #1336 — the per-spec subject's autojoin channel must be WORKER-SCOPED.
+//
+// `AUTOJOIN_CHANNELS` moved off the shared `#bofh` so that the three
+// long-lived seeded users stop collecting a JOIN and a QUIT from every
+// test that provisions a subject (measured: 42 rows over a 6-test pilot,
+// 7.00 per test, all of them in scrollback no spec asked for).
+//
+// That cure is only correct while at most ONE per-spec subject is alive
+// at a time. `playwright.config.ts` says `workers: 1`, and the channel
+// name carries `TEST_PARALLEL_INDEX` so the guarantee survives a future
+// `workers: N` instead of silently re-growing the residue in a channel
+// shared by parallel subjects.
+//
+// This spec is the oracle for the derivation actually happening: the
+// constant is evaluated at module scope, and if Playwright ever stops
+// exporting the worker index there, the name degrades to the `setup`
+// spelling and this goes red. Bare `@playwright/test` import on purpose
+// — it reads a constant, so provisioning a subject for it would be
+// paying for a session nobody uses.
+
+import { expect, test } from "@playwright/test";
+import { AUTOJOIN_CHANNELS } from "../fixtures/seedData";
+
+test("#1336 — the per-spec autojoin channel is worker-scoped, not the shared #bofh", () => {
+  expect(AUTOJOIN_CHANNELS).toHaveLength(1);
+  // `\d+` and not `\d*`: the runner-process spelling (`#spec-wsetup`)
+  // reaching a worker is the exact failure this guards.
+  expect(AUTOJOIN_CHANNELS[0]).toMatch(/^#spec-w\d+$/);
+});

--- a/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
+++ b/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
@@ -27,10 +27,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("issue #14 — operator's own /me renders as '* nick body', not raw privmsg", async ({
   page,

--- a/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
+++ b/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
@@ -20,10 +20,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("issue142 — QUIT reason renders mIRC bold+color spans (not raw control bytes)", async ({
   page,

--- a/cicchetto/e2e/tests/issue189-perform.spec.ts
+++ b/cicchetto/e2e/tests/issue189-perform.spec.ts
@@ -14,10 +14,10 @@
 
 import { loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
+++ b/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
@@ -31,10 +31,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue409-alias-edit.spec.ts
+++ b/cicchetto/e2e/tests/issue409-alias-edit.spec.ts
@@ -13,10 +13,10 @@
 import type { Page } from "@playwright/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue409-alias-tab-scope.spec.ts
+++ b/cicchetto/e2e/tests/issue409-alias-tab-scope.spec.ts
@@ -19,10 +19,10 @@
 
 import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
+++ b/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
@@ -24,10 +24,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
+++ b/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
@@ -17,10 +17,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 const tag = (prefix: string) => `${prefix}-${crypto.randomUUID().slice(0, 6)}`;
 
 test("issue455 — *bold* _underline_ /italic/ render client-side with the markers kept", async ({

--- a/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
+++ b/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
@@ -28,12 +28,12 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 // vjt is autojoined here (seedData.AUTOJOIN_CHANNELS) — the window the peer
 // posts the `#channel`-bearing PRIVMSG into.
-const HOST_CHANNEL = "#bofh";
+const HOST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // A fresh peer nick per run — a static nick rotates to `<nick>1` on a 433
 // collision under the shared leaf, and the join matcher waits on the

--- a/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
+++ b/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
@@ -60,12 +60,12 @@ test("M9 — sidebar X-button PARTs the channel and dismisses the window", async
   // be installed when the PART echo arrives.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Click the X button on #bofh's sidebar entry.
-  // Sidebar.tsx renders `aria-label="Close #bofh"` — use that as the
-  // selector hook so future cosmetic class changes (.sidebar-close
-  // → .sidebar-x or whatever) don't break the test.
+  // Click the X button on the channel's sidebar entry.
+  // Sidebar.tsx renders `aria-label="Close <channel>"` — use that as
+  // the selector hook so future cosmetic class changes
+  // (.sidebar-close → .sidebar-x or whatever) don't break the test.
   await sidebarWindow(page, NETWORK_SLUG, CHANNEL)
-    .locator('button[aria-label="Close #bofh"]')
+    .locator(`button[aria-label="Close ${CHANNEL}"]`)
     .click();
 
   // #195 — the × now opens an explicit "leave #chan?" confirm modal; the PART

--- a/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
+++ b/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
@@ -33,7 +33,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "members-prefix-buddy";
@@ -46,7 +46,7 @@ test("members pane renders @-prefix + full op nick (not clipped)", async ({ page
   // Focus #bofh first to confirm login + ws-ready, then /join the
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o deterministically.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   await expect(
     page.locator(".sidebar-network-section li").filter({ hasText: CHANNEL }),

--- a/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
+++ b/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
@@ -12,10 +12,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("full mIRC: peer PRIVMSG renders strikethrough + monospace + hex-color spans", async ({
   page,

--- a/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
+++ b/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
@@ -33,7 +33,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "p0e-invitee";
@@ -50,7 +50,7 @@ test("P-0e + P-0f — /invite to a peer surfaces invite-ack row in the $server w
   // channel that doesn't have a sidebar slot yet, so /join via
   // composeSend from any focused window. specNick() is needed for
   // selectChannel's join-line wait on the prior step.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   // Wait for the new channel's sidebar entry to appear (proves the
   // JOIN landed + windowState transitioned to :joined; the sidebar

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -423,14 +423,17 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // joined channel on its Phoenix join-ok (subscribe.ts) — REFRESH_LIMIT
     // (200) == the seed size, so #bofh loads ALL rows in the background
     // WITHOUT us focusing it. Register the waiter BEFORE loginAs so the
-    // post-boot fetch can't slip past us; awaiting it proves #bofh is warm
-    // (rows in the store) before we switch into it. Without warmth the
+    // post-boot fetch can't slip past us; awaiting it proves the channel is
+    // warm (rows in the store) before we switch into it. Without warmth the
     // switch's scrollToActivation early-returns on an empty pane and the
     // length-effect tails — the marker jump only fires against a settled,
-    // populated pane. The URL is `.../channels/%23bofh/messages?after=…`
-    // (encodeURIComponent("#bofh") === "%23bofh").
-    const bofhWarm = page.waitForResponse(
-      (r) => r.url().includes(`/channels/%23bofh/messages`) && r.status() === 200,
+    // populated pane. The URL is `.../channels/<encoded>/messages?after=…`,
+    // and the encoding is derived rather than spelled: the `%23bofh` this
+    // used to carry survived every `#bofh` grep and outlived the channel
+    // it named (#1336).
+    const channelWarm = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/channels/${encodeURIComponent(CHANNEL)}/messages`) && r.status() === 200,
       { timeout: 20_000 },
     );
 
@@ -445,7 +448,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     await expect(page.locator('[data-testid="scrollback"]')).toBeVisible({ timeout: 10_000 });
 
     // #bofh scrollback fetched → warm. Only now is the switch a warm one.
-    await bofhWarm;
+    await channelWarm;
 
     // THE SWITCH — click #bofh in the sidebar. key() changes $server→#bofh,
     // firing the channel-switch key-effect (prevKey defined, so NOT the

--- a/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
@@ -53,6 +53,7 @@
 // JS-mounted side-effect bucket. Single visitor login suffices.
 
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -188,41 +189,52 @@ test("@webkit ux-5-bv — mobile members drawer auto-closes when operator taps a
   // both populated AND own-nick presence as part of the precondition.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Open the mobile members drawer (hamburger in TopicBar).
-  await page.getByLabel(/open members sidebar/i).tap();
-  const drawer = page.locator(".shell-members.open");
-  await expect(drawer).toBeVisible({ timeout: 5_000 });
+  // #1336 — the tap below needs a member that is NOT self, and this
+  // spec is the one place in the suite that read one out of the
+  // channel's ambient population. That population used to be the three
+  // long-lived seeded users sitting in the shared `#bofh`; the per-spec
+  // subject now has the channel to itself, so the peer has to be
+  // brought here rather than assumed.
+  const peer = await IrcPeer.connect({ nick: "ux5bv-buddy" });
+  try {
+    await peer.join(CHANNEL);
 
-  // Members list precondition: populated + own-nick present
-  // (`feedback_e2e_visitor_members_list` mandate). specNick() is the
-  // operator's per-network nick on the auto-join channel.
-  const memberButtons = drawer.locator(".members-pane li .member-name");
-  await expect(memberButtons.first()).toBeVisible({ timeout: 10_000 });
-  const memberCount = await memberButtons.count();
-  expect(memberCount).toBeGreaterThan(0);
-  const ownNickPresent = await drawer
-    .locator(`.members-pane li .member-name:has-text("${specNick()}")`)
-    .count();
-  expect(ownNickPresent).toBeGreaterThan(0);
+    // Open the mobile members drawer (hamburger in TopicBar).
+    await page.getByLabel(/open members sidebar/i).tap();
+    const drawer = page.locator(".shell-members.open");
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
 
-  // Find a member other than self (tapping self would be a no-op).
-  // Structured locator — `hasNotText` rejects any row whose text
-  // contains specNick() as substring (so a "vjt-bot" peer would
-  // also be skipped when own-nick is "vjt"). With the seeded
-  // auto-join channel there's always at least one non-self peer, so
-  // `.first()` resolves; if seeding ever drifts the test fails loud
-  // at the tap rather than running a silent off-by-one loop.
-  const target = drawer
-    .locator(".members-pane li .member-name")
-    .filter({ hasNotText: specNick() })
-    .first();
-  await expect(target).toBeVisible({ timeout: 5_000 });
-  await target.tap();
+    // Members list precondition: populated + own-nick present
+    // (`feedback_e2e_visitor_members_list` mandate). specNick() is the
+    // operator's per-network nick on the auto-join channel.
+    const memberButtons = drawer.locator(".members-pane li .member-name");
+    await expect(memberButtons.first()).toBeVisible({ timeout: 10_000 });
+    const memberCount = await memberButtons.count();
+    expect(memberCount).toBeGreaterThan(0);
+    const ownNickPresent = await drawer
+      .locator(`.members-pane li .member-name:has-text("${specNick()}")`)
+      .count();
+    expect(ownNickPresent).toBeGreaterThan(0);
 
-  // Post-tap: drawer should be CLOSED (BV auto-close contract). Pre-BV
-  // the drawer stayed open over the newly-opened query window's
-  // ComposeBox; on iOS the keyboard overlay then sat on top of the
-  // drawer's bottom launcher footer (BM) leaving no visible compose
-  // surface. Auto-close kills the conflict.
-  await expect(page.locator(".shell-members.open")).toBeHidden({ timeout: 5_000 });
+    // Tap the peer that joined above — tapping self would be a no-op.
+    // Structured locator — `hasNotText` rejects any row whose text
+    // contains specNick() as substring (so a "vjt-bot" peer would
+    // also be skipped when own-nick is "vjt"), which is why the row is
+    // reached by exclusion rather than by the peer's own nick.
+    const target = drawer
+      .locator(".members-pane li .member-name")
+      .filter({ hasNotText: specNick() })
+      .first();
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await target.tap();
+
+    // Post-tap: drawer should be CLOSED (BV auto-close contract). Pre-BV
+    // the drawer stayed open over the newly-opened query window's
+    // ComposeBox; on iOS the keyboard overlay then sat on top of the
+    // drawer's bottom launcher footer (BM) leaving no visible compose
+    // surface. Auto-close kills the conflict.
+    await expect(page.locator(".shell-members.open")).toBeHidden({ timeout: 5_000 });
+  } finally {
+    await peer.disconnect("ux-5-bv done");
+  }
 });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49194,3 +49194,36 @@ scrollback the suite carries overall, only what the co-residents were being
 handed per test; and the prose in ~135 spec files still says `#bofh` in
 comments and error strings, which is now stale where it names the seeded
 corpus of the channel under test.
+
+### What the full suite says, and how the three reds are attributed
+
+The full run on this branch after the cure is **3 failed / 752 passed
+(31.3m)**; the run before the last commit was **7 failed / 748 passed
+(31.3m)**. The two sets are DISJOINT. All seven earlier reds came back
+green — including `scroll-on-window-switch.spec.ts`, whose URL-encoded
+`%23bofh` survived every grep on the raw spelling and is what the last
+commit derives — and three different specs went red.
+
+Two of the three are the environment, and the run says so in its own
+telemetry. The #1429 gap census in the same log records `grappa-test`
+log gaps of **17.9s at 16:10:26** and **32.6s at 16:19:12** (container
+clock, UTC; `saturated=1`), with `nginx-test` stalling inside both.
+`issue513-links-mask-empty.spec.ts:27` failed at 16:10:31 and
+`unread-cursor-cluster.spec.ts:182` at 16:19:22 — each inside a measured
+gap, and each inside `loginAs` rather than on an assertion of its own
+(`cicchettoPage.ts:580` waiting for the user topic,
+`cicchettoPage.ts:164` waiting for the shell header).
+
+The third is NOT the environment, and is not a flake: it is **#1504**, a
+measured defect predating this branch. `slash-commands-bundle.spec.ts:152`
+(`/q` closes the query window) failed at 16:18:59 with no gap within 13
+seconds, in 6.0s wall-clock, every barrier returning instantly. Its trace
+also rules out the mechanism the spec's own #268 comment names: the `/q`
+submit was NOT dropped by the in-flight guard, because both of
+`composeSend`'s barriers passed — draft taken, `aria-busy="false"`. At the
+failure the selection has moved OFF the query window onto the channel
+while the query row survives carrying one unread, so the close ran and the
+row came back.
+
+No local full-suite baseline was taken on the branch point, so none of the
+above rests on one; the both-sides evidence is CI's.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49110,3 +49110,87 @@ a lane was not taken. The `/part`-in-a-query-window behaviour the audit found on
 the way (the peer's NICK goes out as a PART target; the server 400s it at
 `validate_channel_name/1`, READ not executed) is behaviour, not record shape,
 and is filed separately.
+<!-- entry #1336-spec-channel -->
+
+---
+
+## 2026-08-18 — #1336: the per-spec subject gets a room of its own
+
+#1078 gave every test its own SUBJECT — its own user, credential, nick,
+seeded scrollback and session — because a shared user can only be cleaned
+by a list, and a list only cleans what somebody remembered to put on it.
+It left one thing shared: the CHANNEL. Every provisioned subject autojoined
+`#bofh`, where the three long-lived seeded users (`vjt`, `m9b-test`,
+`m9b-victim`) sit by compose bind, and bahamut fans a JOIN and a QUIT out
+to whoever is in the room.
+
+### What the residue actually is, measured
+
+A 6-test chromium pilot on `038a33ca`, counting rows in the co-residents'
+scrollback whose sender is a spec subject (`s` + 8 hex):
+
+| run | rows | per test | shape |
+|---|---|---|---|
+| before | 42 | 7.00 | 36 presence (6 JOIN + 6 QUIT each × 3 co-residents) + 6 content |
+| after | 0 | 0 | — |
+| mutant (constant put back to `#bofh`) | 39 | 6.50 | the same 36 presence + 3 content |
+
+The presence half is structural and reproduced to the row; the content half
+is whatever the specs happened to say out loud (two `/me` specs in the
+pilot) and is not stable between runs, which is why the claim rests on the
+36 and not on the totals.
+
+These rows outlive the test that wrote them. The subject is deleted at
+teardown and its OWN copies go with it; the co-residents' copies stay, and
+every later spec reading that channel reads them.
+
+The `~2.9 rows/test` figure inherited from the closed #1137 is NOT this
+number and is not confirmed by it: it averages over the whole suite,
+including the specs that provision no subject at all, so it has a different
+denominator.
+
+### Why the channel's name was changed, and not the specs
+
+It is the CO-RESIDENCE that writes the rows, not the name of the room, so
+the cure is to stop sharing one. A per-TEST channel — the shape the slice
+plan called for — cannot be reached from a module-scope constant, and all
+292 spec files that name `AUTOJOIN_CHANNELS` do so at module scope; every
+one of them also drives the per-spec subject (measured: zero exceptions).
+So a per-test channel would have dragged a 292-file codemod into the
+change, to buy an isolation that `workers: 1` already provides. Changing
+the VALUE of the constant moves all 292 callers without editing one.
+
+`#bofh` is left exactly as seeded, for the specs that drive the seeded
+users directly.
+
+### The constraint this carries, and how it is paid
+
+The cure is correct BECAUSE `playwright.config.ts` runs `workers: 1,
+fullyParallel: false`: at most one per-spec subject is alive at a time, so
+one channel per worker is enough. Under a future `workers: N` the subjects
+would become co-residents of EACH OTHER and the residue would come back
+silently — the worst way. So the name derives from `TEST_PARALLEL_INDEX`,
+which Playwright exports per worker process
+(`playwright/lib/worker/workerMain.js:61`), and the new
+`issue1336-spec-channel-worker-scoped` spec is the oracle that the
+derivation actually resolves inside a worker: it reads `#spec-w0` there,
+and the runner-process
+spelling is deliberately `#spec-wsetup` rather than `#spec-w0` so that a
+name resolved outside a worker cannot impersonate worker zero.
+
+### The one spec that was reading the population
+
+`ux-5-bv` taps a members-pane row that is not self, and took that row from
+the shared channel's ambient population — the three seeded users. It now
+connects its own peer, the same cure the `ux-4-z` bucket-J census got
+earlier in this issue. It is the second and last such site: the sweep for
+non-self member reads (`hasNotText`, `nth()` on members, member-count
+assertions above one, co-resident nicks in live code) found no others.
+
+### What this does not establish
+
+The pilot is six tests, not the suite. Nothing here measures how much
+scrollback the suite carries overall, only what the co-residents were being
+handed per test; and the prose in ~135 spec files still says `#bofh` in
+comments and error strings, which is now stale where it names the seeded
+corpus of the channel under test.


### PR DESCRIPTION
## What

Every test that provisions a subject (#1078) had it autojoin `#bofh`, where the
three long-lived seeded users (`vjt`, `m9b-test`, `m9b-victim`) sit by compose
bind. bahamut fans a JOIN and a QUIT out to whoever is in the room, so each test
wrote presence rows into three OTHER users' scrollback — and those copies outlive
the test, because the subject is deleted at teardown and only its own rows go
with it.

The per-spec subject now autojoins a worker-scoped channel of its own. `#bofh`
is untouched, for the specs that drive the seeded users directly.

## Measured, on a 6-test chromium pilot at `038a33ca`

Rows in the co-residents' scrollback whose sender is a spec subject:

| run | rows | per test | shape |
|---|---|---|---|
| before | 42 | 7.00 | 36 presence (6 JOIN + 6 QUIT × 3 co-residents) + 6 content |
| after | 0 | 0 | — |
| mutant — constant put back to `#bofh` | 39 | 6.50 | the same 36 presence + 3 content |

The presence half reproduces to the row; the content half is whatever the specs
said out loud that run, so the claim rests on the 36. The `~2.9 rows/test`
inherited from the closed #1137 is a full-suite average over a different
denominator — it is neither reproduced nor contradicted here.

## Why the constant's value, and not 292 spec files

A per-TEST channel cannot be reached from a module-scope constant, and all 292
spec files that name `AUTOJOIN_CHANNELS` name it at module scope; every one of
them also drives the per-spec subject (zero exceptions). It would have cost a
292-file codemod to buy isolation that `workers: 1` already provides.

That is the constraint the cure inherits, so the name derives from
`TEST_PARALLEL_INDEX`: under a future `workers: N` the subjects would otherwise
become co-residents of each other and re-grow the residue silently. The new spec
is the oracle that the derivation resolves inside a worker at all — it reads
`#spec-w0`, and the runner-process spelling is `#spec-wsetup` on purpose so a
name resolved outside a worker cannot impersonate worker zero.

## The rest of the diff

- 16 specs that hardcoded `"#bofh"` now read the constant, and one aria-label
  selector is built from it.
- `ux-5-bv` taps a members-pane row that is not self and was the one spec left
  reading the shared channel's ambient population; it brings its own peer now,
  the same cure `ux-4-z` bucket J got earlier in this issue.

## Gates

- `scripts/bun.sh run check` — rc 0 (the 59 CSS warnings are pre-existing; none
  names a file in this diff).
- `scripts/design-notes-gate.sh` — rc 0.
- Pilot green 7/7 with the oracle; mutant red on the oracle with
  `Received "#bofh"`.
- Full `scripts/integration.sh` running locally; result reported separately.

## Not claimed

That the suite is green — the pilot is six tests. The prose in ~135 spec files
still says `#bofh` in comments and error strings, which is stale wherever it
names the seeded corpus of the channel under test; behaviour is unaffected and
chasing it would touch far more files than the cure.