### PR TITLE
test(#1397): union of #1553 + #1557 — the last eight start_irc_server wrappers, and the seven #1544 deferred

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50684,3 +50684,92 @@ an equivalence oracle written against wrapper bodies that a landed branch had
 already rewritten, discovered only after the rebase had cheerfully carried them
 forward as greens that could no longer fail. On a rebase, read what the other
 side's code now SAYS, not merely whether the two sides can be reconciled.
+<!-- entry #1397-startircserver -->
+
+---
+
+## 2026-08-19 — #1397 bucket H: the last eight start_irc_server wrappers, and a slice that changed shape underneath
+
+Eight test files each kept a zero-argument `start_irc_server/0` and called it
+from seventy-two sites. They are gone and the handler is spelled at all
+seventy-two, finishing the set #1535 opened.
+
+### The slice was not the same slice by the time it was worked
+
+Planned against a base where each wrapper still held the two-step body —
+`start_link/1` then `port/1` — this was going to be a behavioural
+consolidation onto `start_server/1`, with a characterization test and an
+equivalence oracle, the shape the sibling dead-port slice used. Both were
+written, both passed, both were discriminating under mutants.
+
+Then #1535 landed, and it had already rewritten every one of the eight bodies
+into a one-line delegation to `start_server(passthrough_handler())`. The
+inlining became pure substitution: the expression a call site now carries is
+byte-for-byte the body of the wrapper it replaces. The characterization test
+was pinning a body that no longer existed anywhere, and the equivalence oracle
+had become a comparison between an expression and itself — a green that could
+not fail and therefore could not mean anything.
+
+Both were discarded rather than rebased. Worth recording, because the rebase
+offered to keep them: the conflicts were resolvable and the tests would have
+gone green on the new base. A test that cannot fail passes every review that
+only reads its colour. The signal that something had changed was not the
+conflict, it was the wrapper body inside it.
+
+### What the slice actually needed instead
+
+`passthrough_handler/0` and `start_server/1` are named at seventy-two call
+sites by this change, and neither had a test — like the twenty copies #1535
+removed, they were exercised only through whatever their callers did next.
+So the missing work was never a characterization; it was coverage of the two
+helpers, in the shape `welcome_handler/2` got when #1544 hoisted it: the
+handler checked as a plain function, the server through a socket.
+
+What `passthrough_handler/0` promises is that it answers NOTHING, whatever
+arrives, and leaves handler state alone. That promise is the whole reason a
+call site must be able to name it instead of inheriting it from a
+zero-argument wrapper — and until now nothing said it.
+
+### The sibling family that looks identical and is not
+
+`u()`/`uniq()` — eighteen copies, one hundred and sixty-four call sites —
+stays. It is a pure alias: a short name for a long expression, hiding nothing,
+because there is no argument at the call site to get wrong.
+`start_irc_server()` hid WHICH PEER, which is decidable at the call site and
+is precisely what the earlier ruling says must stay there. Copy count is not
+the criterion; whether the wrapper removes a decision is.
+
+### The alias is a measurement, not a taste
+
+Six of the eight reached the module by its full name. Inlining meant either
+six alias lines or sixty fully-qualified call sites, and the codebase had
+already answered: 460 aliased inline spellings against 0 qualified. The count
+was taken with a fixed-string grep — in a regex `.` is a wildcard, and the
+whole argument is the count.
+
+Two anchors lied during this slice before either number was believed, both in
+the reassuring direction. A predicate written as an equality against
+`"PING :probe"` never matched, because `packet: :line` hands the delimiter to
+the buffer and the stored line keeps its CRLF; that is why every predicate in
+that suite is a prefix test.
+
+The second is **the sixth false zero this bucket has produced**, and the first
+where the anchor was not the pattern but the FILE LIST. A list held in an
+unquoted shell variable reaches `grep` as ONE filename, because zsh does not
+word-split parameter expansions; `grep` here is ugrep, which puts
+`No such file or directory` on stderr and nothing on stdout, so a `| wc -l`
+turns the error into a clean `0`. The residual-count check answered a
+confident zero for a tree that had seventy-two matches in it. Pass a real
+array (`"${files[@]}"`), and when a list-of-files count comes back zero, re-ask
+it against one known-positive file before believing it.
+
+The five before it were all pattern-shaped: an anchor too wide (`def
+start_server` matching `start_server_with_001`), one too narrow (`defp name\(`
+scoring zero against `defp name, do:`), `\s` and `\b` used under POSIX ERE
+where they do not exist, a brace in an ERE opening an interval and invalidating
+the whole pattern, and `grep -o` discarding the prefix a follow-on `grep -v`
+was meant to filter on. Six distinct mechanisms, one shared symptom: **the
+wrong number always looked like the good news.** A zero is the most suspicious
+result available, not the most reassuring — it is indistinguishable from
+"already done", and every one of the six was caught only by asking a second
+method the same question.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50773,3 +50773,86 @@ wrong number always looked like the good news.** A zero is the most suspicious
 result available, not the most reassuring — it is indistinguishable from
 "already done", and every one of the six was caught only by asking a second
 method the same question.
+<!-- entry #1397-deferred7 -->
+
+---
+
+## 2026-08-19 — #1397: the seven #1544 deferred, the eighth it missed, and a blocker that expired
+
+#1544 collapsed 62 inline 001 handlers onto `IRCServer.welcome_handler/2` and
+left seven behind. This entry records closing them, the one it had not counted,
+and the two rules the closing turned up.
+
+### A declared blocker is a measurement with an expiry date
+
+The deferral had a precise reason, and #1544 wrote it down rather than gesturing
+at "conflicts": the tail of those seven handlers (`end / end / blank`) was
+literally the context of #1535's hunks, so rewriting them would have collided in
+whichever order the branches landed. That was TRUE when written. #1535 has since
+landed, and re-measuring finds nothing in the way.
+
+🥇 The general form, worth more than this instance: **a blocker recorded in an
+issue is a measurement of a moment, not a property of the code.** It is
+re-measured before it is honoured. The failure mode it guards against is the
+opposite of the usual one — not acting on a stale green, but declining to act on
+a stale red, which is invisible because nothing breaks when you obey it.
+
+### No artifact lists the seven, so they were reconstructed — twice
+
+The issue gives a count, never a list, and its own line numbers had moved. Two
+independent methods were run and agree exactly:
+
+  * hashing each candidate BODY with the name masked leaves them as clusters of
+    five and two, byte-identical within each;
+  * replaying #1535's hunks against its own base (`e179e35c`) puts each of the
+    seven exactly four lines above a hunk, with its tail inside the context —
+    and puts nothing else in those files near one.
+
+Agreement of two methods is what makes this "identified" rather than "likely".
+The anchor was validated too: at #1544's own base it counts 62, which is the
+number #1544 published, so it is that census and not a different one.
+
+### The eighth, and the arithmetic it corrects
+
+#1544 reports 62 = 55 migrated + 7 deferred. The same anchor counts 54 + 7 + 1.
+The extra one is the handler in "RPL_WELCOME echoes welcomed nick": no hunk of
+#1535 was near it, so the deferral criterion never covered it, and it groups
+alone only because a three-line comment sits inside its `if`. A name-based
+search cannot see it either — it is bound to `welcomed_nick_handler`.
+
+It migrated, and the rule that decided so is the one the wrapper cluster already
+used, read in the other direction. The comment explains why THIS TEST wants a
+nick it did not request (a caller's reason), not a behaviour the shared helper
+lacks — so it moves to the call site and nothing is hidden. `welcome_handler/2`
+takes the nick as an argument, so the bytes are unchanged. Had the comment
+described an observable the helper does not have, folding it in would have
+buried it, and it would have stayed inline. **A wrapper may hide a no-op; it may
+not hide an observable** — and a comment is subject to the same test.
+
+### The mutant, and the fifty tests that cannot see it
+
+No characterization commit precedes the migration: the inline gesture IS the
+consolidated expression, so a lock would have been a green that cannot fail.
+What the slice needs instead is evidence the call sites now READ the helper, and
+that is a mutant — `welcome_handler/2` stops replying to `USER` — run on both
+sides of the change over the same 64 tests:
+
+| tree | result |
+|---|---|
+| branch, no mutant | 64 tests, 0 failures |
+| branch, mutant | 64 tests, **10 failures** |
+| base (`2d61b51d`), mutant | 64 tests, **0 failures** |
+
+The base row is the one that attributes the kills: before the migration those
+sites carried their own bodies and were immune, so the ten deaths are the
+migration and nothing else.
+
+🥇 The row worth keeping is the asymmetry INSIDE the ten. The kills come from
+three of the eight sites; the other five — the setups of five `server_test`
+describes, 50 of the 64 tests — go on passing with the shared 001 handler
+answering nothing at all. Those describes assert on the bytes their verbs put
+on the wire, never on having registered. So for five of the eight sites the
+migration is behaviour-preserving by CONSTRUCTION (same arguments, same emitted
+string) and unwitnessed by any assertion in the suite. That is worth knowing
+before someone reads a green suite as coverage of this helper: for most of its
+call sites, it is not.

--- a/test/grappa/account_deletion_test.exs
+++ b/test/grappa/account_deletion_test.exs
@@ -21,7 +21,7 @@ defmodule Grappa.AccountDeletionTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{AccountDeletion, Accounts, AdmissionStateHelpers, Scrollback, Session}
+  alias Grappa.{AccountDeletion, Accounts, AdmissionStateHelpers, IRCServer, Scrollback, Session}
   alias Grappa.Accounts.User
   alias Grappa.Networks.Credentials
   alias Grappa.Scrollback.Message
@@ -31,10 +31,6 @@ defmodule Grappa.AccountDeletionTest do
   setup do
     AdmissionStateHelpers.reset_all()
     :ok
-  end
-
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   # A registered visitor = identified on some network. #211 phase 7 —
@@ -66,8 +62,8 @@ defmodule Grappa.AccountDeletionTest do
 
   describe "delete_account/1 — user" do
     test "non-admin user: stops every live session, deletes the row + cascade deps" do
-      {server1, port1} = start_irc_server()
-      {server2, port2} = start_irc_server()
+      {server1, port1} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {server2, port2} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       user = user_fixture(is_admin: false)
       {network1, _} = network_with_server(port: port1)
@@ -77,8 +73,8 @@ defmodule Grappa.AccountDeletionTest do
 
       pid1 = start_session_for(user, network1)
       pid2 = start_session_for(user, network2)
-      :ok = Grappa.IRCServer.await_handshake(server1, 5_000)
-      :ok = Grappa.IRCServer.await_handshake(server2, 5_000)
+      :ok = IRCServer.await_handshake(server1, 5_000)
+      :ok = IRCServer.await_handshake(server2, 5_000)
       ref1 = Process.monitor(pid1)
       ref2 = Process.monitor(pid2)
 
@@ -110,11 +106,11 @@ defmodule Grappa.AccountDeletionTest do
 
   describe "delete_account/1 — visitor" do
     test "registered visitor: stops the session, deletes the row + cascade deps" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = registered_visitor(port)
 
       pid = start_visitor_session_for(visitor, network)
-      :ok = Grappa.IRCServer.await_handshake(server, 5_000)
+      :ok = IRCServer.await_handshake(server, 5_000)
       ref = Process.monitor(pid)
 
       session = visitor_session_fixture(visitor)
@@ -143,7 +139,7 @@ defmodule Grappa.AccountDeletionTest do
 
   describe "the #126 boundary — quit preserves, delete wipes" do
     test "a registered visitor's row SURVIVES detach (quit) but is WIPED by delete_account" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       # Detach (the quit composite's web-revoke leg) no-ops purge_if_anon
       # for a registered identity — the row survives.

--- a/test/grappa/irc_server_test.exs
+++ b/test/grappa/irc_server_test.exs
@@ -143,4 +143,37 @@ defmodule Grappa.IRCServerTest do
                :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false], 1_000)
     end
   end
