### PR TITLE
e2e(#1397): one transport for GET /messages, a narrow promise out

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -324,6 +324,22 @@ export async function adminDeleteTheme(adminToken: string, id: number): Promise<
   }
 }
 
+// #1397 — a non-ok STATUS from `getMessagesPage`, as a type, so a caller can
+// tell it apart from a transport death. Only `assertMessagePersisted` needs
+// the distinction: a 4xx/5xx there means "the row has not landed yet" and is
+// worth another poll, while a thrown fetch means the stack is gone and
+// retrying would mask the fault instead of measuring it. Everyone else lets
+// both propagate and never looks at this class.
+class MessagesPageStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, body: string) {
+    super(`grappaApi.getMessagesPage: GET → ${status} ${body}`);
+    this.name = "MessagesPageStatusError";
+    this.status = status;
+  }
+}
+
 // #1397 — the ONE `GET /networks/:slug/channels/:channel/messages` in the
 // e2e suite. Thirteen sites spoke this request verbatim (ten spec-local
 // `fetchScrollbackPage` copies plus three here); they differed only in
@@ -345,7 +361,7 @@ async function getMessagesPage(
   const url = before === undefined ? base : `${base}?before=${before}`;
   const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
   if (!res.ok) {
-    throw new Error(`grappaApi.getMessagesPage: GET → ${res.status} ${await res.text()}`);
+    throw new MessagesPageStatusError(res.status, await res.text());
   }
   return (await res.json()) as WireMessage[];
 }
@@ -705,26 +721,29 @@ export async function assertMessagePersisted(opts: AssertMessageOpts): Promise<v
   let lastSeen: string[] = [];
   while (Date.now() < deadline) {
     // The one caller for which a non-200 is a RETRY, not a failure: the row
-    // may simply not have landed yet. `getMessagesPage` is fail-fast for
-    // everyone else, so the tolerance lives here, at the polling boundary
-    // that owns it — the deadline below is what turns a persistent failure
-    // into a loud error, with `lastSeen` as the diagnostic.
-    const messages = await getMessagesPage(
-      opts.token,
-      opts.networkSlug,
-      opts.channel,
-      undefined,
-    ).catch(() => undefined);
-    if (messages) {
-      const matched = messages.find(
-        (m) =>
-          m.sender === opts.sender &&
-          (opts.body === undefined || m.body === opts.body) &&
-          (opts.kind === undefined || m.kind === opts.kind),
-      );
-      if (matched) return;
-      lastSeen = messages.map((m) => `${m.kind}/${m.sender}: ${m.body}`);
+    // may simply not have landed yet, and the deadline below is what turns a
+    // persistent absence into a loud error with `lastSeen` attached.
+    //
+    // The catch is deliberately narrow. A transport death is NOT retried:
+    // polling through it would mask the fault instead of measuring it, which
+    // is the no-silent-swallow rule at a boundary. Only the status arm is
+    // tolerated; anything else propagates on the spot.
+    let messages: WireMessage[];
+    try {
+      messages = await getMessagesPage(opts.token, opts.networkSlug, opts.channel, undefined);
+    } catch (err) {
+      if (!(err instanceof MessagesPageStatusError)) throw err;
+      await sleep(intervalMs);
+      continue;
     }
+    const matched = messages.find(
+      (m) =>
+        m.sender === opts.sender &&
+        (opts.body === undefined || m.body === opts.body) &&
+        (opts.kind === undefined || m.kind === opts.kind),
+    );
+    if (matched) return;
+    lastSeen = messages.map((m) => `${m.kind}/${m.sender}: ${m.body}`);
     await sleep(intervalMs);
   }
   throw new Error(

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -324,6 +324,50 @@ export async function adminDeleteTheme(adminToken: string, id: number): Promise<
   }
 }
 
