### PR TITLE
test(#1397): one dead-port helper for six copies, and the seven callers that never dial

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50406,3 +50406,75 @@ not; only the eleven touched specs. Nor that the +0.6 control proves the six
 rounding sites could never have depended on the rounding: it proves only that
 none of them sits within 0.6 px of its threshold in the states these specs
 reach.
+<!-- entry #1397-unusedport -->
+
+---
+
+## 2026-08-19 — #1397 bucket H: one dead-port helper, and the seven callers that never dial
+
+Six test files carried the same four-line body — bind an ephemeral TCP port,
+read the number back, close the listener, return the number — five spelled
+`pick_unused_port` and one `unused_port`, byte-identical in all six. It now
+lives once as `Grappa.IRCServer.pick_unused_port/0`, called from seventeen
+sites across the same six files.
+
+### The census said one thing; reading the call sites said another
+
+The consolidation was specced on the claim that all seventeen call sites want
+the same thing, and that the thing is not a port at all but a REFUSED connect
+— the ground under "upstream unreachable", "connect refused", and "a refused
+connect still counts toward the circuit". Reading the body of the test that
+contains each of the seventeen shows that holds for TEN of them. The other
+SEVEN never dial: a captcha rejection, an IP cap, a login throttle, a
+`refresh_plan` returning `:not_found` (so `start_link/1` answers `:ignore` and
+never spawns), and three accretion gates that answer 403/403/409 before
+anything reaches the network. For those seven the number is only a valid port
+to put in a `%Network{}`.
+
+Two comments already in the suite said as much before this change touched it —
+`auth_controller_test`'s "No IRC handshake anywhere below: a wrong password
+never dials, and neither does a throttled one", and `session_controller_test`'s
+"the accretion allowlist-gate test rejects BEFORE any dial ... the port just
+has to be a valid, unused number". The census had counted definitions and call
+sites correctly and still got the CONTRACT wrong, because a count of identical
+bodies says nothing about what the callers ask of them.
+
+### Which is why the name is mechanical on purpose
+
+The consolidated helper keeps `pick_unused_port`, and not merely as the
+dominant of the two spellings. An intent name — `refused_port` and the like —
+would make the seven non-dialling sites read as claims their tests do not make,
+and a test that appears to assert something it never exercises is the failure
+mode this whole bucket exists to remove. The mechanism is what all seventeen
+share; the refusal is what ten of them additionally depend on. The moduledoc
+records both classes so the split does not have to be re-derived from
+seventeen call sites the next time someone reaches for a better name.
+
+This is the inverse of the `start_server/1` ruling one slice earlier, and the
+two are consistent: there the wrapper HID something decidable at the call site
+(which peer), so it went; here the helper hides nothing — it performs a gesture
+that is identical everywhere — and only the NAME risked asserting more than the
+callers do.
+
+### The equivalence oracle does not compare results
+
+`pick_unused_port/0` returns a different ephemeral number on each call by
+construction, so `assert helper() == inline()` would be a defect dressed as a
+property. The oracle instead puts both to the same question — connect to the
+number and read the verdict — and requires the same answer. Its non-vacuity was
+measured: dropping `:gen_tcp.close(l)` from the helper leaves the listener up,
+the connect succeeds, and exactly one of the six tests in that file dies. The
+characterization test written before the refactor keeps its own inline body and
+stays green under that mutant, which is what makes the pair discriminating
+rather than redundant — one witnesses the gesture, the other witnesses that the
+helper still performs it.
+
+### Three comments left with the body
+
+Each of `client_test`, `server_test` and `session_controller_test` carried a
+comment above its local copy. Deleting a `defp` and leaving its comment behind
+does not preserve information, it relocates a description onto whatever
+function happens to follow — so they went with the body they described. The
+first two explained the ephemeral-bind trick, now stated once on the helper.
+The third recorded the never-dials observation, which survives promoted into
+the moduledoc as one of the two classes above.

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -50,16 +50,6 @@ defmodule Grappa.IRC.ClientTest do
     })
   end
 
