### PR TITLE
test(#1551): name the real door into the SessionLog test transaction

### DIFF
--- a/lib/grappa/session_log.ex
+++ b/lib/grappa/session_log.ex
@@ -31,9 +31,14 @@ defmodule Grappa.SessionLog do
   :attach_session_log_telemetry, false`) — otherwise the global handler
   would route EVERY async test's lifecycle telemetry to this pid, whose
   Repo write would hit a sandbox connection owned by the emitting test.
-  Persistence tests attach + `Sandbox.allow/3` explicitly (mirror of
-  `Grappa.AdminEvents`). Tests touching this module MUST be `async:
-  false` (max_cases: 1 invariant).
+  Persistence tests attach the handler explicitly. They need no
+  `Sandbox.allow/3` for this pid: `Grappa.DataCase` puts every `async:
+  false` suite in SHARED sandbox mode, which already routes the sink's
+  writes onto the running test's connection (measured, #1551). What the
+  attach cannot avoid is the converse — while it is attached, a
+  lifecycle event from ANY session in the VM lands in that same
+  transaction. Tests touching this module MUST be `async: false`
+  (max_cases: 1 invariant).
 
   The emit path is deliberately telemetry-decoupled from the sink: a
   disconnect fired from `Session.Server.terminate/2` must never block on a

--- a/test/grappa/session_log_persistence_test.exs
+++ b/test/grappa/session_log_persistence_test.exs
@@ -6,9 +6,20 @@ defmodule Grappa.SessionLogPersistenceTest do
 
   `async: false` — `Grappa.SessionLog` is a singleton registered as
   `__MODULE__` (max_cases: 1 invariant). The sink boots with
-  `attach_telemetry: false` in test env; this suite attaches the handler
-  itself + allows the sink pid on the test's sandbox connection so its
-  Repo writes land in the test transaction (mirror of AdminEventsTest).
+  `attach_telemetry: false` in test env, so this suite attaches the
+  handler itself.
+
+  It does NOT need a `Sandbox.allow/3` for the sink, and used to carry
+  one that did nothing: `Grappa.DataCase` opens every `async: false`
+  suite with `start_owner!(Repo, shared: not tags[:async])`, and SHARED
+  mode already routes every ownerless process in the VM — the sink
+  included — onto this test's connection. Measured by deleting the
+  `allow` and re-running: green, and the suite's own seven tests are the
+  positive control, since each one reads back rows the sink wrote.
+
+  The door is therefore the ATTACH, not the allow: while the handler is
+  attached, any session-lifecycle event fired anywhere in the VM writes
+  a row into whichever test is running. See #1551.
   """
   use Grappa.DataCase, async: false
 
@@ -32,7 +43,6 @@ defmodule Grappa.SessionLogPersistenceTest do
     :ok =
       :telemetry.attach_many(@handler_id, @events, &SessionLog.handle_telemetry/4, nil)
 
-    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), Process.whereis(SessionLog))
     on_exit(fn -> :telemetry.detach(@handler_id) end)
     :ok
   end


### PR DESCRIPTION
## What

`SessionLogPersistenceTest` carried a `Sandbox.allow/3` for the sink pid,
and two comments — this suite's moduledoc and `SessionLog`'s own
*"Restart / test isolation"* section — presented that call as the reason
the sink's writes land in the test transaction.

That reading is wrong, and the wrongness is load-bearing: issue #1551
reasons its whole cure list about that `allow`, so it aims at a door that
was never the door.

## Why the `allow` is not the door

`Grappa.DataCase` opens every `async: false` suite with
`start_owner!(Repo, shared: not tags[:async])`. In **shared mode** every
ownerless process in the VM — the `SessionLog` singleton included — is
already routed onto the running test's connection. The `allow` grants
nothing shared mode has not already granted.

The real door is the **global telemetry attach**: while the handler is
attached, a lifecycle event from *any* session in the VM writes into
whichever test happens to be running.

## Evidence

Measured, not argued. Deleting the line and re-running the suite leaves
it green — 7 tests, 0 failures, rc=0 — and the suite is its own positive
control: all seven tests read back rows the sink wrote, so had the
`allow` been load-bearing they would have failed together. Baseline and
mutant both rc=0.

## Scope

No behaviour change. One deleted line plus two corrected comments; this
is the record being made true, so that the eventual fix for #1551 aims
at the attach rather than at the sandbox grant.

Refs #1551.