### PR TITLE
test(#1397): a fixture hash that is real, and six reloads that can fail

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51397,3 +51397,87 @@ used to close on "gating one door means the next door added is a fresh
 instance of this bug" — a warning against the shape the code has. It now
 states the obligation on the next writer, and names the three writers
 that already skip the guard (`takeDraft`, `handBack`, `pushHistory`).
+<!-- entry #1397-fixture-oracles -->
+
+---
+
+## 2026-08-19 — #1397: two test-support claims that nothing was checking
+
+Bucket H of the architecture review is a de-duplication issue, and consolidating
+its fixtures surfaced two things that de-duplication is not allowed to decide:
+a fixture that stated in its own moduledoc that it was not doing what its name
+implied, and six assertions that could not fail. Both were filed as questions
+rather than acted on. vjt ruled on both; this entry records the rulings and what
+was measured carrying them out.
+
+### The fixture hash was a placeholder, and the placeholder was worse than slow
+
+`AuthFixtures.user_fixture/1` inserted `password_hash: "x"`. The saving was real
+— nothing under `config/` tunes Argon2 down for tests, so a per-fixture hash pays
+production parameters (m=65536, t=3, p=4) across the ~130 files that import the
+module. The ruling keeps the saving and drops the lie: a REAL Argon2 hash of a
+known password, computed once and pinned as a constant that lives only in test
+support. Hashing is what cost; pinning removes it. Verification costs what it
+always cost, and exactly one test pays it.
+
+That one test is not optional, and the reason is the general one about constants:
+nothing in a suite recomputes a pinned value, so nothing notices when it stops
+being what it claims. A corrupted constant would leave every fixture user
+unverifiable while the files that only want a row to hang a session on kept
+passing. `Grappa.AuthFixturesTest` reads the constant as a claim and checks it
+through the production door, `Accounts.get_user_by_credentials/2`.
+
+The red that test produced before the fix is worth keeping: with `"x"` stored,
+the door did not answer `{:error, :invalid_credentials}` — it RAISED
+`ArgumentError: Invalid Argon2 hash`, because the placeholder cannot be parsed as
+one. The fixture user was not merely unverifiable; it was a landmine for any test
+that wandered into the verify path. The accepted limit, now in the moduledoc
+instead of waiting to be discovered: every fixture user shares one password, and
+a test that needs its own still calls `user_fixture_with_password/1`.
+
+### A reload of the struct the write returned is not a reload
+
+`perform_changeset_test.exs` called `reload_credential/1` six times, and every
+call was handed the struct `Repo.update/1` had just returned. Re-reading and not
+re-reading yield the same field values, so none of the six could fail: the
+encrypt → store → Cloak `:load` round trip the file's own comment names was never
+observed. The assertions would have held with no database behind them.
+
+The two-sided mutant is the whole result, and it is more informative here than
+usual. With `reload_credential/1` replaced by the identity function, the file ran
+**10 tests, 0 failures** before the change and **10 tests, 6 failures** after —
+the six being exactly the six sites, by name. A de-duplication that preserves
+behaviour by construction and one that repairs something look identical from the
+green side; that asymmetry is what tells them apart.
+
+The blindness is PRE-EXISTING on main, measured rather than argued: the same
+mutant against the file's own local `reload/1`, on a detached worktree at
+`origin/main` with nothing else touched, left it green. The consolidation onto
+shared fixtures did not introduce it — it made it visible.
+
+### Which pre-write struct is not a detail
+
+The fix is to hand each reload a struct that PREDATES the write and to assert a
+value that struct does not carry. The trap is that the right struct is not
+uniform: in the clearing and keep-branch tests it is `saved`, not `cred`, because
+`cred` holds nil for exactly the fields those two expect to find nil. A reload
+returning it would pass for the wrong reason — the defect being fixed,
+reintroduced one layer down. The rule is not "reload something older", it is
+"reload something whose in-memory values CONTRADICT the expected outcome".
+
+Two of the six assert an absence (`inspect/1` leaks nothing; the perform door
+cannot reach the server-PASS slot), and a nil is also what an unwritten row says.
+Neither can be repaired by choosing a different struct, so both gained a positive
+control — the perform list landed — which is what makes the nil a refusal and not
+an empty read. Same shape as the empty-recorder controls in #1336.
+
+### Not established
+
+The count reconciles: base 6560 tests measured on a tree byte-identical to
+`8a23e667` for the three touched files, 6561 after, one added test block, zero
+removed, `scripts/check.sh` rc=0 on the branch. What was NOT measured: whether
+the post-write-reload shape occurs anywhere else in the suite — the search was
+never run, and this entry claims nothing about the other files that call the
+shared helper beyond the 23 kills already recorded on the issue. Nor was any
+suite-time effect of the pinned hash measured; the ~100 ms figure remains the
+moduledoc's own claim, inherited, not re-timed here.

--- a/test/grappa/auth_fixtures_test.exs
+++ b/test/grappa/auth_fixtures_test.exs
@@ -1,0 +1,26 @@
+defmodule Grappa.AuthFixturesTest do
+  @moduledoc """
+  #1397 — the positive control for the precomputed Argon2 hash that
+  `Grappa.AuthFixtures.user_fixture/1` stamps on every user it inserts.
+
+  The hash is a constant, so nothing in the suite recomputes it and
+  nothing in the suite would notice if it stopped being a hash of
+  `fixture_password/0`: a corrupted constant makes every fixture user
+  silently unverifiable, and the ~130 files that only need a row to hang
+  a session on would keep passing. This test is the one place that reads
+  the constant as a claim and checks it, through the production door
+  rather than a raw `Argon2.verify_pass/2`.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+
+  test "the fixture password verifies against the precomputed hash" do
+    user = user_fixture()
+
+    assert {:ok, verified} = Accounts.get_user_by_credentials(user.name, fixture_password())
+    assert verified.id == user.id
+  end
+end

--- a/test/grappa/networks/perform_changeset_test.exs
+++ b/test/grappa/networks/perform_changeset_test.exs
@@ -23,6 +23,15 @@ defmodule Grappa.Networks.PerformChangesetTest do
     )
   end
 
+  # #1397 — every `reload_credential/1` here is handed a struct that
+  # PREDATES the write under test, never the one `Repo.update/1` just
+  # returned, and the value asserted is one that struct does not carry.
+  # Reloading the post-write struct yields the same fields whether or not
+  # the read happens, so the round trip the assertions name — encrypt →
+  # store → Cloak `:load` — is not what they observe. The rule has teeth:
+  # in the clearing and keep-branch tests below the pre-write struct is
+  # `saved`, not `cred`, because `cred` carries nil for the fields those
+  # tests expect to find nil, and a reload that returned it would pass.
   describe "Credential.perform_changeset/2" do
     test "encrypts + round-trips perform_list and oper_pass on read (Cloak decrypt)" do
       {_, _, cred} = rotating_credential(%{})
@@ -34,8 +43,8 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
 
       assert cs.valid?
-      {:ok, saved} = Repo.update(cs)
-      reloaded = reload_credential(saved)
+      {:ok, _} = Repo.update(cs)
+      reloaded = reload_credential(cred)
 
       # After Cloak :load, the *_encrypted fields carry the DECRYPTED plaintext.
       assert reloaded.perform_list_encrypted ==
@@ -47,7 +56,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
     test "accessors return the decrypted plaintext, nil when unset" do
       {_, _, cred} = rotating_credential(%{})
 
-      {:ok, saved} =
+      {:ok, _} =
         cred
         |> Credential.perform_changeset(%{
           perform_list: "MODE $nick +x",
@@ -55,7 +64,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
         |> Repo.update()
 
-      reloaded = reload_credential(saved)
+      reloaded = reload_credential(cred)
       assert Credential.perform_list_text(reloaded) == "MODE $nick +x"
       assert Credential.upstream_oper_pass(reloaded) == "s3cr3t"
 
@@ -67,7 +76,7 @@ defmodule Grappa.Networks.PerformChangesetTest do
     test "inspect/1 never leaks perform_list or oper_pass (redact: true)" do
       {_, _, cred} = rotating_credential(%{})
 
-      {:ok, saved} =
+      {:ok, _} =
         cred
         |> Credential.perform_changeset(%{
           perform_list: "OPER vjt topsecret",
@@ -75,7 +84,15 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
         |> Repo.update()
 
-      dump = inspect(reload_credential(saved))
+      reloaded = reload_credential(cred)
+
+      # The refutes below are only worth anything over a struct that DOES
+      # carry the secrets: redaction proven on an empty struct is proven
+      # on nothing.
+      assert Credential.perform_list_text(reloaded) == "OPER vjt topsecret"
+      assert Credential.upstream_oper_pass(reloaded) == "leakme"
+
+      dump = inspect(reloaded)
       refute dump =~ "topsecret"
       refute dump =~ "leakme"
     end
@@ -102,12 +119,12 @@ defmodule Grappa.Networks.PerformChangesetTest do
         })
         |> Repo.update()
 
-      {:ok, cleared} =
+      {:ok, _} =
         saved
         |> Credential.perform_changeset(%{perform_list: "", oper_pass: ""})
         |> Repo.update()
 
-      reloaded = reload_credential(cleared)
+      reloaded = reload_credential(saved)
       assert Credential.perform_list_text(reloaded) == nil
       assert Credential.upstream_oper_pass(reloaded) == nil
     end
@@ -122,12 +139,12 @@ defmodule Grappa.Networks.PerformChangesetTest do
 
       # A later edit that touches ONLY the perform list must not disturb the
       # stored oper secret (get_change == nil → keep-branch).
-      {:ok, updated} =
+      {:ok, _} =
         saved
         |> Credential.perform_changeset(%{perform_list: "MODE $nick +x"})
         |> Repo.update()
 
-      reloaded = reload_credential(updated)
+      reloaded = reload_credential(saved)
       assert Credential.perform_list_text(reloaded) == "MODE $nick +x"
       assert Credential.upstream_oper_pass(reloaded) == "keepme"
     end
@@ -158,12 +175,18 @@ defmodule Grappa.Networks.PerformChangesetTest do
       # home, which is the split brain #124 is named after.
       {_, _, cred} = rotating_credential(%{})
 
-      {:ok, saved} =
+      {:ok, _} =
         cred
         |> Credential.perform_changeset(%{perform_list: "MODE $nick +x", server_pass: "sneaky"})
         |> Repo.update()
 
-      assert reload_credential(saved).server_pass_encrypted == nil
+      reloaded = reload_credential(cred)
+
+      # A nil slot is also what a row nobody wrote to says. The perform
+      # list is the evidence that this read reached the written row, so
+      # the nil below is a refusal and not an absence.
+      assert Credential.perform_list_text(reloaded) == "MODE $nick +x"
+      assert reloaded.server_pass_encrypted == nil
     end
 
     test "rejects a perform list over the byte cap" do

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -4,12 +4,24 @@ defmodule Grappa.AuthFixtures do
   that now traverse the `:authn` pipeline.
 
   The plain `user_fixture/1` bypasses `Grappa.Accounts.create_user/1`
-  and inserts a `%User{}` directly with a placeholder `password_hash`
-  — the ~100 ms Argon2 cost is the dominant sqlite-contention
+  and inserts a `%User{}` directly, carrying a real Argon2 hash of
+  `fixture_password/0` that was computed ONCE and is pinned as a
+  constant — the ~100 ms Argon2 cost is the dominant sqlite-contention
   contributor under the test suite (see `config/test.exs` busy_timeout
-  comment + `test/test_helper.exs` `max_cases: 2` cap). Tests that
-  exercise the real password-verification path call
-  `user_fixture_with_password/1` instead.
+  comment + `test/test_helper.exs` `max_cases: 2` cap), and nothing in
+  `config/` tunes Argon2 down for tests, so hashing per fixture would
+  pay production parameters every time.
+
+  The accepted cost of pinning it: every user this module hands out has
+  the SAME password. A test that needs a password of its own still calls
+  `user_fixture_with_password/1`, which hashes for real.
+
+  The constant is a claim, and `Grappa.AuthFixturesTest` is where it is
+  checked: it asserts `fixture_password/0` verifies against the stored
+  hash through `Accounts.get_user_by_credentials/2`. Without that
+  control a corrupted constant would make every fixture user
+  unverifiable — or, as the placeholder it replaces did, make the
+  production verify door RAISE — and no other test would notice.
 
   `session_fixture/1` mints a live `%Session{}` and returns it; the
   bearer token IS `session.id`. `put_bearer/2` is the conn helper that
@@ -35,10 +47,31 @@ defmodule Grappa.AuthFixtures do
   alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
   alias Grappa.Visitors.Visitor
 
+  @fixture_password "correct-horse-battery-staple"
+
   @doc """
-  Inserts a `%User{}` directly with `password_hash: "x"` — does NOT
-  hash a real password. Use this when the test only needs a user row
-  to attach a session to.
+  The plaintext every `user_fixture/1` user is born holding.
+  """
+  @spec fixture_password() :: String.t()
+  def fixture_password, do: @fixture_password
+
+  # A REAL Argon2 hash of @fixture_password, computed once and pinned here
+  # rather than recomputed per fixture: hashing is the ~100 ms cost this
+  # module exists to keep out of the suite, and `config/` carries no Argon2
+  # tuning at all, so every fixture would pay the production parameters
+  # (m=65536, t=3, p=4) in full. Verifying it costs the same as verifying any
+  # other hash — but only the one test that checks it ever does.
+  @fixture_password_hash "$argon2id$v=19$m=65536,t=3,p=4$z5fqclwLZm0te+1PYDk9yw$d95TAIBwu3CkvogRwYkixjq9KuySBbO1DQ7KOH2XHLs"
+
+  @doc """
+  Inserts a `%User{}` directly, holding a real (precomputed) Argon2 hash
+  of `fixture_password/0`. Use this when the test only needs a user row
+  to attach a session to; the row is nonetheless a login-capable user,
+  so a test that wanders into the verification path gets an answer
+  instead of a crash.
+
+  Every user this returns shares ONE password. A test that needs its own
+  goes through `user_fixture_with_password/1`, which pays a real hash.
   """
   @spec user_fixture(keyword()) :: User.t()
   def user_fixture(attrs \\ []) do
@@ -48,7 +81,7 @@ defmodule Grappa.AuthFixtures do
     {:ok, user} =
       Repo.insert(%User{
         name: name,
-        password_hash: "x",
+        password_hash: @fixture_password_hash,
         is_admin: is_admin
       })
 
@@ -64,7 +97,7 @@ defmodule Grappa.AuthFixtures do
   @spec user_fixture_with_password(keyword()) :: {User.t(), String.t()}
   def user_fixture_with_password(attrs \\ []) do
     name = Keyword.get(attrs, :name, "vjt-#{System.unique_integer([:positive])}")
-    password = Keyword.get(attrs, :password, "correct-horse-battery-staple")
+    password = Keyword.get(attrs, :password, @fixture_password)
     {:ok, user} = Accounts.create_user(%{name: name, password: password})
     {user, password}
   end


### PR DESCRIPTION
Bucket H of the architecture review is a de-duplication issue, and
consolidating its fixtures surfaced two things de-duplication is not allowed
to decide. Both were filed as open questions on #1397 rather than acted on.
**vjt has now ruled on both**; this is that ruling carried out, as two commits
that do not mix.

## 1 — the shared user fixture gets a real hash, and a control

`AuthFixtures.user_fixture/1` stamped `password_hash: "x"`, and the moduledoc
said so: *"does NOT hash a real password"*. The saving it bought is real —
nothing under `config/` tunes Argon2 down for tests (`git grep -n "argon2\|Argon2"
-- config/` is empty), so a per-fixture hash pays production parameters
(m=65536, t=3, p=4) across the 132 files that import the module.

The ruling keeps the saving and drops the lie: a **real Argon2 hash of a known
password, computed once and pinned as a constant**. Per vjt's explicit
constraint the constant lives only in test support — no production code learns
it. Hashing is what cost ~100 ms; pinning removes it. Verification costs what it
always did, and exactly one test pays it.

That one test is the point. Nothing in a suite recomputes a pinned value, so
nothing notices when it stops being what it claims: a corrupted constant would
leave every fixture user unverifiable while the ~130 files that only want a row
to hang a session on kept passing. `Grappa.AuthFixturesTest` checks the claim
through the production door, `Accounts.get_user_by_credentials/2`, not a raw
`Argon2.verify_pass/2`.

**The red is worth reading.** Before the fix that door did not answer
`{:error, :invalid_credentials}` — it RAISED:

```
** (ArgumentError) Invalid Argon2 hash. Please check the 'stored_hash' input to verify_pass.
     (argon2_elixir 4.1.3) lib/argon2.ex:102: Argon2.argon2_type/1
     (grappa 1.2.0) lib/grappa/accounts.ex:1005: Grappa.Accounts.verify_password/2
```

A fixture user was not merely unverifiable, it was a landmine for any test that
wandered into the verify path.

Accepted limit, now in the moduledoc rather than waiting to be discovered: every
fixture user shares one password. A test that needs its own still calls
`user_fixture_with_password/1`, whose default plaintext is now the same constant
instead of a second copy of the literal.

## 2 — the six reloads that could not fail

`perform_changeset_test.exs` called `reload_credential/1` six times, and every
call was handed the struct `Repo.update/1` had just returned. Re-reading and not
re-reading yield the same field values, so **none of the six could fail**: the
encrypt → store → Cloak `:load` round trip the file's own comment names was
never observed. The assertions would have held with no database behind them.

The fix hands each reload a struct that PREDATES the write and asserts a value
that struct does not carry.

**The two-sided mutant is the result, not a detail.** With `reload_credential/1`
replaced by the identity function, run against this file:

| tree | result |
|---|---|
| base (`8a23e667`, file untouched) | 10 tests, **0 failures**, rc=0 |
| after this PR | 10 tests, **6 failures**, rc=2 |

and the six are exactly the six sites, by name — clearing, inspect, #1044,
accessors, round-trip, keep-branch. A consolidation that preserves behaviour by
construction and one that repairs something are indistinguishable from the green
side; that asymmetry is what tells them apart.

**Pre-existing, and measured rather than argued.** vjt confirms the diagnosis:
the blindness belongs to main, not to the consolidation, which only made it
visible. (Recorded on the issue: the same mutant against the file's own local
`reload/1`, on a detached worktree at `origin/main` with nothing else touched,
left it green.)

### Which pre-write struct is not a detail

The right struct is **not uniformly the oldest one**. In the clearing and
keep-branch tests it is `saved`, not `cred`, because `cred` holds nil for exactly
the fields those two expect to find nil — a reload returning it would pass for
the wrong reason, which is the defect being fixed, reintroduced one layer down.
The rule is not "reload something older", it is "reload something whose
in-memory values CONTRADICT the expected outcome".

Two of the six assert an ABSENCE (`inspect/1` leaks nothing; the perform door
cannot reach the server-PASS slot), and a nil is also what an unwritten row says.
Neither can be repaired by choosing a different struct, so both gained a positive
control — the perform list landed — which makes the nil a refusal and not an
empty read. Same shape as the empty-recorder controls in #1336.

## Measurement

Pre-registered before running, then reconciled:

| | tests | failures |
|---|---|---|
| base, measured on a tree byte-identical to `8a23e667` for the three touched files | 6560 | 0 |
| this branch | 6561 | 0 |

Predicted +1 (one added `test` block, zero removed); reconciles exactly.
`scripts/check.sh` rc=0 on the branch — note it HALTED at credo on the first
attempt (`_saved` vs the file's anonymous-`_` convention), so that run's tests
never executed and its silence proved nothing; the green above is the re-run.

## Not established

- **Whether this reload shape occurs elsewhere in the suite.** No search was run.
  This PR claims nothing about the other files that call the shared helper beyond
  the 23 kills already recorded on the issue.
- **Any suite-time effect of the pinned hash.** Not timed. The ~100 ms figure is
  the moduledoc's own inherited claim, not a measurement made here.
- **That the six sites are the only blind assertions in this file.** The mutant
  used was the reload; a different mutant might find more.

#1397 stays open — the duplication axis was closed separately, and this closes
the two questions filed alongside it.
