### PR TITLE
e2e(#1397): one distance-from-bottom verb, sentinel at the call site

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -742,6 +742,26 @@ export function scrollbackLine(page: Page, kind: string, bodyMatch: string | Reg
   });
 }
 
+// Distance in px from the scrollback's tail, or `null` when the pane is not
+// mounted. The sentinel for a missing pane belongs at the CALL SITE, because it
+// has to point the SAME WAY as the assertion that follows — `?? 999` ahead of a
+// `toBeLessThanOrEqual`, `?? 0` ahead of a `toBeGreaterThan` — so an unmounted
+// pane fails the poll instead of satisfying it. A sentinel folded into this
+// function cannot be aligned: it serves both directions at once.
+// Returning `null` rather than throwing is also what keeps the callers'
+// `expect.poll` retrying: `pollMatcher` awaits the generator OUTSIDE the try
+// that retries (playwright 1.59.1, lib/matchers/expect.js:275), so a throw here
+// would abort the poll on the first sample instead of waiting for the mount.
+// The value is a raw float on purpose — every caller compares it against a
+// threshold, and rounding here would decide the sub-pixel band for all of them.
+export async function scrollbackDistanceFromBottom(page: Page): Promise<number | null> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) return null;
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
+
 // #237 — the on-JOIN inline topic line. NOT a `scrollback-line` (it is a
 // presentational, non-message row derived from the topic store — no server
 // message id, so it never enters the unread/cursor math). Its own testid

--- a/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
@@ -34,8 +34,13 @@
 // `@webkit` tag opts this spec into the `webkit-iphone-15` project
 // (playwright.config.ts grep). Default chromium project skips it.
 
-import type { Page } from "@playwright/test";
-import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeTextarea,
+  loginAs,
+  scrollbackDistanceFromBottom,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -48,14 +53,6 @@ const MESSAGE_BODY = `BUG7-ios: own-msg visibility @ ${crypto.randomUUID().slice
 // Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
 // in lockstep by hand — same as issue168 / issue580).
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
-
-async function distanceToBottom(page: Page): Promise<number> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found");
-    return el.scrollHeight - el.scrollTop - el.clientHeight;
-  });
-}
 
 test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({
   page,
@@ -120,6 +117,6 @@ test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compos
   // bottom once the echo laid out. NEVER weaken these, NEVER inflate the poll.
   await expect(ownRow).toBeInViewport();
   await expect
-    .poll(async () => await distanceToBottom(page))
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
     .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 });

--- a/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
@@ -16,10 +16,10 @@
 //
 // `@webkit` opts into the webkit-iphone-15 project.
 
-import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
+  scrollbackDistanceFromBottom,
   scrollbackLine,
   selectChannel,
   sidebarWindow,
@@ -36,14 +36,6 @@ const MESSAGE_BODY = `BUG7-M6-ios: DM own-msg @ ${crypto.randomUUID().slice(0, 8
 // Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
 // in lockstep by hand — same as issue168 / issue580).
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
-
-async function distanceToBottom(page: Page): Promise<number> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found");
-    return el.scrollHeight - el.scrollTop - el.clientHeight;
-  });
-}
 
 test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({
   page,
@@ -93,7 +85,7 @@ test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input"
     // out. NEVER weaken these, NEVER inflate the poll.
     await expect(ownRow).toBeInViewport();
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   } finally {
     await peer.disconnect("BUG7-M6 done");

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -42,6 +42,7 @@ import {
   composeSend,
   loginAs,
   pageScrollbackUp,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
   waitForScrollbackRefreshed,
@@ -71,11 +72,6 @@ async function scrollbackGeometry(
       clientHeight: el.clientHeight,
     };
   });
-}
-
-async function distanceToBottom(page: Page): Promise<number> {
-  const g = await scrollbackGeometry(page);
-  return g.scrollHeight - g.scrollTop - g.clientHeight;
 }
 
 // Seed the SERVER-side read cursor at the given message id (server-owned