-  # Bind ephemeral port, capture number, release immediately. The kernel
-  # may eventually reuse it; the C2 non-blocking-init test only needs the
-  # port to be unbound for the ~10ms it takes the connect to refuse.
-  defp pick_unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
-  end
-
   defp start_client(port, overrides \\ %{}) do
     opts =
       Map.merge(
@@ -1926,7 +1916,7 @@ defmodule Grappa.IRC.ClientTest do
       # → start_link returns {:error, _}. Pinning the {:ok, pid} contract is
       # the load-bearing assertion: it can only hold once the connect moves
       # into handle_continue.
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       Process.flag(:trap_exit, true)
 
       assert {:ok, client} =
@@ -1956,7 +1946,7 @@ defmodule Grappa.IRC.ClientTest do
     # per child; the new pattern lets the exit signal terminate the
     # process immediately.
     test "mailbox responds during connect-fail throttle window (H1)" do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       Process.flag(:trap_exit, true)
 
       assert {:ok, client} =

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -126,5 +126,21 @@ defmodule Grappa.IRCServerTest do
       assert {:error, :econnrefused} =
                :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false], 1_000)
     end
+
+    # The equivalence oracle for the consolidation: the helper must earn
+    # the same verdict the inline gesture above earns, put to it the same
+    # way. Not `assert helper() == inline()` — the two draw different
+    # ephemeral numbers by construction, so equal RESULTS would be a bug,
+    # not the property. What has to match is the port's OBSERVABLE
+    # behaviour, which is the only thing the seventeen call sites could
+    # ever have depended on.
+    test "IRCServer.pick_unused_port/0 earns the same verdict as the inline body" do
+      port = IRCServer.pick_unused_port()
+
+      assert is_integer(port) and port > 0
+
+      assert {:error, :econnrefused} =
+               :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false], 1_000)
+    end
   end
 end

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -102,4 +102,29 @@ defmodule Grappa.IRCServerTest do
       refute function_exported?(IRCServer, :welcome_handler, 0)
     end
   end
+
+  describe "the dead-port body (#1397 bucket H characterization)" do
+    # Six test files carry this same four-line body, five under the name
+    # `pick_unused_port` and one as `unused_port`. Ten of its seventeen
+    # call sites dial the number and want the connect REFUSED, so that
+    # "upstream unreachable" / "connect refused" / "a refused connect
+    # still counts toward the circuit" have something to happen against.
+    # (The other seven never dial — a captcha, an IP cap, a throttle, an
+    # `:ignore` and three accretion gates all reject first — so for them
+    # any valid unused number would do.)
+    #
+    # For the ten, that refusal is the contract, and nothing asserted it
+    # before this test: the six copies were only ever exercised through
+    # what their callers did next.
+    test "the six-copy body yields a port a connect is refused on" do
+      {:ok, l} = :gen_tcp.listen(0, [])
+      {:ok, port} = :inet.port(l)
+      :gen_tcp.close(l)
+
+      assert is_integer(port) and port > 0
+
+      assert {:error, :econnrefused} =
+               :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false], 1_000)
+    end
+  end
 end

--- a/test/grappa/session/lifecycle_log_integration_test.exs
+++ b/test/grappa/session/lifecycle_log_integration_test.exs
@@ -101,7 +101,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   test "abnormal connect failure emits :disconnected clean=false with a reason" do
     # No server on this port → Client connect refuses → Session crashes →
     # terminate/2 abnormal clause fires the disconnect log.
-    port = unused_port()
+    port = IRCServer.pick_unused_port()
     {user, network} = setup_user_and_network(port)
 
     start_session_for(user, network)
@@ -139,7 +139,7 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
   test "backoff-delayed reconnect emits :backoff with delay_ms + attempt" do
     # No live server needed — :backoff fires in handle_continue BEFORE the
     # delayed connect attempt (which would then refuse against the dead port).
-    port = unused_port()
+    port = IRCServer.pick_unused_port()
     {user, network} = setup_user_and_network(port)
 
     # Seed a prior failure so the next spawn's handle_continue delays.
@@ -150,12 +150,5 @@ defmodule Grappa.Session.LifecycleLogIntegrationTest do
     assert_receive {:session_log, :backoff, md}, 1_500
     assert is_integer(md.delay_ms) and md.delay_ms > 0
     assert is_integer(md.attempt) and md.attempt >= 1
-  end
-
-  defp unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
   end
 end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -74,16 +74,6 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
