### PR TITLE
e2e(#1397): extract the user-id lookup into grappaApi, and name it honestly

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -453,6 +453,26 @@ export async function terminateSession(adminToken: string, sessionId: string): P
   }
 }
 
+// The admin surface keys users by id, and a spec that provisions its subject
+// (#1078) only ever learns the NAME — hence the lookup. The name is a
+// PARAMETER and not `specUser()` read from here: this module imports nothing,
+// and reaching for the subject would make it import `specSubject`, which
+// already imports this one.
+export async function findUserIdByName(adminToken: string, userName: string): Promise<string> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.findUserIdByName: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { users: { id: string; name: string }[] };
+  const user = body.users.find((u) => u.name === userName);
+  if (!user) {
+    throw new Error(`grappaApi.findUserIdByName: ${userName} absent from ${JSON.stringify(body)}`);
+  }
+  return user.id;
+}
+
 // #1158 item 4 — the lifecycle log collapsed to one entry per session.
 // A spec uses this as a PRECONDITION barrier, never as the property under
 // test: the log is a bounded global ring written from an async cast, so a

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -21,7 +21,7 @@
 // then reverted in afterEach so the shared stack baseline is restored.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -29,21 +29,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -66,7 +51,7 @@ test.describe("#291 — home launcher in the rail actions drawer", () => {
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -24,7 +24,7 @@
 // shared baseline is restored (mirrors #291).
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -32,21 +32,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -78,7 +63,7 @@ test.describe("#299 — admin reachable from the rail actions drawer", () => {
   // user id has to be resolved per test — a once-per-file lookup would
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
-    vjtUserId = await findVjtUserId(getSeededAdmin().token);
+    vjtUserId = await findUserIdByName(getSeededAdmin().token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -29,27 +29,12 @@
 // channel + rail drawer) without ripple-affecting other specs.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -75,7 +60,7 @@ test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () 
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -38,28 +38,13 @@
 // references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -82,10 +67,10 @@ async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean
 // string, NOT a real bearer token). That bypassed admin auth → 401
 // → `users.users` undefined → `.find` crashed before reaching the UI
 // assertions. Mirrors the working pattern in ux-6-g-admin-mobile-h-scroll
-// (findVjtUserId + setAdminFlag with `getSeededAdmin().token`).
+// (findUserIdByName + setAdminFlag with `getSeededAdmin().token`).
 async function promoteVjtToAdmin(): Promise<{ revert: () => Promise<void> }> {
   const admin = getSeededAdmin();
-  const vjtUserId = await findVjtUserId(admin.token);
+  const vjtUserId = await findUserIdByName(admin.token, specUser().name);
   await setAdminFlag(admin.token, vjtUserId, true);
   return {
     revert: async () => {

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -54,6 +54,7 @@
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
+  findUserIdByName,
   GRAPPA_BASE_URL,
   listSessionLogSessions,
   mintVisitor,
@@ -170,21 +171,6 @@ type Offender = {
   clientW: number;
 };
 
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
-
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
@@ -264,7 +250,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49110,3 +49110,55 @@ a lane was not taken. The `/part`-in-a-query-window behaviour the audit found on
 the way (the peer's NICK goes out as a PART target; the server 400s it at
 `validate_channel_name/1`, READ not executed) is behaviour, not record shape,
 and is filed separately.
+<!-- entry #1397-e2e-findvjtuserid -->
+
+---
+
+## 2026-08-18 — #1397 (e2e): one user-id lookup, and where a shared helper may live
+
+Five spec files carried the same 14-line `findVjtUserId` — byte-identical, md5
+equal across all five, the only helper in the #1397 census with no drift at
+all. It is now `grappaApi.findUserIdByName(adminToken, userName)`, and the five
+copies are gone.
+
+### The fork the extraction hid
+
+The helper reads `specUser()`, which lives in `fixtures/specSubject.ts`, and
+`specSubject` imports `grappaApi`. Dropping the helper into `grappaApi`
+unchanged would therefore have made the two modules import each other.
+`grappaApi` is the only LEAF of the fixture graph — `grep -c '^import'` is
+**0**, and four fixture modules import it — so that cycle would have been paid
+by the one module that has no dependencies at all, for fourteen lines.
+
+Homing it in `specSubject` instead was the cheaper option and was rejected on
+the boundary, not on the cost: a `GET /admin/users` is a VERB, and verbs are
+what gets reused; parking it in the module whose reason for being is the
+subject would make the first caller who wants a NON-subject user duplicate it
+again. Passing the name as a parameter costs each of the five call sites one
+argument and keeps the leaf a leaf.
+
+Accepting the cycle was the third option and is the one worth naming, because
+**no local gate would have caught it**: neither `tsc` nor biome reports an
+import cycle, so the first symptom would have been an obscure e2e red at some
+later date. The choice here is structural and is NOT defended by a red.
+
+### Why the name changed in the same slice
+
+`findVjtUserId` has been false since #1078 gave every test its own subject: it
+resolves `specUser()`, not `vjt`. With the name now supplied by the caller it
+was false twice over, and the five call sites were being edited anyway, so the
+rename cost no extra lines. A wrong name in a SHARED fixture is the kind of
+thing this suite propagates by copy — which is how there came to be five of
+these in the first place.
+
+### What gated it
+
+`bun run check` is rc=0 (the 59 CSS warnings are pre-existing, measured
+identical on the branch point). The behavioural gate is the five specs
+themselves, run before and after.
+
+One trap worth leaving behind for whoever touches these files next: **ten of
+the eleven tests across them are `@webkit`**, and the chromium project carries
+`grepInvert: /@webkit/`. A scoped run with `--project=chromium` therefore
+executes exactly ONE of the eleven and still reports rc=0 — a green that
+measures almost nothing. These five want `--project=webkit-iphone-15`.


### PR DESCRIPTION
## What

Five spec files carried the same 14-line `findVjtUserId` — **byte-identical, md5 equal across all five** (the one helper in the #1397 census with no drift). It is now `grappaApi.findUserIdByName(adminToken, userName)`; the five copies are gone.

Net: **+20** in the fixture, **−85** across the five specs.

## The fork, and why it went this way

The body reads `specUser()`, which lives in `fixtures/specSubject.ts` — and `specSubject` imports `grappaApi`. Dropping the helper in unchanged would have made the two import each other.

`grappaApi` is the **only leaf** of the fixture graph: `grep -c '^import'` is `0`, and four fixture modules import it. Three options were on the table:

- **Parameterise the name (taken).** Keeps the leaf a leaf; costs each call site one argument.
- **Home it in `specSubject` (rejected, though cheaper).** No signature change, but it nails a plain `GET /admin/users` to the module whose reason for being is the subject — the next caller who wants a non-subject user duplicates it a sixth time. Reuse the verbs, not the nouns.
- **Accept the cycle (rejected).** Worth naming because **no local gate sees an import cycle** — neither `tsc` nor biome reports one, so the first symptom would have been an obscure e2e red later. The choice is structural, not enforced by a red.

The rename rides along: `findVjtUserId` stopped being true when #1078 gave every test its own subject (it resolves `specUser()`, not `vjt`), and with the name now passed from outside it was false twice. The call sites were being touched anyway, so it cost no extra lines.

## Test plan

- [x] `bun run check` rc=0 — the 59 CSS warnings are pre-existing, **measured identical** on the branch point (`393f0f89` at rc=0).
- [x] Scoped e2e, the five specs, **before**: 15 passed on `webkit-iphone-15` + 1 on `chromium`, rc=0, on a pristine `393f0f89` worktree.
- [x] Scoped e2e, the five specs, **after**: **16 passed**, rc=0, both projects, on a stack rebuilt from this worktree.
- [x] Mutant (`u.name === userName` → `${userName}-MUTANT`): **1 failed**, killed with `grappaApi.findUserIdByName: s2cbf33fc absent from …` — a string that exists only in this branch, so the runner is provably executing this code and the spec provably depends on the helper.

⚠️ Note for anyone re-running these: **ten of the eleven** tests across the five files are `@webkit`, and the chromium project carries `grepInvert: /@webkit/`. A `--project=chromium` scoped run executes exactly ONE of them and still reports rc=0.