@@ -127,7 +123,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // marker anchor parked the view mid-pane and the send did not follow,
     // so distance-to-tail stayed well above threshold.
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // (b) The just-sent line is visible — the view did NOT jump to / stay
@@ -165,7 +161,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // (#168 completion, 2026-07-03b — vjt point-2 reversed the #46
     // cold-mount-tail wontfix). So activation already sits ABOVE the fold.
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0)
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // Operator PAGES UP with a real wheel gesture. This ALSO clears the
@@ -180,7 +176,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // the send window, where it disarms the follow intent and freezes the pane.
     await pageScrollbackUp(page, 4000, 5_000);
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0)
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // SEND — must snap back to the bottom UNCONDITIONALLY (issue #168 asks:
@@ -192,7 +188,7 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     const sentLine = scrollbackLines(page).filter({ hasText: marker });
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });

--- a/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
+++ b/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
@@ -24,21 +24,18 @@
 // which assert scroll geometry only.
 
 import type { Page } from "@playwright/test";
-import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
-
-async function distFromBottom(page: Page): Promise<number | null> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return null;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
 
 // Scroll to the top and fire a synthetic scroll so the Solid handler runs
 // loadMore (pulls older history, leaving the pane parked near the top).
@@ -65,7 +62,7 @@ async function scrollUpThenRetapLandsAtBottom(page: Page): Promise<void> {
     .toBeGreaterThanOrEqual(50);
   // Starts at the bottom (fresh focus of a fully-read channel).
   await expect
-    .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
     .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
   // Scroll up, loading history, until the row count stops growing.
@@ -82,7 +79,7 @@ async function scrollUpThenRetapLandsAtBottom(page: Page): Promise<void> {
   // Precondition: we are genuinely scrolled UP (not at bottom), and the
   // floating "scroll to bottom" affordance is showing.
   await expect
-    .poll(async () => (await distFromBottom(page)) ?? 0, { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 5_000 })
     .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
   await expect(page.locator('[data-testid="scroll-to-bottom"]')).toBeVisible({ timeout: 5_000 });
 
@@ -93,7 +90,7 @@ async function scrollUpThenRetapLandsAtBottom(page: Page): Promise<void> {
 
   // Contract: the re-tap jumped the scrollback to the newest message.
   await expect
-    .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
     .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   // The floating button hides once atBottom is re-asserted.
   await expect(page.locator('[data-testid="scroll-to-bottom"]')).toBeHidden({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
+++ b/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
@@ -41,6 +41,7 @@ import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
@@ -80,14 +81,6 @@ function fmt(r: Rect): string {
   return `[x ${r.x.toFixed(0)}, y ${r.y.toFixed(0)}, w ${r.width.toFixed(0)}, h ${r.height.toFixed(0)} → right ${(r.x + r.width).toFixed(0)}, bottom ${(r.y + r.height).toFixed(0)}]`;
 }
 
-async function distFromBottom(page: Page): Promise<number | null> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return null;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
-
 // Scroll to the top and fire a synthetic scroll so the Solid handler runs
 // loadMore (pulls older history, leaving the pane parked near the top).
 async function scrollToTop(page: Page): Promise<void> {
@@ -115,7 +108,7 @@ async function scrollChannelUp(page: Page): Promise<void> {
   }
   await scrollToTop(page);
   await expect
-    .poll(async () => (await distFromBottom(page)) ?? 0, { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 5_000 })
     .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
   await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 5_000 });
 }

--- a/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
+++ b/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
@@ -31,6 +31,7 @@ import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
@@ -82,14 +83,6 @@ async function backgroundOf(page: Page, selector: string): Promise<string> {
   }, selector);
 }
 
-async function distFromBottom(page: Page): Promise<number | null> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return null;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
-
 // Scroll to the top and fire a synthetic scroll so the Solid handler runs
 // loadMore (pulls older history, leaving the pane parked near the top).
 async function scrollToTop(page: Page): Promise<void> {
@@ -117,7 +110,7 @@ async function scrollChannelUp(page: Page): Promise<void> {
   }
   await scrollToTop(page);
   await expect
-    .poll(async () => (await distFromBottom(page)) ?? 0, { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 5_000 })
     .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
   await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 5_000 });
 }

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -46,7 +46,12 @@
 // assertion is the authoritative mechanism proof on both.
 
 import type { Page } from "@playwright/test";
