### PR TITLE
test(#1397): one credential fixture for the networks/* test family

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49855,3 +49855,85 @@ rewritten call sites type-checks and fails only at runtime. That is the same
 gap the sibling entries name, and on the `seedCursor` slice it was a runtime
 positive control, not the type-checker, that caught exactly such a
 transposition.
+<!-- entry #1397-networksfam -->
+
+---
+
+## 2026-08-18 — #1397: one credential fixture for the networks/* family, and the residue a name-grep cannot see
+
+Bucket H again, server side. Five files under `test/grappa/networks/`
+(`away`, `commit_password`, `connection_state`, `last_joined_channels`,
+`perform_changeset`) each carried a private `setup_credential` and a private
+`reload`. Both are now in `AuthFixtures` as `user_with_credential/2` and
+`reload_credential/1`; the five copies of each are gone.
+
+### The two axes, and why neither becomes a default
+
+The five `reload` bodies were byte-identical. The five `setup_credential`
+bodies grouped into three md5 classes that are one function on two axes: the
+port (four files pass a dummy `6667`, `connection_state` passes the
+`IRCServer` fake's real port) and a `%{auth_method: :nickserv_identify,
+password: "oldpass"}` merge that only `commit_password` and
+`perform_changeset` want.
+
+Both axes stay at the call site. The port is a required argument, not a
+`6667` default, because the difference between "this file never dials" and
+"this file dials a real fake" is exactly the thing a default would hide —
+the same posture the shared handshake barrier took with its timeout, and
+what the project's no-default-arguments rule asks for anyway. The rotation
+merge is the 20% that does not generalise, so it stays local to the two
+files that want it, renamed `rotating_credential/1` for what it builds. Two
+one-line wrappers survive by design; a shared helper carrying a
+password-rotation default for three files that never rotate a password would
+have been a data-model flag, not reuse.
+
+### Boundary caught the leak the copies were making quietly
+
+`reload_credential/1` first went in as the copies had it — a raw
+`Repo.get_by!(Credential, ...)`. Boundary refused: `AuthFixtures` may name
+`Grappa.Networks.Network` and `Grappa.Accounts.User`, not
+`Grappa.Networks.Credential`. The fix was not to widen the deps and keep the
+raw query but to call `Credentials.get_credential_by_ids/2`, the public verb
+that already runs that query in production — the dep is declared because the
+`%Credential{}` head genuinely references the schema, and the query is no
+longer a second implementation of a context function. Five copies had been
+making the same reference implicitly, one file at a time, where no boundary
+check looks.
+
+### What the census says about the rest, measured on `1a383ac2`
+
+The four helpers earlier slices retired are genuinely at zero local
+definitions: `passthrough_handler`, `admin_session`, `await_handshake`,
+`start_server`. One trap on the way there: `git grep 'def start_server'`
+returns a hit outside `test/support/`, and it is `start_server_with_001` — a
+substring. The anchor that is too wide invents a residue; the anchor that is
+too narrow (`defp? name\(`) reported zero for `passthrough_handler`, whose
+real shape is `defp passthrough_handler, do:` — comma, no parentheses; and
+`git grep -E` has no `\b` or `\s` at all, which produced a whole table of
+plausible zeroes twice on this issue. Every one of those wrong numbers looked
+like good news.
+
+**The largest remaining server-side cluster carries no name.** Grouping the
+`fn state, ... end` handler literals by body rather than by name: 105
+literals over 12 files, 46 distinct bodies — and a single semantic group of
+**62 copies over 7 files** ("if the line starts with `USER`, reply 001
+welcome, else nil"), of which 55 live in `session/server_test.exs` alone.
+Inside those 62, two byte-identical clusters of 41 and 13 differ only in the
+001 prefix spelling (`:irc` vs `:server`). The named `welcome_handler`
+definitions number four. A progress figure grepped by name understates that
+cluster roughly fifteenfold, which is the same blind spot recorded earlier
+for the inlined `passthrough_handler` bodies — that particular inline
+duplication, incidentally, is no longer present on this base.
+
+The issue treats "which 001 spelling is canonical" as a prerequisite for
+consolidating that cluster. It is not: the handshake barrier already
+established the alternative, which is to take the varying part as a required
+argument and let each site keep its own value. That turns the decision into a
+later cleanup instead of a blocker.
+
+_Not established: nothing about the 62 sites' interchangeability in
+behaviour — they were grouped by body, and no test was run to check whether
+any assertion downstream depends on the 001 spelling. No `git log -S`, so
+"differs from" is measured and "derives from" is not. The 105/12 handler
+figure searches `fn state` and is therefore a lower bound, like the issue's
+own e2e count._

--- a/test/grappa/networks/away_test.exs
+++ b/test/grappa/networks/away_test.exs
@@ -22,33 +22,19 @@ defmodule Grappa.Networks.AwayTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Networks, Repo}
+  alias Grappa.Networks
   alias Grappa.Networks.{Credential, Credentials, SessionPlan}
-
-  defp setup_credential(attrs \\ %{}) do
-    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-
-    {network, _} =
-      network_with_server(port: 6667, slug: "test-#{System.unique_integer([:positive])}")
-
-    cred = credential_fixture(user, network, attrs)
-    {user, network, cred}
-  end
-
-  defp reload(%Credential{} = cred) do
-    Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
-  end
 
   describe "Credentials.update_away/4" do
     test "writes reason + since and round-trips on read" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       assert cred.away_reason == nil
       assert cred.away_since == nil
 
       since = DateTime.utc_now()
       assert :ok = Credentials.update_away(cred.user_id, cred.network_id, "lunch", since)
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.away_reason == "lunch"
       # usec precision preserved (:utc_datetime_usec) — verbatim round-trip
       # is load-bearing for the mentions-window honesty.
@@ -56,13 +42,13 @@ defmodule Grappa.Networks.AwayTest do
     end
 
     test "clears the pair on (nil, nil) — the /back path" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_away(cred.user_id, cred.network_id, "gone", DateTime.utc_now())
-      assert reload(cred).away_reason == "gone"
+      assert reload_credential(cred).away_reason == "gone"
 
       assert :ok = Credentials.update_away(cred.user_id, cred.network_id, nil, nil)
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.away_reason == nil
       assert reloaded.away_since == nil
     end
@@ -79,7 +65,7 @@ defmodule Grappa.Networks.AwayTest do
     # `Session.set_explicit_away/3` facade already guards user input; this
     # is the OTHER door (defense-in-depth).
     test "rejects a reason carrying CR/LF/NUL" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       for bad <- ["ha\r\nQUIT", "a\nb", "nul\0byte"] do
         cs = Credential.away_changeset(cred, bad, DateTime.utc_now())
@@ -89,24 +75,24 @@ defmodule Grappa.Networks.AwayTest do
     end
 
     test "accepts a rest-of-line reason with spaces" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       cs = Credential.away_changeset(cred, "out for lunch, back at 2pm", DateTime.utc_now())
       assert cs.valid?
     end
 
     test "the clear changeset (nil, nil) is valid" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       assert Credential.away_changeset(cred, nil, nil).valid?
     end
   end
 
   describe "SessionPlan.resolve/1 away restore threading" do
     test "resolved plan carries restored_away = {reason, since} when persisted" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       since = DateTime.utc_now()
       :ok = Credentials.update_away(cred.user_id, cred.network_id, "brb", since)
 
-      {:ok, plan} = SessionPlan.resolve(reload(cred))
+      {:ok, plan} = SessionPlan.resolve(reload_credential(cred))
 
       assert plan.restored_away == {"brb", since}
       # Persister injected for the user subject (Boundary-clean closure).
@@ -114,9 +100,9 @@ defmodule Grappa.Networks.AwayTest do
     end
 
     test "resolved plan restored_away is nil when not away" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
-      {:ok, plan} = SessionPlan.resolve(reload(cred))
+      {:ok, plan} = SessionPlan.resolve(reload_credential(cred))
 
       assert plan.restored_away == nil
     end
@@ -130,7 +116,7 @@ defmodule Grappa.Networks.AwayTest do
     # and hard failures go :failed via `mark_failed/2`. So the clear lives in
     # disconnect/2 alone; nothing else touches the away columns.
     test "manual disconnect (/disconnect, /quit) clears the persisted away" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_away(cred.user_id, cred.network_id, "lunch", DateTime.utc_now())
 
       assert {:ok, updated} = Networks.disconnect(cred, "user-disconnect")
@@ -139,14 +125,14 @@ defmodule Grappa.Networks.AwayTest do
       # The away columns are the persisted source of truth (not the returned
       # struct, whose away fields may be stale relative to the fresh clear) —
       # assert the DB row.
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.connection_state == :parked
       assert reloaded.away_reason == nil
       assert reloaded.away_since == nil
     end
 
     test "automatic mark_failed (k-line / permanent error) PRESERVES the persisted away" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       since = DateTime.utc_now()
       :ok = Credentials.update_away(cred.user_id, cred.network_id, "brb", since)
 
@@ -155,7 +141,7 @@ defmodule Grappa.Networks.AwayTest do
 
       # A hard upstream failure is not user intent — the away survives in the
       # DB so a later recovery (/connect → restore → re-send) resumes it.
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.away_reason == "brb"
       assert reloaded.away_since == since
     end

--- a/test/grappa/networks/commit_password_test.exs
+++ b/test/grappa/networks/commit_password_test.exs
@@ -14,46 +14,32 @@ defmodule Grappa.Networks.CommitPasswordTest do
   import Grappa.AuthFixtures
 
   alias Grappa.Networks.{Credential, Credentials}
-  alias Grappa.Repo
 
-  defp setup_credential(attrs \\ %{}) do
-    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-
-    {network, _} =
-      network_with_server(port: 6667, slug: "test-#{System.unique_integer([:positive])}")
-
-    cred =
-      credential_fixture(
-        user,
-        network,
-        Map.merge(%{auth_method: :nickserv_identify, password: "oldpass"}, attrs)
-      )
-
-    {user, network, cred}
-  end
-
-  defp reload(%Credential{} = cred) do
-    Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
+  defp rotating_credential(attrs) do
+    user_with_credential(
+      6667,
+      Map.merge(%{auth_method: :nickserv_identify, password: "oldpass"}, attrs)
+    )
   end
 
   describe "Credentials.commit_password/3" do
     test "rotates the stored password and round-trips on read (Cloak decrypt)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
       # password_encrypted carries the DECRYPTED plaintext after load.
       assert cred.password_encrypted == "oldpass"
 
       assert {:ok, %Credential{}} =
                Credentials.commit_password(cred.user_id, cred.network_id, "newpass")
 
-      assert reload(cred).password_encrypted == "newpass"
+      assert reload_credential(cred).password_encrypted == "newpass"
     end
 
     test "preserves every other field — only the password rotates" do
-      {_, _, cred} = setup_credential(%{nick: "vjt", autojoin_channels: ["#grappa", "#italia"]})
+      {_, _, cred} = rotating_credential(%{nick: "vjt", autojoin_channels: ["#grappa", "#italia"]})
 
       assert {:ok, _} = Credentials.commit_password(cred.user_id, cred.network_id, "newpass")
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.nick == "vjt"
       assert reloaded.auth_method == :nickserv_identify
       assert reloaded.autojoin_channels == ["#grappa", "#italia"]
@@ -61,12 +47,12 @@ defmodule Grappa.Networks.CommitPasswordTest do
     end
 
     test "stores a rest-of-line password verbatim, spaces included" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       assert {:ok, _} =
                Credentials.commit_password(cred.user_id, cred.network_id, "my new pass phrase")
 
-      assert reload(cred).password_encrypted == "my new pass phrase"
+      assert reload_credential(cred).password_encrypted == "my new pass phrase"
     end
 
     test "{:error, :not_found} for an unknown (user, network)" do
@@ -77,7 +63,7 @@ defmodule Grappa.Networks.CommitPasswordTest do
 
   describe "Credential.password_changeset/2" do
     test "casts and encrypts the new password, touching nothing else" do
-      {_, _, cred} = setup_credential(%{autojoin_channels: ["#grappa"]})
+      {_, _, cred} = rotating_credential(%{autojoin_channels: ["#grappa"]})
 
       cs = Credential.password_changeset(cred, "newpass")
 
@@ -91,13 +77,13 @@ defmodule Grappa.Networks.CommitPasswordTest do
     end
 
     test "rejects a blank password at the changeset boundary" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       refute Credential.password_changeset(cred, "").valid?
     end
 
     test "rejects CR/LF/NUL — the stored value is re-interpolated into the wire" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       refute Credential.password_changeset(cred, "new\r\npass").valid?
       refute Credential.password_changeset(cred, "new\x00pass").valid?
@@ -111,14 +97,14 @@ defmodule Grappa.Networks.CommitPasswordTest do
 
   describe "Credentials.commit_registration_password/3" do
     test "commits the password AND flips auth_method :none → :nickserv_identify" do
-      {_, _, cred} = setup_credential(%{auth_method: :none, password: nil})
+      {_, _, cred} = rotating_credential(%{auth_method: :none, password: nil})
       assert cred.auth_method == :none
       assert is_nil(cred.password_encrypted)
 
       assert {:ok, %Credential{}} =
                Credentials.commit_registration_password(cred.user_id, cred.network_id, "regpass")
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       # The whole point vs commit_password/3: BOTH the password lands AND the
       # binding is promoted to auto-identify (else the registered nick gets
       # services-enforced on the next reconnect).
@@ -128,7 +114,7 @@ defmodule Grappa.Networks.CommitPasswordTest do
 
     test "preserves nick + autojoin — only password + auth_method change" do
       {_, _, cred} =
-        setup_credential(%{
+        rotating_credential(%{
           auth_method: :none,
           password: nil,
           nick: "wizreg",
@@ -138,7 +124,7 @@ defmodule Grappa.Networks.CommitPasswordTest do
       assert {:ok, _} =
                Credentials.commit_registration_password(cred.user_id, cred.network_id, "regpass")
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.nick == "wizreg"
       assert reloaded.autojoin_channels == ["#bofh"]
     end
@@ -152,7 +138,7 @@ defmodule Grappa.Networks.CommitPasswordTest do
   describe "Credential.registration_changeset/2" do
     test "casts the password + flips auth_method, encrypts, touching nothing else" do
       {_, _, cred} =
-        setup_credential(%{auth_method: :none, password: nil, autojoin_channels: ["#grappa"]})
+        rotating_credential(%{auth_method: :none, password: nil, autojoin_channels: ["#grappa"]})
 
       cs = Credential.registration_changeset(cred, "regpass")
 
@@ -164,13 +150,13 @@ defmodule Grappa.Networks.CommitPasswordTest do
     end
 
     test "rejects a blank password at the changeset boundary" do
-      {_, _, cred} = setup_credential(%{auth_method: :none, password: nil})
+      {_, _, cred} = rotating_credential(%{auth_method: :none, password: nil})
 
       refute Credential.registration_changeset(cred, "").valid?
     end
 
     test "rejects CR/LF/NUL — the password is re-interpolated into IDENTIFY" do
-      {_, _, cred} = setup_credential(%{auth_method: :none, password: nil})
+      {_, _, cred} = rotating_credential(%{auth_method: :none, password: nil})
 
       refute Credential.registration_changeset(cred, "re\r\ngpass").valid?
       refute Credential.registration_changeset(cred, "re\x00gpass").valid?

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -23,16 +23,6 @@ defmodule Grappa.Networks.ConnectionStateTest do
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
-  defp setup_credential(port, attrs \\ %{}) do
-    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-
-    {network, _} =
-      network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
-
-    credential = credential_fixture(user, network, attrs)
-    {user, network, credential}
-  end
-
   # Sets connection_state on a credential row directly (bypasses
   # validation — tests need to seed `:parked` / `:failed` rows
   # without going through the `Networks.connect/disconnect/mark_failed`
@@ -49,14 +39,10 @@ defmodule Grappa.Networks.ConnectionStateTest do
     |> Repo.update!()
   end
 
-  defp reload(%Credential{} = cred) do
-    Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
-  end
-
   describe "connect/1" do
     test "transitions :parked → :connected, clears reason, broadcasts" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, network, fresh} = setup_credential(port)
+      {user, network, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :parked, "manual")
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -90,14 +76,14 @@ defmodule Grappa.Networks.ConnectionStateTest do
       assert is_binary(at)
       assert {:ok, _, 0} = DateTime.from_iso8601(at)
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.connection_state == :connected
       assert reloaded.connection_state_reason == nil
     end
 
     test "transitions :failed → :connected, clears reason, broadcasts" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, _, fresh} = setup_credential(port)
+      {user, _, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :failed, "k-line: trial")
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -119,7 +105,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
     test "idempotent on :connected — returns row unchanged, no broadcast" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, _, cred} = setup_credential(port)
+      {user, _, cred} = user_with_credential(port, %{})
       assert cred.connection_state == :connected
       original_changed_at = cred.connection_state_changed_at
 
@@ -137,7 +123,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
   describe "disconnect/2" do
     test "from :connected with live session: sends QUIT upstream, terminates session, transitions :parked, broadcasts" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, network, cred} = setup_credential(port)
+      {user, network, cred} = user_with_credential(port, %{})
       assert cred.connection_state == :connected
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -172,7 +158,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
     test "from :connected with no live session: transitions :parked, broadcasts (best-effort QUIT skipped silently)" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, _, cred} = setup_credential(port)
+      {user, _, cred} = user_with_credential(port, %{})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -193,7 +179,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
     test "from :parked: returns {:error, :not_connected} unchanged" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, _, fresh} = setup_credential(port)
+      {user, _, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :parked, "first")
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -201,18 +187,18 @@ defmodule Grappa.Networks.ConnectionStateTest do
       assert {:error, :not_connected} = Networks.disconnect(cred, "second")
       refute_receive {:connection_state_changed, _}, 100
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.connection_state == :parked
       assert reloaded.connection_state_reason == "first"
     end
 
     test "from :failed: returns {:error, :not_connected} unchanged" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {_, _, fresh} = setup_credential(port)
+      {_, _, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :failed, "k-line: trial")
 
       assert {:error, :not_connected} = Networks.disconnect(cred, "manual")
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.connection_state == :failed
       assert reloaded.connection_state_reason == "k-line: trial"
     end
@@ -221,7 +207,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
   describe "mark_failed/2" do
     test "from :connected with live session: terminates session, transitions :failed, broadcasts" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, network, cred} = setup_credential(port)
+      {user, network, cred} = user_with_credential(port, %{})
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
@@ -251,7 +237,7 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
     test "idempotent on :failed: returns row unchanged, no broadcast" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {user, _, fresh} = setup_credential(port)
+      {user, _, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :failed, "old reason")
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -265,12 +251,12 @@ defmodule Grappa.Networks.ConnectionStateTest do
 
     test "rejects from :parked: returns {:error, :user_parked}" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {_, _, fresh} = setup_credential(port)
+      {_, _, fresh} = user_with_credential(port, %{})
       cred = set_state(fresh, :parked, "user wants out")
 
       assert {:error, :user_parked} = Networks.mark_failed(cred, "k-line: trial")
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.connection_state == :parked
       assert reloaded.connection_state_reason == "user wants out"
     end
@@ -279,9 +265,9 @@ defmodule Grappa.Networks.ConnectionStateTest do
   describe "Credentials.list_credentials_for_all_users/0 — filter on :connected" do
     test "returns only :connected credentials, skips :parked + :failed" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      {_, _, cred_connected} = setup_credential(port)
-      {_, _, cred_parked} = setup_credential(port)
-      {_, _, cred_failed} = setup_credential(port)
+      {_, _, cred_connected} = user_with_credential(port, %{})
+      {_, _, cred_parked} = user_with_credential(port, %{})
+      {_, _, cred_failed} = user_with_credential(port, %{})
       _ = set_state(cred_parked, :parked, "manual")
       _ = set_state(cred_failed, :failed, "k-line")
 

--- a/test/grappa/networks/last_joined_channels_test.exs
+++ b/test/grappa/networks/last_joined_channels_test.exs
@@ -24,25 +24,10 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
   import Grappa.AuthFixtures
 
   alias Grappa.Networks.{Credential, Credentials, SessionPlan}
-  alias Grappa.Repo
-
-  defp setup_credential(attrs \\ %{}) do
-    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-
-    {network, _} =
-      network_with_server(port: 6667, slug: "test-#{System.unique_integer([:positive])}")
-
-    cred = credential_fixture(user, network, attrs)
-    {user, network, cred}
-  end
-
-  defp reload(%Credential{} = cred) do
-    Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
-  end
 
   describe "Credentials.update_last_joined_channels/3" do
     test "writes the channels list and round-trips on read" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       assert cred.last_joined_channels == []
 
       assert :ok =
@@ -52,7 +37,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  ["#bofh", "#grappa", "#italia"]
                )
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert reloaded.last_joined_channels == ["#bofh", "#grappa", "#italia"]
     end
 
@@ -62,7 +47,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     # channel names (UX-4 bucket A) exactly as the wide path did — the
     # persisted values must be byte-identical, not just the cap behaviour.
     test "canonicalises mixed-case channel names (narrow-changeset parity)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       assert :ok =
                Credentials.update_last_joined_channels(
@@ -71,29 +56,29 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  ["#Sniffo", "#BOFH"]
                )
 
-      assert reload(cred).last_joined_channels == ["#sniffo", "#bofh"]
+      assert reload_credential(cred).last_joined_channels == ["#sniffo", "#bofh"]
     end
 
     test "overwrites prior snapshot on each call (latest write wins)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       assert :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ["#a"])
-      assert reload(cred).last_joined_channels == ["#a"]
+      assert reload_credential(cred).last_joined_channels == ["#a"]
 
       assert :ok =
                Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ["#b", "#c"])
 
-      assert reload(cred).last_joined_channels == ["#b", "#c"]
+      assert reload_credential(cred).last_joined_channels == ["#b", "#c"]
     end
 
     test "empty list shrinks the snapshot to zero" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       assert :ok =
                Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ["#a", "#b"])
 
       assert :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, [])
-      assert reload(cred).last_joined_channels == []
+      assert reload_credential(cred).last_joined_channels == []
     end
 
     test "{:error, :not_found} for unknown (user, network)" do
@@ -115,7 +100,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     # boot-time merge stay bounded — we drop the tail (the snapshot is
     # already sorted, so "oldest by sort key" == "tail").
     test "caps at 200 entries (tail dropped) on oversize input" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       oversize =
         for n <- 1..250, do: "#chan-" <> String.pad_leading(Integer.to_string(n), 3, "0")
@@ -127,7 +112,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  oversize
                )
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
       assert length(reloaded.last_joined_channels) == 200
       # Head retained, tail dropped — the input was already sorted by name,
       # so the tail = lexicographically latest entries.
@@ -137,21 +122,21 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     end
 
     test "200-entry input round-trips unchanged (boundary)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       exactly = for n <- 1..200, do: "##{n}"
 
       assert :ok =
                Credentials.update_last_joined_channels(cred.user_id, cred.network_id, exactly)
 
-      assert reload(cred).last_joined_channels == exactly
+      assert reload_credential(cred).last_joined_channels == exactly
     end
 
     property "result length never exceeds 200 regardless of input size" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       check all(input <- StreamData.list_of(channel_name(), max_length: 400), max_runs: 25) do
         :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, input)
-        reloaded = reload(cred)
+        reloaded = reload_credential(cred)
         assert length(reloaded.last_joined_channels) <= 200
         # Cap preserves head order, only tail drops.
         assert reloaded.last_joined_channels == Enum.take(input, 200)
@@ -165,7 +150,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
   # strict prefix of the truth for the whole restore window.
   describe "Credentials.merge_last_joined_channels/4" do
     test "a live keyset short of the snapshot leaves the snapshot whole" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b #c))
 
       assert :ok =
@@ -176,20 +161,20 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  []
                )
 
-      assert reload(cred).last_joined_channels == ~w(#a #b #c)
+      assert reload_credential(cred).last_joined_channels == ~w(#a #b #c)
     end
 
     test "an EMPTY live keyset does not empty the snapshot" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b))
 
       assert :ok = Credentials.merge_last_joined_channels(cred.user_id, cred.network_id, [], [])
 
-      assert reload(cred).last_joined_channels == ~w(#a #b)
+      assert reload_credential(cred).last_joined_channels == ~w(#a #b)
     end
 
     test "a departure shrinks the snapshot" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #b))
 
       assert :ok =
@@ -200,11 +185,11 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  ["#a"]
                )
 
-      assert reload(cred).last_joined_channels == ["#b"]
+      assert reload_credential(cred).last_joined_channels == ["#b"]
     end
 
     test "a departure from a channel we were not live in still shrinks it" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ~w(#a #stale))
 
       assert :ok =
@@ -215,11 +200,11 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  ["#stale"]
                )
 
-      assert reload(cred).last_joined_channels == ["#a"]
+      assert reload_credential(cred).last_joined_channels == ["#a"]
     end
 
     test "a channel joined for the first time is appended ahead of the stale tail" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, ["#old"])
 
       assert :ok =
@@ -230,11 +215,11 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  []
                )
 
-      assert reload(cred).last_joined_channels == ~w(#new #old)
+      assert reload_credential(cred).last_joined_channels == ~w(#new #old)
     end
 
     test "on overflow the cap drops the not-yet-rejoined tail, not the live keyset" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       stale = for n <- 1..200, do: "#stale-" <> String.pad_leading(Integer.to_string(n), 3, "0")
       :ok = Credentials.update_last_joined_channels(cred.user_id, cred.network_id, stale)
 
@@ -246,7 +231,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  []
                )
 
-      merged = reload(cred).last_joined_channels
+      merged = reload_credential(cred).last_joined_channels
       assert length(merged) == 200
       assert hd(merged) == "#live"
       refute "#stale-200" in merged
@@ -266,7 +251,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     # `validate_length(:last_joined_channels, max: 200)` is the
     # belt-and-braces guard.
     test "rejects oversize list at the changeset boundary (bypassing the context helper)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
 
       oversize =
         for n <- 1..250, do: "#chan-" <> String.pad_leading(Integer.to_string(n), 3, "0")
@@ -286,7 +271,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
     end
 
     test "accepts exactly the cap length at the changeset boundary (boundary)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = user_with_credential(6667, %{})
       exactly = for n <- 1..Credential.last_joined_channels_max(), do: "##{n}"
 
       cs = Credential.changeset(cred, %{last_joined_channels: exactly})
@@ -301,7 +286,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
   describe "SessionPlan.build_plan boot-merge — autojoin + last_joined" do
     test "merges autojoin_channels + last_joined_channels at session_plan build" do
       {_, _, cred} =
-        setup_credential(%{autojoin_channels: ["#bofh", "#grappa"]})
+        user_with_credential(6667, %{autojoin_channels: ["#bofh", "#grappa"]})
 
       assert :ok =
                Credentials.update_last_joined_channels(
@@ -310,7 +295,7 @@ defmodule Grappa.Networks.LastJoinedChannelsTest do
                  ["#italia", "#linux"]
                )
 
-      reloaded = reload(cred)
+      reloaded = reload_credential(cred)
 
       # Direct call into the helper to verify dedupe + order. The full
       # `SessionPlan.resolve/1` path requires DNS/Server fixtures; the

--- a/test/grappa/networks/perform_changeset_test.exs
+++ b/test/grappa/networks/perform_changeset_test.exs
@@ -16,29 +16,16 @@ defmodule Grappa.Networks.PerformChangesetTest do
   alias Grappa.Networks.Credential
   alias Grappa.Repo
 
-  defp setup_credential(attrs \\ %{}) do
-    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
-
-    {network, _} =
-      network_with_server(port: 6667, slug: "test-#{System.unique_integer([:positive])}")
-
-    cred =
-      credential_fixture(
-        user,
-        network,
-        Map.merge(%{auth_method: :nickserv_identify, password: "oldpass"}, attrs)
-      )
-
-    {user, network, cred}
-  end
-
-  defp reload(%Credential{} = cred) do
-    Repo.get_by!(Credential, user_id: cred.user_id, network_id: cred.network_id)
+  defp rotating_credential(attrs) do
+    user_with_credential(
+      6667,
+      Map.merge(%{auth_method: :nickserv_identify, password: "oldpass"}, attrs)
+    )
   end
 
   describe "Credential.perform_changeset/2" do
     test "encrypts + round-trips perform_list and oper_pass on read (Cloak decrypt)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       cs =
         Credential.perform_changeset(cred, %{
@@ -48,7 +35,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
 
       assert cs.valid?
       {:ok, saved} = Repo.update(cs)
-      reloaded = reload(saved)
+      reloaded = reload_credential(saved)
 
       # After Cloak :load, the *_encrypted fields carry the DECRYPTED plaintext.
       assert reloaded.perform_list_encrypted ==
@@ -58,7 +45,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
     end
 
     test "accessors return the decrypted plaintext, nil when unset" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       {:ok, saved} =
         cred
@@ -68,17 +55,17 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
         |> Repo.update()
 
-      reloaded = reload(saved)
+      reloaded = reload_credential(saved)
       assert Credential.perform_list_text(reloaded) == "MODE $nick +x"
       assert Credential.upstream_oper_pass(reloaded) == "s3cr3t"
 
-      {_, _, bare} = setup_credential()
+      {_, _, bare} = rotating_credential(%{})
       assert Credential.perform_list_text(bare) == nil
       assert Credential.upstream_oper_pass(bare) == nil
     end
 
     test "inspect/1 never leaks perform_list or oper_pass (redact: true)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       {:ok, saved} =
         cred
@@ -88,13 +75,13 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
         |> Repo.update()
 
-      dump = inspect(reload(saved))
+      dump = inspect(reload_credential(saved))
       refute dump =~ "topsecret"
       refute dump =~ "leakme"
     end
 
     test "a multi-line perform list is accepted (newlines are the line separator)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       cs =
         Credential.perform_changeset(cred, %{
@@ -105,7 +92,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
     end
 
     test "clearing perform_list / oper_pass with empty string stores nil" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       {:ok, saved} =
         cred
@@ -120,13 +107,13 @@ defmodule Grappa.Networks.PerformChangesetTest do
         |> Credential.perform_changeset(%{perform_list: "", oper_pass: ""})
         |> Repo.update()
 
-      reloaded = reload(cleared)
+      reloaded = reload_credential(cleared)
       assert Credential.perform_list_text(reloaded) == nil
       assert Credential.upstream_oper_pass(reloaded) == nil
     end
 
     test "omitting oper_pass keeps the stored secret (leave-blank-to-keep)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       {:ok, saved} =
         cred
@@ -140,20 +127,20 @@ defmodule Grappa.Networks.PerformChangesetTest do
         |> Credential.perform_changeset(%{perform_list: "MODE $nick +x"})
         |> Repo.update()
 
-      reloaded = reload(updated)
+      reloaded = reload_credential(updated)
       assert Credential.perform_list_text(reloaded) == "MODE $nick +x"
       assert Credential.upstream_oper_pass(reloaded) == "keepme"
     end
 
     test "rejects a NUL byte in perform_list" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
       cs = Credential.perform_changeset(cred, %{perform_list: "MODE $nick +x\0evil"})
       refute cs.valid?
       assert %{perform_list: [_ | _]} = errors_on(cs)
     end
 
     test "rejects CR/LF/NUL in oper_pass (single-line secret)" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
       cs = Credential.perform_changeset(cred, %{oper_pass: "bad\r\npass"})
       refute cs.valid?
       assert %{oper_pass: [_ | _]} = errors_on(cs)
@@ -169,18 +156,18 @@ defmodule Grappa.Networks.PerformChangesetTest do
       # the user branch only. The perform editor is a different door and must
       # stay unable to write it — otherwise a secret gets a second editable
       # home, which is the split brain #124 is named after.
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
 
       {:ok, saved} =
         cred
         |> Credential.perform_changeset(%{perform_list: "MODE $nick +x", server_pass: "sneaky"})
         |> Repo.update()
 
-      assert reload(saved).server_pass_encrypted == nil
+      assert reload_credential(saved).server_pass_encrypted == nil
     end
 
     test "rejects a perform list over the byte cap" do
-      {_, _, cred} = setup_credential()
+      {_, _, cred} = rotating_credential(%{})
       huge = String.duplicate("MODE $nick +x\n", 2000)
       cs = Credential.perform_changeset(cred, %{perform_list: huge})
       refute cs.valid?

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -229,7 +229,7 @@ defmodule Grappa.AuthFixtures do
   def user_with_credential(port, attrs) when is_integer(port) and is_map(attrs) do
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
-    {network, _server} =
+    {network, _} =
       network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
 
     {user, network, credential_fixture(user, network, attrs)}

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -21,6 +21,7 @@ defmodule Grappa.AuthFixtures do
       Grappa.Accounts,
       Grappa.Accounts.User,
       Grappa.Networks,
+      Grappa.Networks.Credential,
       Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Session,
@@ -212,6 +213,39 @@ defmodule Grappa.AuthFixtures do
 
     {:ok, credential} = Credentials.bind_credential(user, network, Map.merge(base, attrs))
     credential
+  end
+
+  @doc """
+  The whole `(user, network-with-server, credential)` triple in one call,
+  each with a unique name/slug so `async: true` files don't collide.
+
+  `port` is required and carries no default on purpose: a file that never
+  dials the server passes a dummy (`6667`), one that does passes the
+  `IRCServer` fake's real port, and the difference has to stay visible at
+  the call site.
+  """
+  @spec user_with_credential(:inet.port_number(), map()) ::
+          {User.t(), Network.t(), Credential.t()}
+  def user_with_credential(port, attrs) when is_integer(port) and is_map(attrs) do
+    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+    {network, _server} =
+      network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
+
+    {user, network, credential_fixture(user, network, attrs)}
+  end
+
+  @doc """
+  Re-reads a credential from the DB by its `(user_id, network_id)` pair —
+  the natural key, not `id`, so it still resolves when the row under test
+  was replaced rather than updated.
+  """
+  @spec reload_credential(Credential.t()) :: Credential.t()
+  def reload_credential(%Credential{} = credential) do
+    {:ok, reloaded} =
+      Credentials.get_credential_by_ids(credential.user_id, credential.network_id)
+
+    reloaded
   end
 
   @doc """


### PR DESCRIPTION
## What

Five files under `test/grappa/networks/` (`away`, `commit_password`, `connection_state`, `last_joined_channels`, `perform_changeset`) each carried a private `setup_credential` and a private `reload`. The five `reload` bodies were byte-identical; the five `setup_credential` bodies grouped into three md5 classes that are one function on two axes.

Both now live in `Grappa.AuthFixtures` as `user_with_credential/2` and `reload_credential/1`. Ten local definitions gone, no new imports — all five files already imported `AuthFixtures`.

Part of #1397 (bucket H test-harness). Zero overlap with the e2e half.

## The two axes stay at the call site

- **The port** (a dummy `6667` in four files, the `IRCServer` fake's real port in `connection_state`) is a required argument, not a default. The difference between "this file never dials" and "this file dials a real fake" is exactly what a default would hide — the same posture the shared handshake barrier took with its timeout, and what the no-default-arguments rule asks for anyway.
- **The password-rotation merge** (`auth_method: :nickserv_identify`, `password: "oldpass"`) is wanted by two files out of five. It stays local, renamed `rotating_credential/1` for what it builds. Two four-line wrappers survive by design: a shared helper carrying a rotation default for three files that never rotate a password would be a flag in the data model, not reuse.

## Boundary caught a reference the copies were making quietly

`reload_credential/1` first went in as the copies had it — a raw `Repo.get_by!(Credential, ...)`. Boundary refused: `AuthFixtures` may name `Grappa.Networks.Network` and `Grappa.Accounts.User`, not `Grappa.Networks.Credential`.

The fix is not a wider deps list around the raw query but `Credentials.get_credential_by_ids/2`, the public verb that already runs that query in production. The dep is declared because the `%Credential{}` head genuinely references the schema. Five copies had been making the same reference implicitly, one file at a time, where no boundary check looks.

## Gates

`scripts/check.sh` in full, rc read from a dedicated file, every stage exhibited rather than inferred from the exit code:

| stage | result |
|---|---|
| credo --strict | 84 checks over 689 files, no issues |
| deps.audit | no vulnerabilities |
| sobelow (Medium) | no vulnerabilities |
| doctor | passed |
| test | 8 doctests, 61 properties, **6546 tests, 0 failures** |
| dialyzer | Total errors: 0 |
| bats | 564 ok / 0 not ok |

The first run of `check.sh` was **rc=1** — Credo consistency, `_server` where the codebase strategy is anonymous `_`, fixed in the third commit. Worth stating because the `ci.check` chain halts at the first non-zero: in that run nothing downstream of Credo had executed, so it was not "green minus one", it was unmeasured.

## Mutants

Two, against the two promoted helpers, over the five files (68 tests):

| mutant | rc | failures | kills in |
|---|---|---|---|
| `reload_credential/1` returns its argument un-reloaded | 2 | 23 | `away`, `commit_password`, `connection_state`, `last_joined_channels` |
| `user_with_credential/2` ignores `attrs` | 2 | 4 | `commit_password`, `last_joined_channels` |

`away` and `connection_state` surviving the second one is a no-op by construction — they pass `%{}`.

**`perform_changeset_test.exs` survives both**, and the reason is not weak assertions: it reloads `saved`, the struct `Repo.update/1` has just returned, so those six re-reads cannot fail. Measured to be pre-existing rather than introduced here: on a detached worktree at the previous base, with the file's own local `reload` neutered, that file still reports rc=0, 10 tests, 0 failures. It is filed as a comment on #1397 next to the open Argon2 question, because fixing it changes what the file asserts — a decision about test intent, not a de-duplication step.

## Not established

- No e2e run: this branch touches no client code, and the e2e lane was not taken.
- The `check.sh` green was measured on the pre-rebase base. The rebase target adds nothing under `test/`, `lib/`, `scripts/` or `mix.exs` — the delta is e2e, cic and docs only — so the transfer is by construction, and CI on this PR is the measurement on the new base.