### PR TITLE
e2e(#1152): resolve the subject's LIVE nick, and make drift loud

### DIFF
--- a/cicchetto/e2e/fixtures/specSubject.ts
+++ b/cicchetto/e2e/fixtures/specSubject.ts
@@ -133,8 +133,27 @@ export async function teardownSpecSubject(subject: SpecSubject): Promise<void> {
 // renaming a call instead of rewriting a signature.
 let current: SpecSubject | null = null;
 
+// #1152 — every nick value the running test actually HANDED OUT, which is
+// what the teardown guard has to judge, and it is not the same thing as
+// the last value cached.
+//
+// Measured on this branch: 19 of the 20 specs that now call
+// `specLiveNick()` also read `specNick()` earlier in the file. Guarding
+// the CACHE alone would let the async call launder it — refresh to the
+// live nick, teardown compares live against live, green — while the stale
+// value those 19 already consumed goes unreported. Recording the values
+// instead makes the guard's question the honest one: was everything this
+// test addressed the nick the session was flying?
+let consumed = new Set<string>();
+
 export function setCurrentSpecSubject(subject: SpecSubject | null): void {
   current = subject;
+  consumed = new Set();
+}
+
+/** Every distinct nick the current test has been handed, in first-seen order. */
+export function consumedSpecNicks(): string[] {
+  return [...consumed];
 }
 
 function requireCurrent(caller: string): SpecSubject {
@@ -159,7 +178,9 @@ export function specUser(): SeededUser {
  * always-correct: see the #1152 note below.
  */
 export function specNick(): string {
-  return requireCurrent("specNick()").nick;
+  const nick = requireCurrent("specNick()").nick;
+  consumed.add(nick);
+  return nick;
 }
 
 // #1152 — the requested nick and the flown nick are two different things.
@@ -243,5 +264,6 @@ export async function specLiveNick(): Promise<string> {
     );
   }
   subject.nick = reading.nick;
+  consumed.add(reading.nick);
   return reading.nick;
 }

--- a/cicchetto/e2e/fixtures/specSubject.ts
+++ b/cicchetto/e2e/fixtures/specSubject.ts
@@ -153,7 +153,95 @@ export function specUser(): SeededUser {
   return requireCurrent("specUser()").user;
 }
 
-/** The per-test user's upstream IRC nick. */
+/**
+ * The per-test user's upstream IRC nick, as last RESOLVED — the requested
+ * one until something re-resolves it. Synchronous, so it cannot be
+ * always-correct: see the #1152 note below.
+ */
 export function specNick(): string {
   return requireCurrent("specNick()").nick;
+}
+
+// #1152 — the requested nick and the flown nick are two different things.
+//
+// `provisionSpecSubject` asks for `nick: name`, but on a 433
+// ERR_NICKNAMEINUSE during registration #676's fallback ladder
+// (`auth_fsm.ex`) re-registers as `<nick>_` and then as two random
+// suffixes, moving `state.nick` with it. Nothing raises; grappa even says
+// so in the scrollback ("nick sbff5a028 was taken — you are registered as
+// sbff5a028_"). Everything downstream that addressed the requested nick is
+// then addressing somebody else.
+//
+// There is no product bug here to fix. `GET /networks` already answers the
+// LIVE nick: `Networks.resolve_network_nick/2` asks the running
+// Session.Server and falls back to the credential's configured nick only
+// when no session is up, for exactly this reason — "a stale nick silently
+// drops all inbound DMs" (`networks_controller.ex`). cic resolves its own
+// nick from that row. This reads the same door instead of inventing a
+// third semantics.
+//
+// 🔴 The hard constraint behind the two-shaped cure: JS has no synchronous
+// fetch, so a synchronous accessor CANNOT be always-correct. It can only
+// be made NOISY. Hence `specLiveNick()` (async, correct) where the nick is
+// the stimulus, and the teardown guard in `fixtures/test.ts` (detection,
+// zero spec edits) everywhere else.
+
+// `connection` is the liveness discriminator, and it is the reason this
+// returns a reading instead of a string: it is `null` exactly when
+// `Session.connection_info/2` finds no live pid, which is exactly when
+// `nick` is the CONFIGURED fallback rather than the flown value. Comparing
+// a cached nick against a fallback would manufacture drift that isn't
+// there, so "no live session" is reported as an absence of measurement,
+// never as a nick.
+export type LiveNickReading =
+  | { kind: "live"; nick: string }
+  | { kind: "unobservable"; reason: string };
+
+type LiveNickRow = { slug: string; nick: string; connection: unknown };
+
+/**
+ * Read the subject's live upstream nick off `GET /networks`, or say why it
+ * could not be read. Never throws on a reachable server: a spec that
+ * revokes its own bearer (the logout journeys seed `specUser().token` into
+ * the page, so a UI logout kills this exact token) has not drifted, it has
+ * stopped being observable, and the two must not be confused.
+ */
+export async function readSpecLiveNick(): Promise<LiveNickReading> {
+  const subject = requireCurrent("readSpecLiveNick()");
+  const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
+    headers: { authorization: `Bearer ${subject.user.token}` },
+  });
+  if (!res.ok) {
+    return {
+      kind: "unobservable",
+      reason: res.status === 401 ? "bearer_revoked" : `${res.status}`,
+    };
+  }
+  const rows = (await res.json()) as LiveNickRow[];
+  const row = rows.find((r) => r.slug === NETWORK_SLUG);
+  if (!row) return { kind: "unobservable", reason: "no_row" };
+  if (row.connection === null) return { kind: "unobservable", reason: "no_live_session" };
+  return { kind: "live", nick: row.nick };
+}
+
+/**
+ * The nick the subject's session is actually flying, re-resolved now, and
+ * cached so the teardown guard compares against a value that was true.
+ *
+ * Use this wherever the nick is the STIMULUS — a DM addressed to it, a
+ * mention typed into a body — because there a stale nick does not fail the
+ * spec, it quietly tests nothing. Throws rather than guessing: addressing
+ * a nick nobody could confirm is the whole of #1152.
+ */
+export async function specLiveNick(): Promise<string> {
+  const subject = requireCurrent("specLiveNick()");
+  const reading = await readSpecLiveNick();
+  if (reading.kind === "unobservable") {
+    throw new Error(
+      `specLiveNick(): no live nick for ${subject.user.name} (${reading.reason}). ` +
+        `Last resolved: ${subject.nick}. Addressing that blind is #1152, so this throws.`,
+    );
+  }
+  subject.nick = reading.nick;
+  return reading.nick;
 }

