### PR TITLE
test(#1397): one 001 handler for 55 copies, and seven wrappers gone

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49855,3 +49855,98 @@ rewritten call sites type-checks and fails only at runtime. That is the same
 gap the sibling entries name, and on the `seedCursor` slice it was a runtime
 positive control, not the type-checker, that caught exactly such a
 transposition.
+<!-- entry #1397-welcome-handler -->
+
+---
+
+## 2026-08-18 — #1397: one 001 handler, and the wrapper rule that cuts both ways
+
+The largest duplicated shape in the test suite was a handler body repeated
+62 times across 7 files: answer a `USER` line with an `001 RPL_WELCOME`,
+stay silent otherwise. It is now `Grappa.IRCServer.welcome_handler/2`, and
+55 of the 62 call it. The remaining 7 are deferred for a reason recorded
+below.
+
+### A name census could not see it
+
+Only 5 of the 62 sat behind a `defp`, so counting helper NAMES undercounted
+this cluster by roughly twelvefold and made the bucket read as nearly done.
+Worse, the five names disagreed with each other: three files called theirs
+`welcome_handler/0`, one `counts_welcome_handler/0`, one
+`start_server_with_001/0` — and a first pass here still missed two more,
+`rfc_handler/0` and `welcoming_handler/0`, because it searched for the
+string `welcome_handler`. They surfaced only from grouping BODIES with the
+names stripped off. The general rule: on a de-duplication bucket, a count
+by name is not evidence, and a zero from a name grep is the least
+trustworthy number available, because it is indistinguishable from done.
+
+### Both arguments mandatory, and why that dissolved the blocker
+
+The issue text assumed consolidating required first deciding which server
+prefix is canonical — the copies split 42 `:irc`, 19 `:server`, 1
+`:irc.test.org`. It does not. Taking the prefix as a mandatory argument
+lets every call site keep the bytes it already had, so the migration is
+behaviour-preserving by construction and the spelling becomes an
+independent cleanup instead of a prerequisite. The nick is a second
+mandatory argument on the same reasoning: 7 of the 62 named someone other
+than `grappa-test`, so it is a second axis and not a detail.
+
+### The wrapper rule, sharpened: a no-op may be hidden, an observable may not
+
+Seven zero-argument wrappers were deleted and their 51 call sites inlined.
+This is the same rule that earlier in this issue SAVED the wrappers hiding
+`passthrough_handler/0`, reaching the opposite verdict because the content
+is opposite. A wrapper hiding a handler that answers nothing costs the call
+site no information. A wrapper hiding a 001 conceals a prefix and a nick
+that go out on the wire and that a test downstream can read — which is what
+a default argument does, wearing a name instead of a `\\`. Under those
+names the seven silently disagreed: two answered from `:server` and
+`:irc.test.org` while three answered from `:irc`, and nothing at any of the
+51 sites said so.
+
+### What the mutants found, which is what stayed GREEN
+
+Two mutants, each disabling one argument, over the six affected files.
+
+Ignoring the NICK killed 11 tests (10 in `server_test`, 1 the new unit
+test). The nick is genuinely load-bearing wherever it varies, so the second
+mandatory argument is justified by measurement and not only by principle.
+
+Ignoring the PREFIX killed exactly one test, and that one is the new unit
+test. **41 migrated call sites had their 001 prefix silently changed — 34
+in `server_test`, 6 in `client_test`, 1 in `nick_controller_test` — and not
+one of them noticed.** Two consequences. First, the premise above is now
+measured rather than argued: unifying the three spellings is a free
+cleanup, carrying zero test risk. Second, the prefix argument is currently
+guarded by nothing except the unit test added here; before it existed, that
+mutant would have killed nothing at all.
+
+### Why 7 sites were left behind
+
+PR #1535 is open and touches four of the same files. The overlap is not
+merely file-level: the tail of those 7 handlers (`end / end / blank`) is
+literally the context of #1535's hunks, so rewriting them would conflict in
+whichever order the branches land. The other 55 are disjoint from every
+hunk in that patch. `git merge-tree` of this branch against #1535's head
+reports a clean merge, which is the check that the deferral actually
+worked; the 7 follow as a second commit here once #1535 is in.
+
+### Method notes worth keeping
+
+A line-keyed exclusion list goes blind the moment the first pass shifts the
+lines under it. The eighth site — the keyword form `if ..., do:, else:`
+inside `start_recover_visitor/1` — fell into the gap between a sweep that
+skipped it as hand-work and a sweep that skipped it as not-a-wrapper. It
+was caught by re-counting the tree, not by trusting either script's report.
+
+`git write-tree` writes the INDEX, not the working tree. It was used here as
+an oracle for a two-commit reconstruction and silently returned the tree of
+the last commit; the comparison that actually held was the shasum of the
+full `git diff` against the state already measured green.
+
+### Limits of this measurement
+
+The mutant table covers the six affected test files, not the suite. No e2e
+spec was run. The 7 deferred sites are unmigrated and untested by any of
+the above; the clean `merge-tree` says the two branches do not collide, not
+that the merged result was ever executed.

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -132,11 +132,6 @@ defmodule Grappa.IRC.ClientTest do
     end
   end
 
-  # Plain RFC 2812 server: no CAP, fires 001 once USER arrives.
-  defp rfc_handler do
-    IRCServer.welcome_handler(":server", "grappa-test")
-  end
-
   describe "peer capture on connect" do
     test "pushes {:irc_peer, {:ok, {ip, port}}} to dispatch_to once the socket is up" do
       # #550 — the admin Sessions inventory surfaces the destination each
@@ -986,7 +981,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :none" do
     test "sends only NICK + USER; no PASS, no CAP, no IDENTIFY" do
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       _ = start_client(port, %{auth_method: :none})
 
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -1000,7 +995,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :server_pass" do
     test "sends PASS BEFORE NICK + USER; no CAP" do
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
 
       _ =
         start_client(port, %{
@@ -1025,7 +1020,7 @@ defmodule Grappa.IRC.ClientTest do
 
   describe "auth_method: :nickserv_identify" do
     test "sends NICK + USER only; the built-in identify moved to Session.Server (#189)" do
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
 
       _ =
         start_client(port, %{
@@ -1375,7 +1370,7 @@ defmodule Grappa.IRC.ClientTest do
       # Server fires 001 immediately on USER (rfc_handler) and IGNORES
       # CAP LS entirely. Without the registered-state transition on 001,
       # the client would sit forever waiting for a CAP LS reply.
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
 
       _ =
         start_client(port, %{
@@ -2031,7 +2026,7 @@ defmodule Grappa.IRC.ClientTest do
     end
 
     test ":none with no password is allowed (the only no-secret branch)" do
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
 
       _ =
         start_client(port, %{
@@ -2497,7 +2492,7 @@ defmodule Grappa.IRC.ClientTest do
       # an under-count is what would kill the fake-lag hypothesis for the
       # wrong reason. The fake server's own tally is the oracle: whatever
       # it received is what the model must have charged for.
-      {server, port} = IRCServer.start_server(rfc_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       client = start_client(port)
       :ok = IRCServer.await_handshake(server, 1_000)
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -134,13 +134,7 @@ defmodule Grappa.IRC.ClientTest do
 
   # Plain RFC 2812 server: no CAP, fires 001 once USER arrives.
   defp rfc_handler do
-    fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    IRCServer.welcome_handler(":server", "grappa-test")
   end
 
   describe "peer capture on connect" do

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -1,12 +1,15 @@
 defmodule Grappa.IRCServerTest do
   @moduledoc """
-  Unit tests for the `Grappa.IRCServer` handshake barrier (#1397 F1).
+  Unit tests for the shared helpers on `Grappa.IRCServer` (#1397).
 
   The fake server is otherwise exercised through its consumers, which is
-  why it has had no test of its own. `await_handshake/2` gets one because
-  it is the first barrier hoisted out of the thirteen local copies, and
-  the property that matters about it is not behavioural but structural:
-  it must NOT grow a default timeout.
+  why it has had no test of its own. A helper earns a test here once it
+  is hoisted out of local copies, because hoisting removes the many
+  hand-written copies that used to state the shape by example.
+
+  `await_handshake/2` (F1) was the first: it is the barrier lifted out of
+  thirteen local copies, and the property that matters about it is not
+  behavioural but structural: it must NOT grow a default timeout.
 
   Commit `84fe0850` removed the default timeout from `wait_for_line/3`
   under the CLAUDE.md no-default-arguments rule, then stamped the value
@@ -57,5 +60,46 @@ defmodule Grappa.IRCServerTest do
 
     assert function_exported?(IRCServer, :await_handshake, 2)
     refute function_exported?(IRCServer, :await_handshake, 1)
+  end
+
+  describe "welcome_handler/2" do
+    test "answers a USER line with 001 assembled from prefix and nick" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      assert {:reply, ":irc 001 grappa-test :Welcome\r\n", %{}} =
+               handler.(%{}, "USER grappa-test 0 * :grappa\r\n")
+    end
+
+    test "both arguments reach the wire, each in its own position" do
+      # Deliberately non-interchangeable values. Every call site in the
+      # suite passes a plausible-looking prefix AND a plausible-looking
+      # nick, so a swapped pair or an ignored second argument would keep
+      # producing a well-formed 001 and pass everywhere. Here it cannot.
+      handler = IRCServer.welcome_handler(":other.example.org", "someone-else")
+
+      assert {:reply, ":other.example.org 001 someone-else :Welcome\r\n", %{}} =
+               handler.(%{}, "USER whoever 0 * :whoever\r\n")
+    end
+
+    test "stays silent on non-USER lines and leaves handler state untouched" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      assert {:reply, nil, %{step: 1}} = handler.(%{step: 1}, "NICK grappa-test\r\n")
+      assert {:reply, nil, %{}} = handler.(%{}, "CAP LS 302\r\n")
+    end
+
+    test "USERHOST does not register: the space in the prefix is load-bearing" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      assert {:reply, nil, %{}} = handler.(%{}, "USERHOST grappa-test\r\n")
+    end
+
+    test "carries no default prefix and no default nick" do
+      Code.ensure_loaded!(IRCServer)
+
+      assert function_exported?(IRCServer, :welcome_handler, 2)
+      refute function_exported?(IRCServer, :welcome_handler, 1)
+      refute function_exported?(IRCServer, :welcome_handler, 0)
+    end
   end
 end

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -20,20 +20,10 @@ defmodule Grappa.PresenceFilter.ResolverTest do
   alias Grappa.{IRCServer, PresenceFilter, UserSettings}
   alias Grappa.PresenceFilter.Resolver
 
-  defp welcome_handler do
-    fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
-  end
-
   # A live session joined to `channel` with exactly `n` members seeded via a
   # 353/366 NAMES burst. Returns `{network, pid, server}`.
   defp session_with_members(user, channel, n) do
-    {server, port} = IRCServer.start_server(welcome_handler())
+    {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
     slug = "az-#{System.unique_integer([:positive])}"
     {network, _} = network_with_server(port: port, slug: slug)
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5364,9 +5364,6 @@ defmodule Grappa.Session.ServerTest do
   # `Grappa.Session.FloodAllowance`'s unit contract; what is proven here is
   # that the live session reads its OWN state and answers over the facade.
   describe "#480 — upstream flood allowance" do
-    # `welcome_handler/0` is defined further down this module and shared:
-    # `defp` is module-wide, and a second copy here would be the duplicate
-    # the compiler warns about.
     defp await_umodes(modes) do
       assert_receive %Phoenix.Socket.Broadcast{
                        event: "event",
@@ -5378,7 +5375,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a session with no oper umode is :ordinary" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5397,7 +5394,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "an oper'd session is :oper" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5414,7 +5411,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "an oper with the flavour's no-throttle umode is :exempt" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
       {network, _} =
@@ -5442,7 +5439,7 @@ defmodule Grappa.Session.ServerTest do
       # The exempt letter is per-flavour and only bahamut's was read at
       # source. `setup_user_and_network` leaves services_flavor nil, which
       # is what an operator who never classified the network has.
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -5462,7 +5459,7 @@ defmodule Grappa.Session.ServerTest do
       # reload does not rewrite live process state, and the throttle asks
       # this on EVERY send — a KeyError here would crash-wave the sessions
       # under load rather than degrade to today's numbers.
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -5477,7 +5474,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "no live session for (subject, network) is :no_session, not a class" do
-      {_, port} = IRCServer.start_server(welcome_handler())
+      {_, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       assert {:error, :no_session} =
@@ -6794,18 +6791,8 @@ defmodule Grappa.Session.ServerTest do
     # hands to `start_server/1` — never answers 001, so registration never
     # completes and no JOIN is ever sent. These tests need the session to
     # actually reach the channels.
-    defp counts_welcome_handler do
-      fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
-    end
-
     test "returns the count per SEEDED channel in one call" do
-      {server, port} = IRCServer.start_server(counts_welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#one", "#two"]})
@@ -6835,7 +6822,7 @@ defmodule Grappa.Session.ServerTest do
     # twin must OMIT the key, or the caller reads 0 members and shows presence
     # on a channel that is about to turn out to have 900.
     test "omits a channel that has not yet observed 366 (pre-NAMES)" do
-      {server, port} = IRCServer.start_server(counts_welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#seeded", "#pending"]})
@@ -7029,18 +7016,8 @@ defmodule Grappa.Session.ServerTest do
     # self-KICK collapse to the same heartbeat (channels-list mutation
     # IS the event; cause is irrelevant to subscribers).
 
-    defp welcome_handler do
-      fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
-    end
-
     test "self-JOIN broadcasts channels_changed on user topic" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
@@ -7056,7 +7033,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-PART broadcasts channels_changed on user topic" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7077,7 +7054,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-KICK broadcasts channels_changed on user topic" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7098,7 +7075,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "other-user JOIN does NOT broadcast (keyset unchanged)" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7126,7 +7103,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "PRIVMSG does NOT broadcast (keyset unchanged)" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -7170,7 +7147,7 @@ defmodule Grappa.Session.ServerTest do
     # channels_changed heartbeat emitted right beside it in the cast handler.
 
     test "send_part broadcasts archive_changed on the user topic post-cleanup" do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#existing"]})
@@ -10116,18 +10093,6 @@ defmodule Grappa.Session.ServerTest do
     # the AWAY lines sent upstream. The handler accepts the handshake and
     # echos back 001 so the session reaches :connected state.
 
-    defp start_server_with_001 do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
-
-      IRCServer.start_server(handler)
-    end
-
     # Condition-poll until at least `want` sent lines match `pred`, or the
     # deadline elapses. `IRCServer.wait_for_line/3` can only match the FIRST
     # buffered line, so a RE-EMIT assertion (#417 same-process reconnect,
@@ -10154,7 +10119,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_explicit_away issues AWAY :reason upstream and returns :ok" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10176,7 +10141,7 @@ defmodule Grappa.Session.ServerTest do
     # for the supervisor respawn (a new process whose init re-resolves the
     # plan from the DB via SessionPlan.resolve).
     test "explicit away persisted in DB is restored + re-sent upstream at 001 (#417)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       # Seed the DB exactly as a prior live session would have on
@@ -10205,7 +10170,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_explicit_away persists away_reason + away_since to the credential (#417)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10226,7 +10191,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_explicit_away clears the persisted away (#417)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10246,7 +10211,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_auto_away does NOT persist — auto-away re-derives from WSPresence (#417)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10267,7 +10232,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a second 001 re-emits in-memory away upstream — same-process reconnect (#417)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10294,7 +10259,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_explicit_away issues bare AWAY and transitions to :present" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10313,7 +10278,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_explicit_away when not :away_explicit returns {:error, :not_explicit}" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10328,7 +10293,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_auto_away when :present issues AWAY :auto-away… upstream" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10354,7 +10319,7 @@ defmodule Grappa.Session.ServerTest do
     # :auto_away_debounce_fire to avoid a real wait (the debounce timing
     # itself is covered by the cancel_and_drain unit tests).
     test "visibility drives auto-away: hidden arms debounce → AWAY, visible unaways (#182)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10409,7 +10374,7 @@ defmodule Grappa.Session.ServerTest do
     # was blocked indefinitely. What makes it reachable is the demotion sweep;
     # what this asserts is the user-visible end of it, a real AWAY line.
     test "a socket that stops affirming visibility stops blocking auto-away (#224)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10458,7 +10423,7 @@ defmodule Grappa.Session.ServerTest do
     # timer only where "nothing happened" needs a witness.
 
     test "the session waits the per-user delay, not the server default (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       # Stored BEFORE the spawn: the value has to be read at the spawn
@@ -10489,7 +10454,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "OFF arms no timer at all and never goes away (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       {:ok, _} =
@@ -10519,7 +10484,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "switching OFF kills a timer armed before the switch (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10548,7 +10513,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "a new delay takes effect on a live session, no restart (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10577,7 +10542,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "retuning re-arms the timer already in flight (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10614,7 +10579,7 @@ defmodule Grappa.Session.ServerTest do
     # forever. The knob and its storage are subject-scoped already, so
     # the only thing in the way was the subscribe gate.
     test "a visitor session goes auto-away when its last device hides (#348)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {visitor, network} = visitor_with_network(port)
       label = Grappa.Subject.label({:visitor, visitor.id})
 
@@ -10644,7 +10609,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_auto_away when :away_explicit is a no-op (explicit takes precedence)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10667,7 +10632,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "set_explicit_away when :away_auto overwrites (explicit always wins)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10688,7 +10653,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_auto_away when :away_auto transitions to :present and issues bare AWAY" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10707,7 +10672,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_auto_away when :away_explicit is a no-op (don't touch explicit away)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10728,7 +10693,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_auto_away when :present is a no-op (already not away)" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
       pid = start_session_for(user, network)
 
@@ -10763,7 +10728,7 @@ defmodule Grappa.Session.ServerTest do
     # broadcast a `mentions_bundle` event on the user-level PubSub topic
     # when the session returns from explicit away AND at least one match exists.
     test "unset_explicit_away broadcasts mentions_bundle on user topic when matches found" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)
@@ -10817,7 +10782,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "unset_explicit_away does NOT broadcast mentions_bundle when no matches found" do
-      {server, port} = start_server_with_001()
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":server", "grappa-test"))
       {user, network, _} = setup_user_and_network(port)
 
       pid = start_session_for(user, network)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -174,13 +174,7 @@ defmodule Grappa.Session.ServerTest do
   # visitor (`:none`, not recoverable). Returns the scaffold map; teardown via
   # `start_visitor_session_for`'s on_exit.
   defp start_recover_visitor(secret) do
-    handler = fn state, line ->
-      if String.starts_with?(line, "USER "),
-        do: {:reply, ":irc 001 #{@recover_nick} :Welcome\r\n", state},
-        else: {:reply, nil, state}
-    end
-
-    {server, port} = IRCServer.start_server(handler)
+    {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", @recover_nick))
 
     {network, _} =
       network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
@@ -425,13 +419,7 @@ defmodule Grappa.Session.ServerTest do
       # never a bare boolean grappa invents. A 221 RPL_UMODEIS carrying +r
       # populates state.umodes; the umode_changed broadcast is the "processed"
       # barrier before we read connection_info.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -496,13 +484,7 @@ defmodule Grappa.Session.ServerTest do
     # (the safe, prod-invariant default) when there is no live pid.
 
     test "returns the live session's CASEMAPPING once a 005 advertises it" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -531,13 +513,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "returns :ascii (bahamut default) before any 005 CASEMAPPING" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -564,13 +540,7 @@ defmodule Grappa.Session.ServerTest do
     # what prod has always assumed rather than refusing every sigil.
 
     test "returns the live session's advertised STATUSMSG set once a 005 carries it" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -597,13 +567,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "returns the bahamut default before any 005 STATUSMSG" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -2437,13 +2401,7 @@ defmodule Grappa.Session.ServerTest do
   # bytes rather than a hand-built state.
   describe "CAP ACK grants the account axis (#388)" do
     test "an ACKed account-notify turns a self ACCOUNT into an identity acquisition" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -2537,13 +2495,7 @@ defmodule Grappa.Session.ServerTest do
     test "306 RPL_NOWAWAY fires away_confirmed(:away) but persists NO $server row" do
       # Reply to USER with 001 so the session reaches registered before we
       # feed the away numeric (mirrors the 221 RPL_UMODEIS test handler).
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -2576,13 +2528,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "305 RPL_UNAWAY fires away_confirmed(:present) but persists NO $server row" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -3439,13 +3385,7 @@ defmodule Grappa.Session.ServerTest do
     # the LAST fragment so cic's scrollback view aligns with the
     # final row id.
     test "PRIVMSG > linelen splits into N upstream lines + N scrollback rows" do
-      welcomed_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-actual :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      welcomed_handler = IRCServer.welcome_handler(":server", "grappa-actual")
 
       {server, port} = IRCServer.start_server(welcomed_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -4205,13 +4145,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "self-NICK rename: subsequent PRIVMSG persists with new nick" do
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -4242,13 +4176,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "other-user NICK rename does NOT affect own SessionStateHelpers.nick(state)" do
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -4279,13 +4207,7 @@ defmodule Grappa.Session.ServerTest do
       # already classified peer ACTIONs correctly (`CTCP.action?/1`); only the
       # outbound persist path hardcoded :privmsg. Pin the fix at the persist
       # boundary — both the persisted row and the broadcast must carry :action.
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -4329,13 +4251,7 @@ defmodule Grappa.Session.ServerTest do
       # already classifies ACTION → :action, so inbound + outbound agree (#14
       # lesson). Non-ACTION CTCP keeps :privmsg and carries typed flat meta
       # (ctcp_verb/ctcp_args) so cic renders "→ CTCP VERB", never \x01.
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -4386,13 +4302,7 @@ defmodule Grappa.Session.ServerTest do
     # above; distinct verb (`send_ctcp` vs `send_privmsg`) so a plain DM still
     # auto-opens.
     setup do
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
@@ -4534,13 +4444,7 @@ defmodule Grappa.Session.ServerTest do
     @notice_nick "vjt"
 
     setup do
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 #{@notice_nick} :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", @notice_nick)
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: @notice_nick})
@@ -4710,13 +4614,7 @@ defmodule Grappa.Session.ServerTest do
     # FAILURE opens none either. This is the behavioral falsification target:
     # revert the server gate and this goes RED.
     setup do
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
@@ -4778,13 +4676,7 @@ defmodule Grappa.Session.ServerTest do
       # Mirror of the inbound EventRouter capture for the outbound door:
       # an operator who holds @ in the channel must have their own message
       # frozen at @ so a later deop doesn't retroactively un-prefix it.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -4849,13 +4741,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "JOIN-self resets members[channel] to %{own_nick => []}" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -4880,13 +4766,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "353 RPL_NAMREPLY populates members with mode prefixes parsed" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -4921,13 +4801,7 @@ defmodule Grappa.Session.ServerTest do
       # "SessionStateHelpers.members(state)[channel] is now populated; re-fetch is safe."
       # Without this, a fresh /join sidebar entry has an empty MembersPane
       # until page reload.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -4969,13 +4843,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "QUIT removes nick from every channel + persists one row per channel" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -5028,13 +4896,7 @@ defmodule Grappa.Session.ServerTest do
       # Both the in-process state map AND the per-channel topic broadcast
       # are part of the contract — cic uses the broadcast to flip the
       # window's render state without polling.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -5093,13 +4955,7 @@ defmodule Grappa.Session.ServerTest do
       # from the moment of join. Every join path (autojoin, /join,
       # NickServ-driven, invite-rejoin) funnels through the self-JOIN echo,
       # so this one arm covers them all.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -5124,13 +4980,7 @@ defmodule Grappa.Session.ServerTest do
       # elicits a 324, EventRouter folds it into channel_modes, and the
       # {:channel_modes_changed} effect broadcasts on the per-channel
       # topic. Guards the full P0 pipeline (query → cache → broadcast).
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -5178,13 +5028,7 @@ defmodule Grappa.Session.ServerTest do
       # Only self-JOIN promotes window state. Other-user JOINs land in
       # scrollback as :persist :join rows and broadcast the row itself
       # via the existing event surface — no `kind: :joined` event.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -5221,13 +5065,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#216 — ISUPPORT CHANMODES/PREFIX capability table" do
     test "005 with CHANMODES + PREFIX stores the isupport table + broadcasts on Topic.user" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5268,13 +5106,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_isupport returns the bahamut default before any 005 (always-succeeds)" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5299,13 +5131,7 @@ defmodule Grappa.Session.ServerTest do
       # reconnect / 005. We reproduce the stale struct with
       # `:sys.replace_state` deleting the key, exactly as a pre-field proc
       # would look post-reload.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5352,13 +5178,7 @@ defmodule Grappa.Session.ServerTest do
     # would leave every connected client sizing its warning against the
     # previous (usually RFC-default) frame for the rest of the session.
     test "005 that changes ONLY LINELEN still republishes the frame budget" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5396,13 +5216,7 @@ defmodule Grappa.Session.ServerTest do
       # analogue of #216's `MODE #chan` join-time query. Umodes are
       # per-session (emitted ONCE at registration), so this rides the
       # numeric-1 handler, not the per-channel :joined arm.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5421,13 +5235,7 @@ defmodule Grappa.Session.ServerTest do
       # umode string, store on the per-session `umodes` field, broadcast the
       # typed `umode_changed` payload on Topic.user (umodes are per
       # (subject, network), like own_nick_changed / isupport_changed).
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5461,13 +5269,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_umodes returns [] before any 221 (always-succeeds)" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5486,13 +5288,7 @@ defmodule Grappa.Session.ServerTest do
       # modal reflects a mid-session `/umode +x` (and services-set +r/+a at
       # IDENTIFY, which flow through the same branch). Reuse the verb (the
       # existing self-mode branch), add the noun (stored state).
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5528,13 +5324,7 @@ defmodule Grappa.Session.ServerTest do
       # self-MODE write paths must tolerate the absent key (Map.get default +
       # Map.put, never `%{state | umodes: ...}`) so the sessions don't
       # crash-wave on the next WS reconnect / umode event.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5702,13 +5492,7 @@ defmodule Grappa.Session.ServerTest do
       # typed supported_umodes_changed payload on Topic.user (umodes are per
       # (subject, network), like umode_changed / isupport_changed). The 004
       # STILL routes to $server for display — see numeric_router_test.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5745,13 +5529,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "get_supported_umodes returns [] before any 004 (always-succeeds)" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -5771,13 +5549,7 @@ defmodule Grappa.Session.ServerTest do
       # (get_supported_umodes) and the write path (004 fold) must tolerate the
       # absent key (Map.get default + Map.put) rather than KeyError-crashing
       # the :transient proc on the next user-topic snapshot / 004.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port)
@@ -6684,13 +6456,7 @@ defmodule Grappa.Session.ServerTest do
       # arm also clears any lingering failure metadata so a re-join +
       # re-fail gets a fresh reason rather than stale text from a prior
       # failure.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6742,13 +6508,7 @@ defmodule Grappa.Session.ServerTest do
       # The :persist :part row already broadcasts the UI feed-line via
       # the existing event surface; emitting an additional `kind: parted`
       # would duplicate the signal and force cic to dedupe.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6785,13 +6545,7 @@ defmodule Grappa.Session.ServerTest do
       # :kicked AND broadcasts kind: :kicked carrying by + reason on
       # the per-channel topic so cic transitions the visual without
       # parsing the scrollback.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6843,13 +6597,7 @@ defmodule Grappa.Session.ServerTest do
       # IRC permits KICK with no trailing reason param. The :kicked
       # broadcast must carry reason: nil rather than an empty string —
       # cic discriminates "no reason given" from "empty reason given".
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6883,13 +6631,7 @@ defmodule Grappa.Session.ServerTest do
       # Only self-target KICK transitions window state. Other-target
       # KICKs land in scrollback as :persist :kick rows; the operator
       # is still in the channel.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6927,13 +6669,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "list_members/3 snapshot" do
     test "returns members in mIRC sort: @ ops first, + voiced second, plain last" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -6996,13 +6732,7 @@ defmodule Grappa.Session.ServerTest do
     # (cic shows "loading…") and the latter returns `{:ok, []}` (cic
     # shows "no members" empty state).
     test "joined channel pre-366 returns :uninitialized" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -7027,13 +6757,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "joined channel post-366 with empty NAMES returns {:ok, []}" do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
 
@@ -8806,13 +8530,7 @@ defmodule Grappa.Session.ServerTest do
     test "registered visitor: 001 stages pending_auth + clears one-shot field" do
       nick = "v_t16_#{System.unique_integer([:positive])}"
 
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 #{nick} :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", nick)
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {anon_visitor, network} = visitor_with_network(port, nick: nick)
@@ -8842,13 +8560,7 @@ defmodule Grappa.Session.ServerTest do
     test "anon visitor (auth_method :none): 001 does NOT stage pending_auth" do
       nick = "v_t16a_#{System.unique_integer([:positive])}"
 
-      rfc_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 #{nick} :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      rfc_handler = IRCServer.welcome_handler(":server", nick)
 
       {server, port} = IRCServer.start_server(rfc_handler)
       {visitor, network} = visitor_with_network(port, nick: nick)

--- a/test/grappa_web/controllers/members_controller_test.exs
+++ b/test/grappa_web/controllers/members_controller_test.exs
@@ -13,16 +13,6 @@ defmodule GrappaWeb.MembersControllerTest do
 
   alias Grappa.{IRCServer, Session}
 
-  defp welcome_handler do
-    fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
-  end
-
   defp setup_session_with_members(vjt, port, slug) do
     {network, _} = network_with_server(port: port, slug: slug)
 
@@ -44,7 +34,7 @@ defmodule GrappaWeb.MembersControllerTest do
 
   describe "GET /networks/:network_id/channels/:channel_id/members" do
     test "returns members in mIRC sort order", %{conn: conn, vjt: vjt} do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -73,7 +63,7 @@ defmodule GrappaWeb.MembersControllerTest do
     end
 
     test "404 for cross-user network access (per-user iso)", %{conn: _conn, vjt: vjt} do
-      {_, port} = IRCServer.start_server(welcome_handler())
+      {_, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -90,7 +80,7 @@ defmodule GrappaWeb.MembersControllerTest do
 
     test "404 when no session is registered for (user, network)",
          %{conn: conn, vjt: vjt} do
-      {_, port} = IRCServer.start_server(welcome_handler())
+      {_, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       slug = "az-#{System.unique_integer([:positive])}"
       {network, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -114,7 +104,7 @@ defmodule GrappaWeb.MembersControllerTest do
       conn: conn,
       vjt: vjt
     } do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       slug = "az-#{System.unique_integer([:positive])}"
       {_, pid} = setup_session_with_members(vjt, port, slug)
 
@@ -138,7 +128,7 @@ defmodule GrappaWeb.MembersControllerTest do
     # {:visitor, _} correctly — handshake + session interaction is the
     # same Session.list_members boundary user-side already exercises.
     test "visitor subject — returns members for visitor's network", %{conn: _conn} do
-      {server, port} = IRCServer.start_server(welcome_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
       {visitor, network} = visitor_with_network(port)
       session = visitor_session_fixture(visitor)
       pid = start_visitor_session_for(visitor, network)

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -20,13 +20,6 @@ defmodule GrappaWeb.NickControllerTest do
   alias Grappa.{IRCServer, Scrollback, Visitors}
   alias Grappa.Networks.Credentials
 
-  # Completes registration (001) so the session is welcomed and inbound
-  # numerics traverse the post-registration path (NumericRouter) instead
-  # of AuthFSM's registration clauses.
-  defp welcoming_handler do
-    IRCServer.welcome_handler(":irc.test.org", "grappa-test")
-  end
-
   defp setup_network(vjt, port, slug) do
     {network, _} = network_with_server(port: port, slug: slug)
     _ = credential_fixture(vjt, network, %{nick: "grappa-test", autojoin_channels: []})
@@ -194,7 +187,7 @@ defmodule GrappaWeb.NickControllerTest do
     # list (`{:server, nil}` — the rejected nick is not a destination).
     test "visitor subject — a nick taken upstream is refused by the ircd's 433, not by the controller (#828)",
          %{conn: _conn} do
-      {server, port} = IRCServer.start_server(welcoming_handler())
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc.test.org", "grappa-test"))
       old_nick = "v828c-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -24,13 +24,7 @@ defmodule GrappaWeb.NickControllerTest do
   # numerics traverse the post-registration path (NumericRouter) instead
   # of AuthFSM's registration clauses.
   defp welcoming_handler do
-    fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":irc.test.org 001 grappa-test :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    IRCServer.welcome_handler(":irc.test.org", "grappa-test")
   end
 
   defp setup_network(vjt, port, slug) do

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -74,6 +74,51 @@ defmodule Grappa.IRCServer do
   def passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
 
   @doc """
+  The registration-completing handler: answers a `USER` line with an
+  `001 RPL_WELCOME` from `prefix` naming `nick`, and stays silent on
+  everything else. What a test hands to `start_server/1` when it needs
+  the session to actually reach `:connected`, rather than merely to
+  observe what the client sent.
+
+  Lifted here from fifty-five copies of the same body across seven
+  files (#1397) — the single largest duplicated shape in the suite, and
+  invisible to a census that counts helper NAMES: only five of the
+  fifty-five had one.
+
+  ## Why both arguments are mandatory
+
+  The copies disagreed on the server prefix (`:irc` in most,
+  `:server` in nineteen, `:irc.test.org` in one) and, in seven of
+  them, on the nick. Consolidating is usually blocked on picking a
+  canonical spelling first; taking both as arguments dissolves that
+  question instead of answering it, because every call site keeps the
+  bytes it already had and the change is behaviour-preserving by
+  construction. Which spelling should win is now an independent
+  cleanup rather than a prerequisite.
+
+  Neither argument carries a default, and no zero-argument wrapper
+  should be added back — not here and not module-locally in a test
+  file, which is where the five named copies had put one. The rule
+  this follows is the one `start_server/1` below records, sharpened:
+  a wrapper may hide a NO-OP, never an OBSERVABLE. Hiding
+  `passthrough_handler/0` was struck down because a call site could no
+  longer say whether it wanted a silent peer or had not thought about
+  the peer at all; hiding a 001 is worse, because the prefix and the
+  nick both go out on the wire and a test downstream can read them.
+  The same rule saved the wrappers that hid a genuine no-op.
+  """
+  @spec welcome_handler(binary(), binary()) :: handler()
+  def welcome_handler(prefix, nick) when is_binary(prefix) and is_binary(nick) do
+    fn state, line ->
+      if String.starts_with?(line, "USER ") do
+        {:reply, "#{prefix} 001 #{nick} :Welcome\r\n", state}
+      else
+        {:reply, nil, state}
+      end
+    end
+  end
+
+  @doc """
   Spawns the fake IRC server with `handler` driving inbound-line
   reactions. Initial handler state is `%{}` — equivalent to
   `start_link/2` with `initial_state` of `%{}`. Use `start_link/2`


### PR DESCRIPTION
## What

The largest duplicated shape in the test suite was one handler body repeated
**62 times across 7 files** — answer a `USER` line with an `001 RPL_WELCOME`,
stay silent otherwise. It becomes `Grappa.IRCServer.welcome_handler(prefix, nick)`.
55 of the 62 now call it; the remaining 7 are deliberately deferred (below).

Only 5 of the 62 sat behind a name, so a census counting helper NAMES
undercounts this cluster by roughly twelvefold and reads as nearly finished.
Two of the seven wrappers — `rfc_handler/0` and `welcoming_handler/0` — were
missed even by a name search for `welcome_handler`, and surfaced only from
grouping bodies with the names stripped off.

## Both arguments mandatory

Consolidating normally requires first deciding which prefix is canonical: the
copies split 42 `:irc`, 19 `:server`, 1 `:irc.test.org`. Taking the prefix as
a mandatory argument dissolves that question rather than answering it — every
call site keeps the bytes it already had, so the change is behaviour-preserving
by construction and the spelling becomes an independent cleanup. The nick is a
second mandatory argument because it is a second axis: 7 of the 62 name someone
other than `grappa-test`.

Seven zero-argument wrappers are deleted and their **51 call sites inlined**.
A wrapper may hide a no-op; it may not hide an observable. This is the same rule
that earlier in #1397 *saved* the wrappers hiding `passthrough_handler/0`,
reaching the opposite verdict because the content is opposite.

## The mutant that stayed green

Two mutants over the six affected files, each disabling one argument:

| mutant | tests killed |
|---|---|
| nick ignored | 11 (10 in `server_test`, 1 the new unit test) |
| prefix ignored | **1 — and it is the new unit test** |

41 migrated call sites had their 001 prefix silently changed and nothing
noticed. Two consequences: unifying the three spellings is a measurably free
follow-up, and the prefix is currently guarded by nothing except the test added
here — before it existed that mutant would have killed nothing at all.

## Why 7 sites are left behind

PR #1535 is open and touches four of the same files, and the overlap is not
merely file-level: the tail of those 7 handlers is literally the context of its
hunks. They follow as a second commit on this PR once #1535 lands, taking the
remaining count to zero. `git merge-tree` against both other open branches is
clean, and the merged trees carry all entry markers with no separator loss.

## Test plan

- [x] `scripts/check.sh` green, every stage exhibited: credo 84 checks / 689
      files no issues · sobelow no vulnerabilities · doctor passed · dialyzer
      `Total errors: 0` · `8 doctests, 61 properties, 6551 tests, 0 failures`
      (6546 before, +5 = the tests added here) · bats `1..564`, zero `not ok`
- [x] `scripts/bats.sh` re-run after the rebase: `1..564`, zero `not ok`
- [x] `scripts/design-notes-gate.sh`: 1 new entry heading, separator and marker present
- [x] RED observed before GREEN on the new helper: 5 failures, then 0
- [x] Mutation bench, both mutants, tree restored clean afterwards