### PR TITLE
test(#1397): give the AdminEvents ring one reset, not seven copies

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49855,3 +49855,83 @@ rewritten call sites type-checks and fails only at runtime. That is the same
 gap the sibling entries name, and on the `seedCursor` slice it was a runtime
 positive control, not the type-checker, that caught exactly such a
 transposition.
+<!-- entry #1397-adminevents-reset -->
+
+---
+
+## 2026-08-19 — #1397: one reset for the AdminEvents ring, and the anchor that hid the family
+
+Bucket H, server side. Seven `setup` blocks opened with the same
+byte-identical line and now call
+`AdmissionStateHelpers.reset_admin_events/0`.
+
+### The line did more than it read
+
+    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+
+It reads as "empty the ring". It REBUILDS the struct, so `persist` and
+`retention` also go back to their `defstruct` defaults. A helper written
+from the apparent intent — `%{s | buffer: []}` — would have preserved a
+leaked `persist: true` and quietly changed all seven call sites. Nothing
+asserted the clobber, so a characterization test landed FIRST, in its own
+commit, and asserts the pre-state before performing the gesture (without
+that, the three post-state assertions also pass against a singleton that
+was already at the defaults).
+
+Measured, not assumed. Mutating the helper to the apparent intent kills
+exactly one test — the equivalence test — and leaves the characterization
+test green, because that one exercises the inline gesture rather than the
+helper. Two tests, two different jobs.
+
+### Where it lives, and the name that is a slight stretch
+
+`Grappa.AdmissionStateHelpers` already existed for this exact failure
+mode: application-wide singletons that outlive a sandbox checkout.
+AdminEvents is not an admission singleton, so the module name is now
+marginally wrong. A second support module for one function would have
+been worse: it splits the pattern across two homes, and the next author
+looking for "where do I reset the singleton" finds one of them and
+invents a third spelling. The moduledoc states the tension instead of
+hiding it.
+
+It is deliberately NOT folded into `reset_all/0`. Thirteen files call
+that today without touching the ring; adding it would change what they
+reset while looking like tidying.
+
+### The mutant that measured something else
+
+Making the helper a no-op fails 16 tests in one run and 14 in the next.
+The number is seed-dependent because ExUnit randomises order and this
+reset exists precisely to defend against order — so the right reading is
+"load-bearing", not a fixed count. In the run whose full distribution was
+captured, the failures came from four of the seven files; the resets in
+`networks_controller_test`, `users_controller_test` and
+`credentials_controller_test` contributed none. That is not an argument
+to delete them — one seed proves nothing about the seeds that flake — but
+it does mean three of the seven copies were never covered by an
+assertion.
+
+### The anchor, which is the transferable part
+
+The family was nearly missed. The census that opened this bucket anchored
+on the literal `fn state`, and on that axis the tail genuinely is
+exhausted: after the 001 cluster closed, the largest remaining
+byte-identical group is three copies in a single file. But the anchor was
+the limit, not the tree. `fn state` intercepts 24 of the 45
+`:sys.replace_state` code sites (54 textual occurrences less 9 inside
+comments) because the lambda parameter is spelled four ways — `state` 24,
+`s` 10, `_` 7, `cs` 3. Re-anchoring from "literal `fn state`" to "body of
+a `defp`" and grouping blind to the name surfaces 31 groups spanning two
+or more files, 90 definitions, the largest at 18 copies.
+
+This is the same false zero this repo keeps producing, and it has now
+appeared in four distinct shapes across three days: an anchor too wide
+(`def start_server` matching `start_server_with_001`), too narrow
+(`defp? name\(` answering 0 for a `defp name, do:`), invalid as ERE
+(`\b` and `\s` do not exist in `git grep -E`, and `{` opens an interval,
+so a pattern containing `%Struct{...}` matches nothing at all), and
+prefix-eating (`grep -o` discards what it did not capture, so a follow-on
+`grep -v` filters nothing). A zero is the most suspicious result
+available, not the most reassuring: it is indistinguishable from "already
+done". Cross three methods — by name, by naked grep, by grouping on the
+BODY — before believing one.

--- a/test/grappa/admin_events_test.exs
+++ b/test/grappa/admin_events_test.exs
@@ -51,10 +51,9 @@ defmodule Grappa.AdminEventsTest do
     # this setup-time drain is empty in the steady-state case.
     AdmissionStateHelpers.reset_session_supervisor()
 
-    # AdminEvents is started by Grappa.Application; clear buffer state
-    # per-test by record-then-snapshot-then-drop. Since record/1 is a
-    # cast, drain via call/2 to force serialization.
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    # AdminEvents is started by Grappa.Application and outlives every
+    # sandbox checkout, so the ring goes back to a booted struct per test.
+    AdmissionStateHelpers.reset_admin_events()
 
     # M-11: AdminEvents boots with `attach_telemetry: false` under
     # `config :grappa, :attach_admin_telemetry, false` in test env
@@ -147,6 +146,31 @@ defmodule Grappa.AdminEventsTest do
       assert post.buffer == []
       assert post.persist == defaults.persist
       assert post.retention == defaults.retention
+    end
+
+    test "reset_admin_events/0 lands the state the inline gesture landed" do
+      defaults = %AdminEvents{}
+
+      dirty = fn ->
+        :ok = AdminEvents.record(Wire.reaper_swept(1))
+        _ = AdminEvents.snapshot()
+
+        :sys.replace_state(AdminEvents, fn s ->
+          %{s | persist: not defaults.persist, retention: defaults.retention + 1}
+        end)
+      end
+
+      dirty.()
+      :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+      inline = :sys.get_state(AdminEvents)
+
+      # Re-dirty, or the comparison below is between two clean states and
+      # would hold for a helper that did nothing at all.
+      dirty.()
+      assert :sys.get_state(AdminEvents) != inline
+
+      AdmissionStateHelpers.reset_admin_events()
+      assert :sys.get_state(AdminEvents) == inline
     end
   end
 

--- a/test/grappa/admin_events_test.exs
+++ b/test/grappa/admin_events_test.exs
@@ -115,6 +115,41 @@ defmodule Grappa.AdminEventsTest do
     end
   end
 
+  describe "the per-test singleton reset (#1397 bucket H characterization)" do
+    # Seven test files open `setup` with the same byte-identical line:
+    #
+    #     :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    #
+    # It reads as "empty the ring", but it REBUILDS the struct, so it also
+    # returns `persist` and `retention` to their `defstruct` defaults
+    # whatever they were. That clobber is the part a shared helper must
+    # preserve, and the part nothing asserted before this test.
+    test "rebuilds the struct whole: buffer emptied AND persist/retention back to defaults" do
+      defaults = %AdminEvents{}
+
+      :ok = AdminEvents.record(Wire.reaper_swept(1))
+      _ = AdminEvents.snapshot()
+
+      :sys.replace_state(AdminEvents, fn s ->
+        %{s | persist: not defaults.persist, retention: defaults.retention + 1}
+      end)
+
+      # Assert the pre-state, or the post-state assertions below pass
+      # against a singleton that was already at the defaults.
+      pre = :sys.get_state(AdminEvents)
+      assert pre.buffer != []
+      assert pre.persist != defaults.persist
+      assert pre.retention != defaults.retention
+
+      :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+
+      post = :sys.get_state(AdminEvents)
+      assert post.buffer == []
+      assert post.persist == defaults.persist
+      assert post.retention == defaults.retention
+    end
+  end
+
   describe "disk-backing (#215 Option B)" do
     # The singleton boots persist:false in test env (config); flip it on +
     # rely on the setup's Sandbox.allow so the pid's Repo writes land in

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -21,16 +21,16 @@ defmodule GrappaWeb.AdminChannelTest do
   import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
-  alias Grappa.{AdminEvents, AdminOverview, Repo, SessionLog}
+  alias Grappa.{AdminEvents, AdminOverview, AdmissionStateHelpers, Repo, SessionLog}
   alias Grappa.AdminEvents.Wire
   alias Grappa.PubSub.Topic
   alias GrappaWeb.UserSocket
   alias Phoenix.Socket.Broadcast
 
   setup do
-    # AdminEvents is the global singleton — reset buffer per-test so
-    # the snapshot push contains exactly what THIS test queued.
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    # The ring must start empty so the snapshot push contains exactly
+    # what THIS test queued.
+    AdmissionStateHelpers.reset_admin_events()
 
     # AdminEvents runs in its own supervised pid; allow it on the
     # sandbox connection ChannelCase already checked out (`async:

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -22,14 +22,14 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Bootstrap, IRCServer, Networks, Session}
+  alias Grappa.{Accounts, AdmissionStateHelpers, Bootstrap, IRCServer, Networks, Session}
   alias Grappa.Bootstrap.Result
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.PubSub.Topic
 
   setup do
     AdmissionStateHelpers.reset_all()
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/grappa_web/controllers/admin/networks_controller_test.exs
+++ b/test/grappa_web/controllers/admin/networks_controller_test.exs
@@ -33,11 +33,10 @@ defmodule GrappaWeb.Admin.NetworksControllerTest do
 
   setup do
     AdmissionStateHelpers.reset_network_circuit()