-import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import {
   fetchScrollbackPage,
   getReadCursor,
@@ -64,14 +69,6 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 // REST default page size (Grappa.Web.MessagesController.@default_limit).
 const REST_PAGE_SIZE = 50;
-
-async function distFromBottom(page: Page): Promise<number> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return 999;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
 
 // Shared body: focus an unread #bofh, tap the floating button, assert the cursor
 // persists to the tail AND a subsequent peer line does not snap the view back.
@@ -101,7 +98,7 @@ async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Pr
   // Divider present, activation parked above the fold, floating button visible.
   await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
   await expect
-    .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 5_000 })
     .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
   const btn = page.locator('[data-testid="scroll-to-bottom"]');
   await expect(btn).toBeVisible({ timeout: 5_000 });
@@ -124,7 +121,7 @@ async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Pr
 
   // View is at the bottom; the floating button hides.
   await expect
-    .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
     .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   await expect(btn).toBeHidden({ timeout: 5_000 });
 
@@ -142,7 +139,7 @@ async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Pr
     await expect(page.getByText(marker)).toBeVisible({ timeout: 15_000 });
     await page.waitForTimeout(700); // past the 500ms settle + any re-assert window
     await expect
-      .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   } finally {
     await peer.disconnect("#310 done");

--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -25,7 +25,13 @@
 // geometry on one engine rather than the user-class parity matrix.
 
 import type { Page } from "@playwright/test";
-import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  scrollbackDistanceFromBottom,
+  scrollbackLine,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
@@ -103,14 +109,6 @@ const FLOOD_SAFE_BURST = 3;
 const PACE_MS = 2_200;
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function distFromBottom(page: Page): Promise<number | null> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return null;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
-
 // Scroll to the very top + fire a synthetic scroll so the Solid onScroll
 // handler runs (recomputes the badge + flips atBottom). Fresh channel ⇒
 // loadMore finds no older history and is a no-op. Mirrors #243/#280.
@@ -156,7 +154,7 @@ async function expectSettledNotAtBottom(page: Page): Promise<void> {
     )
     .toBe(true);
   expect(
-    (await distFromBottom(page)) ?? 0,
+    (await scrollbackDistanceFromBottom(page)) ?? 0,
     "the pane must come to rest above the at-bottom threshold, or the button is right to be gone",
   ).toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 }
@@ -189,7 +187,7 @@ async function lineVisibleInPane(page: Page, needle: string): Promise<boolean> {
 // as the snap having landed (button gone == at bottom == the tap's own goal);
 // the post-tap assertions at the call site stay the source of truth for the
 // end state, so an early return can never mask a wrong one — a button that
-// vanished WITHOUT reaching bottom fails the distFromBottom poll that follows.
+// vanished WITHOUT reaching bottom fails the distance-from-bottom poll below.
 async function tapScrollToBottom(page: Page, selector: string): Promise<void> {
   const btn = page.locator(selector);
   const deadline = Date.now() + 10_000;
@@ -304,7 +302,7 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
       // reaches bottom, which a settling scroll can trigger mid-click (#653/#639).
       await tapScrollToBottom(page, SCROLL_TO_BOTTOM);
       await expect
-        .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+        .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
         .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
       await expect(page.locator(SCROLL_TO_BOTTOM)).toBeHidden({ timeout: 5_000 });
     } finally {

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -54,6 +54,7 @@ import type { Locator, Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
   waitForScrollbackRefreshed,
@@ -70,14 +71,6 @@ const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
 // REST default page size (Grappa.Web.MessagesController.@default_limit).
 const REST_PAGE_SIZE = 50;
-
-async function distanceToBottom(page: Page): Promise<number> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found");
-    return el.scrollHeight - el.scrollTop - el.clientHeight;
-  });
-}
 
 // Test-only force endpoint (ReadCursor.force_set/4) — the production endpoint
 // is advance-only (#233), so a backward mid-page seed must go through force.
@@ -139,7 +132,7 @@ async function arriveParkedOnMarker(page: Page, channel: string): Promise<void> 
     .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
   await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
   await expect
-    .poll(async () => await distanceToBottom(page))
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0)
     .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 }
 
@@ -171,7 +164,7 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     // RED pre-fix: the snap sat after the throwing await, so the view stayed
     // parked on the marker and distance-to-tail stayed above threshold.
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });
@@ -188,7 +181,7 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
 
     // The pane has tail-followed the echo; the failure is still parked.
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
 
