### PR TITLE
e2e(#1336): an instrument that can name the #1079 freeze, or clear it

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -69,6 +69,7 @@ import {
 } from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
 import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
+import type { TraceEvent } from "./scrollTrace";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
 const MOBILE_BREAKPOINT_PX = 768;
@@ -1595,4 +1596,90 @@ export async function pageScrollbackRest(page: Page, timeoutMs: number): Promise
       pollMs: 50,
     },
   );
+}
+
+// #1336 (row #1079) — the in-page half of `scrollTrace.ts`: three channels on
+// one clock, installed before the SPA boots.
+//
+// The channels are `scroll` events, `data-follow` transitions and rows-list
+// recreations, because the freeze this row is about can happen with NO
+// scrollTop write at all (see `scrollTrace.ts` for the full argument). The
+// scroll channel is a PASSIVE listener rather than a patched setter on
+// purpose: it is the very event stream `ScrollbackPane`'s own `onScroll`
+// consumes, so the trace has exactly the fidelity of the arm under study, and
+// nothing here can perturb the timing it is trying to measure.
+export async function installScrollTrace(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    type Recorded = Record<string, unknown>;
+    const events: Recorded[] = [];
+    const at = (): number => Math.round(performance.now());
+    const push = (event: Recorded): void => {
+      events.push(event);
+    };
+
+    const w = window as unknown as {
+      __scrollTrace: { events: Recorded[]; mark(name: string, value: number | null): void };
+    };
+    w.__scrollTrace = {
+      events,
+      mark: (name, value) => push({ kind: "mark", t: at(), name, value }),
+    };
+
+    let attached: Element | null = null;
+    const attach = (el: HTMLElement): void => {
+      attached = el;
+      el.addEventListener(
+        "scroll",
+        () =>
+          push({
+            kind: "scroll",
+            t: at(),
+            scrollTop: Math.round(el.scrollTop),
+            maxScroll: Math.round(el.scrollHeight - el.clientHeight),
+          }),
+        { passive: true },
+      );
+
+      new MutationObserver(() =>
+        push({ kind: "follow", t: at(), follow: el.getAttribute("data-follow") }),
+      ).observe(el, { attributes: true, attributeFilter: ["data-follow"] });
+
+      // A rows recreation is the list DOM being rebuilt under the pane, not
+      // one row appended: only a change of the FIRST child's identity counts,
+      // or every arriving message would read as a recreation.
+      let firstRow = el.firstElementChild;
+      new MutationObserver(() => {
+        if (el.firstElementChild === firstRow) return;
+        firstRow = el.firstElementChild;
+        push({ kind: "rows", t: at() });
+      }).observe(el, { childList: true });
+    };
+
+    const find = (): void => {
+      const el = document.querySelector('[data-testid="scrollback"]');
+      if (el instanceof HTMLElement && el !== attached) attach(el);
+    };
+    new MutationObserver(find).observe(document, { childList: true, subtree: true });
+    find();
+  });
+}
+
+export async function markScrollTrace(
+  page: Page,
+  name: string,
+  value: number | null,
+): Promise<void> {
+  await page.evaluate(
+    ([n, v]) =>
+      (
+        window as unknown as { __scrollTrace: { mark(name: string, value: number | null): void } }
+      ).__scrollTrace.mark(n as string, v as number | null),
+    [name, value] as const,
+  );
+}
+
+export async function readScrollTrace(page: Page): Promise<TraceEvent[]> {
+  return (await page.evaluate(
+    () => (window as unknown as { __scrollTrace: { events: unknown[] } }).__scrollTrace.events,
+  )) as TraceEvent[];
 }

--- a/cicchetto/e2e/fixtures/scrollTrace.test.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.test.ts
@@ -1,0 +1,183 @@
+// #1336 (row #1079) — the classifier is the instrument the row will be judged
+// by, so it is provable without a testnet, like `scrollGesture.test.ts` and
+// `whoisWait.test.ts`. Every trace below is hand-built from the numbers S2
+// recorded in-page (reset 7, marker jump 1055, marker 1078, maxScroll 1415),
+// so a case that passes here describes a pane that actually existed.
+//
+// What the row still needs is not another position recorder. #1079's number is
+// 337 = 1415 - 1078, the pane sitting ON the marker after a send that should
+// have taken it to the bottom; the candidate that leaves it there disarms the
+// follow intent AFTER the send and writes no scrollTop at all. A recorder of
+// positions is blind to that by construction, which is why the classifier's
+// input carries follow transitions and rows recreations beside the geometry.
+
+import { describe, expect, it } from "vitest";
+import {
+  assertTraceIsUsable,
+  classifyPostSend,
+  type TraceEvent,
+  type TraceVerdict,
+} from "./scrollTrace";
+
+const MAX_SCROLL = 1415;
+const MARKER_TOP = 1078;
+const THRESHOLD = 50;
+
+const scroll = (t: number, scrollTop: number): TraceEvent => ({
+  kind: "scroll",
+  t,
+  scrollTop,
+  maxScroll: MAX_SCROLL,
+});
+const follow = (t: number, state: "on" | "off"): TraceEvent => ({
+  kind: "follow",
+  t,
+  follow: state,
+});
+const rows = (t: number): TraceEvent => ({ kind: "rows", t });
+const mark = (t: number, name: string, value: number | null): TraceEvent => ({
+  kind: "mark",
+  t,
+  name,
+  value,
+});
+
+// The activation, as recorded: the rows recreation resets to the top, the
+// marker jump passes through, the pane parks on the marker, and the rest
+// barrier reports where it stopped. Every trace starts here.
+const untilRest: readonly TraceEvent[] = [
+  scroll(45, 7),
+  follow(46, "off"),
+  scroll(59, 1055),
+  scroll(78, MARKER_TOP),
+  follow(79, "off"),
+  mark(80, "rest-exit", MARKER_TOP),
+];
+
+const classify = (events: readonly TraceEvent[]): TraceVerdict =>
+  classifyPostSend(events, { thresholdPx: THRESHOLD });
+
+describe("#1336/#1079 — classifyPostSend", () => {
+  it("calls a pane that reached the bottom after the send OK", () => {
+    const verdict = classify([
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      scroll(140, MAX_SCROLL),
+    ]);
+
+    expect(verdict.kind).toBe("OK");
+    expect(verdict.distance).toBe(0);
+  });
+
+  it("names FROZEN-AT-MARKER when follow is disarmed after the send with no movement", () => {
+    // The candidate that explains the reported number: `scrollToActivation`'s
+    // deferred `setFollowMode(near)` landing after the send's re-arm. Nothing
+    // writes scrollTop afterwards — the pane simply never leaves the marker.
+    const verdict = classify([
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      follow(160, "off"),
+    ]);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.distance).toBe(337);
+    expect(verdict.attributedTo).toBe("activation");
+  });
+
+  it("attributes a disarm that FOLLOWS a scrollTop decrease to the scroll-up arm", () => {
+    const verdict = classify([
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      scroll(150, MAX_SCROLL),
+      scroll(180, MARKER_TOP),
+      follow(181, "off"),
+    ]);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.attributedTo).toBe("scroll-up");
+  });
+
+  it("attributes a stranded pane with NO disarm to the rows recreation", () => {
+    // `tailFollowWhenSettled` has a second silent exit: the list node it was
+    // going to write is no longer connected. Follow stays armed and the pane
+    // still never moves.
+    const verdict = classify([...untilRest, mark(100, "send", null), follow(101, "on"), rows(150)]);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.attributedTo).toBe("rows-recreation");
+  });
+
+  it("calls a pane still being written SLOW, not frozen", () => {
+    // Slowness is not the defect: Playwright's poll absorbs it under its 5s
+    // default, and the value it eventually reports VARIES. Only a terminal
+    // state repeats a number byte for byte, which is what #1079 reported.
+    const verdict = classify([
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      scroll(150, 1200),
+      scroll(180, 1300),
+    ]);
+
+    expect(verdict.kind).toBe("SLOW");
+    expect(verdict.distance).toBe(115);
+  });
+
+  it("measures the distance from the LAST position, not from the rest exit", () => {
+    const verdict = classify([
+      ...untilRest,
+      mark(100, "send", null),
+      scroll(150, 1400),
+      scroll(180, 1400),
+      follow(181, "off"),
+    ]);
+
+    expect(verdict.distance).toBe(15);
+    expect(verdict.kind).toBe("OK");
+  });
+});
+
+describe("#1336/#1079 — assertTraceIsUsable", () => {
+  // The whole point of the presence check: an instrument that recorded nothing
+  // must not read as "no exploitation observed". That is the #1117 shape —
+  // negative assertions passing against an empty recorder — and this row is
+  // inside the epic that exists to refuse it.
+  const usable: readonly TraceEvent[] = [...untilRest, mark(100, "send", null), follow(101, "on")];
+
+  it("accepts a trace carrying all four mandatory markers", () => {
+    expect(() => assertTraceIsUsable(usable)).not.toThrow();
+  });
+
+  it("rejects an EMPTY trace, naming what is missing", () => {
+    expect(() => assertTraceIsUsable([])).toThrow(/rest-exit/);
+  });
+
+  it("rejects a trace with no follow transition at all", () => {
+    const noFollow = usable.filter((e) => e.kind !== "follow");
+    expect(() => assertTraceIsUsable(noFollow)).toThrow(/follow transition/);
+  });
+
+  it("rejects a trace with no scroll write BEFORE the send", () => {
+    // The activation always writes scrollTop three times; a trace without one
+    // means the recorder was installed too late, or not at all.
+    const noPreSend = usable.filter((e) => e.kind !== "scroll");
+    expect(() => assertTraceIsUsable(noPreSend)).toThrow(/before the send/);
+  });
+
+  it("rejects a trace with no send mark", () => {
+    const noSend = usable.filter((e) => !(e.kind === "mark" && e.name === "send"));
+    expect(() => assertTraceIsUsable(noSend)).toThrow(/send/);
+  });
+
+  // Deliberately NOT a mandatory marker, and the design comment on #1336 was
+  // wrong to list it: "the send's own tail write" is absent exactly when the
+  // defect fires. A presence check that trips on the phenomenon it is meant to
+  // license would turn every real catch into an instrument failure.
+  it("accepts a trace where NOTHING was written after the send", () => {
+    expect(() => assertTraceIsUsable(usable)).not.toThrow();
+    expect(usable.filter((e) => e.kind === "scroll" && e.t > 100)).toHaveLength(0);
+  });
+});