+
+  # Both of these are named at seventy-two call sites once the eight
+  # `start_irc_server/0` wrappers are gone (#1397 bucket H), and neither
+  # had a test: they were exercised only through whatever their callers
+  # did next. The same reason `welcome_handler/2` earned one above.
+  describe "passthrough_handler/0" do
+    test "replies to nothing, whatever the line, and leaves handler state untouched" do
+      handler = IRCServer.passthrough_handler()
+
+      assert {:reply, nil, %{step: 1}} = handler.(%{step: 1}, "USER vjt 0 * :Marcello\r\n")
+      assert {:reply, nil, %{}} = handler.(%{}, "PING :probe\r\n")
+    end
+  end
+
+  describe "start_server/1" do
+    test "returns a live peer and the port a client actually reaches it on" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+
+      assert is_pid(server) and Process.alive?(server)
+      assert port == IRCServer.port(server)
+
+      {:ok, sock} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+      on_exit(fn -> :gen_tcp.close(sock) end)
+
+      # `packet: :line` hands the delimiter to the buffer, so a stored line
+      # keeps its CRLF — which is why every predicate here is a prefix test
+      # rather than an equality.
+      :ok = :gen_tcp.send(sock, "PING :probe\r\n")
+
+      assert {:ok, "PING :probe\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PING :probe"), 1_000)
+    end
+  end
 end

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -17,16 +17,12 @@ defmodule Grappa.LiveIntrospectionTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{AdmissionStateHelpers, LiveIntrospection, Session}
+  alias Grappa.{AdmissionStateHelpers, IRCServer, LiveIntrospection, Session}
   alias Grappa.LiveIntrospection.SessionEntry
 
   setup do
     AdmissionStateHelpers.reset_all()
     :ok
