### PR TITLE
cic(#1396): name the submitting window for the fact, and pin part's fallback

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2183,7 +2183,7 @@ describe("compose submit — slash command dispatch", () => {
   // #1396 — the two tests above pin the fallback's VALUE with the active
   // window and the submitting one set to the same channel, so neither can
   // tell which of the two `part` actually read. Measured: swapping
-  // `ctx.channelName` for the ACTIVE window at that site killed 0 of 5615
+  // `ctx.submittedFrom` for the ACTIVE window at that site killed 0 of 5615
   // tests — not even the characterization net, whose `part` row is
   // `/part #other` and so never evaluates the fallback at all.
   //

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2180,6 +2180,38 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  // #1396 — the two tests above pin the fallback's VALUE with the active
+  // window and the submitting one set to the same channel, so neither can
+  // tell which of the two `part` actually read. Measured: swapping
+  // `ctx.channelName` for the ACTIVE window at that site killed 0 of 5615
+  // tests — not even the characterization net, whose `part` row is
+  // `/part #other` and so never evaluates the fallback at all.
+  //
+  // The two genuinely diverge: a queued line (#904) is drained after the
+  // operator has moved on, and ComposeBox's props come from the selection it
+  // was mounted for. Reading the active window there parts the channel the
+  // operator is LOOKING at instead of the one they typed in — silently, and
+  // successfully.
+  it("/part with no arg parts the SUBMITTING window, not the active one", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sel = await import("../lib/selection");
+    vi.mocked(sel.selectedChannel).mockReturnValue({
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/part");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#a", null);
+    expect(result).toEqual({ ok: true });
+  });
+
   it("unknown slash returns {error: 'unknown command'}", async () => {
     localStorage.setItem("grappa-token", "tok");
     const compose = await import("../lib/compose");

--- a/cicchetto/src/lib/commands/context.ts
+++ b/cicchetto/src/lib/commands/context.ts
@@ -22,16 +22,27 @@ export type CommandContext = {
   /** The submitting window. */
   key: ChannelKey;
   networkSlug: string;
-  channelName: string;
+  /**
+   * The submitting window's name, as spelled. Named for the FACT it carries
+   * and not for any use of it, because the uses disagree: `part` reads it as
+   * a default TARGET and the three relay verbs as the WINDOW their echo lands
+   * in. A name like `channelName` reads as "the channel" and invites those
+   * two to be flattened into one pre-resolved value; this one cannot.
+   *
+   * Not derivable from `key`: `channelKey` folds the name (#537), so the
+   * spelling survives only here — and `part` puts it on the WIRE.
+   */
+  submittedFrom: string;
   /** The raw draft, before parsing — the one arm that re-reads it needs it. */
   text: string;
   /** The session bearer, already proven present by the dispatcher. */
   token: string;
   /**
    * The ACTIVE window's channel, or null when the active window is not a
-   * channel. Distinct from `channelName`: a submit can be queued across a
-   * window switch, so the two can disagree, and the arms that default a
-   * target want the active one.
+   * channel. Distinct from `submittedFrom`: a submit can be queued across a
+   * window switch, so the two can disagree. This is the one the arms behind
+   * `requireChannel` want — NOT the one a target defaults to (`part` defaults
+   * to `submittedFrom`, and a test now pins that).
    */
   getActiveChannel: () => string | null;
   /**

--- a/cicchetto/src/lib/commands/relay.ts
+++ b/cicchetto/src/lib/commands/relay.ts
@@ -7,11 +7,11 @@ import type { CommandHandler } from "./context";
  * The verbs that address someone who is NOT this window, while the echo stays
  * here.
  *
- * #1396 — all three read `ctx.channelName`, and all three mean the same thing
- * by it: the window the echo lands in, NOT the recipient. That is a different
- * meaning from `part`'s (where the context is the default TARGET), which is why
- * the record hands over the raw channel and lets each handler say what it is
- * for.
+ * #1396 — all three read `ctx.submittedFrom`, and all three mean the same
+ * thing by it: the window the echo lands in, NOT the recipient. That is a
+ * different meaning from `part`'s (where the same fact is the default TARGET),
+ * which is why the record hands over the submitting window as ONE raw fact,
+ * named for the fact, and lets each handler say what it is for.
  */
 
 /**
@@ -45,7 +45,7 @@ export const ctcpCommand: CommandHandler<"ctcp"> = async (cmd, ctx) => {
   await sendCtcpQuery({
     networkSlug: ctx.networkSlug,
     networkId,
-    sourceChannel: ctx.channelName,
+    sourceChannel: ctx.submittedFrom,
     targetNick: cmd.target,
     verb: cmd.verb,
     args: cmd.args,
@@ -69,7 +69,7 @@ export const pingCommand: CommandHandler<"ping"> = async (cmd, ctx) => {
   await sendCtcpQuery({
     networkSlug: ctx.networkSlug,
     networkId,
-    sourceChannel: ctx.channelName,
+    sourceChannel: ctx.submittedFrom,
     targetNick: cmd.target,
     verb: "PING",
     args: String(sentAtMs),
@@ -80,7 +80,7 @@ export const pingCommand: CommandHandler<"ping"> = async (cmd, ctx) => {
 
 /**
  * #1225 — `/notice <target> <text>`. Routed like a CTCP query, not like /msg:
- * the echo persists in the window it was TYPED in (`ctx.channelName`) and no
+ * the echo persists in the window it was TYPED in (`ctx.submittedFrom`) and no
  * window is opened for the recipient, because a NOTICE opens none by convention
  * (RFC 2812 §3.3.2 — it is the verb you must not reply to) and every client the
  * operators come from echoes it where they are looking. That is also why a
@@ -92,7 +92,7 @@ export const pingCommand: CommandHandler<"ping"> = async (cmd, ctx) => {
  * /msg does.
  */
 export const noticeCommand: CommandHandler<"notice"> = async (cmd, ctx) => {
-  await sendWindowMessage(ctx.networkSlug, ctx.channelName, cmd.body, {
+  await sendWindowMessage(ctx.networkSlug, ctx.submittedFrom, cmd.body, {
     kind: "notice",
     target: cmd.target,
   });

--- a/cicchetto/src/lib/commands/window.ts
+++ b/cicchetto/src/lib/commands/window.ts
@@ -13,12 +13,12 @@ import type { CommandHandler } from "./context";
  * The verbs that decide WHICH window the operator is in: channel membership,
  * and the two that open a pseudo-window.
  *
- * #1396 — a note on `ctx.channelName`, because this file is where the trap
+ * #1396 — a note on `ctx.submittedFrom`, because this file is where the trap
  * lives. Only `part` reads it, and it reads it as a DEFAULT TARGET. The other
  * three never read it: they WRITE a different channel into the selection. The
- * record therefore carries the submitting window's channel as ONE raw fact and
- * lets each handler mean what it means — pre-resolving it into something like
- * a "default target" field is what would collapse those meanings, so nothing
+ * record therefore carries the submitting window as ONE raw fact, named for
+ * the fact — pre-resolving it into something like a "default target" field is
+ * what would collapse that meaning against the relay verbs' one, so nothing
  * here does that.
  */
 
@@ -29,7 +29,7 @@ import type { CommandHandler } from "./context";
  * parts the wrong channel, silently and successfully.
  */
 export const partCommand: CommandHandler<"part"> = async (cmd, ctx) => {
-  const target = cmd.channel ?? ctx.channelName;
+  const target = cmd.channel ?? ctx.submittedFrom;
   await postPart(ctx.token, ctx.networkSlug, target, cmd.reason);
   return { ok: true };
 };

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -617,7 +617,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const dispatchDraft = async (
     key: ChannelKey,
     networkSlug: string,
-    channelName: string,
+    submittedFrom: string,
     text: string,
   ): Promise<DispatchOutcome> => {
     // #385 — expand user-defined aliases (from the aliasList store) before
@@ -634,7 +634,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // CP13 S9 — server-window only accepts slash-commands. The window
     // has no IRC target a PRIVMSG could go to. Plain text gets a friendly
     // error instead of silently failing or vanishing.
-    if (channelName === SERVER_WINDOW_NAME && cmd.kind === "privmsg") {
+    //
+    // #1396 — the THIRD thing this one fact is read as, and the only one that
+    // never crosses into the record: neither a recipient nor a destination,
+    // but a question about the window's KIND. It is a `windowKinds` constant
+    // it compares against, not a channel.
+    if (submittedFrom === SERVER_WINDOW_NAME && cmd.kind === "privmsg") {
       return { error: "Server window accepts only slash-commands. Try /raw <line>" };
     }
 
@@ -724,7 +729,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     const ctx: CommandContext = {
       key,
       networkSlug,
-      channelName,
+      submittedFrom,
       text,
       token: t,
       getActiveChannel,
@@ -750,7 +755,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             home,
             home,
             networkSlug,
-            channelName,
+            submittedFrom,
             cmd.body,
             false,
             nothingToPrepare,
@@ -770,7 +775,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             home,
             home,
             networkSlug,
-            channelName,
+            submittedFrom,
             cmd.body,
             true,
             nothingToPrepare,
@@ -1235,7 +1240,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const submit = async (
     key: ChannelKey,
     networkSlug: string,
-    channelName: string,
+    submittedFrom: string,
   ): Promise<SubmitResult> => {
     // #737 — a drain already owns this window's draft, and that draft holds
     // the residue it has NOT sent yet. Re-submitting would fan the same
@@ -1275,7 +1280,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       for (;;) {
         inHand = text;
         teardownAtDispatch = documentTeardownEpoch();
-        const outcome = await dispatchDraft(key, networkSlug, channelName, text);
+        const outcome = await dispatchDraft(key, networkSlug, submittedFrom, text);
         // A drain that kept the buffer already put its own residue there.
         inHand = "error" in outcome && !("keptBuffer" in outcome) ? text : null;
         if ("error" in outcome) return outcome;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48394,14 +48394,20 @@ amount of test coverage moves. The net corroborates from the other side: the
 pair is its only `indistinguishablePairs` entry, so the coverage that separates
 them is dedicated, not ambient.
 
-**`channelName` has TWO meanings, not three, and the record needs no new
-field.** The plan warned of three. Measured: only `part`, `ctcp`, `ping` and
-`notice` read the parameter at all — `part` as a DEFAULT TARGET, the other
-three as the ECHO window. `join`, `list`, `msg` and `query` never read it; they
-WRITE a different channel into the selection, which is a focus change and not a
-third reading. The meanings stay distinct because the record hands over the raw
-channel and each handler says what it is for. A pre-resolved "default target"
-field is precisely what would have collapsed them into one, so none was added.
+**`channelName` crosses the RECORD boundary with two meanings, not three, and
+the record needs no new field.** The plan warned of three. Measured: of the
+arms behind the seam, only `part`, `ctcp`, `ping` and `notice` read the
+parameter at all — `part` as a DEFAULT TARGET, the other three as the ECHO
+window. `join`, `list`, `msg` and `query` never read it; they WRITE a different
+channel into the selection, which is a focus change and not a third reading.
+The meanings stay distinct because the record hands over the raw channel and
+each handler says what it is for. A pre-resolved "default target" field is
+precisely what would have collapsed them into one, so none was added. **The
+count is two ON THE BOUNDARY only: inside `compose.ts` the same value carries a
+third meaning that never crosses it** — the `$server` gate reads it as the
+submitting window's KIND, not as a target or a destination. A later audit found
+it and renamed the field for the fact it carries; see the 2026-08-18 entry on
+`submittedFrom`.
 
 ### What bought the move
 
@@ -48991,3 +48997,116 @@ That bucket J's vacuity ever fired on a real CI run. The opless path is
 documented by a sibling spec's header and reproduced here deliberately;
 that it occurred unprompted in some past run is not something these four
 rounds establish.
+<!-- entry #1396-submitted-from -->
+
+---
+
+## 2026-08-18 — #1396: one fact, three readings, and the name that stops them collapsing
+
+An audit slice, not a move: no arm changed hands. `CommandContext.channelName`
+became `submittedFrom`, one `/part` characterization test landed, and the
+earlier #1396 entry's "TWO meanings, not three" was corrected where it stands.
+Zero behaviour change.
+
+### The enumeration a grep on the field cannot do
+
+`git grep -c 'ctx\.channelName'` on 038a33ca answers `relay.ts 5 · window.ts 2 ·
+uploadOrchestrator.ts 1`, and every one of those eight numbers is real. What the
+eight are is another matter: three are COMMENTS, and `uploadOrchestrator.ts:743`
+is a FALSE POSITIVE — its `ctx` comes from `lastAttempt.get(key)`, a
+`{file, networkSlug, channelName}` record, proven by the same expression reading
+`ctx.file`, which `CommandContext` does not have. Four code reads of the field
+survive that filter.
+
+The filter also hides three more reads of the SAME per-submission fact, sitting
+on the near side of the record where the value is still `dispatchDraft`'s
+parameter: the `$server` gate and the `privmsg` / `me` arms. Seven readings in
+total, four through the record and three inside `compose.ts`. **This is why the
+earlier entry counted two: it counted the boundary, and the boundary is where a
+field-name grep can see.**
+
+### The three meanings, and the one that never crosses
+
+  * **DEFAULT TARGET** — `part`, one site. Goes on the WIRE, raw.
+  * **ECHO WINDOW** — `ctcp`, `ping`, `notice`. Becomes KEY MATERIAL:
+    `ctcpQuery.ts` folds it through `channelKey`. Same field, a different
+    type-level obligation from the wire one.
+  * **WINDOW KIND** — the `$server` gate. Neither recipient nor destination: a
+    question about what the window IS, answered against a `windowKinds`
+    constant. It never crosses into the record, which is exactly why it was
+    missed.
+
+`privmsg` and `me` are the degenerate case, where target and echo are the same
+argument because they coincide by construction — the reason the collision reads
+as natural.
+
+`key` is not a duplicate of it. `channelKey` folds (#537), so the spelling
+survives only in this field — and `part` puts that spelling on the wire.
+
+### What the mutants measured, and the one that killed nothing
+
+Eight mutants, one at a time, full unit suite each (5615 tests, green baseline).
+DISPLACEMENT = read the ACTIVE window instead of the submitting one at that
+site; POSITIVE CONTROL = read a constant, which proves the site runs at all.
+
+  | reading            | displacement | control |
+  |--------------------|--------------|---------|
+  | echo (relay ×3)    | 1            | 7       |
+  | default target     | **0**        | 2       |
+  | window kind        | 1 (+harness) | 1       |
+  | fused privmsg+me   | 2            | 10      |
+
+**`part`'s fallback killed nothing at all.** The characterization net misses it
+by its own rule: the net forbids a draft that aims at the window it is submitted
+from, so `part`'s row is `/part #other` — an explicit channel, and the `??`
+right-hand side is never evaluated. A rule that keeps the net honest on the
+argument axis blinds it on the fallback axis. That gap is now one test.
+
+**Where the relay and fused mutants DID die, they died on the call log, not on a
+value.** The snapshot diff is entirely additive — `+ selection.selectedChannel()`,
+`+ networks.networkIdBySlug("freenode")` — while the line that carries the
+channel is byte-identical on both sides. No assertion in the suite tells the
+submitting window from the active one at those sites; what stands between the
+two meanings is an ambient-effect diff. A refactor that resolved the wrong
+window WITHOUT adding a call would pass green. **Measured and left uncured**: only
+`part` is closed here, deliberately, because the others need their own fixtures
+and this slice was an audit.
+
+### Why a rename and not two accessors
+
+Costed both at 6 call sites and 0 test sites. Two purpose-named accessors
+(`defaultTarget()` / `echoWindow()`) invent two names for one value and so
+promise a divergence that does not exist today — and the matrix above proves no
+red would defend it. `submittedFrom` names the FACT instead, which is what makes
+the flattening unspellable: nobody reads "submitted from" as "the recipient".
+Renamed to the bottom, `compose.ts`'s local and the pump's parameter included,
+because half a migration leaves two names for one fact — the very shape this
+trap grew in.
+
+Untouched on purpose, and NOT the same fact: `sel.channelName` (the selection
+record) and `uploadOrchestrator`'s own `ctx.channelName`.
+
+### Three gotchas, each worth a red
+
+  * **vitest's JSON reporter drops the snapshot diff.** `failureMessages` holds
+    "Snapshot … mismatched" plus a stack, nothing else. A mutation bench built on
+    `--reporter=json` gives you the SET of dead tests and no way to ask WHY one
+    died; the rerun that answers that must be scoped and use the default
+    reporter. Reading the diff is how the call-log-versus-value finding above
+    exists at all.
+  * **A mutant that injects a call at the top of `dispatchDraft` poisons every
+    test using `mockReturnValueOnce`** — it eats the one-shot value before the
+    arm reads it. Five of the window-kind mutant's eight deaths are that
+    artefact, not coverage. Read a kill set against this before believing it.
+  * **`cicchetto/vitest-out.json` is NOT gitignored** (`git check-ignore` says so;
+    no rule in either `.gitignore`) and the JSON reporter writes it over 1 MiB,
+    which fails `bun run check`. Delete it after every reporter run. Whether it
+    should be ignored instead is not decided here.
+
+### Limits of this measurement
+
+Unit suite only. No e2e, no Elixir gate: this slice touches no server code, and
+a lane was not taken. The `/part`-in-a-query-window behaviour the audit found on
+the way (the peer's NICK goes out as a PART target; the server 400s it at
+`validate_channel_name/1`, READ not executed) is behaviour, not record shape,
+and is filed separately.


### PR DESCRIPTION
An audit slice of #1396. No arm changes hands, no behaviour changes:
`CommandContext.channelName` becomes `submittedFrom`, one characterization
test lands, and the earlier #1396 entry's "TWO meanings, not three" is
corrected where it stands.

## What the audit measured

`git grep -c 'ctx\.channelName'` answers `relay 5 · window 2 ·
uploadOrchestrator 1`. All eight numbers are real; what they are is not.
Three are comments, and `uploadOrchestrator.ts:743` is a false positive —
its `ctx` is a `{file, networkSlug, channelName}` upload record, proven by
the same expression reading `ctx.file`. Four code reads of the field
survive.

The same grep hides three more reads of the same per-submission fact,
sitting before the record where the value is still `dispatchDraft`'s
parameter. Seven readings in total, carrying three meanings:

| meaning | sites | where the value goes |
|---|---|---|
| default TARGET | `part` | the WIRE, raw |
| ECHO window | `ctcp`, `ping`, `notice` | folded into a `ChannelKey` |
| window KIND | the `$server` gate | compared to a `windowKinds` constant, never leaves the function |

The third never crosses the record boundary, which is exactly why the
earlier count of two was right about the boundary and short by one about
the value.

## Mutants: 8, one at a time, full unit suite each

Displacement = read the ACTIVE window instead of the submitting one.
Positive control = read a constant, proving the site runs.

| reading | displacement | control |
|---|---|---|
| echo (relay ×3) | 1 | 7 |
| default target (`part`) | **0** | 2 |
| window kind | 1 attributable (+5 harness artefact) | 1 |
| fused privmsg+me | 2 | 10 |

**`part`'s fallback killed nothing.** The characterization net misses it by
its own rule — no draft may aim at the window it is submitted from, so
`part`'s row is `/part #other` and the `??` right-hand side is never
evaluated. That gap is what the new test closes; the same mutant now
reddens exactly one test and nothing else.

**Where relay and the fused arms DID die, they died on the call log.** The
snapshot diff is purely additive (`+ selection.selectedChannel()`), while
the line carrying the channel is byte-identical. No assertion tells the
submitting window from the active one there. Measured and left uncured on
purpose — those need their own fixtures, and this slice is an audit.

## Why a rename, not two accessors

Both cost 6 call sites and 0 test sites. Accessors (`defaultTarget()` /
`echoWindow()`) invent two names for one value and promise a divergence
that does not exist today, which the matrix above shows no red would
defend. `submittedFrom` names the fact instead — nobody reads "submitted
from" as "the recipient". Renamed to the bottom, including `compose.ts`'s
local and the pump's parameter: half a migration leaves two names for one
fact, which is the shape this trap grew in.

`sel.channelName` and `uploadOrchestrator`'s `ctx.channelName` are
untouched — different records, same spelling.

## Test plan

- [x] `bun run test` — 290 files / 5616 tests, 0 red (re-run after rebase)
- [x] `bun run check` — rc=0
- [x] `scripts/bats.sh` — 564 ok / 0 not ok
- [x] `scripts/design-notes-gate.sh` — 1 new entry, separator + marker present
- [x] Post-rebase: numstat two-sided identical, marker unique, previous
      entry's tail byte-identical, boundary shape read on the file
- [ ] e2e — not run; this slice touches no e2e spec
- [ ] Elixir gate — not run; no server code touched

## Out of scope, filed separately

A bare `/part` in a query window sends the peer's NICK as the PART target
(`$server` sends `$server`). The server rejects both at
`validate_channel_name/1` → `Identifier.valid_channel?`, read and not
executed. Behaviour, not record shape.