### PR TITLE
e2e(#1397): collapse eight bootVisitor copies onto one seeded-subject verb

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -60,7 +60,13 @@
 // cicchetto/src/lib/theme.ts MOBILE_QUERY = `(max-width: 768px)`.
 // Playwright's iPhone 15 device has viewport 393×852 → mobile branch.
 
-import { expect, type Locator, type Page } from "@playwright/test";
+import {
+  type Browser,
+  type BrowserContext,
+  expect,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
 import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 
@@ -98,6 +104,22 @@ export async function expectShellReady(page: Page): Promise<void> {
   });
 }
 
+// The ONE door that puts a bearer + subject envelope into localStorage
+// before first paint. `addInitScript` runs BEFORE any page script, so the
+// values are there when auth.ts's `createSignal` default reads the token
+// and `getSubject()` reads the subject; doing this via `page.evaluate`
+// AFTER goto would race the SPA's first read.
+async function seedAuthLocalStorage(page: Page, token: string, subjectJson: string): Promise<void> {
+  await page.addInitScript(
+    ([t, s]) => {
+      localStorage.setItem("grappa-token", t);
+      localStorage.setItem("grappa-subject", s);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [token, subjectJson] as const,
+  );
+}
+
 // Seed a token + subject into localStorage so cicchetto boots already
 // authenticated, then load the SPA and wait for the shell to be ready
 // (sidebar/bottom-bar populated with at least one network section).
@@ -114,18 +136,7 @@ export async function loginAs(
   vjt: SeededUser,
   opts: { noNetworks?: boolean } = {},
 ): Promise<void> {
-  // addInitScript runs BEFORE any page script — guarantees the
-  // localStorage values are present when auth.ts's `createSignal`
-  // default reads them. Doing this via page.evaluate AFTER goto would
-  // race the SPA's first read.
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [vjt.token, vjt.subjectJson] as const,
-  );
+  await seedAuthLocalStorage(page, vjt.token, vjt.subjectJson);
   await page.goto("/");
 
   // Shell-ready signal: a per-network section appears once the
@@ -170,6 +181,64 @@ export async function loginAs(
   // join_failed broadcasts (Phoenix.PubSub doesn't replay to late
   // subscribers). See `waitForUserTopicReady` for the full why.
   await waitForUserTopicReady(page, vjt.name);
+}
+
+// The visitor subject envelope, MIRRORED from cicchetto/src/lib/api.ts
+// `Subject` rather than imported: e2e/tsconfig.json carries no path
+// mapping into src, the same posture (and for the same reason) as
+// e2e/types/cic-window.d.ts, which inlines the window-hook types.
+//
+// The field set is the whole point. #211 phase 6 dropped `network_slug`
+// and phase 7 dropped `nick`/`ident`/`realname` from this wire: the
+// server's `Grappa.Visitors.Wire` emits `{id, registered, incognito}`,
+// `auth.ts isValidSubject` validates `id` alone, and cic resolves "my
+// nick on network X" from the GET /networks rows (`ownNickForNetwork`),
+// never from the subject. Seven per-spec copies kept seeding the dropped
+// fields for two phases because they went through
+// `JSON.stringify(value: any)` — a signature that type-checks nothing,
+// so no gate could see the drift. Building the envelope HERE, from a
+// declared field set, is what makes that structurally impossible: a
+// caller may hand in a whole MintedVisitor, but only these fields reach
+// localStorage.
+export type VisitorSeed = {
+  id: string;
+  token: string;
+  registered?: boolean;
+  incognito?: boolean;
+};
+
+// Seed a visitor session onto an EXISTING page and load the SPA.
+//
+// The readiness gate is deliberately NOT part of this verb: it genuinely
+// differs per spec (`.shell-main`, the mobile bottom-bar header, a
+// user-topic subscribe, or none at all for the #477 rail specs), and
+// folding four variants behind an enum would bury a real per-spec intent
+// under a shared default. Callers await their own signal.
+export async function bootVisitor(page: Page, visitor: VisitorSeed): Promise<void> {
+  const subject: {
+    kind: "visitor";
+    id: string;
+    registered?: boolean;
+    incognito?: boolean;
+  } = { kind: "visitor", id: visitor.id };
+  if (visitor.registered !== undefined) subject.registered = visitor.registered;
+  if (visitor.incognito !== undefined) subject.incognito = visitor.incognito;
+
+  await seedAuthLocalStorage(page, visitor.token, JSON.stringify(subject));
+  await page.goto("/");
+}
+
+// `bootVisitor` on a context of its own — the shape the browser-level
+// specs need, where each visitor gets an isolated localStorage. Returns
+// the context so the caller can close it.
+export async function bootVisitorContext(
+  browser: Browser,
+  visitor: VisitorSeed,
+): Promise<{ ctx: BrowserContext; page: Page }> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await bootVisitor(page, visitor);
+  return { ctx, page };
 }
 
 // Sidebar / bottom-bar accessors ────────────────────────────────────