+// #1397 — the ONE `GET /networks/:slug/channels/:channel/messages` in the
+// e2e suite. Thirteen sites spoke this request verbatim (ten spec-local
+// `fetchScrollbackPage` copies plus three here); they differed only in
+// cosmetics and in the width of the `as` cast they applied afterwards.
+//
+// `before` is an explicit parameter with no default: the pager and the
+// single-page callers differ in exactly that argument, and defaulting it
+// would hide which of the two a call site is asking for. The server
+// answers DESC (newest first) and `?before=<id>` walks older pages.
+async function getMessagesPage(
+  token: string,
+  networkSlug: string,
+  channel: string,
+  before: number | undefined,
+): Promise<WireMessage[]> {
+  const base = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
+    networkSlug,
+  )}/channels/${encodeURIComponent(channel)}/messages`;
+  const url = before === undefined ? base : `${base}?before=${before}`;
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`grappaApi.getMessagesPage: GET → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as WireMessage[];
+}
+
+// #1397 — the newest page of scrollback for `(networkSlug, channel)`, in
+// the order the server serves it: DESC by `server_time` per
+// `Grappa.Web.MessagesController.index/2`, so `rows[0]` is the newest row
+// and `rows[25]` is the 26th-newest. Specs index the page to pick a known
+// id — the head id, or a mid-page one that plants an unread divider.
+//
+// Deliberately NARROW: every caller reads `.length` and `.id` and nothing
+// else. The wire carries six more fields, but a return type is a promise,
+// and promising fields nobody collects is a promise kept for free — see
+// `getMessagesPage` when a caller genuinely needs the full row.
+export async function fetchScrollbackPage(
+  token: string,
+  networkSlug: string,
+  channel: string,
+): Promise<Array<{ id: number }>> {
+  return getMessagesPage(token, networkSlug, channel, undefined);
+}
+
 // BUGHUNT-3 cascade fix (2026-05-25) — restore the seeded vjt's read
 // cursor on `(networkSlug, channel)` to the current tail row. Used in
 // `afterAll` hooks of specs that intentionally advance the cursor to
