### PR TITLE
test(#1397): retire two fail-open registry barriers onto one that raises

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51209,3 +51209,92 @@ spelling (`toBeHidden` against a locator carrying the class, which passes
 because the locator stops matching) but is the test's last line, followed by
 `finally`. **The window is 12 lines after each site: an interaction further
 away than that escapes this census.** Not exhaustive, and not claimed to be.
+<!-- entry #1397-registry-purge -->
+
+---
+
+## 2026-08-19 — #1397: a barrier that failed open, in the file the fix was named after
+
+Bucket H's server side had one cluster left where the drift was a **barrier**
+rather than a name, and it is the one this entry is about. `bootstrap_test.exs`
+and `spawn_orchestrator_test.exs` each carried a private
+`clear_registry_for/1` that purged `Grappa.SessionRegistry` for one
+`network_id` and then waited for the Registry to observe it. Both waits ended
+in `defp wait_until_registry_clear(_, 0), do: :ok` — **fail-open**: after 500ms
+they returned `:ok` with zombies still registered and the test carried on
+against a dirty registry. The call sites even read `:ok = clear_registry_for(...)`,
+a match that cannot fail because the callee cannot return anything else.
+
+The sharp part is not the duplication. `AdmissionStateHelpers`' own moduledoc
+**already named these two copies as the defect** — *"per-test-file
+`clear_registry_for(network_id)` polling helpers silently exhausted their 500ms
+budget under CI load (returned `:ok` with zombies still present). Loud raise +
+setup-time global reset is the durable fix"* — and both files **already aliased
+that module and already called `reset_all/0` in setup**. The shared module had
+no per-network form, so each file wrote its own weaker one and kept it. A
+promotion is not finished when the canonical exists; it is finished when the
+copies are gone.
+
+### What the two-sided mutant established
+
+One mutant, applied symmetrically to both sides: *the purge does nothing, only
+the wait remains.* Subject: the two adopting files, 42 tests.
+
+| side | control | mutant |
+|---|---|---|
+| branch | rc=0, 42 tests, 0 failures | **rc=2, 42 tests, 4 failures** |
+| base `ea733fc9` | rc=0, 42 tests, 0 failures | **rc=0, 42 tests, 0 failures** |
+
+All four branch failures are the raise itself, naming the survivor count
+(`still has 1 session(s) registered for network_id=1 after 15000ms`; one says
+2). The base produced **zero** raises and zero failures — the neutered purge is
+invisible there, which is precisely the defect stated as a number rather than
+as a story.
+
+Note what that asymmetry means for the de-duplication framing: the slice is
+behaviour-**changing**, not behaviour-preserving. A consolidation whose mutant
+cannot tell the two sides apart has not fixed anything.
+
+### The budget was decided, not inherited
+
+`clear_registry_for!/2` takes `timeout_ms` as a required argument with no
+default — the same posture this bucket's handshake barrier took, and for the
+same reason: consolidating a barrier means deciding the budget at the call
+site. Both call sites moved 500ms → 15s, the module's existing drain budget.
+Re-inheriting 500ms would have consolidated on the number the canonical's own
+docstring records as insufficient under CI load.
+
+### Aggregate postcondition, not per-pid
+
+`reset_session_supervisor/0` raises when a single pid misses its terminate
+window. `clear_registry_for!/2` deliberately does not: its contract is the
+aggregate — *"nothing is registered for this network"* — which is the same
+postcondition production's `Session.stop_session/2` states about its key. A pid
+that ignores `terminate_child/2` is a failure only if it is still registered
+when the poll gives up, and then the poll reports it with a count. One loud
+failure mode beats two.
+
+### Two false zeros, both in the measuring instrument
+
+The census that picked this slice produced two zeros that were artefacts:
+
+* grouping definition bodies with `def`/`defp` left distinct reported **0**
+  site definitions body-identical to a `test/support` one. The real number is
+  1. It was caught only because that one case had already been found by hand;
+* an import oracle anchored on `alias Grappa.Foo` missed the braced form
+  `alias Grappa.{A, B, C}` and reported four files as not importing a helper
+  they call.
+
+Same lesson this bucket has now recorded four times, in a fourth mechanism: **a
+uniform result accuses the instrument before the code.** A zero is worth less
+than the naked grep that agrees with it.
+
+### The server-side counts, re-measured on `ea733fc9`
+
+74 helper names defined in ≥2 site files (234 definitions over 108 files) by
+name; 28 clusters of a byte-identical body spanning ≥2 files (76 definitions
+over 57 files). Of the 58 definitions whose name already exists in
+`test/support`, 25 are the fixture trio blocked on the Argon2 question, 20 are
+behaviour callbacks in stub modules (not duplication at all), and 4 already
+delegate to the canonical they collide with. The inline `passthrough_handler`
+duplication this issue recorded — 14 bodies over 10 files — is now **0**.

--- a/test/grappa/admission_state_helpers_test.exs
+++ b/test/grappa/admission_state_helpers_test.exs
@@ -1,0 +1,84 @@
+defmodule Grappa.AdmissionStateHelpersTest do
+  @moduledoc """
+  Loudness pin for `clear_registry_for!/2` (#1397 bucket H).
+
+  The two per-test-file `clear_registry_for/1` copies this helper
+  replaces failed OPEN: their last clause was
+  `defp wait_until_registry_clear(_, 0), do: :ok`, so once the 500ms
+  budget expired they returned `:ok` with zombies still registered and
+  the test carried on against a dirty registry. That is the failure
+  mode `AdmissionStateHelpers`' own moduledoc already names, and it is
+  what makes a cap assertion fail somewhere else entirely.
+
+  De-duplication alone is preserving by construction, so it cannot
+  witness that the barrier stopped failing open. This test is that
+  witness: it holds a registered pid the purge cannot remove and pins
+  that the helper RAISES rather than returning `:ok`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Grappa.AdmissionStateHelpers
+
+  # Small budget: the test's subject is the raise, not the wait. The
+  # value is passed at the call site precisely so a test can be cheap
+  # while the suite's real callers stay patient.
+  @budget_ms 50
+
+  describe "clear_registry_for!/2" do
+    test "raises when a registered session survives the purge" do
+      network_id = System.unique_integer([:positive])
+      {pid, key} = register_unkillable_session(network_id)
+
+      assert_raise RuntimeError, ~r/still has 1 session.*network_id=#{network_id}/, fn ->
+        AdmissionStateHelpers.clear_registry_for!(network_id, @budget_ms)
+      end
+
+      unregister(pid, key)
+    end
+
+    test "returns :ok when nothing is registered for the network" do
+      assert :ok = AdmissionStateHelpers.clear_registry_for!(System.unique_integer([:positive]), @budget_ms)
+    end
+
+    test "leaves another network's session registered" do
+      mine = System.unique_integer([:positive])
+      theirs = System.unique_integer([:positive])
+      {pid, key} = register_unkillable_session(theirs)
+
+      assert :ok = AdmissionStateHelpers.clear_registry_for!(mine, @budget_ms)
+      assert [_] = Registry.lookup(Grappa.SessionRegistry, key)
+
+      unregister(pid, key)
+    end
+  end
+
+  # A plain process registered under a session key: it is not a
+  # `SessionSupervisor` child, so `terminate_child/2` cannot reach it,
+  # and it is not an OTP process, so the `GenServer.stop` sweep times
+  # out on it. Exactly the zombie shape the 500ms copies gave up on.
+  defp register_unkillable_session(network_id) do
+    key = {:session, {:user, System.unique_integer([:positive])}, network_id}
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        {:ok, _} = Registry.register(Grappa.SessionRegistry, key, nil)
+        send(parent, :registered)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :registered, 1_000
+    {pid, key}
+  end
+
+  defp unregister(pid, key) do
+    Process.exit(pid, :kill)
+
+    Enum.reduce_while(1..100, :waiting, fn _, _ ->
+      case Registry.lookup(Grappa.SessionRegistry, key) do
+        [] -> {:halt, :ok}
+        _ -> Process.sleep(5) && {:cont, :waiting}
+      end
+    end)
+  end
+end

--- a/test/grappa/bootstrap_test.exs
+++ b/test/grappa/bootstrap_test.exs
@@ -74,57 +74,17 @@ defmodule Grappa.BootstrapTest do
     end
   end
 
-  # Terminates every Session.Server in `Grappa.SessionRegistry` whose key
-  # points at `network_id`, then waits until `Registry.count_select/2`
-  # observes the cleanup. Used by the cap test to neutralize zombie
-  # sessions that other tests' DB-sandbox rollbacks make possible:
-  # sqlite reuses rowids after rollback, so a `network.id` minted by the
-  # cap test can collide with a stale Session.Server registered under
-  # the same integer by an earlier test that started a session and
-  # didn't (or couldn't synchronously) reach Registry-cleanup before
-  # bootstrap_test ran. The Session.Server processes outlive the DB
-  # rollback because Registry + SessionSupervisor are application-wide
-  # singletons; the test contract here is "Bootstrap counts live
-  # sessions against the per-network cap" so we MUST start from a
-  # registry that's clean for THIS network.id, not the one inherited
-  # from whichever ID-recycled session wandered in.
-  @clear_registry_attempts 100
-  @clear_registry_poll_ms 5
-  defp clear_registry_for(network_id) when is_integer(network_id) do
-    pids =
-      Registry.select(Grappa.SessionRegistry, [
-        {{{:session, :_, network_id}, :"$1", :_}, [], [:"$1"]}
-      ])
-
-    Enum.each(pids, fn pid ->
-      ref = Process.monitor(pid)
-      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
-
-      receive do
-        {:DOWN, ^ref, :process, ^pid, _} -> :ok
-      after
-        500 -> Process.demonitor(ref, [:flush])
-      end
-    end)
-
-    wait_until_registry_clear(network_id, @clear_registry_attempts)
-  end
-
-  defp wait_until_registry_clear(_, 0), do: :ok
-
-  defp wait_until_registry_clear(network_id, attempts) do
-    count =
-      Registry.count_select(Grappa.SessionRegistry, [
-        {{{:session, :_, network_id}, :_, :_}, [], [true]}
-      ])
-
-    if count == 0 do
-      :ok
-    else
-      Process.sleep(@clear_registry_poll_ms)
-      wait_until_registry_clear(network_id, attempts - 1)
-    end
-  end
+  # The cap tests must start from a registry that is clean for THIS
+  # `network.id`: sqlite recycles rowids after a sandbox rollback, so an
+  # earlier test's Session.Server can still be registered under the same
+  # integer and be counted against the per-network cap this file is
+  # asserting. `AdmissionStateHelpers.clear_registry_for!/2` is the
+  # shared purge; the budget it takes is caller-supplied and this file's
+  # own 500ms predecessor was measured insufficient under CI load (that
+  # is the whole reason the shared one raises instead of giving up), so
+  # it matches the module's 15s registry-drain budget rather than
+  # reinstating the number that failed open.
+  @clear_registry_ms 15_000
 
   describe "run/0 with bound credentials" do
     test "spawns one session per Credential row" do
@@ -642,14 +602,14 @@ defmodule Grappa.BootstrapTest do
       on_exit(fn -> Logger.delete_module_level(Grappa.Bootstrap) end)
 
       # Neutralize zombies inherited via sqlite rowid reuse — see
-      # `clear_registry_for/1` doc above. Must run AFTER the network
+      # `@clear_registry_ms` above. Must run AFTER the network
       # row exists (so we know its id) and BEFORE `Bootstrap.run/0`
       # (so the cap calculation starts from `live = 0` for this id).
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
 
       log = capture_log(fn -> assert {:ok, %Result{}} = Bootstrap.run() end)
 
-      on_exit(fn -> clear_registry_for(network.id) end)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       started_rows =
         Registry.select(Grappa.SessionRegistry, [
@@ -694,8 +654,8 @@ defmodule Grappa.BootstrapTest do
       Logger.put_module_level(Grappa.Bootstrap, :info)
       on_exit(fn -> Logger.delete_module_level(Grappa.Bootstrap) end)
 
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       assert {:ok,
               %Result{

--- a/test/grappa/spawn_orchestrator_test.exs
+++ b/test/grappa/spawn_orchestrator_test.exs
@@ -92,52 +92,22 @@ defmodule Grappa.SpawnOrchestratorTest do
     end
   end
 
-  defp clear_registry_for(network_id) when is_integer(network_id) do
-    pids =
-      Registry.select(Grappa.SessionRegistry, [
-        {{{:session, :_, network_id}, :"$1", :_}, [], [:"$1"]}
-      ])
-
-    Enum.each(pids, fn pid ->
-      ref = Process.monitor(pid)
-      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
-
-      receive do
-        {:DOWN, ^ref, :process, ^pid, _} -> :ok
-      after
-        500 -> Process.demonitor(ref, [:flush])
-      end
-    end)
-
-    # PHASE-1 (post-cr-review cluster, CI flake on
-    # spawn_orchestrator_test:179 "network_cap_exceeded"): poll until
-    # the Registry observes count == 0 for THIS network_id. Mirrors
-    # bootstrap_test.exs's `wait_until_registry_clear/2` helper added
-    # in T31 cleanup. Without this wait, an earlier test's session
-    # whose `on_exit` cleanup had its 500ms `:DOWN` receive expire can
-    # leave a zombie registered against a network.id that sqlite
-    # rowid-recycles into a fresh test's `network.id` — admission's
-    # `count_live_sessions/1` then reads "1 already" against cap=1
-    # and the FIRST `SpawnOrchestrator.spawn/4` returns
-    # `:network_cap_exceeded` instead of `:spawned`.
-    wait_until_registry_clear(network_id, 100)
-  end
-
-  defp wait_until_registry_clear(_, 0), do: :ok
-
-  defp wait_until_registry_clear(network_id, attempts) do
-    count =
-      Registry.count_select(Grappa.SessionRegistry, [
-        {{{:session, :_, network_id}, :_, :_}, [], [true]}
-      ])
-
-    if count == 0 do
-      :ok
-    else
-      Process.sleep(5)
-      wait_until_registry_clear(network_id, attempts - 1)
-    end
-  end
+  # PHASE-1 (post-cr-review cluster, CI flake on
+  # spawn_orchestrator_test:179 "network_cap_exceeded"): the registry
+  # must read count == 0 for THIS network_id before the cap assertion.
+  # An earlier test's session whose `on_exit` cleanup had its `:DOWN`
+  # receive expire can leave a zombie registered against a network.id
+  # that sqlite rowid-recycles into a fresh test's `network.id` —
+  # admission's `count_live_sessions/1` then reads "1 already" against
+  # cap=1 and the FIRST `SpawnOrchestrator.spawn/4` returns
+  # `:network_cap_exceeded` instead of `:spawned`.
+  #
+  # This used to be a private copy of bootstrap_test.exs's helper, and
+  # both copies FAILED OPEN — 500ms then `:ok` with the zombie still
+  # there, which is the very outcome this comment was written to
+  # prevent. `AdmissionStateHelpers.clear_registry_for!/2` raises
+  # instead, on the module's own 15s drain budget.
+  @clear_registry_ms 15_000
 
   defp capacity_input(network_id, flow) do
     %{network_id: network_id, source_ip: nil, flow: flow, requesting_subject: nil}
@@ -176,7 +146,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "happy-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}
@@ -201,7 +171,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "idempot-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}
@@ -221,7 +191,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "ignored-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
 
       subject = {:user, vjt.id}
 
@@ -261,8 +231,8 @@ defmodule Grappa.SpawnOrchestratorTest do
 
       {:ok, plan_b} = SessionPlan.resolve(cred_b)
 
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       cap_in = capacity_input(network.id, :bootstrap_user)
 
@@ -289,8 +259,8 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "idemcap-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port, %{max_concurrent_user_sessions: 1})
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       subject = {:user, vjt.id}
       cap_in = capacity_input(network.id, :bootstrap_user)
@@ -326,8 +296,8 @@ defmodule Grappa.SpawnOrchestratorTest do
 
       {:ok, plan_b} = SessionPlan.resolve(cred_b)
 
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       network_id = network.id
       cap_in = capacity_input(network_id, :bootstrap_user)
@@ -357,7 +327,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "bo-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}
@@ -401,8 +371,8 @@ defmodule Grappa.SpawnOrchestratorTest do
 
       {:ok, plan_b} = SessionPlan.resolve(cred_b)
 
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       subject_b = {:user, vjt_b.id}
       cap_in = capacity_input(network.id, :bootstrap_user)
@@ -437,7 +407,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "bounce-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}
@@ -467,7 +437,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "recon-nolive-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}
@@ -505,8 +475,8 @@ defmodule Grappa.SpawnOrchestratorTest do
 
       {:ok, plan_b} = SessionPlan.resolve(cred_b)
 
-      :ok = clear_registry_for(network.id)
-      on_exit(fn -> clear_registry_for(network.id) end)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
+      on_exit(fn -> AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms) end)
 
       cap_in = capacity_input(network.id, :bootstrap_user)
 
@@ -527,7 +497,7 @@ defmodule Grappa.SpawnOrchestratorTest do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "recon-bo-#{System.unique_integer([:positive])}"
       {network, plan} = setup_credential(vjt, slug, port)
-      :ok = clear_registry_for(network.id)
+      :ok = AdmissionStateHelpers.clear_registry_for!(network.id, @clear_registry_ms)
       on_exit(fn -> stop_session({:user, vjt.id}, network.id) end)
 
       subject = {:user, vjt.id}

--- a/test/support/admission_state_helpers.ex
+++ b/test/support/admission_state_helpers.ex
@@ -35,6 +35,9 @@ defmodule Grappa.AdmissionStateHelpers do
   `clear_registry_for(network_id)` polling helpers silently exhausted
   their 500ms budget under CI load (returned `:ok` with zombies still
   present). Loud raise + setup-time global reset is the durable fix.
+  Those two copies outlived that finding by months and are now retired
+  in favour of `clear_registry_for!/2`, which is the same purge with
+  the raise attached (#1397 bucket H).
 
   ## Usage
 
@@ -72,6 +75,13 @@ defmodule Grappa.AdmissionStateHelpers do
   # separate cluster scope; this is the load-tolerance knob.
   @reset_registry_attempts 600
   @reset_registry_poll_ms 25
+
+  # Per-pid ceiling for both teardown waits (the `:DOWN` after
+  # `terminate_child/2` and the `GenServer.stop` sweep). Extracted from
+  # the two literals `reset_session_supervisor/0` already carried so
+  # `clear_registry_for!/2` can cap its caller-supplied budget against
+  # the same number instead of inventing a second one.
+  @terminate_timeout_ms 2_000
 
   # How far ahead `open_circuit!/1` pins `cooled_at_ms`. Any value that
   # outlives a single test works; a minute matches the forged row the
@@ -223,11 +233,12 @@ defmodule Grappa.AdmissionStateHelpers do
       receive do
         {:DOWN, ^ref, :process, ^pid, _} -> :ok
       after
-        2_000 ->
+        @terminate_timeout_ms ->
           Process.demonitor(ref, [:flush])
 
           raise "AdmissionStateHelpers.reset_session_supervisor: " <>
-                  "Session.Server #{inspect(pid)} did not terminate within 2s"
+                  "Session.Server #{inspect(pid)} did not terminate within " <>
+                  "#{@terminate_timeout_ms}ms"
       end
     end
 
@@ -244,19 +255,100 @@ defmodule Grappa.AdmissionStateHelpers do
     # between `Process.alive?` check + `GenServer.stop` entry); we
     # don't care about the cause, only that the pid is gone by the
     # time `wait_until_registry_clear!/1` polls.
-    leftover_pids = Registry.select(Grappa.SessionRegistry, [{{:_, :"$1", :_}, [], [:"$1"]}])
+    Grappa.SessionRegistry
+    |> Registry.select([{{:_, :"$1", :_}, [], [:"$1"]}])
+    |> sweep_alive(@terminate_timeout_ms)
 
-    Enum.each(leftover_pids, fn pid ->
+    wait_until_registry_clear!(@reset_registry_attempts)
+  end
+
+  @doc """
+  Terminate every `Grappa.Session.Server` registered under
+  `Grappa.SessionRegistry` for `network_id`, then block until the
+  Registry observes the cleanup FOR THAT NETWORK. Raises on timeout —
+  and the raise is the whole point.
+
+  `bootstrap_test.exs` and `spawn_orchestrator_test.exs` each carried a
+  private `clear_registry_for/1` doing this, and both FAILED OPEN:
+  their terminal clause was `wait_until_registry_clear(_, 0), do: :ok`,
+  so an exhausted 500ms budget returned `:ok` with zombies still
+  registered and the test carried on against a dirty registry. This
+  module's moduledoc already names that failure and "loud raise" as the
+  durable fix; the two copies simply outlived the fix (#1397 bucket H).
+
+  `timeout_ms` is REQUIRED, no default: consolidating a barrier means
+  deciding the budget at the call site instead of inheriting whichever
+  value the majority of copies happened to carry — the same posture the
+  handshake barrier took earlier in this bucket. It bounds the Registry
+  poll, and (capped at the 2s per-pid ceiling `reset_session_supervisor/0`
+  uses) each per-pid wait, so a test that only wants to observe the
+  raise can ask for a cheap budget.
+
+  Scoped to `network_id`: sessions on other networks are left alone.
+  That is what makes it usable MID-test — after `reset_all/0` has run in
+  `setup` and the test has since spawned sessions of its own against a
+  `network.id` sqlite may have recycled.
+  """
+  @spec clear_registry_for!(integer(), pos_integer()) :: :ok
+  def clear_registry_for!(network_id, timeout_ms)
+      when is_integer(network_id) and is_integer(timeout_ms) and timeout_ms > 0 do
+    per_pid_ms = min(timeout_ms, @terminate_timeout_ms)
+
+    # Unlike `reset_session_supervisor/0` this does NOT raise per pid.
+    # The contract here is the AGGREGATE postcondition — "nothing is
+    # registered for this network" — which is the same one production's
+    # `Session.stop_session/2` states about its key. A pid that ignores
+    # `terminate_child/2` is not itself the failure; it is a failure only
+    # if it is still registered when the poll gives up, and then the poll
+    # reports it with a count. One loud failure mode, not two.
+    Enum.each(network_pids(network_id), fn pid ->
+      ref = Process.monitor(pid)
+      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _} -> :ok
+      after
+        per_pid_ms -> Process.demonitor(ref, [:flush])
+      end
+    end)
+
+    # Re-select rather than reuse the list above: same two-step shape as
+    # `reset_session_supervisor/0`, and it catches a pid that registered
+    # while the terminate loop was running.
+    sweep_alive(network_pids(network_id), per_pid_ms)
+
+    wait_until_network_clear!(network_id, max(div(timeout_ms, @reset_registry_poll_ms), 1), timeout_ms)
+  end
+
+  defp network_pids(network_id) do
+    Registry.select(Grappa.SessionRegistry, [{{{:session, :_, network_id}, :"$1", :_}, [], [:"$1"]}])
+  end
+
+  defp sweep_alive(pids, stop_timeout_ms) do
+    Enum.each(pids, fn pid ->
       if Process.alive?(pid) do
         try do
-          GenServer.stop(pid, :shutdown, 2_000)
+          GenServer.stop(pid, :shutdown, stop_timeout_ms)
         catch
           :exit, _ -> :ok
         end
       end
     end)
+  end
 
-    wait_until_registry_clear!(@reset_registry_attempts)
+  defp wait_until_network_clear!(network_id, 0, timeout_ms) do
+    raise "AdmissionStateHelpers.clear_registry_for!: Grappa.SessionRegistry still has " <>
+            "#{length(network_pids(network_id))} session(s) registered for " <>
+            "network_id=#{network_id} after #{timeout_ms}ms"
+  end
+
+  defp wait_until_network_clear!(network_id, attempts, timeout_ms) do
+    if network_pids(network_id) == [] do
+      :ok
+    else
+      Process.sleep(@reset_registry_poll_ms)
+      wait_until_network_clear!(network_id, attempts - 1, timeout_ms)
+    end
   end
 
   defp wait_until_registry_clear!(0) do


### PR DESCRIPTION
Bucket H of #1397, server side. One slice: the per-network
`SessionRegistry` purge. #1397 stays open — this is a slice, not the issue.

## Why this cluster and not a bigger one

The server-side duplication was re-measured on the branch base
(`ea733fc9`) with a hand parser calibrated two ways: definition
detection (935 defs = 127 `test/support` + 808 site, byte-identical to
`git grep -c -E '^ *defp? [a-z_]'`) and body extent (0 overruns in 935).

* by NAME: 74 helper names defined in ≥2 site files, 234 definitions,
  108 files
* by BODY (whitespace-normalised, name-blanked, spanning ≥2 files):
  28 clusters, 76 definitions, 57 files

Of the 58 definitions whose name already exists in `test/support`:
**25** are the fixture trio blocked on the open Argon2 question, **20**
are behaviour callbacks in stub modules (`init`/`terminate`/`start_link`/
`handle_info` — not duplication at all), **4** already delegate to the
canonical they collide with. The largest remaining single-body cluster
is `uniq`/`u` — 18 definitions, 18 files, one body, two names — and it
is one line of stdlib, so consolidating it is cosmetics.

This slice was chosen on a different criterion: **it is the only cluster
left where the drift is a barrier**, which is the red class the issue
itself names (#653 / #1336).

## The defect

`bootstrap_test.exs` and `spawn_orchestrator_test.exs` each carried a
private `clear_registry_for/1`. Both waits ended in

```elixir
defp wait_until_registry_clear(_, 0), do: :ok
```

— **fail-open**. After 500ms they returned `:ok` with zombies still
registered and the test carried on against a dirty registry. The call
sites read `:ok = clear_registry_for(network.id)`, a match that cannot
fail because the callee cannot return anything else.

The canonical differs on four axes:

| axis | `reset_session_supervisor/0` | the two copies |
|---|---|---|
| budget exhausted | raises | `do: :ok`, silent |
| budget | 600×25 = 15 000 ms | 100×5 = 500 ms |
| sweep of leftover pids | yes (`GenServer.stop`) | no |
| scope | global | per `network_id` |

And this was never "the helper was unknown": **both files already alias
`AdmissionStateHelpers` and already call `reset_all/0` in setup**. The
shared module had no per-network form, so each file wrote a weaker one.
`AdmissionStateHelpers`' own moduledoc had already named these two
copies as the defect and "loud raise" as the durable fix — the copies
outlived the fix.

## The change

* promote `clear_registry_for!/2` into `AdmissionStateHelpers`: same
  two-step purge as `reset_session_supervisor/0`, scoped to one
  `network_id` so it stays usable mid-test, raising with the surviving
  count instead of giving up;
* adopt it at all 21 call sites; delete 2 `clear_registry_for/1` and 4
  `wait_until_registry_clear/2` clauses;
* `timeout_ms` is a **required argument, no default** — the posture this
  bucket's handshake barrier already took. Both call sites moved 500ms →
  15s, the module's own drain budget; re-inheriting 500ms would have
  consolidated on the number the canonical's docstring records as
  insufficient under CI load.

`clear_registry_for!/2` deliberately does **not** raise per pid the way
`reset_session_supervisor/0` does. Its contract is the aggregate
postcondition — "nothing is registered for this network" — the same one
production's `Session.stop_session/2` states about its key. One loud
failure mode, not two.

## The two-sided mutant

De-duplication alone is preserving by construction, so one mutant was
applied symmetrically to both sides: **the purge does nothing, only the
wait remains.** Subject: the two adopting files, 42 tests.

| side | control | mutant |
|---|---|---|
| branch | rc=0, 42 tests, 0 failures | **rc=2, 42 tests, 4 failures** |
| base `ea733fc9` | rc=0, 42 tests, 0 failures | **rc=0, 42 tests, 0 failures** |

All four branch failures are the raise itself, naming the survivor count
(`still has 1 session(s) registered for network_id=1 after 15000ms`; one
reads 2), spread over both files (3 in `spawn_orchestrator_test`, 1 in
`bootstrap_test`). The base produced **zero** raises: the neutered purge
is invisible there. That asymmetry is the defect as a number.

It also means this slice is behaviour-**changing**, not preserving, and
is stated as such.

## Test count, pre-registered then reconciled

Pre-registered before the run: base + 1. Revised to base + 3 **before**
anything was measured, because a global purge would pass a loudness test
on its own — the two sibling tests pin the scope (silent `:ok` when the
network is clean; another network's session left untouched).

Measured: base `ea733fc9` = **6557**, branch = **6560**. Delta +3, exact.

## Gates

`scripts/check.sh` on the rebased tree, reconciled by counts, not by rc:

* credo 6077 mods/funs, 0 issues
* doctor passed
* `8 doctests, 61 properties, 6560 tests, 0 failures`
* sobelow `Total errors: 0`
* dialyzer `done (passed successfully)`
* bats 564 `ok`, 0 `not ok`
* `design-notes-gate.sh`: 1 new entry heading, separator and marker
  present; four post-rebase checks done (numstat identical, marker
  `grep -Fxc` = 1, previous entry's tail re-captured from the new base
  and `cmp`-identical, boundary read with `od -c`)

## Not asserted

* **No e2e run.** The slice touches no `cicchetto/` file, but the e2e
  suite was not executed and no claim is made about it.
* **The flake was not reproduced.** The fail-open barrier, the 500ms
  budget and the missing sweep are established statically and by the
  mutant; no CI failure was made to happen on demand, and none is
  claimed.
* **Direction of drift.** No `git log -S` per site, so "differs from" is
  established and "derived from" is not — including whether the two
  copies predate or postdate the canonical.
* **The `stop_session` axis is untouched.** The same two files carry
  four different shapes of "stop a session" (fire-and-forget
  `terminate_child` ×2, `terminate_child` + `:DOWN` 500ms, and
  production's `Session.stop_session/2` in two other files, which chases
  the key across transient respawns per #854). Read, not measured, and
  deliberately left for a separate slice.
* **The census is a lower bound** by the same signature-based method the
  issue uses: a duplicated body never extracted into a named function is
  invisible to it. The one known inline case (`passthrough_handler`) was
  checked and is now 0; no general inline-block search was run.
* Two zeros in the measuring instrument were false and are recorded in
  the DESIGN_NOTES entry: `def`/`defp` left distinct in body
  normalisation, and an import oracle blind to `alias Grappa.{A, B, C}`.
