### PR TITLE
e2e(#1397): retire three duplicated e2e helpers (setAdminFlag, adminPatchCaps, seedCursor)

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -473,6 +473,30 @@ export async function findUserIdByName(adminToken: string, userName: string): Pr
   return user.id;
 }
 
+// The admin-chrome specs drive `is_admin` from BOTH sides — they revoke to
+// assert the affordance disappears, then restore it — so the flag is a
+// fixture verb, not an assertion. The id is a PARAMETER for the same reason
+// `findUserIdByName` takes the name: this module imports nothing.
+export async function setAdminFlag(
+  adminToken: string,
+  userId: string,
+  isAdmin: boolean,
+): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ is_admin: isAdmin }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `grappaApi.setAdminFlag: is_admin=${isAdmin} on ${userId} → ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
 // #1158 item 4 — the lifecycle log collapsed to one entry per session.
 // A spec uses this as a PRECONDITION barrier, never as the property under
 // test: the log is a bounded global ring written from an async cast, so a

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -15,6 +15,15 @@
 // operator's prod ritual byte-for-byte (a regression in the mix tasks
 // surfaces in this stack first).
 
+// The ONE import in this module, and it is type-only: `wireTypes.ts` is
+// GENERATED from the server (`mix grappa.gen_wire_types`, drift-gated by #767),
+// and it declares no imports of its own, so it cannot pull a fixture back in
+// and cannot reach the solid-js dependency that keeps `e2e/` from importing
+// the rest of `src/`. Nothing here depends on another fixture module: that is
+// the property that keeps this file cycle-free, and a type erased at compile
+// time does not touch it.
+import type { NetworksAdminWireT } from "../../src/lib/wireTypes";
+
 export const GRAPPA_BASE_URL = "http://grappa-test:4000";
 
 export type LoginResult = {
@@ -494,6 +503,47 @@ export async function setAdminFlag(
     throw new Error(
       `grappaApi.setAdminFlag: is_admin=${isAdmin} on ${userId} → ${res.status} ${await res.text()}`,
     );
+  }
+}
+
+// The two PER-SUBJECT caps, and only those two. `Grappa.Admission` treats them
+// as one axis with two values: `check_network_total/2` has a clause per
+// subject_kind and each reads the column matching its own kind, so the kind
+// SELECTS the column.
+type CapDimension = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions";
+
+// `max_per_ip` joins them here as a separate term because it is a separate
+// axis, not a third value of this one. Admission enforces it in its own
+// function, over a different unit (distinct persisted subjects keyed on
+// `accounts_sessions.ip`, not live registry sessions), and reads `subject_kind`
+// as a FILTER rather than a column selector. The sharpest tell is the sentinel:
+// `nil` on a per-subject cap means UNLIMITED, while `nil` on `max_per_ip` means
+// fall back to the operator default. The server's own generated wire agrees —
+// `AdminEventsWireCapCountsChangedEvent` pairs the two per-subject caps with
+// their live counts and omits `max_per_ip`, there being no per-IP count.
+//
+// Derived from the generated row type rather than spelled by hand, so a rename
+// on the server fails this file at `tsc` instead of drifting past it. Being a
+// PICK is also what keeps the verb honest: the endpoint casts seven fields, and
+// naming three of them is what stops `adminPatchCaps` from moving
+// `visitor_enabled`.
+type NetworkCaps = Partial<Pick<NetworksAdminWireT, CapDimension | "max_per_ip">>;
+
+export async function adminPatchCaps(
+  adminToken: string,
+  slug: string,
+  caps: NetworkCaps,
+): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${adminToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(caps),
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
   }
 }
 

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -386,6 +386,11 @@ export async function restoreReadCursorToTail(
 // authoritative `read_cursor_set` WS path. Caller restores via
 // `restoreReadCursorToTail` in afterAll (BUGHUNT-3 cascade rule) — the
 // tail is a FORWARD move, so the production endpoint still serves it.
+//
+// Seeding the cursor client-side is NOT an alternative: post-CP29 R-1..R-4
+// the cursor is server-owned, cic hydrates it from the `/me` envelope at cold
+// load and from the per-channel join reply on subscribe, and the R-4 migration
+// nukes the legacy localStorage `rc:` keys on boot.
 export async function setReadCursorToId(
   token: string,
   networkSlug: string,

--- a/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
@@ -115,32 +115,6 @@ async function fetchScrollbackPage(
   }>;
 }
 
-// Pre-seed the SERVER-side read cursor for `(NETWORK_SLUG, channel)` at
-// the given message id. Post-CP29 R-1..R-4 the cursor is server-owned;
-// cic hydrates from the `/me` envelope at cold load + per-channel join
-// reply on subscribe. localStorage `rc:` keys are nuked on cic boot
-// (R-4 migration), so the pre-CP29 seedCursor-via-localStorage shape
-// no longer worked.
-//
-// Mirrors `cicchetto/src/lib/readCursor.ts`'s `advanceReadCursor` POST
-// (forward-only via `Grappa.ReadCursor.advance/4` — sending the same
-// id twice is idempotent). Server-side broadcast falls back to a no-op
-// for cross-device fanout because no other WS subscriber exists at
-// seed time; the cold-load `/me` envelope picks the value up when
-// `loginAs` triggers cic boot.
-async function seedCursor(page: Page, channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  // Delegates to the shared `setReadCursorToId` (test-only force endpoint,
-  // `ReadCursor.force_set/4`) so the mid-page seed lands regardless of
-  // prior cursor state — the production endpoint is advance-only since
-  // #233 and would clamp a backward seed to whatever tail a prior spec
-  // left behind (order-dependent flake).
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-  // `page` retained as a parameter for symmetry with the prior helper
-  // shape; not currently used (server is the source of truth post-R-4).
-  void page;
-}
-
 test.describe("CP14 B1 — divider present vs absent: scroll always lands at bottom on window open", () => {
   // Force a tiny viewport so the seeded 50-row REST page reliably
   // overflows the scrollback area. Without this, chromium's default
@@ -160,7 +134,7 @@ test.describe("CP14 B1 — divider present vs absent: scroll always lands at bot
     // Wire shape is DESC, so rows[0] is the newest (highest id).
     const tail = page0[0];
     if (!tail) throw new Error("no seeded rows");
-    await seedCursor(page, CHANNEL, tail.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tail.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -208,7 +182,7 @@ test.describe("CP14 B1 — divider present vs absent: scroll always lands at bot
     // → unreadCount = 25.
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(page, CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -86,10 +86,6 @@ async function fetchScrollbackPage(token: string, channel: string): Promise<Arra
 // cic's mount-time POST may already have landed at store-tail, and the
 // production endpoint has been advance-only since #233 (a backward seed
 // through it would be silently clamped).
-async function seedCursor(token: string, channel: string, messageId: number): Promise<void> {
-  await setReadCursorToId(token, NETWORK_SLUG, channel, messageId);
-}
-
 async function visibleTailId(page: Page): Promise<number | null> {
   return await page.evaluate(() => {
     const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
@@ -220,7 +216,7 @@ test.describe("BUGHUNT-2 cursor — forward-only contract", () => {
     // the settle window so the scroll-settle POST from this wheel-up
     // lands BEFORE we snapshot cursor + visible. Settle POSTs
     // `visible` which advances cursor; we override below with
-    // seedCursor at baseline = mid-pane, so the post-switch leave-arm's
+    // a forced cursor at baseline = mid-pane, so the post-switch leave-arm's
     // visible POST will be < baseline and dropped by the forward-only
     // gate.
     await scrollByPx(page, -400);
@@ -250,7 +246,7 @@ test.describe("BUGHUNT-2 cursor — forward-only contract", () => {
     }
     const baselineRow = candidates[Math.floor(candidates.length / 2)];
     if (!baselineRow) throw new Error("baselineRow not found");
-    await seedCursor(vjt.token, CHANNEL, baselineRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, baselineRow.id);
 
     // Wait for cic to observe the cursor via WS broadcast — otherwise
     // setCursorIfAdvances evaluates against stale local state.

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -101,11 +101,6 @@ async function fetchScrollbackPage(
 // advance-only since #233, so a mid-page (backward) seed through it would
 // be clamped to the tail a prior spec left behind and no divider would
 // render.
-async function seedCursor(channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-}
-
 test.describe("issue #168 — send pins to bottom, never jumps to the unread marker", () => {
   test.use({ viewport: { width: 800, height: 300 } });
 
@@ -119,7 +114,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -171,7 +166,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
@@ -23,7 +23,13 @@
 // seeded headroom (100) so no later spec inherits a cap=1 on the shared
 // runner IP.
 
-import { GRAPPA_BASE_URL, login, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import {
+  adminPatchCaps,
+  GRAPPA_BASE_URL,
+  login,
+  mintVisitor,
+  reapVisitors,
+} from "../fixtures/grappaApi";
 import { ADMIN_IDENTIFIER, ADMIN_PASSWORD } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -31,24 +37,6 @@ import { expect, test } from "../fixtures/test";
 // value later specs rely on (see compose.yaml azzurra seeder).
 const AZZURRA = "azzurra";
 const AZZURRA_SEED_MAX_PER_IP = 100;
-
-async function adminPatchCaps(
-  adminToken: string,
-  slug: string,
-  caps: Record<string, number | null>,
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(caps),
-  });
-  if (!res.ok) {
-    throw new Error(`adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
-  }
-}
 
 test("#171 — 2nd nil-client visitor from the same source IP is rejected 503 too_many_sessions", async () => {
   const admin = await login(ADMIN_IDENTIFIER, ADMIN_PASSWORD);

--- a/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
@@ -89,11 +89,6 @@ async function fetchScrollbackPage(token: string, channel: string): Promise<Arra
 // to the shared `setReadCursorToId` (test-only force endpoint) so the seed
 // lands regardless of prior cursor state — the production endpoint is
 // advance-only since #233 and would clamp a backward seed.
-async function seedCursor(channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-}
-
 test.describe("issue #230 — wheel-up loads older history when content underfills", () => {
   // TALL viewport: the ~50-row tail load must be SHORTER than the container
   // so `.scrollback` is not natively scrollable (the bug's precondition).
@@ -110,7 +105,7 @@ test.describe("issue #230 — wheel-up loads older history when content underfil
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
     if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");
-    await seedCursor(CHANNEL, headId);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, headId);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -21,7 +21,7 @@
 // then reverted in afterEach so the shared stack baseline is restored.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, setAdminFlag } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -29,19 +29,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" },
-    body: JSON.stringify({ is_admin: isAdmin }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `PATCH /admin/users/${userId} is_admin=${isAdmin} → ${res.status} ${await res.text()}`,
-    );
-  }
-}
 
 test.describe("#291 — home launcher in the rail actions drawer", () => {
   let vjtUserId: string;

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -24,7 +24,7 @@
 // shared baseline is restored (mirrors #291).
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, setAdminFlag } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -32,19 +32,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MIN_TAP_TARGET_PX = 44;
 
 test.setTimeout(60_000);
-
-async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" },
-    body: JSON.stringify({ is_admin: isAdmin }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `PATCH /admin/users/${userId} is_admin=${isAdmin} → ${res.status} ${await res.text()}`,
-    );
-  }
-}
 
 // Open the mobile members/rail drawer via the TopicBar hamburger (present on
 // the channel windows these tests drive) and return the drawer locator so

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -117,11 +117,6 @@ async function fetchScrollbackPage(token: string, channel: string): Promise<Arra
   return (await res.json()) as Array<{ id: number }>;
 }
 
