### PR TITLE
test(#1396): pin the down-arrow half of the #737 drain guard

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1173,6 +1173,58 @@ describe("compose submit — slash command dispatch", () => {
     }
   });
 
+  // #737 — the DOWN-arrow half of the recall guard. The mid-drain recall test
+  // above reads as if it covered both halves, and it does call `recallNext`,
+  // but that assertion cannot fail: the `recallPrev` on the line before it was
+  // refused, so `historyCursor` is still null, and `recallNext` returns early
+  // on its own null check before the drain guard is ever consulted. Deleting
+  // the guard leaves the whole suite green.
+  //
+  // Reaching the guard needs a window that is DRAINING while its cursor is
+  // still non-null, and the residue write is what nulls it (it resets to the
+  // live bottom). Only the #907 join gap offers that: `/msg` claims BOTH
+  // candidate homes synchronously, then awaits the query-topic join, so the
+  // query window is locked before a single residue write has run — and its
+  // cursor is wherever the operator left it, because nothing submitted from
+  // there and `takeDraft` never ran on it.
+  it("#737 — the down-arrow is refused on a window claimed mid-history-walk", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const qtj = await import("../lib/queryTopicJoin");
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    // Give the query window one history entry and leave the operator standing
+    // on it: cursor non-null, draft showing the recalled line.
+    compose.setDraft(query, "earlier reply");
+    await compose.submit(query, "freenode", "bob");
+    compose.recallPrev(query);
+    expect(compose.getDraft(query)).toBe("earlier reply");
+
+    let ackJoin!: () => void;
+    qtj.setEnsureQueryTopicJoined(
+      () =>
+        new Promise<void>((resolve) => {
+          ackJoin = resolve;
+        }),
+    );
+
+    compose.setDraft(source, "/msg bob l1\nl2\nl3");
+    const done = compose.submit(source, "freenode", "#a");
+
+    // Parked on the join ACK with both candidate homes claimed (#907), and no
+    // residue written yet — so the cursor the operator left behind is intact.
+    expect(compose.isDraining(query)).toBe(true);
+    compose.recallNext(query);
+    expect(compose.getDraft(query)).toBe("earlier reply");
+
+    ackJoin();
+    await done;
+  });
+
   it("/me action sends as ACTION via scrollback.sendMessage with CTCP framing", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -304,11 +304,19 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   //
   // The claim is per WINDOW, not per component: a ComposeBox-local `sending()`
   // would follow the operator to whatever window they switch to, freezing that
-  // one while leaving the actually-draining window writable. It is also
-  // checked HERE rather than at the doors, because every door lands on this
-  // store — typing, both paste routes (`pasteRoute` → setDraft), arrow-key and
-  // swipe history recall, and tab-complete. Gating one door means the next
-  // door added is a fresh instance of this bug.
+  // one while leaving the actually-draining window writable. It is checked in
+  // this store rather than in the components, because every gesture lands
+  // here — typing, both paste routes (`pasteRoute` → setDraft), arrow-key and
+  // swipe history recall, and tab-complete.
+  //
+  // But it is checked once PER DOOR — five separate `isDraining` returns — and
+  // NOT in the `writeState` funnel they all share, because the funnel has to
+  // stay open for the drain that HOLDS the claim: the residue write below goes
+  // through it. So a new draft writer added to this store does not inherit the
+  // guard; it has to answer the question itself, and three existing ones
+  // (`takeDraft`, `handBack`, `pushHistory`) already write without it.
+  // #1396 found the cost is not hypothetical: one of the five doors was
+  // pinned by no test at all until its own case was written.
   const [drainingKeys, setDrainingKeys] = createSignal<Record<ChannelKey, true>>({});
 
   const isDraining = (key: ChannelKey): boolean => drainingKeys()[key] === true;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51298,3 +51298,84 @@ over 57 files). Of the 58 definitions whose name already exists in
 behaviour callbacks in stub modules (not duplication at all), and 4 already
 delegate to the canonical they collide with. The inline `passthrough_handler`
 duplication this issue recorded — 14 bodies over 10 files — is now **0**.