--- a/cicchetto/e2e/fixtures/scrollTrace.test.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.test.ts
@@ -200,6 +200,46 @@ describe("#1336/#1079 — classifyPostSend", () => {
     expect(classify(frozenShape, THRESHOLD).kind).toBe("OK");
     expect(classify(frozenShape, 0).attributedTo).toBeNull();
   });
+
+  // THE MIRROR of the incident, and the direction that would never have
+  // announced itself. The trace-derived rule could go stale in BOTH senses,
+  // because `maxScroll` is sampled as `scrollHeight - clientHeight` inside the
+  // scroll handler: content growing under a pane that is not following changes
+  // the distance to the bottom while `scrollTop` never moves, so no scroll
+  // event fires and the last record keeps saying "at the tail".
+  //
+  // Under the old rule that read OK and the instrument fell silent. It could
+  // not turn a red into a green — the spec always rethrows the poll failure —
+  // but it degraded a NAMED red into the anonymous one the instrument exists
+  // to replace. Silence was the dangerous direction, so it gets the assertion.
+  it("still accuses when the last recorded position says tail but the live read does not", () => {
+    const grewUnderneath = [
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      // The last geometry the recorder ever heard: the pane AT the tail.
+      scroll(150, MAX_SCROLL),
+      // Then a burst rebuilds the list. Content grows, scrollTop does not
+      // move, and a passive listener is told nothing at all.
+      rows(190),
+      rows(240),
+    ];
+
+    // The mutant, made explicit rather than asserted in prose: the OLD rule
+    // read the distance off the last recorded position, and that arithmetic
+    // yields 0 here — under the threshold, so it returned OK and said nothing.
+    const lastRecorded = [...grewUnderneath].reverse().find((e) => e.kind === "scroll");
+    if (lastRecorded === undefined || lastRecorded.kind !== "scroll")
+      throw new Error("fixture must carry a geometry record");
+    expect(lastRecorded.maxScroll - lastRecorded.scrollTop).toBe(0);
+
+    const verdict = classify(grewUnderneath, 585);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.attributedTo).toBe("rows-recreation");
+    // The number comes from the live read, not from the record that says 0.
+    expect(verdict.distance).toBe(585);
+  });
 });
 
 // The incident this fixture comes from, 2026-08-19, full suite run 1 of 2.

--- a/cicchetto/e2e/fixtures/scrollTrace.test.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.test.ts
@@ -110,6 +110,31 @@ describe("#1336/#1079 — classifyPostSend", () => {
     expect(verdict.attributedTo).toBe("rows-recreation");
   });
 