--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -1,5 +1,6 @@
 import { test as base, expect as baseExpect } from "@playwright/test";
 import {
+  consumedSpecNicks,
   provisionSpecSubject,
   readSpecLiveNick,
   setCurrentSpecSubject,
@@ -112,13 +113,23 @@ export const test = base.extend<{
         // to write a line, or its silence gets read as evidence later).
         const reading = await readSpecLiveNick();
         if (reading.kind === "live") {
+          // The judged value is what the test was HANDED, not what the
+          // cache last held. Measured on this branch: 19 of the 20 specs
+          // that call `specLiveNick()` also read `specNick()` earlier, so
+          // a guard on the cache alone would be laundered by the very
+          // refresh this cure introduced — live compared against live,
+          // green, with the stale value those specs already addressed
+          // never mentioned. A spec that consumed no nick at all is
+          // vacuously fine here, and that is correct: drift cannot reach
+          // what never read it.
+          const stale = consumedSpecNicks().filter((nick) => nick !== reading.nick);
           baseExpect(
-            reading.nick,
-            `the subject's live upstream nick drifted away from the one the ` +
-              `spec has been addressing (#1152) — grappa re-registered after a ` +
-              `433, and every specNick() in this spec named somebody else. Use ` +
-              `specLiveNick() where the nick is the stimulus.`,
-          ).toBe(subject.nick);
+            stale,
+            `this spec addressed a nick the subject was not flying (#1152). ` +
+              `Live: ${reading.nick}. Grappa re-registered after a 433 and ` +
+              `specNick() kept answering the requested nick. Where the nick is ` +
+              `the stimulus, use specLiveNick().`,
+          ).toEqual([]);
         } else {
           process.stderr.write(
             `__NICKGUARD__\tunobservable\t${reading.reason}\t${subject.user.name}\n`,

--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -1,5 +1,10 @@
 import { test as base, expect as baseExpect } from "@playwright/test";
-import { provisionSpecSubject, setCurrentSpecSubject, teardownSpecSubject } from "./specSubject";
+import {
+  provisionSpecSubject,
+  readSpecLiveNick,
+  setCurrentSpecSubject,
+  teardownSpecSubject,
+} from "./specSubject";
 
 // Wrapped Playwright `test` fixture. Specs that need a grappa user MUST
 // import `test` from THIS module instead of `@playwright/test`; the
@@ -81,6 +86,44 @@ export const test = base.extend<{
       setCurrentSpecSubject(subject);
       try {
         await use();
+        // #1152 — the nick guard. `specNick()` hands back the nick the
+        // provision REQUESTED; the session flies whatever survived
+        // registration, and #676's 433 fallback ladder can move it to
+        // `<nick>_` with nothing raised anywhere. 625 call sites in 290 of
+        // the 409 spec files read that accessor, so making it always-right
+        // means making it async — a rewrite that collides with every live
+        // branch, and JS offers no synchronous fetch to avoid it.
+        //
+        // So the window is closed by DETECTION rather than by prevention,
+        // which is the same shape #1336's own cure takes (a recorder that
+        // fails an empty read unless a positive control fired): one read of
+        // the live nick per test, and a drift is a loud red instead of a
+        // dead nick addressed in silence. Specs where the nick is the
+        // STIMULUS use `specLiveNick()` and are correct by construction;
+        // this catches everybody else.
+        //
+        // Runs after `use()` and NOT in the `finally`, mirroring the CSP
+        // guard below: a test that already failed should not collect a
+        // second, derivative failure on the way out.
+        //
+        // An unobservable reading is not a pass and is not a failure — it
+        // is an absence of measurement, and it says so on stderr rather
+        // than passing quietly (the #934 lesson: a path that can skip has
+        // to write a line, or its silence gets read as evidence later).
+        const reading = await readSpecLiveNick();
+        if (reading.kind === "live") {
+          baseExpect(
+            reading.nick,
+            `the subject's live upstream nick drifted away from the one the ` +
+              `spec has been addressing (#1152) — grappa re-registered after a ` +
+              `433, and every specNick() in this spec named somebody else. Use ` +
+              `specLiveNick() where the nick is the stimulus.`,
+          ).toBe(subject.nick);
+        } else {
+          process.stderr.write(
+            `__NICKGUARD__\tunobservable\t${reading.reason}\t${subject.user.name}\n`,
+          );
+        }
       } finally {
         // Clear the accessor BEFORE the network call: if the teardown
         // throws, the next test must fail on "no subject" rather than
@@ -165,4 +208,4 @@ export { expect } from "@playwright/test";
 // exactly the set of specs that import `test` from this module. Reaching
 // them through the same import that brings in `test` makes the coupling
 // impossible to get wrong.
-export { specNick, specUser } from "./specSubject";
+export { readSpecLiveNick, specLiveNick, specNick, specUser } from "./specSubject";

--- a/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
@@ -35,7 +35,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "b3-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -66,7 +66,7 @@ test("CP14 B3 — DM query window shows both inbound and outbound history after 
   try {
     // Inbound: peer → vjt-grappa. Server persists with channel =
     // own_nick AND dm_with = peer (CP14 B3 derivation in EventRouter).
-    peer.privmsg(specNick(), PEER_TO_VJT);
+    peer.privmsg(await specLiveNick(), PEER_TO_VJT);
 
     // Probe via REST against channel = PEER_NICK so the peer-DM
     // aggregation OR-shape (channel == peer OR dm_with == peer) picks

--- a/cicchetto/e2e/tests/issue1152-live-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue1152-live-nick.spec.ts
@@ -36,7 +36,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, readSpecLiveNick, specLiveNick, specNick, specUser, test } from "../fixtures/test";
+import { expect, readSpecLiveNick, specLiveNick, specUser, test } from "../fixtures/test";
 
 // Per-run-unique: bahamut lingers a ghosted nick after disconnect, so a
 // fixed literal 433s the peer itself on a rapid rerun.
@@ -45,7 +45,13 @@ const LIVE_BODY = "#1152 addressed to the live nick";
 const REQUESTED_BODY = "#1152 addressed to the requested nick";
 
 test("a squatted registration moves the live nick, and specLiveNick() follows it", async () => {
-  const requested = specNick();
+  // `specUser().name` and NOT `specNick()`: the provision asks for
+  // `nick: name`, so the account name IS the requested nick, at the
+  // source. Reading it through `specNick()` would ALSO be reading it as
+  // an address, and the teardown guard would rightly redden this spec for
+  // addressing a nick the subject stops holding two lines later. The
+  // squat below wants the string, not the address.
+  const requested = specUser().name;
   const token = specUser().token;
 
   // (1) PRE-STATE. `kind: "live"` is half the assertion: it proves the

--- a/cicchetto/e2e/tests/issue1152-live-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue1152-live-nick.spec.ts
@@ -1,0 +1,119 @@
+// #1152 — the fixture's nick and the session's nick are two different
+// things, and the suite only ever knew the first one.
+//
+// `provisionSpecSubject` asks for `nick: <name>`. If that nick is taken at
+// the moment the session registers, #676's fallback ladder
+// (`auth_fsm.ex`) re-registers as `<name>_` — and then as two random
+// suffixes — with nothing raised: grappa even writes the substitution into
+// the scrollback in plain words. `specNick()` kept answering `<name>`, so
+// every `privmsg(specNick(), …)` in the suite addressed a nick the subject
+// did not hold. The DM went to whoever DID hold it, the spec's own
+// assertion timed out, and the failure looked like a flake.
+//
+// In the wild the trigger is a RACE: the nick is held by the previous
+// test's not-yet-reaped ghost. This spec DISPLACES that trigger — a
+// squatter takes the nick deliberately while the session is parked — so
+// the same 433 arrives on every run instead of on unlucky ones. The race
+// itself is not reproduced here and is not claimed to be.
+//
+// What is pinned, in order:
+//   1. pre-state — requested and live agree, and the live reading is
+//      OBSERVABLE (without this the divergence below could be read as
+//      "these two never agreed", and the guard in `fixtures/test.ts` could
+//      be vacuous without anybody noticing);
+//   2. the divergence — after the squatted registration the live nick is
+//      NOT the requested one;
+//   3. that `specLiveNick()` follows it, product-side: a DM addressed to
+//      the live nick lands in the subject's scrollback;
+//   4. that a DM addressed to the REQUESTED nick does not — asserted only
+//      after (3) has fired, so the absence is a measurement and not an
+//      empty read (#1336's rule).
+
+import {
+  assertMessagePersisted,
+  fetchAllMessagesAsc,
+  patchNetworkConnectionState,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, readSpecLiveNick, specLiveNick, specNick, specUser, test } from "../fixtures/test";
+
+// Per-run-unique: bahamut lingers a ghosted nick after disconnect, so a
+// fixed literal 433s the peer itself on a rapid rerun.
+const PEER_NICK = `n1152p${crypto.randomUUID().slice(0, 6)}`;
+const LIVE_BODY = "#1152 addressed to the live nick";
+const REQUESTED_BODY = "#1152 addressed to the requested nick";
+
+test("a squatted registration moves the live nick, and specLiveNick() follows it", async () => {
+  const requested = specNick();
+  const token = specUser().token;
+
+  // (1) PRE-STATE. `kind: "live"` is half the assertion: it proves the
+  // subject has a session whose nick can be read at all, which is the same
+  // condition the teardown guard needs to be non-vacuous.
+  const before = await readSpecLiveNick();
+  expect(before, "no live nick before the squat — the guard would be vacuous").toMatchObject({
+    kind: "live",
+    nick: requested,
+  });
+
+  // Park first so the squatter takes the nick uncontested, rather than
+  // racing the live session for it.
+  await patchNetworkConnectionState(token, NETWORK_SLUG, { connection_state: "parked" });
+  const squatter = await IrcPeer.connect({ nick: requested });
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    const tReconnect = Date.now();
+    await patchNetworkConnectionState(token, NETWORK_SLUG, { connection_state: "connected" });
+
+    // BARRIER, and it has to be a causal one. The first version of this
+    // bench polled `connection_state == "connected"` and read the nick 35 ms
+    // BEFORE the reconciliation landed — `connection_state` is INTENT, not
+    // liveness, and is already "connected" while the FSM is still walking
+    // the 433 ladder. It went green, cleanly, on a defect that was there.
+    //
+    // The autojoin JOIN is strictly downstream of registration and happens
+    // in BOTH worlds — diverged nick or not — so waiting on it is causal
+    // without presupposing the answer the way waiting on the nick would.
+    await expect
+      .poll(
+        async () => {
+          const rows = await fetchAllMessagesAsc(token, NETWORK_SLUG, AUTOJOIN_CHANNELS[0]);
+          return rows.some((r) => r.kind === "join" && r.server_time >= tReconnect);
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    // (2) THE DIVERGENCE. Not pinned to `<name>_` on purpose: the ladder's
+    // later rungs are random, and the defect is the divergence, not its
+    // spelling.
+    const live = await specLiveNick();
+    expect(live, "the squatted 433 did not move the session's nick").not.toBe(requested);
+
+    // (3) + (4). Both DMs go out on ONE socket, requested-first, and only
+    // then is the live one waited for. That order is what turns the absence
+    // into a measurement rather than an empty read: bahamut processed the
+    // first send before the second, and our session processes what reaches
+    // it in order — so once the second has persisted, the first one's fate
+    // is settled and "not there" means "never routed here".
+    peer.privmsg(requested, REQUESTED_BODY);
+    peer.privmsg(live, LIVE_BODY);
+
+    // POSITIVE CONTROL — the live nick is the one that reaches us.
+    await assertMessagePersisted({
+      token,
+      networkSlug: NETWORK_SLUG,
+      channel: peer.nick,
+      sender: peer.nick,
+      body: LIVE_BODY,
+    });
+
+    // …and the requested nick is not: that DM went to the squatter.
+    const rows = await fetchAllMessagesAsc(token, NETWORK_SLUG, peer.nick);
+    expect(rows.map((r) => r.body)).not.toContain(REQUESTED_BODY);
+  } finally {
+    await peer.disconnect("#1152 done");
+    await squatter.disconnect("#1152 done");
+  }
+});

--- a/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
+++ b/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
@@ -30,7 +30,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const CHANNEL_LINE = "235 ordinary channel traffic";
@@ -74,7 +74,7 @@ async function seedTwoTierUnread(
   await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toBeVisible({ timeout: 10_000 });
 
   // Tier 0 — a DM opens the peer's query window (unfocused → unread).
-  peer.privmsg(specNick(), DM_LINE);
+  peer.privmsg(await specLiveNick(), DM_LINE);
   await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
 
   return peer;

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -32,7 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const DM_LINE = "265 direct message counts";
@@ -73,7 +73,7 @@ async function seedEventOnlyAndMessageWindows(
 
   // Message window — a DM opens the peer's query window (unfocused →
   // unread content).
-  peer.privmsg(specNick(), DM_LINE);
+  peer.privmsg(await specLiveNick(), DM_LINE);
   await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
   await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
 

--- a/cicchetto/e2e/tests/issue422-inbound-dm-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/issue422-inbound-dm-opens-query.spec.ts
@@ -28,7 +28,7 @@
 import { loginAs, waitForDmListenerReady } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specUser, test } from "../fixtures/test";
 
 // Per-run-unique peer nick — bahamut holds a ghosted nick for a linger
 // window after disconnect, so a fixed literal 433s on rapid reruns
@@ -58,7 +58,7 @@ test("inbound DM opens the query window server-side (cic pure renderer) and surv
   try {
     // The operator NEVER opened a query with this peer — no /q, no click.
     // An unsolicited inbound DM is the ONLY trigger.
-    peer.privmsg(specNick(), "unsolicited DM #422");
+    peer.privmsg(await specLiveNick(), "unsolicited DM #422");
 
     // FACET 1 — the window appears with cic as a pure renderer: the server
     // opened it + broadcast the list. (Client auto-open is gone; if the

--- a/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
@@ -52,7 +52,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i532-peer";
@@ -138,7 +138,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
     // First inbound DM → cic auto-opens the query window (server-owned,
     // #422). Focus it so the DM renders, then focus away so selection.ts's
     // leave-arm advances the cursor to this first DM — leaving it READ.
-    peer.privmsg(specNick(), DM_FIRST);
+    peer.privmsg(await specLiveNick(), DM_FIRST);
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
@@ -168,7 +168,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
 
     // Second inbound DM while focused elsewhere → exactly ONE unread
     // content row on the peer window.
-    peer.privmsg(specNick(), DM_SECOND);
+    peer.privmsg(await specLiveNick(), DM_SECOND);
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,

--- a/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
@@ -42,7 +42,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i576-peer";
@@ -79,7 +79,7 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
     // Peer opens the DM. Focus it so it renders (the send-time advance's
     // anti-poison gate #50 needs a non-empty pane), and read it — the
     // cursor baseline will be restored to exactly this line below.
-    peer.privmsg(specNick(), OPENER);
+    peer.privmsg(await specLiveNick(), OPENER);
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
@@ -134,7 +134,7 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
     // A PEER line after the own ones DOES count — proving the badge
     // mechanism is live (the 0 above is the own-exclusion, not a dead
     // badge). Exactly one unread peer line ⟹ "1".
-    peer.privmsg(specNick(), REPLY);
+    peer.privmsg(await specLiveNick(), REPLY);
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,

--- a/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
@@ -32,7 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const DM_LINE = "914 direct message";
@@ -56,7 +56,7 @@ async function seedOneUnreadDm(
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
   const peer = await IrcPeer.connect({ nick: peerNick });
-  peer.privmsg(specNick(), DM_LINE);
+  peer.privmsg(await specLiveNick(), DM_LINE);
   await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
   return peer;
 }

--- a/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
+++ b/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
@@ -39,7 +39,7 @@ import {
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW = "Server";
@@ -76,7 +76,7 @@ test("#973 — a mixed-case query window's unread badge clears on read and stays
   const nick = peer.nick;
   try {
     // 1. Inbound DM auto-opens the query window and puts one on the badge.
-    peer.privmsg(specNick(), FIRST_DM);
+    peer.privmsg(await specLiveNick(), FIRST_DM);
     await expect(sidebarMessageBadge(page, NETWORK_SLUG, nick)).toHaveText("1", {
       timeout: 10_000,
     });
@@ -103,7 +103,7 @@ test("#973 — a mixed-case query window's unread badge clears on read and stays
 
     // 4. A second DM arrives while the operator is away. The badge counts it —
     //    the fix must not have silenced the window, only unstuck the cursor.
-    peer.privmsg(specNick(), SECOND_DM);
+    peer.privmsg(await specLiveNick(), SECOND_DM);
 
     // 5. Exactly "1", not "2". This is the monotonic growth from the report:
     //    with the cursor stuck, the first (already-read) DM was still being

--- a/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
+++ b/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
@@ -31,7 +31,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "m4-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -59,7 +59,7 @@ test("M4 — inbound DM auto-opens query window with unread, clears on focus", a
     // before peer sent" flake).
     await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
 
-    peer.privmsg(specNick(), MESSAGE_BODY);
+    peer.privmsg(await specLiveNick(), MESSAGE_BODY);
 
     // Server-side: row persisted at channel = specNick() (the
     // RECIPIENT nick is the channel for inbound DMs) with sender =

--- a/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
+++ b/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
@@ -23,7 +23,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "m5-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -48,7 +48,7 @@ test("M5 — inbound DM to focused query window renders inline, no unread", asyn
     await composeSend(page, `/query ${peer.nick}`);
     await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
-    peer.privmsg(specNick(), MESSAGE_BODY);
+    peer.privmsg(await specLiveNick(), MESSAGE_BODY);
 
     // Probe via REST against channel = PEER_NICK (peer-DM aggregation
     // OR-shape matches inbound rows). Probing channel = specNick()

--- a/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
+++ b/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
@@ -33,7 +33,7 @@ import {
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "marker-target-buddy";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -88,7 +88,7 @@ test("focused-window send+reply does NOT spawn unread marker", async ({ page }) 
     // socket and never render.
     await waitForDmListenerReady(page, NETWORK_SLUG);
     // Peer replies on the same DM topic.
-    peer.privmsg(specNick(), reply);
+    peer.privmsg(await specLiveNick(), reply);
     // Wait for the reply to land.
     await expect(page.locator('[data-testid="scrollback-line"]', { hasText: reply })).toBeVisible({
       timeout: 5_000,
@@ -121,7 +121,7 @@ test("switching to tall window after focused send scrolls target to bottom", asy
       timeout: 5_000,
     });
     await waitForDmListenerReady(page, NETWORK_SLUG);
-    peer.privmsg(specNick(), reply);
+    peer.privmsg(await specLiveNick(), reply);
     await expect(page.locator('[data-testid="scrollback-line"]', { hasText: reply })).toBeVisible({
       timeout: 5_000,
     });

--- a/cicchetto/e2e/tests/nick-case-incoming.spec.ts
+++ b/cicchetto/e2e/tests/nick-case-incoming.spec.ts
@@ -35,7 +35,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK_LOWER = "foldreplypeer";
 const PEER_NICK_PROPER = "FoldReplyPeer";
@@ -86,7 +86,7 @@ test("incoming reply from a differently-cased nick lands in the opened query win
     // there. Pre-fix the reply was re-keyed to a phantom `FoldReplyPeer`
     // bucket and never rendered in the opened window.
     await waitForDmListenerReady(page, NETWORK_SLUG);
-    peer.privmsg(specNick(), REPLY_BODY);
+    peer.privmsg(await specLiveNick(), REPLY_BODY);
 
     // The reply lands in the SAME (focused) window's scrollback...
     await expect(

--- a/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
+++ b/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
@@ -30,7 +30,7 @@
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK_LOWER = "casepeer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -107,7 +107,7 @@ test("nick case-sensitivity: /q with different casing focuses existing window, n
     // by server-side dm_with normalization) would NOT show.
     // peer.privmsg returns void (irc-framework fire-and-forget); the
     // expect.toContainText 5s wait is the synchronisation point.
-    peer.privmsg(specNick(), "ping from case peer");
+    peer.privmsg(await specLiveNick(), "ping from case peer");
 
     const scrollback = page.locator('[data-testid="scrollback"]');
     await expect(scrollback).toContainText("ping from case peer", { timeout: 5_000 });

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -33,7 +33,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 // Real grappa session (not a seed-per-spec DB) — unique suffixes so retries
 // / sibling specs don't strict-mode-collide on persisted scrollback or on a
@@ -93,7 +93,7 @@ test("query window follows a peer NICK change — relabels, keeps history, route
     ).toBeVisible({ timeout: 5_000 });
 
     await waitForDmListenerReady(page, NETWORK_SLUG);
-    peer.privmsg(specNick(), REPLY_BODY);
+    peer.privmsg(await specLiveNick(), REPLY_BODY);
     await expect(
       page.locator('[data-testid="scrollback-line"]', { hasText: REPLY_BODY }),
     ).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/push-964-device-row.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-row.spec.ts
@@ -43,7 +43,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "n964-dmer";
 const SUB_ID = "964-device-row";
@@ -80,7 +80,7 @@ test("device row shows the activity instant + marks the device you are on", asyn
     // Background the device: a VISIBLE one suppresses the push at source.
     await setPageVisibility(page, false);
     const dmBody = "hi from n964-dmer";
-    peer.privmsg(specNick(), dmBody);
+    peer.privmsg(await specLiveNick(), dmBody);
     const deliveries = await awaitPushDelivery(SUB_ID, {
       token: vjt.token,
       networkSlug: NETWORK_SLUG,

--- a/cicchetto/e2e/tests/push-focus-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-focus-suppression.spec.ts
@@ -37,7 +37,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "focus-suppressor";
 const SUB_ID = "focus-suppression";
@@ -70,7 +70,7 @@ test("server delivers push once the window is blurred though still on-screen, su
     // acked present=true, so the DM can't race the focus update.
     await setPageFocus(page, true);
     const focusedBody = "you are looking at the app — no toast please";
-    peer.privmsg(specNick(), focusedBody);
+    peer.privmsg(await specLiveNick(), focusedBody);
     await assertNoPushDelivery(SUB_ID, {
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
@@ -85,7 +85,7 @@ test("server delivers push once the window is blurred though still on-screen, su
     await resetPushCatcher();
     await setPageFocus(page, false);
     const blurredBody = "you clicked another app — deliver this one";
-    peer.privmsg(specNick(), blurredBody);
+    peer.privmsg(await specLiveNick(), blurredBody);
 
     const deliveries = await awaitPushDelivery(SUB_ID, {
       token: vjt.token,
@@ -101,7 +101,7 @@ test("server delivers push once the window is blurred though still on-screen, su
     await resetPushCatcher();
     await setPageFocus(page, true);
     const refocusedBody = "back in focus — suppress again";
-    peer.privmsg(specNick(), refocusedBody);
+    peer.privmsg(await specLiveNick(), refocusedBody);
     await assertNoPushDelivery(SUB_ID, {
       token: vjt.token,
       networkSlug: NETWORK_SLUG,

--- a/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
@@ -39,7 +39,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "fg-suppressor";
 const SUB_ID = "foreground-suppression";
@@ -67,7 +67,7 @@ test("server suppresses push while a device reports visible, delivers once hidde
     // until WSPresence has acked visible=true, so the DM can't race it.
     await setPageVisibility(page, true);
     const visibleBody = "you are looking at the app — no toast please";
-    peer.privmsg(specNick(), visibleBody);
+    peer.privmsg(await specLiveNick(), visibleBody);
     await assertNoPushDelivery(SUB_ID, {
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
@@ -80,7 +80,7 @@ test("server suppresses push while a device reports visible, delivers once hidde
     await resetPushCatcher();
     await setPageVisibility(page, false);
     const hiddenBody = "now you backgrounded it — deliver this one";
-    peer.privmsg(specNick(), hiddenBody);
+    peer.privmsg(await specLiveNick(), hiddenBody);
 
     const deliveries = await awaitPushDelivery(SUB_ID, {
       token: vjt.token,

--- a/cicchetto/e2e/tests/push-trigger-dm.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-dm.spec.ts
@@ -30,7 +30,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "b5-dmer";
 const SUB_ID = "dm";
@@ -64,7 +64,7 @@ test("DM while push-enabled fires Sender → push-catcher receives a POST", asyn
     // Server-side this hits Session.Server's :persist arm with
     // `channel = own_nick`; Triggers' dm? predicate matches.
     const dmBody = "hi from b5-dmer";
-    peer.privmsg(specNick(), dmBody);
+    peer.privmsg(await specLiveNick(), dmBody);
 
     const deliveries = await awaitPushDelivery(SUB_ID, {
       token: vjt.token,

--- a/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
@@ -51,7 +51,7 @@ import {
 import { assertMessagePersisted, getReadCursor } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "ux6k-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -85,7 +85,7 @@ test("UX-6 K — focus-leave on a peer DM window advances the server-side read c
     // Peer sends an INBOUND DM to vjt. Persisted server-side at
     // `channel = specNick(), dm_with = PEER_NICK` — the storage
     // shape that exposed the K bug.
-    peer.privmsg(specNick(), PM_BODY);
+    peer.privmsg(await specLiveNick(), PM_BODY);
 
     // Probe via REST against channel = PEER_NICK so the peer-DM
     // aggregation (channel == peer OR dm_with == peer) returns the

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -34,7 +34,7 @@ import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
-import { expect, specNick, specUser, test } from "../fixtures/test";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK_DM = "ux6l-dmer";
 const PEER_NICK_MENTION = "ux6l-mentioner";
@@ -75,7 +75,7 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK_DM });
   try {
-    peer.privmsg(specNick(), DM_BODY);
+    peer.privmsg(await specLiveNick(), DM_BODY);
 
     // Step 1: confirm the DM landed SERVER-SIDE. Isolates "peer
     // connection / bahamut load flake" (server has no row) from "cic

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50927,15 +50927,53 @@ And `privmsg` is not the dominant consumer. Grouped by call shape, the 625 are
 led by roughly 425 `selectChannel(page, …, { ownNick: specNick() })`, then 27
 `privmsg`, then 17 `sender: specNick()` — that last one an oracle, not a
 stimulus, and drift there produces a timeout rather than a silent pass. The
-slice was NOT widened on this; it is recorded so the next reader sizes the
-remainder from a number instead of from the 28.
+slice was NOT widened on this; the number is recorded so the next reader sizes
+the remainder from evidence rather than from the 28, and so that what the slice
+does not cover is stated rather than left as a silent cap.
+
+Those ~442 are covered by the guard, not by the conversion, and that is the
+intended posture. But it only became TRUE after the guard was rewritten, which
+is the finding below.
+
+### The cure grew its own blind spot, and it took the same shape
+
+The guard as first written compared the CACHED nick against the live one. That
+is laundered by the very call the cure introduces: `specLiveNick()` refreshes
+the cache, so at teardown the guard compares the live nick against itself, goes
+green, and never mentions the stale value the spec had already addressed
+earlier in the same body. Measured on this branch: **19 of the 20** specs that
+call `specLiveNick()` also read `specNick()` at an earlier line — so the blind
+spot landed on precisely the specs the cure touched, which are the DM specs,
+which are the ones that drift.
+
+(The 19 is a LEXICAL ordering — first `specNick()` line before first
+`specLiveNick()` line — not an execution trace. For straight-line test bodies
+the two coincide; it was not verified case by case.)
+
+The fix is to judge what the test was HANDED rather than what the cache last
+held: `specNick()` and `specLiveNick()` record every value they return, and the
+guard asserts that every recorded value equals the live nick. A spec that read
+no nick at all is then vacuously fine, which is correct — drift cannot reach
+what never read it.
+
+Worth keeping for its own sake: a derived copy plus a guard over it is a
+mechanism with two moving parts, and the SECOND part failed here for the same
+reason the first one did. It is the same argument that declined push-at-gesture
+above, arriving from the other direction.
 
 The ruling also asked for re-resolution after every fixture gesture that
-reconnects. That half was declined, on the timeline below: a read issued right
+reconnects. That half was declined on the timeline below: a read issued right
 after `PATCH connection_state=connected` lands BEFORE the reconciliation it
-means to observe, so it would launder a stale value into the cache — repeating,
-inside the cure, the defect the cure is for. Re-resolution happens at the point
-of USE instead, which cannot be early by construction.
+means to observe, so it would launder a stale value into the cache —
+repeating, inside the cure, the defect the cure is for.
+
+🥇 The structural reason is the better one, and it generalises past this
+issue: **re-resolving at the point of USE leaves no cached object that can
+age.** Push-at-gesture manufactures the stale value at a moment chosen for
+convenience and then posts a guard over it; pull-at-use makes the stale value
+unrepresentable. Given a choice between guarding a derived copy and not
+keeping one, prefer not keeping one — a guard is a thing that can be
+laundered, and the next section is what that looks like when it happens.
 
 ### 🥇 The lesson: an instrument that measures a barrier defect is exposed to it
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50856,3 +50856,99 @@ migration is behaviour-preserving by CONSTRUCTION (same arguments, same emitted
 string) and unwitnessed by any assertion in the suite. That is worth knowing
 before someone reads a green suite as coverage of this helper: for most of its
 call sites, it is not.
+<!-- entry #1152-livenick -->
+
+---
+
+## 2026-08-19 — #1152: the nick the fixture asked for, the nick the session flew
+
+`specNick()` (`cicchetto/e2e/fixtures/specSubject.ts`) answered the nick the
+provision REQUESTED. The session flies whatever survived registration, and the
+two part company without a word: on a 433 ERR_NICKNAMEINUSE, #676's fallback
+ladder (`auth_fsm.ex`) re-registers as `<nick>_` and then as two random
+suffixes, moving `state.nick` with it. Grappa is not even quiet about it — it
+writes the substitution into the scrollback in plain words ("nick sbff5a028 was
+taken — you are registered as sbff5a028_"). Only the fixture believed the old
+one. Every `privmsg(specNick(), …)` then addressed whoever DID hold that nick,
+the spec's own assertion timed out, and the failure read as a flake.
+
+Reproduced 3/3 under `--repeat-each 3`, by DISPLACEMENT: in the wild the nick
+is held by the previous test's not-yet-reaped ghost, which is a race; a
+squatter taking it while the session is parked makes the same 433 deterministic.
+The race itself was not observed and is not claimed.
+
+No product bug is involved. `GET /networks` already answers the LIVE nick —
+`Networks.resolve_network_nick/2` asks the running Session.Server and falls back
+to the credential's configured nick only when no session is up, for exactly this
+reason ("a stale nick silently drops all inbound DMs",
+`networks_controller.ex`) — and cic resolves its own nick from that row. The
+cure reads the same door rather than inventing a third semantics.
+
+### The hard constraint, and why the cure has two shapes
+
+**Sync and always-correct is impossible in JS: there is no synchronous fetch.**
+A synchronous accessor can be made NOISY; it cannot be made right. That is the
+whole reason a fork existed here, and it is worth writing down so the next
+reader does not re-open it.
+
+Making `specNick()` async everywhere was rejected on a MEASURE, not a
+preference: 625 call sites in 290 of the 409 spec files (three anchors — `grep`
+from `e2e/`, `grep` from the repo root, `git grep` — all agreeing at the SHA
+this was measured on; the 627 an earlier pass reported is not reproducible and
+the two-line gap is unexplained). That is a patch colliding with every live
+branch. So the window is closed by DETECTION instead of by prevention, which is
+not a fallback: it is the same shape #1336's own cure takes — a recorder that
+fails an empty read unless a positive control fired. Detection is this epic's
+idiom.
+
+What shipped:
+
+* **a teardown guard, zero spec edits** — `fixtures/test.ts` reads the live
+  nick once per test and fails the test when the cached one has drifted. The
+  `connection` field of the `/networks` row is the liveness discriminator: it
+  is `null` exactly when `Session.connection_info/2` finds no live pid, which is
+  exactly when `nick` is the CONFIGURED fallback. Comparing a cached nick to a
+  fallback would manufacture drift, so that reading is reported as an absence of
+  measurement — on stderr as `__NICKGUARD__ unobservable <reason>`, never
+  silently, per the #934 lesson that a path which can skip has to write a line
+  or its silence gets read as evidence later. A revoked bearer is one such
+  reason and not a drift: the logout journeys seed `specUser().token` into the
+  page, so a UI logout kills the very token the guard would read.
+* **`specLiveNick()` on the 27 sites where the nick is the STIMULUS** — the
+  `privmsg(specNick(), …)` set, where a stale nick does not fail the spec, it
+  quietly tests nothing. It throws rather than guessing.
+
+### Two measurements that corrected the brief
+
+The slice was briefed as 28 sites. 28 is the LINE count; one of them is prose
+inside a comment. 27 are code, across 20 files.
+
+And `privmsg` is not the dominant consumer. Grouped by call shape, the 625 are
+led by roughly 425 `selectChannel(page, …, { ownNick: specNick() })`, then 27
+`privmsg`, then 17 `sender: specNick()` — that last one an oracle, not a
+stimulus, and drift there produces a timeout rather than a silent pass. The
+slice was NOT widened on this; it is recorded so the next reader sizes the
+remainder from a number instead of from the 28.
+
+The ruling also asked for re-resolution after every fixture gesture that
+reconnects. That half was declined, on the timeline below: a read issued right
+after `PATCH connection_state=connected` lands BEFORE the reconciliation it
+means to observe, so it would launder a stale value into the cache — repeating,
+inside the cure, the defect the cure is for. Re-resolution happens at the point
+of USE instead, which cannot be early by construction.
+
+### 🥇 The lesson: an instrument that measures a barrier defect is exposed to it
+
+The first reproduction bench went GREEN — `rc=0`, clean, and it would have
+closed #1152 on a vacuous measurement. Its barrier polled
+`connection_state == "connected"`, which is INTENT, not liveness: it is already
+`"connected"` while the FSM is still walking the 433 ladder. Measured, the nick
+was read 35 ms before the reconciliation that would have changed it — `.567`
+PATCH, `.572` two NICK, `.576/.579` the GETs, `.614` reconcile. Nothing in the
+run said so; only the server logs did.
+
+Redone with a CAUSAL barrier — the autojoin JOIN, which is strictly downstream
+of registration, happens in both worlds, and does not presuppose the answer the
+way waiting on the nick would — the same bench reproduces 3/3.
+
+**A green that reports NON-reproduction deserves the same suspicion as a red.**


### PR DESCRIPTION
## What

`specNick()` answered the nick the provision **requested**. The session flies
whatever survived registration: on a 433 during registration, #676's fallback
ladder (`auth_fsm.ex`) re-registers as `<nick>_` and then as two random
suffixes, moving `state.nick` with it, with nothing raised. Grappa even writes
the substitution into the scrollback in plain words. Only the fixture believed
the old nick — so `privmsg(specNick(), …)` addressed whoever *did* hold it, the
spec's own assertion timed out, and the failure read as a flake.

Consolidated into #1336.

## Reproduced, and how

3/3 under `--repeat-each 3`:

```
__1152__ phase=pre   requested=sbff5a028  live=sbff5a028
__1152__ phase=post  requested=sbff5a028  live=sbff5a028_
```

⚠️ This is a **displacement** of the natural trigger. In the wild the nick is
held by the previous test's not-yet-reaped ghost, which is a **race**. The bench
has a squatter take the nick while the session is parked, so the same 433
arrives deterministically. **The race itself was not observed and is not
claimed.**

## Not a product bug

`GET /networks` already answers the live nick — `Networks.resolve_network_nick/2`
asks the running `Session.Server` precisely because *"a stale nick silently
drops all inbound DMs"* (`networks_controller.ex`) — and cic resolves its own
nick from that row. The cure reads the **same door**; it does not invent a third
semantics.

## The cure has two shapes, and the reason is a hard constraint

**Sync + always-correct is impossible in JS: there is no synchronous fetch.** A
sync accessor can be made *noisy*; it cannot be made right.

Making `specNick()` async everywhere was rejected on a **measure**, not a
preference: **625** call sites in **290** of the **409** spec files (three
anchors agreeing). That is a patch colliding with every live branch.

So:

- **A teardown guard, zero spec edits** (`fixtures/test.ts`) — one live-nick
  read per test; a drift is a loud red instead of a dead nick addressed in
  silence. Detection-instead-of-prevention is **#1336's own idiom**, not a
  fallback.
- **`specLiveNick()` on the 27 sites where the nick is the STIMULUS** — the
  `privmsg` set, where a stale nick does not fail the spec, it quietly tests
  nothing.

`connection == null` is the liveness discriminator: that is exactly when the
row's nick is the *configured fallback*, and comparing a cached nick against a
fallback would manufacture drift. Such a reading is an **absence of
measurement** and says so on stderr (`__NICKGUARD__ unobservable <reason>`) —
never silently. A revoked bearer is one such reason and not a drift: the logout
journeys seed `specUser().token` into the page, so a UI logout kills the very
token the guard reads.

## Two measurements that corrected the brief

- The slice was briefed as **28**. That is the *line* count — one match is prose
  inside a comment. **27 are code**, across 20 files.
- `privmsg` is **not** the dominant consumer. Grouped by call shape the 625 are
  led by ~**425** `selectChannel(…, { ownNick: specNick() })`, then 27
  `privmsg`, then 17 `sender: specNick()`. The slice was **not** widened; the
  number is recorded so the remainder gets sized from evidence.

Re-resolution after every reconnecting *gesture* was declined: a read issued
right after `PATCH connection_state=connected` lands **before** the
reconciliation it means to observe (measured at 35 ms), so it would launder a
stale value into the cache — repeating, inside the cure, the defect the cure is
for. Re-resolution happens at the point of **use** instead.

## The lesson recorded in DESIGN_NOTES

The first reproduction bench went **green** — `rc=0`, clean — and would have
closed #1152 on a vacuous measurement. Its barrier polled
`connection_state == "connected"`, which is **intent, not liveness**: already
`"connected"` while the FSM walks the 433 ladder. The nick was read 35 ms before
the reconcile (`.567` PATCH → `.572` NICK → `.576/.579` GETs → `.614` reconcile).
Only the server logs caught it. Redone with a **causal** barrier (the autojoin
JOIN, downstream of registration, present in both worlds) it reproduces 3/3.

**A green that reports non-reproduction deserves the same suspicion as a red.**

## Gates

| gate | result |
|---|---|
| `bun run check` (biome + tsc ×2) | rc=0 |
| `bun run test` (vitest) | rc=0 — 290 files, 5616 tests |
| `design-notes-gate.sh` | 1 new entry, separator + marker present |
| e2e / integration | **not run locally yet — CI is the measurement here** |

⚠️ The **double mutant is not yet run** (guard broken → `afterEach` reddens; one
of the 27 reverted → spec reddens). It needs the exclusive stack lane and is
pending allocation. A guard that has not been seen to redden is not yet a guard.