-  end
-
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "list_sessions/0" do
@@ -35,7 +31,7 @@ defmodule Grappa.LiveIntrospectionTest do
     end
 
     test "returns one entry per live Session.Server with introspection fields" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -54,7 +50,7 @@ defmodule Grappa.LiveIntrospectionTest do
       # {:irc_peer, _}, so waiting for it guarantees the peer is captured before
       # the scan — the same deterministic barrier the #550 peer-capture test
       # below uses. NOT an assertion weakening: it makes `== []` honest.
-      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       entries = LiveIntrospection.list_sessions()
 
@@ -76,7 +72,7 @@ defmodule Grappa.LiveIntrospectionTest do
     end
 
     test "returns the SessionEntry for a registered subject" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -99,12 +95,12 @@ defmodule Grappa.LiveIntrospectionTest do
       # 127.0.0.1:<port>; USER is sent right after the Client pushes
       # {:irc_peer, _}, so waiting for it guarantees the peer is captured
       # before the registry scan reads it.
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       _ = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
 
-      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       entry = LiveIntrospection.lookup_session({:visitor, visitor.id}, network.id)
 

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -17,7 +17,7 @@ defmodule Grappa.OperatorTest do
   import Grappa.AuthFixtures
 
   alias Grappa.Accounts.User