@@ -206,7 +199,7 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     // re-pins a follower to the tail on any box change.
     await expect(sentLine).toBeInViewport();
     await expect
-      .poll(async () => await distanceToBottom(page))
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999)
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   });
 });

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -33,6 +33,7 @@ import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
   waitForScrollbackRefreshed,
@@ -77,14 +78,6 @@ function delayedWrites(writes: readonly WriteEvent[]): WriteEvent[] {
 
 type Sample = { t: number; top: number; height: number; client: number };
 type WriteEvent = { t: number; kind: string; detail: string; before: number };
-
-async function distanceToBottom(page: Page): Promise<number> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found");
-    return el.scrollHeight - el.scrollTop - el.clientHeight;
-  });
-}
 
 // Install an in-page sampler + a scroll-write spy on the scrollback container,
 // BEFORE the send. The sampler records the geometry on every native `scroll`
@@ -200,7 +193,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     await expect
-      .poll(async () => await distanceToBottom(page), { timeout: 10_000 })
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 10_000 })
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
     await installScrollProbe(page, SAMPLE_WINDOW_MS);
@@ -257,7 +250,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
     // Parked in history, above the fold.
     await expect
-      .poll(async () => await distanceToBottom(page), { timeout: 10_000 })
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 10_000 })
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
     await installScrollProbe(page, SAMPLE_WINDOW_MS);

--- a/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
@@ -34,7 +34,13 @@
 // device. Kept @webkit-only since the bug is iOS-shaped.
 
 import type { Page } from "@playwright/test";
-import { composeSend, loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  loginAs,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -42,14 +48,6 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 const EMPTY_QUERY_PEER = "no-dm-peer-btn";
-
-async function distFromBottom(page: Page): Promise<number | null> {
-  return await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) return null;
-    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
-  });
-}
 
 // Scroll to the top and fire a synthetic scroll so the Solid handler runs
 // loadMore. Returns once the event is dispatched.
@@ -87,7 +85,7 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
     await expect(page.locator(".scrollback-empty")).toBeVisible({ timeout: 5_000 });
     await selectChannel(page, NETWORK_SLUG, CHANNEL);
     await expect
-      .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // Exhaust loadMore: scroll to top until the row count stops growing —
@@ -121,7 +119,7 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
 
     // Contract: #bofh lands at the bottom after the roundtrip — NOT blank.
     await expect
