### PR TITLE
union: carry #1534 + #1530 + #1526 over one gate

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -453,6 +453,26 @@ export async function terminateSession(adminToken: string, sessionId: string): P
   }
 }
 
+// The admin surface keys users by id, and a spec that provisions its subject
+// (#1078) only ever learns the NAME — hence the lookup. The name is a
+// PARAMETER and not `specUser()` read from here: this module imports nothing,
+// and reaching for the subject would make it import `specSubject`, which
+// already imports this one.
+export async function findUserIdByName(adminToken: string, userName: string): Promise<string> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.findUserIdByName: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { users: { id: string; name: string }[] };
+  const user = body.users.find((u) => u.name === userName);
+  if (!user) {
+    throw new Error(`grappaApi.findUserIdByName: ${userName} absent from ${JSON.stringify(body)}`);
+  }
+  return user.id;
+}
+
 // #1158 item 4 — the lifecycle log collapsed to one entry per session.
 // A spec uses this as a PRECONDITION barrier, never as the property under
 // test: the log is a bounded global ring written from an async cast, so a

--- a/cicchetto/e2e/fixtures/seedData.ts
+++ b/cicchetto/e2e/fixtures/seedData.ts
@@ -55,7 +55,35 @@ export const VJT_IDENTIFIER = "vjt@grappa.test";
 
 export const NETWORK_SLUG = "bahamut-test";
 export const NETWORK_NICK = "vjt-grappa";
-export const AUTOJOIN_CHANNELS = ["#bofh"];
+
+// #1336 — the per-spec subject (#1078) autojoins THIS channel, and the
+// three long-lived seeded users (`vjt`, `m9b-test`, `m9b-victim`, bound
+// with `--autojoin '#bofh'` in compose.yaml) are NOT in it. Every
+// provision/teardown used to JOIN and QUIT the shared `#bofh`, and
+// bahamut fanned both out to whoever was sitting there: measured on a
+// 6-test pilot, 42 rows landed in the three co-residents' scrollback,
+// 7.00 per test — rows no spec asked for and every later spec reads.
+//
+// It is the CO-RESIDENCE that writes them, not the channel's name, so
+// the cure is to stop sharing a room, not to rename it. `#bofh` stays
+// exactly as seeded for the specs that drive the seeded users directly.
+//
+// 🔴 Worker-scoped, and the scope is load-bearing: `playwright.config.ts`
+// runs `workers: 1, fullyParallel: false`, so at most ONE per-spec
+// subject is alive at a time and a single channel is enough. Derived
+// from `TEST_PARALLEL_INDEX` (Playwright sets it per worker process,
+// `playwright/lib/worker/workerMain.js`) so that if the suite ever
+// parallelises, the subjects do not silently become co-residents of
+// each other and re-grow the residue this removed. The constant is
+// evaluated once per process, which is what keeps the ~292 spec files
+// that read it unchanged.
+//
+// `globalSetup` runs in the runner process, where Playwright sets no
+// worker index — the `setup` spelling is deliberately NOT `0`, so a
+// channel named `#spec-wsetup` in a failure log reads as "resolved
+// outside a worker" instead of impersonating worker zero.
+const SPEC_WORKER = process.env.TEST_PARALLEL_INDEX ?? "setup";
+export const AUTOJOIN_CHANNELS = [`#spec-w${SPEC_WORKER}`];
 
 // M-cluster M-7 — admin user. Seeded via mix run -e in the seeder
 // sidecar after `create_user` (no --admin flag on the mix task; M-7