-  alias Grappa.{AdmissionStateHelpers, DbLatency, Operator, Session}
+  alias Grappa.{AdmissionStateHelpers, DbLatency, IRCServer, Operator, Session}
   alias Grappa.Networks.Credential
   alias Grappa.Visitors.Visitor
 
@@ -28,13 +28,9 @@ defmodule Grappa.OperatorTest do
     :ok
   end
 
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
-  end
-
   describe "delete_visitor!/1" do
     test "synchronously terminates the visitor's Session.Server and deletes the row" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -74,7 +70,7 @@ defmodule Grappa.OperatorTest do
 
   describe "delete_user/2 (admin user teardown, S7)" do
     test "stops the user's live Session.Server(s) and deletes the row" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {network, _} = network_with_server(port: port)
       _ = credential_fixture(vjt, network, %{nick: "vjt"})
@@ -99,7 +95,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "refuses :last_admin and tears down NOTHING (row + live session survive)" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       raw_admin = user_fixture(name: "sole-#{System.unique_integer([:positive])}")
       {:ok, admin} = Grappa.Accounts.update_admin_flags(raw_admin, %{is_admin: true})
       {network, _} = network_with_server(port: port)
@@ -220,7 +216,7 @@ defmodule Grappa.OperatorTest do
 
   describe "list_credentials_text!/0" do
     test "prints header + one row per bound credential, including parked + failed states" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       slug = "cred-#{System.unique_integer([:positive])}"
       {network, _} = network_with_server(port: port, slug: slug)
@@ -252,7 +248,7 @@ defmodule Grappa.OperatorTest do
 
   describe "list_sessions_text!/0" do
     test "prints header + one row per live Session.Server with introspection" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
 
@@ -352,7 +348,7 @@ defmodule Grappa.OperatorTest do
 
   describe "terminate_session/3 (M-9a)" do
     test "stops the visitor pid and leaves the visitor row" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -365,7 +361,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "stops the user pid and leaves the credential row (state still :connected)" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {network, _} = network_with_server(port: port)
       _ = credential_fixture(vjt, network, %{nick: "vjt"})
@@ -408,7 +404,7 @@ defmodule Grappa.OperatorTest do
 
   describe "disconnect_session/3 (M-9a)" do
     test "user :connected → :parked + pid gone" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {network, _} = network_with_server(port: port)
       _ = credential_fixture(vjt, network, %{nick: "vjt"})
@@ -465,7 +461,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "visitor collapses to terminate (pid gone, row preserved)" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -482,7 +478,7 @@ defmodule Grappa.OperatorTest do
       # fire — otherwise the function correctly returns :not_found
       # before reaching the self-protect branch (so 422 vs 404 doesn't
       # leak "this network has a row" to an unauthorized caller).
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {network, _} = network_with_server(port: port)
       _ = credential_fixture(vjt, network, %{nick: "vjt"})
@@ -505,7 +501,7 @@ defmodule Grappa.OperatorTest do
 
   describe "reconnect_session/2 (#269)" do
     test "visitor with a downed session → :ok + pid back up" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -524,7 +520,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "idempotent when a live session already exists (:already_started → :ok)" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -535,7 +531,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "visitor with no credential on the target network → {:error, :resolve_failed}" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, _} = visitor_with_network(port)
       # A DIFFERENT network the visitor holds no credential on.
       {network_b, _} = network_with_server(port: 1)
@@ -552,7 +548,7 @@ defmodule Grappa.OperatorTest do
     end
 
     test "unknown network id → {:error, :not_found}" do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, _} = visitor_with_network(port)
 
       assert {:error, :not_found} =

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -51,13 +51,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
   # while the session still holds `@configured_nick` — the whole point there
   # is history that predates the rename.
   defp start_session_at_configured_nick do
-    rfc_handler = fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":server 001 #{@configured_nick} :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    rfc_handler = IRCServer.welcome_handler(":server", @configured_nick)
 
     {server, port} = IRCServer.start_server(rfc_handler)
 

--- a/test/grappa/session/nick_change_observability_test.exs
+++ b/test/grappa/session/nick_change_observability_test.exs
@@ -63,13 +63,7 @@ defmodule Grappa.Session.NickChangeObservabilityTest do
   # PING/PONG round-trip flushes the cross-process NICK pipeline (TCP buffer
   # → Client → Session mailbox) so the rename has landed before assertions.
   defp start_renamed_session do