+<!-- entry #1396-drain-guard -->
+
+---
+
+## 2026-08-19 — #1396: the guard that looked covered because the gesture was called
+
+The #737 drain lock refuses every write to a draft a paced send owns. It
+is enforced by five `isDraining` returns in `compose.ts`, one per door:
+`setDraft`, `recallPrev`, `recallNext`, the paste route, and
+`tabComplete`. A mutant bench — delete one guard, run the cic suite, put
+it back — asked which of the five any test actually defends.
+
+Four are defended. `recallNext` was not: with its guard deleted, all
+5616 tests stayed green.
+
+### Calling the gesture is not reaching the branch
+
+The reason it looked covered is worth keeping. The test named
+`#737 — history recall and tab-complete are refused mid-drain too`
+**does call `recallNext`**, right after `recallPrev`, and asserts the
+draft is unchanged. But that second assertion cannot fail. The
+`recallPrev` above it is refused, so `historyCursor` is still null, and
+`recallNext` opens with its own `if (s.historyCursor === null) return s;`
+— it returns before the drain guard is ever consulted. The guard appears
+covered because the gesture was called, not because the branch was
+reached.
+
+**The general shape: a test that exercises two halves of a symmetric
+pair can pin one and leave the other vacuous, and the name will claim
+both.** Up-arrow and down-arrow are not interchangeable evidence. The
+only instrument that tells them apart is the mutant — nothing in the
+test text, the name, or a coverage count distinguishes an assertion that
+holds from one that cannot fail.
+
+### Reaching the guard at all
+
+The branch needs a window that is draining while its cursor is still
+non-null, and the residue write is exactly what nulls it (it resets to
+the live bottom). The one place that exists is the #907 join gap: `/msg`
+claims BOTH candidate homes synchronously and then awaits the
+query-topic join, so the query window is locked before any residue has
+been written, and its cursor is wherever the operator left it — nothing
+submitted from there, so `takeDraft` never ran on it.
+
+Under the mutant the new test fails with `expected '' to be 'earlier
+reply'`: the parked live draft restored over the recalled line. That
+settles a question the static census could not — the guard is
+load-bearing, not dead code.
+
+### The measured negative
+
+`handBack` writes a draft through the same funnel with no guard, and its
+own comment promises "never a clobber". Whether the suite ever reaches
+it while a key is draining was probed with an inverted mutant: a guard
+was ADDED to `handBack`, on the reasoning that anything depending on the
+unguarded behaviour would then die. Nothing died — 5616 passed.
+
+Recorded as a **measured negative, not an omission**: the suite does not
+reach that combination. That is not a proof it is unreachable in
+production, and the difference is the whole point of writing it down.
+
+### A flake nearly bought a false "defended"
+
+The first run of the `recallNext` mutant killed three tests, and the
+verdict would have been "defended". It did not hold up: none of the
+three named #737, two lived in `windowClose.test.ts`, and the durations
+were 5004 ms and 5005 ms — the vitest timeout, not an assertion. Two
+re-runs came back green. **A kill whose victims do not name the
+invariant, and whose durations sit on the timeout, is a flake until a
+re-run says otherwise.**
+
+### Why the guard stays per door
+
+The five checks are not a funnel guard waiting to be factored. The
+funnel is `writeState`, and the drain that HOLDS the claim writes its
+residue through it, so a blind guard there would freeze the legitimate
+owner. Per door is the right shape. What changed is the comment: it
+used to close on "gating one door means the next door added is a fresh
+instance of this bug" — a warning against the shape the code has. It now
+states the obligation on the next writer, and names the three writers
+that already skip the guard (`takeDraft`, `handBack`, `pushHistory`).

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51332,6 +51332,24 @@ only instrument that tells them apart is the mutant — nothing in the
 test text, the name, or a coverage count distinguishes an assertion that
 holds from one that cannot fail.
 
+### One test defending two guards is one point of failure for two
+
+The bench turned up a second economy in the same suite. Deleting the
+`recallPrev` guard and deleting the `tabComplete` guard kill the **same
+single test** — `#737 — history recall and tab-complete are refused
+mid-drain too`. Two doors, one assertion.
+
+That is not coverage; it is a single point of failure standing in for
+two invariants. If that one test is deleted, renamed out of the way, or
+weakened, both guards go undefended at once and nothing says so. And it
+is the *same* economy that produced the hole this entry is about: the
+test bundles three gestures under one name, and the third — the
+down-arrow — turned out to be along for the ride.
+
+**A test whose name lists more than one mechanism is worth mutating once
+per mechanism.** The bundle is what hides which of them the assertions
+actually reach.
+
 ### Reaching the guard at all
 
 The branch needs a window that is draining while its cursor is still