-  # See `Grappa.IRC.ClientTest` — same trick. Bind ephemeral, capture,
-  # release. The connect attempt that follows refuses fast on localhost
-  # because nothing took the port back over in the meantime.
-  defp pick_unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
-  end
-
   defp setup_user_and_network(port, cred_attrs \\ %{}) do
     user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
@@ -601,7 +591,7 @@ defmodule Grappa.Session.ServerTest do
       # crashing the supervisor and cascading through every other Session in
       # the test run. Linking to the test pid (via `start_link`) traps the
       # crash here so the supervisor is never involved.
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {user, network, _} = setup_user_and_network(port)
       Process.flag(:trap_exit, true)
 
@@ -698,7 +688,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "refresh_plan returning {:error, :not_found} → :ignore (no spawn)" do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {user, network, _} = setup_user_and_network(port)
       Process.flag(:trap_exit, true)
 
@@ -8876,7 +8866,7 @@ defmodule Grappa.Session.ServerTest do
       # When the session fails to connect (ECONNREFUSED), it records a backoff
       # failure and the supervisor restarts it (or max_restarts exhausted).
       # The credential stays :connected throughout — no terminal failure.
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {user, network, _} = setup_user_and_network(port)
 
       reloaded =

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -38,13 +38,6 @@ defmodule Grappa.Visitors.LoginTest do
     :ok
   end
 
-  defp pick_unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
-  end
-
   defp setup_visitor_network(port) do
     network_with_server(port: port, slug: "azzurra", visitor_enabled: true)
   end
@@ -204,7 +197,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "a refused connect still counts toward the circuit (#960 boundary)" do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {network, _} = setup_visitor_network(port)
 
       # The other side of the same boundary: an error that DOES describe the
@@ -299,7 +292,7 @@ defmodule Grappa.Visitors.LoginTest do
     end
 
     test "connect refused → {:error, :upstream_unreachable}, anon row purged" do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {network, _} = setup_visitor_network(port)
 
       assert {:error, :upstream_unreachable} = Login.login(login_input(), [])
@@ -322,7 +315,7 @@ defmodule Grappa.Visitors.LoginTest do
     # diagnosis survives the ordering — no elapsed time is measured, so
     # host load cannot flake it.
     test "connect refused → :upstream_unreachable even when the login budget expires first (#1130)" do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {network, _} = setup_visitor_network(port)
 
       assert {:error, :upstream_unreachable} =

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -43,13 +43,6 @@ defmodule GrappaWeb.AuthControllerTest do
     :ok
   end
 
-  defp pick_unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
-  end
-
   defp setup_visitor_network(port),
     do: network_with_server(port: port, slug: "azzurra", visitor_enabled: true)
 
@@ -814,7 +807,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
       stub(Grappa.Admission.CaptchaMock, :wire_name, fn -> "disabled" end)
 
-      {_, _} = setup_visitor_network(pick_unused_port())
+      {_, _} = setup_visitor_network(IRCServer.pick_unused_port())
 
       conn = post(conn, "/auth/login", %{"identifier" => "fresh-anon"})
 
@@ -834,7 +827,7 @@ defmodule GrappaWeb.AuthControllerTest do
       # cap can't fire on a nil client, the rejection can only be the ip
       # cap — and it reuses the same too_many_sessions envelope (cic
       # unchanged, keys on the wire string not the atom).
-      {_, _} = setup_visitor_network(pick_unused_port())
+      {_, _} = setup_visitor_network(IRCServer.pick_unused_port())
 
       {:ok, net} = Grappa.Networks.find_or_create_network(%{slug: "azzurra"})
 
@@ -857,7 +850,7 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "upstream unreachable → 502 upstream_unreachable", %{conn: conn} do
-      port = pick_unused_port()
+      port = IRCServer.pick_unused_port()
       {network, _} = setup_visitor_network(port)
 
       conn = post(conn, "/auth/login", %{"identifier" => "vjt"})
@@ -1715,7 +1708,7 @@ defmodule GrappaWeb.AuthControllerTest do
     setup do
       :ets.delete_all_objects(FailureWindow.table_name())
 
-      {network, _} = setup_visitor_network(pick_unused_port())
+      {network, _} = setup_visitor_network(IRCServer.pick_unused_port())
       {:ok, visitor} = Visitors.find_or_provision_anon("vjt", "azzurra", "1.2.3.4")
       {:ok, _} = Visitors.commit_password(visitor.id, network.id, "s3cret")
 