-    rfc_handler = fn state, line ->
-      if String.starts_with?(line, "USER ") do
-        {:reply, ":server 001 #{@configured_nick} :Welcome\r\n", state}
-      else
-        {:reply, nil, state}
-      end
-    end
+    rfc_handler = IRCServer.welcome_handler(":server", @configured_nick)
 
     {server, port} = IRCServer.start_server(rfc_handler)
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -4093,16 +4093,10 @@ defmodule Grappa.Session.ServerTest do
     # rows are forever (immutable historical record).
 
     test "RPL_WELCOME echoes welcomed nick: subsequent PRIVMSG persists with welcomed nick" do
-      welcomed_nick_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          # Server registers the operator under a different nick than
-          # the one requested (rare but possible — Azzurra used to do
-          # this with case-fold normalization).
-          {:reply, ":server 001 grappa-actual :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      # Server registers the operator under a different nick than the one
+      # requested (rare but possible — Azzurra used to do this with
+      # case-fold normalization).
+      welcomed_nick_handler = IRCServer.welcome_handler(":server", "grappa-actual")
 
       {server, port} = IRCServer.start_server(welcomed_nick_handler)
       {user, network, _} = setup_user_and_network(port)
@@ -10807,13 +10801,7 @@ defmodule Grappa.Session.ServerTest do
 
     setup do
       # Feed 001 so the session autojoins; wait for the JOIN; echo JOIN-self back.
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
@@ -11051,13 +11039,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "C2 — /whois bundle aggregation + Topic.user/1 broadcast" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -11745,13 +11727,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#140 — /names roster bundle (ephemeral names_reply, not persisted)" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -11867,13 +11843,7 @@ defmodule Grappa.Session.ServerTest do
 
   describe "#169 — /who roster bundle (ephemeral who_reply, not persisted)" do
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: []})
@@ -12506,13 +12476,7 @@ defmodule Grappa.Session.ServerTest do
     # "send_quit/2 returns {:error, _} when socket is nil" coverage.
 
     setup do
-      handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
-        else
-          {:reply, nil, state}
-        end
-      end
+      handler = IRCServer.welcome_handler(":server", "grappa-test")
 
       {server, port} = IRCServer.start_server(handler)
       {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -16,17 +16,13 @@ defmodule Grappa.Visitors.ReaperTest do
   import ExUnit.CaptureLog
   import Grappa.AuthFixtures, only: [network_fixture: 1, start_visitor_session_for: 2, visitor_with_network: 2]
 
-  alias Grappa.{AdmissionStateHelpers, Push, QueryWindows, ReadCursor, Session, UserSettings, Visitors}
+  alias Grappa.{AdmissionStateHelpers, IRCServer, Push, QueryWindows, ReadCursor, Session, UserSettings, Visitors}
   alias Grappa.Repo.BusyRetry
   alias Grappa.Visitors.{Reaper, Visitor}
 
   setup do
     AdmissionStateHelpers.reset_all()
     :ok
-  end
-
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   defp expire(visitor) do
@@ -77,7 +73,7 @@ defmodule Grappa.Visitors.ReaperTest do
     end
 
     test "terminates live Session.Server before deleting expired visitor row" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port, [])
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -93,7 +89,7 @@ defmodule Grappa.Visitors.ReaperTest do
       refute Repo.reload(visitor)
 
       assert {:ok, _} =
