### PR TITLE
test(#1551): tear sessions down by key, the way production does

### DIFF
--- a/test/grappa/auth_fixtures_teardown_test.exs
+++ b/test/grappa/auth_fixtures_teardown_test.exs
@@ -1,0 +1,87 @@
+defmodule Grappa.AuthFixturesTeardownTest do
+  @moduledoc """
+  #1551 — the teardown `Grappa.AuthFixtures` registers for every session
+  it spawns must free the registry KEY, not one pid.
+
+  `Session.Server` is `restart: :transient` and the fake `IRCServer` a
+  test connects to dies with the test pid, so an abnormal Client exit at
+  end-of-test is the routine case, not the exotic one. The supervisor
+  restarts the child, the successor re-registers the SAME key, and a
+  teardown holding the pid it spawned tears down nothing: the respawned
+  session outlives the test and keeps emitting lifecycle telemetry into
+  whichever suite runs next. That is the leak #1551 reported.
+
+  The callback under test runs AFTER the test body, so no assertion
+  inside the body can observe it. `ExUnit` runs `on_exit` callbacks in
+  REVERSE order of registration, which is the vantage point this test
+  uses: an assertion registered BEFORE the fixture spawns runs AFTER the
+  fixture's own teardown, and so reads the state that teardown left
+  behind. Nothing else in the suite can see that state — a leaked session
+  only shows up later, as an unattributable failure in another file.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Session}
+
+  @respawn_attempts 400
+  @respawn_retry_ms 5
+
+  test "the teardown the fixture registers frees a key a :transient restart refilled" do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {visitor, network} = visitor_with_network(port)
+    subject = {:visitor, visitor.id}
+
+    # Registered BEFORE the fixture registers its own, so ExUnit's
+    # reverse order runs this one LAST — after the teardown it is judging.
+    on_exit(fn ->
+      assert Session.whereis(subject, network.id) == nil,
+             "the session outlived the teardown AuthFixtures registered for it: the key " <>
+               "#{inspect(subject)}/#{network.id} is still held by a live process, which is " <>
+               "free to write into whichever suite runs next (#1551)"
+    end)
+
+    spawned = start_visitor_session_for(visitor, network)
+    :ok = IRCServer.await_handshake(server, 5_000)
+
+    # The pre-state: without it a teardown that never had anything to do
+    # would read as a teardown that worked.
+    assert Session.whereis(subject, network.id) == spawned
+
+    Process.exit(spawned, :kill)
+    successor = await_respawn(subject, network.id, spawned, @respawn_attempts)
+
+    refute Process.alive?(spawned)
+    assert successor != spawned
+
+    # Positive control for the scenario itself: the gesture the fixture
+    # used to register is a no-op against the dead predecessor, and the
+    # key stays taken by the successor it never saw. If this ever starts
+    # freeing the key, the `on_exit` assertion above has stopped meaning
+    # anything.
+    assert {:error, :not_found} =
+             DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, spawned)
+
+    assert Session.whereis(subject, network.id) == successor
+  end
+
+  defp await_respawn(subject, network_id, spawned, 0) do
+    flunk(
+      "no :transient restart took over #{inspect(subject)}/#{network_id} within " <>
+        "#{@respawn_attempts * @respawn_retry_ms}ms of killing #{inspect(spawned)} — " <>
+        "the scenario this test is about never happened"
+    )
+  end
+
+  defp await_respawn(subject, network_id, spawned, attempts) do
+    case Session.whereis(subject, network_id) do
+      pid when is_pid(pid) and pid != spawned ->
+        pid
+
+      _ ->
+        Process.sleep(@respawn_retry_ms)
+        await_respawn(subject, network_id, spawned, attempts - 1)
+    end
+  end
+end

--- a/test/support/auth_fixtures.ex
+++ b/test/support/auth_fixtures.ex
@@ -298,7 +298,7 @@ defmodule Grappa.AuthFixtures do
     credential = Credentials.get_credential!(user, network)
     {:ok, plan} = SessionPlan.resolve(credential)
     {:ok, pid} = Grappa.Session.start_session({:user, user.id}, network.id, plan)
-    register_session_cleanup(pid)
+    register_session_cleanup({:user, user.id}, network.id)
     pid
   end
 
@@ -314,31 +314,34 @@ defmodule Grappa.AuthFixtures do
   def start_visitor_session_for(%Visitor{} = visitor, %Network{} = network) do
     {:ok, plan} = VisitorSessionPlan.resolve(visitor, network)
     {:ok, pid} = Grappa.Session.start_session({:visitor, visitor.id}, network.id, plan)
-    register_session_cleanup(pid)
+    register_session_cleanup({:visitor, visitor.id}, network.id)
     pid
   end
 
-  # Every Session.Server spawned via these helpers gets an `on_exit`
-  # callback that ATOMICALLY removes the pid from the DynamicSupervisor
-  # via `terminate_child/2`. This is the only correct teardown shape
-  # for `:transient` children whose upstream Client crashes on
-  # `:tcp_closed` / `:connect_failed` (typical end-of-test condition
-  # when the fake IRCServer the session connected to dies with the
-  # test pid): without `terminate_child`, the DynamicSupervisor
-  # restarts the child on every abnormal Client exit, the Session.Server
-  # spins in a `connect → :econnrefused → respawn` loop, and the
-  # SessionRegistry entry survives across test boundaries — poisoning
-  # the next singleton-lane test's setup (see `Grappa.AdminEventsTest`).
-  # `terminate_child/2` is sync + supervisor-mediated; passing a dead
-  # pid is a no-op (returns `{:error, :not_found}` which we discard).
+  # Teardown is keyed on the (subject, network_id) KEY, never on the pid
+  # we happened to spawn (#1551). `Session.Server` is `:transient`, so an
+  # abnormal Client exit — the routine end-of-test condition, since the
+  # fake IRCServer dies with the test pid — makes the supervisor restart
+  # the child under a NEW pid that re-registers the SAME key. A single
+  # `DynamicSupervisor.terminate_child/2` on the original pid then hits a
+  # dead pid, answers `{:error, :not_found}`, and the respawned session
+  # outlives the test: still registered, still emitting lifecycle
+  # telemetry into whichever suite runs next. That is the leak #1551
+  # reported, and it is why this used to be the wrong shape despite the
+  # comment that stood here claiming it was the only correct one.
   #
-  # Note: existing test-callers that explicitly `GenServer.stop(pid,
-  # :normal, _)` at end-of-test still work — `terminate_child/2` on an
-  # already-dead pid is the no-op above, no double-teardown surprises.
-  defp register_session_cleanup(pid) do
-    ExUnit.Callbacks.on_exit(fn ->
-      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
-    end)
+  # `Grappa.Session.stop_session/2` is the production teardown and already
+  # solves this: it re-reads the key each round, chases the respawn for
+  # `@stop_chase_rounds`, and logs an error if the key is still taken at
+  # the end. Tests get the same verb rather than a weaker copy of it.
+  #
+  # `Grappa.AuthFixturesTeardownTest` is what holds this shape in place.
+  # It cannot call this callback — `on_exit` runs after the test — so it
+  # registers its own assertion BEFORE spawning and lets ExUnit's reverse
+  # callback order run it afterwards. Reverting this function to the pid
+  # form turns that test red.
+  defp register_session_cleanup(subject, network_id) do
+    ExUnit.Callbacks.on_exit(fn -> Grappa.Session.stop_session(subject, network_id) end)
   end
 
   @doc """


### PR DESCRIPTION
## The leak

`AuthFixtures` registered its `on_exit` teardown against the pid it had
just spawned, and called one round of `DynamicSupervisor.terminate_child/2`
on it.

`Session.Server` is `:transient`, and the fake `IRCServer` dies with the
test pid — so an abnormal Client exit at end-of-test is the **routine**
case, not the exotic one. The supervisor restarts the child, the new pid
re-registers the SAME key, `terminate_child/2` on the original pid answers
`{:error, :not_found}`, the value is discarded, and the respawned session
outlives the test: still registered, still emitting lifecycle telemetry
into whichever suite runs next.

That is the leak behind #1551, where a foreign `visitor:` row appeared in
`SessionLogPersistenceTest`'s transaction between two adjacent statements.

## The fix is a verb we already ship

`Grappa.Session.stop_session/2` chases: it re-reads the KEY each round
rather than trusting a pid, runs a `flush_pending_restarts` barrier, and
logs an error if the key is still taken after `@stop_chase_rounds`. Its
own comment states the reason — *"terminating one pid therefore does not
free the key"*. The fixture was a weaker copy of it, so it now calls it.

The comment that stood there called `terminate_child/2` *"the only correct
teardown shape"* and dismissed `{:error, :not_found}` as *"a no-op"*. That
sentence is what kept the hole from being read as a hole.

## Gating a teardown that runs after the test

`on_exit` runs after the test body, so no assertion inside the body can
observe it.

The design this started from worked around that by exposing the callback's
body as a public `@doc false` seam on the fixture module and asserting on
the seam. **It was measured before being believed, and it did not hold.**
Three mutants against that shape:

| mutant | result |
|---|---|
| seam body → `:ok` | killed |
| seam body → one `terminate_child/2` on the *current* pid, no chase | **survives** (15/15 green) |
| registration reverted to the pid form — i.e. a straight revert of this diff | **survives** |

The last row is the one that matters: a straight revert of the change under
test left the test green. The defect is structural — the test drove the
*seam*, while the change lives in the *registration*, and the two are
disjoint. The middle row shows the second half of it: the seam only
delegated to `Session.stop_session/2`, whose chase is already gated
deterministically by `session_stop_session_test.exs` (#854), including the
restart-in-flight case. So the seam bought one thing nothing else could
break — "somebody empties a two-line delegation" — at the price of a
public API that existed only for the test.

It is therefore gone, and this note is why a future reader will not find
one here.

`ExUnit` runs `on_exit` callbacks in **reverse registration order**, which
is the vantage point used instead: an assertion registered BEFORE the
fixture spawns runs AFTER the fixture's own teardown, and reads the state
that teardown left behind.

The body kills the spawned pid, waits *on a condition* for the `:transient`
successor, and executes the superseded gesture inline as a positive
control — `terminate_child/2` on the dead predecessor answers
`{:error, :not_found}` and leaves the key taken, so the scenario is proven
real rather than assumed.

## Evidence

Two mutants, each killed on exactly that one assertion:

| mutant | result |
|---|---|
| `on_exit` body emptied | **killed** |
| registration reverted to `register_session_cleanup(pid)` + one `terminate_child/2` | **killed** |

Baseline green 10/10 repeats. Full `scripts/check.sh`: **6562 tests, 8
doctests, 61 properties, 0 failures**; Dialyzer 0 errors; Credo 355
modules; Sobelow and Doctor pass. The count reconciles exactly against the
6561 measured before this change — this PR adds one test.

Both entry points already hold `(subject, network_id)` at the spawn, so
none of the 417 session-spawn call sites across 24 files change.

Refs #1551.
