### PR TITLE
e2e(#1397): absorb the last eleven hand-seeded visitor subjects

### DIFF
--- a/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
+++ b/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
@@ -31,7 +31,7 @@
 // reconnects the subject's network defensively (a pre-#126 RED run of
 // this spec would tear its session down).
 
-import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
+import { bootVisitorContext, loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import {
   GRAPPA_BASE_URL,
   login,
@@ -100,27 +100,14 @@ test.describe("issue #126 — detach lifecycle", () => {
     browser,
   }) => {
     const visitor = await mintVisitor(`e2e126-${Date.now()}`);
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
+    // ephemeral: no NickServ identity → not registered
+    const { ctx, page } = await bootVisitorContext(browser, {
+      id: visitor.id,
+      token: visitor.token,
+      registered: false,
+    });
 
     try {
-      const subjectJson = JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-        // ephemeral: no NickServ identity → not registered
-        registered: false,
-      });
-      await page.addInitScript(
-        ([token, subject]) => {
-          localStorage.setItem("grappa-token", token);
-          localStorage.setItem("grappa-subject", subject);
-          localStorage.setItem("cic.installChoice", "browser");
-        },
-        [visitor.token, subjectJson] as const,
-      );
-      await page.goto("/");
       await openRailMenu(page);
 
       // The ONLY lifecycle verb an ephemeral visitor gets is quit.

--- a/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
+++ b/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
@@ -17,7 +17,7 @@
 // Seeding: featured channels added via the admin REST path, removed in
 // `finally`. Network id resolved by slug from GET /admin/networks.
 
-import { expectShellReady } from "../fixtures/cicchettoPage";
+import { bootVisitorContext, expectShellReady } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -71,27 +71,14 @@ test("issue #135 — visitor home shows welcome + featured + a directory link", 
   const networkId = await resolveNetworkId(admin.token, visitor.network_slug);
   const featuredId = await addFeatured(admin.token, networkId, FEATURED_NAME);
 
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
+  // Seed the visitor bearer + subject so cic boots straight into Shell
+  // (no captcha/anon dance), then auto-lands on the home pane.
+  const { ctx, page } = await bootVisitorContext(browser, {
+    id: visitor.id,
+    token: visitor.token,
+  });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-    };
-
-    // Seed the visitor bearer + subject so cic boots straight into Shell
-    // (no captcha/anon dance), then auto-lands on the home pane.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
     await expectShellReady(page);
 
     // (1) Welcome / orientation copy — the #496 always-on value prop (stable

--- a/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
+++ b/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
@@ -26,6 +26,7 @@
 // nick can oper with `testoper`/`testoperpass`.
 
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -51,28 +52,14 @@ test("issue #148 — visitor /oper ships OPER upstream and renders the 381 notic
   const visitorNick = `oper148-${Date.now()}`;
   const visitor = await mintVisitor(visitorNick);
 
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
+  // Seed the visitor's bearer + subject so cic boots straight into Shell
+  // (no captcha/anon dance), exactly like the share spec's device A.
+  const { ctx, page } = await bootVisitorContext(browser, {
+    id: visitor.id,
+    token: visitor.token,
+  });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
-    // Seed the visitor's bearer + subject so cic boots straight into Shell
-    // (no captcha/anon dance), exactly like the share spec's device A.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
     await expectShellReady(page);
 
     // Focus the visitor's $server window. awaitWsReady:false — the server

--- a/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
+++ b/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
@@ -28,6 +28,7 @@
 // issue MODE freely on any channel they're in (see ircClient.oper docs).
 
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -55,29 +56,15 @@ test("issue #153 — visitor /quote and /mode reach upstream and take effect", a
   const marker = `quote153-${stamp}`;
   const visitor = await mintVisitor(visitorNick);
 
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
+  // Boot cic straight into Shell as the visitor (no captcha/anon dance),
+  // exactly like issue148-visitor-oper.spec.ts.
+  const { ctx, page } = await bootVisitorContext(browser, {
+    id: visitor.id,
+    token: visitor.token,
+  });
   let peer: IrcPeer | null = null;
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
-    // Boot cic straight into Shell as the visitor (no captcha/anon dance),
-    // exactly like issue148-visitor-oper.spec.ts.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
     await expectShellReady(page);
 
     // Focus the visitor's $server window and wait for the upstream

--- a/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
+++ b/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
@@ -37,6 +37,7 @@
 // and the reply numerics render as :notice rows in $server.
 
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -64,28 +65,14 @@ test("issue #155 — native /stats and /rehash ship upstream and render reply nu
   const visitorNick = `v155-${Date.now()}`;
   const visitor = await mintVisitor(visitorNick);
 
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
+  // Boot cic straight into Shell as the visitor (no captcha/anon dance),
+  // exactly like issue148/issue153.
+  const { ctx, page } = await bootVisitorContext(browser, {
+    id: visitor.id,
+    token: visitor.token,
+  });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
-    // Boot cic straight into Shell as the visitor (no captcha/anon dance),
-    // exactly like issue148/issue153.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
     await expectShellReady(page);
 
     // Focus the visitor's $server window and wait for the upstream

--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -27,6 +27,7 @@
 // DeleteAccountModal). Honest scope, mirroring issue126-detach-lifecycle.
 
 import {
+  bootVisitorContext,
   closeSettings,
   expectShellReady,
   openRailMenu,
@@ -218,26 +219,13 @@ test.describe("issue #157 — delete account", () => {
 
   test("a minted (anon) visitor is NOT offered delete account — only quit", async ({ browser }) => {
     const visitor = await mintVisitor(`e2e157v-${Date.now()}`);
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
+    const { ctx, page } = await bootVisitorContext(browser, {
+      id: visitor.id,
+      token: visitor.token,
+      registered: false,
+    });
 
     try {
-      const subjectJson = JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-        registered: false,
-      });
-      await page.addInitScript(
-        ([token, subject]) => {
-          localStorage.setItem("grappa-token", token);
-          localStorage.setItem("grappa-subject", subject);
-          localStorage.setItem("cic.installChoice", "browser");
-        },
-        [visitor.token, subjectJson] as const,
-      );
-      await page.goto("/");
       await openSettingsDrawer(page);
       await expect(page.getByRole("dialog", { name: /settings/i })).toHaveClass(/open/);
 

--- a/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
+++ b/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
@@ -27,6 +27,7 @@
 // server-side or client-side.
 
 import {
+  bootVisitorContext,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -56,28 +57,14 @@ test("issue #184 — /stats reply renders in $server, never a query window named
   const visitorNick = `v184-${Date.now()}`;
   const visitor = await mintVisitor(visitorNick);
 
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
+  // Boot cic straight into Shell as the visitor (no captcha/anon dance),
+  // exactly like issue155.
+  const { ctx, page } = await bootVisitorContext(browser, {
+    id: visitor.id,
+    token: visitor.token,
+  });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
-    // Boot cic straight into Shell as the visitor (no captcha/anon dance),
-    // exactly like issue155.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
     await expectShellReady(page);
 
     // Focus the $server window and wait for the registration numerics

--- a/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
+++ b/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
@@ -13,7 +13,13 @@
 // attributed to the fixed "guest" label server-side (author model B); this
 // spec exercises the client half.
 
-import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  bootVisitorContext,
+  loginAs,
+  openRailMenu,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
 import {
   adminDeleteTheme,
   adminDeleteVisitor,
@@ -105,27 +111,13 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
     browser,
   }) => {
     const visitor = await mintVisitor(`e2e299v-${Date.now()}`);
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
+    const { ctx, page } = await bootVisitorContext(browser, {
+      id: visitor.id,
+      token: visitor.token,
+      registered: false,
+    });
 
     try {
-      const subjectJson = JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-        registered: false,
-      });
-      await page.addInitScript(
-        ([token, subject]) => {
-          localStorage.setItem("grappa-token", token);
-          localStorage.setItem("grappa-subject", subject);
-          localStorage.setItem("cic.installChoice", "browser");
-        },
-        [visitor.token, subjectJson] as const,
-      );
-      await page.goto("/");
-
       await openThemesSubPageDesktop(page);
 
       // Select a built-in card → reveal its actions → copy it. A visitor is a

--- a/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
+++ b/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
@@ -29,6 +29,7 @@
 // still sends exactly `"REHASH"` (the null-filter drops the absent option).
 
 import {
+  bootVisitor,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -70,24 +71,11 @@ test("issue #375 — /rehash <option> forwards the option on the raw wire, bare 
   });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
     // Boot cic straight into Shell as the visitor (no captcha/anon dance),
-    // exactly like issue155/issue148.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
+    // exactly like issue155/issue148. Onto the page made above, NOT a fresh
+    // context: the websocket listener has to be attached before the boot
+    // navigates, or the raw frames it records are missed.
+    await bootVisitor(page, { id: visitor.id, token: visitor.token });
     await expectShellReady(page);
 
     // Focus the visitor's $server window and wait for the upstream

--- a/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
+++ b/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
@@ -25,6 +25,7 @@
 // exactly `"KILL spammer"` (no trailing colon, no stray null/space).
 
 import {
+  bootVisitor,
   composeSend,
   expectShellReady,
   scrollbackLine,
@@ -66,24 +67,11 @@ test("issue #557 — /kill <nick> <reason> ships KILL nick :reason on the raw wi
   });
 
   try {
-    const visitorSubject = {
-      kind: "visitor",
-      id: visitor.id,
-      nick: visitor.nick,
-      network_slug: visitor.network_slug,
-    };
-
     // Boot cic straight into Shell as the visitor (no captcha/anon dance),
-    // exactly like #375/#155/#148.
-    await page.addInitScript(
-      ([token, subjectJson]) => {
-        localStorage.setItem("grappa-token", token);
-        localStorage.setItem("grappa-subject", subjectJson);
-        localStorage.setItem("cic.installChoice", "browser");
-      },
-      [visitor.token, JSON.stringify(visitorSubject)] as const,
-    );
-    await page.goto("/");
+    // exactly like #375/#155/#148. Onto the page made above, NOT a fresh
+    // context: the websocket listener has to be attached before the boot
+    // navigates, or the raw frames it records are missed.
+    await bootVisitor(page, { id: visitor.id, token: visitor.token });
     await expectShellReady(page);
 
     // Focus the visitor's $server window and wait for the upstream registration

--- a/cicchetto/e2e/tests/issue897-link-uptime.spec.ts
+++ b/cicchetto/e2e/tests/issue897-link-uptime.spec.ts
@@ -31,7 +31,7 @@
 // other rows), `ServerInfoCard.test.tsx` (the pure rendering rule).
 
 import { expect, test } from "@playwright/test";
-import { selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { bootVisitorContext, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
   GRAPPA_BASE_URL,
   mintVisitor,
@@ -64,27 +64,14 @@ test.describe("#897 server-info uptime measures the live link", () => {
   }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`e2e897-${Date.now()}`);
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
+    const { ctx, page } = await bootVisitorContext(browser, {
+      id: visitor.id,
+      token: visitor.token,
+      registered: false,
+    });
 
     try {
       const networkId = await resolveNetworkId(visitor.token, visitor.network_slug);
-      const subjectJson = JSON.stringify({
-        kind: "visitor",
-        id: visitor.id,
-        nick: visitor.nick,
-        network_slug: visitor.network_slug,
-        registered: false,
-      });
-      await page.addInitScript(
-        ([token, subject]) => {
-          localStorage.setItem("grappa-token", token);
-          localStorage.setItem("grappa-subject", subject);
-          localStorage.setItem("cic.installChoice", "browser");
-        },
-        [visitor.token, subjectJson] as const,
-      );
-      await page.goto("/");
 
       // ---- 1. LIVE LINK: the duration is present and is a real duration.
       await expect(sidebarWindow(page, visitor.network_slug, SERVER_WINDOW_LABEL)).toHaveCount(1, {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49957,3 +49957,49 @@ Not claimed: that no OTHER spec depends on those fields. Seventeen tests over
 eight files were run, not the suite. Seventeen more files outside this slice
 still seed the dropped fields — a separate axis, deliberately not folded in
 here.
+<!-- entry #1397-e2e-visitorseed -->
+
+---
+
+## 2026-08-19 — #1397 (e2e): the eleven that were left, and the count that was wrong twice
+
+The `bootVisitor` collapse took the eight copies that shared a NAME.
+Eleven more specs hand-built the same visitor subject without ever
+looking like a copy — no helper, just an inline literal plus an
+`addInitScript` — and every one of them still seeded `nick` and/or
+`network_slug`, the fields the server stopped emitting at #211 phase
+6/7. They are now routed through the same two verbs. Nothing was
+invented for them: the verb already existed, which is the only reason
+this was a slice and not a design.
+
+**The census was wrong twice, in the same direction, for the same
+reason.** The briefed figure was 17 files; my own first pass said 12
+after the collapse. Both were counted per FILE — "contains a
+`kind: "visitor"` literal" AND "contains a `nick:` line" — which
+silently admits a file whose two facts live in different literals.
+`issue282` is exactly that: its subject is already `{kind, id}`, and
+the `nick:` the grep found belongs to a stubbed vhost view. Counted
+per LITERAL (the window from `kind: "visitor"` to the closing brace)
+the real numbers are **29 fields across 15 files on origin/main, 21/11
+after the collapse, 0/0 now**. The lesson is not "the number was off":
+it is that a file-level conjunction is not evidence about a literal,
+and the anchor that produced it reads as authoritative in both
+directions — it would equally have hidden a second literal inside a
+file already counted once.
+
+**Two shapes, and the 20% that did not fit.** Nine specs made a bare
+`browser.newContext()` and take `bootVisitorContext`. Two do not:
+`issue375` and `issue557` attach a `page.on("websocket")` recorder
+BEFORE the boot navigates, and a verb that creates its own context
+would swallow the frames they exist to record. They keep their page
+and take `bootVisitor(page, seed)` — the same verb, one layer down.
+That split is why the fixture exposes both arities rather than one
+"do everything" entry point.
+
+**Tradeoff taken, not hidden:** because `bootVisitorContext` creates
+the context, the boot now sits just OUTSIDE each caller's `try`, so a
+throw during `goto` no longer reaps the minted visitor inline; the row
+waits for `Grappa.Visitors.Reaper`. This matches the shape the #477
+helper already shipped, and the leak is bounded and self-healing —
+but it IS a behaviour change, and a spec that ever needs the inline
+reap must build its own context and call the page-level verb.


### PR DESCRIPTION
## What

Eleven specs still built the visitor subject by hand — writing a
`grappa-subject` envelope into `localStorage` with `nick` and
`network_slug` fields the server had already stopped sending. They are
now absorbed onto the verbs that already exist in
`cicchetto/e2e/fixtures/cicchettoPage.ts`: **no new API, no new field**.

- Nine take `bootVisitorContext(browser, seed)`.
- `issue375` and `issue557` take `bootVisitor(page, seed)` instead,
  because they attach a `websocket` listener *before* the boot
  navigates — the context-level verb would navigate too early for them.

**11 files, +76/-211.** Residual `nick`/`network_slug` inside a
`kind: "visitor"` literal under `e2e/tests`: **0 files, 0 fields**
(counted by grouping per literal BODY, not per file — a per-file count
gave the wrong number twice, because `issue282` has a clean subject and
an unrelated `nick:` in a vhost-view stub).

Stacked on #1545, which introduced the shared verb; that has landed, so
this branch now sits directly on `main` with its own two commits.

## Evidence

Bench for every runtime number below: worktree `w1-1397-bv`, sitting
exactly on the base commit. Bench restored afterwards (clean tree).

- **Baseline** (base commit, the eleven specs): rc=0, **16 passed**.
- **Treatment** (this branch): rc=0, **16 passed, same 16 titles**
  (compared after stripping `file:line`, which necessarily moves).
- **Positive control, runtime**: flipping `registered: false` → `true`
  on the ephemeral seed of `issue126` gives rc=1 and **exactly 1 red
  out of 16** — and it is `detach-btn toHaveCount(0)` failing with
  `Expected: 0 / Received: 1`. So the seed shape is load-bearing and
  the suite can see it.
- **Positive control, static**: re-adding `nick` at a new call site
  yields **exactly one** `TS2353 … 'nick' does not exist in type
  'VisitorSeed'`.
- `scripts/bun.sh run check` rc=0 over the **whole** chain (biome && tsc
  && tsc -p e2e/tsconfig.json), 0 `error TS`, 59 CSS warnings unchanged.
- `scripts/design-notes-gate.sh` rc=0; DN marker `#1397-e2e-visitorseed`
  is unique (`grep -Fxc` = 1) and the boundary shape on the file is
  marker / blank / `---` / blank / heading, with no blank before the
  marker.

## What I decline to claim

- **I do not claim the full integration suite is green.** It was never
  run for this branch; only the eleven specs were.
- **I do not claim the type is the guarantee.** TypeScript's
  excess-property check fires on *literals* only — a caller passing a
  variable gets no error. What closes the drift is that the envelope is
  now *constructed* in one place, not that `VisitorSeed` exists.
- **I do not claim a re-run after restoring the mutant.** The evidence
  that the bench is back to the measured state is an empty `git status`
  and an empty `git diff HEAD` on the commit the treatment was measured
  on, not a fresh green run.
- **Pre-existing, not introduced here:** on `webkit-iphone-15` visitor
  contexts are not iPhone-emulated, because `browser.newContext()` does
  not inherit the project's `use` block. Identical before and after this
  change.