-               Grappa.IRCServer.wait_for_line(
+               IRCServer.wait_for_line(
                  server,
                  &(&1 == "QUIT :visitor session expired\r\n"),
                  1_000

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -131,10 +131,6 @@ defmodule GrappaWeb.GrappaChannelTest do
 
   # Shared IRC-fake helpers for after-join snapshot tests.
 
-  defp start_irc_server do
-    IRCServer.start_server(IRCServer.passthrough_handler())
-  end
-
   defp setup_user_and_network_with_session(port, extra_cred_attrs \\ %{}) do
     user_name = "ch-snap-#{System.unique_integer([:positive])}"
     user = user_fixture(name: user_name)
@@ -278,7 +274,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     end
 
     test "after-join snapshot: pushes cached topic_changed if session has topic cached" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -300,7 +296,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     end
 
     test "after-join snapshot: pushes cached channel_modes_changed if session has modes cached" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -326,7 +322,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # per-channel snapshot: a client in ten channels got ten byte-identical
     # copies, and a client in none got zero. This is the fan-out half.
     test "after-join snapshot: does NOT push ISUPPORT on a channel topic (#1255)" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -384,7 +380,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # landed → without snapshot push, cic's members pane stays empty.
       # The snapshot push closes the race by re-emitting the seeded list
       # on the cold subscribe.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -425,7 +421,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # may have fired before WS subscribe; the snapshot push must
       # re-emit it so cic transitions the window from :pending to
       # :joined on reconnect without polling.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       # welcome_session_on_channel feeds the self-JOIN echo, which sets
@@ -450,7 +446,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Snapshot payload must be byte-identical to the event-time
       # broadcast — including by + reason — so cic's renderer doesn't
       # branch on origin. Validates the window_kicked_meta mirror map.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -486,7 +482,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # stayed empty. The user-class equivalent of this test
       # ("CP15 B3") already covered the user path; this is the visitor
       # parity case.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
 
       welcome_visitor_on_channel(
@@ -532,7 +528,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # carries `numeric` as a stable cross-language key for a future
       # cic-side i18n layer (server-provided reasons are
       # upstream-language-locked; numerics are RFC).
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       :ok = IRCServer.await_handshake(irc_server, 1_000)
@@ -832,7 +828,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     end
 
     test "user-topic join pushes presence_snapshot for a live non-empty map (#364 web S4)" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       # Seed the watch list BEFORE end-of-MOTD so arm_presence reads it.
@@ -960,7 +956,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # client on the user topic, and it reaches a client that is in NO
     # channel at all — which the per-channel snapshot could never serve.
     test "after-join snapshot: pushes the network's ISUPPORT on the user topic (#216/#1255)" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -1011,7 +1007,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # and which cic wires to the ordinary channel handler, so the old
       # replay did arrive — through a window unrelated to the fact it
       # carried. What this pins is the door, not a rescue.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       # Registration WITHOUT joining any channel — the deliberate difference
@@ -1052,7 +1048,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # the replay back inside `push_channel_snapshot/4` this receives THREE
       # byte-identical copies and the refutation below fails; the payload
       # describes the network, so one is the only defensible number.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -1095,7 +1091,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # the umode snapshot rides the USER-topic after_join. cic reconnects
       # its WS long after the 221 RPL_UMODEIS fired, so without this the
       # /mode <nick> modal would stay blank until a mid-session change.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -1132,7 +1128,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # field, the banner would come back nameless after every reload. This
       # is the assertion that makes that storage load-bearing rather than
       # incidental.
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
 
       welcome_session_on_channel(irc_server, "#snap")
@@ -1370,7 +1366,7 @@ defmodule GrappaWeb.GrappaChannelTest do
 
   describe "S5.3 — ops verbs: inbound channel events" do
     setup do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
       welcome_session_on_channel(irc_server, "#snap")
       topic = Topic.user(user.name)
@@ -1695,7 +1691,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # Pre-#153 this replied `visitor_not_allowed` via the removed
     # `dispatch_ops_verb`/`check_not_visitor` gate.
     test "op: visitor socket ships MODE upstream (issue #153 — no visitor gate)" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -1799,7 +1795,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # runs BEFORE identity resolution — a malformed channel from a
     # visitor is still rejected with `invalid_channel`, not dispatched.
     test "topic_set: visitor socket ships TOPIC upstream (issue #153)" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -1865,7 +1861,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # generalized this to EVERY verb — see the sibling "op:/topic_set:/raw:
     # visitor socket ships … upstream" tests.
     test "oper: visitor socket ships OPER upstream (issue #148 — not visitor_not_allowed)" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -1990,7 +1986,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # "raw: rejects embedded CRLF" test, which still holds for visitors
     # since validate_args runs before identity resolution).
     test "raw: visitor socket ships the line verbatim upstream (issue #153)" do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2400,7 +2396,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # asymmetry.
   describe "C3 — visitor WHOIS dispatch carve-out" do
     test "visitor socket: whois with live session sends WHOIS upstream" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2429,7 +2425,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # emits `WHOIS <server> <nick>` upstream so the query is answered by that
     # server; single-arg behaviour is byte-identical when "server" is absent.
     test "visitor socket: whois with server emits WHOIS <server> <nick> upstream (#198)" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2487,7 +2483,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # gate at the channel inbound boundary. Pin that visitors hit the
       # same rejection users do (defense in depth — gate fires BEFORE
       # `Session.send_whois/4` is called).
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2517,7 +2513,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     # An absent/unknown token normalizes to :user (covered by the tests
     # above, which never send "source").
     test "whois with source: rail marks the broadcast bundle source: :rail" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2560,7 +2556,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # the same `Session.set_explicit_away/unset_explicit_away` path users do.
   describe "S3.4 — /away explicit away dispatch (user + visitor, issue #62)" do
     test "user socket: away set sends AWAY :reason upstream and returns :ok" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
       welcome_session_on_channel(irc_server, "#snap")
       topic = Topic.user(user.name)
@@ -2582,7 +2578,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     end
 
     test "visitor socket: away set with live session sends AWAY :reason upstream" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2608,7 +2604,7 @@ defmodule GrappaWeb.GrappaChannelTest do
     end
 
     test "visitor socket: away unset after set issues bare AWAY upstream" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2682,7 +2678,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # `Session.send_invite/4` path users do.
   describe "issue #31 — visitor /invite dispatch carve-out" do
     test "visitor socket: invite with live session sends INVITE nick #chan upstream" do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2737,7 +2733,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       # Defense in depth — the inbound `Identifier.valid_nick?` gate fires
       # BEFORE `Session.send_invite/4`, so visitors hit the same rejection
       # users do (mirror of the C3 WHOIS malformed-nick test).
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = setup_visitor_and_network_with_session(port)
       :ok = IRCServer.await_handshake(irc_server, 1_000)
       IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2780,7 +2776,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       @wire_prefix wire_prefix
 
       test "visitor socket: #{@verb} with live session sends upstream line" do
-        {irc_server, port} = start_irc_server()
+        {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
         {visitor, network} = setup_visitor_and_network_with_session(port)
         :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2837,7 +2833,7 @@ defmodule GrappaWeb.GrappaChannelTest do
       end
 
       test "visitor socket: #{@verb} with malformed channel returns a validation error" do
-        {irc_server, port} = start_irc_server()
+        {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
         {visitor, network} = setup_visitor_and_network_with_session(port)
         :ok = IRCServer.await_handshake(irc_server, 1_000)
         IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
@@ -2893,7 +2889,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # which drives two browser contexts on one account.
   describe "#1088 — addressed informational replies" do
     setup do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
       welcome_session_on_channel(irc_server, "#snap")
 
@@ -3330,7 +3326,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # `AuthFSM.new/1` boundary at the IRC core.
   describe "bucket E web/S7 — Channel inbound IRC-shape validation" do
     setup do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
       welcome_session_on_channel(irc_server, "#snap")
       topic = Topic.user(user.name)
@@ -3563,7 +3559,7 @@ defmodule GrappaWeb.GrappaChannelTest do
   # rejects it loudly (mirroring the sibling "visibility" handler).
   describe "#364 web/S2 — away rejects a malformed origin_window" do
     setup do
-      {irc_server, port} = start_irc_server()
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network} = setup_user_and_network_with_session(port)
       welcome_session_on_channel(irc_server, "#snap")
 

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -624,7 +624,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
   describe "POST /admin/credentials — session spawn (#1163)" do
     test "201 + the bound session dials out with no restart", %{conn: conn} do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "bind-spawn-#{uniq()}")
       target_user = user_fixture(name: "bind-spawn-#{uniq()}")
       stop_session_on_exit(target_user, network)
@@ -671,7 +671,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   # admission passes the first test and fails the second.
   describe "POST /admin/credentials — bind door and boot door are one path (#1163)" do
     test "circuit closed: both doors bring a session up", %{conn: conn} do
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "bind-agree-ok-#{uniq()}")
 
       boot_user = boot_bound_user(network, "booted")
@@ -687,7 +687,7 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
     end
 
     test "circuit open: neither door brings a session up", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {network, _} = network_with_server(port: port, slug: "bind-agree-open-#{uniq()}")
       :ok = AdmissionStateHelpers.open_circuit!(network.id)
 
@@ -705,10 +705,6 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
   end
 
   defp uniq, do: System.unique_integer([:positive])
-
-  defp start_irc_server do
-    IRCServer.start_server(IRCServer.passthrough_handler())
-  end
 
   defp stop_session_on_exit(user, network) do
     on_exit(fn -> Session.stop_session({:user, user.id}, network.id, "test teardown") end)

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -35,17 +35,13 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdmissionStateHelpers, Repo, Session}
+  alias Grappa.{Accounts, AdmissionStateHelpers, IRCServer, Repo, Session}
   alias Grappa.Networks.Credential
   alias Grappa.Visitors.Visitor
 
   setup do
     AdmissionStateHelpers.reset_all()
     :ok
-  end
-
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "GET /admin/sessions — auth gate" do
@@ -91,7 +87,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     end
 
     test "200 + entry per live Session.Server with subject_kind and live_state", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -130,12 +126,12 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       # 127.0.0.1:<port>. USER is sent right after the Client pushes
       # {:irc_peer, _}, so waiting for it guarantees the peer is captured
       # before the admin scan reads it.
-      {server, port} = start_irc_server()
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       _ = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
 
-      :ok = Grappa.IRCServer.await_handshake(server, 1_000)
+      :ok = IRCServer.await_handshake(server, 1_000)
 
       session = admin_session()
 
@@ -165,7 +161,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       # state). The controller's batched DB lookup returns no row →
       # `subject_label: nil` surfaces on the wire so the operator can
       # see "orphan pid, no DB row" without remsh-ing into the BEAM.
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -207,7 +203,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       # MAX across all the subject's cookie sessions: multi-device users
       # collapse to "most recent device touch". Visitors typically have
       # exactly one (the anon flow provisions a single cookie).
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -250,7 +246,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       # surface honestly reports `last_seen_at: null` instead of
       # fabricating a "session start time" stand-in. The U-0 honesty
       # rule applied to a new dimension.
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
@@ -348,7 +344,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
 
   describe "DELETE /admin/sessions/:id — admin user" do
     test "204 + pid gone + DB visitor row preserved", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -386,7 +382,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     end
 
     test "422 cannot_disconnect_self when admin deletes own user session", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, admin_sess} = user_and_session()
       {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
 
@@ -441,7 +437,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
 
   describe "POST /admin/sessions/:id/disconnect — admin user" do
     test "204 on user :connected — credential row transitions to :parked, pid gone", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, _} = user_and_session()
       {admin, admin_sess} = user_and_session()
       {:ok, _} = Accounts.update_admin_flags(admin, %{is_admin: true})
