### PR TITLE
test(#1397): migrate the seven sites #1544 deferred, and the eighth it missed

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50578,3 +50578,86 @@ shape this entry's own separator had to match, and then a name-only census was
 run anyway, by the same hand. Knowing the rule and holding it are different
 states. Treat any name-level count here as a lower bound on the truth and an
 upper bound on the finding — including the ones in this entry.
+<!-- entry #1397-deferred7 -->
+
+---
+
+## 2026-08-19 — #1397: the seven #1544 deferred, the eighth it missed, and a blocker that expired
+
+#1544 collapsed 62 inline 001 handlers onto `IRCServer.welcome_handler/2` and
+left seven behind. This entry records closing them, the one it had not counted,
+and the two rules the closing turned up.
+
+### A declared blocker is a measurement with an expiry date
+
+The deferral had a precise reason, and #1544 wrote it down rather than gesturing
+at "conflicts": the tail of those seven handlers (`end / end / blank`) was
+literally the context of #1535's hunks, so rewriting them would have collided in
+whichever order the branches landed. That was TRUE when written. #1535 has since
+landed, and re-measuring finds nothing in the way.
+
+🥇 The general form, worth more than this instance: **a blocker recorded in an
+issue is a measurement of a moment, not a property of the code.** It is
+re-measured before it is honoured. The failure mode it guards against is the
+opposite of the usual one — not acting on a stale green, but declining to act on
+a stale red, which is invisible because nothing breaks when you obey it.
+
+### No artifact lists the seven, so they were reconstructed — twice
+
+The issue gives a count, never a list, and its own line numbers had moved. Two
+independent methods were run and agree exactly:
+
+  * hashing each candidate BODY with the name masked leaves them as clusters of
+    five and two, byte-identical within each;
+  * replaying #1535's hunks against its own base (`e179e35c`) puts each of the
+    seven exactly four lines above a hunk, with its tail inside the context —
+    and puts nothing else in those files near one.
+
+Agreement of two methods is what makes this "identified" rather than "likely".
+The anchor was validated too: at #1544's own base it counts 62, which is the
+number #1544 published, so it is that census and not a different one.
+
+### The eighth, and the arithmetic it corrects
+
+#1544 reports 62 = 55 migrated + 7 deferred. The same anchor counts 54 + 7 + 1.
+The extra one is the handler in "RPL_WELCOME echoes welcomed nick": no hunk of
+#1535 was near it, so the deferral criterion never covered it, and it groups
+alone only because a three-line comment sits inside its `if`. A name-based
+search cannot see it either — it is bound to `welcomed_nick_handler`.
+
+It migrated, and the rule that decided so is the one the wrapper cluster already
+used, read in the other direction. The comment explains why THIS TEST wants a
+nick it did not request (a caller's reason), not a behaviour the shared helper
+lacks — so it moves to the call site and nothing is hidden. `welcome_handler/2`
+takes the nick as an argument, so the bytes are unchanged. Had the comment
+described an observable the helper does not have, folding it in would have
+buried it, and it would have stayed inline. **A wrapper may hide a no-op; it may
+not hide an observable** — and a comment is subject to the same test.
+
+### The mutant, and the fifty tests that cannot see it
+
+No characterization commit precedes the migration: the inline gesture IS the
+consolidated expression, so a lock would have been a green that cannot fail.
+What the slice needs instead is evidence the call sites now READ the helper, and
+that is a mutant — `welcome_handler/2` stops replying to `USER` — run on both
+sides of the change over the same 64 tests:
+
+| tree | result |
+|---|---|
+| branch, no mutant | 64 tests, 0 failures |
+| branch, mutant | 64 tests, **10 failures** |
+| base (`2d61b51d`), mutant | 64 tests, **0 failures** |
+
+The base row is the one that attributes the kills: before the migration those
+sites carried their own bodies and were immune, so the ten deaths are the
+migration and nothing else.
+
+🥇 The row worth keeping is the asymmetry INSIDE the ten. The kills come from
+three of the eight sites; the other five — the setups of five `server_test`
+describes, 50 of the 64 tests — go on passing with the shared 001 handler
+answering nothing at all. Those describes assert on the bytes their verbs put
+on the wire, never on having registered. So for five of the eight sites the
+migration is behaviour-preserving by CONSTRUCTION (same arguments, same emitted
+string) and unwitnessed by any assertion in the suite. That is worth knowing
+before someone reads a green suite as coverage of this helper: for most of its
+call sites, it is not.

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -51,13 +51,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
   # while the session still holds `@configured_nick` — the whole point there
   # is history that predates the rename.
   defp start_session_at_configured_nick do
-    rfc_handler = fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":server 001 #{@configured_nick} :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    rfc_handler = IRCServer.welcome_handler(":server", @configured_nick)
 
     {server, port} = IRCServer.start_server(rfc_handler)
 

--- a/test/grappa/session/nick_change_observability_test.exs
+++ b/test/grappa/session/nick_change_observability_test.exs
@@ -63,13 +63,7 @@ defmodule Grappa.Session.NickChangeObservabilityTest do
   # PING/PONG round-trip flushes the cross-process NICK pipeline (TCP buffer
   # → Client → Session mailbox) so the rename has landed before assertions.
   defp start_renamed_session do
-    rfc_handler = fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":server 001 #{@configured_nick} :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    rfc_handler = IRCServer.welcome_handler(":server", @configured_nick)
 
     {server, port} = IRCServer.start_server(rfc_handler)
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -4093,16 +4093,10 @@ defmodule Grappa.Session.ServerTest do
     # rows are forever (immutable historical record).
 
     test "RPL_WELCOME echoes welcomed nick: subsequent PRIVMSG persists with welcomed nick" do
-      welcomed_nick_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          # Server registers the operator under a different nick than
-          # the one requested (rare but possible — Azzurra used to do
-          # this with case-fold normalization).
-          {:reply, ":server 001 grappa-actual :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      # Server registers the operator under a different nick than the one
+      # requested (rare but possible — Azzurra used to do this with
+      # case-fold normalization).
+      welcomed_nick_handler = IRCServer.welcome_handler(":server", "grappa-actual")
 
       {server, port} = IRCServer.start_server(welcomed_nick_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -10807,13 +10801,7 @@ defmodule Grappa.Session.ServerTest do
 
     setup do
       # Feed 001 so the session autojoins; wait for the JOIN; echo JOIN-self back.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -11051,13 +11039,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "C2 — /whois bundle aggregation + Topic.user/1 broadcast" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -11745,13 +11727,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#140 — /names roster bundle (ephemeral names_reply, not persisted)" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -11867,13 +11843,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#169 — /who roster bundle (ephemeral who_reply, not persisted)" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -12506,13 +12476,7 @@ defmodule Grappa.Session.ServerTest do
     # "send_quit/2 returns {:error, _} when socket is nil" coverage.
 
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})


### PR DESCRIPTION
## What

#1544 collapsed 62 inline 001 handlers onto `IRCServer.welcome_handler/2` and
left seven behind. This migrates them, plus an eighth it had not counted. The
inline 001 handler is now at ZERO in `test/` — the only remaining matches of
the anchor are two `cond` arms in `client_test` that also answer `CAP LS`, so
they are different behaviour, not copies.

## The blocker had expired

#1544 stated its reason precisely rather than gesturing at "conflicts": the
tail of those seven handlers (`end / end / blank`) was literally the context of
#1535's hunks, so rewriting them would have collided in whichever order the
branches landed. That was true when written. **#1535 has landed**, and
re-measuring finds nothing in the way.

The general form is worth more than the instance: a blocker recorded in an
issue is a measurement of a moment, not a property of the code. Nothing breaks
when you keep obeying a stale red, which is exactly why it goes unnoticed.

## No artifact lists the seven, so they were reconstructed — twice

The issue gives a count, never a list, and its line numbers had moved. Two
independent methods agree exactly:

* hashing each candidate BODY with the name masked leaves clusters of five and
  two, byte-identical within each;
* replaying #1535's hunks against its own base (`e179e35c`) puts each of the
  seven exactly four lines above a hunk, tail inside the context — and puts
  nothing else in those files near one.

The anchor itself was calibrated before being trusted: at #1544's own base it
counts **62**, the number #1544 published, so it is that census and not a
different one.

## The eighth — and it corrects the arithmetic #1544 published

#1544 reports `62 = 55 migrated + 7 deferred`. The same anchor counts
**`54 + 7 + 1`**. The extra site is the handler in *"RPL_WELCOME echoes
welcomed nick"*: no hunk of #1535 was near it, so the deferral criterion never
covered it, and it groups alone only because a three-line comment sits inside
its `if`. A name search misses it too — it is bound to `welcomed_nick_handler`.

It migrated. The comment reads *"Server registers the operator under a
different nick than the one requested (rare but possible — Azzurra used to do
this with case-fold normalization)"* — that is why THIS TEST wants a nick it
did not request, a caller's reason, not a behaviour the shared helper lacks.
So it moves to the call site; `welcome_handler/2` takes the nick as an
argument and the bytes on the wire are unchanged. Had it described an
observable the helper does not have, folding it in would have buried it and it
would have stayed inline.

## No characterization commit, and why

The inline gesture IS the consolidated expression here — a pure substitution —
so a lock would have been a green that cannot fail. `welcome_handler/2` has
carried its own test since #1544. What this slice needs is evidence the call
sites now READ it, which is the mutant below.

## The mutant, run on BOTH sides

`welcome_handler/2` stops replying to `USER`, over the same 64 tests:

| tree | result |
|---|---|
| branch, no mutant | 64 tests, 0 failures |
| branch, mutant | 64 tests, **10 failures** |
| base `2d61b51d`, mutant | 64 tests, **0 failures** |

The base row is what attributes the kills: before the migration those sites
carried their own bodies and were immune, so the ten deaths are this change and
nothing else. Anchor was one-shot (aborts if the match count is not 1), tree
committed first, restored with `git checkout HEAD --` and verified clean by
`git status --porcelain` on both sides; the base bench was a throwaway
`--detach` worktree, since removed.

**The asymmetry inside the ten is the finding.** They come from three of the
eight sites. The other five — the setups of five `server_test` describes, **50
of the 64 tests** — go on passing with the shared 001 handler answering nothing
at all; they assert on the bytes their verbs put on the wire, never on having
registered. So for five of eight sites this migration is behaviour-preserving
by CONSTRUCTION and unwitnessed by any assertion. Worth knowing before a green
suite is read as coverage of this helper.

## Test plan

- [x] `scripts/check.sh` rc=0, every stage exhibited: credo `6083 mods/funs,
      found no issues` · dialyzer `Total errors: 0` · sobelow `No
      vulnerabilities found.` · doctor `Doctor validation has passed!` ·
      `8 doctests, 61 properties, 6555 tests, 0 failures` · bats `1..564`,
      zero `not ok`
- [x] Test count UNCHANGED against main (6555 both sides) — correct for a pure
      refactor that neither adds nor removes a test
- [x] `scripts/design-notes-gate.sh`: 1 new entry heading, separator and marker
      present
- [x] Mutation bench, both sides, tree restored clean afterwards
- [x] Post-migration re-census with the WIDE anchor (block form, keyword
      `, do:` form, `cond` arms): zero inline copies left, with a positive
      control proving the anchor still sees the definition in
      `test/support/irc_server.ex`