+  // MEASURED, not imagined: this is the tail of the trace an injected
+  // post-send scroll-back produced in situ (2026-08-19, one run). The pane
+  // reached the tail, the injected write took it back to the marker, and the
+  // recorder logged the disarm BEFORE the decrease that caused it — the
+  // MutationObserver microtask lands between two listeners on the same event.
+  // A classifier that decides "still moving" from events ordered after the
+  // disarm called this SLOW, and it is the frozen shape: 337px, terminal.
+  it("calls the measured injected freeze FROZEN, though a scroll is recorded after the disarm", () => {
+    const verdict = classify([
+      ...untilRest,
+      mark(920, "send", null),
+      follow(940, "on"),
+      rows(966),
+      scroll(884, MAX_SCROLL),
+      follow(884, "off"),
+      scroll(884, MARKER_TOP),
+    ]);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.distance).toBe(337);
+    // It reached the tail and left it: that is the `onScroll` decrease arm,
+    // whatever order the two same-millisecond records arrived in.
+    expect(verdict.attributedTo).toBe("scroll-up");
+  });
+
   it("calls a pane still being written SLOW, not frozen", () => {
     // Slowness is not the defect: Playwright's poll absorbs it under its 5s
     // default, and the value it eventually reports VARIES. Only a terminal

--- a/cicchetto/e2e/fixtures/scrollTrace.test.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.test.ts
@@ -54,17 +54,20 @@ const untilRest: readonly TraceEvent[] = [
   mark(80, "rest-exit", MARKER_TOP),
 ];
 
-const classify = (events: readonly TraceEvent[]): TraceVerdict =>
-  classifyPostSend(events, { thresholdPx: THRESHOLD });
+// The terminal distance is an INPUT, not something derived from the trace.
+// Measured 2026-08-19 on a full suite: derived from the last recorded
+// position, it accused a pane the live DOM said was at the tail. So every
+// case below has to state what the DOM said, separately from what the
+// recorder heard.
+const classify = (events: readonly TraceEvent[], finalDistancePx: number): TraceVerdict =>
+  classifyPostSend(events, { thresholdPx: THRESHOLD, finalDistancePx });
 
 describe("#1336/#1079 — classifyPostSend", () => {
   it("calls a pane that reached the bottom after the send OK", () => {
-    const verdict = classify([
-      ...untilRest,
-      mark(100, "send", null),
-      follow(101, "on"),
-      scroll(140, MAX_SCROLL),
-    ]);
+    const verdict = classify(
+      [...untilRest, mark(100, "send", null), follow(101, "on"), scroll(140, MAX_SCROLL)],
+      0,
+    );
 
     expect(verdict.kind).toBe("OK");
     expect(verdict.distance).toBe(0);
@@ -74,12 +77,10 @@ describe("#1336/#1079 — classifyPostSend", () => {
     // The candidate that explains the reported number: `scrollToActivation`'s
     // deferred `setFollowMode(near)` landing after the send's re-arm. Nothing
     // writes scrollTop afterwards — the pane simply never leaves the marker.
-    const verdict = classify([
-      ...untilRest,
-      mark(100, "send", null),
-      follow(101, "on"),
-      follow(160, "off"),
-    ]);
+    const verdict = classify(
+      [...untilRest, mark(100, "send", null), follow(101, "on"), follow(160, "off")],
+      MAX_SCROLL - MARKER_TOP,
+    );
 
     expect(verdict.kind).toBe("FROZEN-AT-MARKER");
     expect(verdict.distance).toBe(337);
@@ -87,14 +88,17 @@ describe("#1336/#1079 — classifyPostSend", () => {
   });
 
   it("attributes a disarm that FOLLOWS a scrollTop decrease to the scroll-up arm", () => {
-    const verdict = classify([
-      ...untilRest,
-      mark(100, "send", null),
-      follow(101, "on"),
-      scroll(150, MAX_SCROLL),
-      scroll(180, MARKER_TOP),
-      follow(181, "off"),
-    ]);
+    const verdict = classify(
+      [
+        ...untilRest,
+        mark(100, "send", null),
+        follow(101, "on"),
+        scroll(150, MAX_SCROLL),
+        scroll(180, MARKER_TOP),
+        follow(181, "off"),
+      ],
+      MAX_SCROLL - MARKER_TOP,
+    );
 
     expect(verdict.kind).toBe("FROZEN-AT-MARKER");
     expect(verdict.attributedTo).toBe("scroll-up");
@@ -104,7 +108,10 @@ describe("#1336/#1079 — classifyPostSend", () => {
     // `tailFollowWhenSettled` has a second silent exit: the list node it was
     // going to write is no longer connected. Follow stays armed and the pane
     // still never moves.
-    const verdict = classify([...untilRest, mark(100, "send", null), follow(101, "on"), rows(150)]);
+    const verdict = classify(
+      [...untilRest, mark(100, "send", null), follow(101, "on"), rows(150)],
+      MAX_SCROLL - MARKER_TOP,
+    );
 
     expect(verdict.kind).toBe("FROZEN-AT-MARKER");
     expect(verdict.attributedTo).toBe("rows-recreation");
@@ -118,15 +125,18 @@ describe("#1336/#1079 — classifyPostSend", () => {
   // A classifier that decides "still moving" from events ordered after the
   // disarm called this SLOW, and it is the frozen shape: 337px, terminal.
   it("calls the measured injected freeze FROZEN, though a scroll is recorded after the disarm", () => {
-    const verdict = classify([
-      ...untilRest,
-      mark(920, "send", null),
-      follow(940, "on"),
-      rows(966),
-      scroll(884, MAX_SCROLL),
-      follow(884, "off"),
-      scroll(884, MARKER_TOP),
-    ]);
+    const verdict = classify(
+      [
+        ...untilRest,
+        mark(920, "send", null),
+        follow(940, "on"),
+        rows(966),
+        scroll(884, MAX_SCROLL),
+        follow(884, "off"),
+        scroll(884, MARKER_TOP),
+      ],
+      MAX_SCROLL - MARKER_TOP,
+    );
 
     expect(verdict.kind).toBe("FROZEN-AT-MARKER");
     expect(verdict.distance).toBe(337);
@@ -139,29 +149,109 @@ describe("#1336/#1079 — classifyPostSend", () => {
     // Slowness is not the defect: Playwright's poll absorbs it under its 5s
     // default, and the value it eventually reports VARIES. Only a terminal
     // state repeats a number byte for byte, which is what #1079 reported.
-    const verdict = classify([
-      ...untilRest,
-      mark(100, "send", null),
-      follow(101, "on"),
-      scroll(150, 1200),
-      scroll(180, 1300),
-    ]);
+    const verdict = classify(
+      [
+        ...untilRest,
+        mark(100, "send", null),
+        follow(101, "on"),
+        scroll(150, 1200),
+        scroll(180, 1300),
+      ],
+      MAX_SCROLL - 1300,
+    );
 
     expect(verdict.kind).toBe("SLOW");
     expect(verdict.distance).toBe(115);
   });
 
-  it("measures the distance from the LAST position, not from the rest exit", () => {
-    const verdict = classify([
+  // REPLACES "measures the distance from the LAST position, not from the rest
+  // exit". That test passed, and the rule its name pinned was wrong: the last
+  // RECORDED position is not the terminal one. Deleted rather than kept
+  // alongside, because two rules for one number is how the next reader picks
+  // the wrong one.
+  it("takes the distance from the LIVE read, not from the last recorded position", () => {
+    const staleTrace = [
       ...untilRest,
       mark(100, "send", null),
-      scroll(150, 1400),
-      scroll(180, 1400),
-      follow(181, "off"),
-    ]);
+      follow(101, "on"),
+      rows(150),
+      rows(154),
+    ];
 
-    expect(verdict.distance).toBe(15);
+    // The recorder's last position is the marker — 337 away. The DOM says the
+    // pane is at the tail. The DOM wins, and nothing is accused.
+    expect(classify(staleTrace, 0).kind).toBe("OK");
+    expect(classify(staleTrace, 0).distance).toBe(0);
+  });
+
+  // The general rule, not the one incident: whatever the three channels show —
+  // here the STRONGEST frozen signal there is, a disarm after the send with no
+  // movement — a live read at the tail forbids an accusation. The instrument
+  // may only name the arm of a failure that actually happened.
+  it("never accuses when the live read says the pane is at the tail", () => {
+    const frozenShape = [
+      ...untilRest,
+      mark(100, "send", null),
+      follow(101, "on"),
+      follow(160, "off"),
+    ];
+
+    expect(classify(frozenShape, MAX_SCROLL - MARKER_TOP).kind).toBe("FROZEN-AT-MARKER");
+    expect(classify(frozenShape, THRESHOLD).kind).toBe("OK");
+    expect(classify(frozenShape, 0).attributedTo).toBeNull();
+  });
+});
+
+// The incident this fixture comes from, 2026-08-19, full suite run 1 of 2.
+// The classifier accused a pane that was NOT frozen: the poll asserting
+// `distance <= 50` had already PASSED (the test took 1.3s against a 5s expect
+// timeout) and the failure screenshot shows the sent line at the bottom of the
+// pane. Run 2, identical and cold, was green — 756/756 — and its trace differs
+// from this one by exactly ONE record: a post-send `scroll` to 1415/1415
+// arriving 11 ms after the last rows recreation. So the pane always moved;
+// what varied was whether the scroll event had been DELIVERED to the recorder
+// before the trace was read. A passive listener's silence is not evidence of
+// stillness, and this trace is the proof, kept rather than retold.
+const runOneFalseAccusation: readonly TraceEvent[] = [
+  rows(183),
+  { kind: "scroll", t: 197, scrollTop: 354, maxScroll: 361 },
+  rows(342),
+  follow(347, "off"),
+  { kind: "scroll", t: 347, scrollTop: 7, maxScroll: 369 },
+  rows(359),
+  { kind: "scroll", t: 364, scrollTop: 1055, maxScroll: 1417 },
+  { kind: "scroll", t: 380, scrollTop: 1078, maxScroll: 1417 },
+  mark(538, "rest-exit", 1078),
+  mark(557, "send", null),
+  follow(572, "on"),
+  rows(582),
+  rows(586),
+];
+
+describe("#1336/#1079 — the trace that produced a false accusation", () => {
+  it("is a usable trace: the presence check was never the defect", () => {
+    expect(() => assertTraceIsUsable(runOneFalseAccusation)).not.toThrow();
+  });
+
+  it("is called OK, because the live read said the pane was at the tail", () => {
+    // The exact live distance was not recorded — only that the poll accepted
+    // it, so it was <= 50. That omission is itself part of the cure: the
+    // verdict now carries the live number, so a future incident has it.
+    const verdict = classify(runOneFalseAccusation, 0);
+
     expect(verdict.kind).toBe("OK");
+    expect(verdict.attributedTo).toBeNull();
+  });
+
+  it("would still be accused if the live read agreed with the stale record", () => {
+    // The cure must not blunt the instrument: hand it the number the stale
+    // record implied — 1417 - 1078 — and the accusation stands, with the arm
+    // named. Only the DISTANCE moved to a live source; attribution did not.
+    const verdict = classify(runOneFalseAccusation, 1417 - 1078);
+
+    expect(verdict.kind).toBe("FROZEN-AT-MARKER");
+    expect(verdict.distance).toBe(339);
+    expect(verdict.attributedTo).toBe("rows-recreation");
   });
 });
 

--- a/cicchetto/e2e/fixtures/scrollTrace.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.ts
@@ -1,0 +1,164 @@
+// #1336 (row #1079) — what a post-send scrollback trace MEANS, decided in one
+// place instead of by an anonymous number in a failing poll.
+//
+// #1079 reports `scroll-on-window-switch` settling 337px from the bottom
+// against an expected 50, the same number twice on two trees. 337 is
+// `1415 - 1078`: the pane sitting exactly ON the unread marker after a send
+// that should have taken it to the tail. The S2 slice proved the pre-send
+// barrier vacuous and cured it, but never observed the vacuity being
+// EXPLOITED — eight recorded samples exited at the marker every time.
+//
+// The instrument that produced those eight samples recorded POSITIONS, and
+// that is why it could not settle the question. In the candidate that explains
+// the number — `scrollToActivation`'s deferred `setFollowMode(near)` landing
+// after the send's own re-arm — nothing writes `scrollTop` at all: the pane
+// simply never leaves the marker, and `tailFollowWhenSettled` yields on
+// `!followMode()` without writing or rescheduling. A recorder of positions is
+// blind to that BY CONSTRUCTION. So the input here carries three channels on
+// one clock: geometry, follow transitions, and rows recreations (the second
+// silent exit of the same wait, on a list node that is no longer connected).
+//
+// Playwright-free on purpose, for the reason `scrollGesture.ts` gives: the
+// instrument a claim is judged by has to be provable itself, and that means
+// unit-testable without a testnet.
+
+export type TraceEvent =
+  | {
+      readonly kind: "scroll";
+      readonly t: number;
+      readonly scrollTop: number;
+      readonly maxScroll: number;
+    }
+  | { readonly kind: "follow"; readonly t: number; readonly follow: "on" | "off" }
+  | { readonly kind: "rows"; readonly t: number }
+  | {
+      readonly kind: "mark";
+      readonly t: number;
+      readonly name: string;
+      readonly value: number | null;
+    };
+
+// Which arm of `ScrollbackPane` the freeze is attributed to. Read off the
+// CROSSING of the three channels, never off the product: the component keeps
+// no reason for a follow write (`setFollowMode(near)` carries none, and the
+// `onScroll` path discards the one it passes to `nextFollowMode`), so making
+// it publish one would mean making it REMEMBER one — new state, which is a
+// second state model rather than instrumentation.
+export type DisarmCause = "scroll-up" | "activation" | "rows-recreation";
+
+export type TraceVerdict = {
+  // FROZEN-AT-MARKER is the terminal state #1079 photographs; SLOW is a pane
+  // still being written, which Playwright's 5s poll absorbs and which never
+  // reports the same number twice.
+  readonly kind: "OK" | "SLOW" | "FROZEN-AT-MARKER";
+  readonly distance: number;
+  readonly attributedTo: DisarmCause | null;
+};
+
+export type ClassifyOptions = {
+  // The same threshold the spec asserts on, passed in rather than mirrored so
+  // the classifier cannot drift away from the assertion it explains.
+  readonly thresholdPx: number;
+};
+
+const isScroll = (e: TraceEvent): e is Extract<TraceEvent, { kind: "scroll" }> =>
+  e.kind === "scroll";
+
+const markIndex = (events: readonly TraceEvent[], name: string): number =>
+  events.findIndex((e) => e.kind === "mark" && e.name === name);
+
+// The position the pane ENDED on, which is not the position the rest barrier
+// reported: the send is supposed to move it, and the whole question is whether
+// it did. Falls back to nothing when no geometry was recorded at all — a trace
+// in that state is what `assertTraceIsUsable` refuses, and callers run it
+// first.
+function lastGeometry(
+  events: readonly TraceEvent[],
+): Extract<TraceEvent, { kind: "scroll" }> | undefined {
+  return [...events].reverse().find(isScroll);
+}
+
+// The LAST disarm, because a send re-arms and the question is what happened
+// after that. Written as a reverse scan rather than `findLastIndex`, which the
+// e2e tsconfig's lib target does not carry.
+function lastDisarmIndex(events: readonly TraceEvent[]): number {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event !== undefined && event.kind === "follow" && event.follow === "off") return i;
+  }
+  return -1;
+}
+
+export function classifyPostSend(
+  events: readonly TraceEvent[],
+  opts: ClassifyOptions,
+): TraceVerdict {
+  const sendAt = markIndex(events, "send");
+  const after = sendAt < 0 ? [] : events.slice(sendAt + 1);
+  const last = lastGeometry(events);
+  const distance = last === undefined ? Number.NaN : last.maxScroll - last.scrollTop;
+
+  // The assertion the row is about would have passed: whatever the trace shows
+  // on the way, the pane is at the tail.
+  if (distance <= opts.thresholdPx) return { kind: "OK", distance, attributedTo: null };
+
+  const disarmAt = lastDisarmIndex(after);
+  if (disarmAt >= 0) {
+    // Still being written AFTER the disarm is not the frozen shape — the pane
+    // is going somewhere, and where it stops is not yet known.
+    const movedSince = after.slice(disarmAt + 1).filter(isScroll);
+    if (movedSince.length > 0) return { kind: "SLOW", distance, attributedTo: null };
+
+    // `onScroll` disarms on ANY scrollTop decrease, so a decrease standing
+    // immediately before the disarm names that arm; a disarm with no movement
+    // in front of it can only have come from a direct write — the activation
+    // class.
+    const before = after.slice(0, disarmAt).filter(isScroll);
+    const previous = before[before.length - 2];
+    const latest = before[before.length - 1];
+    const decreased =
+      previous !== undefined && latest !== undefined && latest.scrollTop < previous.scrollTop;
+    return {
+      kind: "FROZEN-AT-MARKER",
+      distance,
+      attributedTo: decreased ? "scroll-up" : "activation",
+    };
+  }
+
+  // No disarm, and yet the pane never reached the tail: the other silent exit,
+  // where the list node the deferred tail-follow was going to write has been
+  // recreated under it.
+  if (after.some((e) => e.kind === "rows"))
+    return { kind: "FROZEN-AT-MARKER", distance, attributedTo: "rows-recreation" };
+
+  return { kind: "SLOW", distance, attributedTo: null };
+}
+
+// The presence check, and the reason it exists: an instrument that recorded
+// nothing must never read as "no exploitation observed". That is #1117's shape
+// — negative assertions passing against an empty recorder — and this row sits
+// inside the epic that exists to refuse it.
+//
+// The four markers are the ones present in BOTH outcomes. "The send's own tail
+// write" is deliberately NOT among them, though an earlier draft of the design
+// listed it: it is absent exactly when the defect fires, so requiring it would
+// turn every real catch into an instrument failure.
+export function assertTraceIsUsable(events: readonly TraceEvent[]): void {
+  const restExit = markIndex(events, "rest-exit");
+  if (restExit < 0)
+    throw new Error("scrollTrace: no rest-exit mark — the barrier never reported where it stopped");
+
+  const sendAt = markIndex(events, "send");
+  if (sendAt < 0) throw new Error("scrollTrace: no send mark — the trace cannot be split");
+
+  if (!events.slice(0, sendAt).some(isScroll))
+    throw new Error(
+      "scrollTrace: no scroll write before the send — the activation writes three, " +
+        "so the recorder was installed too late or not at all",
+    );
+
+  if (!events.some((e) => e.kind === "follow"))
+    throw new Error(
+      "scrollTrace: no follow transition anywhere — the `data-follow` observer never fired",
+    );
+}

--- a/cicchetto/e2e/fixtures/scrollTrace.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.ts
@@ -78,15 +78,14 @@ function lastGeometry(
   return [...events].reverse().find(isScroll);
 }
 
-// The LAST disarm, because a send re-arms and the question is what happened
-// after that. Written as a reverse scan rather than `findLastIndex`, which the
-// e2e tsconfig's lib target does not carry.
-function lastDisarmIndex(events: readonly TraceEvent[]): number {
+// The follow state the trace ENDS on. A reverse scan rather than `findLast`,
+// which the e2e tsconfig's lib target does not carry.
+function lastFollowState(events: readonly TraceEvent[]): "on" | "off" | null {
   for (let i = events.length - 1; i >= 0; i -= 1) {
     const event = events[i];
-    if (event !== undefined && event.kind === "follow" && event.follow === "off") return i;
+    if (event !== undefined && event.kind === "follow") return event.follow;
   }
-  return -1;
+  return null;
 }
 
 export function classifyPostSend(
@@ -102,26 +101,26 @@ export function classifyPostSend(
   // on the way, the pane is at the tail.
   if (distance <= opts.thresholdPx) return { kind: "OK", distance, attributedTo: null };
 
-  const disarmAt = lastDisarmIndex(after);
-  if (disarmAt >= 0) {
-    // Still being written AFTER the disarm is not the frozen shape — the pane
-    // is going somewhere, and where it stops is not yet known.
-    const movedSince = after.slice(disarmAt + 1).filter(isScroll);
-    if (movedSince.length > 0) return { kind: "SLOW", distance, attributedTo: null };
-
-    // `onScroll` disarms on ANY scrollTop decrease, so a decrease standing
-    // immediately before the disarm names that arm; a disarm with no movement
-    // in front of it can only have come from a direct write — the activation
-    // class.
-    const before = after.slice(0, disarmAt).filter(isScroll);
-    const previous = before[before.length - 2];
-    const latest = before[before.length - 1];
-    const decreased =
-      previous !== undefined && latest !== undefined && latest.scrollTop < previous.scrollTop;
+  // Follow OFF makes the position TERMINAL: `tailFollowWhenSettled` yields on
+  // `!followMode()` writing nothing and rescheduling nothing, so nobody is
+  // going to bring this pane down. That, and not "no more scroll events", is
+  // what separates frozen from slow — measured: an injected freeze recorded
+  // its disarm BEFORE the decrease that caused it, because the
+  // MutationObserver microtask lands between two listeners on one event, and
+  // an event-order rule called the frozen pane SLOW.
+  if (lastFollowState(events) === "off") {
+    // `onScroll` disarms on any scrollTop DECREASE, so a pane that reached the
+    // tail after the send and then left it went out through that arm; one that
+    // never reached the tail was disarmed by a direct write — the activation
+    // class. Stated as positions rather than as event order, which the same
+    // measurement showed is not reliable to a millisecond.
+    const reachedTail = after
+      .filter(isScroll)
+      .some((e) => e.maxScroll - e.scrollTop <= opts.thresholdPx);
     return {
       kind: "FROZEN-AT-MARKER",
       distance,
-      attributedTo: decreased ? "scroll-up" : "activation",
+      attributedTo: reachedTail ? "scroll-up" : "activation",
     };
   }
 

--- a/cicchetto/e2e/fixtures/scrollTrace.ts
+++ b/cicchetto/e2e/fixtures/scrollTrace.ts
@@ -59,6 +59,21 @@ export type ClassifyOptions = {
   // The same threshold the spec asserts on, passed in rather than mirrored so
   // the classifier cannot drift away from the assertion it explains.
   readonly thresholdPx: number;
+  // The terminal distance, read LIVE off the DOM at classification time — the
+  // same synchronous read the spec's poll makes, not a trace derivation.
+  //
+  // MEASURED 2026-08-19, full suite run 1: derived from the last recorded
+  // position, this accused a pane that was already at the tail. The poll had
+  // PASSED and the screenshot showed the sent line at the bottom; the trace
+  // simply had no post-send geometry, because the `scroll` event had not been
+  // delivered yet when the trace was read. Run 2 was green and its trace
+  // differs by exactly one record — a post-send scroll arriving 11 ms after
+  // the last rows recreation.
+  //
+  // So the rule this encodes: a passive listener's SILENCE is not evidence of
+  // stillness, and only a live read can say where the pane ended. The trace
+  // keeps the job it is good at, which is naming the arm.
+  readonly finalDistancePx: number;
 };
 
 const isScroll = (e: TraceEvent): e is Extract<TraceEvent, { kind: "scroll" }> =>
@@ -66,17 +81,6 @@ const isScroll = (e: TraceEvent): e is Extract<TraceEvent, { kind: "scroll" }> =
 
 const markIndex = (events: readonly TraceEvent[], name: string): number =>
   events.findIndex((e) => e.kind === "mark" && e.name === name);
-
-// The position the pane ENDED on, which is not the position the rest barrier
-// reported: the send is supposed to move it, and the whole question is whether
-// it did. Falls back to nothing when no geometry was recorded at all — a trace
-// in that state is what `assertTraceIsUsable` refuses, and callers run it
-// first.
-function lastGeometry(
-  events: readonly TraceEvent[],
-): Extract<TraceEvent, { kind: "scroll" }> | undefined {
-  return [...events].reverse().find(isScroll);
-}
 
 // The follow state the trace ENDS on. A reverse scan rather than `findLast`,
 // which the e2e tsconfig's lib target does not carry.
@@ -94,11 +98,13 @@ export function classifyPostSend(
 ): TraceVerdict {
   const sendAt = markIndex(events, "send");
   const after = sendAt < 0 ? [] : events.slice(sendAt + 1);
-  const last = lastGeometry(events);
-  const distance = last === undefined ? Number.NaN : last.maxScroll - last.scrollTop;
+  const distance = opts.finalDistancePx;
 
-  // The assertion the row is about would have passed: whatever the trace shows
-  // on the way, the pane is at the tail.
+  // The assertion the row is about DID pass: whatever the three channels show
+  // on the way — up to and including the strongest frozen signal there is —
+  // the pane ended at the tail, so there is nothing to accuse. This is the
+  // gate that makes the accusation downstream of the failure rather than
+  // parallel to it: below, the poll has necessarily already failed.
   if (distance <= opts.thresholdPx) return { kind: "OK", distance, attributedTo: null };
 
   // Follow OFF makes the position TERMINAL: `tailFollowWhenSettled` yields on

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -507,8 +507,18 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
       settleFailure = err;
     }
 
+    // The terminal distance comes from a LIVE read, taken before the trace so
+    // the trace covers every moment the number describes. Deriving it from the
+    // trace's last record accused a pane that was already at the tail
+    // (2026-08-19, full suite run 1): the recorder had simply not been handed
+    // the post-send `scroll` event yet.
+    const settled = await scrollbackGeometry(page);
+    const finalDistancePx = settled.scrollHeight - settled.scrollTop - settled.clientHeight;
     const trace = await readScrollTrace(page);
-    const verdict = classifyPostSend(trace, { thresholdPx: SCROLL_BOTTOM_THRESHOLD_PX });
+    const verdict = classifyPostSend(trace, {
+      thresholdPx: SCROLL_BOTTOM_THRESHOLD_PX,
+      finalDistancePx,
+    });
     // Written to the output path rather than attached as a body: measured, an
     // attachment on a PASSING run does not survive into the report, and a
     // near-miss on a green run is exactly the datum this row is short of.

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -78,16 +78,21 @@
 // overflows the scrollback area; without overflow, "lands at bottom"
 // is vacuously true and "divider above the fold" is unmeasurable.
 
+import { writeFileSync } from "node:fs";
 import type { Page } from "@playwright/test";
 import {
   composeSend,
+  installScrollTrace,
   loginAs,
+  markScrollTrace,
   pageScrollbackRest,
+  readScrollTrace,
   scrollbackLines,
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
+import { assertTraceIsUsable, classifyPostSend } from "../fixtures/scrollTrace";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -400,6 +405,11 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
       { timeout: 20_000 },
     );
 
+    // #1336 (row #1079) — record the switch and the send, on the three
+    // channels the freeze can show up on. Before `loginAs`, because the
+    // recorder is an init script and has to be in place before the SPA boots.
+    await installScrollTrace(page);
+
     await loginAs(page, vjt);
 
     // FROM-window: the always-present $server window mounts ScrollbackPane
@@ -432,7 +442,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // a pane that has stopped. The distance test alone cannot do this: it is
     // satisfied by the reset too, which is the same pane 1071px from where
     // this test means it to be. Rejects by name if the pane never holds still.
-    await pageScrollbackRest(page, 10_000);
+    await markScrollTrace(page, "rest-exit", await pageScrollbackRest(page, 10_000));
 
     // Sanity: the pane overflows (else "not at the tail" is vacuous).
     const g = await scrollbackGeometry(page);
@@ -476,16 +486,45 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // the BOTTOM (#168 post-send authority preserved — the scope fix must
     // not re-break it). The sent line lands in the viewport, divider clears.
     const sent = `switch-then-send ${Date.now()}`;
+    await markScrollTrace(page, "send", null);
     await composeSend(page, sent);
 
     const sentLine = scrollbackLines(page).filter({ hasText: sent });
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
-    await expect
-      .poll(async () => {
-        const cur = await scrollbackGeometry(page);
-        return cur.scrollHeight - cur.scrollTop - cur.clientHeight;
-      })
-      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+    // #1336 (row #1079) — the trace is saved on GREEN as well as on red: a
+    // near-miss on a passing run is the datum this row is short of. The
+    // classification runs afterwards either way, so a freeze is accused BY
+    // NAME instead of arriving as the anonymous `337` the issue reports.
+    let settleFailure: unknown = null;
+    try {
+      await expect
+        .poll(async () => {
+          const cur = await scrollbackGeometry(page);
+          return cur.scrollHeight - cur.scrollTop - cur.clientHeight;
+        })
+        .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+    } catch (err) {
+      settleFailure = err;
+    }
+
+    const trace = await readScrollTrace(page);
+    const verdict = classifyPostSend(trace, { thresholdPx: SCROLL_BOTTOM_THRESHOLD_PX });
+    // Written to the output path rather than attached as a body: measured, an
+    // attachment on a PASSING run does not survive into the report, and a
+    // near-miss on a green run is exactly the datum this row is short of.
+    const tracePath = test.info().outputPath("scroll-trace.json");
+    writeFileSync(tracePath, JSON.stringify({ verdict, trace }, null, 2));
+    await test.info().attach("scroll-trace", { path: tracePath, contentType: "application/json" });
+    // The presence check first: an instrument that recorded nothing must not
+    // license a conclusion either way.
+    assertTraceIsUsable(trace);
+    if (verdict.kind === "FROZEN-AT-MARKER")
+      throw new Error(
+        `#1079: the pane froze ${verdict.distance}px from the bottom after the send, ` +
+          `attributed to ${verdict.attributedTo}`,
+      );
+    // Nothing was frozen, so whatever the poll said stands on its own.
+    if (settleFailure !== null) throw settleFailure;
     await expect(sentLine).toBeInViewport();
     await expect(marker).toHaveCount(0, { timeout: 5_000 });
   });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -3838,6 +3838,13 @@ const ScrollbackPane: Component<Props> = (props) => {
         onWheel={onWheel}
         onKeyDown={onKeyDown}
         data-testid="scrollback"
+        // #1336 (row #1079) — the follow intent, DERIVED, because nothing else
+        // shows it: the `[scroll-authority]` log is development-only, and the
+        // scroll-to-bottom button mirrors `atBottomNow`, which diverges from
+        // this by design. A pane that will not auto-scroll otherwise gives
+        // DevTools nothing to read. `on|off` carries the same cardinality as
+        // the boolean it mirrors, so it compresses nothing.
+        data-follow={followMode() ? "on" : "off"}
       >
         {/* #270 — peer-away banner as an IN-FLOW top row. Persistent +
             DM-contextual (unlike the ephemeral WHOIS / WHOWAS / LUSERS

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51534,3 +51534,134 @@ against a 5000 ms vitest timeout. A re-run of the same mutant returned exactly o
 death. That is the #1563 signature, unchanged and undiagnosed: a kill whose
 victims do not name the invariant, and whose durations sit on the timeout, is a
 flake until a re-run says otherwise.
+<!-- entry #1336-1079-scrolltrace -->
+
+---
+
+## 2026-08-19 — #1336 (row #1079): the recorder that could not see the freeze, and the one attribute that fixes it
+
+#1079 reports `scroll-on-window-switch` settling 337px from the bottom against
+an expected 50, the same number twice on two trees. The S2 slice proved the
+pre-send barrier VACUOUS and cured it with `waitForScrollRest`, and said in its
+own words what it had not shown: the vacuity was never observed being
+EXPLOITED. Eight recorded samples exited at the marker every time.
+
+This slice cures nothing. It builds the instrument that can answer the
+question, because the one S2 used cannot — and that is the finding.
+
+### Two measurements that reshaped the design
+
+**The failing assertion is the POST-SEND one, and no cure barriers it.** The
+issue cites `spec:410` / `spec:512`, both stale. Against the blob current on
+2026-08-08 (522 lines) the test at `:410` is the SWITCH test and the assertion
+at `:512` is the post-send `distance <= 50` poll. The three
+`pageScrollbackRest` calls S2 added all sit BEFORE the send.
+
+**337 is the pane ON the marker — and the mechanism that leaves it there writes
+no scrollTop at all.** `1415 - 1078 = 337`; a post-send DECREASE from a rows
+reset would strand it near the top instead (`1415 - 7 = 1408`). For the pane to
+stay on the marker, follow must be disarmed AFTER the send re-arms it
+(`ScrollbackPane.tsx:2620`) and within the budget of `tailFollowWhenSettled`,
+which yields at `:2915` on `!followMode()` writing nothing and rescheduling
+nothing. The candidate that fits is `scrollToActivation`'s deferred
+`setFollowMode(near)` at `:2319` landing after the send: the send clears the
+marker latch at `:2619`, but that does not cancel an activation rAF already
+scheduled.
+
+So in the candidate that explains the number, **nothing writes `scrollTop`
+after the send**. A recorder of POSITIONS — which is what S2 built, and threw
+away — is blind to it by construction. That is the likeliest reading of eight
+mute samples: not "the exploitation did not happen", but "this instrument could
+not have seen it".
+
+### Three channels, one clock, and no new product state
+
+`scrollTrace.ts` classifies a trace carrying scroll events, `data-follow`
+transitions and rows-list recreations. The CAUSE is not published by the
+component — it is read off the crossing:
+
+| observation | attributed to |
+|---|---|
+| disarm preceded by a scrollTop decrease | `onScroll:3498-3500` |
+| disarm with no movement at all | the `:2319` activation class |
+| no disarm, but the list recreated after the send | `:2914` |
+
+That indirection is deliberate. `setFollowMode(near)` carries no reason and the
+`onScroll` path discards the one it passes to `nextFollowMode`, so publishing a
+cause would mean making the component REMEMBER one — new state, a second state
+model, the opposite of instrumentation.
+
+### The one product change, and why it is not a test hook
+
+`data-follow={followMode() ? "on" : "off"}` on the div that already carries
+`data-testid="scrollback"`. Derived, no new state, mirroring the existing
+`classList={{ "scrollback-locked": scrollLocked() }}` on the same element.
+Nothing else exposes the follow intent: the `[scroll-authority]` log is dead in
+e2e (gated on `MODE === "development"`, and the e2e bundle is a `vite build`),
+and the `scroll-to-bottom` button mirrors `atBottomNow`, which diverges from
+follow BY DESIGN. It serves a human too — a pane that will not auto-scroll
+currently gives DevTools nothing to read.
+
+`on|off` is honest because `followMode` is a boolean (`createSignal(true)`,
+`:1198`; `nextFollowMode` returns `boolean`), so the attribute compresses
+nothing. Were the signal an enum, `on|off` would have been a lie by
+compression. The rule worth keeping: a derived attribute must carry the same
+CARDINALITY as the signal it mirrors.
+
+### The presence check, and the marker that had to be dropped from it
+
+An instrument that recorded nothing must never read as "no exploitation
+observed" — #1117's shape, negative assertions passing against an empty
+recorder. `assertTraceIsUsable` therefore demands four markers: the rest-exit
+mark, the send mark, at least one scroll write BEFORE the send, and at least
+one follow transition.
+
+The design published on the issue listed a fifth, "the send's own tail write",
+and it was wrong: that write is absent EXACTLY when the defect fires. A
+presence check that trips on the phenomenon it exists to license would convert
+every real catch into an instrument failure. Corrected here, with a test whose
+name carries the correction.
+
+### The injected control earned its keep on the first run it could reach
+
+The design pre-registered a mandatory injected break: a post-send write that
+puts the pane back on the marker. It found two things, neither by review.
+
+**A window boundary.** The first injection fired on a timer 150 ms after the
+send. The poll had already exited by then — the pane reached the tail, the
+assertion passed, and the injected write landed AFTER the trace was read. The
+run still failed, on `toBeInViewport()`, with no number and no attribution:
+exactly the anonymous shape this instrument exists to replace. So the observed
+window is "from the send mark to the moment the poll stops", and a freeze
+arriving after a SUCCESSFUL poll is outside it. The natural defect is inside it
+by construction — a pane that never reaches the tail keeps the poll running for
+its full 5 s — but the boundary is real and stated.
+
+**A defect in the classifier.** With the injection re-hooked to the first
+at-tail scroll (deterministic instead of timed), the pane ended 337 px from the
+bottom and the classifier called it `SLOW`. The rule was "a scroll event after
+the last disarm means the pane is still moving", and the trace shows the disarm
+recorded BEFORE the decrease that caused it: the product's `onScroll` and the
+recorder's own listener are two listeners on one event, and the
+MutationObserver microtask carrying `data-follow` lands between them. Ordering
+inside a millisecond is not evidence.
+
+The corrected rule is the product's own semantics: follow OFF makes the
+position terminal, because `tailFollowWhenSettled` yields at `:2915` writing
+nothing and rescheduling nothing. Attribution likewise moved from event order
+to positions — reached the tail after the send and left it, or never reached
+it. Re-run against the same injection the instrument now says "the pane froze
+337px from the bottom after the send, attributed to scroll-up".
+
+### What this slice does NOT establish
+
+* The natural failure is still not reproduced, by anyone, before or after the
+  cures.
+* `:2319` is a candidate that fits the arithmetic, not a measured cause.
+* The scroll channel is a PASSIVE listener rather than a patched setter: it
+  sees exactly what the product's own `onScroll` sees, which is the right
+  fidelity for the arm under study, but not writes the browser coalesces away.
+* The injected control exercises the `scroll-up` arm only. The `activation`
+  arm cannot be injected from outside — it would mean writing `followMode`,
+  which no external observer can do — so that attribution rests on the unit
+  cases, not on an in-situ break.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51665,3 +51665,87 @@ it. Re-run against the same injection the instrument now says "the pane froze
   arm cannot be injected from outside — it would mean writing `followMode`,
   which no external observer can do — so that attribution rests on the unit
   cases, not on an in-situ break.
+
+### The full suite found the second classifier defect, and it was a FALSE ACCUSATION
+
+Two full-suite runs, cold, identical, `workers: 1`, pre-registered at N=2
+before either was started. Run 1: `755 passed, 1 failed` — and the one failure
+was this slice's own spec, accusing by name:
+
+```
+#1079: the pane froze 339px from the bottom after the send, attributed to rows-recreation
+```
+
+339 is `1417 - 1078`: the pane on the marker, the #1079 shape, arrived at
+without an injection. It was still wrong, and three independent measurements
+say so. The poll asserting `distance <= 50` runs BEFORE the trace is read and
+its failure is captured rather than thrown; `playwright.config.ts` sets no
+expect timeout, so a failing poll costs the 5 s default — and the test took
+1.3 s, which means the poll PASSED. The failure screenshot shows the sent line
+at the bottom of the pane with no unread marker. And the trace's last geometry
+record is timestamped 177 ms BEFORE the send mark: there was no post-send
+geometry at all.
+
+Run 2 was green, 756/756, and its trace is the discriminator. The two are
+identical up to and including the two post-send rows recreations. Run 2 then
+carries ONE more record — a `scroll` to `1415/1415`, 11 ms after the last rows
+recreation — and run 1 does not.
+
+So the pane always moved. What varied between two runs of the same code on the
+same host was whether the `scroll` event had been DELIVERED to the recorder
+before the trace was read. `page.evaluate` reads `scrollTop` synchronously, so
+the poll can observe the settled position while the listener has not yet been
+called; the trace read then lands in that window.
+
+**The rule, stated so it outlives the incident: a passive listener's SILENCE is
+not evidence of stillness.** `classifyPostSend` derived the terminal distance
+from `lastGeometry` — the last recorded position — on the premise that a
+passive listener sees every movement. `installScrollTrace` samples `maxScroll`
+as `scrollHeight - clientHeight` only INSIDE the scroll handler, so both halves
+of that subtraction go stale together whenever geometry changes without a
+delivered event.
+
+This is the same CLASS as the defect the injected control found earlier in this
+slice — "ordering inside a millisecond is not evidence" — and it arrived the
+same way, from a control rather than from review. Two of them in one slice is
+the argument for building instruments that can be run against their own past
+output.
+
+### The cure: the accusation moves downstream of the failure
+
+`ClassifyOptions` gains `finalDistancePx`, a LIVE read taken at classification
+time from the same `scrollbackGeometry` helper the poll uses, and
+`classifyPostSend` uses it for `distance`. `lastGeometry` is deleted; the three
+trace channels keep the job they are actually good at, which is naming the arm.
+
+The structural gain is bigger than the bug fixed. With the distance coming from
+a live read, `OK` short-circuits before any attribution, so `FROZEN-AT-MARKER`
+is reachable ONLY when the 5 s poll has really failed. The instrument can no
+longer accuse a passing run — it can only name the arm of a failure that
+happened. A test states that as the general rule rather than as this incident:
+handed the strongest frozen signal there is (a disarm after the send with no
+movement) together with a live read at the tail, the classifier must return
+`OK`.
+
+The run-1 trace is committed verbatim as a fixture, with its three assertions:
+it is usable (the four-marker presence check was never the defect), it is `OK`
+against a live read at the tail, and — the control against blunting the
+instrument — it is still `FROZEN-AT-MARKER` with `rows-recreation` named when
+the live read agrees with the stale record. The test that used to pin
+"measures the distance from the LAST position" is deleted rather than kept
+beside the new one: its name pinned a rule now known to be false, and two rules
+for one number is how the next reader picks the wrong one.
+
+### What the two runs do and do not license
+
+* The natural race is STILL not reproduced. Run 1's red was an instrument
+  error, not a catch, and it must not be read as one.
+* The false accusation is NOT deterministic: one occurrence in two runs. Its
+  rate is unmeasured, and no third pre-cure run was spent on refining a rate
+  that would not change the decision — any nonzero rate disqualifies an
+  accuser.
+* The exact live distance in run 1 was never recorded, only that the poll
+  accepted it, so it was within 50 px. That omission is itself repaired by the
+  cure, which puts the live number in the verdict.
+* The window boundary recorded above is unchanged, and so is the browser
+  coverage caveat: chromium for this spec.


### PR DESCRIPTION
## Summary

Row **#1079** (CLOSED / NOT_PLANNED, under epic #1336) reports the scrollback pane
stopping **337 px** from the tail after a send instead of ≤50. **This slice does not fix
that.** It builds the instrument that can answer whether it happens, and — this is the
part that took the work — an instrument that cannot lie in the direction that matters.

- `cicchetto/e2e/fixtures/scrollTrace.ts` (+ its unit test) — a recorder of rows / scroll /
  follow / mark events and a classifier over them.
- `cicchetto/e2e/fixtures/cicchettoPage.ts` — `installScrollTrace` / `markScrollTrace` /
  `readScrollTrace`.
- `cicchetto/e2e/tests/scroll-on-window-switch.spec.ts` — wired into the SWITCH test only.
- `cicchetto/src/ScrollbackPane.tsx` — one line of product: `data-follow={followMode() ?
  "on" : "off"}`. Follow **intent** is not derivable from position; without it the recorder
  can see where the pane is but not whether it meant to be there.

## The instrument was wrong first, and that is the interesting half

The first full run went red with my own spec accusing *"#1079: the pane froze 339px …
rows-recreation"*. **It was a false accusation**, established three ways: the live
`distance<=50` poll had *passed* (test 1.3 s against a 5000 ms expect timeout), the
screenshot showed the sent row at the bottom, and the last geometry record predated the
send by 177 ms. The classifier was reading a **stale** `lastGeometry` — `maxScroll` was
only ever sampled inside the scroll handler.

The cure (`take the terminal distance from a live read, not the trace`) makes
`ClassifyOptions` take `finalDistancePx` from the same live `scrollbackGeometry` the poll
reads, and deletes `lastGeometry`. The structural gain: **`OK` returns before any
attribution**, so `FROZEN-AT-MARKER` is now reachable only if the 5 s poll genuinely
failed. The instrument can no longer accuse a run that passed.

The defect could err in **both** directions. The loud direction (green → named red)
denounced itself. The silent one (red → *anonymous* red — degraded diagnosis, never a
red turned green, because the spec always re-raises `settleFailure`) now has its own test,
and that test is a **measurement**: injecting the old rule as a mutant kills 4 tests
including the mirror one.

## Evidence

Three post-cure full `integration.sh` runs, same code, `workers: 1`:

| run | spec | verdict | duration |
|---|---|---|---|
| 3 (08:47Z) | ✓ | `OK, distance 7` | 1.1 s |
| 4 (09:29Z) | ✓ | `OK, distance 7` | 1.3 s |
| 5 (10:07Z) | ✓ | `OK, distance 7` | 1.1 s |

Stopping rule was **pre-registered on #1336 before running** (N=2, rising to N=5 if the
instrument came under suspicion — it did, so the clause fired). So was the **near-miss**
criterion, registered before any trace was read: `OK` with distance > 25; a bounce away
from the tail after the `send` mark; a `SLOW` verdict; or a duration well above the 1.3 s
poll-passed signature. **None of the four fired in any of the three runs.**

Other gates: `bun run check` rc=0 · full vitest 291 files / 5633 tests rc=0 ·
`scrollTrace.test.ts` 18/18 · `design-notes-gate.sh` rc=0.

## The uncomfortable parts, stated rather than buried

- **Run 5 exited rc=1.** It was complete (751 passed + 5 failed = **756/756**, chromium
  612/612 and webkit 144/144). Of the five reds: **three are environment**, each bound to
  the closing edge of one of the run's three ~33 s #1420-family stalls at second
  resolution, with the damage signature present (`db30=6 idle30=9 saturated=3`). **Two are
  unattributed** — `issue422-inbound-dm-opens-query.spec.ts:38` and
  `nick-case-incoming.spec.ts:50`, both dying on `page.waitForFunction: Timeout 5000ms
  exceeded`. They are filed as #1566, **not diagnosed**, and they are not attributable in
  either direction because the census names gaps ≥10 s and the damage counters match only
  30–39.9 s: a 5–9 s slowdown is invisible to both instruments by construction (#1429).
  Neither red is in this branch's blast radius, and both were green in runs 1–4.
- **Run 4 took a SIGHUP during its webkit phase.** Its **chromium phase completed
  612/612** — the spec here is chromium and ran at index 552, 2m38s before the signal —
  but the run **supports nothing about webkit** (14/144).
- **Runs 1 and 2 are history, not evidence.** The instrument was defective then.
- **The natural race has never been reproduced**, by anyone, before or after the cures.

## What is NOT measured

- `scrollToActivation`'s deferred `setFollowMode(near)` is the candidate that would explain
  the number 337 — **a candidate, not a measured cause**.
- The injected control exercises only the `scroll-up` arm; the `activation` arm is not
  externally injectable and rests on unit cases.
- The pre-cure false-positive **rate** (1 in 2) is not refined further.
- DOM cost of the derived attribute.
- No real-world sample of the silent direction: it is reasoned from the code and covered by
  a test, not observed in the wild.

## Test plan

- [x] `bun run check` — rc=0
- [x] full vitest — 291 files / 5633 tests, rc=0
- [x] `scrollTrace.test.ts` in isolation — 18/18
- [x] mutation check — old rule injected, kills 4 tests; restored and re-verified 18/18
- [x] full `scripts/integration.sh` ×3 post-cure — spec green in all three, no near-miss
- [x] `scripts/design-notes-gate.sh` — rc=0, one new entry, separator and marker present