### PR TITLE
test(#1396): split the two-door bundle so each door has its own test

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -845,7 +845,19 @@ describe("compose submit — slash command dispatch", () => {
     }
   });
 
-  it("#737 — history recall and tab-complete are refused mid-drain too", async () => {
+  // #737 — one test used to carry both doors: the history walk and
+  // tab-complete, three gestures behind a single set of assertions. Breaking
+  // either guard killed the same test, so the count could not say which door
+  // had opened. They are two tests now, one door each.
+  //
+  // The bundle also called `recallNext` here, and that call is GONE rather
+  // than split out. It could not fail: the `recallPrev` above it was refused,
+  // so `historyCursor` was still null and `recallNext` returned early on its
+  // own null check without ever consulting the drain guard. The down-arrow
+  // half needs a window that is draining while its cursor is still non-null,
+  // which this fixture cannot produce — it is pinned separately below, on the
+  // #907 join gap.
+  it("#737 — the up-arrow recall is refused mid-drain, residue intact", async () => {
     vi.useFakeTimers();
     try {
       localStorage.setItem("grappa-token", "tok");
@@ -854,7 +866,8 @@ describe("compose submit — slash command dispatch", () => {
       const compose = await import("../lib/compose");
       const k = channelKey("freenode", "#a");
 
-      // Seed one history entry so recallPrev has somewhere to walk.
+      // Seed one history entry so recallPrev has somewhere to walk — without
+      // it the walk stops on its own empty-history guard and proves nothing.
       vi.mocked(sb.sendMessage).mockResolvedValue();
       compose.setDraft(k, "earlier line");
       await compose.submit(k, "freenode", "#a");
@@ -877,12 +890,42 @@ describe("compose submit — slash command dispatch", () => {
 
       compose.recallPrev(k);
       expect(compose.getDraft(k)).toBe("b\nc");
-      compose.recallNext(k);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("#737 — tab-complete is refused mid-drain, residue intact", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const members = await import("../lib/members");
+      const k = channelKey("freenode", "#a");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
       expect(compose.getDraft(k)).toBe("b\nc");
 
       // Members MUST be seeded here, or tabComplete returns null on its own
       // empty-members guard and this assertion proves nothing.
-      const members = await import("../lib/members");
       vi.mocked(members.membersByChannel).mockReturnValue({
         [k]: [{ nick: "bruno", modes: [] }],
       });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51481,3 +51481,56 @@ never run, and this entry claims nothing about the other files that call the
 shared helper beyond the 23 kills already recorded on the issue. Nor was any
 suite-time effect of the pinned hash measured; the ~100 ms figure remains the
 moduledoc's own claim, inherited, not re-timed here.
+<!-- entry #1396-door-split -->
+
+---
+
+## 2026-08-19 — #1396: two doors, two tests, two deaths with different names
+
+The previous entry recorded that one test defended two guards and was therefore
+one failure point. This is the follow-through, and the reason it needed a bench
+rather than a tidy-up: a de-duplication that preserves behaviour by construction
+and one that actually separates two oracles look identical from the green side.
+
+The bundle exercised the history walk and tab-complete behind a single set of
+assertions, all of the shape `getDraft(k) === "b\nc"`. Split into one test per
+door, the bench reads:
+
+| run | result |
+|---|---|
+| clean | 290 files, 5618 tests, rc=0 |
+| guard deleted from `recallPrev` | 1 dead — the UP-ARROW test |
+| guard deleted from `tabComplete` | 1 dead — the TAB-COMPLETE test |
+| guard deleted from `recallNext` | 1 dead — the DOWN-ARROW test (#1562's pin) |
+
+Three deaths, three different names. The criterion was never "one dead" three
+times — before the split, two of those mutants killed the SAME test, and a count
+alone could not have told the difference.
+
+### The third gesture was removed, not split
+
+The bundle also called `recallNext`, and that call is gone. It could not fail:
+`recallPrev` above it had been refused, so `historyCursor` was still null and
+`recallNext` returned on its own null check without reaching the drain guard.
+Carrying it into the up-arrow test would have reproduced the illusion being
+undone — a gesture that reads as covered and is not. Calling a function is not
+reaching the branch inside it.
+
+### The injector now anchors on the function, not the line
+
+Three of the five guards are the byte-identical string
+`if (isDraining(key)) return;`, so the mutation tool targets one of them by
+position. Hardcoded line numbers went stale twice in two days (the guards moved
+398/406/420 → 406/414/428 as comments were added above them), and a stale number
+mutates the wrong door while still reporting a plausible kill. It now locates the
+enclosing declaration — unique — takes the first guard line below it, and asserts
+the expected text before deleting anything.
+
+### The flake is still there, and it still has to be re-run
+
+The `recallNext` mutant first reported THREE deaths: the down-arrow test plus two
+in `networks.test.ts` that name no invariant of this work, one of them at 5006 ms
+against a 5000 ms vitest timeout. A re-run of the same mutant returned exactly one
+death. That is the #1563 signature, unchanged and undiagnosed: a kill whose
+victims do not name the invariant, and whose durations sit on the timeout, is a
+flake until a re-run says otherwise.


### PR DESCRIPTION
Follow-through on what the previous #1396 entry recorded: one test defended two
guards, so it was one failure point. Splitting it needed a bench and not a
tidy-up, because a de-duplication that preserves behaviour by construction and
one that genuinely separates two oracles are indistinguishable from the green
side.

## The bundle

`#737 — history recall and tab-complete are refused mid-drain too` exercised
three gestures behind a single set of assertions, all of the shape
`getDraft(k) === "b\nc"`. Two different doors, one test: breaking either guard
killed it, and the count could not say WHICH door had opened.

It is now two tests, one door each.

## The bench — four runs, and the criterion is the NAMES

| run | result |
|---|---|
| clean | 290 files, **5618** tests, rc=0 |
| guard deleted from `recallPrev` | **1 dead — the UP-ARROW test** |
| guard deleted from `tabComplete` | **1 dead — the TAB-COMPLETE test** |
| guard deleted from `recallNext` | **1 dead — the DOWN-ARROW test** (#1562's pin, re-confirmed) |

Three deaths, three different names, read from the failure lines and not from
the counts. Before the split, the first two mutants killed the SAME test —
"1 dead" three times would have proved nothing.

Guard positions were re-derived on this base rather than inherited:
`recallPrev` 414, `recallNext` 428, `tabComplete` 1306 in
`cicchetto/src/lib/compose.ts`.

## The third gesture is removed, not split — and here is why it was vacuous

The bundle also called `compose.recallNext(k)` and asserted the draft was
unchanged. **That assertion could not fail.** The `recallPrev` on the line
before it had already been refused by the drain guard, so `historyCursor` was
still `null`; `recallNext` opens with its own `if (s.historyCursor === null)
return s` inside `writeState`, and returns there without the drain guard ever
mattering. Delete the guard and the assertion still passes — measured in #1562,
where that mutant killed nothing at all.

So the call is deleted rather than carried into the up-arrow test, where it
would have reproduced the same illusion in miniature: a gesture that reads as
covered and is not. The down-arrow half needs a window draining while its cursor
is still non-null, which this fixture cannot build; #1562 pinned it separately on
the #907 join gap, and the fourth run above re-confirms that pin still holds.

The fixture is duplicated between the two tests rather than extracted into a
helper: the neighbouring mid-drain typing test already carries its own copy of
the same 429-paced drain, and a shared helper would have had to touch that test
too — which is pinned by a mutant of its own (3 kills).

## The injector now anchors on the function, not the line

Three of the five drain guards are the byte-identical string
`if (isDraining(key)) return;`, so the mutation tool has to target one by
position. Hardcoded line numbers went stale twice in two days (398/406/420 →
406/414/428 as comments were added above them), and a stale number mutates the
wrong door while still reporting a plausible kill. It now locates the enclosing
declaration — unique — takes the first guard line below it, and asserts the
expected text before deleting anything.

## The flake showed up again

The `recallNext` mutant first reported THREE deaths: the down-arrow test plus two
in `networks.test.ts` that name no invariant of this work, one at **5006 ms**
against a 5000 ms vitest timeout. A re-run of the same mutant returned exactly
one death. That is the #1563 signature — still open, still undiagnosed. A kill
whose victims do not name the invariant, and whose durations sit on the timeout,
is a flake until a re-run says otherwise.

## Not established

- **That the two tests are independent of each other.** They were run together,
  in one suite, every time; no per-file isolation run was made.
- **That `recallNext`'s guard is reachable from any door other than the #907 join
  gap.** #1562 established one path; this PR adds nothing to that.
- **Anything about the two `networks.test.ts` failures beyond "did not reproduce".**
  The re-run separates them from the kill; it does not diagnose them, and #1563
  stays open with both readings alive.
- **cic gates only.** `bun run check` rc=0 and `bun run test` rc=0 on this branch;
  the server-side suite was not re-run, and this branch touches no `.ex`/`.exs`.