-async function seedCursor(channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-}
-
 // Open the per-channel delivery gap (#159): silence live `phx.on("event")` for
 // this channel's topic while the socket + every other channel stay live, so a
 // message posted during the hidden window is MISSED live and only re-fetched by
@@ -157,7 +152,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
-    await seedCursor(CHANNEL, tailId);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -213,7 +208,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -269,7 +264,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
-    await seedCursor(CHANNEL, tailId);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -316,7 +311,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
-    await seedCursor(CHANNEL, tailId);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -94,11 +94,6 @@ async function fetchScrollbackPage(token: string, channel: string): Promise<Arra
 
 // Test-only force endpoint (ReadCursor.force_set/4) — the production endpoint
 // is advance-only (#233), so a backward mid-page seed must go through force.
-async function seedCursor(channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-}
-
 // Fetch-wrap: the send POST reaches the server (which persists + WS-broadcasts
 // the row) but the CLIENT sees a failure — the #580 "server accepted, client
 // POST dropped" shape. Only the send POST is intercepted; every other request
@@ -146,7 +141,7 @@ async function arriveParkedOnMarker(page: Page, channel: string): Promise<void> 
   expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
   const cursorRow = page0[25];
   if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-  await seedCursor(channel, cursorRow.id);
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, cursorRow.id);
 
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -120,22 +120,6 @@ async function scrollbackGeometry(
   });
 }
 
