### PR TITLE
test(#1397): finish the promotion — adopt three IRCServer helpers at 35 inline sites

### DIFF
--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -36,7 +36,7 @@
 
 import { type BrowserContext, expect, type Page } from "@playwright/test";
 import { openSettingsSection } from "./cicchettoPage";
-import { assertMessagePersisted } from "./grappaApi";
+import { assertMessagePersisted, GRAPPA_BASE_URL } from "./grappaApi";
 import { assertNoPushAfterStimulus } from "./pushAbsence";
 
 const PUSH_CATCHER_URL = process.env.E2E_PUSH_CATCHER_URL ?? "http://push-catcher:3000";
@@ -218,8 +218,7 @@ const DEFAULT_NOTIFICATION_PREFS = {
  * silently breaks subsequent channel-mention specs unless reset.
  */
 export async function resetNotificationPrefs(token: string): Promise<void> {
-  const base = "http://grappa-test:4000";
-  await fetch(`${base}/me/settings/notification-prefs`, {
+  await fetch(`${GRAPPA_BASE_URL}/me/settings/notification-prefs`, {
     method: "PUT",
     headers: {
       authorization: `Bearer ${token}`,
@@ -239,10 +238,8 @@ export async function resetNotificationPrefs(token: string): Promise<void> {
  * Push.Sender's per-user fan-out target list.
  */
 export async function resetPushSubscriptions(token: string): Promise<void> {
-  // grappa REST surface for the runner — same base as grappaApi.
-  const base = "http://grappa-test:4000";
   const headers = { authorization: `Bearer ${token}` };
-  const list = await fetch(`${base}/push/subscriptions`, { headers });
+  const list = await fetch(`${GRAPPA_BASE_URL}/push/subscriptions`, { headers });
   if (!list.ok) {
     // Treat missing endpoint / 401 as "nothing to clean" — first-run
     // shape before any subscription has been created.
@@ -250,7 +247,7 @@ export async function resetPushSubscriptions(token: string): Promise<void> {
   }
   const body = (await list.json()) as { subscriptions?: { id: string }[] };
   for (const sub of body.subscriptions ?? []) {
-    await fetch(`${base}/push/subscriptions/${encodeURIComponent(sub.id)}`, {
+    await fetch(`${GRAPPA_BASE_URL}/push/subscriptions/${encodeURIComponent(sub.id)}`, {
       method: "DELETE",
       headers,
     });
@@ -268,10 +265,9 @@ export async function resetPushSubscriptions(token: string): Promise<void> {
  * value — a real barrier, not a sleep.
  */
 export async function awaitDeviceLastUsed(token: string, timeoutMs = 5_000): Promise<void> {
-  const base = "http://grappa-test:4000";
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const res = await fetch(`${base}/push/subscriptions`, {
+    const res = await fetch(`${GRAPPA_BASE_URL}/push/subscriptions`, {
       headers: { authorization: `Bearer ${token}` },
     });
     if (res.ok) {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49110,3 +49110,133 @@ a lane was not taken. The `/part`-in-a-query-window behaviour the audit found on
 the way (the peer's NICK goes out as a PART target; the server 400s it at
 `validate_channel_name/1`, READ not executed) is behaviour, not record shape,
 and is filed separately.
+<!-- entry #1397-adoption -->
+
+---
+
+## 2026-08-18 — #1397: promotion is not adoption, and the grep that stopped being able to see it
+
+Bucket H's server half looked almost finished. Counting the definitions
+`#1397` names, outside `test/support/`, on `f899c25e`:
+
+| helper | issue (`1552312d`) | measured now |
+|---|---|---|
+| `passthrough_handler` | 19 | **0** |
+| `admin_session` | 14 | **0** |
+| `await_handshake` | 13 | **0** |
+| `start_server` | 21 clauses / 20 files | **2** |
+| `user_fixture` | 14 | 14 |
+| `network_fixture` | 7 | 7 |
+| `visitor_fixture` | 4 | 4 |
+| total | 92 over 53 files | **27 over 16** |
+
+Three helpers at zero, all seven canonical in `test/support`. The fixture
+trio's 25 are the copies held on an open question about Argon2 cost and are
+untouched here.
+
+That table is true and it is misleading, which is the whole entry.
+
+### The body outlived the name
+
+A second measurement, on the BODY rather than the name:
+
+| body | named defs left | still spelled out inline |
+|---|---|---|
+| `fn state, _ -> {:reply, nil, state} end` | 0 | **9** over 5 files |
+| the `"USER"`-prefix `wait_for_line` barrier | 0 | **28** over 15 files |
+| `start_link/1` + `port/1` as a pair | 2 | **20** |
+
+The zeros are real and they measure the wrong thing. `passthrough_handler`
+had been promoted and 459 call sites adopted it — while nine sites kept
+writing the body out, and one of those had RENAMED it to `defp passthrough`
+(`session/lifecycle_log_integration_test.exs`), which no grep for the
+promoted name can see. `client_test.exs` is the sharpest single file: it
+calls `IRCServer.passthrough_handler()` near the top and spells the body out
+twice further down.
+
+The #1397 F2 entry above already stated the general form — *a grep on a name
+measures who says the name, not who obeys it*. This is its other half, and
+it bites in the opposite direction: after a promotion, a grep on the name
+measures who no longer says it, and reports adoption that did not happen.
+**Promotion moves a definition; adoption moves the call sites. Only the
+second one removes a duplicate, and only a grep on the VALUE can tell you
+which one you did.**
+
+### `push.ts`, and an instrument that was scoped, not wrong
+
+The F2 entry's closing table reports `http://grappa-test:4000` going 28 → 0.
+That row says `under e2e/tests/`, and re-run today it is still 0 — the row is
+scoped, not stale. A naked `git grep -F` over ALL of `cicchetto` returned
+FOUR: the declaration in `grappaApi.ts:18`, plus three
+`const base = "http://grappa-test:4000"` inside `e2e/fixtures/push.ts`, which
+sat outside the earlier slice's scope the whole time. One of the three even
+carried the comment *"same base as grappaApi"* — a copy that says so.
+
+`push.ts` already imports from `./grappaApi`, and `grappaApi.ts` imports
+nothing at all, so there was no cycle to dodge and not even an import line to
+add. The literal now appears exactly once in `cicchetto/`, at its
+declaration.
+
+### The four `await_handshake` sites that stay, and why
+
+Of the 28 inline barriers, **24 were converted and 4 were not**. The four
+CONSUME the line the predicate matched, and `await_handshake/2` returns `:ok`
+and throws it away:
+
+- `session/server_test.exs:364,1653,1667` pattern-match the exact
+  `USER … \r\n` line to prove ident and realname reached the wire;
+- `visitors/login_test.exs:154` binds it and asserts on it two lines down.
+
+Those are not handshake barriers wearing a different spelling; they are
+assertions ABOUT the handshake line. Converting them would have deleted the
+assertion and left a test that still passed.
+
+So the transform did not key on the call at all — it keyed on the LEFT-HAND
+SIDE being exactly `{:ok, _}`, the sites that already discard the line, which
+is what the canonical does. It then selected the same four to skip that
+reading every site by hand had selected. That agreement is the only reason
+the mechanical pass is trustworthy; a sweep that had matched on the call
+would have eaten all four in silence.
+
+### Tightening 17 predicates, and refusing to call it a fix
+
+Inside those 28 sites the drift the promotion was meant to end was still
+alive: 21 used the loose `"USER"`, 7 the strict `"USER "`, and one waited
+`5_000` where the rest waited `1_000`. Of the 24 converted, **17 tighten** to
+the canonical's strict predicate.
+
+This is NOT a behaviour change and must not be logged as one. A naked
+`git grep` for `USERHOST` across all of `lib/` returns **zero**, and exactly
+one line in `lib/` writes a USER command (`irc/auth_fsm.ex:400`), so the two
+predicates select the same line today — measured, not inherited from the
+moduledoc that asserts it. The tightening removes a trap that does not exist
+yet.
+
+The `5_000` site (`visitors/autoconnect_test.exs`) keeps its `5_000`. That
+number is evidence that one second was once found insufficient, and the
+canonical takes the timeout as an argument precisely so such a site does not
+have to be flattened into the majority.
+
+### What this slice did not do
+
+- **The `start_link` + `port` pair, 20 inline sites**, is the same defect in
+  the third helper and is left for its own slice. The two remaining local
+  `start_server/0` wrappers ARE retired here — they were arity-zero, hardcoded
+  their handler, and had not yet drifted from each other, which is the
+  cheapest moment to delete a pair.
+- **The fixture trio, 25 copies over 16 files**, stays whole. So does the
+  structural cause behind it: neither `data_case.ex` nor `conn_case.ex`
+  imports `AuthFixtures`, so 122 of 338 test files import it by hand and the
+  rest have no shared fixture in scope.
+- **The e2e half is untouched**: 61 definitions over 49 files, reproducing the
+  issue's own count exactly, including the 14-strong byte-identical cluster
+  that spans BOTH `adminLogin` and `adminFriendlyLogin`. Its red is the e2e
+  suite, which needs the exclusive lane.
+
+_Not established: no e2e spec was run for the `push.ts` change — the
+substitution is value-identical by inspection and covered structurally by
+`tsc --noEmit -p e2e/tsconfig.json`, which is a type gate, not a behaviour
+one. The inline censuses above are static: `git grep` plus body extraction,
+whitespace-normalised. On the e2e side no hand-pass was made for bodies
+never extracted into a named function, so 61 remains a lower bound, exactly
+as the issue says._

--- a/test/grappa/irc/client_outbound_cost_test.exs
+++ b/test/grappa/irc/client_outbound_cost_test.exs
@@ -95,7 +95,7 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
     log =
       capture_log(fn ->
         {server, client} = start_pair()
-        {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+        :ok = IRCServer.await_handshake(server, 1_000)
         settle(client)
       end)
 

--- a/test/grappa/irc/client_outbound_cost_test.exs
+++ b/test/grappa/irc/client_outbound_cost_test.exs
@@ -30,7 +30,7 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
   end
 
   defp start_pair do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
 
     {:ok, client} =
       Client.start_link(%{

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -995,8 +995,7 @@ defmodule Grappa.IRC.ClientTest do
       {server, port} = IRCServer.start_server(rfc_handler())
       _ = start_client(port, %{auth_method: :none})
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       lines = IRCServer.sent_lines(server)
       refute Enum.any?(lines, &String.starts_with?(&1, "PASS"))
@@ -1015,8 +1014,7 @@ defmodule Grappa.IRC.ClientTest do
           password: "swordfish"
         })
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       lines = IRCServer.sent_lines(server)
       pass_idx = Enum.find_index(lines, &String.starts_with?(&1, "PASS"))
@@ -1589,7 +1587,7 @@ defmodule Grappa.IRC.ClientTest do
 
       # Wait for the server to have written the 001; then poll for the
       # phase transition (no CAP END is sent — handshake is one-sided).
-      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
       Process.sleep(50)
 
       assert %{fsm: %{phase: :registered, caps_buffer: []}} = :sys.get_state(client)
@@ -2046,8 +2044,7 @@ defmodule Grappa.IRC.ClientTest do
           auth_method: :none
         })
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
     end
   end
 
@@ -2076,8 +2073,7 @@ defmodule Grappa.IRC.ClientTest do
       # First inbound line is the handshake's CAP LS or NICK; the handler
       # bumps the counter to 42 and writes back PING :42. We don't care
       # about the exact line — only that the seeded state was visible.
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
     end
 
     test "start_link/1 still works (no-state delegate to start_link/2)" do
@@ -2087,8 +2083,7 @@ defmodule Grappa.IRC.ClientTest do
       port = IRCServer.port(server)
       _ = start_client(port)
 
-      assert {:ok, _} =
-               IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
     end
   end
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -837,7 +837,7 @@ defmodule Grappa.IRC.ClientTest do
       # 127.0.0.1, so the observed peer proves the ifaddr bind took effect.
       # Assumes 127.0.0.2 is loopback-bindable (Linux/RPi: all 127/8 is
       # loopback; a non-Linux host would fail legibly with :eaddrnotavail).
-      {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: "127.0.0.2"})
@@ -847,7 +847,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "NULL source still connects via the pool/kernel-default path" do
-      {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(server)
 
       _ = start_client(port, %{source_address: nil})

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -55,8 +55,7 @@ defmodule Grappa.LiveIntrospectionTest do
       # {:irc_peer, _}, so waiting for it guarantees the peer is captured before
       # the scan — the same deterministic barrier the #550 peer-capture test
       # below uses. NOT an assertion weakening: it makes `== []` honest.
-      {:ok, _} =
-        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
 
       entries = LiveIntrospection.list_sessions()
 
@@ -106,8 +105,7 @@ defmodule Grappa.LiveIntrospectionTest do
       _ = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
 
-      {:ok, _} =
-        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
 
       entry = LiveIntrospection.lookup_session({:visitor, visitor.id}, network.id)
 

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -42,7 +42,7 @@ defmodule Grappa.PresenceFilter.ResolverTest do
 
     pid = start_session_for(user, network)
 
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
     IRCServer.feed(server, ":grappa-test!u@h JOIN :#{channel}\r\n")

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -30,15 +30,10 @@ defmodule Grappa.PresenceFilter.ResolverTest do
     end
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(welcome_handler())
-    {server, IRCServer.port(server)}
-  end
-
   # A live session joined to `channel` with exactly `n` members seeded via a
   # 353/366 NAMES burst. Returns `{network, pid, server}`.
   defp session_with_members(user, channel, n) do
-    {server, port} = start_server()
+    {server, port} = IRCServer.start_server(welcome_handler())
     slug = "az-#{System.unique_integer([:positive])}"
     {network, _} = network_with_server(port: port, slug: slug)
 

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -68,7 +68,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
 
     _ = start_session_for(user, network)
 
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     # Autojoin JOIN fires only after 001 is fully processed → a barrier
     # proving the nick reconciliation landed before the self-NICK below.
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)

--- a/test/grappa/session/lifecycle_log_integration_test.exs
+++ b/test/grappa/session/lifecycle_log_integration_test.exs
@@ -42,8 +42,6 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     :ok
   end
 
-  defp passthrough, do: fn state, _ -> {:reply, nil, state} end
-
   defp setup_user_and_network(port) do
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
@@ -55,7 +53,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "connect handshake emits :connected with the composite session_id" do
-    {server, port} = IRCServer.start_server(passthrough())
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -69,7 +67,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "001 RPL_WELCOME emits :registered" do
-    {server, port} = IRCServer.start_server(passthrough())
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -84,7 +82,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "clean stop emits :disconnected clean=true with a non-negative duration_ms" do
-    {server, port} = IRCServer.start_server(passthrough())
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
@@ -115,7 +113,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   end
 
   test "self-MODE +r after registration emits :identified" do
-    {server, port} = IRCServer.start_server(passthrough())
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)

--- a/test/grappa/session/lifecycle_log_integration_test.exs
+++ b/test/grappa/session/lifecycle_log_integration_test.exs
@@ -57,7 +57,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
 
     assert_receive {:session_log, :connected, md}, 1_500
     assert md.session_id == "user:#{user.id}:#{network.id}"
@@ -71,7 +71,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     # "grappa-test" = credential_fixture's default nick (AuthFixtures).
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
@@ -86,7 +86,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     # drain the :connected event
     assert_receive {:session_log, :connected, _}, 1_500
 
@@ -117,7 +117,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     {user, network} = setup_user_and_network(port)
 
     pid = start_session_for(user, network)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
     assert_receive {:session_log, :registered, _}, 1_500
 

--- a/test/grappa/session/nick_change_observability_test.exs
+++ b/test/grappa/session/nick_change_observability_test.exs
@@ -82,7 +82,7 @@ defmodule Grappa.Session.NickChangeObservabilityTest do
 
     on_exit(fn -> Session.stop_session({:user, user.id}, network.id) end)
 
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
     IRCServer.feed(server, ":#{@configured_nick}!u@h NICK :#{@live_nick}\r\n")

--- a/test/grappa/session/presence_push_test.exs
+++ b/test/grappa/session/presence_push_test.exs
@@ -91,7 +91,7 @@ defmodule Grappa.Session.PresencePushTest do
   end
 
   defp arm_monitor(server) do
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
     IRCServer.feed(server, ":irc.test.org 005 grappa-test MONITOR=100 :are supported\r\n")
     IRCServer.feed(server, ":irc.test.org 376 grappa-test :End of /MOTD command.\r\n")

--- a/test/grappa/session/rejoin_snapshot_test.exs
+++ b/test/grappa/session/rejoin_snapshot_test.exs
@@ -40,7 +40,7 @@ defmodule Grappa.Session.RejoinSnapshotTest do
     :ok = Credentials.update_last_joined_channels(user.id, network.id, @snapshot)
 
     pid = start_session_for(user, network)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
     Enum.each(@snapshot, fn channel ->

--- a/test/grappa/visitors/autoconnect_test.exs
+++ b/test/grappa/visitors/autoconnect_test.exs
@@ -28,7 +28,7 @@ defmodule Grappa.Visitors.AutoconnectTest do
     {visitor, anchor} = visitor_with_network(port)
     {:ok, _} = Networks.update_network_settings(anchor, %{visitor_enabled: true, visitor_autoconnect: true})
     _ = start_visitor_session_for(visitor, anchor)
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 5_000)
+    :ok = IRCServer.await_handshake(server, 5_000)
     {visitor, anchor}
   end
 

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -707,7 +707,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   defp uniq, do: System.unique_integer([:positive])
 
   defp start_irc_server do
-    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
     {server, IRCServer.port(server)}
   end
 

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -136,8 +136,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       _ = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
 
-      {:ok, _} =
-        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
 
       session = admin_session()
 

--- a/test/grappa_web/controllers/members_controller_test.exs
+++ b/test/grappa_web/controllers/members_controller_test.exs
@@ -48,7 +48,7 @@ defmodule GrappaWeb.MembersControllerTest do
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
-      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
@@ -118,7 +118,7 @@ defmodule GrappaWeb.MembersControllerTest do
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
-      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
       {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
       # Self-JOIN echo lands but NO 353/366 — channel is in
@@ -146,7 +146,7 @@ defmodule GrappaWeb.MembersControllerTest do
       {:ok, cred} = Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
       nick = cred.nick
 
-      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       IRCServer.feed(server, ":#{nick}!u@h JOIN :#test\r\n")
       IRCServer.feed(server, ":irc 353 #{nick} = #test :@#{nick} +alice\r\n")

--- a/test/grappa_web/controllers/members_controller_test.exs
+++ b/test/grappa_web/controllers/members_controller_test.exs
@@ -23,11 +23,6 @@ defmodule GrappaWeb.MembersControllerTest do
     end
   end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(welcome_handler())
-    {server, IRCServer.port(server)}
-  end
-
   defp setup_session_with_members(vjt, port, slug) do
     {network, _} = network_with_server(port: port, slug: slug)
 
@@ -49,7 +44,7 @@ defmodule GrappaWeb.MembersControllerTest do
 
   describe "GET /networks/:network_id/channels/:channel_id/members" do
     test "returns members in mIRC sort order", %{conn: conn, vjt: vjt} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(welcome_handler())
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -78,7 +73,7 @@ defmodule GrappaWeb.MembersControllerTest do
     end
 
     test "404 for cross-user network access (per-user iso)", %{conn: _conn, vjt: vjt} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(welcome_handler())
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -95,7 +90,7 @@ defmodule GrappaWeb.MembersControllerTest do
 
     test "404 when no session is registered for (user, network)",
          %{conn: conn, vjt: vjt} do
-      {_, port} = start_server()
+      {_, port} = IRCServer.start_server(welcome_handler())
       slug = "az-#{System.unique_integer([:positive])}"
       {network, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -119,7 +114,7 @@ defmodule GrappaWeb.MembersControllerTest do
       conn: conn,
       vjt: vjt
     } do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(welcome_handler())
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -143,7 +138,7 @@ defmodule GrappaWeb.MembersControllerTest do
     # {:visitor, _} correctly — handshake + session interaction is the
     # same Session.list_members boundary user-side already exercises.
     test "visitor subject — returns members for visitor's network", %{conn: _conn} do
-      {server, port} = start_server()
+      {server, port} = IRCServer.start_server(welcome_handler())
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -360,7 +360,7 @@ defmodule GrappaWeb.NetworksControllerTest do
 
     test "visitor reconnects a parked network → 200 + :connected, spawns session", %{conn: conn} do
       slug = "net-vis-connect-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(irc_server)
       {network, _} = network_with_server(port: port, slug: slug, visitor_enabled: true)
       visitor = visitor_with_credential_fixture(network_slug: slug, nick: "vconn-#{u()}")
@@ -395,7 +395,7 @@ defmodule GrappaWeb.NetworksControllerTest do
       vjt = user_fixture(name: "vjt-patch-connect-#{u()}")
       session = session_fixture(vjt)
       slug = "net-connect-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(irc_server)
       {network, _} = network_with_server(port: port, slug: slug)
       cred = credential_fixture(vjt, network)
@@ -440,7 +440,7 @@ defmodule GrappaWeb.NetworksControllerTest do
       vjt = user_fixture(name: "vjt-u0-netcap-#{u()}")
       session = session_fixture(vjt)
       slug = "net-u0-netcap-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(irc_server)
       {network, _} = network_with_server(port: port, slug: slug)
       cred = credential_fixture(vjt, network)
@@ -544,7 +544,7 @@ defmodule GrappaWeb.NetworksControllerTest do
         Grappa.Accounts.create_session({:user, vjt.id}, "127.0.0.1", "ua", client_id: client_id)
 
       slug = "net-ux5bc-self-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
       port = IRCServer.port(irc_server)
       {network, _} = network_with_server(port: port, slug: slug)
 

--- a/test/grappa_web/controllers/notify_controller_live_test.exs
+++ b/test/grappa_web/controllers/notify_controller_live_test.exs
@@ -54,7 +54,7 @@ defmodule GrappaWeb.NotifyControllerLiveTest do
     # Welcome past 005 (WATCH advertised) + end-of-MOTD. The DB watch list
     # is empty here, so arm_presence sends no burst — the WATCH lines below
     # come purely from the controller's live notify_changed sync.
-    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    :ok = IRCServer.await_handshake(server, 1_000)
     IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
     IRCServer.feed(server, ":irc.test.org 005 grappa-test WATCH=128 :are supported\r\n")
     IRCServer.feed(server, ":irc.test.org 376 grappa-test :End of MOTD\r\n")


### PR DESCRIPTION
Bucket H, server half. #1397 does not close here.

## Why this slice exists

Counting the definitions #1397 names, outside `test/support/`, the server
half looks nearly done: **92 local copies over 53 files down to 27 over
16**, with `passthrough_handler`, `admin_session` and `await_handshake` all
at **zero**.

That reading is wrong, and the way it is wrong is the point. The
definitions moved; the **bodies stayed**:

| body | named defs left | still inline |
|---|---|---|
| `fn state, _ -> {:reply, nil, state} end` | 0 | **9** over 5 files |
| the `"USER"`-prefix `wait_for_line` barrier | 0 | **28** over 15 files |
| `start_link/1` + `port/1` as a pair | 2 | 20 (left for its own slice) |

One of the nine had been **renamed** to `defp passthrough`, so no grep on
the promoted name could see it. A promotion moves a definition; only
adoption removes a duplicate — and only a grep on the VALUE tells you which
one happened.

## Commits

1. **`push.ts` → `GRAPPA_BASE_URL`** — three `const base = "http://grappa-test:4000"`,
   one of them commented *"same base as grappaApi"*. The file already
   imports from `./grappaApi`, which itself imports nothing, so there was no
   cycle and not even an import line to add. The literal now appears **once**
   in `cicchetto/`, at its declaration.
2. **`passthrough_handler` × 9** including the renamed definition and its
   four callers. Body now appears once under `test/`.
3. **the two `start_server/0`** — arity-zero wrappers that hardcoded their
   handler, retired for the canonical arity-1; six call sites moved.
4. **`await_handshake` × 24 of 28** — see below.
5. **DESIGN\_NOTES entry.**

## The four sites that keep `wait_for_line`, on purpose

`await_handshake/2` returns `:ok` and **discards** the matched line. Four
sites consume it:

- `session/server_test.exs:364,1653,1667` pattern-match the exact
  `USER … \r\n` line to prove ident/realname reached the wire;
- `visitors/login_test.exs:154` binds it and asserts on it two lines down.

Converting those would have deleted a real assertion and left a passing
test. So the transform keys on the **left-hand side being exactly
`{:ok, _}`** — the sites that already throw the line away — and it selected
the same four to skip that reading every site by hand had selected. That
agreement is why the mechanical pass is trustworthy; a sweep matching on the
call would have eaten all four silently.

## The predicate tightening is not a behaviour fix

Inside the 28 the old drift was still alive: 21 loose `"USER"`, 7 strict
`"USER "`, one `5_000` among `1_000`s. **17 of the converted sites tighten**
to the canonical's strict predicate — and that is deliberately *not* logged
as a fix: a naked `git grep` for `USERHOST` over all of `lib/` returns
**zero**, and exactly one line in `lib/` writes a USER command
(`irc/auth_fsm.ex:400`), so both spellings select the same line today. What
it removes is tomorrow's trap.

The `5_000` site (`visitors/autoconnect_test.exs`) **keeps its 5_000** — that
number is evidence one second was once insufficient, and the canonical takes
the timeout as an argument so it need not be flattened.

## Gates

- Full `scripts/check.sh` on this tree at base `393f0f89`: **rc=0** —
  8 doctests, 61 properties, **6546 tests, 0 failures**; **564 bats ok / 0 not ok**;
  Credo, Sobelow and Dialyzer all executed (stage markers verified in the log,
  not inferred from the exit code).
- Full `bun run check` (biome + `tsc --noEmit` + `tsc --noEmit -p e2e/tsconfig.json`): rc=0.
- `scripts/design-notes-gate.sh`: 1 new entry heading, separator and marker present.
- The docs commit landed after the check run and is covered by the
  design-notes gate alone; it touches no code.

## Not established

- **No e2e spec was run** — no lane. The `push.ts` substitution is
  value-identical by inspection and covered structurally by the e2e
  `tsc`, which is a type gate, not a behaviour one.
- The censuses are static (`git grep` + body extraction, whitespace-normalised).
- Still open in #1397: the 20 inline `start_link`+`port` pairs, the
  25-copy fixture trio and its structural cause (neither `DataCase` nor
  `ConnCase` imports `AuthFixtures`), and the whole e2e half — 61
  definitions over 49 files.