@@ -505,7 +501,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     end
 
     test "204 on visitor — collapses to terminate (pid gone, row preserved)", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -528,7 +524,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     end
 
     test "422 cannot_disconnect_self when admin disconnects own user session", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, admin_sess} = user_and_session()
       {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
 
@@ -624,7 +620,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
 
   describe "POST /admin/sessions/:id/reconnect — admin user" do
     test "204 on a downed visitor session — pid comes back up", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -648,7 +644,7 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
     end
 
     test "204 (idempotent) when the visitor session is already live", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -29,7 +29,7 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
   import ExUnit.CaptureIO
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Repo, Session}
+  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, IRCServer, Repo, Session}
   alias Grappa.Visitors.Visitor
   alias GrappaWeb.ShareToken
 
@@ -41,10 +41,6 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
     # status-code assertion alone cannot see.
     AdmissionStateHelpers.reset_admin_events()
     :ok
-  end
-
-  defp start_irc_server do
-    Grappa.IRCServer.start_server(Grappa.IRCServer.passthrough_handler())
   end
 
   describe "DELETE /admin/visitors/:id — auth gate" do
@@ -78,7 +74,7 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
 
   describe "DELETE /admin/visitors/:id — admin user" do
     test "204 + DB row gone + live registry slot freed", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       ref = Process.monitor(pid)
