### PR TITLE
e2e(#1155): close the last spec-side drawer door on the class

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1259,9 +1259,37 @@ export async function closeSettings(page: Page): Promise<void> {
 // barrier and the hazard are the same order of magnitude — ~196 ms of driver
 // latency against a 200 ms animation — so the margin is zero by construction.
 //
-// Playwright cannot see this on its own: its "visible, enabled and stable"
-// check runs on the TARGET's box, and the hamburger never moves. The thing
-// moving is the drawer on top of it.
+// CORRECTED (#1155, 2026-08-19). This used to read "Playwright cannot see this
+// on its own: its 'visible, enabled and stable' check runs on the TARGET's box,
+// and the hamburger never moves." That named THREE of Playwright's four
+// actionability checks and concluded blindness from the three. The fourth —
+// "receives events" — is precisely the one that sees an overlay, and it is
+// active for `tap`: `dom.js` builds the interceptor with `actionType` `"tap"`,
+// an interception is a RETRY (`hitTargetDescription … intercepts pointer
+// events`, then `continue`) rather than a failure, and the tap interceptor
+// covers touch (`pointerdown/pointerup/touchstart/touchend/touchcancel`).
+// `force: true` is what skips it.
+//
+// MEASURED on the settings arm (n=25, in-page probe, webkit-iphone-15), where
+// L = tap-lands − class-barrier-stamp and H = point-clears − the same stamp:
+// L does not sit at a fixed driver latency, it TRACKS H (L−H median 106 ms,
+// minimum within one rAF frame), and inserting a deliberate 400 ms before the
+// tap does NOT add to L (451 ms, not 265+400) because L already contained the
+// wait for H. So on a plain locator tap the driver HOLDS the gesture until the
+// panel stops intercepting it — it is not merely slow.
+//
+// The consequence for this fixture: on a plain-locator caller the geometry
+// barrier is belt-and-braces, not the thing standing between the suite and the
+// bug. It stays because it is the honest statement of what "closed" means, and
+// because the protection it duplicates is the DRIVER's, not ours — a `force`
+// gesture withdraws it entirely (measured on `push.ts:664`: a `force` centre
+// click lands inside the drawer box, 3/3).
+//
+// STILL UNEXPLAINED, deliberately not papered over: the incident recorded
+// above shows a tap that DID land on a members row. With the hit-target check active and
+// covering touch, that should have retried instead. Nothing read so far
+// accounts for it; the class barrier's own unsoundness does not depend on the
+// answer, but the answer is not known.
 //
 // Every caller is a mobile `@webkit` spec, which is what makes the viewport
 // test meaningful: on desktop `.shell-members` is the permanent rail and never

--- a/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
@@ -34,7 +34,13 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: UI shape
 // contract, subject-shape-agnostic. Registered seed suffices.
 
-import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  closeSettings,
+  loginAs,
+  openRailMenu,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -122,9 +128,16 @@ test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer 
   await expect(page.locator(".shell-members.open")).toHaveCount(0, { timeout: 5_000 });
   await expect(page.locator(".settings-drawer.open")).toBeVisible({ timeout: 5_000 });
 
-  // Close settings (× button). Re-open the drawer to test archive launcher.
-  await page.locator(".settings-drawer [data-testid='settings-drawer-close']").tap();
-  await expect(page.locator(".settings-drawer.open")).toHaveCount(0, { timeout: 5_000 });
+  // Close settings (× button), then re-open the members drawer to test the
+  // archive launcher. #1336 (#1155) — the close MUST go through `closeSettings`,
+  // not through a `.settings-drawer.open` count→0 barrier: the class is stripped
+  // at the START of a 200ms translateX(100%) slide, so that barrier returns with
+  // the panel still covering the point the NEXT gesture aims at. Here the next
+  // gesture is the topic-bar hamburger at (355, 31), which sits INSIDE the
+  // drawer's 308px box on this 393px viewport — measured four layers under
+  // `.settings-drawer` when the class barrier let go. The fixture waits on
+  // `not.toBeInViewport` (geometry, not class) instead.
+  await closeSettings(page);
 
   await page.getByLabel(/open members sidebar/i).tap();
   await expect(page.locator(".shell-members.open")).toBeVisible({ timeout: 5_000 });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51035,11 +51035,17 @@ before declaring the substitution equivalent, and neither is a hazard:
 
 ### Measured — the arm under test
 
+⚠️ Read this section as establishing the HOLE — how long the panel keeps
+covering the point after the class barrier lets go. It is not, on its own,
+the reason the barrier is wrong: what happens in that hole is settled further
+down, under "The mutant SURVIVED", and the answer is that the driver waits it
+out. The three-sample figures here were later superseded by n=25.
+
 In-page probe (a rAF sampler armed BEFORE the closing tap; the driver only
 contributes a stamp), webkit-iphone-15, 3 repeats. Settings drawer, next
 point = the topic-bar hamburger:
 
-* margin from the CLASS barrier to the tap point: **−148 / −148 / −160 ms**;
+* hole from the CLASS barrier to the tap point: **−148 / −148 / −160 ms**;
 * margin from the CLASS barrier to the box clearing the edge: −221 / −198 / −212 ms;
 * margin from `not.toBeInViewport` to the tap point: **+279 / +282 / +258 ms**.
 
@@ -51082,20 +51088,81 @@ order-of-magnitude reason the defect exists at all — a driver round trip is
 ~196 ms against a 200 ms window, so sampling from there would have produced a
 FALSE GREEN.
 
-### Two open readings, deliberately not resolved
+### The mutant SURVIVED, and the reason is the useful part
 
-The positive control reproduced the members arm at −147 / −141 / −139 ms to
-the point (−220 / −226 / −227 ms to the edge), against `92df169a`'s published
-band of **−207…−193 ms**. Both are comfortably negative — the direction the
-cure depends on — but they differ by ~15-25 ms, and two readings survive:
+The mutant is the pre-cure shape put back — the CLASS barrier in place of
+`closeSettings`. It was run at `--repeat-each=5` and again at 20, on a clean
+tree restored from HEAD each time, with the injection witnessed (`git diff
+--stat`) rather than assumed. **It survived 50 runs out of 50.** The
+un-mutated control stayed green (10/10), as it must.
 
-1. the published band is STALE (the page has changed since `92df169a`);
-2. the new figure carries a sampling bias — the decimated 3-repeat run and
-   the in-page clock are not the 10-repeat driver-clocked method that
-   produced the band.
+A surviving mutant is not an absolution. The first explanation offered was a
+~196 ms driver latency borrowed from the members-arm incident — a number
+measured on a different arm, which would have been a structure read and a
+magnitude assumed. Measuring it here replaced it, and the replacement is
+better than the guess.
 
-Neither is settled here. The number does not gate the cure (the sign does),
-so a further measurement round was declined rather than guessed.
+The quantity was declared before the run: `L` = the next tap landing in the
+page minus the stamp of the CLASS barrier's return, against `H` = the point
+clearing minus the same stamp. Same origin, same page clock; failure is
+exactly `L < H`, and the stamp's own round-trip biases both equally. On
+n=25:
+
+* `H` min 150 / median 164 / max 169 ms — and the hole reproduced at n=25 in
+  two independent runs (medians 160 and 164), where the earlier figure rested
+  on three samples;
+* `L` min 150 / median 265 / max 291 ms — **not a constant**, but BIMODAL:
+  eleven samples land within one rAF frame of the clear, fourteen a single
+  ~100 ms retry cycle later;
+* `L − H` min −18 / median 106 / max 139 ms.
+
+And the positive control — a deliberate 400 ms inserted before the tap —
+does **not** add: `L` becomes 451 ms, not 265 + 400, because `L` already
+contained the wait for `H`. That non-additivity was not predicted, and it is
+the strongest of the three signs.
+
+**So the driver does not merely run slower than the hole: it HOLDS the tap
+until the panel stops intercepting it.** Playwright's fourth actionability
+check — "receives events" — is active for `tap` (`dom.js` builds the
+interceptor with `actionType` `"tap"`), an interception is a RETRY rather
+than a failure, and the tap interceptor covers touch as well as pointer
+events. `force: true` is what skips it. With the driver waiting, the mutant
+*cannot* die reliably on this arm, which is precisely what 50/50 says.
+
+🥇 Two further things this cost, worth more than the number. The positive
+control killed the instrument twice more: on the first latency run the tap
+listener was armed before the CLOSING tap and so recorded *that* one,
+reporting `L` = −9 ms and staying stone-deaf to the 400 ms injected into the
+control (−10 ms). Three instrument defects on this issue, all three found by
+the positive control and none by the data. And the earlier "two open
+readings" on the −207…−193 ms band are now moot: the band was a margin, and
+margin is no longer the frame in which this is described.
+
+### What the cure actually buys
+
+Stated plainly, because the measurement forces it: on a caller that reaches
+the next target through a plain locator gesture, **the geometry barrier is
+belt-and-braces** — the driver's own hit-target retry is already standing
+where the barrier stands. It ships anyway, for two reasons that are not
+"it might help": a barrier on the CLASS asserts the panel is closed while it
+is demonstrably still on screen, and the protection it duplicates belongs to
+the DRIVER, not to us, so it is withdrawn by any change of gesture.
+
+What would make it load-bearing, concretely: a `force: true` gesture, which
+skips the hit-target check outright (measured on `push.ts:664` — a force
+centre click lands inside the drawer box, 3/3); a coordinate-addressed
+gesture (`page.mouse.*`, `page.touchscreen.*`) or a dispatched event, none of
+which run actionability at all; or a next step that is not a pointer action
+and therefore has nothing to retry.
+
+🔴 **One thing is NOT explained, and is recorded rather than smoothed over.**
+The incident this whole thread rests on shows a tap that *did* land on a
+members row. With the hit-target check active and covering touch, it should
+have retried instead. Reading the two call sites did not account for it —
+they issue the identical plain locator tap, historically as well as today —
+and neither did the CSS: `pointer-events` switches only on the backdrops,
+so both drawers intercept while sliding. The class barrier's unsoundness does
+not depend on the answer, but the answer is not known.
 
 ### Declared and NOT cured
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51114,14 +51114,18 @@ so a further measurement round was declined rather than guessed.
   On 71e7840a: `issue299-footer-admin-reachable.spec.ts:120`,
   `issue299-theme-cards.spec.ts:49`, `issue358-daynight-theme.spec.ts:36`,
   `issue75-theme-editor.spec.ts:65`, `issue75-themes-gallery.spec.ts:37`.
-  Each is a `.shell-members.open` count→0 barrier whose next interaction is
-  `getByTestId("themes-settings-entry").tap()` (immediately in four; after
-  two pure assertions in `issue299-footer-admin-reachable`). The target lives
-  INSIDE the settings drawer that is ENTERING, and the two drawers are a
-  mutex, so they move together: Playwright's own "stable" actionability wait
-  on the entering target happens to outlast the other drawer's exit. Lower
-  risk, for a reason no one chose, that a future IA reshuffle can withdraw
-  without touching these lines.
+  Each is a `.shell-members.open` count→0 barrier whose next INTERACTION is
+  `getByTestId("themes-settings-entry").tap()`. The class is defined on the
+  interposed INTERACTION, not on adjacency of lines: in four of the five that
+  tap is the very next line, and in `issue299-footer-admin-reachable` two pure
+  assertions (`toHaveCount(0)` on two #299 labels) sit in between. Said
+  explicitly because a reader grepping for the adjacent shape finds four and
+  concludes the fifth was miscounted. The target lives INSIDE the settings
+  drawer that is ENTERING, and the two drawers are a mutex, so they move
+  together: Playwright's own "stable" actionability wait on the entering
+  target happens to outlast the other drawer's exit. Lower risk, for a reason
+  no one chose, that a future IA reshuffle can withdraw without touching these
+  lines.
 
 ### Census method, and its declared limit
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50990,3 +50990,149 @@ of registration, happens in both worlds, and does not presuppose the answer the
 way waiting on the nick would — the same bench reproduces 3/3.
 
 **A green that reports NON-reproduction deserves the same suspicion as a red.**
+<!-- entry #1155-inline-barrier -->
+
+---
+
+## 2026-08-19 — #1155: the last inline class-barrier drawer door, and what the probe that found it got wrong twice
+
+`7e988f2e` converted `closeMembersDrawer` from `.shell-members.open`
+count→0 to `not.toBeInViewport` and called it "the last drawer door on the
+class". That was true **among the fixtures** and false **among the specs**.
+This entry closes the one spec-side site that reproduced, and — more usefully
+— records the two ways the instrument that found it lied first.
+
+### The defect, restated
+
+A close barrier waited on the CLASS releases at the START of a 200ms
+`transform: translateX(100%)` slide-out. The panel keeps covering the point
+the next gesture aims at for the rest of that slide, so the next tap is
+received by the drawer and the failure surfaces somewhere else entirely.
+The class is the right subject for an ASSERTION and the wrong subject for a
+BARRIER.
+
+### The cure — one site
+
+`cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts:126-127`, inside
+`@webkit ux-5-bm mobile-channel …`, became one call to `closeSettings`
+(`fixtures/cicchettoPage.ts`), which already performs the same two gestures
+against the geometry rather than the class. Two differences were checked
+before declaring the substitution equivalent, and neither is a hazard:
+
+* The site used `.tap()`, the fixture uses `.click()`. `.click()` is the
+  DELIBERATE form on webkit — `closeMembersDrawer` documents why: `tap()`
+  relies on engine-side click synthesis that is timing-flaky there, while
+  `.click()` fires the synthetic click directly. Same end state.
+* The site anchored the button inside `.settings-drawer`; the fixture takes
+  it by global testid. Not ambiguous: `settings-drawer-close` is emitted at
+  exactly one place in the source (`SettingsDrawer.tsx`), and although
+  `Shell.tsx` mounts `<SettingsDrawer>` twice, the two mounts are the two
+  branches of `<Show when={isMobile()}>` — one renders. The same holds for
+  the fixture's `getByRole("dialog", {name: /settings/i})`: of the twenty
+  `role="dialog"` elements in cic, only `SettingsDrawer` carries a name
+  matching `/settings/i`. Playwright strict mode makes every green run of
+  this spec a live re-witness of both facts.
+
+### Measured — the arm under test
+
+In-page probe (a rAF sampler armed BEFORE the closing tap; the driver only
+contributes a stamp), webkit-iphone-15, 3 repeats. Settings drawer, next
+point = the topic-bar hamburger:
+
+* margin from the CLASS barrier to the tap point: **−148 / −148 / −160 ms**;
+* margin from the CLASS barrier to the box clearing the edge: −221 / −198 / −212 ms;
+* margin from `not.toBeInViewport` to the tap point: **+279 / +282 / +258 ms**.
+
+The point (355, 31) was DERIVED from the live hamburger box, not copied from
+the issue — and it landed on the coordinates #1155 cites. At the moment the
+class barrier returned, the element stack over that point was, 3/3:
+`button.settings-drawer-close` / `header.settings-drawer-header` /
+`aside.settings-drawer` / `div.settings-drawer-backdrop` /
+`button.topic-bar-hamburger` — the intended target four layers down.
+
+Geometry that makes it inevitable (`default.css` on 71e7840a): the root font
+size is `var(--font-size)` = **14px**, not 16, so `.settings-drawer`'s
+`width: 22rem` is 308px and covers x ∈ [85, 393] of a 393px viewport. The
+BACKDROP is not the hazard — its `pointer-events` switches with the class,
+instantaneously. The DRAWER is, because its transform is animated.
+
+### 🥇 The instrument was exposed to the defect it was measuring
+
+Neither of the probe's two defects would have been visible without the
+POSITIVE CONTROL run (the members drawer, whose band was already published
+by `92df169a`). Both are worth more than the number they corrupted.
+
+* **Coverage tested by class SUBSTRING over the top 3 of the stack.** On the
+  members arm the top three were `li.member-op` / `ul` / `div.members-pane` —
+  all DESCENDANTS of the aside, none of them spelling `shell-members`. The
+  probe reported **+82 ms**: the WRONG SIGN. Cure: test coverage by ANCESTRY
+  (`drawer.contains(top)`), computed in-page.
+* **The probe armed before the drawer had come to rest.** `left_min` came
+  back 285 / 257 — the panel was still ENTERING, so a PARTIAL run was being
+  timed, which is why the control kept landing mid-module. Cure: a settle
+  barrier `toBeInViewport({ratio: 1})` before arming — the idiom
+  `openMembersDrawer` already uses.
+
+The second one is **#1155 itself, inside the tool built to measure #1155**:
+`toBeVisible` on a class is not a barrier on geometry. "Your instrument is
+exposed to the defect you measure" was meant literally.
+
+Related: the probe is IN-PAGE and not driver-side for the same
+order-of-magnitude reason the defect exists at all — a driver round trip is
+~196 ms against a 200 ms window, so sampling from there would have produced a
+FALSE GREEN.
+
+### Two open readings, deliberately not resolved
+
+The positive control reproduced the members arm at −147 / −141 / −139 ms to
+the point (−220 / −226 / −227 ms to the edge), against `92df169a`'s published
+band of **−207…−193 ms**. Both are comfortably negative — the direction the
+cure depends on — but they differ by ~15-25 ms, and two readings survive:
+
+1. the published band is STALE (the page has changed since `92df169a`);
+2. the new figure carries a sampling bias — the decimated 3-repeat run and
+   the in-page clock are not the 10-repeat driver-clocked method that
+   produced the band.
+
+Neither is settled here. The number does not gate the cure (the sign does),
+so a further measurement round was declined rather than guessed.
+
+### Declared and NOT cured
+
+* **`push.ts:664` is a MEASURED negative, not an oversight.** It is the only
+  other site of #1155's exact shape, and it cannot reach the hazard: all NINE
+  callers of `enablePushFromSettings` run chromium-only, and the single
+  `@webkit` token in `push-964-device-row` is inside a COMMENT ("no @webkit
+  twin"). A corollary proves the helper is DESKTOP-shaped rather than merely
+  unexercised: on mobile its gesture does not even close the drawer — the
+  backdrop is `inset: 0`, so the `force: true` click starts from the centre
+  (196, 329), which on 393px falls INSIDE the drawer box, and `force` skips
+  the hit-target check. 3/3 failed on `.settings-drawer.open` count 0,
+  "Received: 1". **The condition that reopens this: any caller of
+  `enablePushFromSettings` acquiring a `@webkit` twin.**
+* **Five sites are protected INCIDENTALLY, by accident and not by design.**
+  On 71e7840a: `issue299-footer-admin-reachable.spec.ts:120`,
+  `issue299-theme-cards.spec.ts:49`, `issue358-daynight-theme.spec.ts:36`,
+  `issue75-theme-editor.spec.ts:65`, `issue75-themes-gallery.spec.ts:37`.
+  Each is a `.shell-members.open` count→0 barrier whose next interaction is
+  `getByTestId("themes-settings-entry").tap()` (immediately in four; after
+  two pure assertions in `issue299-footer-admin-reachable`). The target lives
+  INSIDE the settings drawer that is ENTERING, and the two drawers are a
+  mutex, so they move together: Playwright's own "stable" actionability wait
+  on the entering target happens to outlast the other drawer's exit. Lower
+  risk, for a reason no one chose, that a future IA reshuffle can withdraw
+  without touching these lines.
+
+### Census method, and its declared limit
+
+A WIDE anchor on `shell-members|settings-drawer|shell-drawer` across
+`cicchetto/e2e`, in four spellings — `toHaveCount(0)`, `toBeHidden`,
+`not.toBeVisible`, `not.toHaveClass` — returned 25 hits: 2 of #1155's exact
+shape (the site cured here and `push.ts:664`), 5 incidentally protected, and
+the rest ASSERTIONS rather than barriers, with no interaction within the
+window. On the class those are entirely correct — there the class IS the
+subject. Among them `ux-5-bv-mobile-keyboard-react:236` uses the fourth
+spelling (`toBeHidden` against a locator carrying the class, which passes
+because the locator stops matching) but is the test's last line, followed by
+`finally`. **The window is 12 lines after each site: an interaction further
+away than that escapes this census.** Not exhaustive, and not claimed to be.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51178,7 +51178,9 @@ not depend on the answer, but the answer is not known.
   "Received: 1". **The condition that reopens this: any caller of
   `enablePushFromSettings` acquiring a `@webkit` twin.**
 * **Five sites are protected INCIDENTALLY, by accident and not by design.**
-  On 71e7840a: `issue299-footer-admin-reachable.spec.ts:120`,
+  Enumerated on 71e7840a and re-verified unchanged on `ea733fc9` after #1152
+  moved twenty-odd e2e files — same paths, same lines:
+  `issue299-footer-admin-reachable.spec.ts:120`,
   `issue299-theme-cards.spec.ts:49`, `issue358-daynight-theme.spec.ts:36`,
   `issue75-theme-editor.spec.ts:65`, `issue75-themes-gallery.spec.ts:37`.
   Each is a `.shell-members.open` count→0 barrier whose next INTERACTION is


### PR DESCRIPTION
## What this is

`7e988f2e` converted the `closeMembersDrawer` fixture from a
`.shell-members.open` count→0 barrier to `not.toBeInViewport`, and called it
"the last drawer door on the class". True **among the fixtures**, false **among
the specs**. This is the one spec-side site of that shape that reproduced.

A barrier waited on the CLASS releases at the **start** of a 200ms
`transform: translateX(100%)` slide-out, so it returns while the panel is still
covering the point the next gesture aims at. The class is the right subject for
an ASSERTION and the wrong subject for a BARRIER.

## The change

* `cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts:126-127` (inside
  `@webkit ux-5-bm mobile-channel …`) becomes one call to `closeSettings`, plus
  the import. `closeSettings` already performs the same two gestures against
  geometry rather than class — a substitution, not a third semantics.
* `cicchetto/e2e/fixtures/cicchettoPage.ts` — **a claim shipped in #1336 is
  corrected**, see below. It is wrong, so it is not left standing.

Two differences were checked before declaring the substitution equivalent: the
site used `.tap()` where the fixture uses `.click()` (the deliberate webkit
form — `closeMembersDrawer` documents the tap-synthesis race), and the site
anchored the button inside `.settings-drawer` where the fixture takes it by
global testid (**not ambiguous**: one source site, and `Shell.tsx`'s two
`<SettingsDrawer>` mounts are the two branches of `<Show when={isMobile()}>`;
of the twenty `role="dialog"` elements only `SettingsDrawer` is named
`/settings/i`). Playwright strict mode makes every green run re-witness both.

## The mutant survived 50/50 — and that is the finding

The pre-cure shape was put back in place of `closeSettings` and run at
`--repeat-each=5` and again at 20, on a clean tree restored from HEAD each
time, with the injection **witnessed** (`git diff --stat`) rather than assumed:

| side | result |
| --- | --- |
| control, un-mutated | `rc=0`, 10/10 green |
| mutant, 5 repeats | `rc=0`, 10/10 green |
| mutant, 20 repeats | `rc=0`, 40/40 green |

A surviving mutant is not an absolution. The first explanation on offer was a
~196 ms driver latency **borrowed from the members-arm incident** — a structure
read and a magnitude assumed. It was measured here instead.

Quantity declared before running: `L` = the next tap landing in the page minus
the stamp of the class barrier's return; `H` = the point clearing minus the same
stamp. Same origin, same page clock, failure is exactly `L < H`, and the stamp's
round-trip biases both equally. On n=25:

| | min | median | max |
| --- | --- | --- | --- |
| `H` (the hole) | 150 | 164 | 169 |
| `L` | 150 | 265 | 291 |
| `L − H` | −18 | **106** | 139 |

`L` is **not a constant** — it is bimodal: eleven samples land within one rAF
frame of the clear, fourteen a single ~100 ms retry cycle later. And the
positive control, a deliberate 400 ms before the tap, does **not add**: `L`
becomes 451 ms, not 265+400, because `L` already contained the wait for `H`.
That non-additivity was not predicted and is the strongest of the three signs.

**The driver does not merely run slower than the hole: it HOLDS the tap until
the panel stops intercepting it.** With the driver waiting, the mutant cannot
die reliably on this arm — which is exactly what 50/50 says.

Side benefit worth naming: `H` now rests on n=25 in two independent runs
(medians 160 and 164) where yesterday it rested on three samples.

## A claim shipped in #1336 is corrected here

`closeMembersDrawer` asserted *"Playwright cannot see this on its own: its
'visible, enabled and stable' check runs on the TARGET's box"*. That names
**three of Playwright's four** actionability checks and concludes blindness from
the three. The fourth — *receives events* — is the one that sees an overlay:
`dom.js` builds the interceptor with `actionType` `"tap"`, an interception is a
RETRY (`… intercepts pointer events`, then `continue`) rather than a failure,
and the tap interceptor covers touch (`pointerdown/pointerup/touchstart/
touchend/touchcancel`). `force: true` is what skips it.

So the claim **holds for `push.ts:664`'s shape** (force) and **not** for this
fixture's plain-locator callers. Corrected in place in `8891b0e1`, with the
measurement and the source citation beside it, rather than deleted quietly.

## What the cure actually buys — stated plainly

On a caller that reaches its next target through a plain locator gesture, the
geometry barrier is **belt-and-braces**: the driver's own hit-target retry
already stands where the barrier stands. It ships anyway, for two reasons that
are not "it might help":

1. a barrier on the CLASS asserts the panel is closed while it is demonstrably
   still on screen;
2. the protection it duplicates is the **driver's**, not ours, and is withdrawn
   by any change of gesture.

What would make it load-bearing, concretely: a `force: true` gesture, which
skips the hit-target check outright (measured on `push.ts:664` — a force centre
click lands inside the drawer box, 3/3); a coordinate-addressed gesture
(`page.mouse.*`, `page.touchscreen.*`) or a dispatched event, none of which run
actionability at all; or a next step that is not a pointer action.

## 🔴 Not explained, and not smoothed over

The incident this thread rests on shows a tap that **did** land on a members
row. With the hit-target check active and covering touch, it should have
retried. Reading did not account for it: the two call sites issue the identical
plain locator tap, historically as well as today, and `pointer-events` switches
only on the backdrops, so both drawers intercept while sliding. The class
barrier's unsoundness does not depend on the answer, but the answer is not
known and is recorded as unknown.

## Declared, and NOT cured

**`push.ts:664` is a MEASURED negative.** All **nine** callers of
`enablePushFromSettings` run chromium-only; the single `@webkit` token in
`push-964-device-row` is inside a **comment** ("no @webkit twin"). And the
helper is desktop-shaped rather than merely unexercised: on mobile its gesture
does not even close the drawer — backdrop `inset: 0`, `force: true` click from
the centre (196, 329), which on 393px falls inside the drawer box, and `force`
skips the hit-target check. 3/3 failed on `.settings-drawer.open` count 0,
"Received: 1". **Reopens if any caller acquires a `@webkit` twin.**

**Five sites are protected INCIDENTALLY — by accident, not design.** On
`ea733fc9` (re-verified after the rebase, same lines): 
`issue299-footer-admin-reachable.spec.ts:120`,
`issue299-theme-cards.spec.ts:49`, `issue358-daynight-theme.spec.ts:36`,
`issue75-theme-editor.spec.ts:65`, `issue75-themes-gallery.spec.ts:37`. The
class is defined on the interposed **interaction**, not on adjacency: in four
the `themes-settings-entry` tap is the very next line, in
`issue299-footer-admin-reachable` two pure assertions sit in between (said
explicitly — a reader grepping the adjacent shape finds four and concludes the
fifth was miscounted). Their target lives inside the drawer that is ENTERING,
and the two drawers are a mutex.

**The earlier "two open readings" on the −207…−193 ms band are moot.** They were
a disagreement about a *margin*, and margin is no longer the frame: the question
was what happens inside the hole, and that is now measured.

## Instrument defects — three, all found by the positive control

* coverage tested by class SUBSTRING over the stack's top 3 reported **+82 ms**,
  the *wrong sign*, because the top three were descendants of the aside that
  never spell `shell-members`. Cure: ancestry (`drawer.contains(top)`);
* the probe armed before the drawer had come to rest (`left_min` 285 / 257),
  timing a PARTIAL run. Cure: a settle barrier `toBeInViewport({ratio: 1})`;
* the latency probe's tap listener was armed before the CLOSING tap and recorded
  *that* one — `L` = −9 ms, and stone-deaf to the 400 ms injected into its own
  control (−10 ms). Cure: only count a gesture landing after the stamp.

The second is **#1155 itself, inside the tool built to measure #1155**. None of
the three was found by the data; all three were found by the positive control.

## Census, and its declared limit

A wide anchor on `shell-members|settings-drawer|shell-drawer` across
`cicchetto/e2e`, in four spellings (`toHaveCount(0)`, `toBeHidden`,
`not.toBeVisible`, `not.toHaveClass`), returned 25 hits: 2 of this exact shape,
5 incidentally protected, the rest ASSERTIONS rather than barriers. On the class
those are correct — there the class IS the subject. **The window is 12 lines
after each site: an interaction further away escapes this census.** Not
exhaustive, and not claimed to be.

## Gates

* `scripts/bun.sh run check` — rc=0, re-run after the fixture edit AND again
  after rebasing onto `ea733fc9`. biome + `tsc` on `src` + `tsc` on `e2e`.
  1055 files (1054 before the rebase — #1152 landed one new spec), 59 warnings
  + 6 infos unchanged, all pre-existing in `src/themes/default.css`.
* `scripts/design-notes-gate.sh` — rc=0 with the non-vacuous message:
  `1 new entry heading(s), separator and marker present`.
* `scripts/check.sh` not run: no Elixir file touched.
* Five checks expected — this touches `cicchetto/e2e/**`, so `integration` runs
  (37-40 min is its band, not a stall).

Rationale, the three instrument defects, what the cure buys and what is still
unexplained are recorded in `docs/DESIGN_NOTES.md` under
`<!-- entry #1155-inline-barrier -->`.