--- a/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
+++ b/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
@@ -31,7 +31,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "b0-invitee";
@@ -47,7 +47,7 @@ test("B0 — /invite from $server window (no channel context) reaches upstream +
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o (so /invite has the privileges to send). Same template
   // as p0e-invite-ack.spec.ts:53-60.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   await expect(
     page.locator(".sidebar-network-section li").filter({ hasText: CHANNEL }),

--- a/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
@@ -14,10 +14,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("CP13 S10 — peer's bold-formatted PRIVMSG renders with .scrollback-mirc-bold span", async ({
   page,

--- a/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
@@ -28,10 +28,10 @@ import {
   selectChannel,
   sidebarMessageBadge,
 } from "../fixtures/cicchettoPage";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("CP13 S5 — /msg to nonexistent nick: 401 lands in the query window live", async ({ page }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
+++ b/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
@@ -18,11 +18,11 @@ import {
   sidebarMessageBadge,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
 const SERVER_WINDOW_LABEL = "Server";
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.describe("CP13 server-window cluster", () => {
   test("S6 — bottom numeric-inline pane is gone (no `.numeric-inline-pane` in DOM)", async ({

--- a/cicchetto/e2e/tests/issue1336-spec-channel-worker-scoped.spec.ts
+++ b/cicchetto/e2e/tests/issue1336-spec-channel-worker-scoped.spec.ts
@@ -1,0 +1,29 @@
+// #1336 — the per-spec subject's autojoin channel must be WORKER-SCOPED.
+//
+// `AUTOJOIN_CHANNELS` moved off the shared `#bofh` so that the three
+// long-lived seeded users stop collecting a JOIN and a QUIT from every
+// test that provisions a subject (measured: 42 rows over a 6-test pilot,
+// 7.00 per test, all of them in scrollback no spec asked for).
+//
+// That cure is only correct while at most ONE per-spec subject is alive
+// at a time. `playwright.config.ts` says `workers: 1`, and the channel
+// name carries `TEST_PARALLEL_INDEX` so the guarantee survives a future
+// `workers: N` instead of silently re-growing the residue in a channel
+// shared by parallel subjects.
+//
+// This spec is the oracle for the derivation actually happening: the
+// constant is evaluated at module scope, and if Playwright ever stops
+// exporting the worker index there, the name degrades to the `setup`
+// spelling and this goes red. Bare `@playwright/test` import on purpose
+// — it reads a constant, so provisioning a subject for it would be
+// paying for a session nobody uses.
+
+import { expect, test } from "@playwright/test";
+import { AUTOJOIN_CHANNELS } from "../fixtures/seedData";
+
+test("#1336 — the per-spec autojoin channel is worker-scoped, not the shared #bofh", () => {
+  expect(AUTOJOIN_CHANNELS).toHaveLength(1);
+  // `\d+` and not `\d*`: the runner-process spelling (`#spec-wsetup`)
+  // reaching a worker is the exact failure this guards.
+  expect(AUTOJOIN_CHANNELS[0]).toMatch(/^#spec-w\d+$/);
+});

--- a/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
+++ b/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
@@ -27,10 +27,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("issue #14 — operator's own /me renders as '* nick body', not raw privmsg", async ({
   page,

--- a/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
+++ b/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
@@ -20,10 +20,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("issue142 — QUIT reason renders mIRC bold+color spans (not raw control bytes)", async ({
   page,

--- a/cicchetto/e2e/tests/issue189-perform.spec.ts
+++ b/cicchetto/e2e/tests/issue189-perform.spec.ts
@@ -14,10 +14,10 @@
 
 import { loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -21,7 +21,7 @@
 // then reverted in afterEach so the shared stack baseline is restored.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -29,21 +29,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -66,7 +51,7 @@ test.describe("#291 — home launcher in the rail actions drawer", () => {
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -24,7 +24,7 @@
 // shared baseline is restored (mirrors #291).
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -32,21 +32,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -78,7 +63,7 @@ test.describe("#299 — admin reachable from the rail actions drawer", () => {
   // user id has to be resolved per test — a once-per-file lookup would
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
-    vjtUserId = await findVjtUserId(getSeededAdmin().token);
+    vjtUserId = await findUserIdByName(getSeededAdmin().token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
+++ b/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
@@ -31,10 +31,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue409-alias-edit.spec.ts
+++ b/cicchetto/e2e/tests/issue409-alias-edit.spec.ts
@@ -13,10 +13,10 @@
 import type { Page } from "@playwright/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue409-alias-tab-scope.spec.ts
+++ b/cicchetto/e2e/tests/issue409-alias-tab-scope.spec.ts
@@ -19,10 +19,10 @@
 
 import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
+++ b/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
@@ -24,10 +24,10 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = "#bofh";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 

--- a/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
+++ b/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
@@ -17,10 +17,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 const tag = (prefix: string) => `${prefix}-${crypto.randomUUID().slice(0, 6)}`;
 
 test("issue455 — *bold* _underline_ /italic/ render client-side with the markers kept", async ({

--- a/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
+++ b/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
@@ -28,12 +28,12 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 // vjt is autojoined here (seedData.AUTOJOIN_CHANNELS) — the window the peer
 // posts the `#channel`-bearing PRIVMSG into.
-const HOST_CHANNEL = "#bofh";
+const HOST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // A fresh peer nick per run — a static nick rotates to `<nick>1` on a 433
 // collision under the shared leaf, and the join matcher waits on the

--- a/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
+++ b/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
@@ -60,12 +60,12 @@ test("M9 — sidebar X-button PARTs the channel and dismisses the window", async
   // be installed when the PART echo arrives.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Click the X button on #bofh's sidebar entry.
-  // Sidebar.tsx renders `aria-label="Close #bofh"` — use that as the
-  // selector hook so future cosmetic class changes (.sidebar-close
-  // → .sidebar-x or whatever) don't break the test.
+  // Click the X button on the channel's sidebar entry.
+  // Sidebar.tsx renders `aria-label="Close <channel>"` — use that as
+  // the selector hook so future cosmetic class changes
+  // (.sidebar-close → .sidebar-x or whatever) don't break the test.
   await sidebarWindow(page, NETWORK_SLUG, CHANNEL)
-    .locator('button[aria-label="Close #bofh"]')
+    .locator(`button[aria-label="Close ${CHANNEL}"]`)
     .click();
 
   // #195 — the × now opens an explicit "leave #chan?" confirm modal; the PART

--- a/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
+++ b/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
@@ -33,7 +33,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "members-prefix-buddy";
@@ -46,7 +46,7 @@ test("members pane renders @-prefix + full op nick (not clipped)", async ({ page
   // Focus #bofh first to confirm login + ws-ready, then /join the
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o deterministically.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   await expect(
     page.locator(".sidebar-network-section li").filter({ hasText: CHANNEL }),

--- a/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
+++ b/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
@@ -12,10 +12,10 @@
 
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const TEST_CHANNEL = "#bofh";
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("full mIRC: peer PRIVMSG renders strikethrough + monospace + hex-color spans", async ({
   page,

--- a/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
+++ b/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
@@ -33,7 +33,7 @@
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import { NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "p0e-invitee";
@@ -50,7 +50,7 @@ test("P-0e + P-0f — /invite to a peer surfaces invite-ack row in the $server w
   // channel that doesn't have a sidebar slot yet, so /join via
   // composeSend from any focused window. specNick() is needed for
   // selectChannel's join-line wait on the prior step.
-  await selectChannel(page, NETWORK_SLUG, "#bofh", { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
   await composeSend(page, `/join ${CHANNEL}`);
   // Wait for the new channel's sidebar entry to appear (proves the
   // JOIN landed + windowState transitioned to :joined; the sidebar

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -423,14 +423,17 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // joined channel on its Phoenix join-ok (subscribe.ts) — REFRESH_LIMIT
     // (200) == the seed size, so #bofh loads ALL rows in the background
     // WITHOUT us focusing it. Register the waiter BEFORE loginAs so the
-    // post-boot fetch can't slip past us; awaiting it proves #bofh is warm
-    // (rows in the store) before we switch into it. Without warmth the
+    // post-boot fetch can't slip past us; awaiting it proves the channel is
+    // warm (rows in the store) before we switch into it. Without warmth the
     // switch's scrollToActivation early-returns on an empty pane and the
     // length-effect tails — the marker jump only fires against a settled,
-    // populated pane. The URL is `.../channels/%23bofh/messages?after=…`
-    // (encodeURIComponent("#bofh") === "%23bofh").
-    const bofhWarm = page.waitForResponse(
-      (r) => r.url().includes(`/channels/%23bofh/messages`) && r.status() === 200,
+    // populated pane. The URL is `.../channels/<encoded>/messages?after=…`,
+    // and the encoding is derived rather than spelled: the `%23bofh` this
+    // used to carry survived every `#bofh` grep and outlived the channel
+    // it named (#1336).
+    const channelWarm = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/channels/${encodeURIComponent(CHANNEL)}/messages`) && r.status() === 200,
       { timeout: 20_000 },
     );
 
@@ -445,7 +448,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     await expect(page.locator('[data-testid="scrollback"]')).toBeVisible({ timeout: 10_000 });
 
     // #bofh scrollback fetched → warm. Only now is the switch a warm one.
-    await bofhWarm;
+    await channelWarm;
 
     // THE SWITCH — click #bofh in the sidebar. key() changes $server→#bofh,
     // firing the channel-switch key-effect (prevKey defined, so NOT the

--- a/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
@@ -53,6 +53,7 @@
 // JS-mounted side-effect bucket. Single visitor login suffices.
 
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -188,41 +189,52 @@ test("@webkit ux-5-bv — mobile members drawer auto-closes when operator taps a
   // both populated AND own-nick presence as part of the precondition.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Open the mobile members drawer (hamburger in TopicBar).
-  await page.getByLabel(/open members sidebar/i).tap();
-  const drawer = page.locator(".shell-members.open");
-  await expect(drawer).toBeVisible({ timeout: 5_000 });
+  // #1336 — the tap below needs a member that is NOT self, and this
+  // spec is the one place in the suite that read one out of the
+  // channel's ambient population. That population used to be the three
+  // long-lived seeded users sitting in the shared `#bofh`; the per-spec
+  // subject now has the channel to itself, so the peer has to be
+  // brought here rather than assumed.
+  const peer = await IrcPeer.connect({ nick: "ux5bv-buddy" });
+  try {
+    await peer.join(CHANNEL);
 
-  // Members list precondition: populated + own-nick present
-  // (`feedback_e2e_visitor_members_list` mandate). specNick() is the
-  // operator's per-network nick on the auto-join channel.
-  const memberButtons = drawer.locator(".members-pane li .member-name");
-  await expect(memberButtons.first()).toBeVisible({ timeout: 10_000 });
-  const memberCount = await memberButtons.count();
-  expect(memberCount).toBeGreaterThan(0);
-  const ownNickPresent = await drawer
-    .locator(`.members-pane li .member-name:has-text("${specNick()}")`)
-    .count();
-  expect(ownNickPresent).toBeGreaterThan(0);
+    // Open the mobile members drawer (hamburger in TopicBar).
+    await page.getByLabel(/open members sidebar/i).tap();
+    const drawer = page.locator(".shell-members.open");
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
 
-  // Find a member other than self (tapping self would be a no-op).
-  // Structured locator — `hasNotText` rejects any row whose text
-  // contains specNick() as substring (so a "vjt-bot" peer would
-  // also be skipped when own-nick is "vjt"). With the seeded
-  // auto-join channel there's always at least one non-self peer, so
-  // `.first()` resolves; if seeding ever drifts the test fails loud
-  // at the tap rather than running a silent off-by-one loop.
-  const target = drawer
-    .locator(".members-pane li .member-name")
-    .filter({ hasNotText: specNick() })
-    .first();
-  await expect(target).toBeVisible({ timeout: 5_000 });
-  await target.tap();
+    // Members list precondition: populated + own-nick present
+    // (`feedback_e2e_visitor_members_list` mandate). specNick() is the
+    // operator's per-network nick on the auto-join channel.
+    const memberButtons = drawer.locator(".members-pane li .member-name");
+    await expect(memberButtons.first()).toBeVisible({ timeout: 10_000 });
+    const memberCount = await memberButtons.count();
+    expect(memberCount).toBeGreaterThan(0);
+    const ownNickPresent = await drawer
+      .locator(`.members-pane li .member-name:has-text("${specNick()}")`)
+      .count();
+    expect(ownNickPresent).toBeGreaterThan(0);
 
-  // Post-tap: drawer should be CLOSED (BV auto-close contract). Pre-BV
-  // the drawer stayed open over the newly-opened query window's
-  // ComposeBox; on iOS the keyboard overlay then sat on top of the
-  // drawer's bottom launcher footer (BM) leaving no visible compose
-  // surface. Auto-close kills the conflict.
-  await expect(page.locator(".shell-members.open")).toBeHidden({ timeout: 5_000 });
+    // Tap the peer that joined above — tapping self would be a no-op.
+    // Structured locator — `hasNotText` rejects any row whose text
+    // contains specNick() as substring (so a "vjt-bot" peer would
+    // also be skipped when own-nick is "vjt"), which is why the row is
+    // reached by exclusion rather than by the peer's own nick.
+    const target = drawer
+      .locator(".members-pane li .member-name")
+      .filter({ hasNotText: specNick() })
+      .first();
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await target.tap();
+
+    // Post-tap: drawer should be CLOSED (BV auto-close contract). Pre-BV
+    // the drawer stayed open over the newly-opened query window's
+    // ComposeBox; on iOS the keyboard overlay then sat on top of the
+    // drawer's bottom launcher footer (BM) leaving no visible compose
+    // surface. Auto-close kills the conflict.
+    await expect(page.locator(".shell-members.open")).toBeHidden({ timeout: 5_000 });
+  } finally {
+    await peer.disconnect("ux-5-bv done");
+  }
 });

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -29,27 +29,12 @@
 // channel + rail drawer) without ripple-affecting other specs.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -75,7 +60,7 @@ test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () 
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -38,28 +38,13 @@
 // references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(60_000);
-
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
 
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
@@ -82,10 +67,10 @@ async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean
 // string, NOT a real bearer token). That bypassed admin auth → 401
 // → `users.users` undefined → `.find` crashed before reaching the UI
 // assertions. Mirrors the working pattern in ux-6-g-admin-mobile-h-scroll
-// (findVjtUserId + setAdminFlag with `getSeededAdmin().token`).
+// (findUserIdByName + setAdminFlag with `getSeededAdmin().token`).
 async function promoteVjtToAdmin(): Promise<{ revert: () => Promise<void> }> {
   const admin = getSeededAdmin();
-  const vjtUserId = await findVjtUserId(admin.token);
+  const vjtUserId = await findUserIdByName(admin.token, specUser().name);
   await setAdminFlag(admin.token, vjtUserId, true);
   return {
     revert: async () => {

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -54,6 +54,7 @@
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
+  findUserIdByName,
   GRAPPA_BASE_URL,
   listSessionLogSessions,
   mintVisitor,
@@ -170,21 +171,6 @@ type Offender = {
   clientW: number;
 };
 
-async function findVjtUserId(adminToken: string): Promise<string> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users`, {
-    headers: { authorization: `Bearer ${adminToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`GET /admin/users → ${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as { users: { id: string; name: string }[] };
-  const vjt = body.users.find((u) => u.name === specUser().name);
-  if (!vjt) {
-    throw new Error(`vjt user not found in admin users list: ${JSON.stringify(body)}`);
-  }
-  return vjt.id;
-}
-
 async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
@@ -264,7 +250,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
   // hold the id of a user that no longer exists.
   test.beforeEach(async () => {
     const admin = getSeededAdmin();
-    vjtUserId = await findVjtUserId(admin.token);
+    vjtUserId = await findUserIdByName(admin.token, specUser().name);
   });
 
   test.afterEach(async () => {

--- a/cicchetto/src/lib/commands/fanout.ts
+++ b/cicchetto/src/lib/commands/fanout.ts
@@ -1,0 +1,84 @@
+import { requestConfirm } from "../confirmDialog";
+import { friendlyError } from "../friendlyError";
+import { joinedChannelsOnNetwork } from "../joinedChannels";
+import { sendFanOut } from "../sendPipeline";
+import type { CommandHandler } from "./context";
+
+// #431 — above this many channels an /ame|/amsg asks before it writes anything.
+// A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
+// writes to N channels is a spam vector, and ten is where a fan-out stops
+// reading as "the rooms I am in" and starts reading as a broadcast.
+const FANOUT_CONFIRM_THRESHOLD = 10;
+
+/**
+ * #431 — /ame + /amsg: the same body to EVERY joined channel of THIS network.
+ * Deliberately not addressed to the active window: the fan-out is per-NETWORK
+ * (vjt 2026-08-09 — cross-network is out of scope, and no flag for it), so it
+ * works from the $server window just as well as from a channel, and it
+ * includes the window it was typed in.
+ *
+ * ONE handler for two kinds: the pair differ only by the ACTION framing, which
+ * `cmd.kind` already decides, so splitting them would duplicate the confirm
+ * gate and the partial-failure accounting.
+ *
+ * #1396 — it reaches the seam at zero new fields on the record. Everything it
+ * needs beyond `ctx.key` and `ctx.networkSlug` is an ordinary module import,
+ * which is what tells it apart from `privmsg`/`me`/`msg`: those close over the
+ * composer's draft store (`sendPacedBody`), this one never touches the buffer.
+ */
+export const fanOutCommand: CommandHandler<"ame" | "amsg"> = async (cmd, ctx) => {
+  const action = cmd.kind === "ame";
+  // The joined-channel projection #30's channel tab-completion already reads:
+  // server-owned, so `invited` (the window an unsolicited INVITE opens),
+  // `pending`, `failed`, `kicked` and `parked` are all excluded by the same
+  // `joined` predicate, and there is no parallel client-side channel list to
+  // drift from it. Queries and $server cannot appear at all — `window_states`
+  // is channel-keyed by construction on the server, a DM lives in
+  // `queryWindows`.
+  const targets = joinedChannelsOnNetwork(ctx.key).sort();
+  if (targets.length === 0) {
+    return { error: `/${cmd.kind}: no joined channel on ${ctx.networkSlug}` };
+  }
+  // Channels the fan-out has finished, for the "how far did it get" half of a
+  // failure — the number that tells the operator whether retyping the line
+  // would double-send it.
+  let done = 0;
+  const run = (): Promise<void> =>
+    sendFanOut(ctx.networkSlug, targets, cmd.body, action, (n) => {
+      done = n;
+    });
+  if (targets.length > FANOUT_CONFIRM_THRESHOLD) {
+    // The question names every target, not just the count: the blast radius IS
+    // the thing being consented to, so "11 channels" alone would be consent
+    // without disclosure.
+    requestConfirm({
+      title: action ? "Send action to every channel" : "Send message to every channel",
+      body: `Send to ${targets.length} channels on ${ctx.networkSlug}? ${targets.join(", ")}`,
+      confirmLabel: "Send",
+      // Detached: `requestConfirm` resolves nothing, so the send cannot be
+      // awaited here and its failure cannot surface inline the way the
+      // un-gated path's does below. Logged with a grep key instead, mirroring
+      // `windowClose.disconnectNetwork` — the same shape of
+      // destructive-action-behind-a-confirm. Never bare: an unhandled
+      // rejection here would be a fan-out that stopped in silence.
+      onConfirm: () => {
+        void run().catch((err) => {
+          console.warn(
+            `[/${cmd.kind}] fan-out stopped after ${done} of ${targets.length} channels on ${ctx.networkSlug}:`,
+            err,
+          );
+        });
+      },
+      alternative: null,
+    });
+    return { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
+  }
+  try {
+    await run();
+  } catch (e) {
+    return {
+      error: `${friendlyError(e)} — sent to ${done} of ${targets.length} channels`,
+    };
+  }
+  return { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
+};

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -5,6 +5,7 @@ import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
+import { fanOutCommand } from "./commands/fanout";
 import { watchlistCommand } from "./commands/highlight";
 import {
   aliasDefineCommand,
@@ -62,7 +63,6 @@ import {
 } from "./commands/session";
 import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
 import { joinCommand, listCommand, partCommand, queryCommand } from "./commands/window";
-import { requestConfirm } from "./confirmDialog";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -79,7 +79,7 @@ import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // different recipient while echoing here, so it is named for the window, not
 // for one of the verbs it can carry.
 import { selectedChannel, setSelectedChannel } from "./selection";
-import { draftLines, sendBodyLines, sendFanOut, wireBody } from "./sendPipeline";
+import { draftLines, sendBodyLines, wireBody } from "./sendPipeline";
 import { isServicesSender } from "./servicesSender";
 import { parseSlash } from "./slashCommands";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
@@ -208,12 +208,6 @@ const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
   if (keys.length === 0) sessionStorage.removeItem(DRAFTS_KEY);
   else sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(drafts));
 };
-
-// #431 — above this many channels an /ame|/amsg asks before it writes anything.
-// A DECIDED number (vjt, 2026-08-09), not a tuned one: one keystroke that
-// writes to N channels is a spam vector, and ten is where a fan-out stops
-// reading as "the rooms I am in" and starts reading as a broadcast.
-const FANOUT_CONFIRM_THRESHOLD = 10;
 
 /**
  * #1108 — what the current draft will do to the wire, or `null` when there is
@@ -784,68 +778,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = r;
           break;
         }
-        // #431 — /ame + /amsg: the same body to EVERY joined channel of THIS
-        // network. Deliberately not addressed to the active window: the fan-out
-        // is per-NETWORK (vjt 2026-08-09 — cross-network is out of scope, and
-        // no flag for it), so it works from the $server window just as well as
-        // from a channel, and it includes the window it was typed in.
         case "ame":
         case "amsg": {
-          const action = cmd.kind === "ame";
-          // The joined-channel projection #30's channel tab-completion already
-          // reads: server-owned, so `invited` (the window an unsolicited INVITE
-          // opens), `pending`, `failed`, `kicked` and `parked` are all excluded
-          // by the same `joined` predicate, and there is no parallel
-          // client-side channel list to drift from it. Queries and $server
-          // cannot appear at all — `window_states` is channel-keyed by
-          // construction on the server, a DM lives in `queryWindows`.
-          const targets = joinedChannelsOnNetwork(key).sort();
-          if (targets.length === 0) {
-            return { error: `/${cmd.kind}: no joined channel on ${networkSlug}` };
-          }
-          // Channels the fan-out has finished, for the "how far did it get"
-          // half of a failure — the number that tells the operator whether
-          // retyping the line would double-send it.
-          let done = 0;
-          const run = (): Promise<void> =>
-            sendFanOut(networkSlug, targets, cmd.body, action, (n) => {
-              done = n;
-            });
-          if (targets.length > FANOUT_CONFIRM_THRESHOLD) {
-            // The question names every target, not just the count: the blast
-            // radius IS the thing being consented to, so "11 channels" alone
-            // would be consent without disclosure.
-            requestConfirm({
-              title: action ? "Send action to every channel" : "Send message to every channel",
-              body: `Send to ${targets.length} channels on ${networkSlug}? ${targets.join(", ")}`,
-              confirmLabel: "Send",
-              // Detached: `requestConfirm` resolves nothing, so the send cannot
-              // be awaited here and its failure cannot surface inline the way
-              // the un-gated path's does below. Logged with a grep key instead,
-              // mirroring `windowClose.disconnectNetwork` — the same shape of
-              // destructive-action-behind-a-confirm. Never bare: an unhandled
-              // rejection here would be a fan-out that stopped in silence.
-              onConfirm: () => {
-                void run().catch((err) => {
-                  console.warn(
-                    `[/${cmd.kind}] fan-out stopped after ${done} of ${targets.length} channels on ${networkSlug}:`,
-                    err,
-                  );
-                });
-              },
-              alternative: null,
-            });
-            result = { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
-            break;
-          }
-          try {
-            await run();
-          } catch (e) {
-            return {
-              error: `${friendlyError(e)} — sent to ${done} of ${targets.length} channels`,
-            };
-          }
-          result = { ok: `/${cmd.kind}: sent to ${targets.join(", ")}` };
+          result = await fanOutCommand(cmd, ctx);
           break;
         }
         case "ctcp": {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49409,3 +49409,103 @@ row came back.
 
 No local full-suite baseline was taken on the branch point, so none of the
 above rests on one; the both-sides evidence is CI's.
+<!-- entry #1396-fanout -->
+
+---
+
+## 2026-08-18 — #1396: the fan-out pair was never blocked, and the boundary is the draft store
+
+`/ame` and `/amsg` were the last pair anyone believed the send pipeline held
+back. They were not blocked, and this entry records the correction rather than
+the conclusion, because the wrong premise is the part that cost time.
+
+### The premise that fell
+
+Carried for weeks, and stated again when this slice was briefed: the fan-out
+pair is held in `compose.ts` by "the pipeline axis", the same force that holds
+`privmsg` / `me` / `msg`. Measured on `d60a7a72`, that is false, and it was
+already false when the belief was last repeated.
+
+Every value the pair reads is an ordinary module import: `sendFanOut`
+(`./sendPipeline`), `requestConfirm` (`./confirmDialog`),
+`joinedChannelsOnNetwork` (`./joinedChannels`), `friendlyError`. It touches the
+composer buffer nowhere — no `sendPacedBody`, no `claimDrafts`, no `getDraft`.
+`FANOUT_CONFIRM_THRESHOLD` was a module-level const in `compose.ts` with exactly
+one reader, so it travelled with the handler.
+
+### What actually changed under it, and what did not
+
+Two lifts made the pair movable, both landed under #1513 and neither of them
+about this pair. They are NOT the same kind of change, and collapsing them into
+"the hoist moved `sendFanOut`" is what let the premise survive:
+
+* `6ef878fe` moved `sendFanOut` into `./sendPipeline`. It had never been a
+  closure — it was already a module-level `const` at column 0 of `compose.ts`.
+  What blocked `commands/` was that it was never EXPORTED, and `compose.ts`
+  imports `commands/*`, so publishing it there would have pointed the
+  dependency back at the importer. The lift is what removed the obstacle, but
+  the obstacle was reachability, not the draft store.
+* `5779c755` lifted `joinedChannelsOnNetwork` out of the controller closure.
+  THIS one had genuinely been a closure. It is the harder half of the
+  unblocking and the half the premise never named.
+
+So the pair was unblocked by a lift that was not aimed at it, and nobody
+re-measured. The lesson is narrow and worth keeping: **when a slice is declined
+for a stated blocker, the blocker is a measurement with an expiry date, not a
+property.** Re-measure it before repeating it.
+
+### Where the boundary really is
+
+The three arms that remain inline — `privmsg`, `me`, `msg` — are held by
+`sendPacedBody`, a closure over `claimDrafts` / `releaseDrafts` / `getDraft`.
+The boundary is the **draft store**, not the send pipeline, and
+`commands/context.ts` has been saying so in its own words ("`compose.ts` keeps
+the store and the send pipeline") while the spoken version drifted to the
+second half of that sentence. The #1513 ruling stands on its own reason (#737:
+publishing `writeState` would make the drain-lock bypass importable) and is not
+reopened here.
+
+State of the switch after this slice: 55 of 59 arms delegate to a
+`*Command(cmd, ctx)` handler; three bodies remain inline, plus the `default`
+exhaustiveness guard, which is not a verb.
+
+### What bought the move
+
+Five mutants on the arm, run against the FULL unit suite before and after, with
+the set of killing tests compared — not just the count:
+
+| mutant | killers before | after | same set |
+|---|---|---|---|
+| fan-out sends to ONE channel | 7 | 7 | yes |
+| confirm gate never fires | 4 | 4 | yes |
+| ACTION framing forced off | 1 | 1 | yes |
+| empty-target guard removed | 1 | 1 | yes |
+| target list left unsorted | 1 | 1 | yes |
+
+The fan-out mutant is the one that matters for a pair whose whole job is
+reaching every channel, and it reddens the same seven tests on both sides.
+
+### A degeneration measured and deliberately not fixed here
+
+The #1396 characterization net does NOT protect the fan-out. Its `ame` and
+`amsg` rows submit into eleven joined channels leaked from the preceding
+`describe` (the net never seeds `windowStateByChannel` itself), so both rows
+stop at the confirm gate and send nothing. The evidence is the mutant table
+above: the fan-out mutant kills seven tests and NONE of them is a net row,
+while the gate mutant kills two net rows.
+
+The net already declares `indistinguishablePairs: [["ame", "amsg"]]`, but the
+CAUSE of that pairing was not declared — seeding the net with two joined
+channels instead of the leaked eleven flips both inline snapshots, which is how
+the leak was established rather than inferred.
+
+Not repaired inside this slice, deliberately: the move is already bought by the
+dedicated `#431` describes, the degeneration is identical before and after, and
+strengthening the net changes two inline snapshots and needs its own red. Same
+call as #1518.
+
+### Limits of this measurement
+
+The unit suite and `bun run check` are the whole of it. No e2e spec was run.
+The `console.warn` on the detached confirm path is unasserted before and after,
+so the mutant table says nothing about it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49240,3 +49240,55 @@ one. The inline censuses above are static: `git grep` plus body extraction,
 whitespace-normalised. On the e2e side no hand-pass was made for bodies
 never extracted into a named function, so 61 remains a lower bound, exactly
 as the issue says._
+<!-- entry #1397-e2e-findvjtuserid -->
+
+---
+
+## 2026-08-18 — #1397 (e2e): one user-id lookup, and where a shared helper may live
+
+Five spec files carried the same 14-line `findVjtUserId` — byte-identical, md5
+equal across all five, the only helper in the #1397 census with no drift at
+all. It is now `grappaApi.findUserIdByName(adminToken, userName)`, and the five
+copies are gone.
+
+### The fork the extraction hid
+
+The helper reads `specUser()`, which lives in `fixtures/specSubject.ts`, and
+`specSubject` imports `grappaApi`. Dropping the helper into `grappaApi`
+unchanged would therefore have made the two modules import each other.
+`grappaApi` is the only LEAF of the fixture graph — `grep -c '^import'` is
+**0**, and four fixture modules import it — so that cycle would have been paid
+by the one module that has no dependencies at all, for fourteen lines.
+
+Homing it in `specSubject` instead was the cheaper option and was rejected on
+the boundary, not on the cost: a `GET /admin/users` is a VERB, and verbs are
+what gets reused; parking it in the module whose reason for being is the
+subject would make the first caller who wants a NON-subject user duplicate it
+again. Passing the name as a parameter costs each of the five call sites one
+argument and keeps the leaf a leaf.
+
+Accepting the cycle was the third option and is the one worth naming, because
+**no local gate would have caught it**: neither `tsc` nor biome reports an
+import cycle, so the first symptom would have been an obscure e2e red at some
+later date. The choice here is structural and is NOT defended by a red.
+
+### Why the name changed in the same slice
+
+`findVjtUserId` has been false since #1078 gave every test its own subject: it
+resolves `specUser()`, not `vjt`. With the name now supplied by the caller it
+was false twice over, and the five call sites were being edited anyway, so the
+rename cost no extra lines. A wrong name in a SHARED fixture is the kind of
+thing this suite propagates by copy — which is how there came to be five of
+these in the first place.
+
+### What gated it
+
+`bun run check` is rc=0 (the 59 CSS warnings are pre-existing, measured
+identical on the branch point). The behavioural gate is the five specs
+themselves, run before and after.
+
+One trap worth leaving behind for whoever touches these files next: **ten of
+the eleven tests across them are `@webkit`**, and the chromium project carries
+`grepInvert: /@webkit/`. A scoped run with `--project=chromium` therefore
+executes exactly ONE of the eleven and still reports rc=0 — a green that
+measures almost nothing. These five want `--project=webkit-iphone-15`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49292,3 +49292,87 @@ the eleven tests across them are `@webkit`**, and the chromium project carries
 `grepInvert: /@webkit/`. A scoped run with `--project=chromium` therefore
 executes exactly ONE of the eleven and still reports rc=0 — a green that
 measures almost nothing. These five want `--project=webkit-iphone-15`.
+<!-- entry #1336-spec-channel -->
+
+---
+
+## 2026-08-18 — #1336: the per-spec subject gets a room of its own
+
+#1078 gave every test its own SUBJECT — its own user, credential, nick,
+seeded scrollback and session — because a shared user can only be cleaned
+by a list, and a list only cleans what somebody remembered to put on it.
+It left one thing shared: the CHANNEL. Every provisioned subject autojoined
+`#bofh`, where the three long-lived seeded users (`vjt`, `m9b-test`,
+`m9b-victim`) sit by compose bind, and bahamut fans a JOIN and a QUIT out
+to whoever is in the room.
+
+### What the residue actually is, measured
+
+A 6-test chromium pilot on `038a33ca`, counting rows in the co-residents'
+scrollback whose sender is a spec subject (`s` + 8 hex):
+
+| run | rows | per test | shape |
+|---|---|---|---|
+| before | 42 | 7.00 | 36 presence (6 JOIN + 6 QUIT each × 3 co-residents) + 6 content |
+| after | 0 | 0 | — |
+| mutant (constant put back to `#bofh`) | 39 | 6.50 | the same 36 presence + 3 content |
+
+The presence half is structural and reproduced to the row; the content half
+is whatever the specs happened to say out loud (two `/me` specs in the
+pilot) and is not stable between runs, which is why the claim rests on the
+36 and not on the totals.
+
+These rows outlive the test that wrote them. The subject is deleted at
+teardown and its OWN copies go with it; the co-residents' copies stay, and
+every later spec reading that channel reads them.
+
+The `~2.9 rows/test` figure inherited from the closed #1137 is NOT this
+number and is not confirmed by it: it averages over the whole suite,
+including the specs that provision no subject at all, so it has a different
+denominator.
+
+### Why the channel's name was changed, and not the specs
+
+It is the CO-RESIDENCE that writes the rows, not the name of the room, so
+the cure is to stop sharing one. A per-TEST channel — the shape the slice
+plan called for — cannot be reached from a module-scope constant, and all
+292 spec files that name `AUTOJOIN_CHANNELS` do so at module scope; every
+one of them also drives the per-spec subject (measured: zero exceptions).
+So a per-test channel would have dragged a 292-file codemod into the
+change, to buy an isolation that `workers: 1` already provides. Changing
+the VALUE of the constant moves all 292 callers without editing one.
+
+`#bofh` is left exactly as seeded, for the specs that drive the seeded
+users directly.
+
+### The constraint this carries, and how it is paid
+
+The cure is correct BECAUSE `playwright.config.ts` runs `workers: 1,
+fullyParallel: false`: at most one per-spec subject is alive at a time, so
+one channel per worker is enough. Under a future `workers: N` the subjects
+would become co-residents of EACH OTHER and the residue would come back
+silently — the worst way. So the name derives from `TEST_PARALLEL_INDEX`,
+which Playwright exports per worker process
+(`playwright/lib/worker/workerMain.js:61`), and the new
+`issue1336-spec-channel-worker-scoped` spec is the oracle that the
+derivation actually resolves inside a worker: it reads `#spec-w0` there,
+and the runner-process
+spelling is deliberately `#spec-wsetup` rather than `#spec-w0` so that a
+name resolved outside a worker cannot impersonate worker zero.
+
+### The one spec that was reading the population
+
+`ux-5-bv` taps a members-pane row that is not self, and took that row from
+the shared channel's ambient population — the three seeded users. It now
+connects its own peer, the same cure the `ux-4-z` bucket-J census got
+earlier in this issue. It is the second and last such site: the sweep for
+non-self member reads (`hasNotText`, `nth()` on members, member-count
+assertions above one, co-resident nicks in live code) found no others.
+
+### What this does not establish
+
+The pilot is six tests, not the suite. Nothing here measures how much
+scrollback the suite carries overall, only what the co-residents were being
+handed per test; and the prose in ~135 spec files still says `#bofh` in
+comments and error strings, which is now stale where it names the seeded
+corpus of the channel under test.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49376,3 +49376,36 @@ scrollback the suite carries overall, only what the co-residents were being
 handed per test; and the prose in ~135 spec files still says `#bofh` in
 comments and error strings, which is now stale where it names the seeded
 corpus of the channel under test.
+
+### What the full suite says, and how the three reds are attributed
+
+The full run on this branch after the cure is **3 failed / 752 passed
+(31.3m)**; the run before the last commit was **7 failed / 748 passed
+(31.3m)**. The two sets are DISJOINT. All seven earlier reds came back
+green — including `scroll-on-window-switch.spec.ts`, whose URL-encoded
+`%23bofh` survived every grep on the raw spelling and is what the last
+commit derives — and three different specs went red.
+
+Two of the three are the environment, and the run says so in its own
+telemetry. The #1429 gap census in the same log records `grappa-test`
+log gaps of **17.9s at 16:10:26** and **32.6s at 16:19:12** (container
+clock, UTC; `saturated=1`), with `nginx-test` stalling inside both.
+`issue513-links-mask-empty.spec.ts:27` failed at 16:10:31 and
+`unread-cursor-cluster.spec.ts:182` at 16:19:22 — each inside a measured
+gap, and each inside `loginAs` rather than on an assertion of its own
+(`cicchettoPage.ts:580` waiting for the user topic,
+`cicchettoPage.ts:164` waiting for the shell header).
+
+The third is NOT the environment, and is not a flake: it is **#1504**, a
+measured defect predating this branch. `slash-commands-bundle.spec.ts:152`
+(`/q` closes the query window) failed at 16:18:59 with no gap within 13
+seconds, in 6.0s wall-clock, every barrier returning instantly. Its trace
+also rules out the mechanism the spec's own #268 comment names: the `/q`
+submit was NOT dropped by the in-flight guard, because both of
+`composeSend`'s barriers passed — draft taken, `aria-busy="false"`. At the
+failure the selection has moved OFF the query window onto the channel
+while the query row survives carrying one unread, so the close ran and the
+row came back.
+
+No local full-suite baseline was taken on the branch point, so none of the
+above rests on one; the both-sides evidence is CI's.


### PR DESCRIPTION
## Why this exists

All three PRs below were `CONFLICTING` against main at `1a383ac2`, and **a CONFLICTING PR runs no checks at all** — GitHub cannot build `refs/pull/N/merge`, so "no checks reported" reads like *not started yet* when it means *never will*. Rebasing them one at a time would also still never have gated the three **together**: a green attests `branch + base`, never `branch + the other branches`.

So: one union branch, one gate, one merge.

## What it carries

Cut from `origin/main` = `1a383ac2`, 8 commits cherry-picked in order, each branch contributing only its own:

| replaces | branch | head | commits |
|---|---|---|---|
| #1534 | `w1-1397-f6` | `7310d1fe` | 2 — #1397 F6, `grappaApi.findUserIdByName`, 5 specs |
| #1530 | `w1-1336-s2` | `1cfc745b` | 4 — #1336 S2, `#spec-w${TEST_PARALLEL_INDEX}`, 20 specs + `seedData.ts` |
| #1526 | `w2-1396-fanout` | `6e7a9d54` | 2 — #1396, `fanout.ts` + `compose.ts` (carried in verbatim, not rewritten) |

No rebase was needed at push time: main had not moved off `1a383ac2`, so the branch sits directly on it and the gates below apply to exactly these bytes.

## The only overlap was `docs/DESIGN_NOTES.md`

Every cherry-pick reported rc=0 with zero declared conflicts — which is precisely what `merge=union` looks like when it silently eats an entry. Verified rather than assumed:

- **numstat, two-sided, on file** — the union's per-file contribution equals the sum of the three branches' own contributions, file by file (`diff` clean). Totals `add=541 del=235` on both sides.
- **Byte conservation** — main's DESIGN_NOTES is 2 964 749 B; the three appended blocks are 2628 + 5956 + 4892 B; the union file is **2 978 225 B**, the exact sum. Nothing lost, nothing duplicated.
- **Each entry verbatim** — all three appended blocks are exact substrings of the union file.
- **Prefix identity** — main's DESIGN_NOTES is a byte-exact prefix of the union's.
- **Markers** — three added, distinct, each exactly once matched on the whole line; zero duplicated markers anywhere in the file.
- **Boundary shape read on the file**, all three: full stop / marker with no blank line before it / blank / `---` / blank / `## ` heading.
- `scripts/design-notes-gate.sh` → **3 new entry headings**, rc=0. Non-vacuously: run against an uncommitted tree the same gate answers "nothing to check" and still exits 0.

## Test plan

- [x] `bun run check`, whole, from the worktree root — rc=0. The 59 CSS warnings are pre-existing; none names a touched file.
- [x] `bun run test` — **290 files / 5616 tests passed**, rc=0. This is the gate that covers #1526's `fanout.ts` + `compose.ts`.
- [x] e2e over the **25 spec files** the union touches, both projects — **51 passed**, rc=0, 1.9m.
- [x] The stack provably mounted this worktree: `docker inspect grappa-e2e-grappa` shows the `w1-union-3pr` path, so the green belongs to this code and not to a stale bind-mount.

## What this does not establish

The e2e run covers the specs the union **touches**, not the whole suite — the full-suite green is CI's job here. And nothing in this branch re-litigates #1526's content: if its code needs a change, that is w2's call, not this union's.