@@ -147,7 +143,7 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
 
   describe "GET /admin/visitors — admin user (M-4)" do
     test "200 + body has visitors array including live visitor with live_state.alive", %{conn: conn} do
-      {_, port} = start_irc_server()
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)


### PR DESCRIPTION
**This supersedes #1553 and #1557.** Both were MERGEABLE and green on
their own, but both append a DESIGN_NOTES entry, so whichever landed
first would have made the other CONFLICTING. Rebasing them separately
would have cost two serialised ~25-minute gates. This branch carries
both, cherry-picked onto a fresh `origin/main` (`0f8f95c2`), so there is
one gate and one merge.

It is also the more honest arrangement: the two branches had never been
gated *together*. A per-PR green attests `branch + base`, never
`branch + the other branch`.

## What is in it

From #1553 (three commits):
- tests for `passthrough_handler/0` and `start_server/1`, which had none
- deletion of the last eight `start_irc_server` wrappers, with 72 call
  sites inlined
- the DESIGN_NOTES entry

From #1557 (two commits):
- migration of the seven sites #1544 deferred, plus an eighth it missed
  (a keyword-form `if ..., do:, else:` that its block-shaped anchor
  could not see)
- the DESIGN_NOTES entry

## Both entries survive

`docs/DESIGN_NOTES.md` markers go 123 → **125**, each unique
(`grep -Fxc` = 1), and the same holds on the fused tree computed with
`git merge-tree --write-tree` against `origin/main`. Both entry bodies
are byte-identical to their originals (89 and 83 lines, summing to the
`172 / 0` numstat), the preceding entry's tail is unchanged, and both
boundaries read `.\n<!-- entry … -->\n\n---\n\n## …` at byte level.
The three-point numstat matches the sum of the two branches exactly,
file by file, across all 13 files.

## Gate

`scripts/check.sh` rc=0 on `71e7840a`, every stage exhibited:

    credo     6075 mods/funs, found no issues.
    dialyzer  Total errors: 0
    sobelow   No vulnerabilities found.
    doctor    Doctor validation has passed!
    test      8 doctests, 61 properties, 6557 tests, 0 failures
    bats      1..564, zero `not ok`

Two numbers corroborate the change rather than merely permitting it:
the test count is main's 6555 **+2**, matching the two tests added, and
credo's function count is main's 6083 **−8**, matching the eight
deleted wrappers.

`origin/main` had not moved when the gate finished.

## Note on the check count

This branch touches only `test/` and `docs/`, so it gets **four**
checks, not five: the `integration` job keys on `cicchetto/e2e/**` in
its `paths:` filter and does not start. That is a different band, not a
missing check.