@@ -339,18 +383,7 @@ export async function restoreReadCursorToTail(
   networkSlug: string,
   channel: string,
 ): Promise<void> {
-  const messagesUrl = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    networkSlug,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const messagesRes = await fetch(messagesUrl, {
-    headers: { authorization: `Bearer ${token}` },
-  });
-  if (!messagesRes.ok) {
-    throw new Error(
-      `restoreReadCursorToTail: GET /messages → ${messagesRes.status} ${await messagesRes.text()}`,
-    );
-  }
-  const rows = (await messagesRes.json()) as Array<{ id: number }>;
+  const rows = await getMessagesPage(token, networkSlug, channel, undefined);
   const tail = rows[0];
   if (!tail) return;
   const cursorUrl = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
@@ -423,21 +456,12 @@ export async function fetchAllMessagesAsc(
   networkSlug: string,
   channel: string,
 ): Promise<WireMessage[]> {
-  const base = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    networkSlug,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const headers = { authorization: `Bearer ${token}` };
   const byId = new Map<number, WireMessage>();
   let before: number | undefined;
   // Bounded loop: the e2e seed is ~200 rows; 50 pages of ~50 is a safe
   // ceiling that also stops a server bug from spinning forever.
   for (let page = 0; page < 50; page++) {
-    const url = before === undefined ? base : `${base}?before=${before}`;
-    const res = await fetch(url, { headers });
-    if (!res.ok) {
-      throw new Error(`fetchAllMessagesAsc: GET → ${res.status} ${await res.text()}`);
-    }
-    const rows = (await res.json()) as WireMessage[];
+    const rows = await getMessagesPage(token, networkSlug, channel, before);
     if (rows.length === 0) break;
     for (const r of rows) byId.set(r.id, r);
     // Server returns DESC; the oldest id in this page is the next cursor.
@@ -678,14 +702,20 @@ export async function assertMessagePersisted(opts: AssertMessageOpts): Promise<v
   const intervalMs = opts.intervalMs ?? 100;
   const deadline = Date.now() + timeoutMs;
 
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(opts.networkSlug)}/channels/${encodeURIComponent(opts.channel)}/messages`;
-  const headers = { Authorization: `Bearer ${opts.token}` };
-
   let lastSeen: string[] = [];
   while (Date.now() < deadline) {
-    const response = await fetch(url, { headers });
-    if (response.ok) {
-      const messages = (await response.json()) as WireMessage[];
+    // The one caller for which a non-200 is a RETRY, not a failure: the row
+    // may simply not have landed yet. `getMessagesPage` is fail-fast for
+    // everyone else, so the tolerance lives here, at the polling boundary
+    // that owns it — the deadline below is what turns a persistent failure
+    // into a loud error, with `lastSeen` as the diagnostic.
+    const messages = await getMessagesPage(
+      opts.token,
+      opts.networkSlug,
+      opts.channel,
+      undefined,
+    ).catch(() => undefined);
+    if (messages) {
       const matched = messages.find(
         (m) =>
           m.sender === opts.sender &&

--- a/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
@@ -57,7 +57,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -92,29 +92,6 @@ async function scrollbackGeometry(
   });
 }
 
-// Fetch the latest scrollback page via the REST surface using the spec's
-// own bearer (same shape grappaApi.assertMessagePersisted uses). Returns
-// rows in the wire shape (descending server_time per
-// Grappa.Web.MessagesController.index/2). The spec uses these to compute
-// localStorage cursor values that pin the marker to a known position.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{
-    id: number;
-    server_time: number;
-    sender: string;
-  }>;
-}
-
 test.describe("CP14 B1 — divider present vs absent: scroll always lands at bottom on window open", () => {
   // Force a tiny viewport so the seeded 50-row REST page reliably
   // overflows the scrollback area. Without this, chromium's default
@@ -129,7 +106,7 @@ test.describe("CP14 B1 — divider present vs absent: scroll always lands at bot
     // Fetch seeded rows from grappa-test BEFORE we boot the page so we
     // know the server_time of the tail row. Pre-seed cursor at the
     // tail → unreadCount=0 on first render.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     // Wire shape is DESC, so rows[0] is the newest (highest id).
     const tail = page0[0];
@@ -175,7 +152,7 @@ test.describe("CP14 B1 — divider present vs absent: scroll always lands at bot
     // the bottom → 25 rows are "unread" → marker injected mid-page.
     // 25 unreads is enough to push the marker well into the middle of
     // the visible area without being right at the tail.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     // DESC-ordered, so index 25 is the 26th-newest row. Cursor placed
     // there means rows 0..24 (the newest 25) all satisfy `id > cursor`

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -41,7 +41,7 @@ import {
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -68,15 +68,6 @@ async function fetchCursor(token: string, channel: string): Promise<number | nul
     read_cursors?: Record<string, Record<string, number>>;
   };
   return body.read_cursors?.[NETWORK_SLUG]?.[channel] ?? null;
-}
-
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(NETWORK_SLUG)}/channels/${encodeURIComponent(channel)}/messages`;
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!res.ok) {
-    throw new Error(`fetchScrollbackPage: ${res.status} ${await res.text()}`);
-  }
-  return (await res.json()) as Array<{ id: number }>;
 }
 
 // Pre-seed the SERVER-side read cursor for `(NETWORK_SLUG, channel)` at
