### PR TITLE
#1397: fold 25 fixture copies onto AuthFixtures, at the Argon2 door

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51966,3 +51966,128 @@ One interaction is modelled nowhere: the pane rewrites `scrollTop` from
 a queueMicrotask whenever the entry count changes, so a progress ping
 that lands while a finger is down meets a gesture that assumes it owns
 the scroller. No test holds a finger across a ping.
+<!-- entry #1397-fixture-fold -->
+
+---
+
+## 2026-08-19 — #1397: the fixture trio folds, and the suite-time claim its predecessor declined to make
+
+The entry above (`#1397-fixture-oracles`) closes with *"nor was any suite-time
+effect of the pinned hash measured; the ~100 ms figure remains the moduledoc's
+own claim, inherited, not re-timed here."* This one re-times it, because the
+same ruling is what unblocked the twenty-five copies this folds.
+
+### A blocker that had already expired
+
+The fourteen local `user_fixture` copies were held — explicitly, in
+`#1397-adoption` — on an open question about Argon2 cost. vjt ruled it and
+#1564 carried it out, so by the time this slice opened there was nothing left
+holding them. That is `#1397-deferred7`'s rule in its second instance: **a
+blocker recorded in an issue is a measurement of a moment, not a property of
+the code**, and the failure mode is declining to act on a stale red, which is
+invisible because nothing breaks when you obey it.
+
+### What the copies were actually paying
+
+All fourteen went through `Accounts.create_user/1` — changeset plus
+`Argon2.hash_pwd_salt/1` — while the canonical they shadow does a bare
+`Repo.insert` with a precomputed hash. `grep -rniE 'argon2|t_cost|m_cost' config/`
+returns nothing, so `:test` runs argon2_elixir's production defaults in full;
+the moduledoc's claim is corroborated by a grep independent of the moduledoc.
+
+None of the fourteen exercises the verification path. The issue's own text says
+"13 of those 14", implying one does — on today's base that one does not exist:
+the single hit for `login` across all fourteen is **prose inside a comment**
+(`networks_test.exs:504`). The count was a grep artifact and is corrected here.
+
+### The displacement, and the first number that was wrong
+
+| run | suite | async | sync |
+| --- | --- | --- | --- |
+| before (base files restored in place) | **138.2s** | 42.9s | 95.2s |
+| after ×3 | **116.8 / 118.4 / 118.2s** | 25.7s | 92.4s |
+
+≈ **-20s, -15%**, and essentially ALL of it in the async half — which is where
+thirteen of the fourteen files live (`networks_test.exs` is `async: false`).
+That the saving lands where the touched files run is the internal check that
+makes the number readable as this change rather than as noise.
+
+🥇 **The first before/after was measured against a moving host and would have
+claimed twice the truth.** An initial pair read 166.4s → 116.8s (-30%), taken
+while another worker's full gate ran in a second tmux session. The 166.4s was
+that contention, not the fixtures: re-measured back-to-back on an idle host the
+same base is 138.2s. **A before/after is only a displacement if both sides see
+the same machine** — and the way that was caught was noticing the other session
+had disappeared between the two runs, not anything in the numbers.
+
+### Two mutants, two sides, two mechanisms
+
+Against the canonical, over the same 494 tests in the fourteen files:
+
+| mutant | branch | base |
+| --- | --- | --- |
+| `user_fixture/1` ignores `attrs`, constant name | **29 failures** | **0** |
+| `network_fixture/1` ignores `:slug`, constant slug | **17 failures** | **0** |
+
+The base column is what attributes the kills: there the fourteen files still
+carry their own bodies, so the canonical can be broken freely and nothing
+notices. The two mutants also die by different mechanisms and say so in their
+failure lines — `Ecto.ConstraintError` on `users_folded_name_index` for the
+first, `assert a.id != b.id` ("same nick on two networks is two independent
+entries") for the second — which is the standard this project holds a kill to:
+**deaths with different names, read off the failure lines**, not one death
+counted twice.
+
+### Three refusals, each with its reason
+
+**The seven `network_fixture` copies ride along.** They are the canonical
+specialised at a different slug prefix — no drift, no weaker copy — so folding
+them changes no behaviour. That was first read as disqualifying, by the same
+criterion that refused `flush/1` on this issue. It is a category error: for
+`flush/1` the only claim on offer was behavioural, and none could be made; here
+the claim is structural, and being preserving-by-construction is the POINT of a
+de-duplication rather than an objection to it. "Total consistency or nothing"
+settles the rest — seven left behind would be exactly the two patterns #1397
+names.
+
+**The four `visitor_fixture` copies stay.** They call the production door
+`Visitors.find_or_provision_anon/3`; the canonical mirrors that shape rather
+than calling it, and says so in its own comment. Folding them would trade a real
+door for an imitation of one, so those four files keep a narrowed import instead
+— the same `only:` shape thirteen files in the suite already use.
+
+**The e2e half is out of scope and is now two definitions, not sixty-one.**
+Measured on `def49b52`, the nine helpers #1397 names have 8 definitions over 4
+files, six of which are the canonicals in `e2e/fixtures/`. The real residue is
+`loginAs` in `issue252-vhost-selector.spec.ts:34` — the `adminLogin` body
+wearing the `loginAs` name, stopping at `expectShellReady` without the
+`waitForUserTopicReady` barrier the canonical carries — and a `bootVisitor` in
+`issue477` which is NOT a duplicate at all (different signature, and it calls
+the canonical `bootVisitorContext`). It waits for the exclusive e2e lane.
+
+### Three uniform zeros, all instrument
+
+Worth recording because each looked like a finding:
+
+  * `git grep -E` knows neither `\b` nor `\s` — they are not POSIX ERE. Two
+    separate anchors, each returning **0 files** for a helper that has fourteen
+    definitions. Isolated one element at a time to attribute it.
+  * comparing a local body to the canonical with string literals blanked
+    returns "different" for all 25, which is TRUE and answers the wrong
+    question: the canonical is parameterised (`Keyword.get(attrs, :slug, …)`)
+    and the copies are not, so a textual compare can never coincide.
+  * an alias pruner keyed on `Short.` would have deleted two LIVE aliases used
+    only as `%Short{}`. The cure was to stop guessing and let
+    `--warnings-as-errors` name the twenty unused aliases and the one orphaned
+    `uniq/0`, which it did precisely.
+
+### Not established
+
+No claim is made about the 13 further files, 30 call sites, that reach
+`Accounts.create_user/1` inline outside any fixture — they were counted and
+classified by whether they name the verification path, and not read. The
+runtime hash COUNT was never taken: the 44 static sites are neither an upper
+nor a lower bound, since a site inside a `defp` costs one hash per call and one
+inside a `setup` costs one per test. The before side of the timing is a single
+run against three after runs; the after spread is 1.6s and the gap is 20s, but
+one run is one run.

--- a/test/grappa/migrations/collapse_nick_read_cursors_test.exs
+++ b/test/grappa/migrations/collapse_nick_read_cursors_test.exs
@@ -19,23 +19,11 @@ defmodule Grappa.Migrations.CollapseNickReadCursorsTest do
   """
   use Grappa.DataCase, async: true
 
-  alias Grappa.{Accounts, Networks, Repo, ScrollbackHelpers}
+  import Grappa.AuthFixtures
+
+  alias Grappa.{Repo, ScrollbackHelpers}
 
   @nick_predicate "substr(channel,1,1) NOT IN ('#','&','!','+')"
-
-  defp uniq, do: System.unique_integer([:positive])
-
-  defp user_fixture do
-    {:ok, user} =
-      Accounts.create_user(%{name: "cursor-#{uniq()}", password: "correct horse battery staple"})
-
-    user
-  end
-
-  defp network_fixture do
-    {:ok, net} = Networks.find_or_create_network(%{slug: "azzurra-#{uniq()}"})
-    net
-  end
 
   defp message(user, net, channel, st) do
     {:ok, m} =

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -25,24 +25,14 @@ defmodule Grappa.NetworksTest do
   # cheaper than further bumping busy_timeout (already at 30s).
   use Grappa.DataCase, async: false
 
+  import Grappa.AuthFixtures
+
   alias Grappa.{Accounts, Networks, Repo}
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.{Credential, Credentials, Network, Server, Servers, SessionPlan}
   alias Grappa.PubSub.Topic
   alias Grappa.Session.Backoff
   alias Grappa.Visitors.Visitor
-
-  defp user_fixture(name \\ nil) do
-    name = name || "vjt-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
-
-  defp network_fixture(slug \\ nil) do
-    slug = slug || "net-#{System.unique_integer([:positive])}"
-    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
-    network
-  end
 
   # #93 — builds the `{host, enabled}` list as an ascending-priority ring,
   # binds `user` to it and resolves the spawn-door plan.
@@ -175,7 +165,7 @@ defmodule Grappa.NetworksTest do
 
   describe "add_server/2" do
     test "inserts a server attached to the network" do
-      net = network_fixture("azzurra")
+      net = network_fixture(slug: "azzurra")
 
       assert {:ok, %Server{} = srv} =
                Servers.add_server(net, %{
@@ -193,7 +183,7 @@ defmodule Grappa.NetworksTest do
     end
 
     test "returns {:error, :already_exists} on the same (network, host, port)" do
-      net = network_fixture("azzurra")
+      net = network_fixture(slug: "azzurra")
       attrs = %{host: "irc.azzurra.chat", port: 6697, tls: true}
 
       assert {:ok, _} = Servers.add_server(net, attrs)
@@ -213,7 +203,7 @@ defmodule Grappa.NetworksTest do
 
   describe "list_servers/1" do
     test "returns servers ordered by (priority asc, id asc)" do
-      net = network_fixture("azzurra")
+      net = network_fixture(slug: "azzurra")
       {:ok, _} = Servers.add_server(net, %{host: "a", port: 6697, priority: 1})
       {:ok, _} = Servers.add_server(net, %{host: "b", port: 6697, priority: 0})
       {:ok, _} = Servers.add_server(net, %{host: "c", port: 6697, priority: 0})
@@ -480,7 +470,7 @@ defmodule Grappa.NetworksTest do
     test "reuses an existing network and its server when no server is given", %{user: user} do
       # The shape the admin page needs: the operator picks a network that
       # already exists, and supplies per-network settings only.
-      net = network_fixture("azzurra")
+      net = network_fixture(slug: "azzurra")
       {:ok, _} = Servers.add_server(net, %{host: "irc.azzurra.chat", port: 6697, tls: true})
 
       assert {:ok, %Credential{} = cred} =
@@ -493,7 +483,7 @@ defmodule Grappa.NetworksTest do
 
     test "refuses, and writes NO credential, when the network has no enabled server",
          %{user: user} do
-      net = network_fixture("azzurra")
+      net = network_fixture(slug: "azzurra")
       {:ok, _} = Servers.add_server(net, %{host: "irc.azzurra.chat", port: 6697, enabled: false})
 
       assert {:error, :no_enabled_server} =
@@ -715,8 +705,8 @@ defmodule Grappa.NetworksTest do
   describe "list_credentials_for_user/1" do
     test "returns every binding for a user with networks preloaded" do
       user = user_fixture()
-      net1 = network_fixture("net-a")
-      net2 = network_fixture("net-b")
+      net1 = network_fixture(slug: "net-a")
+      net2 = network_fixture(slug: "net-b")
 
       {:ok, _} = Credentials.bind_credential(user, net1, %{nick: "n", auth_method: :none, autojoin_channels: []})
       {:ok, _} = Credentials.bind_credential(user, net2, %{nick: "n", auth_method: :none, autojoin_channels: []})
@@ -740,10 +730,10 @@ defmodule Grappa.NetworksTest do
     end
 
     test "returns every credential across users + networks with :network preloaded" do
-      u1 = user_fixture("alice-#{System.unique_integer([:positive])}")
-      u2 = user_fixture("bob-#{System.unique_integer([:positive])}")
-      net_a = network_fixture("net-a-#{System.unique_integer([:positive])}")
-      net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
+      u1 = user_fixture(name: "alice-#{System.unique_integer([:positive])}")
+      u2 = user_fixture(name: "bob-#{System.unique_integer([:positive])}")
+      net_a = network_fixture(slug: "net-a-#{System.unique_integer([:positive])}")
+      net_b = network_fixture(slug: "net-b-#{System.unique_integer([:positive])}")
 
       {:ok, _} =
         Credentials.bind_credential(u1, net_a, %{nick: "a", auth_method: :none, autojoin_channels: []})
@@ -777,14 +767,14 @@ defmodule Grappa.NetworksTest do
       [lo_user, hi_user] =
         Enum.sort_by(
           [
-            user_fixture("alice-#{System.unique_integer([:positive])}"),
-            user_fixture("bob-#{System.unique_integer([:positive])}")
+            user_fixture(name: "alice-#{System.unique_integer([:positive])}"),
+            user_fixture(name: "bob-#{System.unique_integer([:positive])}")
           ],
           & &1.id
         )
 
-      net_a = network_fixture("net-a-#{System.unique_integer([:positive])}")
-      net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
+      net_a = network_fixture(slug: "net-a-#{System.unique_integer([:positive])}")
+      net_b = network_fixture(slug: "net-b-#{System.unique_integer([:positive])}")
 
       {:ok, _} =
         Credentials.bind_credential(hi_user, net_b, %{
@@ -1154,8 +1144,8 @@ defmodule Grappa.NetworksTest do
 
     test "renders one row per credential, alpha by slug (matches list_credentials_for_user)" do
       user = user_fixture()
-      net_a = network_fixture("net-a-#{System.unique_integer([:positive])}")
-      net_b = network_fixture("net-b-#{System.unique_integer([:positive])}")
+      net_a = network_fixture(slug: "net-a-#{System.unique_integer([:positive])}")
+      net_b = network_fixture(slug: "net-b-#{System.unique_integer([:positive])}")
 
       {:ok, _} =
         Credentials.bind_credential(user, net_a, %{
@@ -1314,7 +1304,7 @@ defmodule Grappa.NetworksTest do
 
     test "keeps the network + servers after the last user unbinds (no auto-delete)" do
       user = user_fixture()
-      net = network_fixture("azzurra-solo")
+      net = network_fixture(slug: "azzurra-solo")
       {:ok, _} = Servers.add_server(net, %{host: "irc.azzurra.chat", port: 6697})
 
       {:ok, _} =
@@ -1337,7 +1327,7 @@ defmodule Grappa.NetworksTest do
     test "keeps the network + servers when another user still has a credential" do
       u1 = user_fixture()
       u2 = user_fixture()
-      net = network_fixture("azzurra-shared")
+      net = network_fixture(slug: "azzurra-shared")
       {:ok, _} = Servers.add_server(net, %{host: "irc.azzurra.chat", port: 6697})
 
       {:ok, _} =
@@ -1376,7 +1366,7 @@ defmodule Grappa.NetworksTest do
     # the network + its scrollback persist, and it returns :ok.
     test "detaches the last user from a visitor-only network with scrollback present" do
       user = user_fixture()
-      net = network_fixture("azzurra-archived")
+      net = network_fixture(slug: "azzurra-archived")
       {:ok, _} = Servers.add_server(net, %{host: "irc.azzurra.chat", port: 6697})
 
       {:ok, _} =
@@ -1415,7 +1405,7 @@ defmodule Grappa.NetworksTest do
 
   describe "get_network_by_slug!/1" do
     test "returns the row on a known slug" do
-      net = network_fixture("known-slug-#{System.unique_integer([:positive])}")
+      net = network_fixture(slug: "known-slug-#{System.unique_integer([:positive])}")
       assert %Network{id: id} = Networks.get_network_by_slug!(net.slug)
       assert id == net.id
     end
@@ -1429,8 +1419,8 @@ defmodule Grappa.NetworksTest do
 
   describe "network_id_by_slug_index/0 (M-4 admin console)" do
     test "returns %{slug => id} for every networks row" do
-      net_a = network_fixture("idx-a-#{System.unique_integer([:positive])}")
-      net_b = network_fixture("idx-b-#{System.unique_integer([:positive])}")
+      net_a = network_fixture(slug: "idx-a-#{System.unique_integer([:positive])}")
+      net_b = network_fixture(slug: "idx-b-#{System.unique_integer([:positive])}")
 
       index = Networks.network_id_by_slug_index()
 
@@ -1442,9 +1432,9 @@ defmodule Grappa.NetworksTest do
   describe "list_all/0 (M-5 admin console)" do
     test "returns every networks row ordered by slug ascending" do
       # Insert in reverse-slug order to prove the ordering isn't accidental.
-      net_z = network_fixture("z-#{System.unique_integer([:positive])}")
-      net_a = network_fixture("a-#{System.unique_integer([:positive])}")
-      net_m = network_fixture("m-#{System.unique_integer([:positive])}")
+      net_z = network_fixture(slug: "z-#{System.unique_integer([:positive])}")
+      net_a = network_fixture(slug: "a-#{System.unique_integer([:positive])}")
+      net_m = network_fixture(slug: "m-#{System.unique_integer([:positive])}")
 
       slugs = Enum.map(Networks.list_all(), & &1.slug)
 

--- a/test/grappa/nick_migration_test.exs
+++ b/test/grappa/nick_migration_test.exs
@@ -23,8 +23,8 @@ defmodule Grappa.NickMigrationTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{NickMigration, QueryWindows, Scrollback, UserSettings}
   alias Grappa.IRC.Identifier
+  alias Grappa.{NickMigration, QueryWindows, Scrollback, UserSettings}
 
   # Every SQL statement Ecto reports while `fun` runs, lowercased. `async:
   # false` because the handler is global: a concurrent test's queries would

--- a/test/grappa/nick_migration_test.exs
+++ b/test/grappa/nick_migration_test.exs
@@ -21,20 +21,10 @@ defmodule Grappa.NickMigrationTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, Networks, NickMigration, QueryWindows, Scrollback, UserSettings}
+  import Grappa.AuthFixtures
+
+  alias Grappa.{NickMigration, QueryWindows, Scrollback, UserSettings}
   alias Grappa.IRC.Identifier
-
-  defp user_fixture do
-    name = "nm-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
-
-  defp network_fixture do
-    slug = "nm-net-#{System.unique_integer([:positive])}"
-    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
-    network
-  end
 
   # Every SQL statement Ecto reports while `fun` runs, lowercased. `async:
   # false` because the handler is global: a concurrent test's queries would

--- a/test/grappa/notify_test.exs
+++ b/test/grappa/notify_test.exs
@@ -25,25 +25,17 @@ defmodule Grappa.NotifyTest do
 
   import ExUnit.CaptureLog
 
-  alias Grappa.{Accounts, Networks, Notify, Visitors}
+  import Grappa.AuthFixtures, only: [user_fixture: 0, network_fixture: 0]
+
+  alias Grappa.{Notify, Visitors}
   alias Grappa.Notify.Entry
   alias Grappa.PubSub.Topic
 
   # ---------------------------------------------------------------------------
-  # Fixtures — inline pattern, same as Grappa.QueryWindowsTest
+  # `visitor_fixture` stays inline: it provisions through the production
+  # door `Visitors.find_or_provision_anon/3`, which the AuthFixtures
+  # twin mirrors rather than calls.
   # ---------------------------------------------------------------------------
-
-  defp user_fixture do
-    name = "notify-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
-
-  defp network_fixture do
-    slug = "notify-net-#{System.unique_integer([:positive])}"
-    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
-    network
-  end
 
   defp visitor_fixture(network_slug) do
     {:ok, visitor} =

--- a/test/grappa/push/sender_test.exs
+++ b/test/grappa/push/sender_test.exs
@@ -34,7 +34,9 @@ defmodule Grappa.Push.SenderTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, Push, Visitors}
+  import Grappa.AuthFixtures, only: [user_fixture: 0]
+
+  alias Grappa.{Push, Visitors}
   alias Grappa.Push.Sender
 
   # Real P-256 client public key + 16-byte auth secret — NOT random
@@ -50,12 +52,6 @@ defmodule Grappa.Push.SenderTest do
     tag: "libera:#sbiffo",
     url: "/?network=libera&channel=%23sbiffo"
   }
-
-  defp user_fixture do
-    name = "sender-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   defp visitor_fixture do
     nick = "sender-visitor-#{System.unique_integer([:positive])}"

--- a/test/grappa/push/triggers_test.exs
+++ b/test/grappa/push/triggers_test.exs
@@ -20,7 +20,9 @@ defmodule Grappa.Push.TriggersTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, Push, UserSettings, Visitors, WSPresence}
+  import Grappa.AuthFixtures, only: [user_fixture: 0]
+
+  alias Grappa.{Push, UserSettings, Visitors, WSPresence}
   alias Grappa.Push.{Subscription, Triggers}
   alias Grappa.Scrollback.Message
 
@@ -352,12 +354,6 @@ defmodule Grappa.Push.TriggersTest do
   # ---------------------------------------------------------------------------
   # evaluate_and_dispatch/2 — end-to-end with Bypass + real subscription
   # ---------------------------------------------------------------------------
-
-  defp user_fixture do
-    name = "trigger-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   defp visitor_fixture do
     nick = "trigger-visitor-#{System.unique_integer([:positive])}"

--- a/test/grappa/push/wire_format_test.exs
+++ b/test/grappa/push/wire_format_test.exs
@@ -36,7 +36,9 @@ defmodule Grappa.Push.WireFormatTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, Push}
+  import Grappa.AuthFixtures
+
+  alias Grappa.Push
   alias Grappa.Push.Sender
 
   @payload %{
@@ -52,12 +54,6 @@ defmodule Grappa.Push.WireFormatTest do
   @gcm_tag_length 16
   # An uncompressed P-256 point: 0x04 ‖ X(32) ‖ Y(32).
   @p256_point_length 65
-
-  defp user_fixture do
-    name = "wire-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   # Stands in for `PushManager.subscribe()`: the client generates a
   # P-256 keypair and a 16-byte auth secret, ships the PUBLIC half to

--- a/test/grappa/push_test.exs
+++ b/test/grappa/push_test.exs
@@ -9,15 +9,10 @@ defmodule Grappa.PushTest do
   """
   use Grappa.DataCase, async: true
 
-  alias Grappa.{Accounts, Push}
-  alias Grappa.Push.Subscription
+  import Grappa.AuthFixtures
 
-  # Inline fixture mirroring the project convention (no ExMachina factory).
-  defp user_fixture do
-    name = "push-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
+  alias Grappa.Push
+  alias Grappa.Push.Subscription
 
   defp valid_attrs(opts \\ []) do
     base = %{

--- a/test/grappa/query_windows_test.exs
+++ b/test/grappa/query_windows_test.exs
@@ -24,25 +24,11 @@ defmodule Grappa.QueryWindowsTest do
   use Grappa.DataCase, async: true
   use ExUnitProperties
 
-  alias Grappa.{Accounts, Networks, QueryWindows}
+  import Grappa.AuthFixtures
+
+  alias Grappa.QueryWindows
   alias Grappa.PubSub.Topic
   alias Grappa.QueryWindows.Window
-
-  # ---------------------------------------------------------------------------
-  # Fixtures — match the inline pattern the project uses (no ExMachina factory)
-  # ---------------------------------------------------------------------------
-
-  defp user_fixture do
-    name = "qw-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
-
-  defp network_fixture do
-    slug = "qw-net-#{System.unique_integer([:positive])}"
-    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
-    network
-  end
 
   # ---------------------------------------------------------------------------
   # open/4

--- a/test/grappa/query_windows_test.exs
+++ b/test/grappa/query_windows_test.exs
@@ -26,8 +26,8 @@ defmodule Grappa.QueryWindowsTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.QueryWindows
   alias Grappa.PubSub.Topic
+  alias Grappa.QueryWindows
   alias Grappa.QueryWindows.Window
 
   # ---------------------------------------------------------------------------

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -24,7 +24,9 @@ defmodule Grappa.ReadCursorTest do
   """
   use Grappa.DataCase, async: true
 
-  alias Grappa.{Accounts, Networks, ReadCursor, Repo, ScrollbackHelpers, Visitors}
+  import Grappa.AuthFixtures, only: [user_fixture: 0, network_fixture: 0]
+
+  alias Grappa.{ReadCursor, Repo, ScrollbackHelpers, Visitors}
   alias Grappa.PubSub.Topic
   alias Grappa.ReadCursor.Cursor
 
@@ -34,23 +36,11 @@ defmodule Grappa.ReadCursorTest do
 
   defp uniq, do: System.unique_integer([:positive])
 
-  defp user_fixture do
-    {:ok, user} =
-      Accounts.create_user(%{name: "rc-user-#{uniq()}", password: "correct horse battery staple"})
-
-    user
-  end
-
   defp visitor_fixture(network_slug) do
     {:ok, visitor} =
       Visitors.find_or_provision_anon("rc-visitor-#{uniq()}", network_slug, "127.0.0.1")
 
     visitor
-  end
-
-  defp network_fixture do
-    {:ok, network} = Networks.find_or_create_network(%{slug: "rc-net-#{uniq()}"})
-    network
   end
 
   # Generic unread-content inserter: `sender: "peer"` so a row stands for

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -26,8 +26,8 @@ defmodule Grappa.ReadCursorTest do
 
   import Grappa.AuthFixtures, only: [user_fixture: 0, network_fixture: 0]
 
-  alias Grappa.{ReadCursor, Repo, ScrollbackHelpers, Visitors}
   alias Grappa.PubSub.Topic
+  alias Grappa.{ReadCursor, Repo, ScrollbackHelpers, Visitors}
   alias Grappa.ReadCursor.Cursor
 
   # ---------------------------------------------------------------------------

--- a/test/grappa/repo/refold_identifiers_ascii_test.exs
+++ b/test/grappa/repo/refold_identifiers_ascii_test.exs
@@ -15,8 +15,8 @@ defmodule Grappa.Repo.Migrations.RefoldIdentifiersAsciiTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Repo
   alias Grappa.QueryWindows.Window
+  alias Grappa.Repo
 
   @migration Grappa.Repo.Migrations.RefoldIdentifiersAscii
   @migration_path "priv/repo/migrations/20260729120000_refold_identifiers_ascii.exs"

--- a/test/grappa/repo/refold_identifiers_ascii_test.exs
+++ b/test/grappa/repo/refold_identifiers_ascii_test.exs
@@ -13,7 +13,9 @@ defmodule Grappa.Repo.Migrations.RefoldIdentifiersAsciiTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, Networks, Repo}
+  import Grappa.AuthFixtures
+
+  alias Grappa.Repo
   alias Grappa.QueryWindows.Window
 
   @migration Grappa.Repo.Migrations.RefoldIdentifiersAscii
@@ -25,18 +27,6 @@ defmodule Grappa.Repo.Migrations.RefoldIdentifiersAsciiTest do
     # don't depend on that — ensure the module is available for direct calls.
     unless Code.ensure_loaded?(@migration), do: Code.require_file(@migration_path)
     :ok
-  end
-
-  defp user_fixture do
-    name = "refold-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
-
-  defp network_fixture do
-    slug = "refold-net-#{System.unique_integer([:positive])}"
-    {:ok, network} = Networks.find_or_create_network(%{slug: slug})
-    network
   end
 
   defp now, do: DateTime.truncate(DateTime.utc_now(), :second)

--- a/test/grappa/user_settings_concurrency_test.exs
+++ b/test/grappa/user_settings_concurrency_test.exs
@@ -36,8 +36,8 @@ defmodule Grappa.UserSettingsConcurrencyTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.UserSettings
   alias Grappa.IRC.Identifier
+  alias Grappa.UserSettings
   alias Grappa.UserSettings.Settings
 
   @handler_id {__MODULE__, :pause_between_read_and_write}

--- a/test/grappa/user_settings_concurrency_test.exs
+++ b/test/grappa/user_settings_concurrency_test.exs
@@ -34,7 +34,9 @@ defmodule Grappa.UserSettingsConcurrencyTest do
   """
   use Grappa.DataCase, async: false
 
-  alias Grappa.{Accounts, UserSettings}
+  import Grappa.AuthFixtures
+
+  alias Grappa.UserSettings
   alias Grappa.IRC.Identifier
   alias Grappa.UserSettings.Settings
 
@@ -45,12 +47,6 @@ defmodule Grappa.UserSettingsConcurrencyTest do
   # timing guess: generous on purpose, because a window too short to let an
   # UNGUARDED writer commit would turn the defect green.
   @peer_grace_ms 1_000
-
-  defp user_fixture do
-    name = "us-conc-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   # Spawns the second writer, then arms the pause. `peer_write` runs only once
   # the paused writer has read, and the pause ends as soon as it reports back.

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -24,20 +24,14 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
   """
   use Grappa.DataCase, async: true
 
-  import Grappa.AuthFixtures, only: [visitor_fixture: 0]
+  import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, UserSettings}
+  alias Grappa.UserSettings
   alias Grappa.UserSettings.Settings
 
   # ---------------------------------------------------------------------------
   # Fixtures
   # ---------------------------------------------------------------------------
-
-  defp user_fixture do
-    name = "dp-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   # A full, valid wire-shape body (string keys, as the controller passes it).
   defp valid_wire(overrides \\ %{}) do

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -18,21 +18,15 @@ defmodule Grappa.UserSettingsTest do
   use Grappa.DataCase, async: true
   use ExUnitProperties
 
-  import Grappa.AuthFixtures, only: [visitor_fixture: 0]
+  import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, Repo, UserSettings}
+  alias Grappa.{Repo, UserSettings}
   alias Grappa.PubSub.Topic
   alias Grappa.UserSettings.Settings
 
   # ---------------------------------------------------------------------------
   # Fixtures
   # ---------------------------------------------------------------------------
-
-  defp user_fixture do
-    name = "us-user-#{System.unique_integer([:positive])}"
-    {:ok, user} = Accounts.create_user(%{name: name, password: "correct horse battery staple"})
-    user
-  end
 
   # The PubSub topic root a settings write broadcasts on, built by the
   # same production function the web edge uses — never spelled out here.

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -20,8 +20,8 @@ defmodule Grappa.UserSettingsTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Repo, UserSettings}
   alias Grappa.PubSub.Topic
+  alias Grappa.{Repo, UserSettings}
   alias Grappa.UserSettings.Settings
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bucket H of the 2026-08-15 architecture review. The server half's last
substantial residue: the fixture trio.

## What moved

The fourteen local `user_fixture` copies all reached
`Accounts.create_user/1` — changeset plus `Argon2.hash_pwd_salt/1` — while
the canonical they shadow stopped paying a runtime hash in #1564 (real
Argon2 hash, precomputed and pinned). `config/` carries no Argon2 tuning,
so those hashes ran the production parameters in full, and none of the
fourteen files exercises the verification path a hash exists to serve.

They were held on an open question about Argon2 cost. vjt ruled it and
#1564 carried it out, so the blocker had expired — the second instance of
`#1397-deferred7`'s rule that a recorded blocker is a measurement of a
moment, re-measured before it is honoured.

The seven `network_fixture` copies ride along: the canonical specialised
at a different slug prefix, no drift. The four `visitor_fixture` copies
deliberately STAY — they call the production door
`Visitors.find_or_provision_anon/3`, which the canonical mirrors rather
than calls, so folding them would trade a real door for an imitation.

Per-file `import`, never a case-template one: the template import is a
compile-time collision across 115 + 61 users (`DESIGN_NOTES #1397`), and
per-file import is the shape the suite already has, 123 files to zero.

## Measurement

Suite, back-to-back on an idle host:

| run | suite | async | sync |
| --- | --- | --- | --- |
| before | **138.2s** | 42.9s | 95.2s |
| after x3 | **116.8 / 118.4 / 118.2s** | 25.7s | 92.4s |

≈ -20s, -15%, essentially all of it in the async half, which is where
thirteen of the fourteen files live (`networks_test.exs` is
`async: false`). An earlier pair read 166.4s → 116.8s and would have
claimed twice that: the 166.4s was measured while another worker's full
gate ran on the same host.

Two mutants against the canonical, over the same 494 tests:

| mutant | branch | base |
| --- | --- | --- |
| `user_fixture/1` ignores `attrs` | **29 failures** | **0** |
| `network_fixture/1` ignores `:slug` | **17 failures** | **0** |

The base column attributes the kills — there the fourteen files still
carry their own bodies. The two die by different mechanisms and say so:
`Ecto.ConstraintError` on `users_folded_name_index` for the first,
`assert a.id != b.id` for the second.

`scripts/check.sh` rc=0: 6561 tests, 0 failures, dialyzer, sobelow
(0 errors), credo, doctor, bats.

## One count in the issue body is corrected

The issue says "13 of those 14 files contain no reference to
get_user_by_credentials / verify_password / Argon2 / login / authenticate",
implying one does. On this base none does: the single `login` hit across
all fourteen is prose inside a comment (`networks_test.exs:504`).

## Declared residue, not hidden debt

The e2e half of bucket H is **two definitions, not sixty-one**. Measured
on `def49b52`, the nine helpers #1397 names have 8 definitions over 4
files, six of them the canonicals in `e2e/fixtures/`. The residue is:

- `loginAs` in `tests/issue252-vhost-selector.spec.ts:34` — the
  `adminLogin` body wearing the `loginAs` name, stopping at
  `expectShellReady` without the `waitForUserTopicReady` barrier the
  canonical carries. In that spec the missing barrier is LATENT, not a
  live race: the spec composes no `/join`.
- `bootVisitor` in `tests/issue477-quit-persistence.spec.ts:63` is NOT a
  duplicate — different signature, and it calls the canonical
  `bootVisitorContext`. Name-shared only.

Left for when the exclusive e2e lane frees up.

## Not established

No claim about the 13 further files / 30 call sites that reach
`Accounts.create_user/1` inline outside any fixture — counted and
classified by whether they name the verification path, not read. The
runtime hash COUNT was never taken: 44 static sites are neither an upper
nor a lower bound, since a site in a `defp` costs one hash per call and
one in a `setup` costs one per test. The before side of the timing is a
single run against three after runs.