-    # MED-1: PATCH emits :network_caps_updated via AdminEvents.record/1
-    # (singleton GenServer started by Grappa.Application). Reset the
-    # ring buffer per-test so cross-test contamination doesn't pollute
-    # the assertion. Same pattern as Grappa.AdminEventsTest.
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    # MED-1: PATCH emits :network_caps_updated via AdminEvents.record/1,
+    # so the ring has to start empty or a prior test's event pollutes the
+    # head-of-buffer assertion.
+    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/grappa_web/controllers/admin/users_controller_test.exs
+++ b/test/grappa_web/controllers/admin/users_controller_test.exs
@@ -26,16 +26,15 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers}
+  alias Grappa.{Accounts, AdmissionStateHelpers}
   alias Grappa.PubSub.Topic
   alias GrappaWeb.UserSocket
 
   setup do
     AdmissionStateHelpers.reset_session_supervisor()
-    # Bucket 4: reset the AdminEvents ring buffer per-test so the
-    # snapshot-assertion path (head-of-buffer check) isn't polluted
-    # by prior tests. Same pattern as NetworksControllerTest.
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    # Bucket 4: the head-of-buffer assertions need the ring to start
+    # empty, or a prior test's event sits where this test's should.
+    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -39,7 +39,7 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
     # ring buffer here lets the refusal cases assert NOTHING was
     # recorded, which is the half of "incognito is refused" that a
     # status-code assertion alone cannot see.
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/grappa_web/controllers/share_token_audit_test.exs
+++ b/test/grappa_web/controllers/share_token_audit_test.exs
@@ -22,10 +22,10 @@ defmodule GrappaWeb.ShareTokenAuditTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.AdminEvents
+  alias Grappa.{AdminEvents, AdmissionStateHelpers}
 
   setup do