@@ -236,7 +227,7 @@ test.describe("BUGHUNT-2 cursor — forward-only contract", () => {
     // size + viewport row density. Pick a row strictly between
     // `visible` and `store` (mid-pane) — any row ID in that range
     // satisfies `visible < baseline ≤ store`.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     const candidates = page0.filter((r) => r.id > (visible as number) && r.id <= (store as number));
     if (candidates.length === 0) {
       throw new Error(

--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -60,7 +60,7 @@ import {
   sidebarWindow,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
@@ -327,7 +327,7 @@ test.describe("issue #1089 — switching into an unread window must not flicker"
 // enough from the top that a scrollTop=0 frame puts it thousands of px
 // off-screen (an unmistakable excursion, not a rounding wobble).
 async function seedMidPageCursor(token: string, channel: string): Promise<void> {
-  const page0 = await fetchScrollbackPage(token, channel);
+  const page0 = await fetchScrollbackPage(token, NETWORK_SLUG, channel);
   expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
   const cursorRow = page0[25];
   if (!cursorRow) throw new Error("seeded page too short for cursor placement");
@@ -419,17 +419,4 @@ async function assertNoVisibleJump(page: Page, tag: string): Promise<Frame[]> {
     )}`,
   ).toEqual([]);
   return frames;
-}
-
-// Fetch the latest scrollback page via REST (same shape as
-// scroll-on-window-switch / issue625) — used to place the cursor mid-page.
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{ id: number }>;
 }

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -46,7 +46,7 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -78,22 +78,6 @@ async function distanceToBottom(page: Page): Promise<number> {
   return g.scrollHeight - g.scrollTop - g.clientHeight;
 }
 
-// Latest REST page in wire shape (DESC by server_time) — used to pick a
-// known message id for the mid-page cursor seed.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{ id: number; server_time: number; sender: string }>;
-}
-
 // Seed the SERVER-side read cursor at the given message id (server-owned
 // post-CP29 R-1..R-4; cic hydrates from the `/me` envelope on cold load).
 // Delegates to the shared `setReadCursorToId`, which hits the TEST-ONLY
@@ -110,7 +94,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
 
     // Seed a cursor 25 rows from the tail → an unread divider is injected
     // mid-page on first focus (25 unread rows, same shape as cp14-b1 sc.2).
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
@@ -162,7 +146,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
     // Mid-page cursor → divider present, pane overflows.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");

--- a/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
@@ -48,7 +48,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -71,19 +71,6 @@ async function scrollbackGeometry(
   });
 }
 
-// Latest REST page (DESC by server_time) — used to pick the HEAD id for the
-// read-cursor seed. Same shape cp14-b1 / issue168 / scroll-on-window-switch use.
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{ id: number }>;
-}
-
 // Seed the SERVER-side read cursor at the given message id (server-owned
 // post-CP29; cic hydrates from the `/me` envelope on cold load). Delegates
 // to the shared `setReadCursorToId` (test-only force endpoint) so the seed
@@ -101,7 +88,7 @@ test.describe("issue #230 — wheel-up loads older history when content underfil
 
     // Seed the cursor to HEAD → no unread divider → cic's cold load is the
     // tail-only ~50-row branch (deterministic, order-independent).
-    const headPage = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
     if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -48,7 +48,7 @@
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import {
-  GRAPPA_BASE_URL,
+  fetchScrollbackPage,
   getReadCursor,
   restoreReadCursorToTail,
   setReadCursorToId,
@@ -73,20 +73,6 @@ async function distFromBottom(page: Page): Promise<number> {
   });
 }
 
-// Latest REST page (DESC by server_time; rows[0] is the newest) — used to pick a
-// known message id for the mid-page cursor seed + the tail id we expect the tap
-// to advance to. Mirror of the #168 local helper.
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!res.ok) {
-    throw new Error(`fetchScrollbackPage: ${res.status} ${await res.text()}`);
-  }
-  return (await res.json()) as Array<{ id: number }>;
-}
-
 // Shared body: focus an unread #bofh, tap the floating button, assert the cursor
 // persists to the tail AND a subsequent peer line does not snap the view back.
 // `peerNick` is passed distinct per project so the two runs never collide on a
@@ -99,7 +85,7 @@ async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Pr
   // focus and the activation parks ABOVE the fold (button shows). Same shape as
   // #168. `setReadCursorToId` hits the test-only force endpoint (the production
   // POST is advance-only since #233, so a backward seed through it would clamp).
-  const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
   expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
   const tailRow = page0[0];
   const cursorRow = page0[25];

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -41,7 +41,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -105,18 +105,6 @@ async function setTabHidden(page: Page, hidden: boolean): Promise<void> {
   await page.waitForTimeout(150);
 }
 
-// Fetch the newest REST page (DESC; [0] === newest === tail). Used to learn the
-// tail id (seed cursor to head = fully read → no divider) and a mid-page id
-// (seed a divider). Same shape as scroll-on-window-switch.spec.ts.
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!res.ok) throw new Error(`fetchScrollbackPage: ${res.status} ${await res.text()}`);
-  return (await res.json()) as Array<{ id: number }>;
-}
-
 // Open the per-channel delivery gap (#159): silence live `phx.on("event")` for
 // this channel's topic while the socket + every other channel stay live, so a
 // message posted during the hidden window is MISSED live and only re-fetched by
@@ -148,7 +136,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     // clears the cursor; without this seed cic would treat them as live-unread
     // and pin a marker to the top — same precondition as scroll-on-window-switch
     // scenario 1).
-    const headPage = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
@@ -204,7 +192,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
 
     // Seed a cursor 25 rows from the tail so an unread divider injects mid-page
     // (same shape as scroll-on-window-switch scenario 3).
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
@@ -260,7 +248,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
     // Fully read → focus lands at the tail, atBottom stays true (no scroll up).
-    const headPage = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
@@ -307,7 +295,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
     // Fully read → no divider; the reader will scroll up into read backlog.
-    const headPage = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
     if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -58,7 +58,7 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -77,19 +77,6 @@ async function distanceToBottom(page: Page): Promise<number> {
     if (!el) throw new Error("scrollback container not found");
     return el.scrollHeight - el.scrollTop - el.clientHeight;
   });
-}
-
-// Latest REST page in wire shape (DESC by server_time) — used to pick a known
-// message id for the mid-page cursor seed (mirror of issue168).
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{ id: number }>;
 }
 
 // Test-only force endpoint (ReadCursor.force_set/4) — the production endpoint
@@ -137,7 +124,7 @@ async function installFailingSendPost(page: Page, hold: boolean): Promise<void> 
 // issue168) and a later "we are at the bottom" assert means something.
 async function arriveParkedOnMarker(page: Page, channel: string): Promise<void> {
   const vjt = specUser();
-  const page0 = await fetchScrollbackPage(vjt.token, channel);
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, channel);
   expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
   const cursorRow = page0[25];
   if (!cursorRow) throw new Error("seeded page too short for cursor placement");

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -37,7 +37,11 @@ import {
   selectChannel,
   waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import {
+  fetchScrollbackPage,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -80,17 +84,6 @@ async function distanceToBottom(page: Page): Promise<number> {
     if (!el) throw new Error("scrollback container not found");
     return el.scrollHeight - el.scrollTop - el.clientHeight;
   });
-}
-
-async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{ id: number }>;
 }
 
 // Install an in-page sampler + a scroll-write spy on the scrollback container,
@@ -248,7 +241,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
 
     // Mid-page cursor → cold-mount lands on the unread marker, ABOVE the fold:
     // the reader is parked in history when they send (vjt's scenario).
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -87,7 +87,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, setReadCursorToId } from "../fixtures/grappaApi";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -120,27 +120,6 @@ async function scrollbackGeometry(
   });
 }
 
-// Fetch the latest scrollback page via REST. Used in scenario 2 to
-// compute the cursor server_time placing the marker mid-pane. Same
-// shape cp14-b1 uses.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number; server_time: number; sender: string }>> {
-  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
-    NETWORK_SLUG,
-  )}/channels/${encodeURIComponent(channel)}/messages`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-  if (!response.ok) {
-    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
-  }
-  return (await response.json()) as Array<{
-    id: number;
-    server_time: number;
-    sender: string;
-  }>;
-}
-
 test.describe("scroll-on-window-switch — re-selecting a window snaps correctly", () => {
   test.use({ viewport: { width: 800, height: 300 } });
 
@@ -169,7 +148,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // "(no marker)" scenario deterministic. Sibling test 2 seeds its OWN
     // mid-page cursor for the divider-present-lands-at-bottom scenario
     // (#168); this is the read-to-tail counterpart, not a workaround.
-    const headPage = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
     if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");
@@ -249,7 +228,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // vjt reversed that: cold-mount now jumps to the frozen divider, SAME as a
     // deliberate switch. This test therefore now mirrors scenario 3's marker
     // contract, reached via cold-mount instead of a switch.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
@@ -339,7 +318,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // (onMount, key-effect defer-skipped) — the same lifecycle as launching the
     // installed PWA. #bofh is never focused before the reload, so its seeded
     // read cursor is never advanced and the unread divider survives the reboot.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");
@@ -397,7 +376,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // Seed a cursor 25 rows from the tail so an unread divider injects
     // mid-page (same shape as scenario 2 / issue168), but here we reach
     // #bofh via a deliberate SWITCH, not a cold mount.
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
     if (!cursorRow) throw new Error("seeded page too short for cursor placement");

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49833,14 +49833,20 @@ the public contract, `WireMessage` still private. `before` is an explicit
 parameter with no default, because the pager and the single-page callers
 differ in exactly that argument.
 
-One deliberate widening, recorded because it is easy to miss on review.
+Folding the polling caller in cost a type, and the reason is worth keeping.
 `assertMessagePersisted` polls, and its old inline request tolerated a non-ok
-STATUS while letting a transport-level throw propagate at once. Catching
-around the shared verb cannot tell those apart, so the retry now also absorbs
-the throw. Both paths still fail loudly — the deadline converts a persistent
-failure into the timeout error with `lastSeen` attached — but the catch is
-wider than the one it replaces, and that was a choice rather than an
-oversight.
+STATUS while letting a transport-level throw propagate at once. A bare catch
+around the shared verb cannot tell those apart, and the first version of this
+slice took that widening on the grounds that both paths still fail loudly.
+That was wrong, and was corrected before the slice ran: an assertion helper
+must retry on not-yet-persisted, never on a dead transport, because there the
+retry masks the fault instead of measuring it — the no-silent-swallow rule at
+a boundary. So `getMessagesPage` throws a typed `MessagesPageStatusError` for
+the status arm, the poll loop catches only that and rethrows anything else,
+and a stack that has gone away still fails at the first attempt rather than
+at the deadline. The general shape: when one caller of a shared verb needs to
+tolerate a subset of its failures, make the subset a type rather than
+widening the catch to the whole.
 
 What is not established: no spec was executed for this entry. The check is
 static only, and `tsc` cannot see argument ORDER — `networkSlug` and

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49773,3 +49773,79 @@ transposition at any of the fifteen would type-check and fail only at runtime.
 No spec was executed for this entry, so that transposition is unmeasured — the
 argument for it is that each call site was rewritten from a wrapper whose own
 call already had the order right, not that anything checked.
+<!-- entry #1397-e2e-fetchscrollbackpage -->
+
+---
+
+## 2026-08-19 — #1397 (e2e): thirteen callers, one request, a narrow promise
+
+The census filed `fetchScrollbackPage` as ten copies over ten files with six
+distinct body hashes, and noted it had "forked on the base URL": eight inline
+`http://grappa-test:4000` literals against one copy using the exported
+`GRAPPA_BASE_URL`. Both halves of that reading needed correcting before any
+of it could be folded.
+
+The base-URL fork does not exist, and had not for some time. `grep` over the
+whole of `cicchetto/e2e` finds the literal exactly once, at the definition in
+`grappaApi.ts`; `git grep` over `origin/main` finds it in zero spec files. All
+ten copies already imported the exported constant. The census text predates
+the landed slices that unified it (`ea484403` deleted twelve shadow
+re-declarations, `0989bcab` routed sixteen invisible literals, `e6f86344` did
+the same for `push.ts`). The lesson generalises past this cluster: a
+per-cluster note written against an older tree describes that tree, and the
+remaining clusters' notes should be re-measured rather than executed.
+
+The six hashes were real but were not the number that mattered. Normalising
+whitespace and commas — the move that collapsed `adminPatchCaps` and
+`seedCursor` — only got six down to five, because braces and the return
+annotation survive that normalisation. Deleting the signature and the `as`
+cast and hashing only the executable statements collapses all ten onto one
+md5. One behaviour, and the six shapes are `res` versus `response` (three
+against seven), braces versus a one-line throw, and where the URL template
+wrapped.
+
+The single real axis was the width of the cast: seven copies said
+`Array<{id: number}>` and three said `{id, server_time, sender}`. That width
+is dead. Across all eighteen call sites the reads are `.length`, `[0]?.id`,
+`page0[25].id`, and one `page0.filter(r => r.id > …)`; `server_time` and
+`sender` appear in those three files only inside comments and inside the
+annotation declaring them. So the shared verb is narrow, and the reasoning is
+that a return type is a promise: six fields nobody collects is a promise
+maintained in exchange for nothing. The alternative — returning the
+`WireMessage` already defined in the file — would also have had to export a
+type that is private today, widening the `grappaApi` leaf against the F6
+ruling.
+
+Narrowness is a claim about callers, so it was tested as one. Unifying on the
+narrow type and running the whole cic check is green; injecting a single read
+of `cursorRow.server_time` at one call site turns it red with exactly one
+diagnostic, TS2339 naming the property, and reverting restores green. The
+gate can see the dependency; there is none.
+
+Absorbing the three copies inside `grappaApi` needed a shape that is not
+"make all three narrow". `restoreReadCursorToTail` reads only `rows[0].id`,
+but `assertMessagePersisted` reads `body`, `kind` and `sender`, and
+`fetchAllMessagesAsc` adds `?before=` and re-sorts ascending — it is a pager
+built on the verb, not the verb. Hence the private `getMessagesPage`
+returning the full row, with the exported `fetchScrollbackPage` as a narrow
+projection over it: one request for all thirteen sites, the narrow promise on
+the public contract, `WireMessage` still private. `before` is an explicit
+parameter with no default, because the pager and the single-page callers
+differ in exactly that argument.
+
+One deliberate widening, recorded because it is easy to miss on review.
+`assertMessagePersisted` polls, and its old inline request tolerated a non-ok
+STATUS while letting a transport-level throw propagate at once. Catching
+around the shared verb cannot tell those apart, so the retry now also absorbs
+the throw. Both paths still fail loudly — the deadline converts a persistent
+failure into the timeout error with `lastSeen` attached — but the catch is
+wider than the one it replaces, and that was a choice rather than an
+oversight.
+
+What is not established: no spec was executed for this entry. The check is
+static only, and `tsc` cannot see argument ORDER — `networkSlug` and
+`channel` are both `string`, so a transposition at any of the eighteen
+rewritten call sites type-checks and fails only at runtime. That is the same
+gap the sibling entries name, and on the `seedCursor` slice it was a runtime
+positive control, not the type-checker, that caught exactly such a
+transposition.


### PR DESCRIPTION
## What

Folds the `fetchScrollbackPage` cluster from the #1397 e2e census: ten
spec-local copies over ten files, 113 lines, plus the three in-fixture
sites that spoke the same request.

- `getMessagesPage` — private, the ONE
  `GET /networks/:slug/channels/:channel/messages`, returning the full
  `WireMessage` row. `before` is explicit, no default.
- `fetchScrollbackPage` — exported, a NARROW projection
  `Array<{ id: number }>`.
- `restoreReadCursorToTail`, `fetchAllMessagesAsc` and
  `assertMessagePersisted` all route through the transport.

Net −111 lines of e2e code (13 sites speaking that GET → 1). Nine of the
ten specs also drop their `GRAPPA_BASE_URL` import.

## Why narrow

All eighteen call sites read `.length` and `.id` and nothing else — the
three copies that declared `{id, server_time, sender}` never dereferenced
the extra two. A return type is a promise, and promising six fields nobody
collects buys nothing. Returning the existing `WireMessage` would also have
meant exporting a type that is private today, widening the `grappaApi` leaf.

## Two corrections to the census

- It recorded a fork on the base URL (eight inline `grappa-test:4000`
  literals). There are **zero** in spec files, on this branch and on `main`;
  landed slices `ea484403` / `0989bcab` / `e6f86344` had already unified it.
  The note predated them — worth knowing before the remaining clusters are
  read as current.
- Six distinct body hashes were real but not the number to act on. Hashing
  only the executable statements collapses all ten onto one md5; the six
  shapes were `res` vs `response`, braces vs a one-line throw, and where the
  URL template wrapped.

## Test plan

- [x] `scripts/bun.sh run check` (whole chain) — rc=0, 59 pre-existing CSS
      warnings. rc=0 on `biome && tsc && tsc -p e2e/tsconfig.json` is the
      only evidence `tsc` ran; an earlier biome red halted the chain and
      showed a misleading "0 error TS".
- [x] Static positive control — one injected `cursorRow.server_time` read
      gives exactly one diagnostic, TS2339 naming the property; reverted,
      green.
- [x] e2e, the 10 touched specs, both projects: 26 chromium + 1 webkit.
      **26 passed, 1 failed.**
- [x] The failure is PRE-EXISTING, not from this change: the identical
      subset run on the base commit fails the identical test
      (`issue310-scroll-to-bottom-btn-cursor`, webkit, read cursor 6076 vs
      the seeded 6054) with the same 1 failed / 26 passed.
- [x] Runtime positive control for the argument transposition `tsc` cannot
      see — `networkSlug` and `channel` are both `string`. One transposition
      injected per file, ten of the eighteen sites: **all ten spec files go
      red** (13 failed / 14 passed). Reverted; tree byte-identical.

## Not claimed

- The full `scripts/integration.sh` suite was not run — only the 10 touched
  specs.
- Eight of the eighteen call sites carry no runtime transposition control of
  their own; the covered ten are one per file.