### PR TITLE
test(#1397): call the canonical start_server/1 at the 22 sites that inlined it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49855,3 +49855,68 @@ rewritten call sites type-checks and fails only at runtime. That is the same
 gap the sibling entries name, and on the `seedCursor` slice it was a runtime
 positive control, not the type-checker, that caught exactly such a
 transposition.
+<!-- entry #1397-startserver -->
+
+---
+
+## 2026-08-18 — #1397: the inlined `start_server/1` body, and which wrapper is a lie
+
+`Grappa.IRCServer.start_server/1` has existed for a while and had 548 callers;
+it also had twenty-two hand-written copies of its two-line body across fourteen
+test files. This entry records how those were selected, which ones were left,
+and why two wrappers of the same shape earned opposite treatment.
+
+### The predicate is the property, not the call shape
+
+A `git grep` for `IRCServer.port(` finds 28 callers in `test/`, and a sweep over
+that shape would have been wrong at four of them. The property that makes a site
+convertible is that it starts the fake peer AND immediately wants its port, with
+neither `start_link` nor a seeded handler state being the thing under assertion.
+The four survivors in `client_test.exs` and `irc_server_test.exs` fail exactly
+that test:
+
+  * the `start_link/2` initial-state case needs an arity `start_server/1` cannot
+    express;
+  * the "start_link/1 still works" case has that call as its subject — converting
+    it deletes the assertion;
+  * the S7 tcp_closed-drain case exercises `IRCServer`'s own primitives, and
+    routing it through a convenience built on top makes it fail for a reason that
+    is not the drain;
+  * `irc_server_test.exs` calls `port/1` on a server it is handed, so it was
+    never one of the copies.
+
+Same posture as the `await_handshake/2` pass earlier the same day, where the
+`{:ok, _}`-shaped predicate protected the four sites that assert on the CONTENT
+of the matched line. The census moved under the slice and both readings are
+kept: selected against `393f0f89` it is 28 callers → 6, the six being the four
+above plus two wrappers #1533 was deleting in parallel; rebased onto
+`1a383ac2` with #1533 landed, the same change reads 26 → 4, and the four are
+exactly the reasoned survivors. A count taken against a base that then moves
+is not wrong, it is dated.
+
+### A wrapper over a no-op is a name; a wrapper over an observable is a lie
+
+Ten of the twenty-two copies lived inside a local zero-arg wrapper. The two
+that wrapped `welcome_handler()` were DELETED in #1533 rather than delegated —
+their call sites now name the handler. The eight that wrap
+`passthrough_handler()` are delegated here instead, and the asymmetry is
+deliberate rather than drift.
+
+The one-pattern rule binds cases that are ALIKE, and these two are not. A
+`welcome_handler` peer WRITES a 001, so hiding it behind a local name hides
+whether registration completes: the wrapper misrepresents what the test set up.
+The passthrough peer's entire contract is to do nothing, so a name over it
+hides no observable at all. That is the line — a wrapper over a no-op is a
+name, a wrapper over an observable is a lie — and it is what "same problem,
+same solution" actually ranges over.
+
+The price confirms the reading from the other side: deleting the eight costs 72
+call sites and an `alias` that does not exist in six of the eight files, and
+buys no change in behaviour. The mechanism would be heavier than the problem.
+
+### `port/1` inside an option map
+
+One site (`client_outbound_cost_test.exs`) called `port/1` inside the client's
+option map rather than binding it first. It converts, but the pair binding has to
+reach the map as a plain variable — a reminder that "the port is used once" is
+not the same as "the port is not needed".

--- a/test/grappa/account_deletion_test.exs
+++ b/test/grappa/account_deletion_test.exs
@@ -34,8 +34,7 @@ defmodule Grappa.AccountDeletionTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   # A registered visitor = identified on some network. #211 phase 7 —

--- a/test/grappa/irc/client_outbound_cost_test.exs
+++ b/test/grappa/irc/client_outbound_cost_test.exs
@@ -30,12 +30,12 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
   end
 
   defp start_pair do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
     {:ok, client} =
       Client.start_link(%{
         host: "127.0.0.1",
-        port: IRCServer.port(server),
+        port: port,
         tls: false,
         dispatch_to: self(),
         logger_metadata: [],

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -837,8 +837,7 @@ defmodule Grappa.IRC.ClientTest do
       # 127.0.0.1, so the observed peer proves the ifaddr bind took effect.
       # Assumes 127.0.0.2 is loopback-bindable (Linux/RPi: all 127/8 is
       # loopback; a non-Linux host would fail legibly with :eaddrnotavail).
-      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       _ = start_client(port, %{source_address: "127.0.0.2"})
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -847,8 +846,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test "NULL source still connects via the pool/kernel-default path" do
-      {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       _ = start_client(port, %{source_address: nil})
       :ok = IRCServer.await_handshake(server, 1_000)

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -26,8 +26,7 @@ defmodule Grappa.LiveIntrospectionTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "list_sessions/0" do

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -29,8 +29,7 @@ defmodule Grappa.OperatorTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "delete_visitor!/1" do

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -59,8 +59,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
       end
     end
 
-    {:ok, server} = IRCServer.start_link(rfc_handler)
-    port = IRCServer.port(server)
+    {server, port} = IRCServer.start_server(rfc_handler)
 
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
     {network, _} = network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")

--- a/test/grappa/session/nick_change_observability_test.exs
+++ b/test/grappa/session/nick_change_observability_test.exs
@@ -71,8 +71,7 @@ defmodule Grappa.Session.NickChangeObservabilityTest do
       end
     end
 
-    {:ok, server} = IRCServer.start_link(rfc_handler)
-    port = IRCServer.port(server)
+    {server, port} = IRCServer.start_server(rfc_handler)
 
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
     {network, _} = network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -11148,8 +11148,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {:ok, server} = IRCServer.start_link(handler)
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
       pid = start_session_for(user, network)
       welcome_session_on_channel(server, "#test")
@@ -11393,8 +11392,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {:ok, server} = IRCServer.start_link(handler)
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
       pid = start_session_for(user, network)
       # Wait for 001 reception so SessionStateHelpers.nick(state) is reconciled (post-001 only).
@@ -12088,8 +12086,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {:ok, server} = IRCServer.start_link(handler)
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
       pid = start_session_for(user, network)
       Process.sleep(50)
@@ -12211,8 +12208,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {:ok, server} = IRCServer.start_link(handler)
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
       pid = start_session_for(user, network)
       Process.sleep(50)
@@ -12851,8 +12847,7 @@ defmodule Grappa.Session.ServerTest do
         end
       end
 
-      {:ok, server} = IRCServer.start_link(handler)
-      port = IRCServer.port(server)
+      {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
       pid = start_session_for(user, network)
       welcome_session_on_channel(server, "#test")

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -26,8 +26,7 @@ defmodule Grappa.Visitors.ReaperTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   defp expire(visitor) do

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -132,8 +132,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # Shared IRC-fake helpers for after-join snapshot tests.
 
   defp start_irc_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
+    IRCServer.start_server(IRCServer.passthrough_handler())
   end
 
   defp setup_user_and_network_with_session(port, extra_cred_attrs \\ %{}) do

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -707,8 +707,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   defp uniq, do: System.unique_integer([:positive])
 
   defp start_irc_server do
-    {:ok, server} = IRCServer.start_link(IRCServer.passthrough_handler())
-    {server, IRCServer.port(server)}
+    IRCServer.start_server(IRCServer.passthrough_handler())
   end
 
   defp stop_session_on_exit(user, network) do

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -45,8 +45,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "GET /admin/sessions — auth gate" do

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -44,8 +44,7 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
   end
 
   defp start_irc_server do
-    {:ok, server} = Grappa.IRCServer.start_link(Grappa.IRCServer.passthrough_handler())
-    {server, Grappa.IRCServer.port(server)}
+    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "DELETE /admin/visitors/:id — auth gate" do

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -360,8 +360,7 @@ defmodule GrappaWeb.NetworksControllerTest do
 
     test "visitor reconnects a parked network → 200 + :connected, spawns session", %{conn: conn} do
       slug = "net-vis-connect-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(irc_server)
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: slug, visitor_enabled: true)
       visitor = visitor_with_credential_fixture(network_slug: slug, nick: "vconn-#{u()}")
       session = visitor_session_fixture(visitor)
@@ -395,8 +394,7 @@ defmodule GrappaWeb.NetworksControllerTest do
       vjt = user_fixture(name: "vjt-patch-connect-#{u()}")
       session = session_fixture(vjt)
       slug = "net-connect-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(irc_server)
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: slug)
       cred = credential_fixture(vjt, network)
 
@@ -440,8 +438,7 @@ defmodule GrappaWeb.NetworksControllerTest do
       vjt = user_fixture(name: "vjt-u0-netcap-#{u()}")
       session = session_fixture(vjt)
       slug = "net-u0-netcap-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(irc_server)
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: slug)
       cred = credential_fixture(vjt, network)
       seed_state(cred, :parked, "user-parked")
@@ -544,8 +541,7 @@ defmodule GrappaWeb.NetworksControllerTest do
         Grappa.Accounts.create_session({:user, vjt.id}, "127.0.0.1", "ua", client_id: client_id)
 
       slug = "net-ux5bc-self-#{u()}"
-      {:ok, irc_server} = IRCServer.start_link(IRCServer.passthrough_handler())
-      port = IRCServer.port(irc_server)
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: slug)
 
       # Pin per-device cap at 1 — the tightest configuration AND the


### PR DESCRIPTION
## What

`Grappa.IRCServer.start_server/1` is `start_link/1` plus `port/1`. Twenty-two
sites across fourteen test files still spelled that body out by hand — eight
inside a local `start_irc_server/0` wrapper, the rest inline in a test body.
They all call the canonical now. Part of #1397.

## Selection, not a sweep

The predicate is the property that makes a site convertible: it starts the fake
peer AND immediately wants its port, and neither `start_link` itself nor a
seeded handler state is what the test asserts on. Four sites fail that
predicate and are left alone, each for a reason:

| site | why it stays |
|---|---|
| `client_test.exs` — `start_link/2` initial state | needs an arity `start_server/1` cannot express |
| `client_test.exs` — "start_link/1 still works" | that call **is** the subject; converting deletes the assertion |
| `client_test.exs` — S7 tcp_closed drain | exercises `IRCServer`'s own primitives; a convenience built on top would make it fail for a reason that is not the drain |
| `irc_server_test.exs` | calls `port/1` on a server it is handed — never one of the copies |

A sweep over the call shape would have eaten all four silently. Same posture as
the `await_handshake/2` pass in #1533.

## Two things a blind sweep would have broken

- The four `networks_controller_test.exs` sites never name the peer again, so
  the pair binding has to drop it — anonymously as `_`, the strategy that file
  already follows and that Credo's consistency check enforces.
- `client_outbound_cost_test.exs` called `port/1` **inside** the client's option
  map rather than binding it. "Used once" is not "not needed".

## Wrappers: eight delegated, not deleted

#1533 DELETED the two wrappers over `welcome_handler()`; the eight over
`passthrough_handler()` are delegated instead. That is deliberate: a
`welcome_handler` peer writes a 001, so a local name over it hides whether
registration completes, while the passthrough peer's contract is to do nothing
and a name over it hides no observable. A wrapper over a no-op is a name; a
wrapper over an observable is a lie. Deleting the eight would cost 72 call
sites and a new `alias` in six files for no behavioural change. Recorded in
DESIGN_NOTES.

## Census

`IRCServer.port/1` callers in `test/`: **26 → 4** on this base. Selected
against `393f0f89` it read 28 → 6; #1533 landed in between and removed two of
those. Both readings are in the DESIGN_NOTES entry — a count taken against a
base that then moves is not wrong, it is dated.

## Gates

`scripts/check.sh` green on this exact tree (post-rebase onto `1a383ac2`):
8 doctests, 61 properties, 6546 tests, 0 failures; Credo, Dialyzer and Sobelow
ran; bats 564 ok / 0 not ok. `design-notes-gate.sh` green.

The rebase opened 8 conflicts, all of them predicted before the rebase — the
lines where #1533 rewrote the same `start_link` call. Each was resolved by
asserting the shape of both sides, and the resulting eight lines were re-read
from the file afterwards.