-// Pre-seed the SERVER-side read cursor for `(NETWORK_SLUG, channel)` at
-// the given message id. Post-CP29 R-1..R-4 the cursor is server-owned;
-// cic hydrates from the `/me` envelope at cold load + per-channel join
-// reply on subscribe. localStorage `rc:` keys are nuked on cic boot
-// (R-4 migration), so the pre-CP29 seedCursor-via-localStorage shape
-// no longer worked. Same shape cp14-b1 uses.
-async function seedCursor(page: Page, channel: string, messageId: number): Promise<void> {
-  const vjt = specUser();
-  // Delegates to the shared `setReadCursorToId` (test-only force endpoint,
-  // `ReadCursor.force_set/4`) so a mid-page seed lands regardless of prior
-  // cursor state — the production endpoint is advance-only since #233 and
-  // would clamp a backward seed (order-dependent flake).
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
-  void page;
-}
-
 // Fetch the latest scrollback page via REST. Used in scenario 2 to
 // compute the cursor server_time placing the marker mid-pane. Same
 // shape cp14-b1 uses.
@@ -189,7 +173,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
     if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");
-    await seedCursor(page, CHANNEL, headId);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, headId);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -269,7 +253,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(page, CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -359,7 +343,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(page, CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
     // Reboot the app BEFORE any window focus, then focus #bofh — a cold mount
@@ -417,7 +401,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(page, CHANNEL, cursorRow.id);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     // Deterministic warmth gate: cic eagerly `refreshScrollback`es every
     // joined channel on its Phoenix join-ok (subscribe.ts) — REFRESH_LIMIT

--- a/cicchetto/e2e/tests/u-2-admission-split.spec.ts
+++ b/cicchetto/e2e/tests/u-2-admission-split.spec.ts
@@ -36,7 +36,12 @@
 // afterEach restores caps to permissive defaults so subsequent specs
 // see the seeder baseline.
 
-import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import {
+  adminPatchCaps,
+  GRAPPA_BASE_URL,
+  login,
+  patchNetworkConnectionState,
+} from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -46,26 +51,6 @@ import {
 import { expect, specUser, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
-
-type CapDimension = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions";
-
-async function adminPatchCaps(
-  adminToken: string,
-  slug: string,
-  caps: Partial<Record<CapDimension | "max_per_ip", number | null>>,
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(caps),
-  });
-  if (!res.ok) {
-    throw new Error(`adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
-  }
-}
 
 // PATCH /networks/:slug {connection_state: "connected"} returning the
 // raw response so the matrix arm can assert status + body shape

--- a/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
+++ b/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
@@ -42,7 +42,12 @@
 // afterEach restores caps to permissive defaults.
 
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import {
+  adminPatchCaps,
+  GRAPPA_BASE_URL,
+  login,
+  patchNetworkConnectionState,
+} from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -54,26 +59,6 @@ import {
 import { expect, specUser, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
-
-type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
-
-async function adminPatchCaps(
-  adminToken: string,
-  slug: string,
-  caps: Partial<Record<CapKnob, number | null>>,
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(caps),
-  });
-  if (!res.ok) {
-    throw new Error(`adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
-  }
-}
 
 // /connect a network via the user-flow REST surface — returns the raw
 // Response so the arm can assert status + body shape without the

--- a/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
@@ -92,7 +92,12 @@
 // restores vjt to :connected so subsequent specs see the seeder
 // baseline. Mirrors u-2 + u-3 cleanup pattern.
 
-import { GRAPPA_BASE_URL, login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import {
+  adminPatchCaps,
+  GRAPPA_BASE_URL,
+  login,
+  patchNetworkConnectionState,
+} from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -102,26 +107,6 @@ import {
 import { expect, specUser, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
-
-type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
-
-async function adminPatchCaps(
-  adminToken: string,
-  slug: string,
-  caps: Partial<Record<CapKnob, number | null>>,
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(caps),
-  });
-  if (!res.ok) {
-    throw new Error(`adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
-  }
-}
 
 // Fetch a single network's admin row by filtering the
 // `GET /admin/networks` index payload. The singular-GET endpoint is

--- a/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
@@ -37,6 +37,7 @@
 
 import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import {
+  adminPatchCaps,
   GRAPPA_BASE_URL,
   login,
   patchNetworkConnectionState,
@@ -51,26 +52,6 @@ import {
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
-
-type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
-
-async function adminPatchCaps(
-  adminToken: string,
-  slug: string,
-  caps: Partial<Record<CapKnob, number | null>>,
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${encodeURIComponent(slug)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(caps),
-  });
-  if (!res.ok) {
-    throw new Error(`adminPatchCaps: ${slug} → ${res.status} ${await res.text()}`);
-  }
-}
 
 async function fetchChannels(token: string): Promise<Array<{ name: string; joined: boolean }>> {
   const res = await fetch(`${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`, {

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -29,28 +29,12 @@
 // channel + rail drawer) without ripple-affecting other specs.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, setAdminFlag } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 test.setTimeout(60_000);
-
-async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ is_admin: isAdmin }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `PATCH /admin/users/${userId} is_admin=${isAdmin} → ${res.status} ${await res.text()}`,
-    );
-  }
-}
 
 test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () => {
   let vjtUserId: string;

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -38,29 +38,13 @@
 // references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
-import { findUserIdByName, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { findUserIdByName, setAdminFlag } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(60_000);
-
-async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ is_admin: isAdmin }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `PATCH /admin/users/${userId} is_admin=${isAdmin} → ${res.status} ${await res.text()}`,
-    );
-  }
-}
 
 // GREEN-CI batch 2 — replaces the original `promoteVjtToAdmin` helper
 // that hardcoded `const adminToken = "admin-vjt"` (just the literal

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -59,6 +59,7 @@ import {
   listSessionLogSessions,
   mintVisitor,
   reapVisitors,
+  setAdminFlag,
 } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -170,22 +171,6 @@ type Offender = {
   scrollW: number;
   clientW: number;
 };
-
-async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ is_admin: isAdmin }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `PATCH /admin/users/${userId} is_admin=${isAdmin} → ${res.status} ${await res.text()}`,
-    );
-  }
-}
 
 // A Vhosts row to measure. Mirrors issue252's candidate rule: the address
 // must be one with no vhost row yet, or the create 409s.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49592,3 +49592,95 @@ on those copies being one shape — not on a run. The e2e project that matters i
 `webkit-iphone-15`: ten of the eleven tests in these files are `@webkit`, and
 the chromium project's `grepInvert: /@webkit/` would execute a single test and
 report rc=0.
+<!-- entry #1397-e2e-adminpatchcaps -->
+
+---
+
+## 2026-08-18 — #1397 (e2e): two cap axes, and a type nobody has to maintain
+
+`adminPatchCaps` stood five times over five spec files. The bodies were
+byte-identical — one md5 once the parameter line is excluded — and the whole
+divergence was the type of `caps`, spelled three ways: a flat three-key
+`CapKnob` in three copies, `CapDimension | "max_per_ip"` in a fourth, and a
+wide-open `Record<string, number | null>` in the fifth.
+
+The first question was whether any of it was load-bearing. Unifying all five on
+the NARROWEST of the three type-checks clean, including the computed
+`{ [arm.cap]: 0 }` key in the admission-split spec; a deliberately bogus key
+reddens both files that were widened, so the green is enforced rather than
+vacuous. No test depended on the divergence. That settled what unifying costs,
+and left open the only thing that actually mattered: which spelling is TRUE.
+
+### Why the two-term spelling won — the axes, not the ergonomics
+
+The flat `CapKnob` reads better and was the majority, and it is wrong.
+`Grappa.Admission` does not treat the three as one family:
+
+- `check_network_total/2` has a clause per `subject_kind`, and each clause
+  reads the column matching its own kind. The kind SELECTS the column, which is
+  what makes the two per-subject caps two values of one axis.
+- `check_ip_cap/2` is a separate function over a single column, and passes
+  `subject_kind` to the COUNT as a filter. Nothing selects anything.
+- They do not even count the same objects: live sessions in the
+  `SessionRegistry` on one side, distinct persisted subjects keyed on
+  `accounts_sessions.ip` on the other.
+- The sentinel is the sharpest tell, because it is outright opposite. `nil` on
+  a per-subject cap short-circuits to `:ok` — unlimited. `nil` on `max_per_ip`
+  falls through to `@default_max_per_ip_per_network`, a compile-env default,
+  which is a cap and not its absence. One `nil` means "no limit" and the other
+  means "the standard limit".
+
+The server had already said as much in a file nobody wrote by hand:
+`AdminEventsWireCapCountsChangedEvent` carries `visitors`, `users`, and the two
+per-subject caps, and omits `max_per_ip` — there being no per-IP count to pair
+it with. A generated wire shape that groups exactly the two is stronger
+evidence than any of the five hand-typed aliases.
+
+So `CapDimension` was deliberate vocabulary in the one spec whose subject IS
+that the two per-subject caps are independent, and the majority spelling was
+the copy that lost the distinction. Majority is not evidence when the copies
+are copies.
+
+### The type is derived, so nobody maintains it
+
+`cicchetto/src/lib/wireTypes.ts` is generated from the server
+(`mix grappa.gen_wire_types`) and drift-gated in CI by #767, and it carries
+`NetworksAdminWireT` with all seven fields the network PATCH casts. The
+parameter is therefore
+`Partial<Pick<NetworksAdminWireT, CapDimension | "max_per_ip">>` rather than a
+hand-written union: a rename on the server regenerates the row type and fails
+THIS file at `tsc`, instead of leaving a stale alias that still compiles
+against a column that no longer exists. That is precisely how the alias came to
+exist in two spellings — it was hand-copied three times.
+
+Being a `Pick` also does the work of the honest name. The endpoint casts seven
+fields, and the widest of the old copies would have let a function called
+`adminPatchCaps` move `visitor_enabled`. That width was never used by any
+caller, and it is a lie removed rather than a capability lost: the compiler now
+rejects the key BY NAME.
+
+### The leaf claim, restated
+
+Two earlier entries in this issue lean on `grappaApi.ts` importing nothing,
+citing `grep -c '^import'` as 0. It is 1 now, and the property those entries
+were actually protecting is intact: what keeps this module cycle-free is that
+it depends on no other FIXTURE, and `wireTypes.ts` is generated, declares no
+imports of its own, and is imported `type`-only, so it is erased before
+anything runs. It is also why the recorded reason `e2e/` mirrors `src/` types
+by hand — those modules pull in solid-js, absent from `e2e/node_modules` — does
+not reach this one; that was checked rather than assumed. Read the earlier
+entries' grep as shorthand for "no fixture dependency", which is what it was
+standing in for.
+
+### What gated it
+
+`bun run check` is rc=0 with the same 59 pre-existing CSS warnings. Two
+mutations carry the rest. A fourth required parameter on the shared
+`adminPatchCaps` killed **fifteen call sites across all five files**, which is
+the wiring: a surviving local copy would have shadowed the import and stayed
+quiet. Passing `visitor_enabled` at a call site fails with TS2353 naming the
+key, which is the narrowing.
+
+No spec was executed for this entry. The behavioural claim rests on the bodies
+being byte-identical and on the fifteen call sites type-checking against a type
+that admits exactly what the copies admitted — not on a run.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49509,3 +49509,86 @@ call as #1518.
 The unit suite and `bun run check` are the whole of it. No e2e spec was run.
 The `console.warn` on the detached confirm path is unasserted before and after,
 so the mutant table says nothing about it.
+<!-- entry #1397-e2e-setadminflag -->
+
+---
+
+## 2026-08-18 — #1397 (e2e): one admin-flag verb, and the home a boundary chose
+
+`setAdminFlag` stood five times across five spec files, 69 lines in all. Hashed
+by body it looked drifted — two groups, twelve lines against fifteen — but the
+two collapse to ONE once whitespace and a trailing comma are normalised: the
+whole difference is the formatter wrapping a `headers` object literal. No
+author ever decided anything different here, so consolidating decided nothing
+either. That is the property that made this the slice to take: the census had
+no other e2e helper at one shape, and the runners-up all hide a real choice
+(`adminPatchCaps` types its `caps` parameter three different ways).
+
+The five files are exactly the caller set of `findUserIdByName`, extracted a
+day earlier in the same issue. They already imported from `grappaApi`, so the
+change adds no import statement anywhere.
+
+### The fork: which fixture module gets to hold it
+
+The sibling #1397 slice put `adminLogin` in `fixtures/cicchettoPage.ts`. This
+one goes to `fixtures/grappaApi.ts`, and the divergence is the boundary rather
+than an inconsistency: `adminLogin(page, admin)` takes a `Page` and drives the
+browser, while `setAdminFlag` is a bare `PATCH /admin/users/:id` that never
+touches one. Sorting by what a helper TALKS TO keeps the two modules meaning
+something — REST verbs on one side, page choreography on the other. Sorting by
+the feature a helper happens to serve ("admin things together") would have put
+a `fetch` next to a `page.click`, and the next reader would have had to grep
+both modules to learn which surface a verb speaks to.
+
+The cheap counter-argument is that `grappaApi` is 994 lines and growing, so a
+sixth admin verb should have started an `adminApi.ts`. Rejected here for the
+same reason the boundary was: splitting by SUBJECT (admin vs user) cuts across
+the split by SURFACE (REST vs page) that the fixture graph already has, and two
+overlapping taxonomies is worse than one long file. A split by surface — if
+`grappaApi` ever earns one — would keep every verb in this slice on the same
+side of the cut, so nothing here forecloses it.
+
+Hosting cost nothing structurally, unlike the `findUserIdByName` fork the day
+before: that helper wanted `specUser()` and would have made the leaf import a
+module that imports it, so the name had to become a parameter. This one needs
+only `GRAPPA_BASE_URL`, declared in `grappaApi` itself. The leaf stays a leaf
+(`grep -c '^import'` is still 0) without anyone having to arrange it.
+
+### What this slice does NOT buy
+
+The issue's argument for collapsing `adminLogin` is a latent flake: `loginAs`
+learned a `waitForUserTopicReady` barrier and none of the twenty hand-rolled
+copies reference it, so the duplicates are behaviourally BEHIND the fixture.
+Nothing of the kind is true here. All five copies do the same thing, correctly,
+and there is no barrier they are missing. This slice buys 49 net lines and one
+place to change the verb — it does not buy determinism, and claiming otherwise
+would misread the census.
+
+Two small things changed on the way in. The thrown message takes the
+`grappaApi.<fn>:` prefix its neighbours use and gains the user id, keeping the
+status and body it already carried. And four of the five files imported
+`GRAPPA_BASE_URL` solely to feed the copy being deleted; those imports are
+pruned, which biome would otherwise have failed on.
+
+### What gated it, and what did not
+
+`bun run check` is rc=0, with the same 59 CSS warnings the branch point has and
+none of them naming a touched file. That check is worth spelling out because a
+green over `src` alone would say nothing about this change: it is
+`biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json`, and the
+third clause is the one that covers `e2e/`.
+
+The wiring was proven by mutation rather than by the green. Giving the exported
+`setAdminFlag` a fourth required parameter lit up **eleven call sites across all
+five files** — which establishes both that the type gate actually reads those
+files and that every call now routes through the shared definition, since a
+surviving local copy would have shadowed the import and stayed silent.
+
+### Limits of this measurement
+
+Static only. No spec was executed for this entry, so the behavioural claim
+rests on the eleven call sites being type-identical to the deleted copies and
+on those copies being one shape — not on a run. The e2e project that matters is
+`webkit-iphone-15`: ten of the eleven tests in these files are `@webkit`, and
+the chromium project's `grepInvert: /@webkit/` would execute a single test and
+report rc=0.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49684,3 +49684,92 @@ key, which is the narrowing.
 No spec was executed for this entry. The behavioural claim rests on the bodies
 being byte-identical and on the fifteen call sites type-checking against a type
 that admits exactly what the copies admitted — not on a run.
+<!-- entry #1397-e2e-seedcursor -->
+
+---
+
+## 2026-08-18 — #1397 (e2e): a wrapper that hid no observable
+
+The census counted `seedCursor` at seven copies over seven files with four
+distinct body hashes, and filed it as four-or-more shapes to reconcile. It is
+**two**, and neither is an implementation: every one of the seven delegates to
+`grappaApi.setReadCursorToId`, which was already shared and which thirteen
+other spec files already call in the open. Six of the seven bound
+`specUser().token` and `NETWORK_SLUG`; the seventh bound the slug alone and
+took the token as a parameter. That is the entire divergence. The four hashes
+were comment prose plus a dead parameter.
+
+So the question was never which shape wins. It was whether a wrapper whose
+whole content is argument binding is worth sharing at all — and the answer
+taken here is no, on three grounds in this order.
+
+**It hides no observable.** A helper earns its name by making something
+unavailable to the caller: a barrier, an invariant, a retry, a shape the caller
+must not get wrong. `seedCursor` made nothing unavailable. It reordered four
+arguments into three. A wrapper that hides no observable is not a name, it is a
+detour, and the reader who follows it arrives where they started.
+
+**One of its parameters was a confessed lie.** Two copies took a `page` they
+immediately discarded with `void page;`, and the code said so out loud —
+*"retained as a parameter for symmetry with the prior helper shape; not
+currently used"*. A parameter kept for symmetry with a shape that no longer
+exists is worse than no helper: it tells fifteen call sites to hand over
+something the callee has no use for.
+
+**Thirteen other files already call the verb directly.** Inlining does not
+invent a house style; it moves the outliers onto the one that already had a
+supermajority.
+
+### Why hosting it somewhere was refused
+
+The alternative was a single bound `seedCursor(channel, id)` in a fixture. Its
+value would be exactly the binding — `specUser()` and `NETWORK_SLUG` — and that
+is what makes it impossible to place. `specUser()` lives in `specSubject.ts`,
+which imports `grappaApi`; `NETWORK_SLUG` lives in `seedData.ts`. Putting the
+bound helper in `grappaApi` is the cycle the `findUserIdByName` slice refused
+earlier in this issue, and a NEW fixture module to host it would end the
+property that refusal was protecting: `grappaApi` is the only leaf of the
+fixture graph. Parameterise the token so it fits the leaf, and what is left is
+`setReadCursorToId(token, slug, channel, id)` — which exists. The wrapper
+dissolves under every placement that does not cost more than it saves.
+
+### `seedCursorToHead` is not an eighth copy
+
+`issue230-mobile-touch-underfill-loadmore.spec.ts` has a `seedCursorToHead`
+that shares a prefix and nothing else: it resolves the head id through
+`fetchAllMessagesAsc` first, then seeds. It is a different verb, it stays, and
+it is named here so the next reader counting copies by prefix does not fold it
+into this one. Counting duplicates by name prefix is how `bootVisitorMobile`
+and this both landed in a census as copies of something they are not.
+
+### One comment was already false
+
+The wrappers carried docblocks explaining why seeding goes through the server.
+Half of that is durable and had no home outside the wrappers — that a
+client-side seed is not an alternative, the cursor being server-owned since
+CP29 R-1..R-4 and the legacy localStorage `rc:` keys being nuked at cic boot by
+the R-4 migration. It is lifted onto `setReadCursorToId` once, rather than
+standing twice next to callers.
+
+The other half was wrong before this slice touched it. It claimed the helper
+*"mirrors `cicchetto/src/lib/readCursor.ts`'s `advanceReadCursor` POST
+(forward-only …)"* — while the body it sat above called `setReadCursorToId`,
+whose own documentation says it reaches the TEST-ONLY force endpoint precisely
+to BYPASS the forward-only clamp that #233 introduced. A duplicated helper
+drifts in its code; its comment drifts faster, because nothing type-checks
+prose.
+
+### What gated it
+
+`bun run check` is rc=0 with the same 59 pre-existing CSS warnings. A required
+fourth parameter on `setReadCursorToId` reddened **28 call sites across 20
+files**, of which exactly the **15** belonging to the seven files here, at the
+expected per-file cardinalities (4, 4, 2, 2, 1, 1, 1).
+
+That mutation proves the fifteen sites reach the shared verb. It does NOT
+isolate them from the thirteen pre-existing callers, and more to the point it
+cannot see argument ORDER: `networkSlug` and `channel` are both `string`, so a
+transposition at any of the fifteen would type-check and fail only at runtime.
+No spec was executed for this entry, so that transposition is unmeasured — the
+argument for it is that each call site was rewritten from a wrapper whose own
+call already had the order right, not that anything checked.


### PR DESCRIPTION
Three slices of the #1397 e2e helper census, each taken because measurement
said it was safe to take — not because the census counted copies.

## setAdminFlag — 5 copies, one shape

Two md5 groups that collapse to ONE once whitespace and a trailing comma are
normalised: the drift was the formatter's, so consolidating decided nothing.
Now `grappaApi.setAdminFlag`, beside `findUserIdByName`, whose caller set is
exactly the same five files. Sorted by the surface a helper talks to — this is
a `PATCH` and never touches a `Page` — rather than by the feature it serves.

## adminPatchCaps — 5 copies, and a type that names two axes

The bodies were byte-identical; only the `caps` parameter diverged, three ways,
and no caller depended on the divergence (unifying on the narrowest
type-checks clean, with a bogus key still rejected).

The parameter keeps the two-term spelling `CapDimension | "max_per_ip"` because
those are two AXES, not three values of one. `Grappa.Admission` enforces the
per-subject caps in a clause per `subject_kind`, each reading the column its
kind selects, over live registry sessions; `max_per_ip` gets its own function,
counts distinct persisted subjects keyed on the session IP, and reads
`subject_kind` as a filter. The sentinel settles it: `nil` means unlimited on a
per-subject cap and means "use the operator default" on `max_per_ip`. The
server's own generated wire agrees — `cap_counts_changed` carries the two
per-subject caps with their live counts and no `max_per_ip`.

The type is DERIVED from the generated `NetworksAdminWireT` rather than
hand-spelled, so the #767 drift gate keeps it aligned and a server-side rename
fails `tsc` here. Being a `Pick` is also what keeps the verb honest: the
endpoint casts seven fields, and naming three is what stops a function called
`adminPatchCaps` from moving `visitor_enabled` — which the widest of the old
copies allowed.

## seedCursor — 7 wrappers retired, not rehomed

None of the seven implemented anything: each delegated to the already-shared
`grappaApi.setReadCursorToId`, which thirteen other spec files already call in
the open. A wrapper that hides no observable is not a name, it is a detour.
Two of them also carried a `page` they discarded with `void page;`, one
commenting that it was "retained as a parameter for symmetry with the prior
helper shape; not currently used".

Rehoming a bound version was refused: binding `specUser()` and `NETWORK_SLUG`
means importing `specSubject` and `seedData`, which `grappaApi` cannot do
without the cycle an earlier slice of #1397 refused, and a new fixture node
would end the leaf property that refusal protects.

`seedCursorToHead` is untouched — it resolves the head id through
`fetchAllMessagesAsc` first, so it shares a prefix and not a body.

## Net

+29/-78, +76/-102 and +21/-82 across the three slices. `grappaApi.ts` gains its
only import, type-only, from the generated import-free `wireTypes.ts`.

## Gates

- `bun run check` rc=0, with the same 59 pre-existing CSS warnings as the
  branch point. The e2e clause matters here:
  `biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json`.
- Static mutation, wiring: a required extra parameter on each shared helper
  killed 11/11, 15/15 and (for the inlined verb) 28 sites across 20 files
  including exactly the 15 belonging to this branch, at the expected per-file
  cardinalities.
- Static mutation, narrowing: passing `visitor_enabled` to `adminPatchCaps`
  fails TS2353 naming the key.
- e2e over the 17 touched spec, BOTH projects: **45 passed**, rc=0 — 30
  chromium and 15 webkit-iphone-15, matching `--list` exactly.
- e2e positive control: one deliberate `NETWORK_SLUG`/`CHANNEL` transposition
  at a single inlined call site turns that spec red (`POST
  /read-cursor/force → 404`), 1 failed / 3 passed. Reverted, 4 passed. The
  green measures argument order rather than assuming it.

## Not established

- The transposition control was injected at ONE of the fifteen sites. It shows
  the suite can see the defect class, not that every site has its own guard.
- No runtime mutant for `setAdminFlag` or `adminPatchCaps`; their evidence is
  static plus these 45.
- The full `scripts/integration.sh` suite was not run — only the 17 touched
  spec. `grappaApi.ts` has callers outside that set.