-      .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+      .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   });
 });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50325,3 +50325,84 @@ prefix-eating (`grep -o` discards what it did not capture, so a follow-on
 available, not the most reassuring: it is indistinguishable from "already
 done". Cross three methods — by name, by naked grep, by grouping on the
 BODY — before believing one.
+<!-- entry #1397-e2e-distbottom -->
+
+---
+
+## 2026-08-19 — #1397 (e2e): four contracts under two names, and two premises retracted
+
+Eleven specs each carried their own "how far is the scrollback from its tail"
+helper, under two names — `distanceToBottom` and `distFromBottom` — in FOUR
+distinct bodies: throw on a missing pane (4 files), delegate to a local
+`scrollbackGeometry` with no guard (1), return `null` (5), return the constant
+`999` (1). Six rounded, five did not. They are now one verb,
+`scrollbackDistanceFromBottom(page): Promise<number | null>`, in
+`fixtures/cicchettoPage.ts`, and the 24 call sites carry the sentinel.
+
+The rule the collapse is built on is not "duplication is bad". It is that **a
+sentinel for a missing pane has to point the same way as the assertion that
+follows, and only the call site knows which way that is.** Nine of the twelve
+sites on the `null` shape already did exactly that — `?? 999` ahead of a
+`toBeLessThanOrEqual`, `?? 0` ahead of a `toBeGreaterThan`, so an unmounted
+pane FAILS the poll — and the migration confirmed it: the rewriter derived each
+sentinel from the matcher below it and would have stopped on a disagreement,
+and it never stopped. `issue310` was the one file that hoisted its sentinel
+INTO the helper, where it serves both directions at once and therefore points
+the wrong way for one of its three uses.
+
+**Retracted premise (mine, and the one this slice was approved on first): "the
+999 hides a red".** It does not, at the granularity that matters. Measured: the
+constant does satisfy `toBeGreaterThan(50)` with no scrollback in the document
+at `issue310:104` — so the ASSERTION is masked — but the same test reads the
+same helper 23 lines later at `issue310:127` against `toBeLessThanOrEqual(50)`,
+where 999 fails. No test outcome was ever masked. The slice proceeded on the
+corrected motivation above, and the false one is recorded here rather than
+quietly replaced: a decision log that keeps only the reasons that held is a log
+that cannot be audited.
+
+**Why the verb returns `null` instead of throwing.** All 24 call sites sit
+inside `expect.poll`, so the choice is not stylistic. Read in the installed
+playwright 1.59.1: `lib/matchers/expect.js:275` awaits the poll generator
+OUTSIDE the `try` that retries (only the matcher's own failure returns
+`continuePolling: true`), `playwright-core/.../timeoutRunner.js:49` awaits
+`raceAgainstDeadline` with no `try`, and `:28` is a bare `Promise.race` with
+only a `.finally`. A throwing helper therefore aborts the poll on its first
+sample instead of waiting for the pane to mount — the opposite of what the four
+throwing copies looked like they were buying. This is a source reading against
+a pinned version, not a runtime probe.
+
+**Why a raw float.** Six of the eleven copies rounded. Rounding inside the verb
+would decide the sub-pixel band for every consumer at once, and unrounding is
+the direction that can only ever tighten an assertion, never weaken one.
+
+**Second retraction, same slice: `waitForNetworkState` was proposed as a
+companion collapse ("two failure semantics under one name") and is withdrawn
+before it was written.** Measured across its four files: all poll
+`attempts = 60` × 500 ms, and all four fail fast on a non-ok response — three
+through a local `getNetworks` that throws, the fourth through its own inline
+`if (!res.ok) throw`. The semantics are identical; only the message prefix and
+the inlining differ. The mutant proposed for it (make `/networks` answer 500
+and watch one file hang for 30 s) is falsified BY CONSTRUCTION: no file would
+hang. Three spellings of one behaviour is a name, not a lie, so it parks
+alongside `scrollbackGeometry` (8 files, one body) under the same test: when no
+mutant can tell the copies apart, collapsing buys tidiness, not correctness.
+**The controls, run on the e2e stack (11 specs, both projects).** Baseline on
+the base commit and treatment on this branch each report 18 passed / 1 failed
+with the SAME twenty titles; the one red is `issue580` case 2 dying in
+`loginAs` on `.sidebar-network-header` — before any distance is measured, on
+both arms, and it passed in two later runs of the same set, so it is not this
+change. M1 opened a scoped window around `issue310`'s masked assertion in which
+the pane carries no `data-testid="scrollback"`, bracketed by two calibration
+reads (open, and still open when the assertion ends): on the base the assertion
+PASSED with zero panes in the document, on this branch it fails with
+`Expected: > 50, Received: 0`, on both projects. That pair is the whole claim,
+and it is why the sentinel moved to the call site. The rounding control (+0.6
+inside the verb) killed NOTHING over the eleven specs, and its own positive
+control (+100) killed 13 of 19 — so the probe can kill, and no site sits within
+0.6 px of its threshold. Nothing had to be decided site by site.
+
+Not claimed: that the full integration suite was run for this change — it was
+not; only the eleven touched specs. Nor that the +0.6 control proves the six
+rounding sites could never have depended on the rounding: it proves only that
+none of them sits within 0.6 px of its threshold in the states these specs
+reach.


### PR DESCRIPTION
## What

Eleven specs each carried their own "how far is the scrollback from its tail"
helper, under two names — `distanceToBottom` and `distFromBottom` — in **four
distinct bodies**: throw on a missing pane (4 files), delegate to a local
`scrollbackGeometry` with no guard (1), return `null` (5), return the constant
`999` (1). Six rounded, five did not. They become one verb in
`fixtures/cicchettoPage.ts`:

```ts
scrollbackDistanceFromBottom(page: Page): Promise<number | null>
```

**11 definitions removed over 11 files, 24 call sites migrated, 12 files,
+84/-115.**

## Why this is not just deduplication

A sentinel for a missing pane has to point the **same way as the assertion that
follows**, and only the call site knows which way that is. Nine of the twelve
sites on the `null` shape already did exactly that — `?? 999` ahead of a
`toBeLessThanOrEqual`, `?? 0` ahead of a `toBeGreaterThan` — so an unmounted
pane FAILS the poll. `issue310` hoisted its sentinel INTO the helper, where it
serves both directions at once and therefore points the wrong way for one of
its three uses.

The migration derived every sentinel from the matcher below it and would have
stopped on a disagreement. It never stopped: the nine pre-existing ones were
deliberate.

## Two premises retracted (both mine, both in the DESIGN_NOTES entry)

1. **"The 999 hides a red" — false at test granularity.** It masks the
   ASSERTION at `issue310:104`, but the same test reads the same helper 23
   lines later at `:127` against `toBeLessThanOrEqual(50)`, where 999 fails.
   No test outcome was ever masked. The slice proceeded on the corrected
   motivation above.
2. **A companion `waitForNetworkState` collapse is withdrawn before being
   written.** All four copies poll `attempts = 60` x 500 ms and all four fail
   fast on a non-ok response (three via a throwing local `getNetworks`, one via
   its own inline throw). Identical semantics; the proposed mutant — make
   `/networks` answer 500 and watch one file hang for 30 s — is falsified by
   construction. Three spellings of one behaviour is a name, not a lie, so it
   parks.

## Why `null` and not a throw

All 24 call sites sit inside `expect.poll`, so this is behavioural, not
stylistic. Read in the installed **playwright 1.59.1**:
`lib/matchers/expect.js:275` awaits the poll generator OUTSIDE the `try` that
retries (only the matcher's own failure returns `continuePolling: true`);
`playwright-core/.../timeoutRunner.js:49` awaits `raceAgainstDeadline` with no
`try`; `:28` is a bare `Promise.race` with only a `.finally`. **A throwing
helper aborts the poll on its first sample** instead of waiting for the pane to
mount. Source reading against a pinned version, not a runtime probe.

## Evidence

| arm | where | result |
|---|---|---|
| baseline | base commit | 18 passed / 1 failed |
| treatment | this branch | 18 passed / 1 failed, **same 20 titles** |
| M1a | base | masked assertion **passes** with the pane hidden |
| M1b | this branch | **red on that assertion**, `Expected: > 50, Received: 0` |
| M2 (+0.6) | this branch | **19 passed, zero kills** |
| M2 calibration (+100) | this branch | **13 failed / 6 passed** |

- **The one red is the same test on both arms**, with the same error —
  `issue580` case 2 dying inside `loginAs` waiting for
  `.sidebar-network-header`, before any distance is measured. It passed in two
  later runs of the same set on the same code. Pre-existing and
  non-deterministic; attributed by re-running the same subset on the base.
- **M1 is the blocking pair.** A scoped window removes
  `data-testid="scrollback"` around exactly the masked assertion, bracketed by
  two calibration reads (window open = 0 matches; window still open when the
  assertion ends). Neither read ever threw, on either arm, on both projects.
- **The +0.6 rounding control kills nothing, and that zero is a real
  negative** — its own positive control at +100 kills 13 of 19, so the
  instrument discriminates. No site sits within 0.6 px of its threshold, so the
  raw-float decision left nothing to decide site by site.
- `scripts/bun.sh run check` is rc=0 over the whole chain, 0 `error TS`, and
  **59 warnings — exactly the base commit's count** (it was 61 mid-change: two
  `noUnusedImports` were mine, from `import type { Page }` left orphaned by the
  deleted defs).
- DESIGN_NOTES marker `#1397-e2e-distbottom` is unique (`grep -Fxc` = 1), the
  boundary shape was read on the file, and both neighbouring entries were
  compared byte-for-byte against `origin/main` after the rebase.

## What I decline to claim

- **The full integration suite was not run** — only the eleven touched specs,
  six times.
- **The +0.6 control does not prove the rounding could never matter**; it
  proves no site sits within 0.6 px of its threshold in the states these specs
  reach.
- **The `expect.poll` finding is a source reading**, version-pinned, not a
  runtime probe.
- **Removing `data-testid` is not proven inert** for the rest of the page; the
  calibration measures the absence of the selector, not the absence of side
  effects.
- On M1a the mobile project died later on an unrelated read-cursor assertion —
  an artefact of running that spec alone (it passes in the eleven-spec runs).
  Not re-attributed further.