--- a/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
+++ b/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
@@ -31,8 +31,8 @@
 // them. #154 rides the #153 server de-gate (visitors may send these verbs)
 // which the testnet already carries.
 
-import type { Browser } from "@playwright/test";
 import {
+  bootVisitorContext,
   composeSend,
   composeTextarea,
   expectShellReady,
@@ -44,40 +44,15 @@ import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-// Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
-// dance) — identical seeding to issue148/issue153.
-async function bootVisitor(browser: Browser, nick: string) {
-  const visitor = await mintVisitor(nick);
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [
-      visitor.token,
-      JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-      }),
-    ] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  return { visitor, ctx, page };
-}
-
 test("issue #154(1) — a rejected ops verb surfaces an inline compose error (no silent green ✓)", async ({
   browser,
 }) => {
   const admin = getSeededAdmin();
   const stamp = Date.now();
   const channel = `#t154a-${stamp}`;
-  const { visitor, ctx, page } = await bootVisitor(browser, `v154a-${stamp}`);
+  const visitor = await mintVisitor(`v154a-${stamp}`);
+  const { ctx, page } = await bootVisitorContext(browser, visitor);
+  await expectShellReady(page);
 
   try {
     // Focus $server and wait for the registration numerics → session is
@@ -127,7 +102,9 @@ test("issue #154(2) — an own-nick /umode renders a 'sets user mode' row in $se
 }) => {
   const admin = getSeededAdmin();
   const stamp = Date.now();
-  const { visitor, ctx, page } = await bootVisitor(browser, `v154b-${stamp}`);
+  const visitor = await mintVisitor(`v154b-${stamp}`);
+  const { ctx, page } = await bootVisitorContext(browser, visitor);
+  await expectShellReady(page);
 
   try {
     // Focus $server and gate on the registration numerics (session connected).

--- a/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
+++ b/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
@@ -21,8 +21,8 @@
 // never carries `.selected` → the post-reload assertion times out.
 // GREEN post-fix: the restore arm re-selects #r187 → the row is `.selected`.
 
-import type { Browser } from "@playwright/test";
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   selectChannel,
@@ -33,40 +33,15 @@ import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-// Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
-// dance) — identical seeding to issue148/issue153/issue154.
-async function bootVisitor(browser: Browser, nick: string) {
-  const visitor = await mintVisitor(nick);
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [
-      visitor.token,
-      JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-      }),
-    ] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  return { visitor, ctx, page };
-}
-
 test("issue #187 — a visitor's last-open channel is restored on refresh/reopen (not $home)", async ({
   browser,
 }) => {
   const admin = getSeededAdmin();
   const stamp = Date.now();
   const channel = `#r187-${stamp}`;
-  const { visitor, ctx, page } = await bootVisitor(browser, `v187-${stamp}`);
+  const visitor = await mintVisitor(`v187-${stamp}`);
+  const { ctx, page } = await bootVisitorContext(browser, visitor);
+  await expectShellReady(page);
 
   try {
     // Focus $server and wait for the registration numerics → the visitor's

--- a/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
@@ -25,19 +25,14 @@
 // Runs on chromium desktop (members pane renders directly in
 // `.shell-members .members-pane`, no mobile drawer).
 
-import type { Browser, Page } from "@playwright/test";
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import {
-  GRAPPA_BASE_URL,
-  type MintedVisitor,
-  mintVisitor,
-  reapVisitors,
-} from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -46,33 +41,6 @@ const VISITOR_NETWORK = "azzurra";
 
 // Full chain + testnet latency + a peer round-trip — well past 30s.
 test.setTimeout(90_000);
-
-async function bootVisitor(
-  browser: Browser,
-  visitor: MintedVisitor,
-): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: Page }> {
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [
-      visitor.token,
-      JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-      }),
-    ] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  return { ctx, page };
-}
 
 test("issue #211 phase 3 — fresh visitor lands JOINED with own nick + a live PRIVMSG (full read-cutover chain)", async ({
   browser,
@@ -90,7 +58,8 @@ test("issue #211 phase 3 — fresh visitor lands JOINED with own nick + a live P
   const visitor = await mintVisitor(`p3-${stamp}`);
   expect(visitor.network_slug).toBe(VISITOR_NETWORK);
 
-  const { ctx, page } = await bootVisitor(browser, visitor);
+  const { ctx, page } = await bootVisitorContext(browser, visitor);
+  await expectShellReady(page);
   let peer: IrcPeer | null = null;
 
   try {

--- a/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
@@ -34,8 +34,13 @@
 //
 // Runs on chromium desktop (members pane renders directly).
 
-import type { Browser, Page } from "@playwright/test";
-import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import type { Browser } from "@playwright/test";
+import {
+  bootVisitorContext,
+  expectShellReady,
+  selectChannel,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, joinChannel, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
@@ -59,29 +64,6 @@ async function setAutoconnect(adminToken: string, slug: string, on: boolean): Pr
   if (!res.ok) {
     throw new Error(`setAutoconnect: ${slug}=${on} → ${res.status} ${await res.text()}`);
   }
-}
-
-async function bootVisitor(
-  browser: Browser,
-  visitor: { id: string; nick: string; token: string },
-): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: Page }> {
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [
-      visitor.token,
-      // #211 phase 6 — the subject wire has NO network_slug (multi-network).
-      JSON.stringify({ kind: "visitor", id: visitor.id, nick: visitor.nick }),
-    ] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  return { ctx, page };
 }
 
 // Poll GET /networks until it lists at least `n` rows (the async
@@ -127,7 +109,8 @@ test("issue #211 phase 6 — fresh visitor AUTO-CONNECTS the visitor_autoconnect
     expect(byslug.get("azzurra")?.connection_state).toBe("connected");
     expect(byslug.get("azzurra2")?.connection_state).toBe("connected");
 
-    const booted = await bootVisitor(browser, visitor);
+    const booted = await bootVisitorContext(browser, visitor);
+    await expectShellReady(booted.page);
     ctx = booted.ctx;
     const page = booted.page;
     await waitForUserTopicReady(page, `visitor:${visitor.id}`);

--- a/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
@@ -39,8 +39,13 @@
 // reconnect backfill (`refreshScrollback` for every `joined` key) heals
 // both networks in one socket resume.
 
-import type { Browser, Page } from "@playwright/test";
-import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import type { Browser } from "@playwright/test";
+import {
+  bootVisitorContext,
+  expectShellReady,
+  selectChannel,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
 import {
   assertMessagePersisted,
   GRAPPA_BASE_URL,
@@ -58,28 +63,6 @@ const SECOND = "azzurra2";
 // peer round-trip on each network — well past the default. Give it
 // plenty of testnet-latency headroom (matches the phase-6 matrix budget).
 test.setTimeout(150_000);
-
-// Boot the ONE visitor into a fresh browser context. The subject wire is
-// phase-7-slim ({id, registered}); per-network nick lives on the
-// GET /networks rows, so no nick/network_slug is seeded here.
-async function bootVisitor(
-  browser: Browser,
-  visitor: { id: string; token: string },
-): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: Page }> {
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [visitor.token, JSON.stringify({ kind: "visitor", id: visitor.id })] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  return { ctx, page };
-}
 
 type NetRow = { slug: string; nick: string; connection_state: string };
 
@@ -279,7 +262,8 @@ test("issue #211 phase 7 — one visitor on TWO networks survives a real cic WS 
 
     // ── BROWSER: boot cic, subscribe both channels, then drop the WS ──
 
-    const booted = await bootVisitor(browser, visitor);
+    const booted = await bootVisitorContext(browser, visitor);
+    await expectShellReady(booted.page);
     ctx = booted.ctx;
     const page = booted.page;
     await waitForUserTopicReady(page, `visitor:${visitor.id}`);

--- a/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
+++ b/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
@@ -27,7 +27,7 @@
 // chromium run of `#260` is intentionally empty.
 
 import type { Page } from "@playwright/test";
-import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import { bootVisitor, loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import {
   GRAPPA_BASE_URL,
   type MintedVisitor,
@@ -98,26 +98,6 @@ const isAtEdge = (snap: StripSnapshot, slug: string): boolean => {
 
 const edgeCount = (snap: StripSnapshot): number =>
   snap.headers.filter((h) => Math.abs(h.left - snap.barLeft) <= EDGE_EPS).length;
-
-// Boot cicchetto as a freshly-minted visitor on the current (mobile)
-// page fixture — mirrors loginAs but for the visitor subject wire
-// ({kind:"visitor", id}). The webkit-iphone-15 viewport makes Shell.tsx
-// render the mobile `.bottom-bar`.
-async function bootVisitorMobile(page: Page, visitor: MintedVisitor): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [visitor.token, JSON.stringify({ kind: "visitor", id: visitor.id })] as const,
-  );
-  await page.goto("/");
-  await expect(page.locator(".bottom-bar-network-header").first()).toBeVisible({
-    timeout: 15_000,
-  });
-  await waitForUserTopicReady(page, `visitor:${visitor.id}`);
-}
 
 async function getNetworks(
   token: string,
@@ -241,7 +221,14 @@ test("@webkit #260 — the sticky header pins under scroll and the next network 
     for (const c of anchorChans) await joinChannelWhenReady(visitor.token, ANCHOR, c);
     for (const c of secondChans) await joinChannelWhenReady(visitor.token, SECOND, c);
 
-    await bootVisitorMobile(page, visitor);
+    // The webkit-iphone-15 viewport makes Shell.tsx render the mobile
+    // `.bottom-bar`, so the readiness gate is the bottom-bar header, not
+    // the desktop `.shell-main`.
+    await bootVisitor(page, visitor);
+    await expect(page.locator(".bottom-bar-network-header").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await waitForUserTopicReady(page, `visitor:${visitor.id}`);
 
     // Wait until the strip is ready to measure: both network groups
     // rendered, the strip OVERFLOWS the viewport, and the last group is

--- a/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
+++ b/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
@@ -43,7 +43,7 @@
 // symmetrically for its ephemeral case).
 
 import type { Browser, Page } from "@playwright/test";
-import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
+import { bootVisitorContext, loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
@@ -66,24 +66,11 @@ async function bootVisitor(
 ): Promise<{ page: Page; teardown: () => Promise<void> }> {
   const label = registered ? "reg" : "anon";
   const visitor = await mintVisitor(`e2e477-${label}-${Date.now()}`);
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  const subjectJson = JSON.stringify({
-    kind: "visitor",
+  const { ctx, page } = await bootVisitorContext(browser, {
     id: visitor.id,
-    nick: visitor.nick,
-    network_slug: visitor.network_slug,
+    token: visitor.token,
     registered,
   });
-  await page.addInitScript(
-    ([token, subject]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subject);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [visitor.token, subjectJson] as const,
-  );
-  await page.goto("/");
   return {
     page,
     teardown: async () => {

--- a/cicchetto/e2e/tests/recover-identity-real.spec.ts
+++ b/cicchetto/e2e/tests/recover-identity-real.spec.ts
@@ -80,6 +80,7 @@
 import type { Browser } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   selectChannel,
@@ -89,36 +90,6 @@ import { GRAPPA_BASE_URL, loginVisitor, mintVisitor, reapVisitors } from "../fix
 import { IrcPeer } from "../fixtures/ircClient";
 import { awaitMail, extractFromMail, resetMailpit } from "../fixtures/mailpit";
 import { getSeededAdmin } from "../fixtures/seedData";
-
-// Boot cic as a visitor (local per-spec helper — the established pattern; each
-// visitor spec inlines its own). Seeds the two auth localStorage keys the SPA
-// reads at module init, navigates, and waits for the shell + user-topic to be
-// live so subsequent home-row assertions see settled state.
-async function bootVisitor(
-  browser: Browser,
-  visitor: { id: string; nick: string; token: string },
-): Promise<{
-  ctx: Awaited<ReturnType<Browser["newContext"]>>;
-  page: import("@playwright/test").Page;
-}> {
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [
-      visitor.token,
-      JSON.stringify({ kind: "visitor", id: visitor.id, nick: visitor.nick }),
-    ] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-  await waitForUserTopicReady(page, `visitor:${visitor.id}`);
-  return { ctx, page };
-}
 
 const NETWORK_SLUG = "azzurra"; // visitor_enabled + real azzurra-services (bahamut-test hub)
 const RECOVER_PASSWORD = "recidpw1"; // 5–32 chars (NickServ floor)
@@ -178,7 +149,9 @@ test.describe("#581 recover-identity (real services)", () => {
       // Server-side proof: the anon credential is NOT recoverable.
       await waitForRecoverable(visitor.token, visitor.network_slug, false, 15_000);
 
-      const booted = await bootVisitor(browser, visitor);
+      const booted = await bootVisitorContext(browser, visitor);
+      await expectShellReady(booted.page);
+      await waitForUserTopicReady(booted.page, `visitor:${visitor.id}`);
       ctx = booted.ctx;
       const page = booted.page;
 
@@ -229,7 +202,9 @@ test.describe("#581 recover-identity (real services)", () => {
       // The +r commit persists the :nickserv_identify credential → recoverable.
       await waitForRecoverable(visitor.token, NETWORK_SLUG, true);
 
-      const booted = await bootVisitor(browser, visitor);
+      const booted = await bootVisitorContext(browser, visitor);
+      await expectShellReady(booted.page);
+      await waitForUserTopicReady(booted.page, `visitor:${visitor.id}`);
       ctx = booted.ctx;
       const page = booted.page;
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49855,3 +49855,97 @@ rewritten call sites type-checks and fails only at runtime. That is the same
 gap the sibling entries name, and on the `seedCursor` slice it was a runtime
 positive control, not the type-checker, that caught exactly such a
 transposition.
+<!-- entry #1397-e2e-bootvisitor -->
+
+---
+
+## 2026-08-19 — #1397 (e2e): the fixture kept swearing to fields the server dropped
+
+`bootVisitor` was the worst of the census residue: seven copies over seven
+files, six distinct body hashes, 171 lines. Two of the census's standing
+assumptions did not survive contact with it, in opposite directions.
+
+The count was too LOW, not too high. An eighth copy lives in
+`issue260-sticky-network-tab.spec.ts` under the name `bootVisitorMobile` — the
+same verb, differing only in that it takes an existing `page` instead of a
+`Browser`. A census that greps for a name cannot see a synonym. Eight copies,
+eight files, 186 lines.
+
+And the md5 count did NOT overstate the semantics here, which is what it had
+done on every earlier cluster. Three successive normalisations — whitespace,
+commas and variable names; then the whole signature; then the return statement
+— each left the count at six. On `fetchScrollbackPage` the same treatment had
+collapsed six hashes onto one behaviour. The lesson is not that md5 overstates,
+it is that md5 tells you nothing either way.
+
+### The axis was real in the bodies and fake in production
+
+What separated the six was the subject envelope seeded into
+`localStorage["grappa-subject"]`: `{kind,id,nick,network_slug}` in three copies,
+`{kind,id,nick}` in two, `{kind,id}` in one, and `{…,registered}` in #477's.
+
+Only `registered` is load-bearing. Three layers, independently, say the rest is
+sediment. The server's `Grappa.Visitors.Wire` emits `{id, registered,
+incognito}` — #211 phase 6 dropped `network_slug` and phase 7 dropped
+`nick`/`ident`/`realname` — and its moduledoc says cic resolves "my nick on
+network X" from the `GET /networks` rows, never from the subject. The client's
+`api.Subject` visitor arm declares `{kind, id, registered?, incognito?}` and
+nothing more. `auth.ts isValidSubject` validates `id` alone, with a comment
+explaining that guarding `nick` would log out every persisted subject. No spec
+reads the key back.
+
+So the seeds had been swearing to two fields for two phases after the wire
+dropped them.
+
+### Why nothing caught it, and what now would
+
+`JSON.stringify(value: any)` — the declared signature, read from the
+TypeScript shipped in this repo. The parameter is `any`, so there is no
+contextual typing and no excess-property check against `Subject`. Every one of
+the eight seeds went through it. **A green `bun run check` was never evidence
+about the subject shape**, which is exactly how the drift survived two phases
+of #211 without a gate objecting.
+
+That, not the line count, is the argument for the shared verb. `bootVisitor`
+now takes a declared `VisitorSeed` and BUILDS the envelope from that field set,
+so a stale field cannot reach localStorage even when a caller hands in a whole
+`MintedVisitor`. Measured, not asserted: re-adding `nick` to the one call site
+that passes an object literal produced
+`TS2353: Object literal may only specify known properties, and 'nick' does not
+exist in type 'VisitorSeed'`. The limit is worth naming — excess-property
+checking fires on literals, so a caller passing a variable still gets no
+warning; the construction, not the type, is what makes the drift impossible.
+
+### What the verb deliberately does NOT own
+
+The readiness gate. It genuinely differs per spec — `.shell-main`, the mobile
+bottom-bar header, a user-topic subscribe, or nothing at all for #477's rail
+timing — and folding four variants behind an enum would bury per-spec intent
+under a shared default. Callers await their own signal, so this change moves
+exactly one axis and a red would have been attributable to it.
+
+Whether #477's absent readiness gate is deliberate or an omission is still
+unmeasured; both readings stay open. The measure that separates them is adding
+`expectShellReady` there and running it.
+
+### What gated it
+
+Baseline first, on `origin/main` in the same worktree, same eight specs, both
+projects: **17 passed**, no pre-existing red in this subset. After the change:
+**17 passed**, same seventeen titles. `bun run check` rc=0 over the whole chain
+with the same 59 pre-existing CSS warnings — and only rc=0 proves it, since the
+chain is `biome && tsc && tsc -p e2e`, and a biome failure leaves the log
+reading rc=1 with zero `error TS`.
+
+A green on removed fields proves nothing unless the suite can see a removed
+field, so the control removed one that is load-bearing: dropping `registered`
+from #477's seed reddened **exactly one test of the seventeen** — `registered
+VISITOR (persistent) → the rail offers BOTH detach and quit`, the one that
+reads it. One mutant, one dead assertion, sixteen untouched. That is what makes
+the treatment green mean something: the same path that detects a `registered`
+removal did not detect the `nick`/`network_slug` removal.
+
+Not claimed: that no OTHER spec depends on those fields. Seventeen tests over
+eight files were run, not the suite. Seventeen more files outside this slice
+still seed the dropped fields — a separate axis, deliberately not folded in
+here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49933,9 +49933,17 @@ unmeasured; both readings stay open. The measure that separates them is adding
 Baseline first, on `origin/main` in the same worktree, same eight specs, both
 projects: **17 passed**, no pre-existing red in this subset. After the change:
 **17 passed**, same seventeen titles. `bun run check` rc=0 over the whole chain
-with the same 59 pre-existing CSS warnings — and only rc=0 proves it, since the
-chain is `biome && tsc && tsc -p e2e`, and a biome failure leaves the log
-reading rc=1 with zero `error TS`.
+with the same 59 pre-existing CSS warnings.
+
+Only rc=0 over the WHOLE chain proves anything, because the chain is
+`biome && tsc && tsc -p e2e`: a biome failure means tsc never runs, and the log
+then reads rc=1 with zero `error TS`. **That is NOT MEASURED, and it reads
+exactly like "the types are fine".** There is no stage marker to grep for — the
+absence of `error TS` is indistinguishable between "tsc passed" and "tsc never
+started". This is not hypothetical here: the static control below first came
+back rc=1 with no `error TS` at all, and the real TS2353 only appeared after
+`biome check --write`. It caught a worker who had been warned about it in
+writing the same day.
 
 A green on removed fields proves nothing unless the suite can see a removed
 field, so the control removed one that is load-bearing: dropping `registered`


### PR DESCRIPTION
## What

Eight near-identical `bootVisitor` helpers (seven under that name, plus
`bootVisitorMobile` in `issue260` — the same verb wearing another name)
collapse onto one shared verb in `cicchetto/e2e/fixtures/cicchettoPage.ts`:

- `VisitorSeed {id, token, registered?, incognito?}`
- `bootVisitor(page, seed)` / `bootVisitorContext(browser, seed)`
- private `seedAuthLocalStorage`, now also used by `loginAs` — the single
  door into the auth localStorage envelope.

## Why

Not the -94 lines. The shared verb **constructs** the envelope from a
declared field set, so `nick` / `network_slug` — which the server dropped
in #211 phase 6/7 — can no longer reach localStorage from a copy that
still swears to them. Hand-rolled seeding sites in the e2e suite: 66 → 58.

## Measurements

- **Baseline** on the pre-branch `origin/main`, same 8 specs, both
  projects: rc=0, 17 passed (no pre-existing red in this subset).
- **Treatment**: rc=0, 17 passed, same 17 titles.
- **Runtime positive control**: dropping `registered` from the issue477
  seed gives rc=1 with exactly 1 of 17 failing — the one assertion that
  reads it. Mutant removed and re-verified green.
- **Static positive control**: re-adding `nick` at the one literal call
  site gives `TS2353 ... 'nick' does not exist in type 'VisitorSeed'`.
  Removed, rc=0.
- `scripts/bun.sh run check` rc=0 over the whole chain (biome + both
  tsc passes); 59 pre-existing CSS warnings. `design-notes-gate.sh` rc=0.

## What I decline to claim

- The full `scripts/integration.sh` suite was **not** run — only the 8
  affected specs, on both projects. The ship gate is the orchestrator's.
- The type is not the guarantee. TS excess-property checking fires only
  on object **literals**; a caller passing a variable gets no error. What
  closes the drift is envelope construction, not the type.
- 17 files outside this slice still hand-seed `nick` / `network_slug`.
  Untouched here; the shared verb that would absorb them now exists.

Part of the #1397 duplicate-helper census.