### PR TITLE
cic(#1445): the pull-to-refresh binder, downward-only and distance-gated

### DIFF
--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -7,6 +7,7 @@ import {
   directoryQuery,
   directorySort,
   isLoadingMore,
+  isRefreshPending,
   loadDirectory,
   loadMore,
   resetDirectory,
@@ -323,6 +324,13 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   const page = () => directoryPage(props.networkSlug);
   const status = () => page()?.status;
 
+  // #1445 — the ONE "a re-capture is under way" reading, because neither half
+  // covers the whole of it: `status` is a SERVER field that only arrives with
+  // a page GET, and the store's latch only spans the gap before that GET
+  // lands. Read by all three affordances below so they cannot disagree about
+  // whether the pane is busy.
+  const busy = () => status() === "refreshing" || isRefreshPending(props.networkSlug);
+
   const onSearchInput = (e: Event) => {
     const val = (e.currentTarget as HTMLInputElement).value;
     const slug = props.networkSlug;
@@ -359,13 +367,8 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
           value={searchText()}
           onInput={onSearchInput}
         />
-        <button
-          type="button"
-          class="directory-refresh"
-          disabled={status() === "refreshing"}
-          onClick={onRefresh}
-        >
-          {status() === "refreshing" ? "Refreshing…" : "Refresh"}
+        <button type="button" class="directory-refresh" disabled={busy()} onClick={onRefresh}>
+          {busy() ? "Refreshing…" : "Refresh"}
         </button>
         {/* #125 — close the directory and return to the previously
             active window (restore the prior selection, not a blank pane). */}
@@ -416,6 +419,7 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
                   <button
                     type="button"
                     class="directory-captured-at directory-stale"
+                    disabled={busy()}
                     onClick={onRefresh}
                   >
                     {capturedAt()} — refresh now

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -57,6 +57,12 @@ const directorySortMock = vi.fn<(slug: string) => "users" | "name">(() => "users
 const [directoryQuerySignal, setDirectoryQuerySignal] = createSignal("");
 const directoryQueryMock = vi.fn<(slug: string) => string>(() => directoryQuerySignal());
 const isLoadingMoreMock = vi.fn<(slug: string) => boolean>(() => false);
+// #1445 — the store's refresh latch, spanning the POST→first-page-GET gap.
+// SIGNAL-backed so a test can raise it the way the store does (from outside
+// the pane, between renders) and the pane's `busy()` has something reactive
+// to follow.
+const [refreshPendingSignal, setRefreshPendingSignal] = createSignal(false);
+const isRefreshPendingMock = vi.fn<(slug: string) => boolean>(() => refreshPendingSignal());
 const loadMoreMock = vi.fn<(slug: string) => Promise<void>>(() => Promise.resolve());
 const resetDirectoryMock = vi.fn<(slug: string) => void>(() => {});
 // #732 — per-slug load error the pane renders with a retry affordance.
@@ -68,6 +74,7 @@ vi.mock("../lib/channelDirectory", () => ({
   directoryQuery: (slug: string) => directoryQueryMock(slug),
   directorySort: (slug: string) => directorySortMock(slug),
   isLoadingMore: (slug: string) => isLoadingMoreMock(slug),
+  isRefreshPending: (slug: string) => isRefreshPendingMock(slug),
   loadDirectory: (slug: string) => loadDirectoryMock(slug),
   loadMore: (slug: string) => loadMoreMock(slug),
   resetDirectory: (slug: string) => resetDirectoryMock(slug),
@@ -163,6 +170,7 @@ describe("DirectoryPane", () => {
     setSelectedChannelMock.mockClear();
     closeToPreviousWindowMock.mockClear();
     directorySortMock.mockReturnValue("users");
+    setRefreshPendingSignal(false);
     setDirectoryQuerySignal("");
     directoryErrorMock.mockReturnValue(null);
     isLoadingMoreMock.mockReturnValue(false);
@@ -537,6 +545,41 @@ describe("DirectoryPane", () => {
 
       const btn = screen.getByRole("button", { name: /refreshing/i });
       expect(btn).toBeDisabled();
+    });
+
+    // #1445 — the gap the server field cannot cover. `status` only changes
+    // when a page GET lands, so across the POST→first-GET window the page
+    // still reads "fresh" and the button used to re-enable itself there. The
+    // page fixture stays FRESH_PAGE on purpose: it is what makes this test
+    // fail on the pre-latch pane rather than duplicate the one above.
+    it("is disabled and relabeled while the store's latch is up, on a 'fresh' page", async () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      // Pre-state: the same page, latch down, is an enabled "Refresh".
+      expect(screen.getByRole("button", { name: /^refresh$/i })).toBeEnabled();
+
+      setRefreshPendingSignal(true);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /refreshing/i })).toBeDisabled();
+      });
+    });
+
+    // The stale CTA is the pane's SECOND door onto the same verb (#732). A
+    // door that stays live while the first is disabled is the silent no-op
+    // that issue closed — the store guard would swallow its POST and nothing
+    // would tell the reader why.
+    it("the stale CTA is disabled while the latch is up", async () => {
+      directoryPageMock.mockReturnValue(STALE_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const cta = screen.getByRole("button", { name: /refresh now/i });
+      expect(cta).toBeEnabled();
+
+      setRefreshPendingSignal(true);
+
+      await waitFor(() => expect(cta).toBeDisabled());
     });
   });
 

--- a/cicchetto/src/__tests__/pullGesture.test.ts
+++ b/cicchetto/src/__tests__/pullGesture.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { bindPullGesture, PULL_COMMIT_PX, PULLING_CLASS } from "../lib/pullGesture";
+import { fireTouch } from "./helpers/touchEvents";
+
+// #1445 — pull down from the top of a scroller to ask for a refresh.
+//
+// WHAT THIS PROVES: the DECISION table. Which drags commit, which spring back,
+// which are never claimed at all, and that the arming condition is re-read
+// mid-drag rather than snapshotted.
+//
+// WHAT IT CANNOT PROVE, and this is half the value of saying so: jsdom sees
+// neither `touch-action` nor Solid's passive event delegation (#308 landmine
+// 1), and a synthetic event drives no compositor. So nothing here says the
+// follow is smooth, that `PULL_COMMIT_PX` is the right distance, or that iOS
+// Safari's own rubber-band at the top of a scroller leaves the transform
+// alone. Those are e2e and on-device questions; the pane wiring and the CSS
+// contract land with the slice that paints the thing.
+
+const X = 200;
+const START_Y = 300;
+
+let list: HTMLDivElement;
+let row: HTMLDivElement;
+let canPull: Mock<() => boolean>;
+let onProgress: Mock<(dy: number) => void>;
+let onCommit: Mock<() => void>;
+let onRelease: Mock<() => void>;
+let dispose: () => void;
+
+beforeEach(() => {
+  list = document.createElement("div");
+  row = document.createElement("div");
+  list.appendChild(row);
+  document.body.appendChild(list);
+  canPull = vi.fn<() => boolean>(() => true);
+  onProgress = vi.fn<(dy: number) => void>();
+  onCommit = vi.fn<() => void>();
+  onRelease = vi.fn<() => void>();
+  dispose = bindPullGesture(list, { canPull, onProgress, onCommit, onRelease });
+});
+
+afterEach(() => {
+  dispose();
+  document.body.innerHTML = "";
+});
+
+// A vertical drag of `dy` px (negative = up) in three steps: the binder claims
+// LATE, on a touchmove, never on the touchstart. Fired on the ROW so the event
+// reaches the bound container by bubbling, as it does in a browser.
+function drag(dy: number): { moves: Event[]; end: Event } {
+  fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+  const moves = [
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + dy / 3 }),
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + (dy * 2) / 3 }),
+  ];
+  const end = fireTouch(row, "touchend", { clientX: X, clientY: START_Y + dy });
+  return { moves, end };
+}
+
+describe("bindPullGesture — commit vs spring back", () => {
+  it("commits a downward pull past the commit distance", () => {
+    drag(PULL_COMMIT_PX + 20);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+
+  it("springs back on a short pull, however fast — distance is the only route", () => {
+    // 60px: past the 8px slop and the 40px swipe floor, so this is a CLAIMED
+    // pull that simply did not go far enough — not an unclaimed drag. Without
+    // that the assertion would pass against a binder with no commit distance.
+    //
+    // It also guards the deliberate divergence from the viewer's dismiss,
+    // which commits on velocity as well as distance. jsdom stamps every
+    // synthetic event 0, so this drag is INSTANTANEOUS: any velocity route
+    // would read it as a flick and commit. One gesture, one mutant, both
+    // claims — a separate "flick" test would be the same drag asserting the
+    // same thing twice.
+    drag(PULL_COMMIT_PX - 20);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bindPullGesture — following the finger", () => {
+  it("reports the running downward travel so the caller can move its slot", () => {
+    drag(90);
+    expect(onProgress.mock.calls.map(([dy]) => dy)).toEqual([30, 60]);
+  });
+
+  it("floors the reported travel at 0 when the finger goes back above its origin", () => {
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + 60 }); // claim
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y - 40 }); // back up past it
+    expect(onProgress.mock.calls.map(([dy]) => dy)).toEqual([60, 0]);
+  });
+
+  it("wears the pulling class for exactly the claimed part of the touch", () => {
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    expect(list.classList.contains(PULLING_CLASS)).toBe(false); // not until claimed
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + 60 });
+    expect(list.classList.contains(PULLING_CLASS)).toBe(true);
+    fireTouch(row, "touchend", { clientX: X, clientY: START_Y + 60 });
+    expect(list.classList.contains(PULLING_CLASS)).toBe(false);
+  });
+
+  it("claims the gesture once downward intent is proven", () => {
+    const { moves } = drag(90);
+    expect(moves.every((m) => m.defaultPrevented)).toBe(true);
+  });
+});
+
+describe("bindPullGesture — what it must NOT take", () => {
+  it("leaves an UPWARD drag entirely alone — native scroll is untouched", () => {
+    // The hard constraint. `verticalClaim` is direction-agnostic, so nothing
+    // but the explicit downward gate keeps this drag out of our hands, and
+    // taking it would preventDefault ordinary list scrolling.
+    const { moves, end } = drag(-120);
+    expect(moves.some((m) => m.defaultPrevented)).toBe(false);
+    expect(end.defaultPrevented).toBe(false);
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+
+  it("leaves a horizontal-dominant drag alone", () => {
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    const move = fireTouch(row, "touchmove", { clientX: X + 120, clientY: START_Y + 20 });
+    fireTouch(row, "touchend", { clientX: X + 140, clientY: START_Y + 24 });
+    expect(move.defaultPrevented).toBe(false);
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("stands down when the caller says it cannot pull (list not at the top)", () => {
+    canPull.mockReturnValue(false);
+    const { moves } = drag(PULL_COMMIT_PX + 20);
+    expect(moves.some((m) => m.defaultPrevented)).toBe(false);
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("re-reads canPull mid-drag instead of snapshotting it at touchstart", () => {
+    // Before the claim, native scroll is still running: a finger can drag UP,
+    // carry the list away from the top, then come back DOWN. A touchstart
+    // snapshot would claim that reversal as a pull on a list scrolled well
+    // past 0. Arming true at touchstart and false by the time the downward
+    // move arrives is exactly that shape.
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    canPull.mockReturnValue(false);
+    const move = fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + 90 });
+    expect(move.defaultPrevented).toBe(false);
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("ignores a two-finger gesture — a pinch belongs to the content", () => {
+    fireTouch(
+      row,
+      "touchstart",
+      { clientX: X, clientY: START_Y },
+      { clientX: X + 40, clientY: START_Y + 40 },
+    );
+    fireTouch(
+      row,
+      "touchmove",
+      { clientX: X, clientY: START_Y + 200 },
+      { clientX: X + 40, clientY: START_Y + 240 },
+    );
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("drops a claimed pull on touchcancel without committing", () => {
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    fireTouch(row, "touchmove", { clientX: X, clientY: START_Y + PULL_COMMIT_PX + 20 });
+    fireTouch(row, "touchcancel", { clientX: X, clientY: START_Y + PULL_COMMIT_PX + 20 });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+    expect(list.classList.contains(PULLING_CLASS)).toBe(false);
+  });
+
+  it("says nothing on a touchcancel that never claimed", () => {
+    fireTouch(row, "touchstart", { clientX: X, clientY: START_Y });
+    fireTouch(row, "touchcancel", { clientX: X, clientY: START_Y });
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+});
+
+describe("bindPullGesture — lifecycle", () => {
+  it("stops listening once disposed (Solid never re-invokes a ref at unmount)", () => {
+    dispose();
+    drag(PULL_COMMIT_PX + 20);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+    dispose = (): void => {}; // afterEach must not double-dispose
+  });
+});

--- a/cicchetto/src/__tests__/pullGesture.test.ts
+++ b/cicchetto/src/__tests__/pullGesture.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { bindPullGesture, PULL_COMMIT_PX, PULLING_CLASS } from "../lib/pullGesture";
+import { SWIPE_MIN_PX } from "../lib/swipe";
 import { fireTouch } from "./helpers/touchEvents";
 
 // #1445 — pull down from the top of a scroller to ask for a refresh.
@@ -19,6 +20,14 @@ import { fireTouch } from "./helpers/touchEvents";
 
 const X = 200;
 const START_Y = 300;
+
+// A travel that clears the bare swipe floor but NOT the pull's commit
+// distance. Derived from BOTH constants on purpose: a magnitude written as
+// `PULL_COMMIT_PX - 20` is invisible to the value of PULL_COMMIT_PX — halve
+// the constant and the drag shrinks with it, staying under the floor and
+// passing anyway. Measured: a mutant dropping PULL_COMMIT_PX to SWIPE_MIN_PX
+// survived the whole suite until this was anchored between the two.
+const BETWEEN_FLOOR_AND_COMMIT = (SWIPE_MIN_PX + PULL_COMMIT_PX) / 2;
 
 let list: HTMLDivElement;
 let row: HTMLDivElement;
@@ -65,10 +74,11 @@ describe("bindPullGesture — commit vs spring back", () => {
     expect(onRelease).not.toHaveBeenCalled();
   });
 
-  it("springs back on a short pull, however fast — distance is the only route", () => {
-    // 60px: past the 8px slop and the 40px swipe floor, so this is a CLAIMED
-    // pull that simply did not go far enough — not an unclaimed drag. Without
-    // that the assertion would pass against a binder with no commit distance.
+  it("springs back between the swipe floor and the commit distance, however fast", () => {
+    // Past the 8px slop and past the 40px swipe floor, so this is a CLAIMED
+    // pull that simply did not go far enough — not an unclaimed drag. That is
+    // what makes the commit distance the thing under test: relax it to the
+    // bare floor and this drag commits.
     //
     // It also guards the deliberate divergence from the viewer's dismiss,
     // which commits on velocity as well as distance. jsdom stamps every
@@ -76,7 +86,7 @@ describe("bindPullGesture — commit vs spring back", () => {
     // would read it as a flick and commit. One gesture, one mutant, both
     // claims — a separate "flick" test would be the same drag asserting the
     // same thing twice.
-    drag(PULL_COMMIT_PX - 20);
+    drag(BETWEEN_FLOOR_AND_COMMIT);
     expect(onCommit).not.toHaveBeenCalled();
     expect(onRelease).toHaveBeenCalledTimes(1);
   });

--- a/cicchetto/src/lib/channelDirectory.test.ts
+++ b/cicchetto/src/lib/channelDirectory.test.ts
@@ -7,6 +7,7 @@ import {
   directoryQuery,
   directorySort,
   isLoadingMore,
+  isRefreshPending,
   loadDirectory,
   loadMore,
   onDirectoryComplete,
@@ -168,6 +169,80 @@ describe("channelDirectory store", () => {
     const spy = vi.spyOn(api, "refreshDirectory");
     await triggerRefresh("freenode");
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // --- #1445 refresh latch: the POST→first-GET gap ---
+
+  test("a second triggerRefresh while the first is in flight makes no second POST", async () => {
+    // The POST only ASKS for a re-capture, and nothing in the store said
+    // "busy" until the first page GET reported `refreshing`. Across that gap
+    // the Refresh button stayed enabled, so a double tap sent two captures.
+    // The gate keeps the first POST unsettled for exactly as long as the
+    // second call needs to be refused.
+    const gate = deferred<void>();
+    const spy = vi.spyOn(api, "refreshDirectory").mockReturnValue(gate.promise);
+
+    const first = triggerRefresh("latch1");
+    const second = triggerRefresh("latch1");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  // The positive control for the test above: a guard that simply swallowed
+  // every refresh after the first would pass it and break the feature. This
+  // is the assertion that tells "suppressed the duplicate" from "killed the
+  // door".
+  test("the latch stands down once a page lands, so a later refresh POSTs again", async () => {
+    const spy = vi.spyOn(api, "refreshDirectory").mockResolvedValue(undefined);
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "fresh" }));
+
+    await triggerRefresh("latch2");
+    expect(spy).toHaveBeenCalledTimes(1);
+    // The server's completion ping re-GETs; that page write is the handoff.
+    await onDirectoryComplete("latch2");
+    await triggerRefresh("latch2");
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test("isRefreshPending spans exactly the gap — false, true after the POST, false once a page lands", async () => {
+    vi.spyOn(api, "refreshDirectory").mockResolvedValue(undefined);
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "refreshing" }));
+
+    // The pre-state, asserted rather than assumed: without it a latch that
+    // was ALWAYS true would read the same at the second assertion.
+    expect(isRefreshPending("latch3")).toBe(false);
+    await triggerRefresh("latch3");
+    expect(isRefreshPending("latch3")).toBe(true);
+    await onDirectoryProgress("latch3");
+    expect(isRefreshPending("latch3")).toBe(false);
+  });
+
+  test("a rejected POST releases the latch — a refusal must not disable the door", async () => {
+    vi.spyOn(api, "refreshDirectory").mockRejectedValue(new api.ApiError(503, "unavailable"));
+
+    await triggerRefresh("latch4");
+
+    expect(isRefreshPending("latch4")).toBe(false);
+    // The rejection path is what ran, not a POST that never happened: the
+    // error copy is the witness.
+    expect(directoryError("latch4")).not.toBeNull();
+  });
+
+  test("closing the pane releases the latch (resetDirectory)", async () => {
+    const gate = deferred<void>();
+    vi.spyOn(api, "refreshDirectory").mockReturnValue(gate.promise);
+
+    const pending = triggerRefresh("latch5");
+    expect(isRefreshPending("latch5")).toBe(true);
+    resetDirectory("latch5");
+    expect(isRefreshPending("latch5")).toBe(false);
+
+    gate.resolve();
+    await pending;
   });
 
   // --- #677 pagination: loadMore appends the next keyset page ---

--- a/cicchetto/src/lib/channelDirectory.ts
+++ b/cicchetto/src/lib/channelDirectory.ts
@@ -71,6 +71,14 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // when it settled. Every async verb in this module writes it; the pane
   // renders it with a reload affordance.
   const [errors, setErrors] = createSignal<Record<string, string>>({});
+  // #1445 — per-slug "a re-capture has been asked for" latch. It spans the gap
+  // the refresh POST opens: the POST only ASKS the server to re-capture, so
+  // between its 202 and the first page GET reporting `refreshing` NOTHING in
+  // the store said busy. Measured, not reasoned — with no latch the guard's
+  // own test sends two POSTs for a double tap. Same shape as `loadingMore`
+  // deliberately: an in-flight guard that doubles as a render source, one
+  // boolean per slug, identity-scoped.
+  const [refreshPending, setRefreshPending] = createSignal<Record<string, boolean>>({});
 
   // #732 — request identity. `issued` is a single monotonic counter and
   // `newest[slug]` is the id of the latest request ISSUED for that slug; a
@@ -107,6 +115,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => setViews({}));
   onIdentityChange(() => setLoadingMore({}));
   onIdentityChange(() => setErrors({}));
+  onIdentityChange(() => setRefreshPending({}));
   onIdentityChange(() => {
     for (const slug of Object.keys(newest)) invalidate(slug);
   });
@@ -117,6 +126,23 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     setErrors((prev) => {
       if (!(slug in prev)) return prev;
       const { [slug]: _cleared, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  // #1445 — the latch stands down on the first page write for this slug after
+  // the POST, whatever that page says: from that moment the store holds
+  // fresher information than the latch does. A `refreshing` status hands the
+  // signal over to `status` itself; a terminal one means the capture already
+  // finished. Deliberately NO timer backstop — the only case one would guard
+  // is a 202 followed by no ping at all, not even `directory_failed`, and a
+  // stale timer releasing the NEXT latch early costs more than that case is
+  // worth. The bound is stated instead: a pane close (resetDirectory) or an
+  // identity rotation releases it.
+  const releaseRefreshLatch = (slug: string): void => {
+    setRefreshPending((prev) => {
+      if (!(slug in prev)) return prev;
+      const { [slug]: _released, ...rest } = prev;
       return rest;
     });
   };
@@ -139,9 +165,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       if (!isNewest(slug, id)) return;
       setPages((prev) => ({ ...prev, [slug]: { id, page } }));
       clearError(slug);
+      releaseRefreshLatch(slug);
     } catch (err) {
       if (!isNewest(slug, id)) return;
       setErrors((prev) => ({ ...prev, [slug]: describe(err) }));
+      // A failed GET releases it too: the pane now shows an error with a
+      // reload, and a latch held past that is a door disabled with no capture
+      // on the way. Released in the arms rather than a `finally` so a
+      // SUPERSEDED response (the !isNewest returns above) cannot release a
+      // latch a newer POST has since taken.
+      releaseRefreshLatch(slug);
     }
   };
 
@@ -167,6 +200,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
   // #677 — true while a loadMore for `slug` is in flight (sentinel spinner).
   const isLoadingMore = (slug: string): boolean => loadingMore()[slug] ?? false;
+
+  // #1445 — true across the POST→first-page-write gap. The pane ORs it with
+  // `status === "refreshing"` to get one honest "busy": neither half covers
+  // the whole re-capture on its own.
+  const isRefreshPending = (slug: string): boolean => refreshPending()[slug] ?? false;
 
   // #677 — fetch the NEXT keyset page and APPEND. No-op when: no token, no
   // page yet (nothing to page from), no next_cursor (already at the end),
@@ -230,6 +268,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // user does next inherits a snapshot the close was supposed to discard.
     invalidate(slug);
     clearError(slug);
+    releaseRefreshLatch(slug);
     setViews((prev) => ({ ...prev, [slug]: { ...currentView(slug), q: "" } }));
     setPages((prev) => {
       const { [slug]: _dropped, ...rest } = prev;
@@ -263,6 +302,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const triggerRefresh = async (slug: string): Promise<void> => {
     const t = token();
     if (!t) return;
+    // #1445 — every door onto the re-capture comes through here: the toolbar
+    // button, the stale CTA, and the pull gesture to come. The guard lives at
+    // the verb rather than on whichever door happens to be disabled, so a new
+    // door cannot reopen the hole.
+    if (refreshPending()[slug]) return;
+    setRefreshPending((prev) => ({ ...prev, [slug]: true }));
     // Not `issue`: a re-capture request must not supersede a page GET in
     // flight. It rides the current id purely so a rejection arriving after a
     // close — or after an identity rotation — cannot park copy on a slug that
@@ -271,6 +316,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     try {
       await api.refreshDirectory(t, slug);
     } catch (err) {
+      // A refusal releases the latch at once: no capture is coming, so no page
+      // write is either, and a door left disabled is worse than the duplicate
+      // this guards against.
+      releaseRefreshLatch(slug);
       if (isNewest(slug, id)) setErrors((prev) => ({ ...prev, [slug]: describe(err) }));
     }
   };
@@ -285,6 +334,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     directoryQuery,
     directorySort,
     isLoadingMore,
+    isRefreshPending,
     loadDirectory,
     loadMore,
     resetDirectory,
@@ -302,6 +352,7 @@ export const directoryPage = exports_.directoryPage;
 export const directoryQuery = exports_.directoryQuery;
 export const directorySort = exports_.directorySort;
 export const isLoadingMore = exports_.isLoadingMore;
+export const isRefreshPending = exports_.isRefreshPending;
 export const loadDirectory = exports_.loadDirectory;
 export const loadMore = exports_.loadMore;
 export const resetDirectory = exports_.resetDirectory;

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -20,7 +20,7 @@
 // transform of its own, because the modal and the backdrop move together and a
 // binder that knew about both would be a binder that knew about the viewer.
 import { isFastSwipe, type Point, swipeDirection } from "./swipe";
-import { verticalClaim } from "./touchGesture";
+import { soleTouch, verticalClaim } from "./touchGesture";
 
 // How far down (or up) the drag must reach to dismiss on distance alone,
 // as a fraction of the viewport height. A fraction rather than a pixel
@@ -58,15 +58,6 @@ export type DismissGestureParams = {
   // Claimed but not committed, or cancelled: put it back.
   onRelease: () => void;
 };
-
-// The ONE place "single finger only" is spelled: undefined for a pinch, which
-// is the image's gesture and not ours. Every arm reads it, so there is no
-// second copy of the predicate to drift — and mutating it is what a spec
-// asserting the pinch is ignored actually has to kill.
-function soleTouch(e: TouchEvent): Touch | undefined {
-  const list = e.touches.length > 0 ? e.touches : e.changedTouches;
-  return list.length === 1 ? list[0] : undefined;
-}
 
 export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams): () => void {
   let start: Point | null = null; // non-null ⇒ armed

--- a/cicchetto/src/lib/pullGesture.ts
+++ b/cicchetto/src/lib/pullGesture.ts
@@ -1,0 +1,153 @@
+// #1445 — pull down from the top of a scroller to ask for a refresh, with the
+// affordance following the finger. The channel directory is the first consumer;
+// the module is written pane-agnostic because this is the PWA's first
+// pull-to-refresh and whatever shape it takes becomes the pattern for the rest.
+//
+// The FOURTH binder over one core, not a fourth gesture engine: it composes
+// `./swipe`'s direction/floor geometry and `./touchGesture`'s angle gate,
+// exactly as `bindEdgeGesture`, `bindMessageGestures` and `bindDismissGesture`
+// do. Four answers to "what counts as a swipe" is the drift those three were
+// each written to avoid.
+//
+// Element-level listeners with a non-passive touchmove: Solid delegates touch
+// to a single PASSIVE document listener, where preventDefault silently no-ops
+// (#308 landmine 1). Returns a disposer the caller wraps in `onCleanup` — Solid
+// does NOT re-invoke a function ref with undefined at unmount the way React
+// does (#308 landmine 3), so cleanup is explicit.
+//
+// Like `bindDismissGesture` it reports PROGRESS and writes no paint of its own:
+// the pulled slot, its cap and its spinner belong to the pane, and a binder
+// that knew about them would be a binder that knew about the directory.
+import { type Point, SWIPE_MIN_PX, swipeDirection } from "./swipe";
+import { soleTouch, verticalClaim } from "./touchGesture";
+
+// How far down the finger must travel for the release to spend a refresh.
+//
+// Derived from `SWIPE_MIN_PX` rather than picked, so this does not become a
+// second vocabulary for the same physical gesture. It is deliberately STRICTER
+// than that floor: 40px answers "was this a gesture at all", while this answers
+// "did they mean to spend a server round-trip and a disabled button for the
+// length of a capture". Doubling is a defensible default, NOT a measurement —
+// the same standing `DISMISS_COMMIT_FRACTION` carries in the sibling binder.
+// vjt calibrates on-device; nothing here was verified on a phone.
+export const PULL_COMMIT_PX = SWIPE_MIN_PX * 2;
+
+// Worn by the bound element for exactly as long as the finger is driving a
+// CLAIMED pull, so the stylesheet can drop its snap-back transition and let the
+// slot track the finger instead of easing behind it. Same device as
+// `SWIPING_CLASS` in `messageGestures` and `DRAGGING_CLASS` in the viewer.
+export const PULLING_CLASS = "pull-gesture-active";
+
+export type PullGestureParams = {
+  // May the pull arm right now? The directory passes
+  // `() => el.scrollTop === 0`: a pull is only a pull at the top of the list,
+  // anywhere else the same drag is native scrolling.
+  //
+  // Injected rather than read off the element because this module is
+  // DOM-generic and jsdom has no layout — the same reason `viewportWidth` and
+  // `canDismiss` are injected in the sibling binders.
+  canPull: () => boolean;
+  // Running downward travel in px, floored at 0, on every claimed move. The
+  // caller translates its slot and ramps the spinner with it, capping against
+  // PULL_COMMIT_PX. Floored because a pull has no negative magnitude: once
+  // claimed we own the touch, so a finger dragged back ABOVE its origin must
+  // read as "no pull", never as an upward paint.
+  onProgress: (dy: number) => void;
+  // Released past the commit distance: ask for the refresh.
+  onCommit: () => void;
+  // Claimed but not committed, or cancelled: put the slot back.
+  onRelease: () => void;
+};
+
+export function bindPullGesture(el: HTMLElement, params: PullGestureParams): () => void {
+  let start: Point | null = null; // non-null ⇒ a touch is in flight
+  let claimed = false; // downward intent proven at the top → we own the gesture
+
+  const disarm = (): void => {
+    start = null;
+    claimed = false;
+    el.classList.remove(PULLING_CLASS);
+  };
+
+  const onStart = (e: TouchEvent): void => {
+    disarm();
+    const t = soleTouch(e);
+    if (t === undefined) return;
+    start = { x: t.clientX, y: t.clientY };
+  };
+
+  const onMove = (e: TouchEvent): void => {
+    if (start === null) return;
+    const t = soleTouch(e);
+    if (t === undefined) return;
+    const current = { x: t.clientX, y: t.clientY };
+    if (!claimed) {
+      // DOWNWARD only. `verticalClaim` is direction-agnostic and the viewer's
+      // dismiss commits either way, but a pull that claimed the upward drag
+      // would preventDefault the most ordinary gesture there is — scrolling a
+      // list. Mirror of the rightward-only gate in `bindMessageGestures`.
+      if (current.y <= start.y) return;
+      // Read LIVE, never snapshotted at touchstart. Before we claim, native
+      // scroll is still running: a finger that drags UP first scrolls the list
+      // away from the top and then comes back DOWN, and a touchstart snapshot
+      // would claim that reversal as a pull with the list scrolled to 200px.
+      // Same lesson as #123's scroll-boundary handoff, for the same reason.
+      if (!params.canPull()) return;
+      // Claim LATE and vertical-dominant: a horizontal drag is released whole,
+      // so a future left/right binding on this surface stays possible.
+      if (!verticalClaim(start, current)) return;
+      claimed = true;
+      el.classList.add(PULLING_CLASS);
+    }
+    // Own the gesture: suppress native pan. Reached ONLY after a downward
+    // claim at the top of the scroller.
+    if (e.cancelable) e.preventDefault();
+    params.onProgress(Math.max(0, current.y - start.y));
+  };
+
+  const onEnd = (e: TouchEvent): void => {
+    const s = start;
+    const wasClaimed = claimed;
+    disarm();
+    if (!wasClaimed || s === null) return;
+    const t = e.changedTouches[0];
+    if (t === undefined) {
+      params.onRelease();
+      return;
+    }
+    // ONE gate, doing both halves: `swipeDirection` floors the travel at the
+    // distance we hand it AND requires the vertical axis to dominate, so a
+    // claimed pull that wandered sideways on the way out does not commit.
+    //
+    // Distance ONLY — no velocity route, deliberately unlike the viewer's
+    // dismiss, which commits on a short fast flick as well. At the top of a
+    // list a flick is the commonest thing a finger does, and the cost here is
+    // asymmetric: a spurious commit spends an upstream LIST capture and
+    // disables the refresh affordances for its whole duration, where a
+    // spurious spring-back costs one repeated gesture. Adding the flick route
+    // later is additive; taking it away after it has fired on people is not.
+    if (swipeDirection(s, { x: t.clientX, y: t.clientY }, PULL_COMMIT_PX) === "down") {
+      params.onCommit();
+      return;
+    }
+    params.onRelease();
+  };
+
+  const onCancel = (): void => {
+    const wasClaimed = claimed;
+    disarm();
+    if (wasClaimed) params.onRelease();
+  };
+
+  el.addEventListener("touchstart", onStart, { passive: true });
+  el.addEventListener("touchmove", onMove, { passive: false });
+  el.addEventListener("touchend", onEnd, { passive: true });
+  el.addEventListener("touchcancel", onCancel, { passive: true });
+  return () => {
+    disarm();
+    el.removeEventListener("touchstart", onStart);
+    el.removeEventListener("touchmove", onMove);
+    el.removeEventListener("touchend", onEnd);
+    el.removeEventListener("touchcancel", onCancel);
+  };
+}

--- a/cicchetto/src/lib/touchGesture.ts
+++ b/cicchetto/src/lib/touchGesture.ts
@@ -83,6 +83,18 @@ export const verticalClaim = (
   return ay >= ax * k;
 };
 
+// The ONE place "single finger only" is spelled, for the binders whose gesture
+// a second finger cancels rather than modifies: a pinch (#213) belongs to the
+// content, not to them. It lives here rather than in one binder because the
+// predicate is shared, and a second copy is what lets two gestures on one app
+// disagree about when a touch stops being theirs. `bindMessageGestures` keeps
+// its own `firstTouch` on purpose — that one is a different predicate (it
+// falls back to `changedTouches` and does its arity check separately).
+export function soleTouch(e: TouchEvent): Touch | undefined {
+  const list = e.touches.length > 0 ? e.touches : e.changedTouches;
+  return list.length === 1 ? list[0] : undefined;
+}
+
 // Parameters for the two edge → open-drawer gestures. `viewportWidth` is
 // injected (not read off the element) so the geometry is testable in jsdom,
 // which has no layout; the call site passes `() => window.innerWidth`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51749,3 +51749,119 @@ for one number is how the next reader picks the wrong one.
   cure, which puts the live number in the verdict.
 * The window boundary recorded above is unchanged, and so is the browser
   coverage caveat: chromium for this spec.
+<!-- entry #1445-refresh-latch -->
+
+---
+
+## 2026-08-19 — #1445: the refresh latch, and the gap the server field cannot cover
+
+#1445 asks for a pull-to-refresh in the channel directory. Building the
+gesture first would have stacked it on a hole, so this is the store half
+alone: the gesture lands in a later slice.
+
+### The gap was already open, on the button
+
+`ChannelDirectory.triggerRefresh` only ASKS the server to re-capture. The
+rows arrive later through the progress/complete/failed pings, each of
+which re-GETs page 1 — which is why a 202 clears nothing. Until that
+first GET lands, `status` still reads whatever it read before the POST.
+
+`DirectoryPane` disabled its Refresh button off `status === "refreshing"`
+alone, so across that window the button was enabled and labelled
+"Refresh" while a capture was already on its way. This was NOT a hazard
+the gesture would have introduced: it is a defect the button shipped
+with. Measured, not reasoned — the first test in
+`channelDirectory.test.ts` fails on the parent commit with two POSTs for
+one double tap, and that same test is the cure's oracle.
+
+### The guard sits at the verb, not at a door
+
+There are already two doors onto the re-capture (the toolbar button and
+the stale CTA at the bottom of the meta row) and #1445 adds a third. A
+guard on whichever door happens to be disabled is a guard each new door
+can reopen, so it lives in `triggerRefresh` itself. The pane's job is
+only to SHOW it: one `busy()` accessor ORing the server status with the
+latch, read by all three affordances so they cannot disagree.
+
+The stale CTA is disabled too. Left live it would take a click the store
+now swallows, which is precisely the silent no-op #732 closed.
+
+### Why it releases on the first page write, whatever that page says
+
+The latch stands down on the first `fetchInto` settle for the slug after
+the POST, in BOTH arms and regardless of the status it carries: from
+that moment the store holds fresher information than the latch does. A
+`refreshing` status hands the signal over to `status` itself; a terminal
+one means the capture already finished; a failed GET means the pane is
+showing an error with a reload, and a latch held past that is a door
+disabled with no capture coming. The release sits inside the arms rather
+than in a `finally` so a SUPERSEDED response cannot release a latch a
+newer POST has since taken.
+
+Deliberately **no timer backstop**, against the issue's own sketch. The
+only case a timer would guard is a 202 followed by no ping at all — not
+even `directory_failed` — and the cost is a stale timer releasing the
+NEXT latch early, which is a lifecycle hazard heavier than the case it
+covers. The bound is stated instead: a pane close (`resetDirectory`) or
+an identity rotation releases it. If a measurement later shows the gap
+is genuinely unbounded, adding the timer is additive.
+
+### Declared behaviour change
+
+The Refresh button now stays disabled until the refresh has actually
+finished, where before it came back the moment the POST returned. This
+is a visible change to an existing control and is called out rather than
+left to be discovered. The tiebreak is minimum surprise, and it favours
+the latch: a button that re-enables mid-capture breaks the promise the
+interface just made.
+
+### Two of the issue's own directions are superseded — measured
+
+The issue body, written against `38e75561`, says to mirror
+`bindMessageGestures` "on the vertical axis" and to claim the axis via
+`swipe.ts`'s `claimAxis`. Both were re-measured on `cda50a5f` and both
+are stale:
+
+* `lib/mediaViewerGesture.ts` (#1438) is ALREADY a vertical
+  follow-the-finger binder, and it already exposes the `onProgress`
+  channel the issue asks for, alongside `onCommit` / `onRelease`. The
+  issue cites #1438 once, and only for two inherited landmines — not as
+  the shape to copy. Mirroring the horizontal binder would re-derive
+  what #1438 derived.
+* `verticalClaim` (`touchGesture.ts`) is the exact primitive, added by
+  #1438 for this job. `claimAxis` carries a `selectionActive` flag and a
+  textarea `ScrollBoundary` that mean nothing on a row list.
+
+What the issue got right about `bindMessageGestures` is narrower than it
+claimed, and it is the part that matters: the DIRECTION GATE. Recorded
+here so the gesture slice does not re-walk it.
+
+### The 20% that does not fit — the domain boundary for the gesture slice
+
+`bindDismissGesture` covers most of what the pull needs. What does not:
+
+* **Direction.** `verticalClaim` is direction-agnostic and the dismiss
+  binder commits on up OR down. A pull must claim DOWN only: claiming an
+  upward drag at the top of a list would `preventDefault` native scroll.
+  The shape to copy is `messageGestures.ts`'s rightward-only gate.
+* **Threshold.** The dismiss binder commits on a fraction of viewport
+  HEIGHT. That is the wrong magnitude for a pull at the top of a list;
+  `SWIPE_MIN_PX` is the starting point.
+* **Arming.** `canDismiss()` at touchstart maps cleanly onto
+  `scrollTop === 0`. This one FITS — noted so it is not mistaken for a
+  gap.
+
+A `direction: "down" | "both"` flag on the existing binder was rejected:
+that is the shared-data-model-with-a-type-flag shape CLAUDE.md calls a
+boundary violation. The house precedent is the opposite — three binders
+(edge, message, dismiss) each COMPOSING one pure core. A fourth is
+written the same way.
+
+### Not established
+
+The size of the POST→first-GET gap was never measured, only bounded by
+the behaviour above; whether a 202 can be followed by total silence is
+unknown; and nothing here touches the gesture, so none of #1445's
+device-level questions (feel, threshold in px, whether iOS Safari's
+rubber-band at the top of the scroller fights a transform) are answered
+or affected.


### PR DESCRIPTION
Second slice of #1445: the gesture engine alone — no pane, no paint, no CSS.
Those land in the third slice, whose oracle is e2e.

> **Stacked on #1569.** The branch is cut from `w2-1445-latch`, so the diff
> below is the **union F1+F2** — deliberately, because a PR based on the other
> branch would run no CI at all (the workflows are `branches: [main]`) and
> report "no checks". When #1569 merges, a rebase shrinks this diff by itself.

## Shape: the fourth binder over one core

It composes `swipe.ts`'s geometry and `touchGesture.ts`'s angle gate exactly as
`bindEdgeGesture`, `bindMessageGestures` and `bindDismissGesture` do. Four
answers to "what counts as a swipe" is the drift those three were each written
to avoid. It reports progress and writes no paint: the slot, its cap and its
spinner belong to the pane.

The issue asked to mirror `bindMessageGestures` on the vertical axis and to
claim via `claimAxis`. Measurement said otherwise — `mediaViewerGesture.ts`
(#1438) is already the vertical follow-the-finger binder and `verticalClaim`
is already the primitive. #1569's DESIGN_NOTES entry records that; this PR is
the 20% that genuinely does **not** fit `bindDismissGesture`:

* **Downward only.** `verticalClaim` is direction-agnostic and the dismiss
  commits either way. A pull that claimed the upward drag would
  `preventDefault` the most ordinary gesture there is — scrolling a list.
* **`canPull()` read LIVE**, never snapshotted at touchstart. Before the claim
  native scroll is still running, so a finger can drag UP, carry the list off
  the top, and come back DOWN; a snapshot would claim that reversal as a pull
  on a list scrolled to 200px. Same lesson as #123's boundary handoff.
* **Distance only, no velocity route** — deliberately unlike the dismiss. At
  the top of a list a flick is the commonest thing a finger does, and the costs
  are asymmetric: a spurious commit spends an upstream LIST capture and
  disables the refresh affordances for its whole duration; a spurious
  spring-back costs one repeated gesture. **A reversible product call** —
  additive to add later, not removable once it has fired on people.
* **`PULL_COMMIT_PX` derived from `SWIPE_MIN_PX`**, not picked, so this is not
  a second vocabulary. Stricter than that floor on purpose. A defensible
  default, NOT a measurement.

A `direction: "down" | "both"` flag on the existing binder was rejected as the
shared-data-model-with-a-type-flag shape CLAUDE.md calls a boundary violation.

`soleTouch` moves to the shared core in its own commit rather than being copied
— behaviour-inert, with the #1438 suite as the witness.

## Test plan

- [x] `bun run test` — 292 files, **5657** passed, rc=0
- [x] `bun run check` — rc=0
- [x] Count reconciled against a measured base, both axes: 290 files / 5625
      tests at F1, `+1` file `+18` tests from `scrollTrace.test.ts` (arrived on
      main), `+1` file `+14` tests here. Exact on both.
- [x] Four mutants, one per mechanism that is new relative to the dismiss
      binder. Each kills **exactly one** test, and the four victims are
      disjoint and correctly named: dropping the downward gate kills only
      "leaves an UPWARD drag entirely alone"; snapshotting `canPull` kills only
      "re-reads canPull mid-drag"; relaxing `PULL_COMMIT_PX` to the bare floor
      kills only "springs back between the swipe floor and the commit
      distance"; dropping the zero-floor kills only "floors the reported travel
      at 0".
- [x] **That fourth mutant survived at first** — the drag was written
      `PULL_COMMIT_PX - 20`, relative to the very constant under test, so
      halving the constant shrank the drag with it and the assertion passed for
      the wrong reason. Anchoring the magnitude between BOTH constants closed
      the blind spot; its own commit records why.

## Not covered, on purpose rather than by omission

jsdom sees neither `touch-action` nor Solid's passive delegation (#308 landmine
1), and a synthetic event drives no compositor. So this proves the **decision
table** and nothing about the feel, about `PULL_COMMIT_PX` being the right
distance, or about iOS Safari's rubber-band at the top of a scroller fighting a
transform. Those are the third slice's e2e and vjt's device call — the same
standing #213 and #1438 carry.