--- a/test/grappa_web/controllers/session_controller_test.exs
+++ b/test/grappa_web/controllers/session_controller_test.exs
@@ -37,16 +37,6 @@ defmodule GrappaWeb.SessionControllerTest do
     :ok
   end
 
-  # A port nothing listens on — the accretion allowlist-gate test rejects
-  # BEFORE any dial, so the disabled network's server endpoint is never
-  # contacted; the port just has to be a valid, unused number.
-  defp pick_unused_port do
-    {:ok, l} = :gen_tcp.listen(0, [])
-    {:ok, port} = :inet.port(l)
-    :gen_tcp.close(l)
-    port
-  end
-
   # A registered visitor = identified on some network. #211 phase 7 —
   # `commit_password/3` writes the per-network Cloak-encrypted secret on
   # the `(visitor, network)` credential; "registered/permanent" is DERIVED
@@ -117,7 +107,7 @@ defmodule GrappaWeb.SessionControllerTest do
       {visitor, _} = registered_visitor(port_a)
 
       # A network that is NOT visitor_enabled.
-      {_, _} = network_with_server(port: pick_unused_port(), slug: "locked", visitor_enabled: false)
+      {_, _} = network_with_server(port: IRCServer.pick_unused_port(), slug: "locked", visitor_enabled: false)
 
       session = visitor_session_fixture(visitor)
 
@@ -219,7 +209,7 @@ defmodule GrappaWeb.SessionControllerTest do
          %{conn: conn} do
       {_, session} = user_and_session()
       # A network the operator did NOT opt into the self-serve tier.
-      {_, _} = network_with_server(port: pick_unused_port(), slug: "locked", visitor_enabled: false)
+      {_, _} = network_with_server(port: IRCServer.pick_unused_port(), slug: "locked", visitor_enabled: false)
 
       conn
       |> put_bearer(session.id)
@@ -229,7 +219,7 @@ defmodule GrappaWeb.SessionControllerTest do
 
     test "user accreting a network they ALREADY hold → 409 already_attached", %{conn: conn} do
       {user, session} = user_and_session()
-      {network, _} = network_with_server(port: pick_unused_port(), slug: "held", visitor_enabled: true)
+      {network, _} = network_with_server(port: IRCServer.pick_unused_port(), slug: "held", visitor_enabled: true)
 
       {:ok, _} =
         Credentials.bind_credential(user, network, %{nick: "vjt", auth_method: :none, autojoin_channels: []})

--- a/test/support/irc_server.ex
+++ b/test/support/irc_server.ex
@@ -218,6 +218,44 @@ defmodule Grappa.IRCServer do
     :ok
   end
 
+  @doc """
+  A TCP port with nothing listening on it — bind an ephemeral port, read
+  it back, release it, return the number.
+
+  The seventeen call sites this replaces (#1397) split in two, and the
+  split is why the name describes the MECHANISM rather than an intent:
+
+    * Ten dial it and want the connect REFUSED — "upstream unreachable",
+      "connect refused", "a refused connect still counts toward the
+      circuit", `Server.start_link/1` still answering `{:ok, pid}` when
+      nothing is up there. `irc_server_test.exs` asserts that refusal.
+
+    * Seven never dial at all. A captcha, an IP cap, a login throttle, a
+      deleted-row `:ignore` and three accretion gates all reject before
+      anything reaches the network, so the port is only ever a valid
+      number to put in a `%Network{}`. Naming this `refused_port` would
+      make those seven read as claims the tests do not make.
+
+  So the name stays, and not merely because `pick_unused_port` was the
+  dominant of the two spellings the six copies had drifted into
+  (five that way, one as `unused_port`).
+
+  Carries a TOCTOU window by construction: between the close and the
+  caller's connect, something else may bind the port. Consolidating the
+  six copies neither introduces nor fixes that — it is the property the
+  ten dialling call sites have always depended on, now named in one
+  place instead of being re-derived in six. The refusal being asserted
+  in one test means the day the window starts mattering, one test says
+  so rather than six unrelated suites going intermittent.
+  """
+  @spec pick_unused_port() :: :inet.port_number()
+  def pick_unused_port do
+    {:ok, l} = :gen_tcp.listen(0, [])
+    {:ok, port} = :inet.port(l)
+    :gen_tcp.close(l)
+    port
+  end
+
   ## GenServer
 
   @impl GenServer