### PR DESCRIPTION
## The defect

The #737 drain lock refuses every write to a draft that a paced send
owns. It is enforced by five `isDraining` returns in `compose.ts`, one
per door: `setDraft`, `recallPrev`, `recallNext`, the paste route and
`tabComplete`.

A mutant bench — delete one guard, run the cic suite, restore, repeat —
asked which of the five any test actually defends. **Four are defended.
`recallNext` was not: with its guard deleted, all 5616 tests stayed
green.**

## Why it looked covered

The test named `#737 — history recall and tab-complete are refused
mid-drain too` **does call `recallNext`**, immediately after
`recallPrev`, and asserts the draft is unchanged. That assertion cannot
fail. The `recallPrev` above it is refused, so `historyCursor` is still
null, and `recallNext` opens with its own `if (s.historyCursor === null)
return s;` — it returns before the drain guard is consulted.

The guard appeared covered because the gesture was called, not because
the branch was reached. A test that exercises two halves of a symmetric
pair can pin one and leave the other vacuous, and the name will claim
both.

## Reaching the branch

It needs a window that is draining while its cursor is still non-null,
and the residue write is exactly what nulls it. The one place that
exists is the #907 join gap: `/msg` claims BOTH candidate homes
synchronously and then awaits the query-topic join, so the query window
is locked before any residue has been written, and its cursor is
wherever the operator left it — nothing submitted from there, so
`takeDraft` never ran on it.

## Two-sided acceptance, measured

| side | result |
| --- | --- |
| clean tree | 290 files, **5617 passed**, rc=0 |
| guard deleted | **exactly 1 failed**, this test, 5616 passed |

The failure is `expected '' to be 'earlier reply'` — the parked live
draft restored over the recalled line. That also settles what a static
census could not: the guard is **load-bearing, not dead code**.

## The measured negative

`handBack` writes a draft through the same funnel with no guard, and its
own comment promises "never a clobber". Whether the suite ever reaches
it while a key is draining was probed with an inverted mutant: a guard
was **added** to `handBack`, on the reasoning that anything depending on
the unguarded behaviour would die. Nothing died — 5616 passed.

Recorded as a measured negative, not dropped: the suite does not reach
that combination. That is **not** a proof it is unreachable in
production.

## A flake nearly bought a false "defended"

The first run of the `recallNext` mutant killed three tests, and the
verdict would have been "defended". It did not hold up: none of the
three named #737, two lived in `windowClose.test.ts`, and the durations
were 5004 ms and 5005 ms — the vitest timeout, not an assertion. Two
re-runs came back green.

## The second commit

The #737 comment closed on *"gating one door means the next door added
is a fresh instance of this bug"* — a warning against the shape the code
actually has, since the guard is five per-door checks and the
`writeState` funnel they share carries none.

That is **not** fixed by moving the check into the funnel: the drain
that HOLDS the claim writes its residue through it, so a blind guard
there would freeze the legitimate owner. Per door is the right shape, so
the comment now states the obligation on the next writer and names the
three writers that already skip it (`takeDraft`, `handBack`,
`pushHistory`). The preceding sentence is left alone — "checked HERE
rather than at the doors" reads as this store versus the components, and
that part is true. Only the promise about the next door was not.

## Declared NOT measured

- Only `run test` and `run check` were run; no server-side gate and no
  e2e — this touches no `cicchetto/e2e/**` file and no Elixir.
- The other four guards were mutated **once** each, not three times.
  Only `recallNext` got the repeat treatment, because only it looked
  wrong.
- M2 and M5 kill the *same* test: one assertion covers two guards, which
  is the very shape that left the third uncovered. Not addressed here.
- Whether the `windowClose.test.ts` timeout flake is known or new was
  not investigated — it was neutralised by re-running, not diagnosed.
- The bench proves the suite's coverage of the guard, not that the
  clobber it prevents is reachable from the UI in production.
