### PR TITLE
cic(#1445): latch the directory refresh across the POST/GET gap

### DIFF
--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -7,6 +7,7 @@ import {
   directoryQuery,
   directorySort,
   isLoadingMore,
+  isRefreshPending,
   loadDirectory,
   loadMore,
   resetDirectory,
@@ -323,6 +324,13 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   const page = () => directoryPage(props.networkSlug);
   const status = () => page()?.status;
 
+  // #1445 — the ONE "a re-capture is under way" reading, because neither half
+  // covers the whole of it: `status` is a SERVER field that only arrives with
+  // a page GET, and the store's latch only spans the gap before that GET
+  // lands. Read by all three affordances below so they cannot disagree about
+  // whether the pane is busy.
+  const busy = () => status() === "refreshing" || isRefreshPending(props.networkSlug);
+
   const onSearchInput = (e: Event) => {
     const val = (e.currentTarget as HTMLInputElement).value;
     const slug = props.networkSlug;
@@ -359,13 +367,8 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
           value={searchText()}
           onInput={onSearchInput}
         />
-        <button
-          type="button"
-          class="directory-refresh"
-          disabled={status() === "refreshing"}
-          onClick={onRefresh}
-        >
-          {status() === "refreshing" ? "Refreshing…" : "Refresh"}
+        <button type="button" class="directory-refresh" disabled={busy()} onClick={onRefresh}>
+          {busy() ? "Refreshing…" : "Refresh"}
         </button>
         {/* #125 — close the directory and return to the previously
             active window (restore the prior selection, not a blank pane). */}
@@ -416,6 +419,7 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
                   <button
                     type="button"
                     class="directory-captured-at directory-stale"
+                    disabled={busy()}
                     onClick={onRefresh}
                   >
                     {capturedAt()} — refresh now

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -57,6 +57,12 @@ const directorySortMock = vi.fn<(slug: string) => "users" | "name">(() => "users
 const [directoryQuerySignal, setDirectoryQuerySignal] = createSignal("");
 const directoryQueryMock = vi.fn<(slug: string) => string>(() => directoryQuerySignal());
 const isLoadingMoreMock = vi.fn<(slug: string) => boolean>(() => false);
+// #1445 — the store's refresh latch, spanning the POST→first-page-GET gap.
+// SIGNAL-backed so a test can raise it the way the store does (from outside
+// the pane, between renders) and the pane's `busy()` has something reactive
+// to follow.
+const [refreshPendingSignal, setRefreshPendingSignal] = createSignal(false);
+const isRefreshPendingMock = vi.fn<(slug: string) => boolean>(() => refreshPendingSignal());
 const loadMoreMock = vi.fn<(slug: string) => Promise<void>>(() => Promise.resolve());
 const resetDirectoryMock = vi.fn<(slug: string) => void>(() => {});
 // #732 — per-slug load error the pane renders with a retry affordance.
@@ -68,6 +74,7 @@ vi.mock("../lib/channelDirectory", () => ({
   directoryQuery: (slug: string) => directoryQueryMock(slug),
   directorySort: (slug: string) => directorySortMock(slug),
   isLoadingMore: (slug: string) => isLoadingMoreMock(slug),
+  isRefreshPending: (slug: string) => isRefreshPendingMock(slug),
   loadDirectory: (slug: string) => loadDirectoryMock(slug),
   loadMore: (slug: string) => loadMoreMock(slug),
   resetDirectory: (slug: string) => resetDirectoryMock(slug),
@@ -163,6 +170,7 @@ describe("DirectoryPane", () => {
     setSelectedChannelMock.mockClear();
     closeToPreviousWindowMock.mockClear();
     directorySortMock.mockReturnValue("users");
+    setRefreshPendingSignal(false);
     setDirectoryQuerySignal("");
     directoryErrorMock.mockReturnValue(null);
     isLoadingMoreMock.mockReturnValue(false);
@@ -537,6 +545,41 @@ describe("DirectoryPane", () => {
 
       const btn = screen.getByRole("button", { name: /refreshing/i });
       expect(btn).toBeDisabled();
+    });
+
+    // #1445 — the gap the server field cannot cover. `status` only changes
+    // when a page GET lands, so across the POST→first-GET window the page
+    // still reads "fresh" and the button used to re-enable itself there. The
+    // page fixture stays FRESH_PAGE on purpose: it is what makes this test
+    // fail on the pre-latch pane rather than duplicate the one above.
+    it("is disabled and relabeled while the store's latch is up, on a 'fresh' page", async () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      // Pre-state: the same page, latch down, is an enabled "Refresh".
+      expect(screen.getByRole("button", { name: /^refresh$/i })).toBeEnabled();
+
+      setRefreshPendingSignal(true);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /refreshing/i })).toBeDisabled();
+      });
+    });
+
+    // The stale CTA is the pane's SECOND door onto the same verb (#732). A
+    // door that stays live while the first is disabled is the silent no-op
+    // that issue closed — the store guard would swallow its POST and nothing
+    // would tell the reader why.
+    it("the stale CTA is disabled while the latch is up", async () => {
+      directoryPageMock.mockReturnValue(STALE_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const cta = screen.getByRole("button", { name: /refresh now/i });
+      expect(cta).toBeEnabled();
+
+      setRefreshPendingSignal(true);
+
+      await waitFor(() => expect(cta).toBeDisabled());
     });
   });
 

--- a/cicchetto/src/lib/channelDirectory.test.ts
+++ b/cicchetto/src/lib/channelDirectory.test.ts
@@ -7,6 +7,7 @@ import {
   directoryQuery,
   directorySort,
   isLoadingMore,
+  isRefreshPending,
   loadDirectory,
   loadMore,
   onDirectoryComplete,
@@ -168,6 +169,80 @@ describe("channelDirectory store", () => {
     const spy = vi.spyOn(api, "refreshDirectory");
     await triggerRefresh("freenode");
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // --- #1445 refresh latch: the POST→first-GET gap ---
+
+  test("a second triggerRefresh while the first is in flight makes no second POST", async () => {
+    // The POST only ASKS for a re-capture, and nothing in the store said
+    // "busy" until the first page GET reported `refreshing`. Across that gap
+    // the Refresh button stayed enabled, so a double tap sent two captures.
+    // The gate keeps the first POST unsettled for exactly as long as the
+    // second call needs to be refused.
+    const gate = deferred<void>();
+    const spy = vi.spyOn(api, "refreshDirectory").mockReturnValue(gate.promise);
+
+    const first = triggerRefresh("latch1");
+    const second = triggerRefresh("latch1");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  // The positive control for the test above: a guard that simply swallowed
+  // every refresh after the first would pass it and break the feature. This
+  // is the assertion that tells "suppressed the duplicate" from "killed the
+  // door".
+  test("the latch stands down once a page lands, so a later refresh POSTs again", async () => {
+    const spy = vi.spyOn(api, "refreshDirectory").mockResolvedValue(undefined);
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "fresh" }));
+
+    await triggerRefresh("latch2");
+    expect(spy).toHaveBeenCalledTimes(1);
+    // The server's completion ping re-GETs; that page write is the handoff.
+    await onDirectoryComplete("latch2");
+    await triggerRefresh("latch2");
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test("isRefreshPending spans exactly the gap — false, true after the POST, false once a page lands", async () => {
+    vi.spyOn(api, "refreshDirectory").mockResolvedValue(undefined);
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "refreshing" }));
+
+    // The pre-state, asserted rather than assumed: without it a latch that
+    // was ALWAYS true would read the same at the second assertion.
+    expect(isRefreshPending("latch3")).toBe(false);
+    await triggerRefresh("latch3");
+    expect(isRefreshPending("latch3")).toBe(true);
+    await onDirectoryProgress("latch3");
+    expect(isRefreshPending("latch3")).toBe(false);
+  });
+
+  test("a rejected POST releases the latch — a refusal must not disable the door", async () => {
+    vi.spyOn(api, "refreshDirectory").mockRejectedValue(new api.ApiError(503, "unavailable"));
+
+    await triggerRefresh("latch4");
+
+    expect(isRefreshPending("latch4")).toBe(false);
+    // The rejection path is what ran, not a POST that never happened: the
+    // error copy is the witness.
+    expect(directoryError("latch4")).not.toBeNull();
+  });
+
+  test("closing the pane releases the latch (resetDirectory)", async () => {
+    const gate = deferred<void>();
+    vi.spyOn(api, "refreshDirectory").mockReturnValue(gate.promise);
+
+    const pending = triggerRefresh("latch5");
+    expect(isRefreshPending("latch5")).toBe(true);
+    resetDirectory("latch5");
+    expect(isRefreshPending("latch5")).toBe(false);
+
+    gate.resolve();
+    await pending;
   });
 
   // --- #677 pagination: loadMore appends the next keyset page ---

--- a/cicchetto/src/lib/channelDirectory.ts
+++ b/cicchetto/src/lib/channelDirectory.ts
@@ -71,6 +71,14 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // when it settled. Every async verb in this module writes it; the pane
   // renders it with a reload affordance.
   const [errors, setErrors] = createSignal<Record<string, string>>({});
+  // #1445 — per-slug "a re-capture has been asked for" latch. It spans the gap
+  // the refresh POST opens: the POST only ASKS the server to re-capture, so
+  // between its 202 and the first page GET reporting `refreshing` NOTHING in
+  // the store said busy. Measured, not reasoned — with no latch the guard's
+  // own test sends two POSTs for a double tap. Same shape as `loadingMore`
+  // deliberately: an in-flight guard that doubles as a render source, one
+  // boolean per slug, identity-scoped.
+  const [refreshPending, setRefreshPending] = createSignal<Record<string, boolean>>({});
 
   // #732 — request identity. `issued` is a single monotonic counter and
   // `newest[slug]` is the id of the latest request ISSUED for that slug; a
@@ -107,6 +115,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => setViews({}));
   onIdentityChange(() => setLoadingMore({}));
   onIdentityChange(() => setErrors({}));
+  onIdentityChange(() => setRefreshPending({}));
   onIdentityChange(() => {
     for (const slug of Object.keys(newest)) invalidate(slug);
   });
@@ -117,6 +126,23 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     setErrors((prev) => {
       if (!(slug in prev)) return prev;
       const { [slug]: _cleared, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  // #1445 — the latch stands down on the first page write for this slug after
+  // the POST, whatever that page says: from that moment the store holds
+  // fresher information than the latch does. A `refreshing` status hands the
+  // signal over to `status` itself; a terminal one means the capture already
+  // finished. Deliberately NO timer backstop — the only case one would guard
+  // is a 202 followed by no ping at all, not even `directory_failed`, and a
+  // stale timer releasing the NEXT latch early costs more than that case is
+  // worth. The bound is stated instead: a pane close (resetDirectory) or an
+  // identity rotation releases it.
+  const releaseRefreshLatch = (slug: string): void => {
+    setRefreshPending((prev) => {
+      if (!(slug in prev)) return prev;
+      const { [slug]: _released, ...rest } = prev;
       return rest;
     });
   };
@@ -139,9 +165,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       if (!isNewest(slug, id)) return;
       setPages((prev) => ({ ...prev, [slug]: { id, page } }));
       clearError(slug);
+      releaseRefreshLatch(slug);
     } catch (err) {
       if (!isNewest(slug, id)) return;
       setErrors((prev) => ({ ...prev, [slug]: describe(err) }));
+      // A failed GET releases it too: the pane now shows an error with a
+      // reload, and a latch held past that is a door disabled with no capture
+      // on the way. Released in the arms rather than a `finally` so a
+      // SUPERSEDED response (the !isNewest returns above) cannot release a
+      // latch a newer POST has since taken.
+      releaseRefreshLatch(slug);
     }
   };
 
@@ -167,6 +200,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
   // #677 — true while a loadMore for `slug` is in flight (sentinel spinner).
   const isLoadingMore = (slug: string): boolean => loadingMore()[slug] ?? false;
+
+  // #1445 — true across the POST→first-page-write gap. The pane ORs it with
+  // `status === "refreshing"` to get one honest "busy": neither half covers
+  // the whole re-capture on its own.
+  const isRefreshPending = (slug: string): boolean => refreshPending()[slug] ?? false;
 
   // #677 — fetch the NEXT keyset page and APPEND. No-op when: no token, no
   // page yet (nothing to page from), no next_cursor (already at the end),
@@ -230,6 +268,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // user does next inherits a snapshot the close was supposed to discard.
     invalidate(slug);
     clearError(slug);
+    releaseRefreshLatch(slug);
     setViews((prev) => ({ ...prev, [slug]: { ...currentView(slug), q: "" } }));
     setPages((prev) => {
       const { [slug]: _dropped, ...rest } = prev;
@@ -263,6 +302,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const triggerRefresh = async (slug: string): Promise<void> => {
     const t = token();
     if (!t) return;
+    // #1445 — every door onto the re-capture comes through here: the toolbar
+    // button, the stale CTA, and the pull gesture to come. The guard lives at
+    // the verb rather than on whichever door happens to be disabled, so a new
+    // door cannot reopen the hole.
+    if (refreshPending()[slug]) return;
+    setRefreshPending((prev) => ({ ...prev, [slug]: true }));
     // Not `issue`: a re-capture request must not supersede a page GET in
     // flight. It rides the current id purely so a rejection arriving after a
     // close — or after an identity rotation — cannot park copy on a slug that
@@ -271,6 +316,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     try {
       await api.refreshDirectory(t, slug);
     } catch (err) {
+      // A refusal releases the latch at once: no capture is coming, so no page
+      // write is either, and a door left disabled is worse than the duplicate
+      // this guards against.
+      releaseRefreshLatch(slug);
       if (isNewest(slug, id)) setErrors((prev) => ({ ...prev, [slug]: describe(err) }));
     }
   };
@@ -285,6 +334,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     directoryQuery,
     directorySort,
     isLoadingMore,
+    isRefreshPending,
     loadDirectory,
     loadMore,
     resetDirectory,
@@ -302,6 +352,7 @@ export const directoryPage = exports_.directoryPage;
 export const directoryQuery = exports_.directoryQuery;
 export const directorySort = exports_.directorySort;
 export const isLoadingMore = exports_.isLoadingMore;
+export const isRefreshPending = exports_.isRefreshPending;
 export const loadDirectory = exports_.loadDirectory;
 export const loadMore = exports_.loadMore;
 export const resetDirectory = exports_.resetDirectory;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51749,3 +51749,119 @@ for one number is how the next reader picks the wrong one.
   cure, which puts the live number in the verdict.
 * The window boundary recorded above is unchanged, and so is the browser
   coverage caveat: chromium for this spec.
+<!-- entry #1445-refresh-latch -->
+
+---
+
+## 2026-08-19 — #1445: the refresh latch, and the gap the server field cannot cover
+
+#1445 asks for a pull-to-refresh in the channel directory. Building the
+gesture first would have stacked it on a hole, so this is the store half
+alone: the gesture lands in a later slice.
+
+### The gap was already open, on the button
+
+`ChannelDirectory.triggerRefresh` only ASKS the server to re-capture. The
+rows arrive later through the progress/complete/failed pings, each of
+which re-GETs page 1 — which is why a 202 clears nothing. Until that
+first GET lands, `status` still reads whatever it read before the POST.
+
+`DirectoryPane` disabled its Refresh button off `status === "refreshing"`
+alone, so across that window the button was enabled and labelled
+"Refresh" while a capture was already on its way. This was NOT a hazard
+the gesture would have introduced: it is a defect the button shipped
+with. Measured, not reasoned — the first test in
+`channelDirectory.test.ts` fails on the parent commit with two POSTs for
+one double tap, and that same test is the cure's oracle.
+
+### The guard sits at the verb, not at a door
+
+There are already two doors onto the re-capture (the toolbar button and
+the stale CTA at the bottom of the meta row) and #1445 adds a third. A
+guard on whichever door happens to be disabled is a guard each new door
+can reopen, so it lives in `triggerRefresh` itself. The pane's job is
+only to SHOW it: one `busy()` accessor ORing the server status with the
+latch, read by all three affordances so they cannot disagree.
+
+The stale CTA is disabled too. Left live it would take a click the store
+now swallows, which is precisely the silent no-op #732 closed.
+
+### Why it releases on the first page write, whatever that page says
+
+The latch stands down on the first `fetchInto` settle for the slug after
+the POST, in BOTH arms and regardless of the status it carries: from
+that moment the store holds fresher information than the latch does. A
+`refreshing` status hands the signal over to `status` itself; a terminal
+one means the capture already finished; a failed GET means the pane is
+showing an error with a reload, and a latch held past that is a door
+disabled with no capture coming. The release sits inside the arms rather
+than in a `finally` so a SUPERSEDED response cannot release a latch a
+newer POST has since taken.
+
+Deliberately **no timer backstop**, against the issue's own sketch. The
+only case a timer would guard is a 202 followed by no ping at all — not
+even `directory_failed` — and the cost is a stale timer releasing the
+NEXT latch early, which is a lifecycle hazard heavier than the case it
+covers. The bound is stated instead: a pane close (`resetDirectory`) or
+an identity rotation releases it. If a measurement later shows the gap
+is genuinely unbounded, adding the timer is additive.
+
+### Declared behaviour change
+
+The Refresh button now stays disabled until the refresh has actually
+finished, where before it came back the moment the POST returned. This
+is a visible change to an existing control and is called out rather than
+left to be discovered. The tiebreak is minimum surprise, and it favours
+the latch: a button that re-enables mid-capture breaks the promise the
+interface just made.
+
+### Two of the issue's own directions are superseded — measured
+
+The issue body, written against `38e75561`, says to mirror
+`bindMessageGestures` "on the vertical axis" and to claim the axis via
+`swipe.ts`'s `claimAxis`. Both were re-measured on `cda50a5f` and both
+are stale:
+
+* `lib/mediaViewerGesture.ts` (#1438) is ALREADY a vertical
+  follow-the-finger binder, and it already exposes the `onProgress`
+  channel the issue asks for, alongside `onCommit` / `onRelease`. The
+  issue cites #1438 once, and only for two inherited landmines — not as
+  the shape to copy. Mirroring the horizontal binder would re-derive
+  what #1438 derived.
+* `verticalClaim` (`touchGesture.ts`) is the exact primitive, added by
+  #1438 for this job. `claimAxis` carries a `selectionActive` flag and a
+  textarea `ScrollBoundary` that mean nothing on a row list.
+
+What the issue got right about `bindMessageGestures` is narrower than it
+claimed, and it is the part that matters: the DIRECTION GATE. Recorded
+here so the gesture slice does not re-walk it.
+
+### The 20% that does not fit — the domain boundary for the gesture slice
+
+`bindDismissGesture` covers most of what the pull needs. What does not:
+
+* **Direction.** `verticalClaim` is direction-agnostic and the dismiss
+  binder commits on up OR down. A pull must claim DOWN only: claiming an
+  upward drag at the top of a list would `preventDefault` native scroll.
+  The shape to copy is `messageGestures.ts`'s rightward-only gate.
+* **Threshold.** The dismiss binder commits on a fraction of viewport
+  HEIGHT. That is the wrong magnitude for a pull at the top of a list;
+  `SWIPE_MIN_PX` is the starting point.
+* **Arming.** `canDismiss()` at touchstart maps cleanly onto
+  `scrollTop === 0`. This one FITS — noted so it is not mistaken for a
+  gap.
+
+A `direction: "down" | "both"` flag on the existing binder was rejected:
+that is the shared-data-model-with-a-type-flag shape CLAUDE.md calls a
+boundary violation. The house precedent is the opposite — three binders
+(edge, message, dismiss) each COMPOSING one pure core. A fourth is
+written the same way.
+
+### Not established
+
+The size of the POST→first-GET gap was never measured, only bounded by
+the behaviour above; whether a 202 can be followed by total silence is
+unknown; and nothing here touches the gesture, so none of #1445's
+device-level questions (feel, threshold in px, whether iOS Safari's
+rubber-band at the top of the scroller fights a transform) are answered
+or affected.


### PR DESCRIPTION
First slice of #1445. The issue asks for a pull-to-refresh gesture in the
channel directory; this is the **store half only**, because the gesture
would otherwise have been stacked on a hole. The gesture lands separately.

## ⚠️ Declared behaviour change

**The Refresh button now stays disabled until the refresh has actually
finished**, where before it re-enabled itself the moment the POST returned.
The stale "refresh now" CTA is disabled on the same terms. This is a visible
change to an existing control, called out here rather than left to be
discovered.

## What was wrong

`triggerRefresh` only ASKS the server to re-capture — the rows arrive later
through the progress/complete/failed pings, each of which re-GETs page 1.
Until that first GET lands, `status` still reads whatever it read before the
POST, so nothing in the store said "busy". The button, disabled off
`status === "refreshing"` alone, stayed enabled across that gap.

This is **not** a hazard the gesture would have introduced — it is a defect
the button shipped with. Measured, not reasoned: the first test added here
fails on the parent commit with **two POSTs for one double tap**.

## Shape

* The latch mirrors `loadingMore`, the in-flight guard this module already
  has: one boolean per slug, identity-scoped, doubling as a render source.
* It is taken **at the verb**, not at a door. There are already two doors
  onto the re-capture and #1445 adds a third; a guard on whichever door is
  disabled is a guard the next door reopens.
* It releases on the first page write for the slug after the POST, in both
  settled arms and whatever status that page carries — from that moment the
  store holds fresher information than the latch does. Inside the arms, not
  a `finally`, so a superseded response cannot release a latch a newer POST
  has taken.
* **No timer backstop**, against the issue's own sketch: the only case it
  would guard is a 202 followed by no ping at all, not even
  `directory_failed`, and a stale timer releasing the next latch early is a
  heavier hazard than the case it covers. The bound is stated instead — a
  pane close or an identity rotation releases it. Adding the timer later is
  additive.

## Two of the issue's directions are superseded (measured, recorded in DESIGN_NOTES)

Re-measured on `cda50a5f`: `mediaViewerGesture.ts` (#1438) is already a
vertical follow-the-finger binder exposing the `onProgress` channel the
issue asks for, and `verticalClaim` is the exact claim primitive. The
issue's "mirror `bindMessageGestures`" / "use `claimAxis`" would re-derive
#1438. What survives of that advice is narrower and is the part that
matters — the direction gate. The 20% of `bindDismissGesture` that genuinely
does not fit a pull is written down for the gesture slice.

## Test plan

- [x] `bun run test` — 290 files, **5625** passed, rc=0 (base 5618 + 7 added)
- [x] `bun run check` (biome + tsc src & e2e) — rc=0
- [x] Base measurement: the double-POST test fails on the parent with
      `expected "refreshDirectory" to be called 1 times, but got 2 times`
- [x] Three two-sided mutants, each killing a disjoint and correctly-named set:
      dropping the pane's OR kills exactly the 2 new pane tests (47 survive);
      dropping the store guard kills exactly the double-POST test (41 survive);
      dropping the release kills exactly the two release tests (40 survive)
- [ ] Not covered: the gesture, and every device-level question in #1445