### PR TITLE
test(#1397): one shared adminLogin for the twenty local admin-login copies

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -183,6 +183,36 @@ export async function loginAs(
   await waitForUserTopicReady(page, vjt.name);
 }
 
+// Admin sibling of `loginAs`: the same `seedAuthLocalStorage` seeding,
+// gated on `expectShellReady` instead of the per-network header +
+// user-topic ack above.
+//
+// #1397 — this replaces twenty local copies that lived in twenty spec
+// files under two names (`adminLogin` x12, `adminFriendlyLogin` x8).
+// The two names were synonyms: with the name masked, every body runs
+// the same three statements. All the variance sat in the SIGNATURE, on
+// two axes — the seed type was spelled three ways (`SeededUser`,
+// `ReturnType<typeof getSeededAdmin>`, a local `Admin`, which are one
+// type since `getSeededAdmin(): SeededUser`), and four of the twenty
+// fetched the seed themselves rather than taking it, which is why
+// fourteen call sites now spell `getSeededAdmin()` out loud.
+//
+// Deliberately NOT `loginAs`, though the seeding half is now literally
+// the same call. The seeded admin (`admin-vjt`) has NO networks bound,
+// so `loginAs`'s per-network-header selector never resolves for it;
+// reaching it would mean `noNetworks: true`, whose own comment above
+// calls that a weakening of the post-login invariant. Adopting
+// `loginAs` would also buy `waitForUserTopicReady`, which none of the
+// twenty specs needs today — none of them composes `/join` — and which
+// rests on `socketUserName()` matching the seeded admin name,
+// unverified at the time of writing. The barrier question is open, not
+// settled: see DESIGN_NOTES 2026-08-18.
+export async function adminLogin(page: Page, admin: SeededUser): Promise<void> {
+  await seedAuthLocalStorage(page, admin.token, admin.subjectJson);
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
 // The visitor subject envelope, MIRRORED from cicchetto/src/lib/api.ts
 // `Subject` rather than imported: e2e/tsconfig.json carries no path
 // mapping into src, the same posture (and for the same reason) as

--- a/cicchetto/e2e/tests/admin-network-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-network-crud.spec.ts
@@ -9,7 +9,7 @@
 // other specs — never delete those. Tests create unique slugs (timestamp
 // suffix) and best-effort delete in finally.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -17,22 +17,6 @@ import { expect, test } from "../fixtures/test";
 function userIdFromSubject(subjectJson: string): string {
   const subj = JSON.parse(subjectJson) as { kind: string; id: string };
   return subj.id;
-}
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
 }
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {

--- a/cicchetto/e2e/tests/admin-server-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-server-crud.spec.ts
@@ -8,26 +8,10 @@
 // Uses a freshly-created ephemeral network per test (so we don't
 // pollute the seeded networks' server lists).
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);

--- a/cicchetto/e2e/tests/admin-user-networks.spec.ts
+++ b/cicchetto/e2e/tests/admin-user-networks.spec.ts
@@ -22,7 +22,7 @@
 // `--repeat-each`: two repeats can start inside the same millisecond, and a
 // slug collision would fail the second one for the wrong reason.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -36,22 +36,6 @@ function unique(prefix: string): string {
   const id = `${prefix}-${Date.now() % 1_000_000}-${Math.random().toString(36).slice(2, 6)}`;
   if (id.length > 32) throw new Error(`unique: "${id}" is ${id.length} chars, slug limit is 32`);
   return id;
-}
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
 }
 
 async function openUsersTab(page: import("@playwright/test").Page): Promise<void> {

--- a/cicchetto/e2e/tests/admin-users.spec.ts
+++ b/cicchetto/e2e/tests/admin-users.spec.ts
@@ -13,26 +13,10 @@
 // Cleanup: tests create unique usernames (timestamp suffix) and
 // best-effort delete via REST in finally to avoid leaking rows.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openUsersTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);

--- a/cicchetto/e2e/tests/featured-channels.spec.ts
+++ b/cicchetto/e2e/tests/featured-channels.spec.ts
@@ -10,26 +10,10 @@
 // Uses a freshly-created ephemeral network per test so we don't pollute
 // the seeded networks' featured lists.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);

--- a/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
+++ b/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
@@ -21,26 +21,12 @@
 // until the first `"overview"` push lands, so `toBeVisible()` waits on the
 // arrival of real server data rather than on a timer.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 // admin-vjt has no network bind, so `loginAs`'s network-section shell-ready
 // selector would time out. Same shape as m7-admin-gate / m11-admin-events.
-async function adminLogin(page: import("@playwright/test").Page): Promise<void> {
-  const seed = getSeededAdmin();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
-
 const CELLS = [
   "admin-overview-sessions",
   "admin-overview-visitors",
@@ -73,7 +59,7 @@ async function expectOneLine(pane: import("@playwright/test").Locator): Promise<
 test("#1073 the admin bar carries live stats, on one line, in the shared band", async ({
   page,
 }) => {
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   const pane = await openAdminConsole(page);
 
   // Barrier AND assertion: nothing renders until the server's first push.
@@ -107,7 +93,7 @@ test("#1073 the admin bar carries live stats, on one line, in the shared band", 
 });
 
 test("#1073 @webkit on a phone the stats keep the ☰ at the far end", async ({ page }) => {
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   const pane = await openAdminConsole(page);
 
   const stats = pane.locator(".topic-bar .admin-overview-stats");

--- a/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
+++ b/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
@@ -24,22 +24,8 @@
 
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminSessionsTab } from "../fixtures/cicchettoPage";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
-
-async function adminLogin(page: Page): Promise<void> {
-  const seed = getSeededAdmin();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 function idFromSubjectJson(subjectJson: string): string {
   const subject = JSON.parse(subjectJson) as { id?: string };
@@ -65,7 +51,7 @@ async function userRowKey(page: Page): Promise<string> {
 test("#1157 @webkit a phone gives the row's verbs one control, and it is the menu", async ({
   page,
 }) => {
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
   const key = await userRowKey(page);
 
@@ -81,7 +67,7 @@ test("#1157 @webkit a phone gives the row's verbs one control, and it is the men
 });
 
 test("#1157 @webkit the dropdown arms a verb rather than running it", async ({ page }) => {
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
   const key = await userRowKey(page);
 
@@ -110,7 +96,7 @@ test("#1157 @webkit the dropdown arms a verb rather than running it", async ({ p
 });
 
 test("#1157 a desktop keeps both verbs side by side and grows no menu", async ({ page }) => {
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
   const key = await userRowKey(page);
 

--- a/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
+++ b/cicchetto/e2e/tests/issue1163-admin-bind-dials.spec.ts
@@ -54,25 +54,10 @@
 // The assertions are repeated after a full page reload so the witness is a
 // second server round-trip, not a client-side artifact of the bind response.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-type Admin = ReturnType<typeof getSeededAdmin>;
-
-async function adminLogin(page: import("@playwright/test").Page, seed: Admin): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 // #1158 — the console door moved. Binding is no longer a database-wide form
 // that asks which user; it is the `+` on that one user's page, reached by

--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -51,27 +51,13 @@
 // Per `feedback_e2e_user_class_parity_matrix`: admin-gated, the EXEMPT shape.
 
 import type { Locator, Page } from "@playwright/test";
-import { adminSessionRowKey, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, adminSessionRowKey, openAdminConsole } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 // admin-vjt has no network bind, so `loginAs`'s network-section shell-ready
 // selector would time out. Same shape as #1073 / m7-admin-gate / m11-events.
-async function adminLogin(page: Page): Promise<void> {
-  const seed = getSeededAdmin();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
-
 async function openSessionsTab(page: Page): Promise<void> {
   await openAdminConsole(page);
   await page.getByTestId("admin-tab-sessions").click();
@@ -113,7 +99,7 @@ test("#1223 @webkit on a phone the whole card heading opens the row, not just th
   const visitor = await mintVisitor(`tap1223-${Date.now()}`);
 
   try {
-    await adminLogin(page);
+    await adminLogin(page, getSeededAdmin());
     await openSessionsTab(page);
 
     const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -185,7 +171,7 @@ test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
   const visitor = await mintVisitor(`wide1223-${Date.now()}`);
 
   try {
-    await adminLogin(page);
+    await adminLogin(page, getSeededAdmin());
     await openSessionsTab(page);
 
     const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -225,7 +211,7 @@ test("#1223 @webkit on a phone no field is on the card and in the panel at once"
   const admin = getSeededAdmin();
   const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
 
-  await adminLogin(page);
+  await adminLogin(page, getSeededAdmin());
   await openUsersTab(page);
 
   const row = page.getByTestId(`admin-user-row-${adminId}`);
@@ -276,7 +262,7 @@ test("#1223 @webkit on a phone the detail panel spans its table, with no gutters
   const visitor = await mintVisitor(`gutter1223-${Date.now()}`);
 
   try {
-    await adminLogin(page);
+    await adminLogin(page, getSeededAdmin());
     await openSessionsTab(page);
 
     const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -338,7 +324,7 @@ test("#1223 @webkit on a phone no panel value is broken mid-token", async ({ pag
   const visitor = await mintVisitor(`token1223-${Date.now()}`);
 
   try {
-    await adminLogin(page);
+    await adminLogin(page, getSeededAdmin());
     await openSessionsTab(page);
 
     const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -432,7 +418,7 @@ test.describe("#1223 the 769-899 band", () => {
     const admin = getSeededAdmin();
     const adminId = (JSON.parse(admin.subjectJson) as { id: string }).id;
 
-    await adminLogin(page);
+    await adminLogin(page, getSeededAdmin());
     await openUsersTab(page);
 
     const row = page.getByTestId(`admin-user-row-${adminId}`);

--- a/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
+++ b/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
@@ -49,27 +49,13 @@
 // shape — non-admin cannot reach this surface at all.
 
 import type { Locator, Page } from "@playwright/test";
-import { adminSessionRowKey, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, adminSessionRowKey, openAdminConsole } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 // admin-vjt has no network bind, so `loginAs`'s network-section
 // shell-ready selector would time out. Same shape as #1223 / #1073.
-async function adminLogin(page: Page): Promise<void> {
-  const seed = getSeededAdmin();
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
-
 async function openSessionsTab(page: Page): Promise<void> {
   await openAdminConsole(page);
   await page.getByTestId("admin-tab-sessions").click();
@@ -184,7 +170,7 @@ for (const width of [393, 440]) {
       const visitor = await mintVisitor(`dens1244-${Date.now()}`);
 
       try {
-        await adminLogin(page);
+        await adminLogin(page, getSeededAdmin());
         await openSessionsTab(page);
 
         const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -252,7 +238,7 @@ for (const width of [393, 440]) {
       const visitor = await mintVisitor(`densp1244-${Date.now()}`);
 
       try {
-        await adminLogin(page);
+        await adminLogin(page, getSeededAdmin());
         await openSessionsTab(page);
 
         const key = await adminSessionRowKey(page, "visitor", visitor.id);
@@ -331,7 +317,7 @@ test.describe("#1244 the nesting around a record card", () => {
     const visitor = await mintVisitor(`frame1244-${Date.now()}`);
 
     try {
-      await adminLogin(page);
+      await adminLogin(page, getSeededAdmin());
       await openSessionsTab(page);
 
       const key = await adminSessionRowKey(page, "visitor", visitor.id);

--- a/cicchetto/e2e/tests/issue215-session-log.spec.ts
+++ b/cicchetto/e2e/tests/issue215-session-log.spec.ts
@@ -15,31 +15,15 @@
 // `m11-admin-events-live.spec.ts`.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);
 }
 
 test("#215 Session Log tab renders the persisted session-lifecycle tail", async ({ page }) => {
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminPane(page);
 
   await page.getByTestId("admin-tab-session_log").click();

--- a/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
+++ b/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
@@ -16,26 +16,10 @@
 // pool"). #256 is a cic-only change, so the RED→GREEN leg here is the UI
 // enforce-forward (tick → checked + disabled), not the read-side OR.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);

--- a/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
+++ b/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
@@ -15,26 +15,10 @@
 // autocomplete lands a grant whose subject_id is the visitor UUID, not the
 // typed nick — is the value proof.
 
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-
-async function adminLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);

--- a/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
@@ -41,28 +41,12 @@
 // visitors against azzurra would 503 if the revert didn't run.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole, openRailMenu } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole, openRailMenu } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 const AZZURRA_SLUG = "azzurra";
 const AZZURRA_BASELINE_CAP = 100;
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 // PATCH /admin/networks/:slug — partial body shape per M-10. Only
 // max_concurrent_visitor_sessions is sent; max_per_ip unchanged.
@@ -85,7 +69,7 @@ test("M-Z admin operator journey: drawer → 3 tabs → cap-saturation event lan
   page,
 }) => {
   const admin = getSeededAdmin();
-  await adminFriendlyLogin(page, admin);
+  await adminLogin(page, admin);
 
   // STEP 1 — Login as admin → the rail's 🔧 admin launcher is visible.
   // #986 — the settings-drawer "admin console" entry this step used to

--- a/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
+++ b/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
@@ -18,24 +18,8 @@
 // by the time the spec runs.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openAdminNetworksTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);
@@ -44,7 +28,7 @@ async function openAdminNetworksTab(page: import("@playwright/test").Page): Prom
 }
 
 test("M-10 admin Networks tab lists seeded network rows", async ({ page }) => {
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminNetworksTab(page);
 
   // bahamut-test (user network) + azzurra (visitor network) both
@@ -61,7 +45,7 @@ test("M-10 admin Networks tab lists seeded network rows", async ({ page }) => {
 });
 
 test("M-10 cap editor: edit + Save round-trips through server", async ({ page }) => {
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminNetworksTab(page);
 
   const slug = "bahamut-test";
@@ -106,7 +90,7 @@ test("M-10 cap editor: edit + Save round-trips through server", async ({ page })
 });
 
 test("M-10 Sweep visitors inline-confirm fires + renders swept count", async ({ page }) => {
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminNetworksTab(page);
 
   const reap = page.getByTestId("admin-networks-force-reap");

--- a/cicchetto/e2e/tests/m11-admin-events-live.spec.ts
+++ b/cicchetto/e2e/tests/m11-admin-events-live.spec.ts
@@ -16,31 +16,15 @@
 // land in the Events tab within the expected fan-out window.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);
 }
 
 test("M-11 Events tab renders + receives reaper_swept after Sweep visitors", async ({ page }) => {
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminPane(page);
 
   // Mount triggered the channel join + snapshot push. Switch to

--- a/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
+++ b/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
@@ -29,30 +29,9 @@
 // expanded RailActions menu, which is absolutely positioned, capped by
 // a JS-measured max-height and overlays the members list.
 
-import { expectShellReady, openRailMenu } from "../fixtures/cicchettoPage";
-import type { SeededUser } from "../fixtures/grappaApi";
+import { adminLogin, openRailMenu } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
-
-// admin-vjt has no network bind — loginAs's `.sidebar-network-section h3`
-// shell-ready selector would time out. Wait on the always-visible
-// settings cog button instead (rendered in the no-network fallback
-// header via `aria-label="open settings"`).
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: SeededUser,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 const cases = [
   {
@@ -69,7 +48,7 @@ const cases = [
 
 for (const c of cases) {
   test(`M-7 admin launcher gate — ${c.label}`, async ({ page }) => {
-    await adminFriendlyLogin(page, c.seed());
+    await adminLogin(page, c.seed());
 
     // #500 — every rail affordance lives behind the launcher menu.
     await openRailMenu(page);

--- a/cicchetto/e2e/tests/m9b-admin-sessions-actions.spec.ts
+++ b/cicchetto/e2e/tests/m9b-admin-sessions-actions.spec.ts
@@ -28,7 +28,7 @@
 // every other admin spec — out of scope here.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminSessionsTab } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminSessionsTab } from "../fixtures/cicchettoPage";
 import { patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   getSeededAdmin,
@@ -61,22 +61,6 @@ test.afterEach(async () => {
   });
 });
 
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
-
 // A subject's id, however the fixture happens to carry it: the two m9b
 // users expose a composite `user:<id>:<network>` session id, vjt and
 // wiz-test expose the persisted subject JSON. Both reduce to the id, which
@@ -106,7 +90,7 @@ test("M-9b admin Sessions view lists every seeded user bind", async ({ page }) =
     { name: WIZ_USER, id: idFromSubjectJson(getSeededWizUser().subjectJson) },
   ];
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
 
   // This asserted an EXACT total, and #1157 took that away twice over.
@@ -150,7 +134,7 @@ test("#242 admin Sessions tab shows the network slug (not the raw network_id FK)
     connection_state: "connected",
   });
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
 
   const victimRow = page.getByTestId(`admin-session-row-${victim.sessionId}`);
@@ -186,7 +170,7 @@ test("M-9b arming Disconnect on one row disarms the same row's Terminate (single
 }) => {
   const victim = getSeededM9bVictim();
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
 
   const disc = page.getByTestId(`admin-session-disconnect-${victim.sessionId}`);
@@ -217,7 +201,7 @@ test("M-9b admin Disconnect inline-confirm transitions Disconnect → Confirm di
     connection_state: "connected",
   });
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
 
   const victimDisconnect = page.getByTestId(`admin-session-disconnect-${victim.sessionId}`);
@@ -254,7 +238,7 @@ test("M-9b admin Terminate inline-confirm fires DELETE", async ({ page }) => {
     connection_state: "connected",
   });
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
 
   const victimTerminate = page.getByTestId(`admin-session-terminate-${victim.sessionId}`);

--- a/cicchetto/e2e/tests/u5-admin-networks-live-counts.spec.ts
+++ b/cicchetto/e2e/tests/u5-admin-networks-live-counts.spec.ts
@@ -20,25 +20,9 @@
 // review).
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { patchNetworkConnectionState } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededM9bVictim, NETWORK_SLUG } from "../fixtures/seedData";
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);
@@ -54,7 +38,7 @@ test("U-5 Networks live user-count drops after a session is terminated", async (
     connection_state: "connected",
   });
 
-  await adminFriendlyLogin(page, getSeededAdmin());
+  await adminLogin(page, getSeededAdmin());
   await openAdminPane(page);
 
   // 1. Open Networks tab; capture the bahamut-test row's USER live

--- a/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
@@ -27,24 +27,8 @@
 // seedData) to PUT it back in afterEach.
 
 import { expect, test } from "@playwright/test";
-import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-
-async function adminFriendlyLogin(
-  page: import("@playwright/test").Page,
-  seed: ReturnType<typeof getSeededAdmin>,
-): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openAdminPaneAndSettingsTab(page: import("@playwright/test").Page): Promise<void> {
   // openAdminConsole waits for the settings drawer to finish its 200ms
@@ -74,7 +58,7 @@ test.describe("UX-6-B admin Settings tab", () => {
   });
 
   test("renders default settings + can flip active host litterbox → embedded", async ({ page }) => {
-    await adminFriendlyLogin(page, getSeededAdmin());
+    await adminLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 
     // Defaults from B1: embedded host + 10 MB per-file + 10 GB global.
@@ -90,7 +74,7 @@ test.describe("UX-6-B admin Settings tab", () => {
   });
 
   test("422 invalid_setting flags the offending field", async ({ page }) => {
-    await adminFriendlyLogin(page, getSeededAdmin());
+    await adminLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 
     // Zero image per-file cap → server returns 422 invalid_setting
@@ -103,7 +87,7 @@ test.describe("UX-6-B admin Settings tab", () => {
   });
 
   test("PUT /admin/settings fans out server_settings_changed on user-topics", async ({ page }) => {
-    await adminFriendlyLogin(page, getSeededAdmin());
+    await adminLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 
     // Listen on the page console + waitForResponse for the PUT, then
@@ -138,7 +122,7 @@ test.describe("UX-6-B admin Settings tab", () => {
     request,
   }) => {
     const admin = getSeededAdmin();
-    await adminFriendlyLogin(page, admin);
+    await adminLogin(page, admin);
     await openAdminPaneAndSettingsTab(page);
 
     const duration = page.getByTestId("admin-settings-video-max-duration");
@@ -157,7 +141,7 @@ test.describe("UX-6-B admin Settings tab", () => {
   });
 
   test("422 invalid_setting flags the video duration field (#201)", async ({ page }) => {
-    await adminFriendlyLogin(page, getSeededAdmin());
+    await adminLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 
     const duration = page.getByTestId("admin-settings-video-max-duration");

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50578,3 +50578,84 @@ shape this entry's own separator had to match, and then a name-only census was
 run anyway, by the same hand. Knowing the rule and holding it are different
 states. Treat any name-level count here as a lower bound on the truth and an
 upper bound on the finding — including the ones in this entry.
+<!-- entry #1397-adminlogin -->
+
+---
+
+## 2026-08-18 — #1397: twenty admin logins, one name, and the barrier NOT bought
+
+Twenty e2e spec files each carried their own admin-login helper, under two
+names: `adminLogin` in twelve, `adminFriendlyLogin` in eight, 54 call sites
+between them. This entry records the measurement that collapsed them, and
+the fork that was walked up to and deliberately not taken.
+
+### The two names were synonyms — measured, not assumed
+
+Extracting all twenty bodies and hashing them whitespace-normalised gives six
+clusters, which looks like six behaviours. It is one. The two largest clusters
+are seven `adminLogin` and seven `adminFriendlyLogin` that are byte-identical
+EXCEPT the function name — which is why an earlier census that masked the name
+reported a single cluster of fourteen spanning both names. Both readings were
+right; only the name-masked one was informative.
+
+The remaining six are the same statements again. All twenty seed the same
+three localStorage keys, `goto("/")`, and wait on `expectShellReady`. The
+whole variance is in the signature: four files fetched the seed inside the
+helper instead of taking it, and the seed type was spelled three ways —
+`SeededUser`, `ReturnType<typeof getSeededAdmin>`, and a local
+`type Admin = ReturnType<typeof getSeededAdmin>` — which are ONE type, since
+`getSeededAdmin(): SeededUser`. Nothing behavioural distinguished a single
+one of the twenty from any other.
+
+So the de-duplication is free, and the seed is now spelled at the fourteen
+call sites that had hidden it behind a zero-argument wrapper — the same trade
+this file recorded earlier the same day for the fake IRC server's helpers.
+
+### The fork: `loginAs` exists, and the shared admin helper still does not use it
+
+`loginAs` in the same fixtures module has a BYTE-IDENTICAL seeding half. The
+tempting move is to delete the twenty and call it. It was rejected, and the
+reason is a cost, not a taste:
+
+  * the seeded admin (`admin-vjt`) has NO networks bound, so `loginAs`'s
+    per-network-header ready selector never resolves for it. Reaching it means
+    `noNetworks: true`, and that option's own comment in this codebase calls it
+    a weakening — from "shell fully populated" to "DOM has homepane
+    scaffolding". Buying it costs a barrier that `expectShellReady` gives for
+    free, since `.shell-main` is exactly the network-independent signal;
+  * it would also add `waitForUserTopicReady`, a REAL barrier against a real
+    race — but one none of these twenty runs into today: not one of them
+    composes `/join` or otherwise depends on a user-topic broadcast. The
+    closest counterexample, the admin events-live spec, depends on
+    `grappa:admin:events`, joined at AdminPane mount, which is a different
+    topic and a different barrier;
+  * and it rests on an unverified link: `waitForUserTopicReady` matches on the
+    user NAME, so it only fires if `socketUserName()` for the admin subject
+    equals the seeded admin name. The join itself is gated on token + name
+    only, not on networks, so it should — but "should" is not a measurement,
+    and closing it costs one e2e run.
+
+🥇 The rule this instance is an example of: **do not buy a barrier with a
+declared weakening on the strength of a link you have not measured.** The
+question stays open on #1397 with its price attached (one e2e run), rather
+than being answered as a side effect of a de-duplication that had no need to
+answer it.
+
+### What the gates can and cannot see here
+
+Worth writing down, because it bounds every future change to this helper. Two
+mutants were run against the shared helper:
+
+  * REMOVE the `expectShellReady` barrier from it — `bun run check` and the
+    5616-test vitest suite both stay GREEN. No gate reachable without the
+    exclusive e2e lane can see a behavioural break in this helper;
+  * REMOVE the seed parameter from its signature — `tsc --noEmit -p
+    e2e/tsconfig.json` fails with 54 errors across 20 files, which is exactly
+    the census. The type-checker is a complete oracle for the WIRING and a
+    blind one for the BEHAVIOUR.
+
+A stale comment went out with the helper it described, in the M-7 gate spec:
+it claimed the spec waits on the settings cog because `loginAs`'s
+`.sidebar-network-section h3` would time out. The helper below it called
+`expectShellReady`, not the cog, and that selector no longer exists in the
+fixtures module — both halves were already false when it was deleted.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50659,3 +50659,28 @@ it claimed the spec waits on the settings cog because `loginAs`'s
 `.sidebar-network-section h3` would time out. The helper below it called
 `expectShellReady`, not the cog, and that selector no longer exists in the
 fixtures module — both halves were already false when it was deleted.
+
+### The body changed shape under the rebase: `seedAuthLocalStorage`
+
+As first written, the shared helper spelled the three `localStorage.setItem`
+calls itself, because when it was written nothing else expressed them. Between
+that writing and the rebase onto main, this fixtures module grew
+`seedAuthLocalStorage(page, token, subjectJson)` — module-private, and already
+called by BOTH `loginAs` and `bootVisitor`. The helper now delegates to it
+instead of restating the three keys. That is the slice applied to itself: a
+helper whose reason to exist is removing copies may not carry one, and shipping
+it as written would have made the seeding gesture's third inline copy the one
+inside the de-duplication. Anything added here later is the fourth — call the
+verb.
+
+🥇 How it surfaced is the transferable part, and it is a rule this file has
+already paid for once. The rebase conflicted on this module, and the conflict
+was trivially resolvable: keep both blocks, they touch different functions.
+**Resolvability was not the signal. The BODY inside the conflict was** — the
+other side showed `bootVisitor` calling a verb that did not exist when this
+branch started, which is the whole reason to read a conflict rather than settle
+it. The slice recorded earlier the same day paid the opposite price: a lock and
+an equivalence oracle written against wrapper bodies that a landed branch had
+already rewritten, discovered only after the rebase had cheerfully carried them
+forward as greens that could no longer fail. On a rebase, read what the other
+side's code now SAYS, not merely whether the two sides can be reconciled.


### PR DESCRIPTION
## What

Twenty e2e spec files each carried their own admin-login helper, under two
names — `adminLogin` in twelve files, `adminFriendlyLogin` in eight. All
twenty run the same three statements: seed the auth localStorage keys,
`goto("/")`, wait on `expectShellReady`. They become one exported
`adminLogin(page, admin)` in `cicchetto/e2e/fixtures/cicchettoPage.ts`.

## The variance was two axes, not one

Grouping the twenty bodies by hash with the NAME masked leaves five clusters,
which looks like five behaviours and is one. All the variance sits in the
SIGNATURE:

* the seed type was spelled three ways — `SeededUser`,
  `ReturnType<typeof getSeededAdmin>`, and a local
  `type Admin = ReturnType<typeof getSeededAdmin>` — which are one type,
  since `getSeededAdmin(): SeededUser`;
* four of the twenty took NO seed and fetched it themselves. Those are the
  fourteen call sites that now spell `getSeededAdmin()` out loud, in
  `issue1073` (2), `issue1157` (3), `issue1223` (6) and `issue1244` (3).

The shared helper takes the seed as a mandatory argument, so nothing is
hidden behind a zero-argument wrapper and no call site changes meaning.

## The body delegates to `seedAuthLocalStorage`

The helper does NOT restate the three `localStorage.setItem` calls. Main grew
`seedAuthLocalStorage(page, token, subjectJson)` while this branch was out,
and both `loginAs` and `bootVisitor` already call it. A helper whose reason to
exist is removing copies may not carry one.

That verb surfaced from reading the BODY inside the rebase conflict rather
than just resolving it — the conflict was trivially resolvable either way, so
resolvability was not the signal. Recorded as a rule in DESIGN_NOTES.

## `loginAs` was walked up to and NOT adopted

Its seeding half is now literally the same call, but the seeded admin
(`admin-vjt`) has no networks bound, so reaching `loginAs` means
`noNetworks: true` — a documented weakening of the post-login invariant — and
buys `waitForUserTopicReady`, a real barrier against a race none of these
twenty specs runs into today. It also rests on an unverified link
(`socketUserName()` matching the seeded admin name). The question stays open
with its price attached: one e2e run.

## Test plan

- [x] `scripts/bun.sh run check` rc=0 — `biome check && tsc --noEmit &&
      tsc --noEmit -p e2e/tsconfig.json`, 1054 files checked, 59 warnings and
      6 infos all pre-existing in `src/themes/default.css`, a file this branch
      does not touch. The e2e `tsc` pass is the oracle that matters here: a
      mutant removing the seed parameter fails it with 54 errors across 20
      files, which is exactly the census.
- [x] `scripts/design-notes-gate.sh`: 1 new entry heading, separator and
      marker present.
- [x] Four DESIGN_NOTES checks after each rebase: numstat identical (81/0,
      zero deletions), marker unique and total +1, preceding-entry tail
      re-captured from the new base and byte-identical, boundary read with
      `od -c`.
- [ ] Behaviour is NOT covered by any gate reachable without the exclusive
      e2e lane: removing the `expectShellReady` barrier from the helper keeps
      both `bun run check` and the vitest suite green. The type-checker is a
      complete oracle for the WIRING and a blind one for the BEHAVIOUR.