### PR TITLE
docs(#1397): park the auth-seed slice, and record the measurement that killed it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50478,3 +50478,75 @@ function happens to follow — so they went with the body they described. The
 first two explained the ephemeral-bind trick, now stated once on the helper.
 The third recorded the never-dials observation, which survives promoted into
 the moduledoc as one of the two classes above.
+<!-- entry #1397-fetta2-parked -->
+
+---
+
+## 2026-08-19 — #1397: the auth-seed slice, parked because the mutant said so
+
+Fourteen spec files open with the same five-line `page.addInitScript`
+lambda: bearer, subject envelope, `cic.installChoice`. Nine of them sit
+inside no helper at all. The obvious move is to collapse them onto
+`loginAs`, which already does seed + goto + a readiness gate. The move was
+NOT made, and the reason is a measurement rather than a preference.
+
+### What the mutant answered
+
+`loginAs` ends on `waitForUserTopicReady` — a gate on the user-topic WS
+subscribe, added because compose-driven specs that fire `/join` right
+after login race the JOIN ack and miss `window_pending`/`join_failed`
+(Phoenix PubSub does not replay to late subscribers). If that barrier were
+load-bearing for the nine, the collapse would be a cure and not just tidying.
+
+The mutant wraps the user-topic `ch.join()` in `socket.ts` in a
+`setTimeout`, so the window between shell-ready and subscribe is held open
+on purpose. Three runs on the e2e stack:
+
+* base, unmutated: eleven tests green, and a calibration spec reading
+  `__cic_userTopicReady` reports `first=1` — at shell-ready the window is
+  ALREADY shut. That calibration FAILS here, and its failure is the
+  positive control: the instrument reads a real quantity instead of
+  always answering "open".
+* mutant at 2s: the calibration passes with `first=-1` (the seam Set does
+  not yet exist) and the stamp landing 1956ms after shell-ready, so the
+  window is genuinely open — and **all eleven tests stay green**.
+* mutant at 12s, past the barrier's own 5s timeout: `issue481`, which does
+  go through `loginAs`, dies inside `waitForUserTopicReady`; the same three
+  admin specs stay green. The knob kills, through exactly the code path the
+  collapse would introduce, so the zero above is a true zero rather than a
+  blunt instrument.
+
+The nine sites do not read anything the user topic provides. Collapsing
+them would not remove a race; it would ADD a dependency they do not have —
+in the 12s run the inline specs are the ones still standing. That is the
+trade the criterion forbids: buying lines and paying in behaviour. Parked,
+alongside `scrollbackGeometry` and `waitForNetworkState`, for the same
+reason those were: when no mutant can tell the copies apart, the
+duplication is a NAME, not a lie.
+
+### Two retractions, both mine
+
+The census that sized this slice was wrong twice before it was right. A
+scope attributor that dropped a function name when the signature spanned
+several lines filed twelve `adminLogin` and eight `adminFriendlyLogin`
+copies as top-level, inflating the slice from fourteen to thirty-two; it
+was caught only by demanding the parser reproduce a previously known
+count. And `issue1061` was filed as collapsible from a window of seven
+lines BELOW the call, while ten lines ABOVE it the spec already explains
+that its boot is open-coded precisely because it stubs the WS offline and
+the fixture's gate cannot express that. A census that reads only downhill
+from the gesture cannot see the premise.
+
+### The homonym that costs an hour
+
+`issue252-vhost-selector.spec.ts` calls `loginAs(page, admin)` and it is
+NOT the fixture's `loginAs`: the file declares a local one that shadows
+it, and imports only `expectShellReady`, `openAdminConsole` and
+`openSettingsDrawer`. Read as the fixture verb, that line looks like proof
+that a network-less admin can clear a `.sidebar-network-header` gate —
+which `Sidebar.tsx` renders only inside `<Show when={networks().length >
+0}>`, so it cannot. The apparent contradiction was entirely an artefact of
+the shadowing name, and the measure that dissolved it was the import list,
+free, where a whole e2e run was spent instead. Two further local homonyms
+of exported fixture verbs exist (`bootVisitor`, `scrollbackLine`); whether
+their bodies diverge observably is not measured here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50547,6 +50547,34 @@ that a network-less admin can clear a `.sidebar-network-header` gate —
 which `Sidebar.tsx` renders only inside `<Show when={networks().length >
 0}>`, so it cannot. The apparent contradiction was entirely an artefact of
 the shadowing name, and the measure that dissolved it was the import list,
-free, where a whole e2e run was spent instead. Two further local homonyms
-of exported fixture verbs exist (`bootVisitor`, `scrollbackLine`); whether
-their bodies diverge observably is not measured here.
+free, where a whole e2e run was spent instead.
+
+Two further local homonyms of exported fixture verbs exist, and measuring
+them shrinks the finding instead of widening it. `bootVisitor`
+(`issue477-quit-persistence`) takes `(browser, registered)` and DELEGATES to
+the fixture's own `bootVisitorContext`; `scrollbackLine`
+(`unread-divider-beyond-window`) is a block-scoped arrow inside one test body,
+selecting on `data-msg-id` where the fixture verb selects on kind plus body
+text. Neither is reachable by mistake, because the arity differs — ARITY, not
+the name, is what makes a shadow confusable, and only `issue252`'s matches its
+fixture twin argument for argument.
+
+The rename that would fix that one site is deliberately NOT made here. It is
+two lines in an e2e spec, and an e2e spec is gated by a ~40-minute integration
+run: the change would spend forty minutes to buy back the hour that exactly one
+reader has lost so far. This paragraph is the cheaper instrument, and it costs
+the next reader nothing. A future slice that already touches
+`issue252-vhost-selector.spec.ts` should fold the rename in for free.
+
+### The rule, broken twenty minutes after reading it
+
+The census that produced those three names compared DECLARED names against
+EXPORTED names and read neither a body nor a signature — so it reported three
+confusable shadows where measuring finds one and two false positives. The entry
+immediately above this one in this file closes on exactly that instruction:
+cross three methods, by name, by naked grep, and by grouping on the BODY,
+before believing one. It was read an hour earlier, while checking the boundary
+shape this entry's own separator had to match, and then a name-only census was
+run anyway, by the same hand. Knowing the rule and holding it are different
+states. Treat any name-level count here as a lower bound on the truth and an
+upper bound on the finding — including the ones in this entry.


### PR DESCRIPTION
## What this is

A docs-only entry in `docs/DESIGN_NOTES.md`. No code changes. It records a
slice of the #1397 duplication cluster that was **investigated and then
parked**, together with the measurement that decided it — and the two
retractions I owe for having sized it wrong first.

## The slice, and why it is not being collapsed

Fourteen spec files open with the same five-line `page.addInitScript` auth
seed (bearer, subject envelope, `cic.installChoice`); nine sit inside no
enclosing helper. Collapsing them onto the existing `loginAs` looks free.

It is not free, because `loginAs` ends on `waitForUserTopicReady`. A mutant
that wraps the user-topic `ch.join()` in a `setTimeout` holds that window
open on purpose:

| arm | calibration | the nine specs |
|---|---|---|
| base, unmutated | `first=1` — window already shut at shell-ready; **calibration fails**, which is the positive control | green |
| mutant 2s | `first=-1`, stamp 1956ms after shell-ready — window genuinely open | **all green** |
| mutant 12s (past the barrier's own 5s timeout) | — | still green, while `issue481` (which does use the fixture verb) dies inside `waitForUserTopicReady` |

The knob demonstrably kills, through exactly the code path the collapse
would introduce, so the zero is a true zero rather than a blunt instrument.
The nine sites do not read anything the user topic provides: collapsing them
would not remove a race, it would **add** a dependency they do not have. That
is buying lines and paying in behaviour, which is the inverse of the criterion
this cluster has been applying — so it is parked next to `scrollbackGeometry`
and `waitForNetworkState`, for the same reason those were.

## Retractions carried in the entry

* My scope attributor dropped a function name whenever the signature spanned
  several lines, filing 12 `adminLogin` + 8 `adminFriendlyLogin` copies as
  top-level and inflating the slice from 14 sites to 32. Caught only by
  requiring the parser to reproduce a previously known count first.
* `issue1061` was filed as collapsible from a seven-line window **below** the
  call, while ten lines **above** it the spec already explains that its boot is
  open-coded because it stubs the WS offline. A census that reads only downhill
  from the gesture cannot see the premise.
* `issue252` declares a **local `loginAs` that shadows the fixture's**. Read as
  the fixture verb it looks like proof that a bindless admin clears a
  `.sidebar-network-header` gate, which `Sidebar.tsx` renders only inside
  `<Show when={networks().length > 0}>`. The apparent contradiction was an
  artefact of the shadowing name, and the measure that dissolved it was the
  import list — free — where I spent a full e2e run instead.

## Test plan

- [x] `scripts/design-notes-gate.sh` → rc=0, "1 new entry heading(s), separator and marker present"
- [x] Marker `<!-- entry #1397-fetta2-parked -->` is the first appended line, no blank before it; unique in the file (121 markers, zero duplicates)
- [x] Rebase discipline: numstat against the merge-base captured before and after — identical, `72 0 docs/DESIGN_NOTES.md`, deletions zero
- [x] Neighbour check both ways: the previous entry is byte-intact in the file, and `origin/main`'s `docs/DESIGN_NOTES.md` is a byte-exact **prefix** of this branch's (adds exactly 72 lines at the tail, touches nothing else)
- No code paths change, so no unit/integration gate applies to this diff.

## What I decline to claim

1. That the nine sites *should never* be deduplicated — only that collapsing them onto a barrier-bearing verb costs more than it returns, measured with these destination verbs.
2. That the collapse would turn CI red. Measured: at 12s the barrier kills what carries it. Under normal conditions the window is tens of milliseconds and the barrier only waits.
3. That the five excluded sites are homogeneous. They are five different axes; I read them, I did not measure them.
4. That my census is exhaustive. It matches an `.addInitScript(` call whose next 14 lines carry the three `setItem` keys — a lower bound, not a total.
5. That the calibration's 1956ms is the pure window. It includes the 300ms the instrument waits between its two readings.
6. That `__cic_userTopicReady` says anything about production. It is an e2e seam production never reads.
7. That delaying the client-side join is the only way to open that window. A server-side delay or a dropped ack are different classes I did not touch.
8. That `issue481` is green in CI today. In the 12s arm it is red by my own mutant's hand, deliberately; I did not run it unmutated.
9. That the two other local homonyms (`bootVisitor`, `scrollbackLine`) diverge from the verbs they shadow. Unmeasured, and the entry says so.
10. That this parks the #1397 cluster. Other slices remain, each parked with its own stated reason.