-    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
+    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/support/admission_state_helpers.ex
+++ b/test/support/admission_state_helpers.ex
@@ -1,16 +1,21 @@
 defmodule Grappa.AdmissionStateHelpers do
   @moduledoc """
-  Cross-test reset helpers for the application-singleton ETS tables AND
+  Cross-test reset helpers for the application-wide singletons that
+  survive a sandbox checkout — the ETS tables AND
   `Grappa.SessionSupervisor` Registry that Cluster T31's admission gate
-  reads from.
+  reads from, plus the `Grappa.AdminEvents` ring buffer (#1397 bucket H;
+  it is not an admission singleton, but it has the same lifetime and the
+  same per-test reset need, and a second module for one function would
+  have split the pattern in two).
 
   ## Why this exists (no-silent-drops B6.8 HIGH-12 + T-3 prelude)
 
-  Three application-wide singletons survive `Ecto.Adapters.SQL.Sandbox`
+  Four application-wide singletons survive `Ecto.Adapters.SQL.Sandbox`
   checkout/checkin AND `mix test` boundary across container runs:
 
     * `Grappa.Admission.NetworkCircuit` — ETS table `:admission_network_circuit_state`
     * `Grappa.Session.Backoff` — ETS table `:session_backoff_state`
+    * `Grappa.AdminEvents` — GenServer ring buffer, registered as the module
     * `Grappa.SessionSupervisor` + `Grappa.SessionRegistry` — DynamicSupervisor
       children, indexed by `{:session, subject, network_id}`
 
@@ -50,8 +55,9 @@ defmodule Grappa.AdmissionStateHelpers do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Admission, Grappa.Session]
+    deps: [Grappa.Admission, Grappa.AdminEvents, Grappa.Session]
 
+  alias Grappa.AdminEvents
   alias Grappa.Admission.NetworkCircuit
   alias Grappa.Session.Backoff
 
@@ -165,6 +171,26 @@ defmodule Grappa.AdmissionStateHelpers do
       :ets.delete(:session_backoff_state, key)
     end
 
+    :ok
+  end
+
+  @doc """
+  Return the `Grappa.AdminEvents` singleton to a freshly-booted struct:
+  empty ring buffer, and `persist` / `retention` back at their
+  `defstruct` defaults.
+
+  Resetting the WHOLE struct rather than just the buffer is deliberate —
+  it is what the seven `setup` blocks this replaced already did, and a
+  suite that leaks `persist: true` writes admin rows from an unrelated
+  test's process. `admin_events_test.exs` locks that clobber.
+
+  Deliberately NOT part of `reset_all/0`: thirteen files call that one
+  today without touching the ring, and folding this in would silently
+  change what they reset.
+  """
+  @spec reset_admin_events() :: :ok
+  def reset_admin_events do
+    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
     :ok
   end
 


### PR DESCRIPTION
Bucket H of #1397, server side. Seven `setup` blocks carried the same
byte-identical line; they now call
`Grappa.AdmissionStateHelpers.reset_admin_events/0`.

## The line did more than it read

    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)

It reads as "empty the ring". It REBUILDS the struct, so `persist` and
`retention` also return to their `defstruct` defaults. A helper written
from the apparent intent — `%{s | buffer: []}` — would have preserved a
leaked `persist: true` and changed behaviour at all seven sites without
failing a test. Nothing asserted that clobber, so the characterization
test landed FIRST and on its own commit, and it asserts the pre-state
before performing the gesture (without that, the post-state assertions
also pass against a singleton already sitting at the defaults).

## Commits

1. `70741f75` — LOCK: characterize what the gesture actually does.
2. `38002fde` — the seven sites, plus the equivalence test.
3. `00428f55` — DESIGN_NOTES.

## Where it lives

`AdmissionStateHelpers` already existed for this failure mode:
application-wide singletons that outlive a sandbox checkout. AdminEvents
is not an admission singleton, so the module name is now marginally
wrong — the moduledoc says so rather than hiding it. A second support
module for one function splits the pattern across two homes, and the next
author finds one of them and invents a third spelling.

Deliberately NOT folded into `reset_all/0`: thirteen files call that today
without touching the ring.

## Measured

Mutants, each restoring from HEAD:

- LOCK test, gesture mutated to the apparent intent → 1 failure, on a
  post-state assertion (`==`).
- LOCK test, pre-state dirtying removed → 1 failure, on the pre-state
  assertion (`!=`). Different assertion, not the same one twice.
- Helper mutated to the apparent intent → 1 failure, and it is the
  equivalence test only; the characterization test stays green because it
  exercises the inline gesture rather than the helper.
- Helper made a no-op → 16 failures in one run, 14 in the next. The
  number is seed-dependent and does not exist as a fixed quantity —
  ExUnit randomises order and this reset defends against order. What that
  run did show is filed as #1546: three of the seven sites contributed no
  failures, two of them provably (they never read the ring at all).

`scripts/check.sh` green end to end: credo `found no issues`, dialyzer
`Total errors: 0`, sobelow `No vulnerabilities found`, doctor passed,
`8 doctests, 61 properties, 6548 tests, 0 failures` (6546 on the base,
plus the two tests added here), bats `1..564` with zero `not ok`.
`design-notes-gate.sh` reports `1 new entry heading(s), separator and
marker present`.