### PR DESCRIPTION
Bucket H of #1397, server side. Six test files carried the same four-line
body — bind an ephemeral TCP port, read the number back, close the
listener, return the number — five spelled `pick_unused_port` and one
`unused_port`, byte-identical in all six. It becomes
`Grappa.IRCServer.pick_unused_port/0`, called from seventeen sites.

## The spec's premise turned out to be false, and that changed the outcome

The slice was specced on "none of the seventeen call sites wants a port;
they all want a connect to be REFUSED". Reading the body of the test that
contains each of the seventeen shows that holds for **ten**. The other
**seven never dial at all**: a captcha rejection, an IP cap, a login
throttle, a `refresh_plan` returning `:not_found` (so `start_link/1`
answers `:ignore` and never spawns), and three accretion gates that answer
403/403/409 before anything reaches the network.

Two comments already in the suite said so before this branch touched it —
`auth_controller_test`'s *"No IRC handshake anywhere below: a wrong
password never dials, and neither does a throttled one"*, and
`session_controller_test`'s *"the accretion allowlist-gate test rejects
BEFORE any dial ... the port just has to be a valid, unused number"*.

The census had counted the six definitions and seventeen call sites
correctly and still got the CONTRACT wrong. A count of byte-identical
bodies says nothing about what the callers ask of them.

## Which is why the name stays mechanical

The helper keeps `pick_unused_port`, not as a compromise but as the right
answer. An intent name like `refused_port` would make those seven sites
read as claims their tests do not make — which is the exact defect this
bucket exists to remove. The moduledoc records both classes so the split
does not have to be re-derived from seventeen call sites next time
somebody reaches for a better name.

This is the inverse of the `start_server/1` ruling one slice earlier, and
the two agree: there the wrapper HID something decidable at the call site
(which peer), so it went; here the helper hides nothing — the gesture is
identical everywhere — and only the NAME risked over-promising.

## Commits

1. **LOCK** — characterizes the inline body and asserts
   `{:error, :econnrefused}`, the contract nothing asserted. Lands first,
   so the net demonstrably predates the change it guards.
2. **Refactor** — helper + six deletions + seventeen call sites, plus the
   equivalence oracle.
3. **Docs** — DESIGN_NOTES entry on the census that counted right and read
   wrong.

## The equivalence oracle does not compare results

`pick_unused_port/0` returns a different ephemeral number per call by
construction, so `assert helper() == inline()` would be a defect dressed
as a property. The oracle puts both to the same question — connect and
read the verdict — and requires the same answer.

Non-vacuity measured: dropping `:gen_tcp.close(l)` from the helper leaves
the listener up, the connect succeeds, and **exactly one of the six tests
in that file dies** (the oracle: expected `{:error, :econnrefused}`, got
`{:ok, #Port<...>}`). The LOCK, which keeps its own inline body, stays
GREEN under that same mutant — which is what makes the pair discriminating
rather than redundant: one witnesses the gesture, the other witnesses that
the helper still performs it.

## Also removed

Three comments that described the deleted body. Left behind they would
have floated above whichever function happened to follow, which is worse
than no comment. The two that explained the ephemeral-bind trick are now
stated once on the helper; the third recorded the never-dials observation,
which survives promoted into the moduledoc as one of the two classes.

## Gates

Measured at base `b3372ba7`, full `scripts/check.sh` rc=0, every stage
exhibited:

| stage | marker |
|---|---|
| credo | 6094 mods/funs, found no issues |
| dialyzer | Total errors: 0 |
| sobelow | No vulnerabilities found |
| doctor | Doctor validation has passed! |
| test | 8 doctests, 61 properties, **6548 tests, 0 failures** (6546 + the 2 this branch adds) |
| bats | 1..564, zero `not ok` |

`design-notes-gate.sh` re-run after the rebase onto `b5617abd`: *"1 new
entry heading(s), separator and marker present"*.

**Not claimed:** `check.sh` has not been re-run since the rebase. The
delta from `b3372ba7` to `b5617abd` is nine `cicchetto/e2e` TypeScript
specs plus `docs/DESIGN_NOTES.md` — no Elixir, no `test/`, no bats
fixture — so no stage above reads a changed byte, but that is a
reading, not a measurement. CI on this PR is the measurement.